### PR TITLE
Add forum topic management

### DIFF
--- a/forumAdminTopicsPage.go
+++ b/forumAdminTopicsPage.go
@@ -116,3 +116,14 @@ func forumTopicCreatePage(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/forum/admin/topics", http.StatusTemporaryRedirect)
 
 }
+
+func forumAdminTopicDeletePage(w http.ResponseWriter, r *http.Request) {
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	vars := mux.Vars(r)
+	topicId, _ := strconv.Atoi(vars["topic"])
+	if err := queries.DeleteForumTopic(r.Context(), int32(topicId)); err != nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	http.Redirect(w, r, "/forum/admin/topics", http.StatusTemporaryRedirect)
+}

--- a/main.go
+++ b/main.go
@@ -286,6 +286,7 @@ func run() error {
 	fr.HandleFunc("/admin/topics", forumAdminTopicsPage).Methods("GET").MatcherFunc(RequiredAccess("administrator"))
 	fr.HandleFunc("/admin/topics", taskDoneAutoRefreshPage).Methods("POST").MatcherFunc(RequiredAccess("administrator"))
 	fr.HandleFunc("/admin/topic/{topic}/edit", forumAdminTopicEditPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskForumTopicChange))
+	fr.HandleFunc("/admin/topic/{topic}/delete", forumAdminTopicDeletePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskForumTopicDelete))
 	fr.HandleFunc("/admin/topic", forumTopicCreatePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskForumTopicCreate))
 	fr.HandleFunc("/admin/topic/{topic}/levels", forumAdminTopicRestrictionLevelPage).Methods("GET").MatcherFunc(RequiredAccess("administrator"))
 	fr.HandleFunc("/admin/topic/{topic}/levels", forumAdminTopicRestrictionLevelChangePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskUpdateTopicRestriction))

--- a/queries-forum.sql
+++ b/queries-forum.sql
@@ -141,3 +141,7 @@ SET threads = (
 )
 WHERE idforumtopic = ?;
 
+-- name: DeleteForumTopic :exec
+-- Removes a forum topic by ID.
+DELETE FROM forumtopic WHERE idforumtopic = ?;
+

--- a/queries-forum.sql.go
+++ b/queries-forum.sql.go
@@ -726,3 +726,12 @@ func (q *Queries) UpsertUsersForumTopicLevelPermission(ctx context.Context, arg 
 	)
 	return err
 }
+
+// deleteForumTopic removes a forum topic by ID.
+const deleteForumTopic = `-- name: DeleteForumTopic :exec
+DELETE FROM forumtopic WHERE idforumtopic = ?`
+
+func (q *Queries) DeleteForumTopic(ctx context.Context, idforumtopic int32) error {
+	_, err := q.db.ExecContext(ctx, deleteForumTopic, idforumtopic)
+	return err
+}

--- a/task_constants.go
+++ b/task_constants.go
@@ -79,6 +79,9 @@ const (
 	// TaskForumTopicCreate creates a new forum topic.
 	TaskForumTopicCreate = "Forum topic create"
 
+	// TaskForumTopicDelete removes a forum topic.
+	TaskForumTopicDelete = "Forum topic delete"
+
 	// TaskLogin performs a user login.
 	TaskLogin = "Login"
 

--- a/templates/forumAdminTopicsPage.gohtml
+++ b/templates/forumAdminTopicsPage.gohtml
@@ -5,35 +5,51 @@
             <th>Title
             <th>Description
             <th>Category
+            <th>Threads
+            <th>Posts
+            <th>View
             <th>Restrictions
             <th>Options?
         </tr>
         {{ range .Topics }}
             <tr>
-                <form method="post" action="/forum/admin/topic/{{ .Idforumtopic }}/edit">
-                    <td>{{ .Idforumtopic }}
-                    <td><input name="name" value="{{ .Title.String }}">
-                    <td><textarea name="desc">{{ .Description.String }}</textarea>
-                    <td>{{ $fcid := .ForumcategoryIdforumcategory }} {{ $fcid }} <select name="cid" value="{{ .ForumcategoryIdforumcategory }}"><option value="0">None</option>{{ range $.Categories }}<option value="{{.Idforumcategory}}" {{if eq $fcid .Idforumcategory}}selected{{end}}>{{.Title.String}}</option>  {{ end }}</select>
-                    <td><a href="/forum/admin/topic/{{ .Idforumtopic }}/levels">Permission Levels</a>
-                    <td>
+                <td>{{ .Idforumtopic }}</td>
+                <td>
+                    <form method="post" action="/forum/admin/topic/{{ .Idforumtopic }}/edit">
+                        <input name="name" value="{{ .Title.String }}">
+                </td>
+                <td><textarea name="desc">{{ .Description.String }}</textarea></td>
+                <td>{{ $fcid := .ForumcategoryIdforumcategory }} <select name="cid" value="{{ .ForumcategoryIdforumcategory }}"><option value="0">None</option>{{ range $.Categories }}<option value="{{.Idforumcategory}}" {{if eq $fcid .Idforumcategory}}selected{{end}}>{{.Title.String}}</option>  {{ end }}</select></td>
+                <td align="center">{{ .Threads.Int32 }}</td>
+                <td align="center">{{ .Comments.Int32 }}</td>
+                <td><a href="/forum/topic/{{ .Idforumtopic }}">View</a></td>
+                <td><a href="/forum/admin/topic/{{ .Idforumtopic }}/levels">Permission Levels</a></td>
+                <td>
                         <input type="hidden" name="tid" value="{{ .Idforumtopic }}">
                         <input type="submit" name="task" value="Forum topic change">
-                    </td>
-                </form>
+                    </form>
+                    <form method="post" action="/forum/admin/topic/{{ .Idforumtopic }}/delete" style="display:inline">
+                        <input type="submit" name="task" value="Forum topic delete">
+                    </form>
+                </td>
             </tr>
         {{ end }}
         <tr>
-            <form method="post" action="/forum/admin/topic">
-                <td>New
-                <td><input name="name" value="">
-                <td><textarea name="desc"></textarea>
-                <td><select name="pcid" value=""><option value="0">None</option>{{ range $.Categories }}<option value="{{.Idforumcategory}}">{{.Title.String}}</option>{{ end }}</select>
-                <td>TBA
-                <td>
+            <td>New</td>
+            <td>
+                <form method="post" action="/forum/admin/topic">
+                    <input name="name" value="">
+            </td>
+            <td><textarea name="desc"></textarea></td>
+            <td><select name="pcid" value=""><option value="0">None</option>{{ range $.Categories }}<option value="{{.Idforumcategory}}">{{.Title.String}}</option>{{ end }}</select></td>
+            <td>0</td>
+            <td>0</td>
+            <td></td>
+            <td>TBA</td>
+            <td>
                     <input type="submit" name="task" value="Forum topic create">
-                </td>
-            </form>
+                </form>
+            </td>
         </tr>
     </table>
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- show thread and post counts plus view links on forum topics admin page
- allow deleting forum topics
- wire up route and constants for deletion

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685669ef6ce8832fa9ce8dedc5db404f