### PR TITLE
Compute reply/edit permissions

### DIFF
--- a/linkerCommentsPage.go
+++ b/linkerCommentsPage.go
@@ -37,10 +37,11 @@ func linkerCommentsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
-		CanReply: true,  // TODO
-		CanEdit:  false, // TODO
+		CoreData: cd,
+		CanReply: cd.UserID != 0,
+		CanEdit:  false,
 		Offset:   offset,
 	}
 
@@ -70,6 +71,7 @@ func linkerCommentsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data.Link = link
+	data.CanEdit = cd.HasRole("administrator") || uid == link.UsersIdusers
 
 	commentRows, err := queries.GetCommentsByThreadIdForUser(r.Context(), GetCommentsByThreadIdForUserParams{
 		UsersIdusers:             uid,

--- a/linkerShowPage.go
+++ b/linkerShowPage.go
@@ -19,9 +19,10 @@ func linkerShowPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int
 	}
 
+	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
-		CanReply: true, // TODO
+		CoreData: cd,
+		CanReply: cd.UserID != 0,
 	}
 
 	vars := mux.Vars(r)

--- a/templates/showLinkComments.gohtml
+++ b/templates/showLinkComments.gohtml
@@ -26,6 +26,8 @@
                 {{ template "languageCombobox" $ }}
                 <input type="submit" name="task" value="Reply">
             </form>
+        {{ else }}
+            Please sign-in (or sign-up) to write a reply.<br>
         {{ end }}
 
     {{ else }}

--- a/writingsArticlePage.go
+++ b/writingsArticlePage.go
@@ -41,10 +41,11 @@ func writingsArticlePage(w http.ResponseWriter, r *http.Request) {
 		CategoryBreadcrumbs []*Writingcategory
 	}
 
+	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
-		CanReply: true,  // TODO
-		CanEdit:  false, // TODO
+		CoreData: cd,
+		CanReply: cd.UserID != 0,
+		CanEdit:  false,
 	}
 
 	vars := mux.Vars(r)
@@ -70,6 +71,7 @@ func writingsArticlePage(w http.ResponseWriter, r *http.Request) {
 
 	data.Writing = writing
 	data.IsAuthor = writing.UsersIdusers == uid
+	data.CanEdit = cd.HasRole("administrator") || (cd.HasRole("writer") && data.IsAuthor)
 	data.CategoryId = writing.WritingcategoryIdwritingcategory
 
 	languageRows, err := queries.FetchLanguages(r.Context())


### PR DESCRIPTION
## Summary
- determine access levels for posts
- compute `CanReply` and `CanEdit` using permissions
- show login message if user can't reply

## Testing
- `go test ./...` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856a286f600832f80b6b6c26aff8495