### PR TITLE
Fix lint workflow

### DIFF
--- a/.github/workflows/lint_vet.yaml
+++ b/.github/workflows/lint_vet.yaml
@@ -19,6 +19,6 @@ jobs:
       - name: Go Vet
         run: go vet ./...
       - name: Golangci Lint
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.1


### PR DESCRIPTION
## Summary
- upgrade golangci-lint GitHub action to v8
- run golangci-lint v2

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685747f9795c832f8f62de0a851fb4a2