### PR TITLE
Use errors.Is for sql.ErrNoRows

### DIFF
--- a/forumFeed.go
+++ b/forumFeed.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/gorilla/feeds"
 	"github.com/gorilla/mux"
@@ -63,7 +64,7 @@ func forumTopicRssPage(w http.ResponseWriter, r *http.Request) {
 		Idforumtopic: int32(topicID),
 	})
 	if err != nil {
-		if err != sql.ErrNoRows {
+		if !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("GetForumTopicByIdForUser error: %s", err)
 		}
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -74,7 +75,7 @@ func forumTopicRssPage(w http.ResponseWriter, r *http.Request) {
 		UsersIdusers:           uid,
 		ForumtopicIdforumtopic: int32(topicID),
 	})
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -100,7 +101,7 @@ func forumTopicAtomPage(w http.ResponseWriter, r *http.Request) {
 		Idforumtopic: int32(topicID),
 	})
 	if err != nil {
-		if err != sql.ErrNoRows {
+		if !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("GetForumTopicByIdForUser error: %s", err)
 		}
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -111,7 +112,7 @@ func forumTopicAtomPage(w http.ResponseWriter, r *http.Request) {
 		UsersIdusers:           uid,
 		ForumtopicIdforumtopic: int32(topicID),
 	})
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/imagebbsFeed.go
+++ b/imagebbsFeed.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/gorilla/feeds"
 	"github.com/gorilla/mux"
@@ -58,7 +59,7 @@ func imagebbsFeed(r *http.Request, title string, boardID int, rows []*GetAllImag
 func imagebbsRssPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	boards, err := queries.GetAllImageBoards(r.Context())
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query boards error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -66,7 +67,7 @@ func imagebbsRssPage(w http.ResponseWriter, r *http.Request) {
 	var posts []*GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCountRow
 	for _, b := range boards {
 		rows, err := queries.GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCount(r.Context(), b.Idimageboard)
-		if err != nil && err != sql.ErrNoRows {
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("feed query error: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
@@ -84,7 +85,7 @@ func imagebbsRssPage(w http.ResponseWriter, r *http.Request) {
 func imagebbsAtomPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	boards, err := queries.GetAllImageBoards(r.Context())
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query boards error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -92,7 +93,7 @@ func imagebbsAtomPage(w http.ResponseWriter, r *http.Request) {
 	var posts []*GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCountRow
 	for _, b := range boards {
 		rows, err := queries.GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCount(r.Context(), b.Idimageboard)
-		if err != nil && err != sql.ErrNoRows {
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("feed query error: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
@@ -112,7 +113,7 @@ func imagebbsBoardRssPage(w http.ResponseWriter, r *http.Request) {
 	bid, _ := strconv.Atoi(vars["boardno"])
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	rows, err := queries.GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCount(r.Context(), int32(bid))
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -142,7 +143,7 @@ func imagebbsBoardAtomPage(w http.ResponseWriter, r *http.Request) {
 	bid, _ := strconv.Atoi(vars["boardno"])
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	rows, err := queries.GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCount(r.Context(), int32(bid))
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/linkerFeed.go
+++ b/linkerFeed.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/gorilla/feeds"
 	"net/http"
@@ -55,7 +56,7 @@ func linkerRssPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
 	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), int32(catID))
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
@@ -70,7 +71,7 @@ func linkerAtomPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
 	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), int32(catID))
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary
- use `errors.Is` with `sql.ErrNoRows` instead of manual comparisons
- add missing `errors` imports

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68557279e004832fb99264b5e537166b