### PR TITLE
Replace direct sql.ErrNoRows checks with errors.Is

### DIFF
--- a/forumFeed.go
+++ b/forumFeed.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/gorilla/feeds"
 	"github.com/gorilla/mux"
@@ -65,7 +66,7 @@ func forumTopicRssPage(w http.ResponseWriter, r *http.Request) {
 		Idforumtopic: int32(topicID),
 	})
 	if err != nil {
-		if err != sql.ErrNoRows {
+		if !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("GetForumTopicByIdForUser error: %s", err)
 		}
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -76,7 +77,7 @@ func forumTopicRssPage(w http.ResponseWriter, r *http.Request) {
 		UsersIdusers:           uid,
 		ForumtopicIdforumtopic: int32(topicID),
 	})
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -105,7 +106,7 @@ func forumTopicAtomPage(w http.ResponseWriter, r *http.Request) {
 		Idforumtopic: int32(topicID),
 	})
 	if err != nil {
-		if err != sql.ErrNoRows {
+		if !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("GetForumTopicByIdForUser error: %s", err)
 		}
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -116,7 +117,7 @@ func forumTopicAtomPage(w http.ResponseWriter, r *http.Request) {
 		UsersIdusers:           uid,
 		ForumtopicIdforumtopic: int32(topicID),
 	})
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/imagebbsFeed.go
+++ b/imagebbsFeed.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/gorilla/feeds"
 	"github.com/gorilla/mux"
@@ -58,7 +59,7 @@ func imagebbsFeed(r *http.Request, title string, boardID int, rows []*GetAllImag
 func imagebbsRssPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	boards, err := queries.GetAllImageBoards(r.Context())
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query boards error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -66,7 +67,7 @@ func imagebbsRssPage(w http.ResponseWriter, r *http.Request) {
 	var posts []*GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCountRow
 	for _, b := range boards {
 		rows, err := queries.GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCount(r.Context(), b.Idimageboard)
-		if err != nil && err != sql.ErrNoRows {
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("feed query error: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
@@ -84,7 +85,7 @@ func imagebbsRssPage(w http.ResponseWriter, r *http.Request) {
 func imagebbsAtomPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	boards, err := queries.GetAllImageBoards(r.Context())
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query boards error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -92,7 +93,7 @@ func imagebbsAtomPage(w http.ResponseWriter, r *http.Request) {
 	var posts []*GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCountRow
 	for _, b := range boards {
 		rows, err := queries.GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCount(r.Context(), b.Idimageboard)
-		if err != nil && err != sql.ErrNoRows {
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("feed query error: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
@@ -112,7 +113,7 @@ func imagebbsBoardRssPage(w http.ResponseWriter, r *http.Request) {
 	bid, _ := strconv.Atoi(vars["boardno"])
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	rows, err := queries.GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCount(r.Context(), int32(bid))
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -142,7 +143,7 @@ func imagebbsBoardAtomPage(w http.ResponseWriter, r *http.Request) {
 	bid, _ := strconv.Atoi(vars["boardno"])
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	rows, err := queries.GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCount(r.Context(), int32(bid))
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/linkerFeed.go
+++ b/linkerFeed.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/gorilla/feeds"
 	"net/http"
@@ -55,7 +56,7 @@ func linkerRssPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
 	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), int32(catID))
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
@@ -70,7 +71,7 @@ func linkerAtomPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
 	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), int32(catID))
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary
- replace manual sql.ErrNoRows comparisons with errors.Is
- add errors import where needed

## Testing
- `go test ./...` *(fails: userLangPage.go:196:6: userLangSaveLanguageActionPage redeclared in this block)*

------
https://chatgpt.com/codex/tasks/task_e_685638fe45e8832f93d2ec729e4229a4