### PR TITLE
Implement linker feeds

### DIFF
--- a/linkerFeed.go
+++ b/linkerFeed.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/gorilla/feeds"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+func linkerFeed(r *http.Request, rows []*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow) *feeds.Feed {
+	feed := &feeds.Feed{
+		Title:       "Latest links",
+		Link:        &feeds.Link{Href: r.URL.Path},
+		Description: "Latest submitted links",
+		Created:     time.Now(),
+	}
+	for _, row := range rows {
+		if !row.Title.Valid {
+			continue
+		}
+		desc := ""
+		if row.Description.Valid {
+			var conv = &A4code2html{}
+			conv.codeType = ct_tagstrip
+			conv.input = row.Description.String
+			conv.Process()
+			desc = conv.output.String()
+		}
+		href := fmt.Sprintf("/linker/show/%d", row.Idlinker)
+		if row.Url.Valid && row.Url.String != "" {
+			href = row.Url.String
+		}
+		item := &feeds.Item{
+			Title:   row.Title.String,
+			Link:    &feeds.Link{Href: href},
+			Created: time.Now(),
+			Description: fmt.Sprintf("%s\n-\n%s", desc, func() string {
+				if row.Posterusername.Valid {
+					return row.Posterusername.String
+				}
+				return ""
+			}()),
+		}
+		if row.Listed.Valid {
+			item.Created = row.Listed.Time
+		}
+		feed.Items = append(feed.Items, item)
+	}
+	return feed
+}
+
+func linkerRssPage(w http.ResponseWriter, r *http.Request) {
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
+	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), int32(catID))
+	if err != nil && err != sql.ErrNoRows {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	feed := linkerFeed(r, rows)
+	if err := feed.WriteRss(w); err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}
+
+func linkerAtomPage(w http.ResponseWriter, r *http.Request) {
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
+	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), int32(catID))
+	if err != nil && err != sql.ErrNoRows {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	feed := linkerFeed(r, rows)
+	if err := feed.WriteAtom(w); err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/linkerFeed_test.go
+++ b/linkerFeed_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"database/sql"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestLinkerFeed(t *testing.T) {
+	rows := []*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow{
+		{
+			Idlinker:       1,
+			Title:          sql.NullString{String: "Example", Valid: true},
+			Url:            sql.NullString{String: "http://example.com", Valid: true},
+			Description:    sql.NullString{String: "desc", Valid: true},
+			Listed:         sql.NullTime{Time: time.Unix(0, 0), Valid: true},
+			Posterusername: sql.NullString{String: "bob", Valid: true},
+		},
+	}
+	r := httptest.NewRequest("GET", "http://example.com/linker/rss", nil)
+	feed := linkerFeed(r, rows)
+	if len(feed.Items) != 1 {
+		t.Fatalf("expected 1 item got %d", len(feed.Items))
+	}
+	if feed.Items[0].Link.Href != "http://example.com" {
+		t.Errorf("unexpected link %s", feed.Items[0].Link.Href)
+	}
+	if feed.Items[0].Title != "Example" {
+		t.Errorf("unexpected title %s", feed.Items[0].Title)
+	}
+}

--- a/linkerPage.go
+++ b/linkerPage.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 func linkerPage(w http.ResponseWriter, r *http.Request) {
@@ -68,8 +69,10 @@ func linkerPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func CustomLinkerIndex(data *CoreData, r *http.Request) {
-	data.RSSFeedUrl = "/linker/rss"
-	data.AtomFeedUrl = "/linker/atom"
+	if r.URL.Path == "/linker" || strings.HasPrefix(r.URL.Path, "/linker/category/") {
+		data.RSSFeedUrl = "/linker/rss"
+		data.AtomFeedUrl = "/linker/atom"
+	}
 
 	userHasAdmin := data.HasRole("administrator")
 	if userHasAdmin {

--- a/main.go
+++ b/main.go
@@ -180,8 +180,8 @@ func main() {
 	fr.HandleFunc("/admin/restrictions/topics", forumAdminTopicsRestrictionLevelChangePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher("Set topic restriction"))
 
 	lr := r.PathPrefix("/linker").Subrouter()
-	//lr.HandleFunc(".rss", linkerRssPage).Methods("GET")
-	//lr.HandleFunc(".atom", linkerAtomPage).Methods("GET")
+	lr.HandleFunc("/rss", linkerRssPage).Methods("GET")
+	lr.HandleFunc("/atom", linkerAtomPage).Methods("GET")
 	lr.HandleFunc("", linkerPage).Methods("GET")
 	lr.HandleFunc("/categories", linkerCategoriesPage).Methods("GET")
 	lr.HandleFunc("/category/{category}", linkerCategoryPage).Methods("GET")


### PR DESCRIPTION
## Summary
- add RSS and Atom feed handlers for linker content
- expose `/linker/rss` and `/linker/atom` routes
- show feed links only on linker listing pages
- test feed generation

## Testing
- `go test -run TestLinkerFeed -v`
- `go test ./...` *(fails: expectations not matched)*

------
https://chatgpt.com/codex/tasks/task_e_6855508672cc832f97ef176cdc86b86b