### PR TITLE
Enable admin FAQ question creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -239,6 +239,7 @@ func run() error {
 	faqr.HandleFunc("/admin/questions", faqAdminQuestionsPage).Methods("GET", "POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(NoTask())
 	faqr.HandleFunc("/admin/questions", faqQuestionsEditActionPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskEdit))
 	faqr.HandleFunc("/admin/questions", faqQuestionsDeleteActionPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskRemoveRemove))
+	faqr.HandleFunc("/admin/questions", faqQuestionsCreateActionPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskCreate))
 
 	br := r.PathPrefix("/blogs").Subrouter()
 	br.HandleFunc("/rss", blogsRssPage).Methods("GET")

--- a/templates/faqAdminQuestionPage.gohtml
+++ b/templates/faqAdminQuestionPage.gohtml
@@ -1,11 +1,11 @@
 {{ template "head" $ }}
    <font size="5">Section: Unanswered/Uncategorized Questions</font><br>
     {{- range .Rows }}
-		<form method="post" action="">
-			<table width="100%">
-				<tr>
-					<th bgcolor="lightgrey">Q:
-					</th>
+                <form method="post" action="">
+                        <table width="100%">
+                                <tr>
+                                        <th bgcolor="lightgrey">Q:
+                                        </th>
 				</tr>
 				<tr>
 					<td>
@@ -23,19 +23,52 @@
 				</tr>
 				<tr>
 					<td>
-						<input type="submit" name="task" value="Edit">
-						<input type="submit" name="task" value="Remove">
-						<select name="category">
-							<option value="0">Hidden</option>
-							{{$FaqcategoriesIdfaqcategories := .FaqcategoriesIdfaqcategories }}
-							{{- range $.Categories }}
-							<option value="{{ .Idfaqcategories }}" {{if eq $FaqcategoriesIdfaqcategories .Idfaqcategories}}selected{{end}}>{{ .Name.String }} {{if eq $FaqcategoriesIdfaqcategories .Idfaqcategories}}(Current){{end}}</option>
-							{{- end }}
-						</select>
-						<input type="hidden" name="faq" value="{{ .Idfaq }}">
-					</td>
-				</tr>
-			</table>
-		</form><br>
+                                                <input type="submit" name="task" value="Edit">
+                                                <input type="submit" name="task" value="Remove">
+                                                <select name="category">
+                                                        <option value="0">Hidden</option>
+                                                        {{$FaqcategoriesIdfaqcategories := .FaqcategoriesIdfaqcategories }}
+                                                        {{- range $.Categories }}
+                                                        <option value="{{ .Idfaqcategories }}" {{if eq $FaqcategoriesIdfaqcategories .Idfaqcategories}}selected{{end}}>{{ .Name.String }} {{if eq $FaqcategoriesIdfaqcategories .Idfaqcategories}}(Current){{end}}</option>
+                                                        {{- end }}
+                                                </select>
+                                                <input type="hidden" name="faq" value="{{ .Idfaq }}">
+                                        </td>
+                                </tr>
+                        </table>
+                </form><br>
     {{- end }}
+            <form method="post" action="">
+                    <table width="100%">
+                            <tr>
+                                    <th bgcolor="lightgrey">Q:
+                                    </th>
+                            </tr>
+                            <tr>
+                                    <td>
+                                            <textarea name="question" cols="60" rows="5"></textarea><br>
+                                    </td>
+                            </tr>
+                            <tr>
+                                    <th bgcolor="lightgrey">A:
+                                    </th>
+                            </tr>
+                            <tr>
+                                    <td>
+                                            <textarea name="answer" cols="60" rows="5"></textarea><br>
+                                    </td>
+                            </tr>
+                            <tr>
+                                    <td>
+                                            <input type="submit" name="task" value="Create">
+                                            <select name="category">
+                                                    <option value="0">Hidden</option>
+                                                    {{- range $.Categories }}
+                                                    <option value="{{ .Idfaqcategories }}">{{ .Name.String }}</option>
+                                                    {{- end }}
+                                            </select>
+                                    </td>
+                            </tr>
+                    </table>
+            </form>
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- expand admin FAQ question page with a creation form
- handle POST creation action in the handler and routing
- add route for question creation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685663c95f94832f88b2229da2ddfeb5