### PR TITLE
Add copy feature and input validation for topic restrictions

### DIFF
--- a/main.go
+++ b/main.go
@@ -295,6 +295,7 @@ func run() error {
 	fr.HandleFunc("/admin/topic/{topic}/levels", forumAdminTopicRestrictionLevelChangePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskUpdateTopicRestriction))
 	fr.HandleFunc("/admin/topic/{topic}/levels", forumAdminTopicRestrictionLevelChangePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskSetTopicRestriction))
 	fr.HandleFunc("/admin/topic/{topic}/levels", forumAdminTopicRestrictionLevelDeletePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskDeleteTopicRestriction))
+	fr.HandleFunc("/admin/topic/{topic}/levels", forumAdminTopicRestrictionLevelCopyPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskCopyTopicRestriction))
 	fr.HandleFunc("/admin/users", forumAdminUserPage).Methods("GET").MatcherFunc(RequiredAccess("administrator"))
 	fr.HandleFunc("/admin/user/{user}/levels", forumAdminUserLevelUpdatePage).Methods("GET", "POST").MatcherFunc(And(RequiredAccess("administrator"), AdminUsersMaxLevelNotLowerThanTargetLevel(), TargetUsersLevelNotHigherThanAdminsMax())).MatcherFunc(TaskMatcher(TaskSetUserLevel))
 	fr.HandleFunc("/admin/user/{user}/levels", forumAdminUserLevelUpdatePage).Methods("GET", "POST").MatcherFunc(And(RequiredAccess("administrator"), AdminUsersMaxLevelNotLowerThanTargetLevel(), TargetUsersLevelNotHigherThanAdminsMax())).MatcherFunc(TaskMatcher(TaskUpdateUserLevel))

--- a/templates/forumAdminTopicRestrictionLevelPage.gohtml
+++ b/templates/forumAdminTopicRestrictionLevelPage.gohtml
@@ -9,14 +9,14 @@
                 <tr>
                     <form method="post">
                         <td><input type="hidden" name="ftid" value="{{ .Idforumtopic }}">{{ $format }}</td>
-                        <td><input name="view" value="{{ .Viewlevel.Int32 }}" size="8"></td>
-                        <td><input name="reply" value="{{ .Replylevel.Int32 }}" size="8"></td>
-                        <td><input name="newthread" value="{{ .Newthreadlevel.Int32 }}" size="8"></td>
-                        <td><input name="see" value="{{ .Seelevel.Int32 }}" size="8"></td>
-                        <td><input name="invite" value="{{ .Invitelevel.Int32 }}" size="8"></td>
-                        <td><input name="read" value="{{ .Readlevel.Int32 }}" size="8"></td>
-                        <td><input name="mod" value="{{ .Modlevel.Int32 }}" size="8"></td>
-                        <td><input name="admin" value="{{ .Adminlevel.Int32 }}" size="8"></td>
+                        <td><input type="number" name="view" value="{{ .Viewlevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="reply" value="{{ .Replylevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="newthread" value="{{ .Newthreadlevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="see" value="{{ .Seelevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="invite" value="{{ .Invitelevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="read" value="{{ .Readlevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="mod" value="{{ .Modlevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="admin" value="{{ .Adminlevel.Int32 }}" size="8" min="0" step="1" required></td>
                         <td>
                             {{- if .ForumtopicIdforumtopic.Valid }}
                                 <input type="submit" name="task" value="Update topic restriction">
@@ -28,6 +28,25 @@
                     </form>
                 </tr>
             {{- end }}
+            <tr>
+                <form method="post">
+                    <td colspan="10">
+                        Copy restrictions from
+                        <select name="fromTopic" required>
+                            {{- range $.Restrictions }}
+                                <option value="{{ .Idforumtopic }}">{{ .Title.String }}</option>
+                            {{- end }}
+                        </select>
+                        to
+                        <select name="toTopic" required>
+                            {{- range $.Restrictions }}
+                                <option value="{{ .Idforumtopic }}">{{ .Title.String }}</option>
+                            {{- end }}
+                        </select>
+                        <input type="submit" name="task" value="Copy topic restriction">
+                    </td>
+                </form>
+            </tr>
     </table><br>
     Remember:
     <ul>

--- a/templates/forumAdminTopicsRestrictionLevelPage.gohtml
+++ b/templates/forumAdminTopicsRestrictionLevelPage.gohtml
@@ -9,14 +9,14 @@
                 <tr>
                     <form method="post">
                         <td><input type="hidden" name="ftid" value="{{ .Idforumtopic }}">{{ $format }}</td>
-                        <td><input type="number" name="view" value="{{ .Viewlevel.Int32 }}" size="8" required></td>
-                        <td><input type="number" name="reply" value="{{ .Replylevel.Int32 }}" size="8" required></td>
-                        <td><input type="number" name="newthread" value="{{ .Newthreadlevel.Int32 }}" size="8" required></td>
-                        <td><input type="number" name="see" value="{{ .Seelevel.Int32 }}" size="8" required></td>
-                        <td><input type="number" name="invite" value="{{ .Invitelevel.Int32 }}" size="8" required></td>
-                        <td><input type="number" name="read" value="{{ .Readlevel.Int32 }}" size="8" required></td>
-                        <td><input type="number" name="mod" value="{{ .Modlevel.Int32 }}" size="8" required></td>
-                        <td><input type="number" name="admin" value="{{ .Adminlevel.Int32 }}" size="8" required></td>
+                        <td><input type="number" name="view" value="{{ .Viewlevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="reply" value="{{ .Replylevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="newthread" value="{{ .Newthreadlevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="see" value="{{ .Seelevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="invite" value="{{ .Invitelevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="read" value="{{ .Readlevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="mod" value="{{ .Modlevel.Int32 }}" size="8" min="0" step="1" required></td>
+                        <td><input type="number" name="admin" value="{{ .Adminlevel.Int32 }}" size="8" min="0" step="1" required></td>
                         <td>
                             {{- if .ForumtopicIdforumtopic.Valid }}
                                 <input type="submit" name="task" value="Update topic restriction">
@@ -32,13 +32,13 @@
                 <form method="post">
                     <td colspan="10">
                         Copy restrictions from
-                        <select name="fromTopic">
+                        <select name="fromTopic" required>
                             {{- range $.Restrictions }}
                                 <option value="{{ .Idforumtopic }}">{{ .Title.String }}</option>
                             {{- end }}
                         </select>
                         to
-                        <select name="toTopic">
+                        <select name="toTopic" required>
                             {{- range $.Restrictions }}
                                 <option value="{{ .Idforumtopic }}">{{ .Title.String }}</option>
                             {{- end }}


### PR DESCRIPTION
## Summary
- validate numeric inputs on topic restriction page
- enable copying restrictions between topics
- expose copy endpoint for single-topic pages

## Testing
- `go test ./...` *(fails: PermissionWithUser redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_68568db848f4832f8b0b419160ae7cc4