### PR TITLE
Handle invalid sessions gracefully

### DIFF
--- a/core.go
+++ b/core.go
@@ -40,10 +40,13 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		session, err := GetSession(request)
 		if err != nil {
-			http.Error(writer, "Internal Server Error", http.StatusInternalServerError)
-			return
+			log.Printf("core middleware session: %v", err)
+			clearSession(writer, request)
 		}
-		uid, _ := session.Values["UID"].(int32)
+		var uid int32
+		if err == nil {
+			uid, _ = session.Values["UID"].(int32)
+		}
 		queries := request.Context().Value(ContextValues("queries")).(*Queries)
 
 		level := "reader"

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/sessions"
+)
+
+func TestCoreAdderMiddlewareBadSession(t *testing.T) {
+	store = sessions.NewCookieStore([]byte("test"))
+	h := CoreAdderMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: sessionName, Value: "bad"})
+	ctx := context.WithValue(req.Context(), ContextValues("queries"), New(nil))
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	sc := rr.Header().Get("Set-Cookie")
+	if !strings.Contains(sc, "Max-Age=0") {
+		t.Errorf("expected cleared cookie, got %q", sc)
+	}
+}
+
+func TestGetSessionOrFailBadSession(t *testing.T) {
+	store = sessions.NewCookieStore([]byte("test"))
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: sessionName, Value: "bad"})
+	rr := httptest.NewRecorder()
+	sess, ok := GetSessionOrFail(rr, req)
+	if ok {
+		t.Fatalf("expected failure, got session %v", sess)
+	}
+	if rr.Code != http.StatusFound {
+		t.Fatalf("expected redirect got %d", rr.Code)
+	}
+	sc := rr.Header().Get("Set-Cookie")
+	if !strings.Contains(sc, "Max-Age=0") {
+		t.Errorf("expected cleared cookie, got %q", sc)
+	}
+	loc := rr.Header().Get("Location")
+	if loc != "/login" {
+		t.Errorf("unexpected location %q", loc)
+	}
+}

--- a/userLogoutPage.go
+++ b/userLogoutPage.go
@@ -17,8 +17,8 @@ func userLogoutPage(w http.ResponseWriter, r *http.Request) {
 
 	session, err := GetSession(r)
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
+		log.Printf("logout get session: %v", err)
+		clearSession(w, r)
 	}
 	delete(session.Values, "UID")
 	delete(session.Values, "LoginTime")


### PR DESCRIPTION
## Summary
- guard against session store errors by clearing the session cookie and redirecting to login
- log bad session events in middleware, logout handler, and session getter
- add regression tests for invalid session cookies

## Testing
- `go test ./...` *(fails: recordProvider redeclared in notify_thread_test.go)*

------
https://chatgpt.com/codex/tasks/task_e_6856b02da9ac832fa9698535ec4e5cbc