### PR TITLE
Fix user email display in preferences

### DIFF
--- a/templates/userEmailPage.gohtml
+++ b/templates/userEmailPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-    Your registered email address is: {{ .UserData.Email }}<br>
+    Your registered email address is: {{ .UserData.Email.String }}<br>
 
     <form method="post">
         <input type="checkbox" name="emailupdates" {{ if .UserPreferences.EmailUpdates }}checked{{ end }}>Receive replies notifications via email<br>


### PR DESCRIPTION
## Summary
- fix user email preferences page to display just the email

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685798d84ff0832fa40192868b78ec43