### PR TITLE
Add news user permissions page and template

### DIFF
--- a/newsUserPermissionsPage.go
+++ b/newsUserPermissionsPage.go
@@ -10,13 +10,18 @@ import (
 )
 
 func newsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	if !(cd.HasRole("writer") || cd.HasRole("administrator")) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	type Data struct {
 		*CoreData
 		Rows []*GetPermissionsByUserIdAndSectionNewsRow
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: cd,
 	}
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
@@ -33,7 +38,7 @@ func newsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	data.Rows = rows
 
 	CustomNewsIndex(data.CoreData, r)
-	if err := renderTemplate(w, r, "adminUsersPermissionsPage.gohtml", data); err != nil {
+	if err := renderTemplate(w, r, "newsUserPermissionsPage.gohtml", data); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/templates/newsUserPermissionsPage.gohtml
+++ b/templates/newsUserPermissionsPage.gohtml
@@ -1,0 +1,42 @@
+{{ template "head" $ }}
+                <table border="1">
+                        <tr>
+                                <th>ID</th>
+                                <th>User</th>
+                                <th>Email</th>
+                                <th>Level</th>
+                                <th>Delete?</th>
+                        </tr>
+                        {{range .Rows}}
+                                <tr>
+                                        <td>{{.Idpermissions}}</td>
+                                        <td>{{.Username.String}}</td>
+                                        <td>{{.Email.String}}</td>
+                                        <td>{{.Level.String}}</td>
+                                        <td>
+                                                <form method="post">
+                                                        <input type="hidden" name="permid" value="{{.Idpermissions}}">
+                                                        <input type="submit" name="task" value="User Disallow">
+                                                </form>
+                                        </td>
+                                </tr>
+                        {{end}}
+                        <tr>
+                                <td><form method="post">NEW</td>
+                                <td><input name="username"></td>
+                                <td>?</td>
+                                <td>
+                                        <select name="level">
+                                                <option value="reader">reader</option>
+                                                <option value="writer">writer</option>
+                                                <option value="moderator">moderator</option>
+                                                <option value="administrator">administrator</option>
+                                        </select>
+                                </td>
+                                <td>
+                                        <input type="submit" name="task" value="User Allow">
+                                </td>
+                        </tr>
+                </table>
+                Permissions should be valid only.
+{{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- add handler for `/news/user/permissions` checking writer/admin roles
- add template for managing news permissions
- register route already requiring administrator access

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685663c84110832fb7ae5de4cdca2300