### PR TITLE
Implement email notification queue

### DIFF
--- a/email_queue.go
+++ b/email_queue.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"time"
+)
+
+type EmailQueueItem struct {
+	IDEmailQueue int64
+	Email        string
+	Page         string
+	Created      time.Time
+}
+
+func (q *Queries) EnqueueEmail(ctx context.Context, email, page string) error {
+	const insert = "INSERT INTO emailQueue (email, page, created) VALUES (?, ?, NOW())"
+	_, err := q.db.ExecContext(ctx, insert, email, page)
+	return err
+}
+
+func (q *Queries) ListQueuedEmails(ctx context.Context, limit int32) ([]EmailQueueItem, error) {
+	const selectQuery = "SELECT idemailQueue, email, page, created FROM emailQueue ORDER BY idemailQueue LIMIT ?"
+	rows, err := q.db.QueryContext(ctx, selectQuery, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []EmailQueueItem
+	for rows.Next() {
+		var it EmailQueueItem
+		if err := rows.Scan(&it.IDEmailQueue, &it.Email, &it.Page, &it.Created); err != nil {
+			return nil, err
+		}
+		items = append(items, it)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func (q *Queries) DeleteQueuedEmail(ctx context.Context, id int64) error {
+	const deleteQuery = "DELETE FROM emailQueue WHERE idemailQueue = ?"
+	_, err := q.db.ExecContext(ctx, deleteQuery, id)
+	return err
+}

--- a/email_queue_test.go
+++ b/email_queue_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNotifyChangeQueues(t *testing.T) {
+	st := &stubEnqueuer{}
+	ctx := context.WithValue(context.Background(), ContextValues("queries"), st)
+	err := notifyChange(ctx, logMailProvider{}, "a@b.com", "p")
+	if err != nil {
+		t.Fatalf("notify error: %v", err)
+	}
+	if st.email != "a@b.com" || st.page != "p" {
+		t.Fatalf("stored %+v", st)
+	}
+}
+
+type stubStore struct {
+	items   []EmailQueueItem
+	deleted []int64
+}
+
+func (s *stubStore) ListQueuedEmails(ctx context.Context, limit int32) ([]EmailQueueItem, error) {
+	return s.items, nil
+}
+func (s *stubStore) DeleteQueuedEmail(ctx context.Context, id int64) error {
+	s.deleted = append(s.deleted, id)
+	return nil
+}
+
+type recordProvider struct{ sent int }
+
+func (r *recordProvider) Send(ctx context.Context, to, subject, body string) error {
+	r.sent++
+	return nil
+}
+
+func TestProcessEmailQueue(t *testing.T) {
+	store := &stubStore{items: []EmailQueueItem{{IDEmailQueue: 1, Email: "a@b", Page: "p"}}}
+	prov := &recordProvider{}
+	processEmailQueue(context.Background(), store, prov)
+	if prov.sent != 1 {
+		t.Fatalf("sent %d", prov.sent)
+	}
+	if len(store.deleted) != 1 || store.deleted[0] != 1 {
+		t.Fatalf("deleted %+v", store.deleted)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -67,6 +67,9 @@ func main() {
 	}
 	emailConfigFile = *emailCfgPath
 
+	provider := getEmailProvider()
+	startEmailQueueWorker(provider)
+
 	r := mux.NewRouter()
 
 	r.Use(DBAdderMiddleware)

--- a/schema.sql
+++ b/schema.sql
@@ -334,3 +334,11 @@ CREATE TABLE `writtingApprovedUsers` (
   KEY `writing_has_users_FKIndex2` (`users_idusers`)
 );
 
+
+CREATE TABLE `emailQueue` (
+  `idemailQueue` int(10) NOT NULL AUTO_INCREMENT,
+  `email` tinytext NOT NULL,
+  `page` tinytext NOT NULL,
+  `created` datetime DEFAULT NOW(),
+  PRIMARY KEY (`idemailQueue`)
+);


### PR DESCRIPTION
## Summary
- add schema table `emailQueue`
- enqueue notifications instead of sending immediately
- add worker to process queued emails
- launch worker on startup
- test queuing and processing logic

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685539daa758832fa5c34c1825aba6d7