### PR TITLE
Add SendGrid provider and docs

### DIFF
--- a/email.go
+++ b/email.go
@@ -51,6 +51,7 @@ type EmailConfig struct {
 	JMAPIdentity string
 	JMAPUser     string
 	JMAPPass     string
+	SendGridKey  string
 }
 
 // MailProvider defines a simple interface that all mail backends must
@@ -322,6 +323,9 @@ func providerFromConfig(cfg EmailConfig) MailProvider {
 			identity:  id,
 		}
 
+	case "sendgrid":
+		return sendGridProviderFromConfig(cfg)
+
 	case "log":
 		return logMailProvider{}
 
@@ -375,6 +379,9 @@ func resolveEmailConfig(cli, file, env EmailConfig) EmailConfig {
 		if src.JMAPPass != "" {
 			cfg.JMAPPass = src.JMAPPass
 		}
+		if src.SendGridKey != "" {
+			cfg.SendGridKey = src.SendGridKey
+		}
 	}
 
 	merge(env)
@@ -421,6 +428,8 @@ func loadEmailConfigFile(path string) (EmailConfig, error) {
 				cfg.JMAPUser = val
 			case "JMAP_PASS":
 				cfg.JMAPPass = val
+			case "SENDGRID_KEY":
+				cfg.SendGridKey = val
 			}
 		}
 	}
@@ -440,6 +449,7 @@ func loadEmailConfig() EmailConfig {
 		JMAPIdentity: os.Getenv("JMAP_IDENTITY"),
 		JMAPUser:     os.Getenv("JMAP_USER"),
 		JMAPPass:     os.Getenv("JMAP_PASS"),
+		SendGridKey:  os.Getenv("SENDGRID_KEY"),
 	}
 
 	fileCfg, err := loadEmailConfigFile(emailConfigFile)

--- a/email_sendgrid.go
+++ b/email_sendgrid.go
@@ -1,0 +1,40 @@
+//go:build sendgrid
+// +build sendgrid
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	sendgrid "github.com/sendgrid/sendgrid-go"
+	"github.com/sendgrid/sendgrid-go/helpers/mail"
+)
+
+// sendGridProvider sends mail using the SendGrid API.
+type sendGridProvider struct{ apiKey string }
+
+func (s sendGridProvider) Send(ctx context.Context, to, subject, body string) error {
+	from := mail.NewEmail("", SourceEmail)
+	toAddr := mail.NewEmail("", to)
+	msg := mail.NewSingleEmail(from, subject, toAddr, body, body)
+	client := sendgrid.NewSendClient(s.apiKey)
+	resp, err := client.SendWithContext(ctx, msg)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("sendgrid: status %d: %s", resp.StatusCode, resp.Body)
+	}
+	return nil
+}
+
+func sendGridProviderFromConfig(cfg EmailConfig) MailProvider {
+	key := cfg.SendGridKey
+	if key == "" {
+		log.Printf("Email disabled: SENDGRID_KEY not set")
+		return nil
+	}
+	return sendGridProvider{apiKey: key}
+}

--- a/email_sendgrid_stub.go
+++ b/email_sendgrid_stub.go
@@ -1,0 +1,8 @@
+//go:build !sendgrid
+// +build !sendgrid
+
+package main
+
+func sendGridProviderFromConfig(cfg EmailConfig) MailProvider {
+	return nil
+}

--- a/email_sendgrid_stub_test.go
+++ b/email_sendgrid_stub_test.go
@@ -1,0 +1,12 @@
+//go:build !sendgrid
+// +build !sendgrid
+
+package main
+
+import "testing"
+
+func TestSendGridProviderUnavailable(t *testing.T) {
+	if p := providerFromConfig(EmailConfig{Provider: "sendgrid", SendGridKey: "k"}); p != nil {
+		t.Fatalf("expected nil provider when sendgrid tag not enabled")
+	}
+}

