### PR TITLE
Improve config handling and add panic recovery

### DIFF
--- a/email_queue.go
+++ b/email_queue.go
@@ -8,6 +8,10 @@ import (
 
 // emailQueueWorker periodically sends pending emails using the provided provider.
 func emailQueueWorker(ctx context.Context, q *Queries, provider MailProvider, interval time.Duration) {
+	if q == nil || provider == nil {
+		log.Printf("email queue worker disabled: missing queue or provider")
+		return
+	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -22,6 +26,9 @@ func emailQueueWorker(ctx context.Context, q *Queries, provider MailProvider, in
 
 // processPendingEmail sends a single queued email if available.
 func processPendingEmail(ctx context.Context, q *Queries, provider MailProvider) {
+	if q == nil || provider == nil {
+		return
+	}
 	if !emailSendingEnabled() {
 		return
 	}

--- a/startup.go
+++ b/startup.go
@@ -15,8 +15,9 @@ var (
 	dbLogVerbosity int
 )
 
-func InitDB() *UserError {
-	cfg := loadDBConfig()
+// InitDB opens the database connection using the provided configuration
+// and ensures the schema exists.
+func InitDB(cfg DBConfig) *UserError {
 	dbLogVerbosity = cfg.LogVerbosity
 	if cfg.User == "" {
 		cfg.User = "a4web"
@@ -60,12 +61,12 @@ func InitDB() *UserError {
 }
 
 // checkDatabase attempts to connect and ping the configured database.
-func checkDatabase() *UserError {
-	return InitDB()
+func checkDatabase(cfg DBConfig) *UserError {
+	return InitDB(cfg)
 }
 
-func performStartupChecks() error {
-	if ue := checkDatabase(); ue != nil {
+func performStartupChecks(cfg DBConfig) error {
+	if ue := checkDatabase(cfg); ue != nil {
 		return fmt.Errorf("%s: %w", ue.ErrorMessage, ue.Err)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- load DB and email config once in `run`
- pass DB config into startup routines
- guard email queue worker against nil dependencies
- add `safeGo` helper to exit on goroutine panics

## Testing
- `go test ./...` *(fails: recordProvider redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_6856ac3cd6bc832fad7bfa7624fcdc30