### PR TITLE
Use /usr for preferences

### DIFF
--- a/main.go
+++ b/main.go
@@ -400,16 +400,20 @@ func run() error {
 	ir := r.PathPrefix("/information").Subrouter()
 	ir.HandleFunc("", informationPage).Methods("GET")
 
-	ur := r.PathPrefix("/user").Subrouter()
+	ur := r.PathPrefix("/usr").Subrouter()
 	ur.HandleFunc("", userPage).Methods("GET").MatcherFunc(RequiresAnAccount())
 	ur.HandleFunc("/logout", userLogoutPage).Methods("GET")
 	ur.HandleFunc("/lang", userLangPage).Methods("GET").MatcherFunc(RequiresAnAccount())
 	ur.HandleFunc("/lang", userLangSaveLanguagesActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveLanguages))
-	ur.HandleFunc("/lang", userLangSaveLanguageActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveLanguage))
+	ur.HandleFunc("/lang", userLangSaveLanguagePreferenceActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveLanguage))
 	ur.HandleFunc("/lang", userLangSaveAllActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveAll))
 	ur.HandleFunc("/email", userEmailPage).Methods("GET").MatcherFunc(RequiresAnAccount())
 	ur.HandleFunc("/email", userEmailSaveActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveAll))
 	ur.HandleFunc("/email", userEmailTestActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskTestMail))
+
+	// Redirect legacy paths to the updated usr endpoints.
+	r.HandleFunc("/user/lang", redirectPermanent("/usr/lang"))
+	r.HandleFunc("/user/email", redirectPermanent("/usr/email"))
 
 	rr := r.PathPrefix("/register").Subrouter()
 	rr.HandleFunc("", registerPage).Methods("GET").MatcherFunc(Not(RequiresAnAccount()))
@@ -522,6 +526,14 @@ func AddNewsIndex(handler http.Handler) http.Handler {
 // mainCSSHandler serves the site's stylesheet.
 func mainCSSHandler(w http.ResponseWriter, r *http.Request) {
 	http.ServeContent(w, r, "main.css", time.Time{}, bytes.NewReader(getMainCSSData()))
+}
+
+// redirectPermanent returns a handler that redirects to the provided path using
+// StatusPermanentRedirect to preserve the request method.
+func redirectPermanent(to string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, to, http.StatusPermanentRedirect)
+	}
 }
 
 // TODO we could do better

--- a/templates/userPage.gohtml
+++ b/templates/userPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
     User preferences:<br><br>
-    Modify <a href="/user/lang">Language settings</a><br>
-    Modify <a href="/user/email">Email and notification settings</a><br>
+    Modify <a href="/usr/lang">Language settings</a><br>
+    Modify <a href="/usr/email">Email and notification settings</a><br>
 {{ template "tail" $ }}

--- a/userEmailPage.go
+++ b/userEmailPage.go
@@ -77,7 +77,7 @@ func userEmailSaveActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, "/user/email", http.StatusSeeOther)
+	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }
 
 func userEmailTestActionPage(w http.ResponseWriter, r *http.Request) {
@@ -99,5 +99,5 @@ func userEmailTestActionPage(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	http.Redirect(w, r, "/user/email", http.StatusSeeOther)
+	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }

--- a/userLangPage_test.go
+++ b/userLangPage_test.go
@@ -29,7 +29,7 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 	form.Set("language1", "on")
 	form.Set("defaultLanguage", "2")
 
-	req := httptest.NewRequest("POST", "/user/lang", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest("POST", "/usr/lang", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	sess, _ := store.Get(req, sessionName)
@@ -76,7 +76,7 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 	form.Set("dothis", "Save languages")
 	form.Set("language1", "on")
 
-	req := httptest.NewRequest("POST", "/user/lang", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest("POST", "/usr/lang", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	sess, _ := store.Get(req, sessionName)
@@ -122,7 +122,7 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	form.Set("dothis", "Save language")
 	form.Set("defaultLanguage", "2")
 
-	req := httptest.NewRequest("POST", "/user/lang", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest("POST", "/usr/lang", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	sess, _ := store.Get(req, sessionName)


### PR DESCRIPTION
## Summary
- switch preference routes back to `/usr/*`
- redirect from `/user/*` to `/usr/*`
- fix handler registration typo
- update template and tests

## Testing
- `go test ./...` *(fails: remaining SQL mock expectations)*
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_68563fb9ee50832f8bb39c62894bae5b