### PR TITLE
Remove unused per-component config file vars

### DIFF
--- a/app_config_test.go
+++ b/app_config_test.go
@@ -7,12 +7,12 @@ import (
 func TestLoadAppConfigFile(t *testing.T) {
 	useMemFS(t)
 	file := "app.conf"
-	content := "DB_CONFIG_FILE=db.conf\nEMAIL_CONFIG_FILE=email.conf\n"
+	content := "DB_USER=dbuser\nEMAIL_PROVIDER=smtp\n"
 	if err := writeFile(file, []byte(content), 0644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	m := loadAppConfigFile(file)
-	if m["DB_CONFIG_FILE"] != "db.conf" || m["EMAIL_CONFIG_FILE"] != "email.conf" {
+	if m["DB_USER"] != "dbuser" || m["EMAIL_PROVIDER"] != "smtp" {
 		t.Fatalf("unexpected map: %#v", m)
 	}
 }

--- a/config/env.go
+++ b/config/env.go
@@ -61,18 +61,10 @@ const (
 
 	// EnvDBLogVerbosity controls the verbosity level of database logging.
 	EnvDBLogVerbosity = "DB_LOG_VERBOSITY"
-	// EnvDBConfigFile specifies the path to the database configuration file.
-	EnvDBConfigFile = "DB_CONFIG_FILE"
-
-	// EnvHTTPConfigFile specifies the path to the HTTP configuration file.
-	EnvHTTPConfigFile = "HTTP_CONFIG_FILE"
 	// EnvListen is the network address the HTTP server listens on.
 	EnvListen = "LISTEN"
 	// EnvHostname is the base URL advertised by the HTTP server.
 	EnvHostname = "HOSTNAME"
-
-	// EnvPaginationConfigFile specifies the path to the pagination configuration file.
-	EnvPaginationConfigFile = "PAGINATION_CONFIG_FILE"
 
 	// EnvSessionSecret is the secret used to encrypt session cookies.
 	EnvSessionSecret = "SESSION_SECRET"
@@ -81,8 +73,6 @@ const (
 
 	// EnvSendGridKey is the API key for the SendGrid email provider.
 	EnvSendGridKey = "SENDGRID_KEY"
-	// EnvEmailConfigFile specifies the path to the email configuration file.
-	EnvEmailConfigFile = "EMAIL_CONFIG_FILE"
 	// EnvAdminEmails is a comma-separated list of administrator email addresses.
 	EnvAdminEmails = "ADMIN_EMAILS"
 	// EnvAdminNotify toggles sending administrator notification emails.


### PR DESCRIPTION
## Summary
- drop unused `*_CONFIG_FILE` variables from `config/env.go`
- update app config test to use existing variables

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858d1d758a0832faa71c27b27b969d6