### PR TITLE
Add topic-level controls to forum admin users

### DIFF
--- a/forumAdminUserPage.go
+++ b/forumAdminUserPage.go
@@ -3,24 +3,37 @@ package main
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
 )
 
 func forumAdminUserPage(w http.ResponseWriter, r *http.Request) {
 
+	type UserTopic struct {
+		User   *User
+		Topics []*GetAllForumTopicsForUserWithPermissionsRestrictionsAndTopicRow
+	}
+
 	type Data struct {
 		*CoreData
-		Rows []*User
+		Rows   []*UserTopic
+		Search string
 	}
 
 	data := Data{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		Search:   r.URL.Query().Get("search"),
 	}
+
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 
-	rows, err := queries.AllUsers(r.Context())
+	users, err := queries.AllUsers(r.Context())
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -29,7 +42,64 @@ func forumAdminUserPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	data.Rows = rows
+
+	if data.Search != "" {
+		q := strings.ToLower(data.Search)
+		var filtered []*User
+		for _, u := range users {
+			if strings.Contains(strings.ToLower(u.Username.String), q) ||
+				strings.Contains(strings.ToLower(u.Email.String), q) {
+				filtered = append(filtered, u)
+			}
+		}
+		users = filtered
+	}
+
+	const pageSize = 15
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > len(users) {
+		offset = len(users)
+	}
+	end := offset + pageSize
+	if end > len(users) {
+		end = len(users)
+	}
+
+	for _, u := range users[offset:end] {
+		topics, err := queries.GetAllForumTopicsForUserWithPermissionsRestrictionsAndTopic(r.Context(), u.Idusers)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			log.Printf("getAllUsersTopicLevels Error: %s", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		data.Rows = append(data.Rows, &UserTopic{User: u, Topics: topics})
+	}
+
+	if data.Search != "" {
+		data.CustomIndexItems = append(data.CustomIndexItems, IndexItem{
+			Name: "Next 15",
+			Link: fmt.Sprintf("/forum/admin/users?search=%s&offset=%d", url.QueryEscape(data.Search), offset+pageSize),
+		})
+		if offset > 0 {
+			data.CustomIndexItems = append(data.CustomIndexItems, IndexItem{
+				Name: "Previous 15",
+				Link: fmt.Sprintf("/forum/admin/users?search=%s&offset=%d", url.QueryEscape(data.Search), offset-pageSize),
+			})
+		}
+	} else {
+		data.CustomIndexItems = append(data.CustomIndexItems, IndexItem{
+			Name: "Next 15",
+			Link: fmt.Sprintf("/forum/admin/users?offset=%d", offset+pageSize),
+		})
+		if offset > 0 {
+			data.CustomIndexItems = append(data.CustomIndexItems, IndexItem{
+				Name: "Previous 15",
+				Link: fmt.Sprintf("/forum/admin/users?offset=%d", offset-pageSize),
+			})
+		}
+	}
 
 	CustomForumIndex(data.CoreData, r)
 

--- a/templates/forumAdminUserPage.gohtml
+++ b/templates/forumAdminUserPage.gohtml
@@ -1,18 +1,32 @@
 {{ template "head" $ }}
-    <table border="1">
+    <form method="get">
+        <input name="search" value="{{ $.Search }}">
+        <input type="submit" value="Search">
+    </form>
+    {{- range $.Rows }}
+    <h3>{{ .User.Username.String }} ({{ .User.Email.String }})</h3>
+    <table border="1" width="100%">
         <tr>
-            <th>ID</th>
-            <th>User</th>
-            <th>Email</th>
-            <th>Options?</th>
+            <th>Topic</th>
+            <th>Level</th>
+            <th>Invite Level Max</th>
+            <th>Options</th>
         </tr>
-        {{range $.Rows}}
-            <tr>
-                <td>{{.Idusers}}</td>
-                <td>{{.Username.String}}</td>
-                <td>{{.Email.String}}</td>
-                <td><a href="/forum/admin/user/{{.Idusers}}/levels">Configure users access levels</a>
-            </tr>
-        {{end}}
+        {{- $u := .User }}
+        {{- range .Topics }}
+        <tr>
+            <form method="post" action="/forum/admin/user/{{ $u.Idusers }}/levels">
+                <td><input type="hidden" name="tid" value="{{ .Idforumtopic }}">{{ .Title.String }}</td>
+                <td><input name="level" value="{{ .Level.Int32 }}" size="8"></td>
+                <td><input name="inviteMax" value="{{ .Invitemax.Int32 }}" size="8"></td>
+                <td>
+                    <input type="submit" name="task" value="Update user level">
+                    <input type="submit" name="task" value="Delete user level">
+                </td>
+            </form>
+        </tr>
+        {{- end }}
     </table>
+    <a href="/forum/admin/user/{{ .User.Idusers }}/levels">Configure users access levels</a>
+    {{- end }}
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- enhance forum admin user page to show forum/topic levels
- allow updating levels inline
- add pagination and search support

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685669f033cc832face2e0919b2f0c20