### PR TITLE
Handle invalid sessions gracefully

### DIFF
--- a/loginPage_test.go
+++ b/loginPage_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/sessions"
+)
+
+func TestLoginActionPageRedirect(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta(login)).
+		WithArgs(sql.NullString{String: "", Valid: true}, "").
+		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "passwd", "username"}).
+			AddRow(1, "e", "p", ""))
+
+	queries := New(db)
+
+	store = sessions.NewCookieStore([]byte("test"))
+	r := httptest.NewRequest("POST", "/login", nil)
+	w := httptest.NewRecorder()
+	sess, _ := store.Get(r, sessionName)
+	sess.Values["return_path"] = "/dest"
+	sess.Save(r, w)
+	for _, c := range w.Result().Cookies() {
+		r.AddCookie(c)
+	}
+	rr := httptest.NewRecorder()
+	ctx := r.Context()
+	ctx = context.WithValue(ctx, ContextValues("queries"), queries)
+	ctx = context.WithValue(ctx, ContextValues("session"), sess)
+	ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{})
+	r = r.WithContext(ctx)
+
+	loginActionPage(rr, r)
+
+	if rr.Result().StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+	if loc := rr.Result().Header.Get("Location"); loc != "/dest" {
+		t.Errorf("loc=%s", loc)
+	}
+}
+
+func TestLoginActionPageReturnForm(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta(login)).
+		WithArgs(sql.NullString{String: "", Valid: true}, "").
+		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "passwd", "username"}).
+			AddRow(1, "e", "p", ""))
+
+	queries := New(db)
+
+	store = sessions.NewCookieStore([]byte("test"))
+	r := httptest.NewRequest("POST", "/login", nil)
+	w := httptest.NewRecorder()
+	sess, _ := store.Get(r, sessionName)
+	sess.Values["return_path"] = "/post"
+	sess.Values["return_method"] = http.MethodPost
+	vals := url.Values{"a": {"1"}}
+	sess.Values["return_form"] = vals.Encode()
+	sess.Save(r, w)
+	for _, c := range w.Result().Cookies() {
+		r.AddCookie(c)
+	}
+	rr := httptest.NewRecorder()
+	ctx := r.Context()
+	ctx = context.WithValue(ctx, ContextValues("queries"), queries)
+	ctx = context.WithValue(ctx, ContextValues("session"), sess)
+	ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{})
+	r = r.WithContext(ctx)
+
+	loginActionPage(rr, r)
+
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "name=\"a\" value=\"1\"") {
+		t.Errorf("form data not present")
+	}
+}

--- a/templates/goBackPage.gohtml
+++ b/templates/goBackPage.gohtml
@@ -1,0 +1,11 @@
+{{ template "head" $ }}
+<p>You were redirected to login. Click the button below to return.</p>
+<form method="{{ .Method }}" action="{{ .Path }}">
+{{- range $k, $vals := .Form }}
+    {{- range $vals }}
+    <input type="hidden" name="{{ $k }}" value="{{ . }}">
+    {{- end }}
+{{- end }}
+    <button type="submit">Go back</button>
+</form>
+{{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- improve session middleware so invalid session data triggers logout instead of a 500
- add regression test for invalid sessions
- preserve original request in session and redirect back after login
- show a go back page when restoring POST data

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855744b1e64832f9e9372685a70ac02