### PR TITLE
Add migration script for 0.0.2

### DIFF
--- a/linkerAdminCategoriesPage.go
+++ b/linkerAdminCategoriesPage.go
@@ -50,7 +50,8 @@ func linkerAdminCategoriesUpdatePage(w http.ResponseWriter, r *http.Request) {
 	if err := queries.RenameLinkerCategory(r.Context(), RenameLinkerCategoryParams{
 		Title:            sql.NullString{Valid: true, String: title},
 		Position:         int32(pos),
-  }; err != nil {
+		Idlinkercategory: int32(cid),
+	}); err != nil {
 		log.Printf("updateLinkerCategorySortOrder Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -93,7 +94,7 @@ func linkerAdminCategoriesDeletePage(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Category in use", http.StatusBadRequest)
 			return
 		}
-  }
+	}
 	count, err := queries.CountLinksByCategory(r.Context(), int32(cid))
 	if err != nil {
 		log.Printf("countLinks Error: %s", err)

--- a/migrations/0002.sql
+++ b/migrations/0002.sql
@@ -1,0 +1,56 @@
+-- Upgrade from schema version 1 (v0.0.1) to 2 (v0.0.2)
+-- Adds new notification and email queue tables and updates existing structures.
+
+-- Add page_size column to preferences if it doesn't exist
+ALTER TABLE preferences
+    ADD COLUMN IF NOT EXISTS page_size INT NOT NULL DEFAULT 15;
+
+-- Add position and sortorder columns to linkerCategory if they don't exist
+ALTER TABLE linkerCategory
+    ADD COLUMN IF NOT EXISTS position INT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS sortorder INT NOT NULL DEFAULT 0;
+
+-- Ensure blogs.written has a timestamp default
+ALTER TABLE blogs
+    MODIFY written DATETIME NOT NULL DEFAULT NOW();
+
+-- Drop obsolete sidTable
+DROP TABLE IF EXISTS sidTable;
+
+-- Core new tables for v0.0.2
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id INT NOT NULL AUTO_INCREMENT,
+    users_idusers INT NOT NULL,
+    item_type VARCHAR(32) NOT NULL,
+    target_id INT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS pending_emails (
+    id INT NOT NULL AUTO_INCREMENT,
+    to_email TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    sent_at DATETIME DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id INT NOT NULL AUTO_INCREMENT,
+    users_idusers INT NOT NULL,
+    link TEXT,
+    message TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    read_at DATETIME DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+
+-- Update schema version
+INSERT INTO schema_version (version) VALUES (2)
+    ON DUPLICATE KEY UPDATE version = VALUES(version);

--- a/queries-linker.sql.go
+++ b/queries-linker.sql.go
@@ -40,8 +40,13 @@ const createLinkerCategory = `-- name: CreateLinkerCategory :exec
 INSERT INTO linkerCategory (title, position) VALUES (?, ?)
 `
 
-func (q *Queries) CreateLinkerCategory(ctx context.Context, title sql.NullString, position int32) error {
-	_, err := q.db.ExecContext(ctx, createLinkerCategory, title, position)
+type CreateLinkerCategoryParams struct {
+	Title    sql.NullString
+	Position int32
+}
+
+func (q *Queries) CreateLinkerCategory(ctx context.Context, arg CreateLinkerCategoryParams) error {
+	_, err := q.db.ExecContext(ctx, createLinkerCategory, arg.Title, arg.Position)
 	return err
 }
 
@@ -111,25 +116,26 @@ func (q *Queries) DeleteLinkerQueuedItem(ctx context.Context, idlinkerqueue int3
 }
 
 const getAllLinkerCategories = `-- name: GetAllLinkerCategories :many
-SELECT idlinkercategory, title, position
+SELECT idlinkerCategory, title, position
 FROM linkerCategory
 ORDER BY position
-```
-const getAllLinkerCategoriesWithSortOrder = `-- name: GetAllLinkerCategoriesWithSortOrder :many
-SELECT idlinkerCategory, title, sortorder
-FROM linkerCategory
-ORDER BY sortorder
 `
 
-func (q *Queries) GetAllLinkerCategories(ctx context.Context) ([]*Linkercategory, error) {
+type GetAllLinkerCategoriesRow struct {
+	Idlinkercategory int32
+	Title            sql.NullString
+	Position         int32
+}
+
+func (q *Queries) GetAllLinkerCategories(ctx context.Context) ([]*GetAllLinkerCategoriesRow, error) {
 	rows, err := q.db.QueryContext(ctx, getAllLinkerCategories)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*Linkercategory
+	var items []*GetAllLinkerCategoriesRow
 	for rows.Next() {
-		var i Linkercategory
+		var i GetAllLinkerCategoriesRow
 		if err := rows.Scan(&i.Idlinkercategory, &i.Title, &i.Position); err != nil {
 			return nil, err
 		}
@@ -144,15 +150,27 @@ func (q *Queries) GetAllLinkerCategories(ctx context.Context) ([]*Linkercategory
 	return items, nil
 }
 
-func (q *Queries) GetAllLinkerCategoriesWithSortOrder(ctx context.Context) ([]*Linkercategory, error) {
-	rows, err := q.db.QueryContext(ctx, getAllLinkerCategories)
+const getAllLinkerCategoriesWithSortOrder = `-- name: GetAllLinkerCategoriesWithSortOrder :many
+SELECT idlinkerCategory, title, sortorder
+FROM linkerCategory
+ORDER BY sortorder
+`
+
+type GetAllLinkerCategoriesWithSortOrderRow struct {
+	Idlinkercategory int32
+	Title            sql.NullString
+	Sortorder        int32
+}
+
+func (q *Queries) GetAllLinkerCategoriesWithSortOrder(ctx context.Context) ([]*GetAllLinkerCategoriesWithSortOrderRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllLinkerCategoriesWithSortOrder)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*Linkercategory
+	var items []*GetAllLinkerCategoriesWithSortOrderRow
 	for rows.Next() {
-		var i Linkercategory
+		var i GetAllLinkerCategoriesWithSortOrderRow
 		if err := rows.Scan(&i.Idlinkercategory, &i.Title, &i.Sortorder); err != nil {
 			return nil, err
 		}
@@ -325,6 +343,49 @@ func (q *Queries) GetLinkerCategoriesWithCount(ctx context.Context) ([]*GetLinke
 	return items, nil
 }
 
+const getLinkerCategoryLinkCounts = `-- name: GetLinkerCategoryLinkCounts :many
+SELECT c.idlinkerCategory, c.title, c.position, COUNT(l.idlinker) as LinkCount
+FROM linkerCategory c
+LEFT JOIN linker l ON c.idlinkerCategory = l.linkerCategory_idlinkerCategory
+GROUP BY c.idlinkerCategory
+ORDER BY c.position
+`
+
+type GetLinkerCategoryLinkCountsRow struct {
+	Idlinkercategory int32
+	Title            sql.NullString
+	Position         int32
+	Linkcount        int64
+}
+
+func (q *Queries) GetLinkerCategoryLinkCounts(ctx context.Context) ([]*GetLinkerCategoryLinkCountsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getLinkerCategoryLinkCounts)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetLinkerCategoryLinkCountsRow
+	for rows.Next() {
+		var i GetLinkerCategoryLinkCountsRow
+		if err := rows.Scan(
+			&i.Idlinkercategory,
+			&i.Title,
+			&i.Position,
+			&i.Linkcount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending = `-- name: GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending :one
 SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linkercategory_idlinkercategory, l.forumthread_idforumthread, l.title, l.url, l.description, l.listed, u.username, lc.title
 FROM linker l
@@ -446,49 +507,6 @@ type RenameLinkerCategoryParams struct {
 func (q *Queries) RenameLinkerCategory(ctx context.Context, arg RenameLinkerCategoryParams) error {
 	_, err := q.db.ExecContext(ctx, renameLinkerCategory, arg.Title, arg.Position, arg.Idlinkercategory)
 	return err
-}
-
-const getLinkerCategoryLinkCounts = `-- name: GetLinkerCategoryLinkCounts :many
-SELECT c.idlinkerCategory, c.title, c.position, COUNT(l.idlinker) as LinkCount
-FROM linkerCategory c
-LEFT JOIN linker l ON c.idlinkerCategory = l.linkerCategory_idlinkerCategory
-GROUP BY c.idlinkerCategory
-ORDER BY c.position
-`
-
-type GetLinkerCategoryLinkCountsRow struct {
-	Idlinkercategory int32
-	Title            sql.NullString
-	Position         int32
-	Linkcount        int64
-}
-
-func (q *Queries) GetLinkerCategoryLinkCounts(ctx context.Context) ([]*GetLinkerCategoryLinkCountsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getLinkerCategoryLinkCounts)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*GetLinkerCategoryLinkCountsRow
-	for rows.Next() {
-		var i GetLinkerCategoryLinkCountsRow
-		if err := rows.Scan(
-			&i.Idlinkercategory,
-			&i.Title,
-			&i.Position,
-			&i.Linkcount,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }
 
 const selectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId = `-- name: SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId :execlastid

--- a/readme.md
+++ b/readme.md
@@ -167,6 +167,19 @@ Create a new file implementing this interface and add a case in
 dependencies should live behind a build tag. See `email_sendgrid.go` for an
 example provider built with the `sendgrid` tag.
 
+## Database Upgrades
+
+When upgrading from v0.0.1 use the SQL script under `migrations/0002.sql` to
+bring the database schema up to date. Apply it using the `mysql` command line
+tool:
+
+```bash
+mysql -u a4web -p a4web < migrations/0002.sql
+```
+
+The script adds new tables for notifications and email queues, updates existing
+columns and records the schema version.
+
 ## Admin tools
 
 ### Permission section checker


### PR DESCRIPTION
## Summary
- fix linker admin category handler syntax
- regenerate linker SQL to remove stray backticks
- add migration script for upgrading to v0.0.2
- document migration in README

## Testing
- `go test ./...` *(fails: adminForumFlaggedPostsPage redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_6856a2043914832f9dd378ae7ceec1a1