### PR TITLE
Fix forum quote parsing index panic

### DIFF
--- a/forum.go
+++ b/forum.go
@@ -19,10 +19,11 @@ func processCommentFullQuote(username, text string) string {
 		case '[':
 			bc++
 		case '\\':
-			switch text[it+1] {
-			case '[', ']':
-				out.WriteByte(text[it+1])
-				it++
+			if it+1 < len(text) {
+				if text[it+1] == '[' || text[it+1] == ']' {
+					out.WriteByte(text[it+1])
+					it++
+				}
 			}
 		case '\n':
 			if bc == 0 && nlc == 1 {


### PR DESCRIPTION
## Summary
- guard escape sequence parsing in forum comment quoting

## Testing
- `go test ./...` *(fails: `goa4web [build failed]` due to unused import)*

------
https://chatgpt.com/codex/tasks/task_e_68482cf997cc832f82f3b5f4697bc13d