### PR TITLE
Update forum category view with counts

### DIFF
--- a/templates/forumCategories.gohtml
+++ b/templates/forumCategories.gohtml
@@ -8,14 +8,20 @@
             <tr>
                 <td>
                     {{ if and $.Admin .Edit }}
-                        <form method="post">
+                        <form method="post" action="/forum/admin/category/{{ .Idforumcategory }}">
                             Title <input name="name" value="{{ .Title.String }}">: -
                             Description: <textarea name="desc" cols="30" rows="2">{{ .Description.String }}</textarea>
+                            {{ $pid := .ForumcategoryIdforumcategory }}
+                            Parent <select name="pcid" value="{{ $pid }}"><option value="0">None</option>{{ range $.Categories }}<option value="{{ .Idforumcategory }}" {{ if eq $pid .Idforumcategory }}selected{{ end }}>{{ .Title.String }}</option>{{ end }}</select>
+                            ({{ len .Topics }} topics)
                             <input type="hidden" name="cid" value="{{ .Idforumcategory }}">
                             <input type="submit" name="task" value="Forum category change">
+                            {{ if eq (len .Topics) 0 }}
+                            <input type="submit" name="task" formaction="/forum/admin/category/delete" value="Delete Category">
+                            {{ end }}
                         </form>
                     {{ else }}
-                        <strong><a href="/forum/category/{{ .Idforumcategory }}">{{ .Title.String }}</a>:</strong> - {{ .Description.String }}<br>
+                        <strong><a href="/forum/category/{{ .Idforumcategory }}">{{ .Title.String }}</a></strong> - {{ .Description.String }} ({{ len .Topics }})<br>
                     {{ end }}
                 </td>
             </tr>


### PR DESCRIPTION
## Summary
- add topic count and parent dropdown in forum category template
- include delete button when category has no topics

## Testing
- `go test ./...` *(fails: PermissionWithUser redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_68568db4920c832f8d463aeed296733a