### PR TITLE
Add admin forum tools and progress messages

### DIFF
--- a/adminForumFlaggedPostsPage.go
+++ b/adminForumFlaggedPostsPage.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+// adminForumFlaggedPostsPage displays posts flagged for moderator review.
+func adminForumFlaggedPostsPage(w http.ResponseWriter, r *http.Request) {
+	type Data struct {
+		*CoreData
+	}
+	data := Data{CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData)}
+	if err := renderTemplate(w, r, "adminForumFlaggedPostsPage.gohtml", data); err != nil {
+		log.Printf("Template Error: %s", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/adminForumHandler.go
+++ b/adminForumHandler.go
@@ -28,15 +28,20 @@ func adminForumRemakeForumThreadPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	data := struct {
 		*CoreData
-		Errors []string
-		Back   string
+		Errors   []string
+		Messages []string
+		Back     string
 	}{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 		Back:     "/admin/forum",
 	}
 
+	data.Messages = append(data.Messages, "Recalculating forum thread metadata...")
+
 	if err := queries.RecalculateAllForumThreadMetaData(r.Context()); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("recalculateForumThreadByIdMetaData_firstpost: %w", err).Error())
+	} else {
+		data.Messages = append(data.Messages, "Thread metadata rebuilt.")
 	}
 	err := renderTemplate(w, r, "adminRunTaskPage.gohtml", data)
 	if err != nil {
@@ -50,14 +55,18 @@ func adminForumRemakeForumTopicPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	data := struct {
 		*CoreData
-		Errors []string
-		Back   string
+		Errors   []string
+		Messages []string
+		Back     string
 	}{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 		Back:     "/admin/forum",
 	}
+	data.Messages = append(data.Messages, "Rebuilding forum topic metadata...")
 	if err := queries.RebuildAllForumTopicMetaColumns(r.Context()); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("rebuildForumTopicByIdMetaColumns_lastaddition_lastposter: %w", err).Error())
+	} else {
+		data.Messages = append(data.Messages, "Topic metadata rebuilt.")
 	}
 	err := renderTemplate(w, r, "adminRunTaskPage.gohtml", data)
 	if err != nil {

--- a/adminForumModeratorLogsPage.go
+++ b/adminForumModeratorLogsPage.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+// adminForumModeratorLogsPage displays recent moderator actions.
+func adminForumModeratorLogsPage(w http.ResponseWriter, r *http.Request) {
+	type Data struct {
+		*CoreData
+	}
+	data := Data{CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData)}
+	if err := renderTemplate(w, r, "adminForumModeratorLogsPage.gohtml", data); err != nil {
+		log.Printf("Template Error: %s", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/main.go
+++ b/main.go
@@ -444,6 +444,8 @@ func run() error {
 	ar.HandleFunc("/forum", adminForumPage).Methods("GET")
 	ar.HandleFunc("/forum", adminForumRemakeForumThreadPage).Methods("POST").MatcherFunc(TaskMatcher(TaskRemakeStatisticInformationOnForumthread))
 	ar.HandleFunc("/forum", adminForumRemakeForumTopicPage).Methods("POST").MatcherFunc(TaskMatcher(TaskRemakeStatisticInformationOnForumtopic))
+	ar.HandleFunc("/forum/flagged", adminForumFlaggedPostsPage).Methods("GET")
+	ar.HandleFunc("/forum/logs", adminForumModeratorLogsPage).Methods("GET")
 	ar.HandleFunc("/forum/list", adminForumWordListPage).Methods("GET")
 	ar.HandleFunc("/users", adminUsersPage).Methods("GET")
 	ar.HandleFunc("/users/disable", adminUserDisablePage).Methods("POST")

--- a/templates/adminForumFlaggedPostsPage.gohtml
+++ b/templates/adminForumFlaggedPostsPage.gohtml
@@ -1,0 +1,3 @@
+{{ template "head" $ }}
+<p>No flagged posts found.</p>
+{{ template "tail" $ }}

--- a/templates/adminForumModeratorLogsPage.gohtml
+++ b/templates/adminForumModeratorLogsPage.gohtml
@@ -1,0 +1,3 @@
+{{ template "head" $ }}
+<p>No moderator logs available.</p>
+{{ template "tail" $ }}

--- a/templates/adminForumPage.gohtml
+++ b/templates/adminForumPage.gohtml
@@ -1,8 +1,10 @@
 {{ template "head" $ }}
 			<strong>What shall we do?</strong><br>
-			View something:<br>
-			<a href="/admin/forum/list">Complete word list</a><br>
-			<br>
+                        View something:<br>
+                        <a href="/admin/forum/list">Complete word list</a><br>
+                        <a href="/admin/forum/flagged">Flagged posts</a><br>
+                        <a href="/admin/forum/logs">Moderator logs</a><br>
+                        <br>
 			Preform something:<br>
 			<form method="post">
 				<input type="submit" name="task" value="Remake statistic information on forumthread"><br>

--- a/templates/adminRunTaskPage.gohtml
+++ b/templates/adminRunTaskPage.gohtml
@@ -1,4 +1,11 @@
 {{ template "head" $ }}
+{{- if $.Messages }}
+        <ul>
+        {{- range $.Messages }}
+                <li>{{ . }}</li>
+        {{- end }}
+        </ul>
+{{- end }}
 {{- if $.Errors }}
         Errors occurred:
         <ul>


### PR DESCRIPTION
## Summary
- show links to view flagged posts and moderator logs in forum admin page
- implement placeholder pages for flagged posts and moderator logs
- display progress messages when rebuilding thread/topic metadata
- show task messages in the admin task results page
- expose new admin routes

## Testing
- `go vet ./...` *(fails: PermissionWithUser redeclared)*
- `go test ./...` *(fails: PermissionWithUser redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_68568dd46314832f81f2606aab8bc3fa