### PR TITLE
Implement language preference handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -306,6 +306,8 @@ func main() {
 	ur.HandleFunc("/logout", userLogoutPage).Methods("GET")
 	ur.HandleFunc("/lang", userLangPage).Methods("GET").MatcherFunc(RequiresAnAccount())
 	ur.HandleFunc("/lang", userLangSaveLanguagesActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Save languages"))
+	ur.HandleFunc("/lang", userLangSaveLanguageActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Save language"))
+	ur.HandleFunc("/lang", userLangSaveAllActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Save all"))
 	ur.HandleFunc("/email", userEmailPage).Methods("GET").MatcherFunc(RequiresAnAccount())
 	ur.HandleFunc("/email", userEmailSaveActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Save all"))
 	ur.HandleFunc("/email", userEmailTestActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Test mail"))

--- a/queries_ext.go
+++ b/queries_ext.go
@@ -59,3 +59,42 @@ func (q *Queries) GetUserLanguages(ctx context.Context, userID int32) ([]*Userla
 	}
 	return items, nil
 }
+
+// DeleteUserLanguagesByUser removes all language selections for a user.
+func (q *Queries) DeleteUserLanguagesByUser(ctx context.Context, userID int32) error {
+	_, err := q.db.ExecContext(ctx, "DELETE FROM userlang WHERE users_idusers = ?", userID)
+	return err
+}
+
+type InsertUserLangParams struct {
+	UsersIdusers       int32
+	LanguageIdlanguage int32
+}
+
+// InsertUserLang adds a user language record.
+func (q *Queries) InsertUserLang(ctx context.Context, arg InsertUserLangParams) error {
+	_, err := q.db.ExecContext(ctx, "INSERT INTO userlang (users_idusers, language_idlanguage) VALUES (?, ?)", arg.UsersIdusers, arg.LanguageIdlanguage)
+	return err
+}
+
+type InsertPreferenceParams struct {
+	LanguageIdlanguage int32
+	UsersIdusers       int32
+}
+
+// InsertPreference creates a new preference row for the user.
+func (q *Queries) InsertPreference(ctx context.Context, arg InsertPreferenceParams) error {
+	_, err := q.db.ExecContext(ctx, "INSERT INTO preferences (language_idlanguage, users_idusers) VALUES (?, ?)", arg.LanguageIdlanguage, arg.UsersIdusers)
+	return err
+}
+
+type UpdatePreferenceParams struct {
+	LanguageIdlanguage int32
+	UsersIdusers       int32
+}
+
+// UpdatePreference updates the user's default language preference.
+func (q *Queries) UpdatePreference(ctx context.Context, arg UpdatePreferenceParams) error {
+	_, err := q.db.ExecContext(ctx, "UPDATE preferences SET language_idlanguage = ? WHERE users_idusers = ?", arg.LanguageIdlanguage, arg.UsersIdusers)
+	return err
+}

--- a/userLangPage_test.go
+++ b/userLangPage_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/sessions"
+)
+
+func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := New(db)
+	store = sessions.NewCookieStore([]byte("test"))
+
+	form := url.Values{}
+	form.Set("dothis", "Save all")
+	form.Set("language1", "on")
+	form.Set("defaultLanguage", "2")
+
+	req := httptest.NewRequest("POST", "/user/lang", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	sess, _ := store.Get(req, sessionName)
+	sess.Values["UID"] = int32(1)
+	w := httptest.NewRecorder()
+	sess.Save(req, w)
+	for _, c := range w.Result().Cookies() {
+		req.AddCookie(c)
+	}
+	rr := httptest.NewRecorder()
+
+	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)
+	ctx = context.WithValue(ctx, ContextValues("session"), sess)
+	req = req.WithContext(ctx)
+
+	rows := sqlmock.NewRows([]string{"idlanguage", "nameof"}).AddRow(1, "en").AddRow(2, "fr")
+	mock.ExpectQuery(regexp.QuoteMeta(fetchLanguages)).WillReturnRows(rows)
+	mock.ExpectExec("DELETE FROM userlang").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO userlang").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT idpreferences").WithArgs(int32(1)).WillReturnError(sql.ErrNoRows)
+	mock.ExpectExec("INSERT INTO preferences").WithArgs(int32(2), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	userLangSaveAllActionPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Result().StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+}
+
+func TestUserLangSaveLanguagesActionPage(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := New(db)
+	store = sessions.NewCookieStore([]byte("test"))
+
+	form := url.Values{}
+	form.Set("dothis", "Save languages")
+	form.Set("language1", "on")
+
+	req := httptest.NewRequest("POST", "/user/lang", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	sess, _ := store.Get(req, sessionName)
+	sess.Values["UID"] = int32(1)
+	w := httptest.NewRecorder()
+	sess.Save(req, w)
+	for _, c := range w.Result().Cookies() {
+		req.AddCookie(c)
+	}
+	rr := httptest.NewRecorder()
+
+	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)
+	ctx = context.WithValue(ctx, ContextValues("session"), sess)
+	req = req.WithContext(ctx)
+
+	rows := sqlmock.NewRows([]string{"idlanguage", "nameof"}).AddRow(1, "en")
+	mock.ExpectQuery(regexp.QuoteMeta(fetchLanguages)).WillReturnRows(rows)
+	mock.ExpectExec("DELETE FROM userlang").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO userlang").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	userLangSaveLanguagesActionPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Result().StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+}
+
+func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := New(db)
+	store = sessions.NewCookieStore([]byte("test"))
+
+	form := url.Values{}
+	form.Set("dothis", "Save language")
+	form.Set("defaultLanguage", "2")
+
+	req := httptest.NewRequest("POST", "/user/lang", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	sess, _ := store.Get(req, sessionName)
+	sess.Values["UID"] = int32(1)
+	w := httptest.NewRecorder()
+	sess.Save(req, w)
+	for _, c := range w.Result().Cookies() {
+		req.AddCookie(c)
+	}
+	rr := httptest.NewRecorder()
+
+	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)
+	ctx = context.WithValue(ctx, ContextValues("session"), sess)
+	req = req.WithContext(ctx)
+
+	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates"}).
+		AddRow(1, 1, 1, nil)
+	mock.ExpectQuery("SELECT idpreferences").WithArgs(int32(1)).WillReturnRows(prefRows)
+	mock.ExpectExec("UPDATE preferences").WithArgs(int32(2), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	userLangSaveLanguageActionPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Result().StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- implement separate handlers for saving languages, preferences, and the combined action
- wire all three actions to the router
- extend tests for new handler functions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68556cd8aa94832f99fb6ccac691eb80