### PR TITLE
Sanitize URLs in anchors

### DIFF
--- a/a4code2html_longer_test.go
+++ b/a4code2html_longer_test.go
@@ -21,3 +21,13 @@ func TestA4code2htmlUnclosed(t *testing.T) {
 		t.Errorf("got %q want %q", got, want)
 	}
 }
+
+func TestA4code2htmlBadURL(t *testing.T) {
+	c := NewA4Code2HTML()
+	c.input = "[link javascript:alert(1) example]"
+	c.Process()
+	want := "javascript:alert(1)example"
+	if got := c.Output(); got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}

--- a/html.go
+++ b/html.go
@@ -27,7 +27,11 @@ func categoryLevel(categoryName string, level int) string {
 }
 
 func externalLink(pagename, linkName string) string {
-	return fmt.Sprintf("<a href=\"%s\" target=\"_blank\">%s</a>", pagename, linkName)
+	safe, ok := sanitizeURL(pagename)
+	if ok {
+		return fmt.Sprintf("<a href=\"%s\" target=\"_blank\">%s</a>", safe, linkName)
+	}
+	return safe
 }
 
 func formatCategories(input string) string {

--- a/html_test.go
+++ b/html_test.go
@@ -34,3 +34,11 @@ func TestExternalLink(t *testing.T) {
 		t.Errorf("externalLink=%q", got)
 	}
 }
+
+func TestExternalLinkBadURL(t *testing.T) {
+	got := externalLink("javascript:alert(1)", "X")
+	want := "javascript:alert(1)"
+	if got != want {
+		t.Errorf("externalLink bad=%q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- sanitize URLs before outputting them in `<a>` tags using `url.Parse` and `html.EscapeString`
- skip creating links for invalid schemes
- cover sanitization logic with tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685539d736f4832fb9d628ca5cef472f