### PR TITLE
Add admin server stats page

### DIFF
--- a/adminServerStatsPage.go
+++ b/adminServerStatsPage.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"runtime"
+)
+
+func adminServerStatsPage(w http.ResponseWriter, r *http.Request) {
+	type Stats struct {
+		Goroutines int
+		Alloc      uint64
+		TotalAlloc uint64
+		Sys        uint64
+		HeapAlloc  uint64
+		HeapSys    uint64
+		NumGC      uint32
+	}
+
+	type Data struct {
+		*CoreData
+		Stats Stats
+	}
+
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+
+	data := Data{
+		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		Stats: Stats{
+			Goroutines: runtime.NumGoroutine(),
+			Alloc:      mem.Alloc,
+			TotalAlloc: mem.TotalAlloc,
+			Sys:        mem.Sys,
+			HeapAlloc:  mem.HeapAlloc,
+			HeapSys:    mem.HeapSys,
+			NumGC:      mem.NumGC,
+		},
+	}
+
+	if err := renderTemplate(w, r, "adminServerStatsPage.gohtml", data); err != nil {
+		log.Printf("Template Error: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/main.go
+++ b/main.go
@@ -470,6 +470,7 @@ func run() error {
 	ar.HandleFunc("/permissions/sections", adminPermissionsSectionRenamePage).Methods("POST").MatcherFunc(TaskMatcher(TaskRenameSection))
 	ar.HandleFunc("/email/queue", adminEmailQueuePage).Methods("GET")
 	ar.HandleFunc("/notifications", adminNotificationsPage).Methods("GET")
+	ar.HandleFunc("/stats", adminServerStatsPage).Methods("GET")
 	ar.HandleFunc("/search", adminSearchPage).Methods("GET")
 	ar.HandleFunc("/search", adminSearchRemakeCommentsSearchPage).Methods("POST").MatcherFunc(TaskMatcher(TaskRemakeCommentsSearch))
 	ar.HandleFunc("/search", adminSearchRemakeNewsSearchPage).Methods("POST").MatcherFunc(TaskMatcher(TaskRemakeNewsSearch))

--- a/templates/adminPage.gohtml
+++ b/templates/adminPage.gohtml
@@ -9,6 +9,7 @@
     <li><a href="/admin/permissions/sections">Permission Sections</a></li>
     <li><a href="/admin/email/queue">Queued Emails</a></li>
     <li><a href="/admin/notifications">Notifications</a></li>
+    <li><a href="/admin/stats">Server Stats</a></li>
 </ul>
 
 <p>Site statistics:</p>

--- a/templates/adminServerStatsPage.gohtml
+++ b/templates/adminServerStatsPage.gohtml
@@ -1,0 +1,13 @@
+{{ template "head" $ }}
+<h2>Server Runtime Statistics</h2>
+<table border="1">
+    <tr><th>Metric</th><th>Value</th></tr>
+    <tr><td>Goroutines</td><td>{{ .Stats.Goroutines }}</td></tr>
+    <tr><td>Alloc</td><td>{{ .Stats.Alloc }}</td></tr>
+    <tr><td>Total Alloc</td><td>{{ .Stats.TotalAlloc }}</td></tr>
+    <tr><td>System</td><td>{{ .Stats.Sys }}</td></tr>
+    <tr><td>Heap Alloc</td><td>{{ .Stats.HeapAlloc }}</td></tr>
+    <tr><td>Heap Sys</td><td>{{ .Stats.HeapSys }}</td></tr>
+    <tr><td>GC Count</td><td>{{ .Stats.NumGC }}</td></tr>
+</table>
+{{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- add /admin/stats route and handler
- gather runtime stats from `runtime` package
- render stats in new `adminServerStatsPage.gohtml`
- link stats page from admin landing page

## Testing
- `go test ./...` *(fails: build errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_6856a23975d8832f96cd5603d54df0ab