### PR TITLE
Fix category role handling

### DIFF
--- a/templates/listWritingCategories.gohtml
+++ b/templates/listWritingCategories.gohtml
@@ -5,7 +5,7 @@
             {{ $title := .Title.String }}
             {{ $description := .Description.String }}
             {{ $id := .Idwritingcategory }}
-            {{ if eq $.EditingCategoryId $id }}
+            {{ if and $.IsAdmin (eq $.EditingCategoryId $id) }}
                 <tr>
                     <th><a href="/writings/admin/categories?category={{ $id }}">{{ $title }}</a></th>
                     <td>{{ $description }}</td>
@@ -27,7 +27,7 @@
                 </tr>
             {{ else }}
                 <tr>
-                    <th><a href="/writings/category/{{ $id }}">{{ $title }}</a></th>
+                    <th><a href="/writings/category/{{ $id }}">{{ $title }}</a>{{ if $.IsAdmin }} [<a href="?edit={{ $id }}">Edit</a>]{{ end }}</th>
                     <td>{{ $description }}</td>
                 </tr>
             {{ end }}

--- a/writingsCategoriesPage.go
+++ b/writingsCategoriesPage.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"strconv"
 )
 
 func writingsCategoriesPage(w http.ResponseWriter, r *http.Request) {
@@ -12,17 +13,22 @@ func writingsCategoriesPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Categories                       []*Writingcategory
 		CategoryBreadcrumbs              []*Writingcategory
-		EditingCategoryId                int32 // TODO
-		IsAdmin                          bool  // TODO
-		IsWriter                         bool  // TODO
+		EditingCategoryId                int32
+		IsAdmin                          bool
+		IsWriter                         bool
 		Abstracts                        []*GetPublicWritingsInCategoryRow
 		WritingcategoryIdwritingcategory int32
 	}
 
 	data := Data{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
-		IsWriter: true,
 	}
+
+	data.IsAdmin = data.CoreData.HasRole("administrator")
+	data.IsWriter = data.CoreData.HasRole("writer") || data.IsAdmin
+	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
+	data.EditingCategoryId = int32(editID)
+	data.WritingcategoryIdwritingcategory = 0
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 

--- a/writingsCategoryPage.go
+++ b/writingsCategoryPage.go
@@ -15,22 +15,27 @@ func writingsCategoryPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Categories                       []*Writingcategory
 		CategoryBreadcrumbs              []*Writingcategory
-		EditingCategoryId                int32 // TODO
-		CategoryId                       int32 // TODO
-		WritingcategoryIdwritingcategory int32 // TODO
-		IsAdmin                          bool  // TODO
-		IsWriter                         bool  // TODO
+		EditingCategoryId                int32
+		CategoryId                       int32
+		WritingcategoryIdwritingcategory int32
+		IsAdmin                          bool
+		IsWriter                         bool
 		Abstracts                        []*GetPublicWritingsInCategoryRow
 	}
 
 	data := Data{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
-		IsWriter: true,
 	}
+
+	data.IsAdmin = data.CoreData.HasRole("administrator")
+	data.IsWriter = data.CoreData.HasRole("writer") || data.IsAdmin
+	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
+	data.EditingCategoryId = int32(editID)
 
 	vars := mux.Vars(r)
 	categoryId, _ := strconv.Atoi(vars["category"])
 	data.CategoryId = int32(categoryId)
+	data.WritingcategoryIdwritingcategory = data.CategoryId
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 

--- a/writingsPage.go
+++ b/writingsPage.go
@@ -15,15 +15,21 @@ func writingsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*CoreData
 		Categories                       []*Writingcategory
-		EditingCategoryId                int32 // TODO
-		CategoryId                       int32 // TODO
-		WritingcategoryIdwritingcategory int32 // TODO
-		IsAdmin                          int32 // TODO
+		EditingCategoryId                int32
+		CategoryId                       int32
+		WritingcategoryIdwritingcategory int32
+		IsAdmin                          bool
 	}
 
 	data := Data{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
+
+	data.IsAdmin = data.CoreData.HasRole("administrator")
+	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
+	data.EditingCategoryId = int32(editID)
+	data.CategoryId = 0
+	data.WritingcategoryIdwritingcategory = data.CategoryId
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 


### PR DESCRIPTION
## Summary
- populate `IsAdmin`, `IsWriter` and `EditingCategoryId` based on current user role
- ensure categories templates only show edit controls for admins

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685564c1692c832fb95a3518aa10f4b2