### PR TITLE
Add admin email and notification tracking

### DIFF
--- a/adminEmailQueuePage.go
+++ b/adminEmailQueuePage.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func adminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
+	type Data struct {
+		*CoreData
+		Emails []*PendingEmail
+	}
+	data := Data{
+		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+	}
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	items, err := queries.ListUnsentPendingEmails(r.Context())
+	if err != nil {
+		log.Printf("list pending emails: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	data.Emails = items
+	if err := renderTemplate(w, r, "adminEmailQueuePage.gohtml", data); err != nil {
+		log.Printf("template error: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/adminNotificationsPage.go
+++ b/adminNotificationsPage.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func adminNotificationsPage(w http.ResponseWriter, r *http.Request) {
+	type Data struct {
+		*CoreData
+		Notifications []*Notification
+	}
+	data := Data{
+		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+	}
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	items, err := queries.RecentNotifications(r.Context(), 50)
+	if err != nil {
+		log.Printf("recent notifications: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	data.Notifications = items
+	if err := renderTemplate(w, r, "adminNotificationsPage.gohtml", data); err != nil {
+		log.Printf("template error: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/admin_tracking_test.go
+++ b/admin_tracking_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestListUnsentPendingEmails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := New(db)
+	rows := sqlmock.NewRows([]string{"id", "to_email", "subject", "body", "created_at"}).AddRow(1, "a@test", "s", "b", time.Now())
+	mock.ExpectQuery("SELECT id, to_email, subject, body, created_at FROM pending_emails WHERE sent_at IS NULL ORDER BY id").WillReturnRows(rows)
+	if _, err := q.ListUnsentPendingEmails(context.Background()); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expect: %v", err)
+	}
+}
+
+func TestRecentNotifications(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := New(db)
+	rows := sqlmock.NewRows([]string{"id", "users_idusers", "link", "message", "created_at", "read_at"}).AddRow(1, 1, "/l", "m", time.Now(), nil)
+	mock.ExpectQuery("SELECT id, users_idusers, link, message, created_at, read_at FROM notifications ORDER BY id DESC LIMIT ?").WithArgs(int32(5)).WillReturnRows(rows)
+	if _, err := q.RecentNotifications(context.Background(), 5); err != nil {
+		t.Fatalf("recent: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expect: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -461,6 +461,8 @@ func run() error {
 	ar.HandleFunc("/languages", adminLanguagesCreatePage).Methods("POST").MatcherFunc(TaskMatcher(TaskCreateLanguage))
 	ar.HandleFunc("/permissions/sections", adminPermissionsSectionPage).Methods("GET")
 	ar.HandleFunc("/permissions/sections", adminPermissionsSectionRenamePage).Methods("POST").MatcherFunc(TaskMatcher(TaskRenameSection))
+	ar.HandleFunc("/email/queue", adminEmailQueuePage).Methods("GET")
+	ar.HandleFunc("/notifications", adminNotificationsPage).Methods("GET")
 	ar.HandleFunc("/search", adminSearchPage).Methods("GET")
 	ar.HandleFunc("/search", adminSearchRemakeCommentsSearchPage).Methods("POST").MatcherFunc(TaskMatcher(TaskRemakeCommentsSearch))
 	ar.HandleFunc("/search", adminSearchRemakeNewsSearchPage).Methods("POST").MatcherFunc(TaskMatcher(TaskRemakeNewsSearch))

--- a/templates/adminEmailQueuePage.gohtml
+++ b/templates/adminEmailQueuePage.gohtml
@@ -1,0 +1,13 @@
+{{ template "head" $ }}
+<table border="1">
+    <tr><th>ID</th><th>To</th><th>Subject</th><th>Created</th></tr>
+    {{- range .Emails }}
+    <tr>
+        <td>{{ .ID }}</td>
+        <td>{{ .ToEmail }}</td>
+        <td>{{ .Subject }}</td>
+        <td>{{ if .CreatedAt.Valid }}{{ .CreatedAt.Time }}{{ end }}</td>
+    </tr>
+    {{- end }}
+</table>
+{{ template "tail" $ }}

--- a/templates/adminNotificationsPage.gohtml
+++ b/templates/adminNotificationsPage.gohtml
@@ -1,0 +1,14 @@
+{{ template "head" $ }}
+<table border="1">
+    <tr><th>ID</th><th>User</th><th>Message</th><th>Link</th><th>Read</th></tr>
+    {{- range .Notifications }}
+    <tr>
+        <td>{{ .ID }}</td>
+        <td>{{ .UsersIdusers }}</td>
+        <td>{{ .Message.String }}</td>
+        <td>{{ .Link.String }}</td>
+        <td>{{ if .ReadAt.Valid }}yes{{ else }}no{{ end }}</td>
+    </tr>
+    {{- end }}
+</table>
+{{ template "tail" $ }}

--- a/templates/adminPage.gohtml
+++ b/templates/adminPage.gohtml
@@ -7,6 +7,8 @@
     <li><a href="/admin/search">Search</a></li>
     <li><a href="/admin/forum">Forum</a></li>
     <li><a href="/admin/permissions/sections">Permission Sections</a></li>
+    <li><a href="/admin/email/queue">Queued Emails</a></li>
+    <li><a href="/admin/notifications">Notifications</a></li>
 </ul>
 
 <p>Site statistics:</p>


### PR DESCRIPTION
## Summary
- add admin email queue and notifications routes
- implement queries to fetch pending emails and recent notifications
- add handler pages and templates to display email and notification queues
- provide tests for new queries

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68568ea6df34832fa668ef2093084475