### PR TITLE
Centralize env vars

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -56,4 +56,33 @@ const (
 
 	// EnvStatsStartYear sets the first year displayed by the usage stats page.
 	EnvStatsStartYear = "STATS_START_YEAR"
+
+	// EnvDBLogVerbosity controls the verbosity level of database logging.
+	EnvDBLogVerbosity = "DB_LOG_VERBOSITY"
+	// EnvDBConfigFile specifies the path to the database configuration file.
+	EnvDBConfigFile = "DB_CONFIG_FILE"
+
+	// EnvHTTPConfigFile specifies the path to the HTTP configuration file.
+	EnvHTTPConfigFile = "HTTP_CONFIG_FILE"
+	// EnvListen is the network address the HTTP server listens on.
+	EnvListen = "LISTEN"
+	// EnvHostname is the base URL advertised by the HTTP server.
+	EnvHostname = "HOSTNAME"
+
+	// EnvPaginationConfigFile specifies the path to the pagination configuration file.
+	EnvPaginationConfigFile = "PAGINATION_CONFIG_FILE"
+
+	// EnvSessionSecret is the secret used to encrypt session cookies.
+	EnvSessionSecret = "SESSION_SECRET"
+	// EnvSessionSecretFile specifies the file containing the session secret.
+	EnvSessionSecretFile = "SESSION_SECRET_FILE"
+
+	// EnvSendGridKey is the API key for the SendGrid email provider.
+	EnvSendGridKey = "SENDGRID_KEY"
+	// EnvEmailConfigFile specifies the path to the email configuration file.
+	EnvEmailConfigFile = "EMAIL_CONFIG_FILE"
+	// EnvAdminEmails is a comma-separated list of administrator email addresses.
+	EnvAdminEmails = "ADMIN_EMAILS"
+	// EnvAdminNotify toggles sending administrator notification emails.
+	EnvAdminNotify = "ADMIN_NOTIFY"
 )

