### PR TITLE
Fix FAQ admin categories route

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,12 +210,6 @@ func run() error {
 
 	r := mux.NewRouter()
 
-	r.Use(DBAdderMiddleware)
-	r.Use(UserAdderMiddleware)
-	r.Use(CoreAdderMiddleware)
-	r.Use(RequestLoggerMiddleware)
-	r.Use(SecurityHeadersMiddleware)
-
 	// TODO consider adsense / adwords / etc
 
 	r.HandleFunc("/main.css", mainCSSHandler).Methods("GET")
@@ -250,6 +244,8 @@ func run() error {
 	faqr.HandleFunc("/admin/answer", faqAnswerAnswerActionPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskAnswer))
 	faqr.HandleFunc("/admin/answer", faqAnswerRemoveActionPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskRemoveRemove))
 	faqr.HandleFunc("/admin/categories", faqAdminCategoriesPage).Methods("GET").MatcherFunc(RequiredAccess("administrator"))
+	// also handle trailing slash for compatibility
+	faqr.HandleFunc("/admin/categories/", faqAdminCategoriesPage).Methods("GET").MatcherFunc(RequiredAccess("administrator"))
 	faqr.HandleFunc("/admin/categories", faqCategoriesRenameActionPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskRenameCategory))
 	faqr.HandleFunc("/admin/categories", faqCategoriesDeleteActionPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskDeleteCategory))
 	faqr.HandleFunc("/admin/categories", faqCategoriesCreateActionPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskCreateCategory))
@@ -515,7 +511,13 @@ func run() error {
 	//r.HandleFunc("/callback", callbackHandler)
 	//r.HandleFunc("/logout", logoutHandler)
 
-	handler = r
+	handler = newMiddlewareChain(
+		DBAdderMiddleware,
+		UserAdderMiddleware,
+		CoreAdderMiddleware,
+		RequestLoggerMiddleware,
+		SecurityHeadersMiddleware,
+	).Wrap(r)
 	if csrfEnabled() {
 		handler = newCSRFMiddleware(sessionSecret, httpCfg, version).Wrap(handler)
 	}

--- a/router_wrapper.go
+++ b/router_wrapper.go
@@ -11,3 +11,14 @@ type routerWrapper interface {
 type routerWrapperFunc func(http.Handler) http.Handler
 
 func (f routerWrapperFunc) Wrap(h http.Handler) http.Handler { return f(h) }
+
+// newMiddlewareChain returns a routerWrapper that wraps a handler with the provided
+// middleware functions in the order supplied.
+func newMiddlewareChain(mw ...func(http.Handler) http.Handler) routerWrapper {
+	return routerWrapperFunc(func(h http.Handler) http.Handler {
+		for i := len(mw) - 1; i >= 0; i-- {
+			h = mw[i](h)
+		}
+		return h
+	})
+}


### PR DESCRIPTION
## Summary
- handle trailing slash for FAQ admin categories path so admin pages work with or without `/`
- wrap the router with core middleware chain so matcher functions see context

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68579ab516e0832f959f95cdd8ee6471