### PR TITLE
Add DOCTYPE and simplify CSS import

### DIFF
--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -1,13 +1,10 @@
 {{define "head"}}
+<!DOCTYPE html>
 <html>
-	<head>
-		<title>{{$.Title}}</title>
-		{{template "headdata"}}
-		<style type="text/css">
-        <!--
-        @import url("/main.css");
-        -->
-        </style>
+        <head>
+                <title>{{$.Title}}</title>
+                {{template "headdata"}}
+                <link rel="stylesheet" href="/main.css">
         {{ if $.AutoRefresh }}
             <meta http-equiv="refresh" content="1">
         {{ end }}


### PR DESCRIPTION
## Summary
- add `<!DOCTYPE html>` at the start of head template
- switch from `<style>` with `@import` to a simpler `<link>` tag

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68556b9a7824832f83abd4187da1d275