### PR TITLE
Fix admin permission table alignment

### DIFF
--- a/templates/adminUsersPermissionsPage.gohtml
+++ b/templates/adminUsersPermissionsPage.gohtml
@@ -9,6 +9,7 @@
             <th class="sortable">User</th>
             <th class="sortable">Email</th>
             <th class="sortable">Level</th>
+            <th class="section" style="display:none">Section</th>
             <th>Edit</th>
             <th>Delete</th>
         </tr>


### PR DESCRIPTION
## Summary
- align edit and delete columns in admin users permissions table

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6857993c9124832f85e18f00bc5bd57f