### PR TITLE
Add admin usage stats page

### DIFF
--- a/adminUsageStatsPage.go
+++ b/adminUsageStatsPage.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func adminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
+	type Data struct {
+		*CoreData
+		ForumTopics       []*BoardPostCountRow
+		ForumCategories   []*CategoryCountRow
+		WritingCategories []*CategoryCountRow
+		LinkerCategories  []*GetLinkerCategoryLinkCountsRow
+		Imageboards       []*BoardPostCountRow
+		Users             []*UserPostCountRow
+		Monthly           []*MonthlyUsageRow
+		UserMonthly       []*UserMonthlyUsageRow
+		StartYear         int
+	}
+	data := Data{CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData)}
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+
+	var err error
+	if data.ForumTopics, err = queries.ForumTopicThreadCounts(r.Context()); err != nil {
+		log.Printf("forum topic counts: %v", err)
+	}
+	if data.ForumCategories, err = queries.ForumCategoryThreadCounts(r.Context()); err != nil {
+		log.Printf("forum category counts: %v", err)
+	}
+	if data.Imageboards, err = queries.ImageboardPostCounts(r.Context()); err != nil {
+		log.Printf("imageboard post counts: %v", err)
+	}
+	if data.Users, err = queries.UserPostCounts(r.Context()); err != nil {
+		log.Printf("user post counts: %v", err)
+	}
+	if data.WritingCategories, err = queries.WritingCategoryCounts(r.Context()); err != nil {
+		log.Printf("writing category counts: %v", err)
+	}
+	if data.LinkerCategories, err = queries.GetLinkerCategoryLinkCounts(r.Context()); err != nil {
+		log.Printf("linker category counts: %v", err)
+	}
+	if data.Monthly, err = queries.MonthlyUsageCounts(r.Context(), int32(statsStartYear)); err != nil {
+		log.Printf("monthly usage counts: %v", err)
+	}
+	if data.UserMonthly, err = queries.UserMonthlyUsageCounts(r.Context(), int32(statsStartYear)); err != nil {
+		log.Printf("user monthly usage counts: %v", err)
+	}
+	data.StartYear = statsStartYear
+
+	if err := renderTemplate(w, r, "adminUsageStatsPage.gohtml", data); err != nil {
+		log.Printf("template error: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/config/env.go
+++ b/config/env.go
@@ -53,4 +53,7 @@ const (
 	EnvPageSizeMin = "PAGE_SIZE_MIN"
 	// EnvPageSizeMax defines the maximum allowed page size.
 	EnvPageSizeMax = "PAGE_SIZE_MAX"
+
+	// EnvStatsStartYear sets the first year displayed by the usage stats page.
+	EnvStatsStartYear = "STATS_START_YEAR"
 )

--- a/main.go
+++ b/main.go
@@ -61,13 +61,14 @@ var (
 	dbNameFlag         = flag.String("db-name", "", "database name")
 	dbLogVerbosityFlag = flag.Int("db-log-verbosity", 0, "database logging verbosity")
 
-	listenFlag       = flag.String("listen", ":8080", "server listen address")
-	hostnameFlag     = flag.String("hostname", "", "server base URL")
-	httpCfgPath      = flag.String("http-config", "", "path to HTTP configuration file")
-	feedsEnabledFlag = flag.String("feeds-enabled", "", "enable or disable feeds")
-	listenFlagSet    bool
-	hostnameFlagSet  bool
-	feedsFlagSet     bool
+	listenFlag         = flag.String("listen", ":8080", "server listen address")
+	hostnameFlag       = flag.String("hostname", "", "server base URL")
+	httpCfgPath        = flag.String("http-config", "", "path to HTTP configuration file")
+	feedsEnabledFlag   = flag.String("feeds-enabled", "", "enable or disable feeds")
+	statsStartYearFlag = flag.String("stats-start-year", "", "start year for usage stats")
+	listenFlagSet      bool
+	hostnameFlagSet    bool
+	feedsFlagSet       bool
 
 	srv *Server
 	//
@@ -190,12 +191,13 @@ func run() error {
 		cliFeeds = *feedsEnabledFlag
 	}
 	loadFeedsEnabled(cliFeeds, appCfg)
+	loadStatsStartYear(*statsStartYearFlag, appCfg)
 
 	if err := performStartupChecks(); err != nil {
 		return err
 	}
 
-  dbCfg := loadDBConfig()
+	dbCfg := loadDBConfig()
 	emailCfg := loadEmailConfig()
 
 	if err := performStartupChecks(dbCfg); err != nil {
@@ -499,6 +501,7 @@ func run() error {
 	ar.HandleFunc("/sessions/delete", adminSessionsDeletePage).Methods("POST")
 	ar.HandleFunc("/settings", adminSiteSettingsPage).Methods("GET", "POST")
 	ar.HandleFunc("/stats", adminServerStatsPage).Methods("GET")
+	ar.HandleFunc("/usage", adminUsageStatsPage).Methods("GET")
 	ar.HandleFunc("/search", adminSearchPage).Methods("GET")
 	ar.HandleFunc("/search", adminSearchRemakeCommentsSearchPage).Methods("POST").MatcherFunc(TaskMatcher(TaskRemakeCommentsSearch))
 	ar.HandleFunc("/search", adminSearchRemakeNewsSearchPage).Methods("POST").MatcherFunc(TaskMatcher(TaskRemakeNewsSearch))

--- a/stats_config.go
+++ b/stats_config.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/arran4/goa4web/config"
+)
+
+var statsStartYear int
+
+func parseInt(v string) (int, bool) {
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+func resolveStatsStartYear(cli, file, env string) int {
+	if n, ok := parseInt(cli); ok {
+		return n
+	}
+	if n, ok := parseInt(file); ok {
+		return n
+	}
+	if n, ok := parseInt(env); ok {
+		return n
+	}
+	return 2005
+}
+
+func loadStatsStartYear(cli string, file map[string]string) {
+	fileVal := ""
+	if v, ok := file["STATS_START_YEAR"]; ok {
+		fileVal = v
+	}
+	statsStartYear = resolveStatsStartYear(cli, fileVal, os.Getenv(config.EnvStatsStartYear))
+}

--- a/templates/adminPage.gohtml
+++ b/templates/adminPage.gohtml
@@ -12,6 +12,7 @@
     <li><a href="/admin/notifications">Notifications</a></li>
     <li><a href="/admin/settings">Site Settings</a></li>
     <li><a href="/admin/stats">Server Stats</a></li>
+    <li><a href="/admin/usage">Usage Stats</a></li>
 </ul>
 
 <p>Site statistics:</p>

--- a/templates/adminUsageStatsPage.gohtml
+++ b/templates/adminUsageStatsPage.gohtml
@@ -1,0 +1,67 @@
+{{ template "head" $ }}
+<h2>Usage Statistics</h2>
+
+<h3>Threads per Forum Topic</h3>
+<table border="1">
+    <tr><th>Topic</th><th>Threads</th></tr>
+    {{- range .ForumTopics }}
+    <tr><td>{{ .Name.String }}</td><td>{{ .Count }}</td></tr>
+    {{- end }}
+</table>
+
+<h3>Threads per Forum Category</h3>
+<table border="1">
+    <tr><th>Category</th><th>Threads</th></tr>
+    {{- range .ForumCategories }}
+    <tr><td>{{ .Name.String }}</td><td>{{ .Count }}</td></tr>
+    {{- end }}
+</table>
+
+<h3>Writings per Category</h3>
+<table border="1">
+    <tr><th>Category</th><th>Writings</th></tr>
+    {{- range .WritingCategories }}
+    <tr><td>{{ .Name.String }}</td><td>{{ .Count }}</td></tr>
+    {{- end }}
+</table>
+
+<h3>Links per Category</h3>
+<table border="1">
+    <tr><th>Category</th><th>Links</th></tr>
+    {{- range .LinkerCategories }}
+    <tr><td>{{ .Title.String }}</td><td>{{ .Linkcount }}</td></tr>
+    {{- end }}
+</table>
+
+<h3>Posts per Imageboard</h3>
+<table border="1">
+    <tr><th>Board</th><th>Posts</th></tr>
+    {{- range .Imageboards }}
+    <tr><td>{{ .Name.String }}</td><td>{{ .Count }}</td></tr>
+    {{- end }}
+</table>
+
+<h3>Posts by User</h3>
+<table border="1">
+    <tr><th>User</th><th>Blogs</th><th>News</th><th>Comments</th><th>Images</th><th>Links</th><th>Writings</th></tr>
+    {{- range .Users }}
+    <tr><td>{{ .Username.String }}</td><td>{{ .Blogs }}</td><td>{{ .News }}</td><td>{{ .Comments }}</td><td>{{ .Images }}</td><td>{{ .Links }}</td><td>{{ .Writings }}</td></tr>
+    {{- end }}
+</table>
+
+<h3>Monthly Usage (from {{ .StartYear }})</h3>
+<table border="1">
+    <tr><th>Year</th><th>Month</th><th>Blogs</th><th>News</th><th>Comments</th><th>Images</th><th>Links</th></tr>
+    {{- range .Monthly }}
+    <tr><td>{{ .Year }}</td><td>{{ .Month }}</td><td>{{ .Blogs }}</td><td>{{ .News }}</td><td>{{ .Comments }}</td><td>{{ .Images }}</td><td>{{ .Links }}</td></tr>
+    {{- end }}
+</table>
+
+<h3>Monthly Usage Per User (from {{ .StartYear }})</h3>
+<table border="1">
+    <tr><th>User</th><th>Year</th><th>Month</th><th>Blogs</th><th>News</th><th>Comments</th><th>Images</th><th>Links</th><th>Writings</th></tr>
+    {{- range .UserMonthly }}
+    <tr><td>{{ .Username.String }}</td><td>{{ .Year }}</td><td>{{ .Month }}</td><td>{{ .Blogs }}</td><td>{{ .News }}</td><td>{{ .Comments }}</td><td>{{ .Images }}</td><td>{{ .Links }}</td><td>{{ .Writings }}</td></tr>
+    {{- end }}
+</table>
+{{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- add database helper functions for usage statistics
- display new statistics via `/admin/usage`
- link "Usage Stats" from the main admin page
- add monthly usage table with configurable start year
- expand the statistics to show counts by categories and user monthly usage

## Testing
- `go vet ./...` *(fails: Sortorder redeclared)*
- `go test ./...` *(fails to build: Sortorder redeclared, missing methods)*

------
https://chatgpt.com/codex/tasks/task_e_68573d7c5e4c832fa077388c56872f4d