### PR TITLE
Implement letter and page jump for admin search list

### DIFF
--- a/adminSearchWordListHandler.go
+++ b/adminSearchWordListHandler.go
@@ -1,27 +1,61 @@
 package main
 
 import (
+	"database/sql"
 	_ "embed"
 	_ "github.com/go-sql-driver/mysql" // Import the MySQL driver.
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 )
 
+type PageLink struct {
+	Num    int
+	Link   string
+	Active bool
+}
+
+type WordCount struct {
+	Word  sql.NullString
+	Count int32
+}
+
 func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*CoreData
-		Rows     []*WordListWithCountsRow
-		NextLink string
-		PrevLink string
+		Rows       []WordCount
+		NextLink   string
+		PrevLink   string
+		PageLinks  []PageLink
+		Letters    []string
+		CurrentLtr string
 	}
 
 	data := Data{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 
-	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	letters := make([]string, len(Alphabet))
+	for i, c := range Alphabet {
+		letters[i] = strings.ToUpper(string(c))
+	}
+	data.Letters = letters
+
+	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	if page < 1 {
+		page = 1
+	}
+	letter := strings.ToLower(r.URL.Query().Get("letter"))
+	if len(letter) > 1 {
+		letter = letter[:1]
+	}
+	data.CurrentLtr = strings.ToUpper(letter)
+
+	const pageSize = 1000
+
+	offset := (page - 1) * pageSize
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 
@@ -40,40 +74,72 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	const pageSize = 1000
-	rows, err := queries.WordListWithCounts(r.Context(), WordListWithCountsParams{
-		Limit:  pageSize + 1,
-		Offset: int32(offset),
-	})
-	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
 
-	hasMore := len(rows) > pageSize
-	if hasMore {
-		rows = rows[:pageSize]
+	var (
+		rows       []WordCount
+		err        error
+		totalCount int64
+	)
+	if letter != "" {
+		totalCount, err = queries.CountWordListByPrefix(r.Context(), letter)
+		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		prefRows, err2 := queries.WordListWithCountsByPrefix(r.Context(), WordListWithCountsByPrefixParams{
+			Prefix: letter,
+			Limit:  int32(pageSize),
+			Offset: int32(offset),
+		})
+		if err2 != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		for _, r := range prefRows {
+			rows = append(rows, WordCount{Word: r.Word, Count: r.Count})
+		}
+	} else {
+		totalCount, err = queries.CountWordList(r.Context())
+		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		allRows, err2 := queries.WordListWithCounts(r.Context(), WordListWithCountsParams{
+			Limit:  int32(pageSize),
+			Offset: int32(offset),
+		})
+		if err2 != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		for _, r := range allRows {
+			rows = append(rows, WordCount{Word: r.Word, Count: r.Count})
+		}
 	}
 	data.Rows = rows
 
+	numPages := int((totalCount + int64(pageSize-1)) / int64(pageSize))
+
 	base := "/admin/search/list"
-	if hasMore {
-		if strings.Contains(base, "?") {
-			data.NextLink = base + "&offset=" + strconv.Itoa(offset+pageSize)
-		} else {
-			data.NextLink = base + "?offset=" + strconv.Itoa(offset+pageSize)
-		}
-	}
-	if offset > 0 {
-		if strings.Contains(base, "?") {
-			data.PrevLink = base + "&offset=" + strconv.Itoa(offset-pageSize)
-		} else {
-			data.PrevLink = base + "?offset=" + strconv.Itoa(offset-pageSize)
-		}
+	vals := url.Values{}
+	if letter != "" {
+		vals.Set("letter", letter)
 	}
 
-	err = renderTemplate(w, r, "adminSearchWordListPage.gohtml", data)
-	if err != nil {
+	for i := 1; i <= numPages; i++ {
+		vals.Set("page", strconv.Itoa(i))
+		data.PageLinks = append(data.PageLinks, PageLink{Num: i, Link: base + "?" + vals.Encode(), Active: i == page})
+	}
+	if page < numPages {
+		vals.Set("page", strconv.Itoa(page+1))
+		data.NextLink = base + "?" + vals.Encode()
+	}
+	if page > 1 {
+		vals.Set("page", strconv.Itoa(page-1))
+		data.PrevLink = base + "?" + vals.Encode()
+	}
+
+	if err = renderTemplate(w, r, "adminSearchWordListPage.gohtml", data); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/consts.go
+++ b/consts.go
@@ -33,4 +33,7 @@ const (
 
 	// DefaultPageSize defines the number of items shown per page.
 	DefaultPageSize = 15
+
+	// Alphabet lists letters for search navigation.
+	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 )

--- a/queries-search.sql
+++ b/queries-search.sql
@@ -16,6 +16,28 @@ FROM searchwordlist swl
 ORDER BY swl.word
 LIMIT ? OFFSET ?;
 
+-- name: CountWordList :one
+SELECT COUNT(*)
+FROM searchwordlist;
+
+-- name: CountWordListByPrefix :one
+SELECT COUNT(*)
+FROM searchwordlist
+WHERE word LIKE CONCAT(sqlc.arg(prefix), '%');
+
+-- name: WordListWithCountsByPrefix :many
+SELECT swl.word,
+       (SELECT COUNT(*) FROM commentsSearch cs WHERE cs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT COUNT(*) FROM siteNewsSearch ns WHERE ns.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT COUNT(*) FROM blogsSearch bs WHERE bs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT COUNT(*) FROM linkerSearch ls WHERE ls.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT COUNT(*) FROM writingSearch ws WHERE ws.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT COUNT(*) FROM imagepostSearch ips WHERE ips.searchwordlist_idsearchwordlist=swl.idsearchwordlist) AS count
+FROM searchwordlist swl
+WHERE swl.word LIKE CONCAT(sqlc.arg(prefix), '%')
+ORDER BY swl.word
+LIMIT ? OFFSET ?;
+
 -- name: RemakeCommentsSearch :exec
 -- This query selects data from the "comments" table and populates the "commentsSearch" table with the specified columns.
 -- Then, it iterates over the "queue" linked list to add each text and ID pair to the "commentsSearch" using the "comments_idcomments".

--- a/templates/adminSearchWordListPage.gohtml
+++ b/templates/adminSearchWordListPage.gohtml
@@ -1,10 +1,16 @@
 {{ template "head" $ }}
-    [<a href="/admin">Admin:</a> <a href="/admin/search/list">(This page/Refresh)</a>]<br />
-                        Complete word list with counts:<ul>
-                        {{range $.Rows}}
-                                <li>{{.Word.String}} - {{.Count}}</li>
-                        {{- end}}
-                        </ul>
-                        {{if $.PrevLink}}<a href="{{$.PrevLink}}">Previous</a>{{end}}
-                        {{if $.NextLink}}<a href="{{$.NextLink}}">Next</a>{{end}}
+[<a href="/admin">Admin:</a> <a href="/admin/search/list">Word List</a>]<br />
+Jump to:
+{{ range $.Letters }} <a href="/admin/search/list?letter={{.}}">{{ . }}</a> {{ end }}<br />
+{{ if $.CurrentLtr }}Showing words starting with "{{ $.CurrentLtr }}"{{ end }}
+<ul>
+{{ range $.Rows }}
+    <li>{{ .Word.String }} - {{ .Count }}</li>
+{{- end }}
+</ul>
+{{ if $.PrevLink }}<a href="{{ $.PrevLink }}">Previous</a>{{ end }}
+{{ range $.PageLinks }}
+    {{ if .Active }}<strong>{{ .Num }}</strong>{{ else }}<a href="{{ .Link }}">{{ .Num }}</a>{{ end }}
+{{ end }}
+{{ if $.NextLink }}<a href="{{ $.NextLink }}">Next</a>{{ end }}
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- allow jumping by letter and paged navigation
- track list letters via new `Alphabet` constant
- add DB queries for counting and listing words by prefix
- update admin search word list handler and template

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68579a251128832fbaedfeea48c3b6eb