### PR TITLE
Wrap startup errors; document error policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,5 @@ provided by the `io/fs` package or mocks when file access is required.
 
 SQL query files are compiled using `sqlc`. Do not manually edit the generated
 `*.sql.go` files; instead update the corresponding `.sql` file and run `sqlc generate`.
+
+- Errors in critical functions like main() or run() must be logged or wrapped using fmt.Errorf with context. Prefer doing both when the error propagates.

--- a/main.go
+++ b/main.go
@@ -183,7 +183,7 @@ func run() error {
 	emailCfg := loadEmailConfig()
 
 	if err := performStartupChecks(dbCfg); err != nil {
-		return err
+		return fmt.Errorf("startup checks: %w", err)
 	}
 
 	if dbPool != nil {

--- a/postupdate.go
+++ b/postupdate.go
@@ -1,6 +1,9 @@
 package main
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // PostUpdate refreshes metadata on the given forum thread and topic.
 // It recalculates thread counters and rebuilds the topic aggregates.
@@ -21,10 +24,10 @@ import "context"
 // and RebuildForumTopicByIdMetaColumns generated via sqlc.
 func PostUpdate(ctx context.Context, q *Queries, threadID, topicID int32) error {
 	if err := q.RecalculateForumThreadByIdMetaData(ctx, threadID); err != nil {
-		return err
+		return fmt.Errorf("recalc thread metadata: %w", err)
 	}
 	if err := q.RebuildForumTopicByIdMetaColumns(ctx, topicID); err != nil {
-		return err
+		return fmt.Errorf("rebuild topic metadata: %w", err)
 	}
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"github.com/gorilla/sessions"
 	"log"
 	"net"
@@ -29,12 +30,15 @@ func (s *Server) Addr() string { return s.addr }
 func (s *Server) Start(addr string) error {
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
-		return err
+		return fmt.Errorf("listen %s: %w", addr, err)
 	}
 	s.addr = ln.Addr().String()
 	s.httpServer = &http.Server{Handler: s.Router}
 	log.Printf("Server started on http://%s", s.addr)
-	return s.httpServer.Serve(ln)
+	if err := s.httpServer.Serve(ln); err != nil {
+		return fmt.Errorf("serve: %w", err)
+	}
+	return nil
 }
 
 // Shutdown gracefully stops the HTTP server.
@@ -42,5 +46,8 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	if s.httpServer == nil {
 		return nil
 	}
-	return s.httpServer.Shutdown(ctx)
+	if err := s.httpServer.Shutdown(ctx); err != nil {
+		return fmt.Errorf("shutdown server: %w", err)
+	}
+	return nil
 }

--- a/startup.go
+++ b/startup.go
@@ -75,15 +75,15 @@ func performStartupChecks(cfg DBConfig) error {
 // ensureSchema creates core tables if they do not exist and inserts a version row.
 func ensureSchema(ctx context.Context, db *sql.DB) error {
 	if _, err := db.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)"); err != nil {
-		return err
+		return fmt.Errorf("create schema_version: %w", err)
 	}
 	var count int
 	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM schema_version").Scan(&count); err != nil {
-		return err
+		return fmt.Errorf("count schema_version: %w", err)
 	}
 	if count == 0 {
 		if _, err := db.ExecContext(ctx, "INSERT INTO schema_version (version) VALUES (1)"); err != nil {
-			return err
+			return fmt.Errorf("insert schema_version: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
- note error handling requirement in AGENTS
- wrap startup check errors with fmt.Errorf for context
- add fmt.Errorf context in server start/shutdown and schema operations
- provide context for post update failures

## Testing
- `go test ./...` *(fails: securecookie base64 decode errors)*

------
https://chatgpt.com/codex/tasks/task_e_685738546370832fb638daaea46d6b5e