### PR TITLE
Improve topic restriction admin page

### DIFF
--- a/forumAdminTopicsRestrictions.go
+++ b/forumAdminTopicsRestrictions.go
@@ -128,3 +128,51 @@ func forumAdminTopicsRestrictionLevelDeletePage(w http.ResponseWriter, r *http.R
 
 	taskDoneAutoRefreshPage(w, r)
 }
+
+func forumAdminTopicsRestrictionLevelCopyPage(w http.ResponseWriter, r *http.Request) {
+	fromID, err := strconv.Atoi(r.PostFormValue("fromTopic"))
+	if err != nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	toID, err := strconv.Atoi(r.PostFormValue("toTopic"))
+	if err != nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+
+	src, err := queries.GetForumTopicRestrictionsByForumTopicId(r.Context(), int32(fromID))
+	if err != nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	if len(src) == 0 || !src[0].ForumtopicIdforumtopic.Valid {
+		if err := queries.DeleteTopicRestrictionsByForumTopicId(r.Context(), int32(toID)); err != nil {
+			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			return
+		}
+	} else {
+		row := src[0]
+		if err := queries.UpsertForumTopicRestrictions(r.Context(), UpsertForumTopicRestrictionsParams{
+			ForumtopicIdforumtopic: int32(toID),
+			Viewlevel:              row.Viewlevel,
+			Replylevel:             row.Replylevel,
+			Newthreadlevel:         row.Newthreadlevel,
+			Seelevel:               row.Seelevel,
+			Invitelevel:            row.Invitelevel,
+			Readlevel:              row.Readlevel,
+			Modlevel:               row.Modlevel,
+			Adminlevel:             row.Adminlevel,
+		}); err != nil {
+			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			return
+		}
+	}
+
+	notifyAdmins(r.Context(), getEmailProvider(), queries, r.URL.Path)
+
+	taskDoneAutoRefreshPage(w, r)
+}

--- a/main.go
+++ b/main.go
@@ -304,6 +304,7 @@ func run() error {
 	fr.HandleFunc("/admin/restrictions/topics", forumAdminTopicsRestrictionLevelChangePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskUpdateTopicRestriction))
 	fr.HandleFunc("/admin/restrictions/topics", forumAdminTopicsRestrictionLevelDeletePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskDeleteTopicRestriction))
 	fr.HandleFunc("/admin/restrictions/topics", forumAdminTopicsRestrictionLevelChangePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskSetTopicRestriction))
+	fr.HandleFunc("/admin/restrictions/topics", forumAdminTopicsRestrictionLevelCopyPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskCopyTopicRestriction))
 
 	lr := r.PathPrefix("/linker").Subrouter()
 	lr.HandleFunc("/rss", linkerRssPage).Methods("GET")

--- a/task_constants.go
+++ b/task_constants.go
@@ -168,6 +168,9 @@ const (
 	// TaskSetTopicRestriction sets a new topic restriction.
 	TaskSetTopicRestriction = "Set topic restriction"
 
+	// TaskCopyTopicRestriction copies restriction levels from one topic to another.
+	TaskCopyTopicRestriction = "Copy topic restriction"
+
 	// TaskSetUserLevel sets a user's access level.
 	TaskSetUserLevel = "Set user level"
 

--- a/templates/forumAdminTopicsRestrictionLevelPage.gohtml
+++ b/templates/forumAdminTopicsRestrictionLevelPage.gohtml
@@ -9,14 +9,14 @@
                 <tr>
                     <form method="post">
                         <td><input type="hidden" name="ftid" value="{{ .Idforumtopic }}">{{ $format }}</td>
-                        <td><input name="view" value="{{ .Viewlevel.Int32 }}" size="8"></td>
-                        <td><input name="reply" value="{{ .Replylevel.Int32 }}" size="8"></td>
-                        <td><input name="newthread" value="{{ .Newthreadlevel.Int32 }}" size="8"></td>
-                        <td><input name="see" value="{{ .Seelevel.Int32 }}" size="8"></td>
-                        <td><input name="invite" value="{{ .Invitelevel.Int32 }}" size="8"></td>
-                        <td><input name="read" value="{{ .Readlevel.Int32 }}" size="8"></td>
-                        <td><input name="mod" value="{{ .Modlevel.Int32 }}" size="8"></td>
-                        <td><input name="admin" value="{{ .Adminlevel.Int32 }}" size="8"></td>
+                        <td><input type="number" name="view" value="{{ .Viewlevel.Int32 }}" size="8" required></td>
+                        <td><input type="number" name="reply" value="{{ .Replylevel.Int32 }}" size="8" required></td>
+                        <td><input type="number" name="newthread" value="{{ .Newthreadlevel.Int32 }}" size="8" required></td>
+                        <td><input type="number" name="see" value="{{ .Seelevel.Int32 }}" size="8" required></td>
+                        <td><input type="number" name="invite" value="{{ .Invitelevel.Int32 }}" size="8" required></td>
+                        <td><input type="number" name="read" value="{{ .Readlevel.Int32 }}" size="8" required></td>
+                        <td><input type="number" name="mod" value="{{ .Modlevel.Int32 }}" size="8" required></td>
+                        <td><input type="number" name="admin" value="{{ .Adminlevel.Int32 }}" size="8" required></td>
                         <td>
                             {{- if .ForumtopicIdforumtopic.Valid }}
                                 <input type="submit" name="task" value="Update topic restriction">
@@ -28,6 +28,25 @@
                     </form>
                 </tr>
             {{- end }}
+            <tr>
+                <form method="post">
+                    <td colspan="10">
+                        Copy restrictions from
+                        <select name="fromTopic">
+                            {{- range $.Restrictions }}
+                                <option value="{{ .Idforumtopic }}">{{ .Title.String }}</option>
+                            {{- end }}
+                        </select>
+                        to
+                        <select name="toTopic">
+                            {{- range $.Restrictions }}
+                                <option value="{{ .Idforumtopic }}">{{ .Title.String }}</option>
+                            {{- end }}
+                        </select>
+                        <input type="submit" name="task" value="Copy topic restriction">
+                    </td>
+                </form>
+            </tr>
     </table><br>
     Remember:
     <ul>


### PR DESCRIPTION
## Summary
- validate numeric fields in topic restriction admin form
- allow copying restrictions from one topic to another
- add task constant and handler for copying topic restrictions

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685669f2fffc832f957520eab44363cc