### PR TITLE
Fix admin languages link with redirect

### DIFF
--- a/adminLanguagesHandler.go
+++ b/adminLanguagesHandler.go
@@ -10,6 +10,10 @@ import (
 	"strconv"
 )
 
+func adminLanguageRedirect(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, "/admin/languages", http.StatusMovedPermanently)
+}
+
 func adminLanguagesPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*CoreData

--- a/main.go
+++ b/main.go
@@ -433,6 +433,7 @@ func run() error {
 	ar.HandleFunc("/users/permissions", adminUsersPermissionsPermissionUserAllowPage).Methods("POST").MatcherFunc(TaskMatcher(TaskUserAllow))
 	ar.HandleFunc("/users/permissions", adminUsersPermissionsDisallowPage).Methods("POST").MatcherFunc(TaskMatcher(TaskUserDisallow))
 	ar.HandleFunc("/languages", adminLanguagesPage).Methods("GET")
+	ar.HandleFunc("/language", adminLanguageRedirect).Methods("GET")
 	ar.HandleFunc("/languages", adminLanguagesRenamePage).Methods("POST").MatcherFunc(TaskMatcher(TaskRenameLanguage))
 	ar.HandleFunc("/languages", adminLanguagesDeletePage).Methods("POST").MatcherFunc(TaskMatcher(TaskDeleteLanguage))
 	ar.HandleFunc("/languages", adminLanguagesCreatePage).Methods("POST").MatcherFunc(TaskMatcher(TaskCreateLanguage))

--- a/templates/index.gohtml
+++ b/templates/index.gohtml
@@ -17,7 +17,7 @@
         <hr>Admin tools:<br>
         <a href="/admin/users">Person Controls</a><br>
         <a href="/admin/users/permissions">Permission Controls</a><br>
-        <a href="/admin/language">Language Controls</a><br>
+        <a href="/admin/languages">Language Controls</a><br>
         <a href="/admin/search">Search Controls</a><br>
         <a href="/admin/forum">Forum Controls</a><br>
     {{ end }}


### PR DESCRIPTION
## Summary
- fix broken admin languages link
- add `/admin/language` redirect to `/admin/languages`

## Testing
- `go test ./...` *(fails: undefined: userLangSaveLanguageActionPage)*

------
https://chatgpt.com/codex/tasks/task_e_68563fb3904c832fb687170fd749824c