--- a/db_config.go
+++ b/db_config.go
@@ -62,7 +62,7 @@ func loadDBConfigFile(path string) (DBConfig, error) {
 				cfg.Port = val
 			case config.EnvDBName:
 				cfg.Name = val
-			case "DB_LOG_VERBOSITY":
+			case config.EnvDBLogVerbosity:
 				if v, err := strconv.Atoi(val); err == nil {
 					cfg.LogVerbosity = v
 				}
@@ -82,7 +82,7 @@ func loadDBConfig() DBConfig {
 		Port: os.Getenv(config.EnvDBPort),
 		Name: os.Getenv(config.EnvDBName),
 	}
-	if lv := os.Getenv("DB_LOG_VERBOSITY"); lv != "" {
+	if lv := os.Getenv(config.EnvDBLogVerbosity); lv != "" {
 		if v, err := strconv.Atoi(lv); err == nil {
 			env.LogVerbosity = v
 		}
@@ -90,7 +90,7 @@ func loadDBConfig() DBConfig {
 
 	cfgPath := dbConfigFile
 	if cfgPath == "" {
-		cfgPath = os.Getenv("DB_CONFIG_FILE")
+		cfgPath = os.Getenv(config.EnvDBConfigFile)
 	}
 	fileCfg, err := loadDBConfigFile(cfgPath)
 	if err != nil && !os.IsNotExist(err) {

--- a/email.go
+++ b/email.go
@@ -415,12 +415,12 @@ func loadEmailConfig() EmailConfig {
 		JMAPIdentity: os.Getenv(config.EnvJMAPIdentity),
 		JMAPUser:     os.Getenv(config.EnvJMAPUser),
 		JMAPPass:     os.Getenv(config.EnvJMAPPass),
-		SendGridKey:  os.Getenv("SENDGRID_KEY"),
+		SendGridKey:  os.Getenv(config.EnvSendGridKey),
 	}
 
 	cfgPath := emailConfigFile
 	if cfgPath == "" {
-		cfgPath = os.Getenv("EMAIL_CONFIG_FILE")
+		cfgPath = os.Getenv(config.EnvEmailConfigFile)
 	}
 	fileCfg, err := loadEmailConfigFile(cfgPath)
 	if err != nil && !os.IsNotExist(err) {
@@ -435,7 +435,7 @@ func loadEmailConfig() EmailConfig {
 // interpreted as a comma-separated list. If not set and a Queries value is
 // provided, the database is queried for administrator accounts.
 func getAdminEmails(ctx context.Context, q *Queries) []string {
-	env := os.Getenv("ADMIN_EMAILS")
+	env := os.Getenv(config.EnvAdminEmails)
 	var emails []string
 	if env != "" {
 		for _, e := range strings.Split(env, ",") {
@@ -463,7 +463,7 @@ func getAdminEmails(ctx context.Context, q *Queries) []string {
 // notifyAdmins sends a change notification email to all administrator
 // addresses returned by getAdminEmails.
 func adminNotificationsEnabled() bool {
-	v := strings.ToLower(os.Getenv("ADMIN_NOTIFY"))
+	v := strings.ToLower(os.Getenv(config.EnvAdminNotify))
 	if v == "" {
 		return true
 	}

--- a/http_config.go
+++ b/http_config.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"os"
 	"strings"
+
+	"github.com/arran4/goa4web/config"
 )
 
 // HTTPConfig holds parameters for the HTTP server.
@@ -62,9 +64,9 @@ func loadHTTPConfigFile(path string) (HTTPConfig, error) {
 			key := strings.TrimSpace(line[:i])
 			val := strings.TrimSpace(line[i+1:])
 			switch key {
-			case "LISTEN":
+			case config.EnvListen:
 				cfg.Listen = val
-			case "HOSTNAME":
+			case config.EnvHostname:
 				cfg.Hostname = val
 			}
 		}
@@ -76,12 +78,12 @@ func loadHTTPConfigFile(path string) (HTTPConfig, error) {
 // and command line flags applying the precedence defined in AGENTS.md.
 func loadHTTPConfig() HTTPConfig {
 	env := HTTPConfig{
-		Listen:   os.Getenv("LISTEN"),
-		Hostname: os.Getenv("HOSTNAME"),
+		Listen:   os.Getenv(config.EnvListen),
+		Hostname: os.Getenv(config.EnvHostname),
 	}
 	cfgPath := httpConfigFile
 	if cfgPath == "" {
-		cfgPath = os.Getenv("HTTP_CONFIG_FILE")
+		cfgPath = os.Getenv(config.EnvHTTPConfigFile)
 	}
 	fileCfg, err := loadHTTPConfigFile(cfgPath)
 	if err != nil && !os.IsNotExist(err) {

--- a/pagination_config.go
+++ b/pagination_config.go
@@ -94,7 +94,7 @@ func loadPaginationConfig() PaginationConfig {
 
 	cfgPath := paginationConfigFile
 	if cfgPath == "" {
-		cfgPath = os.Getenv("PAGINATION_CONFIG_FILE")
+		cfgPath = os.Getenv(config.EnvPaginationConfigFile)
 	}
 	fileCfg, err := loadPaginationConfigFile(cfgPath)
 	if err != nil && !os.IsNotExist(err) {

--- a/session_secret.go
+++ b/session_secret.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"os"
 	"strings"
+
+	"github.com/arran4/goa4web/config"
 )
 
 // loadSessionSecret returns the session secret using the following priority:
@@ -20,12 +22,12 @@ func loadSessionSecret(cliSecret, path string) (string, error) {
 		return cliSecret, nil
 	}
 
-	if env := os.Getenv("SESSION_SECRET"); env != "" {
+	if env := os.Getenv(config.EnvSessionSecret); env != "" {
 		return env, nil
 	}
 
 	if path == "" {
-		path = os.Getenv("SESSION_SECRET_FILE")
+		path = os.Getenv(config.EnvSessionSecretFile)
 		if path == "" {
 			path = ".session_secret"
 		}


### PR DESCRIPTION
## Summary
- add missing environment variable constants to `config/env.go`
- reference those constants across the codebase

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6857490d65f4832fa11ce50c43c2afdd