### PR TITLE
Add admin conversation management

### DIFF
--- a/forumAdminThreadsPage.go
+++ b/forumAdminThreadsPage.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+)
+
+func forumAdminThreadsPage(w http.ResponseWriter, r *http.Request) {
+	type Group struct {
+		TopicTitle string
+		Threads    []*GetAllForumThreadsWithTopicRow
+	}
+	type Data struct {
+		*CoreData
+		Groups map[int32]*Group
+		Order  []int32
+	}
+
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+
+	rows, err := queries.GetAllForumThreadsWithTopic(r.Context())
+	if err != nil {
+		log.Printf("GetAllForumThreadsWithTopic: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	data := Data{
+		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		Groups:   make(map[int32]*Group),
+	}
+
+	for _, row := range rows {
+		g, ok := data.Groups[row.ForumtopicIdforumtopic]
+		if !ok {
+			g = &Group{TopicTitle: row.TopicTitle.String}
+			data.Groups[row.ForumtopicIdforumtopic] = g
+			data.Order = append(data.Order, row.ForumtopicIdforumtopic)
+		}
+		g.Threads = append(g.Threads, row)
+	}
+
+	CustomForumIndex(data.CoreData, r)
+
+	if err := renderTemplate(w, r, "forumAdminThreadsPage.gohtml", data); err != nil {
+		log.Printf("Template Error: %s", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}
+
+func forumAdminThreadDeletePage(w http.ResponseWriter, r *http.Request) {
+	threadID, err := strconv.Atoi(mux.Vars(r)["thread"])
+	if err != nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	topicID, err := strconv.Atoi(r.PostFormValue("topic"))
+	if err != nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	if err := ThreadDelete(r.Context(), queries, int32(threadID), int32(topicID)); err != nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	http.Redirect(w, r, "/forum/admin/conversations", http.StatusTemporaryRedirect)
+}

--- a/main.go
+++ b/main.go
@@ -288,6 +288,9 @@ func run() error {
 	fr.HandleFunc("/admin/category/delete", forumAdminCategoryDeletePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskDeleteCategory))
 	fr.HandleFunc("/admin/topics", forumAdminTopicsPage).Methods("GET").MatcherFunc(RequiredAccess("administrator"))
 	fr.HandleFunc("/admin/topics", taskDoneAutoRefreshPage).Methods("POST").MatcherFunc(RequiredAccess("administrator"))
+
+	fr.HandleFunc("/admin/conversations", forumAdminThreadsPage).Methods("GET").MatcherFunc(RequiredAccess("administrator"))
+	fr.HandleFunc("/admin/thread/{thread}/delete", forumAdminThreadDeletePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskForumThreadDelete))
 	fr.HandleFunc("/admin/topic/{topic}/edit", forumAdminTopicEditPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskForumTopicChange))
 	fr.HandleFunc("/admin/topic/{topic}/delete", forumAdminTopicDeletePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskForumTopicDelete))
 	fr.HandleFunc("/admin/topic", forumTopicCreatePage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskForumTopicCreate))

--- a/notify_thread_test.go
+++ b/notify_thread_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 )
 
-type recordProvider struct{ to string }
+type notifyRecordProvider struct{ to string }
 
-func (r *recordProvider) Send(ctx context.Context, to, subj, body string) error {
+func (r *notifyRecordProvider) Send(ctx context.Context, to, subj, body string) error {
 	r.to = to
 	return nil
 }
@@ -25,12 +25,12 @@ func TestNotifyThreadSubscribers(t *testing.T) {
 	rows := sqlmock.NewRows([]string{
 		"idcomments", "forumthread_idforumthread", "users_idusers", "language_idlanguage",
 		"written", "text", "idusers", "email", "passwd", "username",
-		"idpreferences", "language_idlanguage_2", "users_idusers_2", "emailforumupdates",
-	}).AddRow(1, 2, 2, 1, nil, "t", 2, "e", "p", "bob", 1, 1, 2, 1)
+		"idpreferences", "language_idlanguage_2", "users_idusers_2", "emailforumupdates", "page_size",
+	}).AddRow(1, 2, 2, 1, nil, "t", 2, "e", "p", "bob", 1, 1, 2, 1, 15)
 	mock.ExpectQuery(regexp.QuoteMeta(listUsersSubscribedToThread)).
 		WithArgs(int32(2), int32(1)).
 		WillReturnRows(rows)
