### PR TITLE
Fix template date parsing

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"embed"
 	"html/template"
+	"io/fs"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -13,4 +15,23 @@ var testTemplates embed.FS
 func TestCompileGoHTML(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
 	template.Must(template.New("").Funcs(NewFuncs(r)).ParseFS(testTemplates, "templates/*.gohtml"))
+}
+
+func TestParseEachTemplate(t *testing.T) {
+	entries, err := fs.ReadDir(testTemplates, "templates")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".gohtml") {
+			continue
+		}
+		t.Run(e.Name(), func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/", nil)
+			path := "templates/" + e.Name()
+			if _, err := template.New("").Funcs(NewFuncs(r)).ParseFS(testTemplates, path); err != nil {
+				t.Errorf("failed to parse %s: %v", e.Name(), err)
+			}
+		})
+	}
 }

--- a/templates/forumAdminUserLevelPage.gohtml
+++ b/templates/forumAdminUserLevelPage.gohtml
@@ -11,7 +11,7 @@
                         <td><input type="hidden" name="uid" value="{{ .Idusers }}">{{ .Username.String }}
                         <td><input name="level" value="{{ .Level.Int32 }}" size="8">
                         <td><input name="inviteMax" value="{{ .Invitemax.Int32 }}" size="8">
-                        <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format \"2006-01-02\" }}{{ end }}">
+                        <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format "2006-01-02" }}{{ end }}">
                         <td>
                             <input type="submit" name="task" value="Update user level">
                             <input type="submit" name="task" value="Delete user level">

--- a/templates/forumAdminUserPage.gohtml
+++ b/templates/forumAdminUserPage.gohtml
@@ -22,7 +22,7 @@
                 <td>{{ with index $.Categories .ForumcategoryIdforumcategory }}{{ .Title.String }}{{ end }}</td>
                 <td><input name="level" value="{{ .Level.Int32 }}" size="8"></td>
                 <td><input name="inviteMax" value="{{ .Invitemax.Int32 }}" size="8"></td>
-                <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format \"2006-01-02\" }}{{ end }}"></td>
+                <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format "2006-01-02" }}{{ end }}"></td>
                 <td>
                     <input type="submit" name="task" value="Update user level">
                     <input type="submit" name="task" value="Delete user level">

--- a/templates/forumAdminUsersRestrictionsPage.gohtml
+++ b/templates/forumAdminUsersRestrictionsPage.gohtml
@@ -16,7 +16,7 @@
                     <td>{{ .Username.String }}<input type="hidden" name="uid" value="{{ .Idusers }}">
                     <td><input name="level" value="{{ .Level.Int32 }}" size="8">
                     <td><input name="inviteMax" value="{{ .Invitemax.Int32 }}" size="8">
-                    <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format \"2006-01-02\" }}{{ end }}">
+                    <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format "2006-01-02" }}{{ end }}">
                     <td>
                         <input type="submit" name="task" value="Update user level">
                         <input type="submit" name="task" value="Delete user level">


### PR DESCRIPTION
## Summary
- fix malformed date format in forum admin templates
- add tests that parse each template file to catch parse errors

## Testing
- `go test ./...` *(fails: recordProvider redeclared)*
- `go test ./config`

------
https://chatgpt.com/codex/tasks/task_e_6856ae2d4808832f88d83f37e7316fe4