### PR TITLE
Add search and batch user management to linker admin

### DIFF
--- a/linkerAdminUserLevelsPage.go
+++ b/linkerAdminUserLevelsPage.go
@@ -6,16 +6,25 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 func linkerAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
+	type PermissionUser struct {
+		*Permission
+		Username sql.NullString
+		Email    sql.NullString
+	}
+
 	type Data struct {
 		*CoreData
-		UserLevels []*Permission
+		UserLevels []*PermissionUser
+		Search     string
 	}
 
 	data := Data{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		Search:   r.URL.Query().Get("search"),
 	}
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
@@ -29,7 +38,28 @@ func linkerAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	data.UserLevels = rows
+
+	var perms []*PermissionUser
+	for _, p := range rows {
+		u, err := queries.GetUserById(r.Context(), p.UsersIdusers)
+		if err != nil {
+			log.Printf("GetUserById Error: %s", err)
+			continue
+		}
+		perms = append(perms, &PermissionUser{Permission: p, Username: u.Username, Email: u.Email})
+	}
+
+	if data.Search != "" {
+		q := strings.ToLower(data.Search)
+		var filtered []*PermissionUser
+		for _, row := range perms {
+			if strings.Contains(strings.ToLower(row.Username.String), q) {
+				filtered = append(filtered, row)
+			}
+		}
+		perms = filtered
+	}
+	data.UserLevels = perms
 
 	CustomLinkerIndex(data.CoreData, r)
 	if err := renderTemplate(w, r, "linkerAdminUserLevelsPage.gohtml", data); err != nil {
@@ -41,41 +71,46 @@ func linkerAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 
 func linkerAdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	username := r.PostFormValue("username")
+	usernames := r.PostFormValue("usernames")
 	where := r.PostFormValue("where")
 	level := r.PostFormValue("level")
-	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
-	if err != nil {
-		log.Printf("GetUserByUsername Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
-	if err := queries.PermissionUserAllow(r.Context(), PermissionUserAllowParams{
-		UsersIdusers: u.Idusers,
-		Section: sql.NullString{
-			String: where,
-			Valid:  true,
-		},
-		Level: sql.NullString{
-			String: level,
-			Valid:  true,
-		},
-	}); err != nil {
-		log.Printf("permissionUserAllow Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
+	fields := strings.FieldsFunc(usernames, func(r rune) bool {
+		return r == ',' || r == '\n' || r == '\r' || r == '\t' || r == ' '
+	})
+	for _, username := range fields {
+		if username == "" {
+			continue
+		}
+		u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
+		if err != nil {
+			log.Printf("GetUserByUsername Error: %s", err)
+			continue
+		}
+		if err := queries.PermissionUserAllow(r.Context(), PermissionUserAllowParams{
+			UsersIdusers: u.Idusers,
+			Section:      sql.NullString{String: where, Valid: true},
+			Level:        sql.NullString{String: level, Valid: true},
+		}); err != nil {
+			log.Printf("permissionUserAllow Error: %s", err)
+		}
 	}
 	taskDoneAutoRefreshPage(w, r)
 }
 
 func linkerAdminUserLevelsRemoveActionPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	permid, _ := strconv.Atoi(r.PostFormValue("permid"))
-	if err := queries.PermissionUserDisallow(r.Context(), int32(permid)); err != nil {
-		log.Printf("permissionUserDisallow Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
+	r.ParseForm()
+	ids := r.Form["permids"]
+	if len(ids) == 0 {
+		if id := r.PostFormValue("permid"); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	for _, idStr := range ids {
+		permid, _ := strconv.Atoi(idStr)
+		if err := queries.PermissionUserDisallow(r.Context(), int32(permid)); err != nil {
+			log.Printf("permissionUserDisallow Error: %s", err)
+		}
 	}
 	taskDoneAutoRefreshPage(w, r)
 }

--- a/templates/linkerAdminUserLevelsPage.gohtml
+++ b/templates/linkerAdminUserLevelsPage.gohtml
@@ -1,6 +1,11 @@
 {{ template "head" $ }}
+    <form method="get">
+        <input name="search" value="{{$.Search}}">
+        <input type="submit" value="Filter">
+    </form>
     <table border="1">
         <tr>
+            <th>Select</th>
             <th>ID</th>
             <th>User</th>
             <th>Email</th>
@@ -10,6 +15,7 @@
         {{- if .UserLevels }}
             {{- range $result := .UserLevels }}
                 <tr>
+                    <td><input type="checkbox" name="permids" form="batchRemoveForm" value="{{ $result.ID }}"></td>
                     <td>{{ $result.ID }}</td>
                     <td>{{ $result.Username.String }}</td>
                     <td>{{ $result.Email.String }}</td>
@@ -23,27 +29,26 @@
                 </tr>
             {{- end }}
         {{- else }}
-            <tr><td colspan="5">No results</td></tr>
+            <tr><td colspan="6">No results</td></tr>
         {{- end }}
         <tr>
-            <td>
-                <form method="post">NEW
-            </td>
-            <td><input name="username"></td>
-            <td>?</td>
-            <td>
-                <select name="level">
-                    <option value="reader">reader</option>
-                    <option value="writer">writer</option>
-                    <option value="moderator">moderator</option>
-                    <option value="administrator">administrator</option>
-                </select>
-            </td>
-            <td>
-                <input type="submit" name="task" value="User Allow">
+            <td colspan="6">
+                <form method="post">
+                    Usernames (space or comma separated):<br>
+                    <textarea name="usernames" rows="2" cols="40"></textarea><br>
+                    <select name="level">
+                        <option value="reader">reader</option>
+                        <option value="writer">writer</option>
+                        <option value="moderator">moderator</option>
+                        <option value="administrator">administrator</option>
+                    </select>
+                    <input type="submit" name="task" value="User Allow">
                 </form>
             </td>
         </tr>
     </table>
+    <form id="batchRemoveForm" method="post">
+        <input type="submit" name="task" value="User Disallow">
+    </form>
     <p>Permissions should be valid only.</p>
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- allow filtering linker user levels by username
- support batch allow/remove actions

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685669f847c4832fb37c01e287d5880e