### PR TITLE
Fix scanning of escaped special characters

### DIFF
--- a/a4code2html.go
+++ b/a4code2html.go
@@ -83,14 +83,21 @@ func (c *A4code2html) getNext(endAtEqual bool) string {
 		c.input = c.input[1:]
 
 		switch ch {
-		case '\n', ']', '[', ' ', '\r', '=' /*, '*', '/', '_'*/ :
+		case '\n', ']', '[', ' ', '\r', '=':
 			loop = false
 		case '\\':
-			ch = c.input[0]
-			c.input = c.input[1:]
-			if ch != ' ' && ch != '[' && ch != ']' && ch != '=' && ch != '\\' /* && ch != '*' && ch != '/' && ch != '_'*/ {
-				result.WriteByte('\\')
+			if len(c.input) > 0 {
+				ch = c.input[0]
 				c.input = c.input[1:]
+				switch ch {
+				case ' ', '[', ']', '=', '\\', '*', '/', '_':
+					result.WriteByte(ch)
+				default:
+					result.WriteByte('\\')
+					result.WriteByte(ch)
+				}
+			} else {
+				result.WriteByte('\\')
 			}
 		default:
 			result.WriteByte(ch)
@@ -269,7 +276,7 @@ func (c *A4code2html) nextcomm() {
 		case '\\':
 			ch = c.input[0]
 			c.input = c.input[1:]
-			if ch != ' ' && ch != '[' && ch != ']' && ch != '=' && ch != '\\' {
+			if ch != ' ' && ch != '[' && ch != ']' && ch != '=' && ch != '\\' && ch != '*' && ch != '/' && ch != '_' {
 				c.output.WriteByte('\\')
 			}
 			fallthrough

--- a/a4code2html_internal_test.go
+++ b/a4code2html_internal_test.go
@@ -34,3 +34,48 @@ func TestNextcommSimple(t *testing.T) {
 		t.Fatalf("output %q", got)
 	}
 }
+
+func TestGetNextSpecialChars(t *testing.T) {
+	specials := []byte{'*', '/', '_'}
+	for _, ch := range specials {
+		c := NewA4Code2HTML()
+		c.input = string(ch) + "]"
+		if got := c.getNext(true); got != string(ch) || c.input != "" {
+			t.Fatalf("char %q got %q remaining %q", ch, got, c.input)
+		}
+
+		c = NewA4Code2HTML()
+		c.input = "\\" + string(ch) + "]"
+		if got := c.getNext(false); got != string(ch) || c.input != "" {
+			t.Fatalf("escape %q got %q remaining %q", ch, got, c.input)
+		}
+	}
+}
+
+func TestProcessSpecialCommands(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want string
+	}{
+		{"*", "<strong>text</strong>"},
+		{"/", "<i>text</i>"},
+		{"_", "<u>text</u>"},
+	}
+	for _, tt := range tests {
+		c := NewA4Code2HTML()
+		c.input = "[" + tt.cmd + " text]"
+		c.Process()
+		if got := c.Output(); got != tt.want {
+			t.Fatalf("cmd %q got %q", tt.cmd, got)
+		}
+	}
+}
+
+func TestProcessEscapedSpecialChars(t *testing.T) {
+	c := NewA4Code2HTML()
+	c.input = "start \\* mid \\/ end \\_"
+	c.Process()
+	if got := c.Output(); got != "start * mid / end _" {
+		t.Fatalf("got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- handle `*`, `/`, and `_` as escapable characters in `getNext` and `nextcomm`
- add tests showing usage of these characters in markup and text

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68556ce9cb5c832f8933ffbdc049e00e