### PR TITLE
Use role middleware for admin routes

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -1,24 +1,7 @@
 package main
 
-import (
-	"golang.org/x/exp/slices"
-	"log"
-	"net/http"
-)
+import "net/http"
 
 func AdminCheckerMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		cd := request.Context().Value(ContextValues("coreData")).(*CoreData)
-		levelRequired := []string{"administrator"}
-		if !slices.Contains(levelRequired, cd.SecurityLevel) {
-			err := getCompiledTemplates(NewFuncs(request)).ExecuteTemplate(writer, "adminNoAccessPage.gohtml", request.Context().Value(ContextValues("coreData")).(*CoreData))
-			if err != nil {
-				log.Printf("Template Error: %s", err)
-				http.Error(writer, "Internal Server Error", http.StatusInternalServerError)
-				return
-			}
-			return
-		}
-		next.ServeHTTP(writer, request.WithContext(request.Context()))
-	})
+	return RoleCheckerMiddleware("administrator")(next)
 }

--- a/role_middleware.go
+++ b/role_middleware.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"database/sql"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// roleAllowed checks if the current request has one of the provided roles.
+func roleAllowed(r *http.Request, roles ...string) bool {
+	cd, ok := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	if ok && cd != nil {
+		for _, lvl := range roles {
+			if cd.HasRole(lvl) {
+				return true
+			}
+		}
+		return false
+	}
+
+	user, uok := r.Context().Value(ContextValues("user")).(*User)
+	queries, qok := r.Context().Value(ContextValues("queries")).(*Queries)
+	if !uok || !qok {
+		return false
+	}
+	section := strings.Split(strings.TrimPrefix(r.URL.Path, "/"), "/")[0]
+	perm, err := queries.GetPermissionsByUserIdAndSectionAndSectionAll(r.Context(), GetPermissionsByUserIdAndSectionAndSectionAllParams{
+		UsersIdusers: user.Idusers,
+		Section:      sql.NullString{String: section, Valid: true},
+	})
+	if err != nil || !perm.Level.Valid {
+		return false
+	}
+	cd = &CoreData{SecurityLevel: perm.Level.String}
+	for _, lvl := range roles {
+		if cd.HasRole(lvl) {
+			return true
+		}
+	}
+	return false
+}
+
+// RoleCheckerMiddleware ensures the user has one of the supplied roles.
+func RoleCheckerMiddleware(roles ...string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !roleAllowed(r, roles...) {
+				err := getCompiledTemplates(NewFuncs(r)).ExecuteTemplate(w, "adminNoAccessPage.gohtml", r.Context().Value(ContextValues("coreData")).(*CoreData))
+				if err != nil {
+					log.Printf("Template Error: %s", err)
+					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				}
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/role_middleware_test.go
+++ b/role_middleware_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
+	req := httptest.NewRequest("GET", "/admin", nil)
+	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{SecurityLevel: "administrator"})
+	req = req.WithContext(ctx)
+
+	called := false
+	h := RoleCheckerMiddleware("administrator")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if !called {
+		t.Errorf("handler not called")
+	}
+	if rr.Code != http.StatusOK {
+		t.Errorf("unexpected status %d", rr.Code)
+	}
+}
+
+func TestRoleCheckerMiddlewareDenied(t *testing.T) {
+	req := httptest.NewRequest("GET", "/admin", nil)
+	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{SecurityLevel: "reader"})
+	req = req.WithContext(ctx)
+
+	called := false
+	h := RoleCheckerMiddleware("administrator")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if called {
+		t.Errorf("handler should not be called")
+	}
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected template render, got status %d", rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- extract `roleAllowed` check used by route matchers
- add `RoleCheckerMiddleware` for verifying user roles
- implement admin middleware with new role checker
- test the new middleware

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858a6d562ac832f95ea6ce1e6552be0