### PR TITLE
Add Goreleaser config and CI

### DIFF
--- a/.github/workflows/go_releaser.yaml
+++ b/.github/workflows/go_releaser.yaml
@@ -1,0 +1,29 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.18
+RUN adduser -D -u 10001 app
+USER app
+COPY goa4web /usr/local/bin/goa4web
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/goa4web"]

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,0 +1,58 @@
+version: 2
+project_name: goa4web
+builds:
+  -
+    id: goa4web
+    main: .
+    binary: goa4web
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+    ldflags: -s -w
+archives:
+  -
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: "{{ .ProjectName }}_checksums.txt"
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+nfpms:
+  -
+    vendor: Ubels Software Development
+    homepage: https://github.com/arran4/goa4web
+    maintainer: Arran Ubels <arran@ubels.com.au>
+    description: Goa4web web application
+    license: MIT
+    formats:
+      - apk
+      - deb
+      - rpm
+      - termux.deb
+      - archlinux
+    release: 1
+    section: default
+    priority: extra
+dockers:
+  -
+    image_templates:
+      - "ghcr.io/arran4/goa4web:{{ .Tag }}"
+      - "ghcr.io/arran4/goa4web:latest"
+    dockerfile: Dockerfile
+    goos: linux
+    goarch: amd64
+  -
+    image_templates:
+      - "ghcr.io/arran4/goa4web:{{ .Tag }}-arm64"
+    dockerfile: Dockerfile
+    goos: linux
+    goarch: arm64


### PR DESCRIPTION
## Summary
- add goreleaser configuration with multi-OS builds and docker images
- add Dockerfile for container releases
- add GitHub Actions workflow to run GoReleaser

## Testing
- `go test ./...` *(fails: data_test.go imported and not used)*

------
https://chatgpt.com/codex/tasks/task_e_684eacea9ae8832fb6d1550f22787338