### PR TITLE
Add permission section drilldown page

### DIFF
--- a/adminPermissionsSectionViewPage.go
+++ b/adminPermissionsSectionViewPage.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"database/sql"
+	"log"
+	"net/http"
+)
+
+// adminPermissionsSectionViewPage lists all permissions for a specific section.
+func adminPermissionsSectionViewPage(w http.ResponseWriter, r *http.Request) {
+	type Data struct {
+		*CoreData
+		Section string
+		Rows    []*PermissionWithUser
+	}
+	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	section := r.URL.Query().Get("section")
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	rows, err := queries.GetPermissionsBySectionWithUsers(r.Context(), section)
+	if err != nil && err != sql.ErrNoRows {
+		log.Printf("GetPermissionsBySectionWithUsers error: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	data := Data{CoreData: cd, Section: section, Rows: rows}
+	if err := renderTemplate(w, r, "adminPermissionsSectionViewPage.gohtml", data); err != nil {
+		log.Printf("Template Error: %s", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/main.go
+++ b/main.go
@@ -488,6 +488,7 @@ func run() error {
 	ar.HandleFunc("/languages", adminLanguagesCreatePage).Methods("POST").MatcherFunc(TaskMatcher(TaskCreateLanguage))
 	ar.HandleFunc("/categories", adminCategoriesPage).Methods("GET")
 	ar.HandleFunc("/permissions/sections", adminPermissionsSectionPage).Methods("GET")
+	ar.HandleFunc("/permissions/sections/view", adminPermissionsSectionViewPage).Methods("GET")
 	ar.HandleFunc("/permissions/sections", adminPermissionsSectionRenamePage).Methods("POST").MatcherFunc(TaskMatcher(TaskRenameSection))
 	ar.HandleFunc("/email/queue", adminEmailQueuePage).Methods("GET")
 	ar.HandleFunc("/email/queue", adminEmailQueueResendActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskResend))

--- a/readme.md
+++ b/readme.md
@@ -217,3 +217,5 @@ columns and records the schema version.
 ### Permission section checker
 
 The `/admin/permissions/sections` page lists all distinct values found in the `permissions.section` column. It provides buttons to convert existing rows between `writing` and `writings`. These once-off tools help normalise data if older migrations used inconsistent names.
+
+The linked counts now let you drill down to view all permissions for a section via `/admin/permissions/sections/view?section=<name>`.

--- a/templates/adminPermissionsSectionPage.gohtml
+++ b/templates/adminPermissionsSectionPage.gohtml
@@ -4,7 +4,7 @@
     <tr><th>Section</th><th>Count</th></tr>
     {{ range $.Sections }}
     <tr>
-        <td>{{ .Section.String }}</td>
+        <td><a href="/admin/permissions/sections/view?section={{ .Section.String }}">{{ .Section.String }}</a></td>
         <td>{{ .Sectioncount }}</td>
     </tr>
     {{ end }}

--- a/templates/adminPermissionsSectionViewPage.gohtml
+++ b/templates/adminPermissionsSectionViewPage.gohtml
@@ -1,0 +1,15 @@
+{{ template "head" $ }}
+[<a href="/admin/permissions/sections">Back to sections</a>]<br/>
+<h3>Permissions for {{ .Section }}</h3>
+<table border="1">
+    <tr><th>ID</th><th>User</th><th>Email</th><th>Level</th></tr>
+    {{ range .Rows }}
+    <tr>
+        <td>{{ .Idpermissions }}</td>
+        <td>{{ .Username.String }}</td>
+        <td>{{ .Email.String }}</td>
+        <td>{{ .Level.String }}</td>
+    </tr>
+    {{ end }}
+</table>
+{{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- add handler and template for viewing permissions by section
- link from permission section counts to the new page
- wire the new route in `main.go`
- mention the drilldown feature in the README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68579a5ad938832fb620a538cfa51e22