### PR TITLE
Add user page size controls

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -48,4 +48,6 @@ const (
 	EnvPageSizeMin = "PAGE_SIZE_MIN"
 	// EnvPageSizeMax defines the maximum allowed page size.
 	EnvPageSizeMax = "PAGE_SIZE_MAX"
+	// EnvPageSizeDefault defines the default page size.
+	EnvPageSizeDefault = "PAGE_SIZE_DEFAULT"
 )

--- a/linkerAdminCategoriesPage.go
+++ b/linkerAdminCategoriesPage.go
@@ -50,8 +50,9 @@ func linkerAdminCategoriesUpdatePage(w http.ResponseWriter, r *http.Request) {
 	if err := queries.RenameLinkerCategory(r.Context(), RenameLinkerCategoryParams{
 		Title:            sql.NullString{Valid: true, String: title},
 		Position:         int32(pos),
-  }; err != nil {
-		log.Printf("updateLinkerCategorySortOrder Error: %s", err)
+		Idlinkercategory: int32(cid),
+	}); err != nil {
+		log.Printf("updateLinkerCategory Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
@@ -93,7 +94,7 @@ func linkerAdminCategoriesDeletePage(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Category in use", http.StatusBadRequest)
 			return
 		}
-  }
+	}
 	count, err := queries.CountLinksByCategory(r.Context(), int32(cid))
 	if err != nil {
 		log.Printf("countLinks Error: %s", err)

--- a/main.go
+++ b/main.go
@@ -63,6 +63,11 @@ var (
 	dbNameFlag         = flag.String("db-name", "", "database name")
 	dbLogVerbosityFlag = flag.Int("db-log-verbosity", 0, "database logging verbosity")
 
+	pageSizeMinFlag     = flag.Int("page-size-min", 0, "minimum allowed page size")
+	pageSizeMaxFlag     = flag.Int("page-size-max", 0, "maximum allowed page size")
+	pageSizeDefaultFlag = flag.Int("page-size-default", 0, "default page size")
+	paginationCfgPath   = flag.String("pagination-config", "", "path to pagination configuration file")
+
 	listenFlag      = flag.String("listen", ":8080", "server listen address")
 	hostnameFlag    = flag.String("hostname", "", "server base URL")
 	httpCfgPath     = flag.String("http-config", "", "path to HTTP configuration file")
@@ -163,6 +168,18 @@ func run() error {
 	if emailConfigFile == "" {
 		if v, ok := appCfg["EMAIL_CONFIG_FILE"]; ok {
 			emailConfigFile = v
+		}
+	}
+
+	cliPaginationConfig = PaginationConfig{
+		Min:     *pageSizeMinFlag,
+		Max:     *pageSizeMaxFlag,
+		Default: *pageSizeDefaultFlag,
+	}
+	paginationConfigFile = *paginationCfgPath
+	if paginationConfigFile == "" {
+		if v, ok := appCfg["PAGINATION_CONFIG_FILE"]; ok {
+			paginationConfigFile = v
 		}
 	}
 
@@ -424,6 +441,8 @@ func run() error {
 	ur.HandleFunc("/email", userEmailTestActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskTestMail))
 	ur.HandleFunc("/paging", userPagingPage).Methods("GET").MatcherFunc(RequiresAnAccount())
 	ur.HandleFunc("/paging", userPagingSaveActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveAll))
+	ur.HandleFunc("/page-size", userPageSizePage).Methods("GET").MatcherFunc(RequiresAnAccount())
+	ur.HandleFunc("/page-size", userPageSizeSaveActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveAll))
 	ur.HandleFunc("/notifications", userNotificationsPage).Methods("GET").MatcherFunc(RequiresAnAccount())
 	ur.HandleFunc("/notifications/dismiss", userNotificationsDismissActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskDismiss))
 	ur.HandleFunc("/notifications/rss", notificationsRssPage).Methods("GET").MatcherFunc(RequiresAnAccount())

--- a/pagination.go
+++ b/pagination.go
@@ -4,7 +4,10 @@ import "net/http"
 
 // getPageSize returns the preferred page size within configured bounds.
 func getPageSize(r *http.Request) int {
-	size := DefaultPageSize
+	size := appPaginationConfig.Default
+	if size == 0 {
+		size = DefaultPageSize
+	}
 	if pref, _ := r.Context().Value(ContextValues("preference")).(*Preference); pref != nil && pref.PageSize != 0 {
 		size = int(pref.PageSize)
 	}

--- a/pagination_config_test.go
+++ b/pagination_config_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestLoadPaginationConfigFile(t *testing.T) {
 	useMemFS(t)
 	file := "pagination.conf"
-	content := "PAGE_SIZE_MIN=10\nPAGE_SIZE_MAX=40\n"
+	content := "PAGE_SIZE_MIN=10\nPAGE_SIZE_MAX=40\nPAGE_SIZE_DEFAULT=20\n"
 	if err := writeFile(file, []byte(content), 0644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -13,17 +13,17 @@ func TestLoadPaginationConfigFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if cfg.Min != 10 || cfg.Max != 40 {
+	if cfg.Min != 10 || cfg.Max != 40 || cfg.Default != 20 {
 		t.Fatalf("unexpected cfg: %#v", cfg)
 	}
 }
 
 func TestResolvePaginationConfigPrecedence(t *testing.T) {
-	env := PaginationConfig{Min: 5, Max: 30}
-	file := PaginationConfig{Min: 8, Max: 20}
-	cli := PaginationConfig{Min: 12}
+	env := PaginationConfig{Min: 5, Max: 30, Default: 15}
+	file := PaginationConfig{Min: 8, Max: 20, Default: 18}
+	cli := PaginationConfig{Min: 12, Default: 22}
 	cfg := resolvePaginationConfig(cli, file, env)
-	if cfg.Min != 12 || cfg.Max != 20 {
+	if cfg.Min != 12 || cfg.Max != 20 || cfg.Default != 22 {
 		t.Fatalf("merged %#v", cfg)
 	}
 }
@@ -31,14 +31,14 @@ func TestResolvePaginationConfigPrecedence(t *testing.T) {
 func TestLoadPaginationConfigEnvPath(t *testing.T) {
 	useMemFS(t)
 	file := "pagination.conf"
-	if err := writeFile(file, []byte("PAGE_SIZE_MIN=7\n"), 0644); err != nil {
+	if err := writeFile(file, []byte("PAGE_SIZE_MIN=7\nPAGE_SIZE_DEFAULT=9\n"), 0644); err != nil {
 		t.Fatalf("write file: %v", err)
 	}
 	t.Setenv("PAGINATION_CONFIG_FILE", file)
 	paginationConfigFile = ""
 	cliPaginationConfig = PaginationConfig{}
 	cfg := loadPaginationConfig()
-	if cfg.Min != 7 {
-		t.Fatalf("want 7 got %d", cfg.Min)
+	if cfg.Min != 7 || cfg.Default != 9 {
+		t.Fatalf("unexpected %#v", cfg)
 	}
 }

--- a/queries-linker.sql.go
+++ b/queries-linker.sql.go
@@ -114,7 +114,8 @@ const getAllLinkerCategories = `-- name: GetAllLinkerCategories :many
 SELECT idlinkercategory, title, position
 FROM linkerCategory
 ORDER BY position
-```
+`
+
 const getAllLinkerCategoriesWithSortOrder = `-- name: GetAllLinkerCategoriesWithSortOrder :many
 SELECT idlinkerCategory, title, sortorder
 FROM linkerCategory

--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,18 @@ See `examples/http.conf` for the file format.
 
 `HOSTNAME` should include the scheme and optional port, e.g. `http://example.com`.
 
+## Pagination Configuration
+
+The minimum, maximum and default page sizes used throughout the site can be
+configured in the same manner:
+
+1. Command line flags (`--page-size-min`, `--page-size-max`, `--page-size-default`)
+2. Values from a config file specified with `--pagination-config` or `PAGINATION_CONFIG_FILE`
+3. Environment variables `PAGE_SIZE_MIN`, `PAGE_SIZE_MAX` and `PAGE_SIZE_DEFAULT`
+4. Built-in defaults (5, 50 and 15 respectively)
+
+The config file uses the same `key=value` format as other configuration files.
+
 ### Implementing Custom Providers
 
 New email backends can be added by satisfying the `MailProvider` interface

--- a/templates/userPage.gohtml
+++ b/templates/userPage.gohtml
@@ -3,4 +3,5 @@
     Modify <a href="/usr/lang">Language settings</a><br>
     Modify <a href="/usr/email">Email and notification settings</a><br>
     Modify <a href="/usr/paging">Pagination settings</a><br>
+    Modify <a href="/usr/page-size">Page size limits</a><br>
 {{ template "tail" $ }}

--- a/templates/userPageSizePage.gohtml
+++ b/templates/userPageSizePage.gohtml
@@ -1,0 +1,11 @@
+{{ template "head" $ }}
+<form method="post">
+    Min page size:
+    <input type="number" name="min" value="{{.Min}}"><br>
+    Max page size:
+    <input type="number" name="max" value="{{.Max}}"><br>
+    Default page size:
+    <input type="number" name="default" value="{{.Def}}"><br>
+    <input type="submit" name="task" value="Save all">
+</form>
+{{ template "tail" $ }}

--- a/userLangPage.go
+++ b/userLangPage.go
@@ -95,7 +95,7 @@ func saveUserLanguagePreference(r *http.Request, queries *Queries, uid int32) er
 			return queries.InsertPreference(r.Context(), InsertPreferenceParams{
 				LanguageIdlanguage: int32(langID),
 				UsersIdusers:       uid,
-				PageSize:           DefaultPageSize,
+				PageSize:           int32(appPaginationConfig.Default),
 			})
 		}
 		return err
@@ -114,7 +114,7 @@ func saveDefaultLanguage(r *http.Request, queries *Queries, uid int32) error {
 	pref, err := queries.GetPreferenceByUserID(r.Context(), uid)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			_, err = queries.db.ExecContext(r.Context(), "INSERT INTO preferences (language_idlanguage, users_idusers, page_size) VALUES (?, ?, ?)", langID, uid, DefaultPageSize)
+			_, err = queries.db.ExecContext(r.Context(), "INSERT INTO preferences (language_idlanguage, users_idusers, page_size) VALUES (?, ?, ?)", langID, uid, appPaginationConfig.Default)
 			return err
 		}
 		return err

--- a/userPageSizePage.go
+++ b/userPageSizePage.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+)
+
+func userPageSizePage(w http.ResponseWriter, r *http.Request) {
+	data := struct {
+		*CoreData
+		Min int
+		Max int
+		Def int
+	}{
+		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		Min:      appPaginationConfig.Min,
+		Max:      appPaginationConfig.Max,
+		Def:      appPaginationConfig.Default,
+	}
+	if err := renderTemplate(w, r, "userPageSizePage.gohtml", data); err != nil {
+		log.Printf("template error: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}
+
+func userPageSizeSaveActionPage(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Redirect(w, r, "/usr/page-size", http.StatusSeeOther)
+		return
+	}
+	min, _ := strconv.Atoi(r.FormValue("min"))
+	max, _ := strconv.Atoi(r.FormValue("max"))
+	def, _ := strconv.Atoi(r.FormValue("default"))
+	cfg := resolvePaginationConfig(PaginationConfig{Min: min, Max: max, Default: def}, PaginationConfig{}, PaginationConfig{})
+	appPaginationConfig = cfg
+	http.Redirect(w, r, "/usr/page-size", http.StatusSeeOther)
+}

--- a/userPagingPage.go
+++ b/userPagingPage.go
@@ -10,7 +10,10 @@ import (
 
 func userPagingPage(w http.ResponseWriter, r *http.Request) {
 	pref, _ := r.Context().Value(ContextValues("preference")).(*Preference)
-	size := DefaultPageSize
+	size := appPaginationConfig.Default
+	if size == 0 {
+		size = DefaultPageSize
+	}
 	if pref != nil {
 		size = int(pref.PageSize)
 	}


### PR DESCRIPTION
## Summary
- add UserPageSizePage to modify pagination bounds
- wire page-size routes and templates
- link the page on the user preferences page
- clean up generated query file
- fix linker admin categories page compile errors
- allow configuring default, min and max page size via CLI/file/env

## Testing
- `go test ./...` *(fails: adminForumFlaggedPostsPage redeclared, queries_ext.go undefined sql, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6856a24651b0832fbb3987e0ebb2163a