### PR TITLE
Add access checks for blog handlers

### DIFF
--- a/blogsBlogAddPage.go
+++ b/blogsBlogAddPage.go
@@ -10,7 +10,11 @@ import (
 )
 
 func blogsBlogAddPage(w http.ResponseWriter, r *http.Request) {
-	// TODO add guard
+	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	if !(cd.HasRole("writer") || cd.HasRole("administrator")) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	type Data struct {
 		*CoreData
 		Languages          []*Language
@@ -19,7 +23,7 @@ func blogsBlogAddPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           cd,
 		SelectedLanguageId: 1,
 		Mode:               "Add",
 	}

--- a/blogsBlogEditPage.go
+++ b/blogsBlogEditPage.go
@@ -10,7 +10,11 @@ import (
 )
 
 func blogsBlogEditPage(w http.ResponseWriter, r *http.Request) {
-	// TODO add guard
+	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	if !(cd.HasRole("writer") || cd.HasRole("administrator")) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	type Data struct {
 		*CoreData
 		Languages          []*Language
@@ -20,7 +24,7 @@ func blogsBlogEditPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           cd,
 		SelectedLanguageId: 1,
 		Mode:               "Edit",
 	}

--- a/blogsUserPermissionsPage.go
+++ b/blogsUserPermissionsPage.go
@@ -10,14 +10,18 @@ import (
 )
 
 func getPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Request) {
-	// TODO add guard
+	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	if !cd.HasRole("administrator") {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	type Data struct {
 		*CoreData
 		Rows []*GetPermissionsByUserIdAndSectionBlogsRow
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: cd,
 	}
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)

--- a/blogs_handlers_test.go
+++ b/blogs_handlers_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest("GET", "/blogs/add", nil)
+	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{SecurityLevel: "reader"})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	blogsBlogAddPage(rr, req)
+	if rr.Result().StatusCode != http.StatusForbidden {
+		t.Fatalf("expected %d got %d", http.StatusForbidden, rr.Result().StatusCode)
+	}
+}
+
+func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest("GET", "/blogs/1/edit", nil)
+	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{SecurityLevel: "reader"})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	blogsBlogEditPage(rr, req)
+	if rr.Result().StatusCode != http.StatusForbidden {
+		t.Fatalf("expected %d got %d", http.StatusForbidden, rr.Result().StatusCode)
+	}
+}
+
+func TestGetPermissionsByUserIdAndSectionBlogsPage_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest("GET", "/blogs/user/permissions", nil)
+	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{SecurityLevel: "writer"})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	getPermissionsByUserIdAndSectionBlogsPage(rr, req)
+	if rr.Result().StatusCode != http.StatusForbidden {
+		t.Fatalf("expected %d got %d", http.StatusForbidden, rr.Result().StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure blog add, edit and permissions pages check caller role
- forbid access if lacking the expected role
- add tests for new guards

## Testing
- `go test ./...` *(fails: TestRequiredAccessAllowed, TestRequiredAccessDenied)*

------
https://chatgpt.com/codex/tasks/task_e_68555098aca4832fbf4399c1b817e5a9