### PR TITLE
Embed templates in test

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"embed"
 	"html/template"
-	"os"
+	"net/http/httptest"
 	"testing"
 )
 
+//go:embed templates/*.gohtml
+var testTemplates embed.FS
+
 func TestCompileGoHTML(t *testing.T) {
-	template.Must(template.New("").Funcs(NewFuncs(r)).ParseFS(os.DirFS("./templates"), "*.gohtml"))
+	r := httptest.NewRequest("GET", "/", nil)
+	template.Must(template.New("").Funcs(NewFuncs(r)).ParseFS(testTemplates, "templates/*.gohtml"))
 }


### PR DESCRIPTION
## Summary
- embed gohtml templates within `TestCompileGoHTML`
- parse templates from the embedded filesystem

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68459d7b94c8832fb43ccc474fe1e0e8