### PR TITLE
Add blog permission filters and bulk actions

### DIFF
--- a/main.go
+++ b/main.go
@@ -248,6 +248,8 @@ func run() error {
 	br.HandleFunc("/user/permissions", getPermissionsByUserIdAndSectionBlogsPage).Methods("GET").MatcherFunc(RequiredAccess("administrator"))
 	br.HandleFunc("/users/permissions", blogsUsersPermissionsPermissionUserAllowPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskUserAllow))
 	br.HandleFunc("/users/permissions", blogsUsersPermissionsDisallowPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskUserDisallow))
+	br.HandleFunc("/users/permissions", blogsUsersPermissionsBulkAllowPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskUsersAllow))
+	br.HandleFunc("/users/permissions", blogsUsersPermissionsBulkDisallowPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskUsersDisallow))
 	br.HandleFunc("/add", blogsBlogAddPage).Methods("GET").MatcherFunc(RequiredAccess("writer", "administrator"))
 	br.HandleFunc("/add", blogsBlogAddActionPage).Methods("POST").MatcherFunc(RequiredAccess("writer", "administrator")).MatcherFunc(TaskMatcher(TaskAdd))
 	br.HandleFunc("/bloggers", blogsBloggersPage).Methods("GET")

--- a/task_constants.go
+++ b/task_constants.go
@@ -204,6 +204,12 @@ const (
 	// TaskUserDisallow removes a user's permission or level.
 	TaskUserDisallow = "User Disallow"
 
+	// TaskUsersAllow grants multiple users a permission or level.
+	TaskUsersAllow = "Users Allow"
+
+	// TaskUsersDisallow removes multiple user permissions or levels.
+	TaskUsersDisallow = "Users Disallow"
+
 	// TaskUserDoNothing is used when no action should be taken on a user.
 	TaskUserDoNothing = "User do nothing"
 

--- a/templates/blogsUserPermissionsPage.gohtml
+++ b/templates/blogsUserPermissionsPage.gohtml
@@ -1,42 +1,47 @@
 {{ template "head" $ }}
-		<table border="1">
-			<tr>
-				<th>ID
-				<th>User
-				<th>Email
-				<th>Level
-				<th>Delete?
-			</tr>
-			{{range .Rows}}
-				<tr>
-					<td>{{.ID}}
-					<td>{{.Username}}
-					<td>{{.Email}}
-					<td>{{.Level}}
-					<td>
-						<form method="post">
-							<input type="hidden" name="permid" value="{{.Idpermissions}}">
-							<input type="submit" name="task" value="User Disallow">
-						</form>
-					</td>
-				</tr>
-			{{end}}
-			<tr>
-				<td><form method="post">NEW
-				<td><input name="username">
-				<td>?
-				<td>
-					<select name="level">
-						<option value="reader">reader
-						<option value="writer">writer
-						<option value="moderator">moderator
-						<option value="administrator">administrator
-					</select>
-				</td>
-				<td>
-					<input type="submit" name="task" value="User Allow">
-				</td>
-			</tr>
-		</table>
-		Permissions should be valid only.
+<form method="get">
+    Filter by level:
+    <select name="level">
+        <option value=""{{if eq .Filter ""}} selected{{end}}>all</option>
+        <option value="reader"{{if eq .Filter "reader"}} selected{{end}}>reader</option>
+        <option value="writer"{{if eq .Filter "writer"}} selected{{end}}>writer</option>
+        <option value="moderator"{{if eq .Filter "moderator"}} selected{{end}}>moderator</option>
+        <option value="administrator"{{if eq .Filter "administrator"}} selected{{end}}>administrator</option>
+    </select>
+    <input type="submit" value="Filter">
+</form>
+
+<form method="post">
+    <table border="1">
+        <tr>
+            <th>Select</th>
+            <th>ID</th>
+            <th>User</th>
+            <th>Email</th>
+            <th>Level</th>
+        </tr>
+        {{range .Rows}}
+        <tr>
+            <td><input type="checkbox" name="permid" value="{{.Idpermissions}}"></td>
+            <td>{{.Idpermissions}}</td>
+            <td>{{.Username.String}}</td>
+            <td>{{.Email.String}}</td>
+            <td>{{.Level.String}}</td>
+        </tr>
+        {{end}}
+    </table>
+    <input type="submit" name="task" value="Users Disallow"><br><br>
+    Usernames (comma or newline separated):<br>
+    <textarea name="usernames" rows="3" cols="40"></textarea><br>
+    Level:
+    <select name="level">
+        <option value="reader">reader</option>
+        <option value="writer">writer</option>
+        <option value="moderator">moderator</option>
+        <option value="administrator">administrator</option>
+    </select>
+    <input type="submit" name="task" value="Users Allow">
+</form>
+
+Permissions should be valid only.
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- tailor blogs user permission template for blog roles
- allow filtering by role and bulk allowing/disallowing
- wire up new bulk handlers and tasks

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685669e413ac832faa0e74c7bf15d984