### PR TITLE
Add admin categories overview page

### DIFF
--- a/adminCategoriesPage.go
+++ b/adminCategoriesPage.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"log"
+	"net/http"
+)
+
+func adminCategoriesPage(w http.ResponseWriter, r *http.Request) {
+	type Data struct {
+		*CoreData
+		Section           string
+		ForumCategories   []*GetAllGetAllForumCategoriesWithSubcategoryCountRow
+		WritingCategories []*Writingcategory
+		LinkerCategories  []*GetLinkerCategoryLinkCountsRow
+	}
+
+	data := Data{
+		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		Section:  r.URL.Query().Get("section"),
+	}
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+
+	if data.Section == "" || data.Section == "forum" {
+		rows, err := queries.GetAllGetAllForumCategoriesWithSubcategoryCount(r.Context())
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			log.Printf("adminCategories forum: %v", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		data.ForumCategories = rows
+	}
+	if data.Section == "" || data.Section == "writings" {
+		rows, err := queries.FetchAllCategories(r.Context())
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			log.Printf("adminCategories writings: %v", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		data.WritingCategories = rows
+	}
+	if data.Section == "" || data.Section == "linker" {
+		rows, err := queries.GetLinkerCategoryLinkCounts(r.Context())
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			log.Printf("adminCategories linker: %v", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		data.LinkerCategories = rows
+	}
+
+	if err := renderTemplate(w, r, "adminCategoriesPage.gohtml", data); err != nil {
+		log.Printf("Template Error: %s", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/main.go
+++ b/main.go
@@ -466,6 +466,7 @@ func run() error {
 	ar.HandleFunc("/languages", adminLanguagesRenamePage).Methods("POST").MatcherFunc(TaskMatcher(TaskRenameLanguage))
 	ar.HandleFunc("/languages", adminLanguagesDeletePage).Methods("POST").MatcherFunc(TaskMatcher(TaskDeleteLanguage))
 	ar.HandleFunc("/languages", adminLanguagesCreatePage).Methods("POST").MatcherFunc(TaskMatcher(TaskCreateLanguage))
+	ar.HandleFunc("/categories", adminCategoriesPage).Methods("GET")
 	ar.HandleFunc("/permissions/sections", adminPermissionsSectionPage).Methods("GET")
 	ar.HandleFunc("/permissions/sections", adminPermissionsSectionRenamePage).Methods("POST").MatcherFunc(TaskMatcher(TaskRenameSection))
 	ar.HandleFunc("/email/queue", adminEmailQueuePage).Methods("GET")

--- a/templates/adminCategoriesPage.gohtml
+++ b/templates/adminCategoriesPage.gohtml
@@ -1,0 +1,138 @@
+{{ template "head" $ }}
+<form method="get">
+    <label>Section:</label>
+    <select name="section">
+        <option value="" {{ if eq .Section "" }}selected{{ end }}>All</option>
+        <option value="forum" {{ if eq .Section "forum" }}selected{{ end }}>Forum</option>
+        <option value="writings" {{ if eq .Section "writings" }}selected{{ end }}>Writings</option>
+        <option value="linker" {{ if eq .Section "linker" }}selected{{ end }}>Linker</option>
+    </select>
+    <input type="submit" value="Filter">
+</form>
+
+{{ if or (eq .Section "" ) (eq .Section "forum") }}
+<h2>Forum Categories</h2>
+<table border="1">
+    <tr>
+        <th>ID</th>
+        <th>Parent ID</th>
+        <th>Title</th>
+        <th>Description</th>
+        <th>Child Category Count</th>
+        <th>Topic Count</th>
+        <th>Options</th>
+    </tr>
+    {{ range .ForumCategories }}
+    <tr>
+        <form method="post" action="/forum/admin/category/{{ .Idforumcategory }}">
+            <td>{{ .Idforumcategory }}</td>
+            <td>{{ $fcid := .ForumcategoryIdforumcategory }} {{ $fcid }} <select name="pcid" value="{{ .ForumcategoryIdforumcategory }}"><option value="0">None</option>{{ range $.ForumCategories }}<option value="{{.Idforumcategory}}" {{if eq $fcid .Idforumcategory}}selected{{end}}>{{.Title.String}}</option>{{ end }}</select></td>
+            <td><input name="name" value="{{ .Title.String }}"></td>
+            <td><textarea name="desc">{{ .Description.String }}</textarea></td>
+            <td>{{ .Subcategorycount }}</td>
+            <td>{{ .Topiccount }}</td>
+            <td>
+                <input type="hidden" name="cid" value="{{ .Idforumcategory }}">
+                <input type="submit" name="task" value="Forum category change">
+                {{ if eq .Topiccount 0 }}<input type="submit" name="task" formaction="/forum/admin/category/delete" value="Delete Category">{{ end }}
+            </td>
+        </form>
+    </tr>
+    {{ end }}
+    <tr>
+        <form method="post" action="/forum/admin/category">
+            <td>NEW</td>
+            <td><select name="pcid" value=""><option value="0">None</option>{{ range $.ForumCategories }}<option value="{{.Idforumcategory}}">{{.Title.String}}</option>{{ end }}</select></td>
+            <td><input name="name" value=""></td>
+            <td><textarea name="desc"></textarea></td>
+            <td>TBA</td>
+            <td>0</td>
+            <td><input type="submit" name="task" value="Forum category create"></td>
+        </form>
+    </tr>
+</table>
+{{ end }}
+
+{{ if or (eq .Section "" ) (eq .Section "writings") }}
+<h2>Writing Categories</h2>
+<table border="1">
+    <tr>
+        <th>ID</th>
+        <th>Parent ID</th>
+        <th>Title</th>
+        <th>Description</th>
+        <th>Options</th>
+    </tr>
+    {{ range .WritingCategories }}
+    <tr>
+        <form method="post" action="/writings/admin/category">
+            <td><input type="hidden" name="wcid" value="{{ .Idwritingcategory }}">{{ .Idwritingcategory }}</td>
+            <td>{{ $fcid := .WritingcategoryIdwritingcategory }} {{ $fcid }} <select name="pcid" value="{{ .WritingcategoryIdwritingcategory }}"><option value="0">None</option>{{ range $.WritingCategories }}<option value="{{.Idwritingcategory}}" {{if eq $fcid .Idwritingcategory}}selected{{end}}>{{.Title.String}}</option>{{ end }}</select></td>
+            <td><input name="name" value="{{ .Title.String }}"></td>
+            <td><textarea name="desc">{{ .Description.String }}</textarea></td>
+            <td>
+                <input type="hidden" name="cid" value="{{ .Idwritingcategory }}">
+                <input type="submit" name="task" value="writing category change">
+                <br><a href="/admin/category/{{ .Idwritingcategory }}/permissions">Permissions</a>
+            </td>
+        </form>
+    </tr>
+    {{ end }}
+    <tr>
+        <form method="post" action="/writings/admin/category">
+            <td>NEW</td>
+            <td><select name="pcid" value=""><option value="0">None</option>{{ range $.WritingCategories }}<option value="{{.Idwritingcategory}}">{{.Title.String}}</option>{{ end }}</select></td>
+            <td><input name="name" value=""></td>
+            <td><textarea name="desc"></textarea></td>
+            <td><input type="submit" name="task" value="writing category create"></td>
+        </form>
+    </tr>
+</table>
+{{ end }}
+
+{{ if or (eq .Section "" ) (eq .Section "linker") }}
+<h2>Linker Categories</h2>
+<table>
+    <tr>
+        <th>ID</th>
+        <th>Order</th>
+        <th>Title</th>
+        <th>Links</th>
+        <th>Options</th>
+    </tr>
+    {{- range .LinkerCategories }}
+    <tr>
+        <td>{{ .Idlinkercategory }}</td>
+        <td>
+            <form method="post" action="/linker/admin/categories">
+                <input type="hidden" name="cid" value="{{ .Idlinkercategory }}">
+                <input type="number" name="position" value="{{ .Position }}" size="3">
+        </td>
+        <td><input name="title" value="{{ .Title.String }}"></td>
+        <td>{{ .Linkcount }}</td>
+        <td>
+            <input type="submit" name="task" value="Update">
+            <input type="submit" name="task" value="Rename Category">
+            {{ if eq .Linkcount 0 }}<input type="submit" name="task" value="Delete Category">{{ end }}
+            </form>
+        </td>
+    </tr>
+    {{- end }}
+    <tr>
+        <td>NEW</td>
+        <td></td>
+        <td>
+            <form method="post" action="/linker/admin/categories">
+                <input name="title" value="">
+        </td>
+        <td>0</td>
+        <td>
+            <input name="order" type="number" value="0" style="width:4em">
+            <input type="submit" name="task" value="Create Category">
+            </form>
+        </td>
+    </tr>
+</table>
+{{ end }}
+
+{{ template "tail" $ }}

--- a/templates/adminPage.gohtml
+++ b/templates/adminPage.gohtml
@@ -4,6 +4,7 @@
     <li><a href="/admin/users">Users</a></li>
     <li><a href="/admin/users/permissions">User Permissions</a></li>
     <li><a href="/admin/languages">Languages</a></li>
+    <li><a href="/admin/categories">Categories</a></li>
     <li><a href="/admin/search">Search</a></li>
     <li><a href="/admin/forum">Forum</a></li>
     <li><a href="/admin/permissions/sections">Permission Sections</a></li>


### PR DESCRIPTION
## Summary
- implement `adminCategoriesPage` with forum, writings and linker sections
- create template for categories filter and editing
- link the page from admin dashboard
- expose `/admin/categories` route

## Testing
- `go test ./...` *(fails: linkerAdminCategoriesPage.go:53:4: syntax error: unexpected semicolon...)*

------
https://chatgpt.com/codex/tasks/task_e_6856a2cfc0d4832f9f3375714e3837b8