### PR TITLE
Add schema version updates to migrations

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -36,4 +36,7 @@ const (
 
 	// Alphabet lists letters for search navigation.
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
+
+	// ExpectedSchemaVersion defines the required database schema version.
+	ExpectedSchemaVersion = 6
 )

--- a/migrations/0003.sql
+++ b/migrations/0003.sql
@@ -1,4 +1,3 @@
--- Add sessions table to track active user sessions
 CREATE TABLE IF NOT EXISTS `sessions` (
   `session_id` varchar(128) NOT NULL,
   `users_idusers` int NOT NULL,
@@ -6,3 +5,6 @@ CREATE TABLE IF NOT EXISTS `sessions` (
   PRIMARY KEY (`session_id`),
   KEY `sessions_user_idx` (`users_idusers`)
 );
+
+-- Record upgrade to schema version 3
+UPDATE schema_version SET version = 3 WHERE version = 2;

--- a/migrations/0004.sql
+++ b/migrations/0004.sql
@@ -1,4 +1,3 @@
--- Add search table for image posts
 CREATE TABLE IF NOT EXISTS `imagepostSearch` (
   `imagepost_idimagepost` INT NOT NULL DEFAULT 0,
   `searchwordlist_idsearchwordlist` INT NOT NULL DEFAULT 0,
@@ -6,3 +5,6 @@ CREATE TABLE IF NOT EXISTS `imagepostSearch` (
   KEY `imagepostSearch_FKIndex1` (`imagepost_idimagepost`),
   KEY `imagepostSearch_FKIndex2` (`searchwordlist_idsearchwordlist`)
 );
+
+-- Record upgrade to schema version 4
+UPDATE schema_version SET version = 4 WHERE version = 3;

--- a/migrations/0005.sql
+++ b/migrations/0005.sql
@@ -1,3 +1,6 @@
 -- Add expires_at column to userstopiclevel for permission expiration tracking
 ALTER TABLE userstopiclevel
     ADD COLUMN IF NOT EXISTS expires_at DATETIME DEFAULT NULL;
+
+-- Record upgrade to schema version 5
+UPDATE schema_version SET version = 5 WHERE version = 4;

--- a/migrations/0006.sql
+++ b/migrations/0006.sql
@@ -6,3 +6,6 @@ CREATE TABLE IF NOT EXISTS `login_attempts` (
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 );
+
+-- Record upgrade to schema version 6
+UPDATE schema_version SET version = 6 WHERE version = 5;

--- a/startup.go
+++ b/startup.go
@@ -86,5 +86,12 @@ func ensureSchema(ctx context.Context, db *sql.DB) error {
 			return fmt.Errorf("insert schema_version: %w", err)
 		}
 	}
+	var version int
+	if err := db.QueryRowContext(ctx, "SELECT version FROM schema_version").Scan(&version); err != nil {
+		return fmt.Errorf("select schema_version: %w", err)
+	}
+	if version != ExpectedSchemaVersion {
+		return fmt.Errorf("database schema version %d does not match expected %d", version, ExpectedSchemaVersion)
+	}
 	return nil
 }

--- a/startup_test.go
+++ b/startup_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestEnsureSchemaVersionMatch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM schema_version")).
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(ExpectedSchemaVersion))
+
+	if err := ensureSchema(context.Background(), db); err != nil {
+		t.Fatalf("ensureSchema: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestEnsureSchemaVersionMismatch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM schema_version")).
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(ExpectedSchemaVersion - 1))
+
+	if err := ensureSchema(context.Background(), db); err == nil {
+		t.Fatalf("expected error")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure migrations record schema version upgrades
- add check for expected schema version at startup

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6858c654a6c4832f83f15ff316d7a1f7