### PR TITLE
Use http.Error for server error responses

### DIFF
--- a/core.go
+++ b/core.go
@@ -13,8 +13,7 @@ import (
 )
 
 func handleDie(w http.ResponseWriter, message string) {
-	w.Header().Set("Content-Type", "text/html")
-	fmt.Fprint(w, "<b><font color=red>You encountered an error: "+message+"....</font></b>")
+	http.Error(w, message, http.StatusInternalServerError)
 }
 
 // IndexItem struct.

--- a/core_test.go
+++ b/core_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -10,12 +11,14 @@ import (
 func TestHandleDie(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handleDie(rr, "oops")
-	if ct := rr.Header().Get("Content-Type"); ct != "text/html" {
-		t.Errorf("expected Content-Type text/html, got %q", ct)
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", rr.Code)
 	}
-	expected := "<b><font color=red>You encountered an error: oops....</font></b>"
-	if rr.Body.String() != expected {
-		t.Errorf("unexpected body: %q", rr.Body.String())
+	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Errorf("expected Content-Type text/plain; charset=utf-8, got %q", ct)
+	}
+	if body := rr.Body.String(); body != "oops\n" {
+		t.Errorf("unexpected body: %q", body)
 	}
 }
 


### PR DESCRIPTION
## Summary
- send consistent 500 errors from `handleDie`
- update tests for new behaviour

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855724c60d8832f8064750ff1f4761e