### PR TITLE
Add environment vars for config file paths

### DIFF
--- a/db_config.go
+++ b/db_config.go
@@ -19,6 +19,7 @@ type DBConfig struct {
 var cliDBConfig DBConfig
 
 // dbConfigFile is the optional path to a configuration file read at startup.
+// If empty, the DB_CONFIG_FILE environment variable is consulted.
 var dbConfigFile string
 
 // resolveDBConfig merges configuration values with the order of precedence
@@ -92,7 +93,11 @@ func loadDBConfig() DBConfig {
 		Name: os.Getenv("DB_NAME"),
 	}
 
-	fileCfg, err := loadDBConfigFile(dbConfigFile)
+	cfgPath := dbConfigFile
+	if cfgPath == "" {
+		cfgPath = os.Getenv("DB_CONFIG_FILE")
+	}
+	fileCfg, err := loadDBConfigFile(cfgPath)
 	if err != nil && !os.IsNotExist(err) {
 		log.Printf("DB config file error: %v", err)
 	}

--- a/db_config_test.go
+++ b/db_config_test.go
@@ -33,3 +33,18 @@ func TestResolveDBConfigPrecedence(t *testing.T) {
 		t.Fatalf("merged %#v", cfg)
 	}
 }
+
+func TestLoadDBConfigEnvPath(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "db.conf")
+	if err := os.WriteFile(file, []byte("DB_USER=envfile\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	t.Setenv("DB_CONFIG_FILE", file)
+	dbConfigFile = ""
+	cliDBConfig = DBConfig{}
+	cfg := loadDBConfig()
+	if cfg.User != "envfile" {
+		t.Fatalf("want envfile got %q", cfg.User)
+	}
+}

--- a/email.go
+++ b/email.go
@@ -34,6 +34,7 @@ const (
 var cliEmailConfig EmailConfig
 
 // emailConfigFile is the optional path to a configuration file read at startup.
+// If empty, the EMAIL_CONFIG_FILE environment variable is consulted.
 var emailConfigFile string
 
 // EmailConfig stores configuration for selecting and configuring the mail
@@ -452,7 +453,11 @@ func loadEmailConfig() EmailConfig {
 		SendGridKey:  os.Getenv("SENDGRID_KEY"),
 	}
 
-	fileCfg, err := loadEmailConfigFile(emailConfigFile)
+	cfgPath := emailConfigFile
+	if cfgPath == "" {
+		cfgPath = os.Getenv("EMAIL_CONFIG_FILE")
+	}
+	fileCfg, err := loadEmailConfigFile(cfgPath)
 	if err != nil && !os.IsNotExist(err) {
 		log.Printf("Email config file error: %v", err)
 	}

--- a/email_config_test.go
+++ b/email_config_test.go
@@ -33,3 +33,18 @@ func TestResolveEmailConfigPrecedence(t *testing.T) {
 		t.Fatalf("merged %#v", cfg)
 	}
 }
+
+func TestLoadEmailConfigEnvPath(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "email.conf")
+	if err := os.WriteFile(file, []byte("EMAIL_PROVIDER=log\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	t.Setenv("EMAIL_CONFIG_FILE", file)
+	emailConfigFile = ""
+	cliEmailConfig = EmailConfig{}
+	cfg := loadEmailConfig()
+	if cfg.Provider != "log" {
+		t.Fatalf("want log got %q", cfg.Provider)
+	}
+}

--- a/http_config.go
+++ b/http_config.go
@@ -15,6 +15,7 @@ type HTTPConfig struct {
 var cliHTTPConfig HTTPConfig
 
 // httpConfigFile is the optional path to a configuration file read at startup.
+// If empty, the HTTP_CONFIG_FILE environment variable is consulted.
 var httpConfigFile string
 
 // resolveHTTPConfig merges configuration values with the order of precedence
@@ -62,7 +63,11 @@ func loadHTTPConfigFile(path string) (HTTPConfig, error) {
 // and command line flags applying the precedence defined in AGENTS.md.
 func loadHTTPConfig() HTTPConfig {
 	env := HTTPConfig{Listen: os.Getenv("LISTEN")}
-	fileCfg, err := loadHTTPConfigFile(httpConfigFile)
+	cfgPath := httpConfigFile
+	if cfgPath == "" {
+		cfgPath = os.Getenv("HTTP_CONFIG_FILE")
+	}
+	fileCfg, err := loadHTTPConfigFile(cfgPath)
 	if err != nil && !os.IsNotExist(err) {
 		log.Printf("HTTP config file error: %v", err)
 	}

--- a/http_config_test.go
+++ b/http_config_test.go
@@ -32,3 +32,18 @@ func TestResolveHTTPConfigPrecedence(t *testing.T) {
 		t.Fatalf("merged %#v", cfg)
 	}
 }
+
+func TestLoadHTTPConfigEnvPath(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "http.conf")
+	if err := os.WriteFile(file, []byte("LISTEN=:9\n"), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("HTTP_CONFIG_FILE", file)
+	httpConfigFile = ""
+	cliHTTPConfig = HTTPConfig{}
+	cfg := loadHTTPConfig()
+	if cfg.Listen != ":9" {
+		t.Fatalf("want :9 got %q", cfg.Listen)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -400,8 +400,9 @@ func main() {
 	}
 
 	httpCfg := loadHTTPConfig()
-	log.Printf("Server started on %s", httpCfg.Listen)
-	log.Fatal(http.ListenAndServe(httpCfg.Listen, nil))
+	if err := srv.Start(httpCfg.Listen); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func runTemplate(template string) func(http.ResponseWriter, *http.Request) {

--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ This project was originally developed for a single server environment and remain
 Database connection details can be supplied in several ways. Values are resolved in the following order:
 
 1. Command line flags (`--db-user` etc.)
-2. Values from a config file specified with `--db-config`
+2. Values from a config file specified with `--db-config` or `DB_CONFIG_FILE`
 3. Environment variables such as `DB_USER`
 4. Built-in defaults
 
@@ -115,7 +115,7 @@ Configuration values can also be provided in a file and via command line flags.
 The resolution order is:
 
 1. Command line flags (`--smtp-host` etc.)
-2. Values from a config file specified with `--email-config`
+2. Values from a config file specified with `--email-config` or `EMAIL_CONFIG_FILE`
 3. Environment variables such as `SMTP_HOST`
 4. Built-in defaults
 


### PR DESCRIPTION
## Summary
- allow DB, email and HTTP config paths via `*_CONFIG_FILE` env vars
- document new environment vars in the README
- use server Start() in `main.go`
- test env path handling for config loaders

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6856002f1728832f946c42c2a1878633