### PR TITLE
Fix Linker topic constant names

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -9,7 +9,7 @@ const (
 	ImagebbsTopicDescription = "THIS IS A HIDDEN FORUM FOR A IMAGE BBS"
 	NewsTopicName            = "A NEWS TOPIC"
 	NewsTopicDescription     = "THIS IS A HIDDEN FORUM FOR A NEWS TOPIC"
-	LinkderTopicName         = "A LINKER TOPIC"
-	LinkderTopicDescription  = "THIS IS A HIDDEN FORUM FOR A LINKER TOPIC"
+	LinkerTopicName          = "A LINKER TOPIC"
+	LinkerTopicDescription   = "THIS IS A HIDDEN FORUM FOR A LINKER TOPIC"
 	FeedsEnabled             = true
 )

--- a/linkerCommentsPage.go
+++ b/linkerCommentsPage.go
@@ -162,7 +162,7 @@ func linkerCommentsReplyPage(w http.ResponseWriter, r *http.Request) {
 
 	var pthid int32 = link.ForumthreadIdforumthread
 	pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{
-		String: LinkderTopicName,
+		String: LinkerTopicName,
 		Valid:  true,
 	})
 	var ptid int32
@@ -170,11 +170,11 @@ func linkerCommentsReplyPage(w http.ResponseWriter, r *http.Request) {
 		ptidi, err := queries.CreateForumTopic(r.Context(), CreateForumTopicParams{
 			ForumcategoryIdforumcategory: 0,
 			Title: sql.NullString{
-				String: LinkderTopicName,
+				String: LinkerTopicName,
 				Valid:  true,
 			},
 			Description: sql.NullString{
-				String: LinkderTopicDescription,
+				String: LinkerTopicDescription,
 				Valid:  true,
 			},
 		})

--- a/linkerShowPage.go
+++ b/linkerShowPage.go
@@ -81,7 +81,7 @@ func linkerShowReplyPage(w http.ResponseWriter, r *http.Request) {
 
 	var pthid int32 = link.ForumthreadIdforumthread
 	pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{
-		String: LinkderTopicName,
+		String: LinkerTopicName,
 		Valid:  true,
 	})
 	var ptid int32
@@ -89,11 +89,11 @@ func linkerShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		ptidi, err := queries.CreateForumTopic(r.Context(), CreateForumTopicParams{
 			ForumcategoryIdforumcategory: 0,
 			Title: sql.NullString{
-				String: LinkderTopicName,
+				String: LinkerTopicName,
 				Valid:  true,
 			},
 			Description: sql.NullString{
-				String: LinkderTopicName,
+				String: LinkerTopicName,
 				Valid:  true,
 			},
 		})

--- a/searchResultLinkerActionPage.go
+++ b/searchResultLinkerActionPage.go
@@ -27,7 +27,7 @@ func searchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
 	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
 	uid, _ := session.Values["UID"].(int32)
 
-	ftbn, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: LinkderTopicName})
+	ftbn, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: LinkerTopicName})
 	if err != nil {
 		log.Printf("findForumTopicByTitle Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)


### PR DESCRIPTION
## Summary
- rename `LinkderTopicName` → `LinkerTopicName`
- rename `LinkderTopicDescription` → `LinkerTopicDescription`
- update all usages

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685572609938832fb6549c0dbc607f54