### PR TITLE
Add reload config admin page

### DIFF
--- a/adminReloadConfigPage.go
+++ b/adminReloadConfigPage.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func adminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
+	data := struct {
+		*CoreData
+		Errors   []string
+		Messages []string
+		Back     string
+	}{
+		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		Back:     "/admin",
+	}
+
+	loadAppConfigFile(configFile)
+	srv.DBConfig = loadDBConfig()
+	srv.EmailConfig = loadEmailConfig()
+	loadPaginationConfig()
+	loadHTTPConfig()
+
+	data.Messages = append(data.Messages, "Configuration reloaded")
+
+	if err := renderTemplate(w, r, "adminRunTaskPage.gohtml", data); err != nil {
+		log.Printf("Template Error: %s", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/main.go
+++ b/main.go
@@ -478,6 +478,7 @@ func run() error {
 	ar.HandleFunc("/search", adminSearchRemakeWritingSearchPage).Methods("POST").MatcherFunc(TaskMatcher(TaskRemakeWritingSearch))
 	ar.HandleFunc("/search/list", adminSearchWordListPage).Methods("GET")
 	ar.HandleFunc("/search/list.txt", adminSearchWordListDownloadPage).Methods("GET")
+	ar.HandleFunc("/reload", adminReloadConfigPage).Methods("POST")
 	ar.HandleFunc("/shutdown", adminShutdownPage).Methods("POST")
 
 	// oauth shit


### PR DESCRIPTION
## Summary
- add adminReloadConfigPage
- expose `/admin/reload` route

## Testing
- `go test ./...` *(fails: build errors in linkerAdminCategoriesPage.go)*

------
https://chatgpt.com/codex/tasks/task_e_6856a23e7960832f872dc0a9ced3545d