### PR TITLE
Add filtering and batch actions to linker admin user levels

### DIFF
--- a/templates/linkerAdminUserLevelsPage.gohtml
+++ b/templates/linkerAdminUserLevelsPage.gohtml
@@ -1,8 +1,9 @@
 {{ template "head" $ }}
     <form method="get">
-        <input name="search" value="{{$.Search}}">
+        Username: <input name="search" value="{{$.Search}}">
         <input type="submit" value="Filter">
     </form>
+    <form method="post">
     <table border="1">
         <tr>
             <th>Select</th>
@@ -10,22 +11,15 @@
             <th>User</th>
             <th>Email</th>
             <th>Level</th>
-            <th>Delete?</th>
         </tr>
         {{- if .UserLevels }}
             {{- range $result := .UserLevels }}
                 <tr>
-                    <td><input type="checkbox" name="permids" form="batchRemoveForm" value="{{ $result.ID }}"></td>
+                    <td><input type="checkbox" name="permids" value="{{ $result.ID }}"></td>
                     <td>{{ $result.ID }}</td>
                     <td>{{ $result.Username.String }}</td>
                     <td>{{ $result.Email.String }}</td>
                     <td>{{ $result.Level.String }}</td>
-                    <td>
-                        <form method="post">
-                            <input type="hidden" name="permid" value="{{ $result.ID }}">
-                            <input type="submit" name="task" value="User Disallow">
-                        </form>
-                    </td>
                 </tr>
             {{- end }}
         {{- else }}
@@ -33,22 +27,19 @@
         {{- end }}
         <tr>
             <td colspan="6">
-                <form method="post">
-                    Usernames (space or comma separated):<br>
-                    <textarea name="usernames" rows="2" cols="40"></textarea><br>
-                    <select name="level">
-                        <option value="reader">reader</option>
-                        <option value="writer">writer</option>
-                        <option value="moderator">moderator</option>
-                        <option value="administrator">administrator</option>
-                    </select>
-                    <input type="submit" name="task" value="User Allow">
-                </form>
+                Usernames (space or comma separated):<br>
+                <textarea name="usernames" rows="2" cols="40"></textarea><br>
+                <select name="level">
+                    <option value="reader">reader</option>
+                    <option value="writer">writer</option>
+                    <option value="moderator">moderator</option>
+                    <option value="administrator">administrator</option>
+                </select>
             </td>
         </tr>
     </table>
-    <form id="batchRemoveForm" method="post">
-        <input type="submit" name="task" value="User Disallow">
+    <input type="submit" name="task" value="User Disallow">
+    <input type="submit" name="task" value="User Allow">
     </form>
     <p>Permissions should be valid only.</p>
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- add username filter to linker user level admin page
- support batch allow and disallow actions

## Testing
- `go test ./...` *(fails: PermissionWithUser redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_68568dbb1b48832f89269fd14bacca10