### PR TITLE
Refactor app config tests to use memfs

### DIFF
--- a/app_config.go
+++ b/app_config.go
@@ -13,7 +13,7 @@ func loadAppConfigFile(path string) map[string]string {
 	if path == "" {
 		return values
 	}
-	b, err := os.ReadFile(path)
+	b, err := readFile(path)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			log.Printf("app config file error: %v", err)

--- a/app_config_test.go
+++ b/app_config_test.go
@@ -1,16 +1,14 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 )
 
 func TestLoadAppConfigFile(t *testing.T) {
-	dir := t.TempDir()
-	file := filepath.Join(dir, "app.conf")
+	useMemFS(t)
+	file := "app.conf"
 	content := "DB_CONFIG_FILE=db.conf\nEMAIL_CONFIG_FILE=email.conf\n"
-	if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+	if err := writeFile(file, []byte(content), 0644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	m := loadAppConfigFile(file)
@@ -20,8 +18,8 @@ func TestLoadAppConfigFile(t *testing.T) {
 }
 
 func TestLoadAppConfigFileMissing(t *testing.T) {
-	dir := t.TempDir()
-	file := filepath.Join(dir, "none.conf")
+	useMemFS(t)
+	file := "none.conf"
 	m := loadAppConfigFile(file)
 	if len(m) != 0 {
 		t.Fatalf("expected empty map, got %#v", m)


### PR DESCRIPTION
## Summary
- use the memfs helper in app config tests
- allow `loadAppConfigFile` to read via the overridable `readFile`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685748fd6374832f98ec3bcb66e0d003