### PR TITLE
Implement news permissions page

### DIFF
--- a/newsAdminUserLevelsPage.go
+++ b/newsAdminUserLevelsPage.go
@@ -2,21 +2,36 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"log"
 	"net/http"
+	"strconv"
 )
 
 func newsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*CoreData
+		UserLevels []*Permission
 	}
 
 	data := Data{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 
-	// SKIP. TODO replace completely
-	// Custom Index???
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	rows, err := queries.GetUsersPermissions(r.Context())
+	if err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+		default:
+			log.Printf("getUsersPermissions Error: %s", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+	}
+	data.UserLevels = rows
+
+	CustomNewsIndex(data.CoreData, r)
 
 	if err := getCompiledTemplates(NewFuncs(r)).ExecuteTemplate(w, "newsAdminUserLevelsPage.gohtml", data); err != nil {
 		log.Printf("Template Error: %s", err)
@@ -57,16 +72,17 @@ func newsAdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) 
 }
 
 func newsAdminUserLevelsRemoveActionPage(w http.ResponseWriter, r *http.Request) {
-	// TODO
-	/*
-			char *postid = cont.post.getS("id");
-		if (postid == NULL)
-			postid = "0";
-		a4string query("DELETE FROM permissions WHERE idpermissions=%d",
-				atoi(postid));
-		a4mysqlResult *result = cont.sql.query(query.raw());
-		delete result;
-
-	*/
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	permid, err := strconv.Atoi(r.PostFormValue("permid"))
+	if err != nil {
+		log.Printf("strconv.Atoi(permid) Error: %s", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	if err := queries.PermissionUserDisallow(r.Context(), int32(permid)); err != nil {
+		log.Printf("permissionUserDisallow Error: %s", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
 	taskDoneAutoRefreshPage(w, r)
 }

--- a/templates/newsAdminUserLevelsPage.gohtml
+++ b/templates/newsAdminUserLevelsPage.gohtml
@@ -1,41 +1,48 @@
 {{ template "head" $ }}
-    {{ with .PermissionResult }}
-        <table border=1>
+    <table border="1">
         <tr>
-            <th>ID
-            <th>User
-            <th>Email
-            <th>Level
-            <th>Delete?
-        {{ range .Rows }}
-            <tr>
-            <td>{{ .GetColumn "idpermissions" }}
-            <td>{{ .GetColumn "username" }}
-            <td>{{ .GetColumn "email" }}
-            <td>{{ .GetColumn "level" }}
-            <td>
-                <form method="post">
-                <input type="hidden" name="id" value="{{ .GetColumn "idpermissions" }}">
-                <input type="submit" name="exec" value="remove">
-                </form>
-            </tr>
-        {{ end }}
-        <tr>
-            <td><form method="post">NEW</td>
-            <td><input name="username"></td>
-            <td>?</td>
-            <td>
-                <select name="level">
-                    <option value="{{ .auth_reader }}">reader
-                    <option value="{{ .auth_writer }}">writer
-                    <option value="{{ .auth_moderator }}">moderator
-                    <option value="{{ .auth_administrator }}">administrator
-                </select>
-            </td>
-            <td><input type="submit" name="exec" value="allow"></form></td>
+            <th>ID</th>
+            <th>User</th>
+            <th>Email</th>
+            <th>Level</th>
+            <th>Delete?</th>
         </tr>
-        </table>
-    {{ else }}
-        Oddly, no permissions granted. {{ .Errors }}<br>
-    {{ end }}
+        {{- if .UserLevels }}
+            {{- range .UserLevels }}
+                <tr>
+                    <td>{{ .Idpermissions }}</td>
+                    <td>{{ .Username.String }}</td>
+                    <td>{{ .Email.String }}</td>
+                    <td>{{ .Level.String }}</td>
+                    <td>
+                        <form method="post">
+                            <input type="hidden" name="permid" value="{{ .Idpermissions }}">
+                            <input type="submit" name="task" value="remove">
+                        </form>
+                    </td>
+                </tr>
+            {{- end }}
+        {{- else }}
+            <tr><td colspan="5">No results</td></tr>
+        {{- end }}
+        <tr>
+            <form method="post">
+                <td>NEW</td>
+                <td><input name="username"></td>
+                <td>?</td>
+                <td>
+                    <select name="level">
+                        <option value="reader">reader</option>
+                        <option value="writer">writer</option>
+                        <option value="moderator">moderator</option>
+                        <option value="administrator">administrator</option>
+                    </select>
+                </td>
+                <td>
+                    <input type="submit" name="task" value="allow">
+                </td>
+            </form>
+        </tr>
+    </table>
+    <p>Permissions should be valid only.</p>
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- query user permissions in newsAdminUserLevelsPage
- revoke a user permission in newsAdminUserLevelsRemoveActionPage
- render user level information in the template

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_68555ee7b524832f9aad5110be2b655c