### PR TITLE
Index approved links in search

### DIFF
--- a/linker_search_test.go
+++ b/linker_search_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestLinkerApproveAddsToSearch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := New(db)
+
+	// Approve item from queue id 1
+	mock.ExpectExec("INSERT INTO linker").
+		WithArgs(int32(1)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	rows := sqlmock.NewRows([]string{"idlinker", "language_idlanguage", "users_idusers", "linkercategory_idlinkerCategory", "forumthread_idforumthread", "title", "url", "description", "listed", "username", "title_2"}).
+		AddRow(1, 1, 1, 1, 0, "Foo", "http://foo", "Bar", time.Now(), "u", "c")
+	mock.ExpectQuery("SELECT l.idlinker").WithArgs(int32(1)).WillReturnRows(rows)
+
+	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").WithArgs("foo").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT IGNORE INTO linkerSearch").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").WithArgs("bar").WillReturnResult(sqlmock.NewResult(2, 1))
+	mock.ExpectExec("INSERT IGNORE INTO linkerSearch").WithArgs(int32(1), int32(2)).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	req := httptest.NewRequest("POST", "/admin/queue?qid=1", nil)
+	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)
+	ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	linkerAdminQueueApproveActionPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/queries-linker.sql
+++ b/queries-linker.sql
@@ -26,7 +26,7 @@ FROM linkerQueue l
 JOIN users u ON l.users_idusers = u.idusers
 JOIN linkerCategory c ON l.linkerCategory_idlinkerCategory = c.idlinkerCategory
 ;
--- name: SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId :exec
+-- name: SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId :execlastid
 INSERT INTO linker (users_idusers, linkerCategory_idlinkerCategory, language_idlanguage, title, `url`, description)
 SELECT l.users_idusers, l.linkerCategory_idlinkerCategory, l.language_idlanguage, l.title, l.url, l.description
 FROM linkerQueue l

--- a/queries-linker.sql.go
+++ b/queries-linker.sql.go
@@ -364,16 +364,19 @@ func (q *Queries) RenameLinkerCategory(ctx context.Context, arg RenameLinkerCate
 	return err
 }
 
-const selectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId = `-- name: SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId :exec
+const selectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId = `-- name: SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId :execlastid
 INSERT INTO linker (users_idusers, linkerCategory_idlinkerCategory, language_idlanguage, title, ` + "`" + `url` + "`" + `, description)
 SELECT l.users_idusers, l.linkerCategory_idlinkerCategory, l.language_idlanguage, l.title, l.url, l.description
 FROM linkerQueue l
 WHERE l.idlinkerQueue = ?
 `
 
-func (q *Queries) SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId(ctx context.Context, idlinkerqueue int32) error {
-	_, err := q.db.ExecContext(ctx, selectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId, idlinkerqueue)
-	return err
+func (q *Queries) SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId(ctx context.Context, idlinkerqueue int32) (int64, error) {
+	result, err := q.db.ExecContext(ctx, selectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId, idlinkerqueue)
+	if err != nil {
+		return 0, err
+	}
+	return result.LastInsertId()
 }
 
 const updateLinkerQueuedItem = `-- name: UpdateLinkerQueuedItem :exec

--- a/queries-search.sql
+++ b/queries-search.sql
@@ -156,6 +156,11 @@ INSERT IGNORE INTO writingSearch
 (writing_idwriting, searchwordlist_idsearchwordlist)
 VALUES (?, ?);
 
+-- name: AddToLinkerSearch :exec
+INSERT IGNORE INTO linkerSearch
+(linker_idlinker, searchwordlist_idsearchwordlist)
+VALUES (?, ?);
+
 
 -- name: WritingSearchDelete :exec
 DELETE FROM writingSearch

--- a/queries-search.sql.go
+++ b/queries-search.sql.go
@@ -43,6 +43,22 @@ func (q *Queries) AddToForumWritingSearch(ctx context.Context, arg AddToForumWri
 	return err
 }
 
+const addToLinkerSearch = `-- name: AddToLinkerSearch :exec
+INSERT IGNORE INTO linkerSearch
+(linker_idlinker, searchwordlist_idsearchwordlist)
+VALUES (?, ?)
+`
+
+type AddToLinkerSearchParams struct {
+	LinkerIdlinker                 int32
+	SearchwordlistIdsearchwordlist int32
+}
+
+func (q *Queries) AddToLinkerSearch(ctx context.Context, arg AddToLinkerSearchParams) error {
+	_, err := q.db.ExecContext(ctx, addToLinkerSearch, arg.LinkerIdlinker, arg.SearchwordlistIdsearchwordlist)
+	return err
+}
+
 const commentsSearchFirstInRestrictedTopic = `-- name: CommentsSearchFirstInRestrictedTopic :many
 SELECT DISTINCT cs.comments_idcomments
 FROM commentsSearch cs

--- a/required_access_test.go
+++ b/required_access_test.go
@@ -5,60 +5,27 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
 )
 
 func TestRequiredAccessAllowed(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock: %v", err)
-	}
-	defer db.Close()
-
-	queries := New(db)
-
-	rows := sqlmock.NewRows([]string{"idpermissions", "users_idusers", "section", "level"}).
-		AddRow(1, 1, "blogs", "writer")
-	mock.ExpectQuery("SELECT idpermissions").WithArgs(int32(1), "blogs").WillReturnRows(rows)
-
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
 	ctx := context.WithValue(req.Context(), ContextValues("user"), &User{Idusers: 1})
-	ctx = context.WithValue(ctx, ContextValues("queries"), queries)
+	ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{SecurityLevel: "writer"})
 	req = req.WithContext(ctx)
 
 	if !RequiredAccess("writer")(req, &mux.RouteMatch{}) {
 		t.Errorf("expected access allowed")
 	}
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("expectations: %v", err)
-	}
 }
 
 func TestRequiredAccessDenied(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock: %v", err)
-	}
-	defer db.Close()
-
-	queries := New(db)
-
-	rows := sqlmock.NewRows([]string{"idpermissions", "users_idusers", "section", "level"}).
-		AddRow(1, 1, "blogs", "reader")
-	mock.ExpectQuery("SELECT idpermissions").WithArgs(int32(1), "blogs").WillReturnRows(rows)
-
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
 	ctx := context.WithValue(req.Context(), ContextValues("user"), &User{Idusers: 1})
-	ctx = context.WithValue(ctx, ContextValues("queries"), queries)
+	ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{SecurityLevel: "reader"})
 	req = req.WithContext(ctx)
 
 	if RequiredAccess("writer")(req, &mux.RouteMatch{}) {
 		t.Errorf("expected access denied")
-	}
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("expectations: %v", err)
 	}
 }

--- a/search.go
+++ b/search.go
@@ -50,3 +50,17 @@ func SearchWordIdsFromText(w http.ResponseWriter, r *http.Request, text string, 
 	}
 	return wordIds, false
 }
+
+func InsertWordsToLinkerSearch(w http.ResponseWriter, r *http.Request, wordIds []int64, queries *Queries, lid int64) bool {
+	for _, wid := range wordIds {
+		if err := queries.AddToLinkerSearch(r.Context(), AddToLinkerSearchParams{
+			LinkerIdlinker:                 int32(lid),
+			SearchwordlistIdsearchwordlist: int32(wid),
+		}); err != nil {
+			log.Printf("Error: addToLinkerSearch: %s", err)
+			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- index approved queued links so they're searchable
- support inserting approved link text into `linkerSearch`
- add search utility for links
- fix RequiredAccess tests for new behavior
- test linker queue approve indexing

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68555ef2a184832f94ad4196f2e1790b