### PR TITLE
Fix blogs RSS handler

### DIFF
--- a/blogsPage.go
+++ b/blogsPage.go
@@ -166,7 +166,8 @@ func blogsRssPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	if err := feed.WriteAtom(w); err != nil {
+	w.Header().Set("Content-Type", "application/rss+xml")
+	if err := feed.WriteRss(w); err != nil {
 		log.Printf("Feed write Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/blogsPage_test.go
+++ b/blogsPage_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestBlogsRssPageWritesRSS(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := New(db)
+
+	mock.ExpectQuery(regexp.QuoteMeta(getUserByUsername)).
+		WithArgs("bob").
+		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "passwd", "username"}).
+			AddRow(1, "e", "p", "bob"))
+
+	mock.ExpectQuery(regexp.QuoteMeta(getBlogEntriesForUserDescending)).
+		WithArgs(int32(0), int32(0), int32(1), int32(1), int32(15), int32(0)).
+		WillReturnRows(sqlmock.NewRows([]string{"idblogs", "forumthread_idforumthread", "users_idusers", "language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)"}).
+			AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), "bob", 0))
+
+	req := httptest.NewRequest("GET", "http://example.com/blogs/rss?rss=bob", nil)
+	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	blogsRssPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/rss+xml" {
+		t.Errorf("Content-Type=%q", ct)
+	}
+
+	var v struct{ XMLName xml.Name }
+	if err := xml.Unmarshal(rr.Body.Bytes(), &v); err != nil {
+		t.Fatalf("xml parse: %v", err)
+	}
+	if v.XMLName.Local != "rss" {
+		t.Errorf("expected root rss got %s", v.XMLName.Local)
+	}
+}


### PR DESCRIPTION
## Summary
- generate proper RSS feed for /blogs/rss
- specify RSS content type header
- add regression test validating RSS output

## Testing
- `go test ./...` *(fails: TestRequiredAccessAllowed, TestRequiredAccessDenied)*

------
https://chatgpt.com/codex/tasks/task_e_685550935d04832f8eaec81753a7521e