### PR TITLE
Fix a4code link parsing

### DIFF
--- a/a4code2html.go
+++ b/a4code2html.go
@@ -91,8 +91,14 @@ func (c *A4code2html) getNext(endAtEqual bool) string {
 		c.input = c.input[1:]
 
 		switch ch {
-		case '\n', ']', '[', ' ', '\r', '=':
+		case '\n', ']', '[', ' ', '\r':
 			loop = false
+		case '=':
+			if endAtEqual {
+				loop = false
+			} else {
+				result.WriteByte(ch)
+			}
 		case '\\':
 			if len(c.input) > 0 {
 				ch = c.input[0]


### PR DESCRIPTION
## Summary
- fix `getNext` to only break on `=` when needed

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685798709fc8832fac04527d40d7de10