--- a/email_sendgrid_test.go
+++ b/email_sendgrid_test.go
@@ -1,0 +1,13 @@
+//go:build sendgrid
+// +build sendgrid
+
+package main
+
+import "testing"
+
+func TestSendGridProviderFromConfig(t *testing.T) {
+	p := providerFromConfig(EmailConfig{Provider: "sendgrid", SendGridKey: "k"})
+	if _, ok := p.(sendGridProvider); !ok {
+		t.Fatalf("expected sendGridProvider, got %#v", p)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
+	github.com/sendgrid/rest v2.6.9+incompatible // indirect
+	github.com/sendgrid/sendgrid-go v3.16.1+incompatible // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,10 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/sendgrid/rest v2.6.9+incompatible h1:1EyIcsNdn9KIisLW50MKwmSRSK+ekueiEMJ7NEoxJo0=
+github.com/sendgrid/rest v2.6.9+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
+github.com/sendgrid/sendgrid-go v3.16.1+incompatible h1:zWhTmB0Y8XCDzeWIm2/BIt1GjJohAA0p6hVEaDtHWWs=
+github.com/sendgrid/sendgrid-go v3.16.1+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
 github.com/shirou/gopsutil/v3 v3.23.7 h1:C+fHO8hfIppoJ1WdsVm1RoI0RwXoNdfTK7yWXV0wVj4=
 github.com/shirou/gopsutil/v3 v3.23.7/go.mod h1:c4gnmoRC0hQuaLqvxnx1//VXQ0Ms/X9UnJF8pddY5z4=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ var (
 	jmapIdentityFlag  = flag.String("jmap-identity", "", "JMAP identity")
 	jmapUserFlag      = flag.String("jmap-user", "", "JMAP user")
 	jmapPassFlag      = flag.String("jmap-pass", "", "JMAP pass")
+	sendGridKeyFlag   = flag.String("sendgrid-key", "", "SendGrid API key")
 
 	dbCfgPath  = flag.String("db-config", "", "path to database configuration file")
 	dbUserFlag = flag.String("db-user", "", "database user")
@@ -81,7 +82,7 @@ func main() {
 
 	performStartupChecks()
 
-  cliDBConfig = DBConfig{
+	cliDBConfig = DBConfig{
 		User: *dbUserFlag,
 		Pass: *dbPassFlag,
 		Host: *dbHostFlag,
@@ -90,7 +91,6 @@ func main() {
 	}
 	dbConfigFile = *dbCfgPath
 
-  
 	cliEmailConfig = EmailConfig{
 		Provider:     *emailProviderFlag,
 		SMTPHost:     *smtpHostFlag,
@@ -103,6 +103,7 @@ func main() {
 		JMAPIdentity: *jmapIdentityFlag,
 		JMAPUser:     *jmapUserFlag,
 		JMAPPass:     *jmapPassFlag,
+		SendGridKey:  *sendGridKeyFlag,
 	}
 	emailConfigFile = *emailCfgPath
 

--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,7 @@ Email notifications can be sent via several backends. Set `EMAIL_PROVIDER` to se
 - `local`: Uses the local `sendmail` binary.
 - `jmap`: Sends mail using JMAP. Requires `JMAP_ENDPOINT`, `JMAP_USER`, `JMAP_PASS`,
   `JMAP_ACCOUNT`, and `JMAP_IDENTITY`.
+- `sendgrid`: Uses the SendGrid API. Requires the `sendgrid` build tag and a `SENDGRID_KEY`.
 - `log`: Writes emails to the application log.
 
 If configuration or credentials are missing, email is disabled and a log message is printed.
@@ -119,6 +120,22 @@ The resolution order is:
 
 The config file uses a simple `key=value` format matching the environment
 variable names.
+
+### Implementing Custom Providers
+
+New email backends can be added by satisfying the `MailProvider` interface
+defined in `email.go`:
+
+```go
+type MailProvider interface {
+    Send(ctx context.Context, to, subject, body string) error
+}
+```
+
+Create a new file implementing this interface and add a case in
+`providerFromConfig` that returns your provider. Providers that rely on optional
+dependencies should live behind a build tag. See `email_sendgrid.go` for an
+example provider built with the `sendgrid` tag.
 
 ## Admin tools
 


### PR DESCRIPTION
## Summary
- document how to implement new mail providers
- add sendgrid-backed provider behind `sendgrid` build tag
- extend email configuration for SendGrid API key
- expose `--sendgrid-key` CLI option
- update tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68557289e820832fa4f4979e6b6a2480