### PR TITLE
Add admin board metrics

### DIFF
--- a/queries-imagebbs.sql.go
+++ b/queries-imagebbs.sql.go
@@ -244,3 +244,12 @@ func (q *Queries) UpdateImagePostByIdForumThreadId(ctx context.Context, arg Upda
 	_, err := q.db.ExecContext(ctx, updateImagePostByIdForumThreadId, arg.ForumthreadIdforumthread, arg.Idimagepost)
 	return err
 }
+
+// CountThreadsByBoard returns the number of unique threads for a board.
+func (q *Queries) CountThreadsByBoard(ctx context.Context, boardID int32) (int32, error) {
+	var c int32
+	err := q.db.QueryRowContext(ctx,
+		"SELECT COUNT(DISTINCT forumthread_idforumthread) FROM imagepost WHERE imageboard_idimageboard = ?",
+		boardID).Scan(&c)
+	return c, err
+}

--- a/templates/imagebbsAdminBoardsPage.gohtml
+++ b/templates/imagebbsAdminBoardsPage.gohtml
@@ -1,22 +1,31 @@
 {{ template "head" $ }}
-		<table border="1">
-			<tr>
-				<th>ID
-				<th>Title
-				<th>Description
-				<th>Parent board
-				<th>Options?
-			{{ range .Boards }}
-				<tr>
-					<form method="post" action="/imagebbs/admin/board/{{.Idimageboard}}">
-						<td>{{ .Idimageboard }}
-						<td><input name="name" value="{{ .Title.String }}">
-						<td><textarea name="desc">{{ .Description.String }}</textarea>
-                        <td>{{ $pbid := .ImageboardIdimageboard }} {{ $pbid }} <select name="pbid" value="{{ .ImageboardIdimageboard }}"><option value="0">None</option>{{ range $.Boards }}<option value="{{.Idimageboard}}" {{if eq $pbid .Idimageboard}}selected{{end}}>{{.Title.String}}</option>  {{ end }}</select>
-						<td>
-							<input type="hidden" name="bid" value="{{ .Idimageboard }}">
-							<input type="submit" name="task" value="Modify board">
-						</form>
-			{{ end }}
-		</table>
+                <table border="1">
+                        <tr>
+                                <th>ID
+                                <th>Title
+                                <th>Description
+                                <th>Parent board
+                                <th>Threads
+                                <th>Mod Level
+                                <th>Visible
+                                <th>Options?
+                        {{ range .Boards }}
+                                <tr>
+                                        <form method="post" action="/imagebbs/admin/board/{{.Idimageboard}}">
+                                                <td>{{ .Idimageboard }}
+                                                <td><input name="name" value="{{ .Title.String }}">
+                                                <td><textarea name="desc">{{ .Description.String }}</textarea>
+                                                <td>{{ $pbid := .ImageboardIdimageboard }} {{ $pbid }} <select name="pbid" value="{{ .ImageboardIdimageboard }}"><option value="0">None</option>{{ range $.Boards }}<option value="{{.Idimageboard}}" {{if eq $pbid .Idimageboard}}selected{{end}}>{{.Title.String}}</option>{{ end }}</select>
+                                                <td>{{ .Threads }}
+                                                <td>{{ .ModLevel }}
+                                                <td>{{ if .Visible }}Yes{{ else }}No{{ end }}
+                                                <td>
+                                                        <input type="hidden" name="bid" value="{{ .Idimageboard }}">
+                                                        <input type="submit" name="task" value="Modify board">
+                                                        <input type="submit" name="task" value="Toggle NSFW">
+                                                </td>
+                                        </form>
+                                </tr>
+                        {{ end }}
+                </table>
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- add thread count helper for ImageBBS boards
- compute board metrics in admin handler
- expose moderation, visibility and NSFW controls in ImageBBS admin template

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685669fe1130832f86d59b1cd19f307b