### PR TITLE
Ensure writer/admin check on blog permissions

### DIFF
--- a/blogsUserPermissionsPage.go
+++ b/blogsUserPermissionsPage.go
@@ -11,7 +11,7 @@ import (
 
 func getPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
-	if !cd.HasRole("administrator") {
+	if !(cd.HasRole("writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}

--- a/blogs_handlers_test.go
+++ b/blogs_handlers_test.go
@@ -31,7 +31,7 @@ func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 
 func TestGetPermissionsByUserIdAndSectionBlogsPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/user/permissions", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{SecurityLevel: "writer"})
+	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{SecurityLevel: "reader"})
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	getPermissionsByUserIdAndSectionBlogsPage(rr, req)


### PR DESCRIPTION
## Summary
- enforce writer or administrator role check in `getPermissionsByUserIdAndSectionBlogsPage`
- update tests to verify unauthorized access with lower privileges

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685564cc54b4832fbb24b5ed5260d174