### PR TITLE
Implement email queue actions

### DIFF
--- a/adminEmailQueuePage.go
+++ b/adminEmailQueuePage.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net/http"
+	"strconv"
 )
 
 func adminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
@@ -26,4 +27,44 @@ func adminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
+}
+
+func adminEmailQueueResendActionPage(w http.ResponseWriter, r *http.Request) {
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	provider := getEmailProvider()
+	if err := r.ParseForm(); err != nil {
+		log.Printf("ParseForm: %v", err)
+	}
+	for _, idStr := range r.Form["id"] {
+		id, _ := strconv.Atoi(idStr)
+		e, err := queries.GetPendingEmailByID(r.Context(), int32(id))
+		if err != nil {
+			log.Printf("get email: %v", err)
+			continue
+		}
+		if provider != nil {
+			if err := provider.Send(r.Context(), e.ToEmail, e.Subject, e.Body); err != nil {
+				log.Printf("send email: %v", err)
+				continue
+			}
+		}
+		if err := queries.MarkEmailSent(r.Context(), e.ID); err != nil {
+			log.Printf("mark sent: %v", err)
+		}
+	}
+	taskDoneAutoRefreshPage(w, r)
+}
+
+func adminEmailQueueDeleteActionPage(w http.ResponseWriter, r *http.Request) {
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	if err := r.ParseForm(); err != nil {
+		log.Printf("ParseForm: %v", err)
+	}
+	for _, idStr := range r.Form["id"] {
+		id, _ := strconv.Atoi(idStr)
+		if err := queries.DeletePendingEmail(r.Context(), int32(id)); err != nil {
+			log.Printf("delete email: %v", err)
+		}
+	}
+	taskDoneAutoRefreshPage(w, r)
 }

--- a/main.go
+++ b/main.go
@@ -469,6 +469,8 @@ func run() error {
 	ar.HandleFunc("/permissions/sections", adminPermissionsSectionPage).Methods("GET")
 	ar.HandleFunc("/permissions/sections", adminPermissionsSectionRenamePage).Methods("POST").MatcherFunc(TaskMatcher(TaskRenameSection))
 	ar.HandleFunc("/email/queue", adminEmailQueuePage).Methods("GET")
+	ar.HandleFunc("/email/queue", adminEmailQueueResendActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskResend))
+	ar.HandleFunc("/email/queue", adminEmailQueueDeleteActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskDelete))
 	ar.HandleFunc("/notifications", adminNotificationsPage).Methods("GET")
 	ar.HandleFunc("/search", adminSearchPage).Methods("GET")
 	ar.HandleFunc("/search", adminSearchRemakeCommentsSearchPage).Methods("POST").MatcherFunc(TaskMatcher(TaskRemakeCommentsSearch))

--- a/queries_ext.go
+++ b/queries_ext.go
@@ -155,6 +155,23 @@ func (q *Queries) ListUnsentPendingEmails(ctx context.Context) ([]*PendingEmail,
 	return items, rows.Err()
 }
 
+// GetPendingEmailByID returns a single pending email.
+func (q *Queries) GetPendingEmailByID(ctx context.Context, id int32) (*PendingEmail, error) {
+	row := q.db.QueryRowContext(ctx, "SELECT id, to_email, subject, body FROM pending_emails WHERE id = ?", id)
+	var p PendingEmail
+	err := row.Scan(&p.ID, &p.ToEmail, &p.Subject, &p.Body)
+	if err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// DeletePendingEmail removes an email from the queue.
+func (q *Queries) DeletePendingEmail(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, "DELETE FROM pending_emails WHERE id = ?", id)
+	return err
+}
+
 // ListUsers returns a limited set of users ordered by ID.
 type ListUsersParams struct {
 	Limit  int32

--- a/task_constants.go
+++ b/task_constants.go
@@ -186,6 +186,9 @@ const (
 	// TaskTestMail sends a test email to the current user.
 	TaskTestMail = "Test mail"
 
+	// TaskResend attempts to send queued emails immediately.
+	TaskResend = "Resend"
+
 	// TaskDismiss marks a notification as read.
 	TaskDismiss = "Dismiss"
 

--- a/templates/adminEmailQueuePage.gohtml
+++ b/templates/adminEmailQueuePage.gohtml
@@ -1,8 +1,10 @@
 {{ template "head" $ }}
+<form method="post">
 <table border="1">
-    <tr><th>ID</th><th>To</th><th>Subject</th><th>Created</th></tr>
+    <tr><th>Select</th><th>ID</th><th>To</th><th>Subject</th><th>Created</th></tr>
     {{- range .Emails }}
     <tr>
+        <td><input type="checkbox" name="id" value="{{ .ID }}"></td>
         <td>{{ .ID }}</td>
         <td>{{ .ToEmail }}</td>
         <td>{{ .Subject }}</td>
@@ -10,4 +12,7 @@
     </tr>
     {{- end }}
 </table>
+<input type="submit" name="task" value="Resend">
+<input type="submit" name="task" value="Delete">
+</form>
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- allow admins to resend or delete queued emails
- support deleting queued emails
- wire up email queue POST routes
- add Resend task constant

## Testing
- `go test ./...` *(fails: linkerAdminCategoriesPage.go:53:4: syntax error: unexpected semicolon in argument list; possibly missing comma or ))*

------
https://chatgpt.com/codex/tasks/task_e_6856a2564088832f82f7dd5cbd0027da