-	rec := &recordProvider{}
+	rec := &notifyRecordProvider{}
 	notifyThreadSubscribers(context.Background(), rec, q, 2, 1, "/p")
 	if rec.to != "bob" {
 		t.Fatalf("expected mail to bob got %s", rec.to)

--- a/queries-forum.sql
+++ b/queries-forum.sql
@@ -151,3 +151,9 @@ DELETE FROM forumcategory WHERE idforumcategory = ?;
 DELETE FROM forumtopic WHERE idforumtopic = ?;
 
 
+-- name: GetAllForumThreadsWithTopic :many
+SELECT th.*, t.title AS topic_title
+FROM forumthread th
+LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic = t.idforumtopic
+ORDER BY t.idforumtopic, th.lastaddition DESC;
+

--- a/queries-forum.sql.go
+++ b/queries-forum.sql.go
@@ -179,6 +179,56 @@ func (q *Queries) GetAllForumCategoriesWithSubcategoryCount(ctx context.Context)
 	return items, nil
 }
 
+const getAllForumThreadsWithTopic = `-- name: GetAllForumThreadsWithTopic :many
+SELECT th.idforumthread, th.firstpost, th.lastposter, th.forumtopic_idforumtopic, th.comments, th.lastaddition, th.locked, t.title AS topic_title
+FROM forumthread th
+LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic = t.idforumtopic
+ORDER BY t.idforumtopic, th.lastaddition DESC
+`
+
+type GetAllForumThreadsWithTopicRow struct {
+	Idforumthread          int32
+	Firstpost              int32
+	Lastposter             int32
+	ForumtopicIdforumtopic int32
+	Comments               sql.NullInt32
+	Lastaddition           sql.NullTime
+	Locked                 sql.NullBool
+	TopicTitle             sql.NullString
+}
+
+func (q *Queries) GetAllForumThreadsWithTopic(ctx context.Context) ([]*GetAllForumThreadsWithTopicRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllForumThreadsWithTopic)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetAllForumThreadsWithTopicRow
+	for rows.Next() {
+		var i GetAllForumThreadsWithTopicRow
+		if err := rows.Scan(
+			&i.Idforumthread,
+			&i.Firstpost,
+			&i.Lastposter,
+			&i.ForumtopicIdforumtopic,
+			&i.Comments,
+			&i.Lastaddition,
+			&i.Locked,
+			&i.TopicTitle,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getAllForumTopics = `-- name: GetAllForumTopics :many
 SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.title, t.description, t.threads, t.comments, t.lastaddition
 FROM forumtopic t
@@ -241,8 +291,8 @@ type GetAllForumTopicsByCategoryIdForUserWithLastPosterNameRow struct {
 	Threads                      sql.NullInt32
 	Comments                     sql.NullInt32
 	Lastaddition                 sql.NullTime
-        Lastposterusername           sql.NullString
-       ExpiresAt                    sql.NullTime
+	Lastposterusername           sql.NullString
+	ExpiresAt                    sql.NullTime
 }
 
 func (q *Queries) GetAllForumTopicsByCategoryIdForUserWithLastPosterName(ctx context.Context, arg GetAllForumTopicsByCategoryIdForUserWithLastPosterNameParams) ([]*GetAllForumTopicsByCategoryIdForUserWithLastPosterNameRow, error) {
@@ -262,10 +312,10 @@ func (q *Queries) GetAllForumTopicsByCategoryIdForUserWithLastPosterName(ctx con
 			&i.Description,
 			&i.Threads,
 			&i.Comments,
-                        &i.Lastaddition,
-                        &i.Lastposterusername,
-                        &i.ExpiresAt,
-                ); err != nil {
+			&i.Lastaddition,
+			&i.Lastposterusername,
+			&i.ExpiresAt,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -299,9 +349,9 @@ type GetAllForumTopicsForUserRow struct {
 	Comments                     sql.NullInt32
 	Lastaddition                 sql.NullTime
 	Lastposterusername           sql.NullString
-        Seelevel                     sql.NullInt32
-        Level                        sql.NullInt32
-       ExpiresAt                    sql.NullTime
+	Seelevel                     sql.NullInt32
+	Level                        sql.NullInt32
+	ExpiresAt                    sql.NullTime
 }
 
 func (q *Queries) GetAllForumTopicsForUser(ctx context.Context, usersIdusers int32) ([]*GetAllForumTopicsForUserRow, error) {
@@ -322,11 +372,11 @@ func (q *Queries) GetAllForumTopicsForUser(ctx context.Context, usersIdusers int
 			&i.Threads,
 			&i.Comments,
 			&i.Lastaddition,
-                        &i.Lastposterusername,
-                        &i.Seelevel,
-                        &i.Level,
-                        &i.ExpiresAt,
-                ); err != nil {
+			&i.Lastposterusername,
+			&i.Seelevel,
+			&i.Level,
+			&i.ExpiresAt,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -365,9 +415,9 @@ type GetAllForumTopicsForUserWithPermissionsRestrictionsAndTopicRow struct {
 	UsersIdusers                 int32
 	ForumtopicIdforumtopic       int32
 	Level                        sql.NullInt32
-       Invitemax                    sql.NullInt32
-       ExpiresAt                    sql.NullTime
-       ForumtopicIdforumtopic_2     int32
+	Invitemax                    sql.NullInt32
+	ExpiresAt                    sql.NullTime
+	ForumtopicIdforumtopic_2     int32
 	Viewlevel                    sql.NullInt32
 	Replylevel                   sql.NullInt32
 	Newthreadlevel               sql.NullInt32
@@ -402,10 +452,10 @@ func (q *Queries) GetAllForumTopicsForUserWithPermissionsRestrictionsAndTopic(ct
 			&i.Lastaddition,
 			&i.UsersIdusers,
 			&i.ForumtopicIdforumtopic,
-                        &i.Level,
-                        &i.Invitemax,
-                        &i.ExpiresAt,
-                        &i.ForumtopicIdforumtopic_2,
+			&i.Level,
+			&i.Invitemax,
+			&i.ExpiresAt,
+			&i.ForumtopicIdforumtopic_2,
 			&i.Viewlevel,
 			&i.Replylevel,
 			&i.Newthreadlevel,
@@ -452,9 +502,9 @@ type GetAllForumTopicsWithPermissionsAndTopicRow struct {
 	UsersIdusers                 int32
 	ForumtopicIdforumtopic       int32
 	Level                        sql.NullInt32
-        Invitemax                    sql.NullInt32
-       ExpiresAt                    sql.NullTime
-        ForumtopicIdforumtopic_2     sql.NullInt32
+	Invitemax                    sql.NullInt32
+	ExpiresAt                    sql.NullTime
+	ForumtopicIdforumtopic_2     sql.NullInt32
 	Viewlevel                    sql.NullInt32
 	Replylevel                   sql.NullInt32
 	Newthreadlevel               sql.NullInt32
@@ -489,10 +539,10 @@ func (q *Queries) GetAllForumTopicsWithPermissionsAndTopic(ctx context.Context) 
 			&i.Lastaddition,
 			&i.UsersIdusers,
 			&i.ForumtopicIdforumtopic,
-                        &i.Level,
-                        &i.Invitemax,
-                        &i.ExpiresAt,
-                        &i.ForumtopicIdforumtopic_2,
+			&i.Level,
+			&i.Invitemax,
+			&i.ExpiresAt,
+			&i.ForumtopicIdforumtopic_2,
 			&i.Viewlevel,
 			&i.Replylevel,
 			&i.Newthreadlevel,
@@ -742,20 +792,20 @@ ON DUPLICATE KEY UPDATE level = VALUES(level), invitemax = VALUES(invitemax), ex
 `
 
 type UpsertUsersForumTopicLevelPermissionParams struct {
-        ForumtopicIdforumtopic int32
-        UsersIdusers           int32
-        Level                  sql.NullInt32
-        Invitemax              sql.NullInt32
-       ExpiresAt              sql.NullTime
+	ForumtopicIdforumtopic int32
+	UsersIdusers           int32
+	Level                  sql.NullInt32
+	Invitemax              sql.NullInt32
+	ExpiresAt              sql.NullTime
 }
 
 func (q *Queries) UpsertUsersForumTopicLevelPermission(ctx context.Context, arg UpsertUsersForumTopicLevelPermissionParams) error {
-        _, err := q.db.ExecContext(ctx, upsertUsersForumTopicLevelPermission,
-                arg.ForumtopicIdforumtopic,
-                arg.UsersIdusers,
-                arg.Level,
-                arg.Invitemax,
-               arg.ExpiresAt,
-        )
-        return err
+	_, err := q.db.ExecContext(ctx, upsertUsersForumTopicLevelPermission,
+		arg.ForumtopicIdforumtopic,
+		arg.UsersIdusers,
+		arg.Level,
+		arg.Invitemax,
+		arg.ExpiresAt,
+	)
+	return err
 }

--- a/queries-threads.sql
+++ b/queries-threads.sql
@@ -62,3 +62,7 @@ ORDER BY t.lastaddition DESC;
 -- name: MakeThread :execlastid
 INSERT INTO forumthread (forumtopic_idforumtopic) VALUES (?);
 
+
+-- name: DeleteForumThread :exec
+DELETE FROM forumthread WHERE idforumthread = ?;
+

--- a/queries-threads.sql.go
+++ b/queries-threads.sql.go
@@ -10,6 +10,15 @@ import (
 	"database/sql"
 )
 
+const deleteForumThread = `-- name: DeleteForumThread :exec
+DELETE FROM forumthread WHERE idforumthread = ?
+`
+
+func (q *Queries) DeleteForumThread(ctx context.Context, idforumthread int32) error {
+	_, err := q.db.ExecContext(ctx, deleteForumThread, idforumthread)
+	return err
+}
+
 const getThreadByIdForUserByIdWithLastPoserUserNameAndPermissions = `-- name: GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissions :one
 SELECT th.idforumthread, th.firstpost, th.lastposter, th.forumtopic_idforumtopic, th.comments, th.lastaddition, th.locked, lu.username AS LastPosterUsername, r.seelevel, u.level
 FROM forumthread th

--- a/task_constants.go
+++ b/task_constants.go
@@ -82,6 +82,9 @@ const (
 	// TaskForumTopicDelete removes a forum topic.
 	TaskForumTopicDelete = "Forum topic delete"
 
+	// TaskForumThreadDelete removes a forum thread.
+	TaskForumThreadDelete = "Forum thread delete"
+
 	// TaskLogin performs a user login.
 	TaskLogin = "Login"
 

--- a/templates/forumAdminPage.gohtml
+++ b/templates/forumAdminPage.gohtml
@@ -3,6 +3,7 @@
 <ul>
     <li><a href="/forum/admin/categories">Manage Categories</a></li>
     <li><a href="/forum/admin/topics">Manage Topics</a></li>
+    <li><a href="/forum/admin/conversations">Manage Conversations</a></li>
     <li><a href="/forum/admin/users">Manage Users</a></li>
     <li><a href="/forum/admin/restrictions/users">User Restrictions</a></li>
     <li><a href="/forum/admin/restrictions/topics">Topic Restrictions</a></li>

--- a/templates/forumAdminThreadsPage.gohtml
+++ b/templates/forumAdminThreadsPage.gohtml
@@ -1,0 +1,23 @@
+{{ template "head" $ }}
+{{ range $idx, $tid := .Order }}
+    {{ $grp := index $.Groups $tid }}
+    <h2>{{ $grp.TopicTitle }}</h2>
+    <table border="1">
+        <tr><th>ID<th>Posts<th>Last Addition<th>View<th>Delete</tr>
+        {{ range $grp.Threads }}
+            <tr>
+                <td>{{ .Idforumthread }}</td>
+                <td>{{ .Comments.Int32 }}</td>
+                <td>{{ .Lastaddition.Time }}</td>
+                <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic }}/thread/{{ .Idforumthread }}">View</a></td>
+                <td>
+                    <form method="post" action="/forum/admin/thread/{{ .Idforumthread }}/delete" style="display:inline">
+                        <input type="hidden" name="topic" value="{{ .ForumtopicIdforumtopic }}">
+                        <input type="submit" name="task" value="Forum thread delete">
+                    </form>
+                </td>
+            </tr>
+        {{ end }}
+    </table>
+{{ end }}
+{{ template "tail" $ }}

--- a/templates/forumAdminUserLevelPage.gohtml
+++ b/templates/forumAdminUserLevelPage.gohtml
@@ -11,7 +11,7 @@
                         <td><input type="hidden" name="uid" value="{{ .Idusers }}">{{ .Username.String }}
                         <td><input name="level" value="{{ .Level.Int32 }}" size="8">
                         <td><input name="inviteMax" value="{{ .Invitemax.Int32 }}" size="8">
-                        <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format \"2006-01-02\" }}{{ end }}">
+                        <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format "2006-01-02" }}{{ end }}">
                         <td>
                             <input type="submit" name="task" value="Update user level">
                             <input type="submit" name="task" value="Delete user level">

--- a/templates/forumAdminUserPage.gohtml
+++ b/templates/forumAdminUserPage.gohtml
@@ -22,7 +22,7 @@
                 <td>{{ with index $.Categories .ForumcategoryIdforumcategory }}{{ .Title.String }}{{ end }}</td>
                 <td><input name="level" value="{{ .Level.Int32 }}" size="8"></td>
                 <td><input name="inviteMax" value="{{ .Invitemax.Int32 }}" size="8"></td>
-                <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format \"2006-01-02\" }}{{ end }}"></td>
+                <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format "2006-01-02" }}{{ end }}"></td>
                 <td>
                     <input type="submit" name="task" value="Update user level">
                     <input type="submit" name="task" value="Delete user level">

--- a/templates/forumAdminUsersRestrictionsPage.gohtml
+++ b/templates/forumAdminUsersRestrictionsPage.gohtml
@@ -16,7 +16,7 @@
                     <td>{{ .Username.String }}<input type="hidden" name="uid" value="{{ .Idusers }}">
                     <td><input name="level" value="{{ .Level.Int32 }}" size="8">
                     <td><input name="inviteMax" value="{{ .Invitemax.Int32 }}" size="8">
-                    <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format \"2006-01-02\" }}{{ end }}">
+                    <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format "2006-01-02" }}{{ end }}">
                     <td>
                         <input type="submit" name="task" value="Update user level">
                         <input type="submit" name="task" value="Delete user level">

--- a/thread_delete.go
+++ b/thread_delete.go
@@ -1,0 +1,11 @@
+package main
+
+import "context"
+
+// ThreadDelete removes a forum thread and updates topic statistics.
+func ThreadDelete(ctx context.Context, q *Queries, threadID, topicID int32) error {
+	if err := q.DeleteForumThread(ctx, threadID); err != nil {
+		return err
+	}
+	return q.RebuildForumTopicByIdMetaColumns(ctx, topicID)
+}

--- a/thread_delete_test.go
+++ b/thread_delete_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestThreadDelete(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	q := New(db)
+	mock.ExpectExec("DeleteForumThread").
+		WithArgs(int32(1)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("RebuildForumTopicByIdMetaColumns").
+		WithArgs(int32(2)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	if err := ThreadDelete(context.Background(), q, 1, 2); err != nil {
+		t.Fatalf("ThreadDelete: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add const for deleting forum threads
- support listing forum threads grouped by topic for admin
- allow deleting a thread and update topic metadata
- wire up routes and menu link
- fix template date formatting
- adjust notify thread test for updated schema

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6856a8ca0e78832f8794f0424d3a8604