### PR TITLE
Introduce Server wrapper

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 
 	performStartupChecks()
 
-  cliDBConfig = DBConfig{
+	cliDBConfig = DBConfig{
 		User: *dbUserFlag,
 		Pass: *dbPassFlag,
 		Host: *dbHostFlag,
@@ -90,7 +90,6 @@ func main() {
 	}
 	dbConfigFile = *dbCfgPath
 
-  
 	cliEmailConfig = EmailConfig{
 		Provider:     *emailProviderFlag,
 		SMTPHost:     *smtpHostFlag,
@@ -374,10 +373,15 @@ func main() {
 	//r.HandleFunc("/callback", callbackHandler)
 	//r.HandleFunc("/logout", logoutHandler)
 
-	http.Handle("/", csrfMiddleware(r))
+	srv := &Server{
+		DBConfig:    loadDBConfig(),
+		EmailConfig: loadEmailConfig(),
+		Router:      csrfMiddleware(r),
+		Store:       store,
+		DB:          dbPool,
+	}
 
-	log.Println("Server started on http://localhost:8080")
-	log.Fatal(http.ListenAndServe(":8080", nil))
+	log.Fatal(srv.Start(":8080"))
 }
 
 func runTemplate(template string) func(http.ResponseWriter, *http.Request) {

--- a/server.go
+++ b/server.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"database/sql"
+	"github.com/gorilla/sessions"
+	"log"
+	"net"
+	"net/http"
+)
+
+// Server bundles the application's configuration, router and runtime dependencies.
+type Server struct {
+	DBConfig    DBConfig
+	EmailConfig EmailConfig
+	Router      http.Handler
+	Store       *sessions.CookieStore
+	DB          *sql.DB
+
+	addr string
+}
+
+// Addr returns the address the server is listening on after Start is called.
+func (s *Server) Addr() string { return s.addr }
+
+// Start begins serving HTTP requests on the given address. If the port is
+// specified as :0, the automatically chosen address can be retrieved via Addr().
+func (s *Server) Start(addr string) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	s.addr = ln.Addr().String()
+	log.Printf("Server started on http://%s", s.addr)
+	return http.Serve(ln, s.Router)
+}


### PR DESCRIPTION
## Summary
- create a `Server` type that keeps configuration and dependencies
- add `Start` method to run the HTTP server
- use `Server` in `main` as the entry point

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855727d05e0832f940a4453c52a0723