### PR TITLE
Add search index stats and download option

### DIFF
--- a/adminSearchWordListHandler.go
+++ b/adminSearchWordListHandler.go
@@ -1,31 +1,76 @@
 package main
 
 import (
-	"database/sql"
 	_ "embed"
 	_ "github.com/go-sql-driver/mysql" // Import the MySQL driver.
 	"log"
 	"net/http"
+	"strconv"
+	"strings"
 )
 
 func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*CoreData
-		Rows []sql.NullString
+		Rows     []*WordListWithCountsRow
+		NextLink string
+		PrevLink string
 	}
 
 	data := Data{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 
-	rows, err := queries.CompleteWordList(r.Context())
+	if r.URL.Query().Get("download") != "" {
+		rows, err := queries.CompleteWordList(r.Context())
+		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("Content-Disposition", "attachment; filename=wordlist.txt")
+		for _, row := range rows {
+			if row.Valid {
+				_, _ = w.Write([]byte(row.String + "\n"))
+			}
+		}
+		return
+	}
+	const pageSize = 1000
+	rows, err := queries.WordListWithCounts(r.Context(), WordListWithCountsParams{
+		Limit:  pageSize + 1,
+		Offset: int32(offset),
+	})
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
+
+	hasMore := len(rows) > pageSize
+	if hasMore {
+		rows = rows[:pageSize]
+	}
 	data.Rows = rows
+
+	base := "/admin/search/list"
+	if hasMore {
+		if strings.Contains(base, "?") {
+			data.NextLink = base + "&offset=" + strconv.Itoa(offset+pageSize)
+		} else {
+			data.NextLink = base + "?offset=" + strconv.Itoa(offset+pageSize)
+		}
+	}
+	if offset > 0 {
+		if strings.Contains(base, "?") {
+			data.PrevLink = base + "&offset=" + strconv.Itoa(offset-pageSize)
+		} else {
+			data.PrevLink = base + "?offset=" + strconv.Itoa(offset-pageSize)
+		}
+	}
 
 	err = renderTemplate(w, r, "adminSearchWordListPage.gohtml", data)
 	if err != nil {

--- a/queries-search.sql
+++ b/queries-search.sql
@@ -3,6 +3,18 @@
 SELECT word
 FROM searchwordlist;
 
+-- name: WordListWithCounts :many
+-- Show each search word with total usage counts across all search tables.
+SELECT swl.word,
+       (SELECT COUNT(*) FROM commentsSearch cs WHERE cs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT COUNT(*) FROM siteNewsSearch ns WHERE ns.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT COUNT(*) FROM blogsSearch bs WHERE bs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT COUNT(*) FROM linkerSearch ls WHERE ls.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT COUNT(*) FROM writingSearch ws WHERE ws.searchwordlist_idsearchwordlist=swl.idsearchwordlist) AS count
+FROM searchwordlist swl
+ORDER BY swl.word
+LIMIT ? OFFSET ?;
+
 -- name: RemakeCommentsSearch :exec
 -- This query selects data from the "comments" table and populates the "commentsSearch" table with the specified columns.
 -- Then, it iterates over the "queue" linked list to add each text and ID pair to the "commentsSearch" using the "comments_idcomments".

--- a/queries-search.sql.go
+++ b/queries-search.sql.go
@@ -257,6 +257,17 @@ SELECT word
 FROM searchwordlist
 `
 
+const wordListWithCounts = `-- name: WordListWithCounts :many
+SELECT swl.word,
+       (SELECT COUNT(*) FROM commentsSearch cs WHERE cs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT COUNT(*) FROM siteNewsSearch ns WHERE ns.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT COUNT(*) FROM blogsSearch bs WHERE bs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT COUNT(*) FROM linkerSearch ls WHERE ls.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT COUNT(*) FROM writingSearch ws WHERE ws.searchwordlist_idsearchwordlist=swl.idsearchwordlist) AS count
+FROM searchwordlist swl
+ORDER BY swl.word
+LIMIT ? OFFSET ?`
+
 // This query selects all words from the "searchwordlist" table and prints them.
 func (q *Queries) CompleteWordList(ctx context.Context) ([]sql.NullString, error) {
 	rows, err := q.db.QueryContext(ctx, completeWordList)
@@ -271,6 +282,39 @@ func (q *Queries) CompleteWordList(ctx context.Context) ([]sql.NullString, error
 			return nil, err
 		}
 		items = append(items, word)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+type WordListWithCountsParams struct {
+	Limit  int32
+	Offset int32
+}
+
+type WordListWithCountsRow struct {
+	Word  sql.NullString
+	Count int64
+}
+
+func (q *Queries) WordListWithCounts(ctx context.Context, arg WordListWithCountsParams) ([]*WordListWithCountsRow, error) {
+	rows, err := q.db.QueryContext(ctx, wordListWithCounts, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*WordListWithCountsRow
+	for rows.Next() {
+		var i WordListWithCountsRow
+		if err := rows.Scan(&i.Word, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err

--- a/queries_ext.go
+++ b/queries_ext.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 )
 
 // GetPermissionsByUserID returns all permissions for the given user.
@@ -182,13 +181,6 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]*Us
 		items = append(items, &u)
 	}
 	return items, rows.Err()
-}
-
-// PermissionWithUser includes permission information along with user details.
-type PermissionWithUser struct {
-	Permission
-	Username sql.NullString
-	Email    sql.NullString
 }
 
 // GetPermissionsBySectionWithUsers lists permissions for a section with user info.

--- a/templates/adminSearchPage.gohtml
+++ b/templates/adminSearchPage.gohtml
@@ -1,11 +1,21 @@
 {{ template "head" $ }}
-		<strong>What shall we do?</strong><br>
-		View something:<br>
-		<a href="/admin/search/list">Show complete word list</a><br>
-		<br>
-		Preform something:<br>
-		<form method="post">
-			<input type="submit" name="task" value="Remake comments search"><br>
+                <strong>What shall we do?</strong><br>
+                Current search index counts:<br>
+                <ul>
+                        <li>Word list: {{ .Stats.WordList }}</li>
+                        <li>Comments: {{ .Stats.Comments }}</li>
+                        <li>News: {{ .Stats.News }}</li>
+                        <li>Blogs: {{ .Stats.Blogs }}</li>
+                        <li>Linker: {{ .Stats.Linker }}</li>
+                        <li>Writings: {{ .Stats.Writings }}</li>
+                </ul>
+                View something:<br>
+                <a href="/admin/search/list">Show complete word list</a><br>
+                <a href="/admin/search/list?download=1">Download word list</a><br>
+                <br>
+                Preform something:<br>
+                <form method="post">
+                        <input type="submit" name="task" value="Remake comments search"><br>
 			<input type="submit" name="task" value="Remake news search"><br>
 			<input type="submit" name="task" value="Remake blog search"><br>
 			<input type="submit" name="task" value="Remake linker search"><br>

--- a/templates/adminSearchWordListPage.gohtml
+++ b/templates/adminSearchWordListPage.gohtml
@@ -1,7 +1,9 @@
 {{ template "head" $ }}
-			Complete word list:<ul>
-			{{range $.Rows}}
-				<li>{{- .String}}</li>
-			{{- end}}
-			</ul>
+                        Complete word list with counts:<ul>
+                        {{range $.Rows}}
+                                <li>{{.Word.String}} - {{.Count}}</li>
+                        {{- end}}
+                        </ul>
+                        {{if $.PrevLink}}<a href="{{$.PrevLink}}">Previous</a>{{end}}
+                        {{if $.NextLink}}<a href="{{$.NextLink}}">Next</a>{{end}}
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- show counts for search indices on admin search page
- provide option to download word list
- fix duplicate struct in queries_ext.go
- add paginated word list view with counts

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68568dc26ed0832fadef01bf303dcbc3