### PR TITLE
Add subscription table and email notification queue

### DIFF
--- a/forumThreadNewPage.go
+++ b/forumThreadNewPage.go
@@ -61,34 +61,7 @@ func forumThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d", topicId, threadId)
 
-	provider := getEmailProvider()
-
-	if rows, err := queries.ListUsersSubscribedToThread(r.Context(), ListUsersSubscribedToThreadParams{
-		ForumthreadIdforumthread: int32(threadId),
-		Idusers:                  uid,
-	}); err != nil {
-		log.Printf("Error: listUsersSubscribedToThread: %s", err)
-	} else if provider != nil {
-		for _, row := range rows {
-			if err := notifyChange(r.Context(), provider, row.Username.String, endUrl); err != nil {
-				log.Printf("Error: notifyChange: %s", err)
-			}
-		}
-	}
-
-	if rows, err := queries.ListUsersSubscribedToThread(r.Context(), ListUsersSubscribedToThreadParams{
-		Idusers:                  uid,
-		ForumthreadIdforumthread: int32(threadId),
-	}); err != nil {
-		log.Printf("Error: listUsersSubscribedToThread: %s", err)
-	} else if provider != nil {
-		for _, row := range rows {
-			if err := notifyChange(r.Context(), provider, row.Username.String, endUrl); err != nil {
-				log.Printf("Error: notifyChange: %s", err)
-
-			}
-		}
-	}
+	queueThreadNotifications(r.Context(), queries, int32(threadId), uid, endUrl)
 
 	cid, err := queries.CreateComment(r.Context(), CreateCommentParams{
 		LanguageIdlanguage:       int32(languageId),

--- a/forumTopicThreadReplyPage.go
+++ b/forumTopicThreadReplyPage.go
@@ -25,34 +25,7 @@ func forumTopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicId, threadId)
 
-	provider := getEmailProvider()
-
-	if rows, err := queries.ListUsersSubscribedToThread(r.Context(), ListUsersSubscribedToThreadParams{
-		ForumthreadIdforumthread: int32(threadId),
-		Idusers:                  uid,
-	}); err != nil {
-		log.Printf("Error: listUsersSubscribedToThread: %s", err)
-	} else if provider != nil {
-		for _, row := range rows {
-			if err := notifyChange(r.Context(), provider, row.Username.String, endUrl); err != nil {
-				log.Printf("Error: notifyChange: %s", err)
-			}
-		}
-	}
-
-	if rows, err := queries.ListUsersSubscribedToThread(r.Context(), ListUsersSubscribedToThreadParams{
-		Idusers:                  uid,
-		ForumthreadIdforumthread: int32(threadId),
-	}); err != nil {
-		log.Printf("Error: listUsersSubscribedToThread: %s", err)
-	} else if provider != nil {
-		for _, row := range rows {
-			if err := notifyChange(r.Context(), provider, row.Username.String, endUrl); err != nil {
-				log.Printf("Error: notifyChange: %s", err)
-
-			}
-		}
-	}
+	queueThreadNotifications(r.Context(), queries, int32(threadId), uid, endUrl)
 
 	cid, err := queries.CreateComment(r.Context(), CreateCommentParams{
 		LanguageIdlanguage:       int32(languageId),

--- a/imagebbsBoardThreadPage.go
+++ b/imagebbsBoardThreadPage.go
@@ -213,20 +213,7 @@ func imagebbsBoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) 
 
 	endUrl := fmt.Sprintf("/imagebbss/imagebbs/%d/comments", bid)
 
-	provider := getEmailProvider()
-
-	if rows, err := queries.ListUsersSubscribedToThread(r.Context(), ListUsersSubscribedToThreadParams{
-		ForumthreadIdforumthread: pthid,
-		Idusers:                  uid,
-	}); err != nil {
-		log.Printf("Error: listUsersSubscribedToThread: %s", err)
-	} else if provider != nil {
-		for _, row := range rows {
-			if err := notifyChange(r.Context(), provider, row.Username.String, endUrl); err != nil {
-				log.Printf("Error: notifyChange: %s", err)
-			}
-		}
-	}
+	queueThreadNotifications(r.Context(), queries, pthid, uid, endUrl)
 
 	//if rows, err := queries.SomethingNotifyImagebbss(r.Context(), SomethingNotifyImagebbssParams{
 	//	Idusers: uid,

--- a/linkerCommentsPage.go
+++ b/linkerCommentsPage.go
@@ -215,32 +215,16 @@ func linkerCommentsReplyPage(w http.ResponseWriter, r *http.Request) {
 
 	endUrl := fmt.Sprintf("/linker/comments/%d", linkId)
 
-	provider := getEmailProvider()
-
-	if rows, err := queries.ListUsersSubscribedToThread(r.Context(), ListUsersSubscribedToThreadParams{
-		ForumthreadIdforumthread: pthid,
-		Idusers:                  uid,
-	}); err != nil {
-		log.Printf("Error: listUsersSubscribedToThread: %s", err)
-	} else if provider != nil {
-		for _, row := range rows {
-			if err := notifyChange(r.Context(), provider, row.Username.String, endUrl); err != nil {
-				log.Printf("Error: notifyChange: %s", err)
-			}
-		}
-	}
+	queueThreadNotifications(r.Context(), queries, pthid, uid, endUrl)
 
 	if rows, err := queries.ListUsersSubscribedToLinker(r.Context(), ListUsersSubscribedToLinkerParams{
 		Idusers:  uid,
 		Idlinker: int32(linkId),
 	}); err != nil {
 		log.Printf("Error: listUsersSubscribedToThread: %s", err)
-	} else if provider != nil {
+	} else {
 		for _, row := range rows {
-			if err := notifyChange(r.Context(), provider, row.Username.String, endUrl); err != nil {
-				log.Printf("Error: notifyChange: %s", err)
-
-			}
+			enqueueEmail(row.Username.String, endUrl)
 		}
 	}
 

--- a/models.go
+++ b/models.go
@@ -242,6 +242,12 @@ type Writtingapproveduser struct {
 	Editdoc          sql.NullBool
 }
 
+type Subscription struct {
+	Idsubscriptions          int32
+	UsersIdusers             int32
+	ForumthreadIdforumthread int32
+}
+
 type _1OldForumthread struct {
 	Idforumthread          int32
 	ForumtopicIdforumtopic int32

--- a/newsPostPage.go
+++ b/newsPostPage.go
@@ -242,20 +242,7 @@ func newsPostReplyActionPage(w http.ResponseWriter, r *http.Request) {
 
 	endUrl := fmt.Sprintf("/news/news/%d", pid)
 
-	provider := getEmailProvider()
-
-	if rows, err := queries.ListUsersSubscribedToThread(r.Context(), ListUsersSubscribedToThreadParams{
-		ForumthreadIdforumthread: pthid,
-		Idusers:                  uid,
-	}); err != nil {
-		log.Printf("Error: listUsersSubscribedToThread: %s", err)
-	} else if provider != nil {
-		for _, row := range rows {
-			if err := notifyChange(r.Context(), provider, row.Username.String, endUrl); err != nil {
-				log.Printf("Error: notifyChange: %s", err)
-			}
-		}
-	}
+	queueThreadNotifications(r.Context(), queries, pthid, uid, endUrl)
 
 	// TODO
 	//if rows, err := queries.SomethingNotifyNews(r.Context(), somethingNotifyNewssParams{

--- a/notification.go
+++ b/notification.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"context"
+	"log"
+)
+
+type subscriberLister interface {
+	ListSubscribersForThread(ctx context.Context, arg ListSubscribersForThreadParams) ([]*ListSubscribersForThreadRow, error)
+}
+
+func queueThreadNotifications(ctx context.Context, q subscriberLister, threadID, excludeUser int32, url string) {
+	rows, err := q.ListSubscribersForThread(ctx, ListSubscribersForThreadParams{
+		ForumthreadIdforumthread: threadID,
+		Idusers:                  excludeUser,
+	})
+	if err != nil {
+		log.Printf("Error: listSubscribersForThread: %s", err)
+		return
+	}
+	for _, row := range rows {
+		enqueueEmail(row.Username.String, url)
+	}
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+type stubSubscriber struct{}
+
+func (stubSubscriber) ListSubscribersForThread(ctx context.Context, arg ListSubscribersForThreadParams) ([]*ListSubscribersForThreadRow, error) {
+	return []*ListSubscribersForThreadRow{
+		{Username: sql.NullString{String: "u1@example.com", Valid: true}},
+		{Username: sql.NullString{String: "u2@example.com", Valid: true}},
+	}, nil
+}
+
+func TestQueueThreadNotifications(t *testing.T) {
+	clearEmailQueue()
+	q := stubSubscriber{}
+	queueThreadNotifications(context.Background(), q, 1, 2, "/page")
+	items := getQueuedEmails()
+	if len(items) != 2 {
+		t.Fatalf("queued %d notifications", len(items))
+	}
+	if items[0].To != "u1@example.com" || items[0].URL != "/page" {
+		t.Fatalf("unexpected first item: %+v", items[0])
+	}
+}

--- a/queries-subscription.sql
+++ b/queries-subscription.sql
@@ -1,0 +1,13 @@
+-- name: CreateSubscription :exec
+INSERT INTO subscriptions (users_idusers, forumthread_idforumthread)
+VALUES (?, ?) ON DUPLICATE KEY UPDATE users_idusers=users_idusers;
+
+-- name: DeleteSubscription :exec
+DELETE FROM subscriptions WHERE users_idusers = ? AND forumthread_idforumthread = ?;
+
+-- name: ListSubscribersForThread :many
+SELECT u.username
+FROM subscriptions s
+JOIN users u ON s.users_idusers = u.idusers
+JOIN preferences p ON u.idusers = p.users_idusers
+WHERE s.forumthread_idforumthread = ? AND p.emailforumupdates = 1 AND u.idusers != ?;

--- a/queries-subscription.sql.go
+++ b/queries-subscription.sql.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+)
+
+const createSubscription = `INSERT INTO subscriptions (users_idusers, forumthread_idforumthread) VALUES (?, ?) ON DUPLICATE KEY UPDATE users_idusers=users_idusers`
+
+func (q *Queries) CreateSubscription(ctx context.Context, userID, threadID int32) error {
+	_, err := q.db.ExecContext(ctx, createSubscription, userID, threadID)
+	return err
+}
+
+const deleteSubscription = `DELETE FROM subscriptions WHERE users_idusers = ? AND forumthread_idforumthread = ?`
+
+func (q *Queries) DeleteSubscription(ctx context.Context, userID, threadID int32) error {
+	_, err := q.db.ExecContext(ctx, deleteSubscription, userID, threadID)
+	return err
+}
+
+type ListSubscribersForThreadParams struct {
+	ForumthreadIdforumthread int32
+	Idusers                  int32
+}
+
+type ListSubscribersForThreadRow struct {
+	Username sql.NullString
+}
+
+const listSubscribersForThread = `SELECT u.username FROM subscriptions s JOIN users u ON s.users_idusers = u.idusers JOIN preferences p ON u.idusers = p.users_idusers WHERE s.forumthread_idforumthread = ? AND p.emailforumupdates = 1 AND u.idusers != ?`
+
+func (q *Queries) ListSubscribersForThread(ctx context.Context, arg ListSubscribersForThreadParams) ([]*ListSubscribersForThreadRow, error) {
+	rows, err := q.db.QueryContext(ctx, listSubscribersForThread, arg.ForumthreadIdforumthread, arg.Idusers)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListSubscribersForThreadRow
+	for rows.Next() {
+		var i ListSubscribersForThreadRow
+		if err := rows.Scan(&i.Username); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/schema.sql
+++ b/schema.sql
@@ -334,3 +334,13 @@ CREATE TABLE `writtingApprovedUsers` (
   KEY `writing_has_users_FKIndex2` (`users_idusers`)
 );
 
+CREATE TABLE `subscriptions` (
+  `idsubscriptions` int(10) NOT NULL AUTO_INCREMENT,
+  `users_idusers` int(10) NOT NULL DEFAULT 0,
+  `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`idsubscriptions`),
+  UNIQUE KEY `sub_unique` (`users_idusers`,`forumthread_idforumthread`),
+  KEY `subscriptions_FK1` (`forumthread_idforumthread`),
+  KEY `subscriptions_FK2` (`users_idusers`)
+);
+

--- a/writingsArticlePage.go
+++ b/writingsArticlePage.go
@@ -257,20 +257,7 @@ func writingsArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 
 	endUrl := fmt.Sprintf("/article/%d", aid)
 
-	provider := getEmailProvider()
-
-	if rows, err := queries.ListUsersSubscribedToThread(r.Context(), ListUsersSubscribedToThreadParams{
-		ForumthreadIdforumthread: pthid,
-		Idusers:                  uid,
-	}); err != nil {
-		log.Printf("Error: listUsersSubscribedToThread: %s", err)
-	} else if provider != nil {
-		for _, row := range rows {
-			if err := notifyChange(r.Context(), provider, row.Username.String, endUrl); err != nil {
-				log.Printf("Error: notifyChange: %s", err)
-			}
-		}
-	}
+	queueThreadNotifications(r.Context(), queries, pthid, uid, endUrl)
 
 	// TODO
 	//if rows, err := queries.SomethingNotifyArticle(r.Context(), SomethingNotifyArticlesParams{


### PR DESCRIPTION
## Summary
- create `subscriptions` table and generated models
- implement subscription query methods
- add in-memory email queue and helper for queuing thread notifications
- update reply handlers to use queue and new queries
- test notification queuing

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685539ee0590832faf8ca470839250ba