### PR TITLE
Extend runtime config

### DIFF
--- a/adminSiteSettingsPage.go
+++ b/adminSiteSettingsPage.go
@@ -11,7 +11,7 @@ func adminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Bad Request", http.StatusBadRequest)
 			return
 		}
-		feedsEnabled = r.PostFormValue("feeds_enabled") != ""
+		appRuntimeConfig.FeedsEnabled = r.PostFormValue("feeds_enabled") != ""
 		http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
 		return
 	}
@@ -23,7 +23,7 @@ func adminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
-	data.CoreData.FeedsEnabled = feedsEnabled
+	data.CoreData.FeedsEnabled = appRuntimeConfig.FeedsEnabled
 
 	if err := renderTemplate(w, r, "adminSiteSettingsPage.gohtml", data); err != nil {
 		log.Printf("template error: %v", err)

--- a/adminUsageStatsPage.go
+++ b/adminUsageStatsPage.go
@@ -40,13 +40,13 @@ func adminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 	if data.LinkerCategories, err = queries.GetLinkerCategoryLinkCounts(r.Context()); err != nil {
 		log.Printf("linker category counts: %v", err)
 	}
-	if data.Monthly, err = queries.MonthlyUsageCounts(r.Context(), int32(statsStartYear)); err != nil {
+	if data.Monthly, err = queries.MonthlyUsageCounts(r.Context(), int32(appRuntimeConfig.StatsStartYear)); err != nil {
 		log.Printf("monthly usage counts: %v", err)
 	}
-	if data.UserMonthly, err = queries.UserMonthlyUsageCounts(r.Context(), int32(statsStartYear)); err != nil {
+	if data.UserMonthly, err = queries.UserMonthlyUsageCounts(r.Context(), int32(appRuntimeConfig.StatsStartYear)); err != nil {
 		log.Printf("user monthly usage counts: %v", err)
 	}
-	data.StartYear = statsStartYear
+	data.StartYear = appRuntimeConfig.StatsStartYear
 
 	if err := renderTemplate(w, r, "adminUsageStatsPage.gohtml", data); err != nil {
 		log.Printf("template error: %v", err)

--- a/core.go
+++ b/core.go
@@ -82,7 +82,7 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 			IndexItems:        idx,
 			UserID:            uid,
 			Title:             "Arran4's Website",
-			FeedsEnabled:      feedsEnabled,
+			FeedsEnabled:      appRuntimeConfig.FeedsEnabled,
 			NotificationCount: count,
 			Announcement:      ann,
 		})

--- a/main.go
+++ b/main.go
@@ -164,16 +164,14 @@ func run() error {
 	cliRuntimeConfig.PageSizeMax = *pageSizeMaxFlag
 	cliRuntimeConfig.PageSizeDefault = *pageSizeDefaultFlag
 
+	if feedsFlagSet {
+		cliFeedsEnabled = *feedsEnabledFlag
+	}
+	cliStatsStartYear = *statsStartYearFlag
+
 	cfg := loadRuntimeConfig(appCfg)
 
 	var handler http.Handler
-
-	var cliFeeds string
-	if feedsFlagSet {
-		cliFeeds = *feedsEnabledFlag
-	}
-	loadFeedsEnabled(cliFeeds, appCfg)
-	loadStatsStartYear(*statsStartYearFlag, appCfg)
 
 	if err := performStartupChecks(cfg); err != nil {
 		return fmt.Errorf("startup checks: %w", err)
@@ -541,7 +539,7 @@ func run() error {
 	ibr.HandleFunc("/admin/board", taskDoneAutoRefreshPage).Methods("POST").MatcherFunc(RequiredAccess("administrator"))
 	ibr.HandleFunc("/admin/board/{board}", imagebbsAdminBoardModifyBoardActionPage).Methods("POST").MatcherFunc(RequiredAccess("administrator")).MatcherFunc(TaskMatcher(TaskModifyBoard))
 
-  // oauth shit
+	// oauth shit
 	//r.HandleFunc("/login", loginPage)
 	//r.HandleFunc("/callback", callbackHandler)
 	//r.HandleFunc("/logout", logoutHandler)

--- a/runtime_config.go
+++ b/runtime_config.go
@@ -36,10 +36,15 @@ type RuntimeConfig struct {
 	PageSizeMin     int
 	PageSizeMax     int
 	PageSizeDefault int
+
+	FeedsEnabled   bool
+	StatsStartYear int
 }
 
 var cliRuntimeConfig RuntimeConfig
 var appRuntimeConfig RuntimeConfig
+var cliFeedsEnabled string
+var cliStatsStartYear string
 
 // loadRuntimeConfig builds the runtime configuration from CLI flags, optional
 // config files and environment variables following the precedence rules from
@@ -134,6 +139,17 @@ func loadRuntimeConfig(fileVals map[string]string) RuntimeConfig {
 	config.Merge(&cfg, fileCfg)
 	config.Merge(&cfg, cliRuntimeConfig)
 
+	cfg.FeedsEnabled = resolveFeedsEnabled(
+		cliFeedsEnabled,
+		fileVals[config.EnvFeedsEnabled],
+		os.Getenv(config.EnvFeedsEnabled),
+	)
+	cfg.StatsStartYear = resolveStatsStartYear(
+		cliStatsStartYear,
+		fileVals[config.EnvStatsStartYear],
+		os.Getenv(config.EnvStatsStartYear),
+	)
+
 	normalizeRuntimeConfig(&cfg)
 	appRuntimeConfig = cfg
 	return cfg
@@ -164,6 +180,9 @@ func normalizeRuntimeConfig(cfg *RuntimeConfig) {
 	}
 	if cfg.PageSizeDefault > cfg.PageSizeMax {
 		cfg.PageSizeDefault = cfg.PageSizeMax
+	}
+	if cfg.StatsStartYear == 0 {
+		cfg.StatsStartYear = 2005
 	}
 }
 

--- a/site_config.go
+++ b/site_config.go
@@ -1,13 +1,6 @@
 package main
 
-import (
-	"os"
-	"strings"
-
-	"github.com/arran4/goa4web/config"
-)
-
-var feedsEnabled = true
+import "strings"
 
 func parseBool(v string) (bool, bool) {
 	if v == "" {
@@ -34,12 +27,4 @@ func resolveFeedsEnabled(cli, file, env string) bool {
 		return b
 	}
 	return true
-}
-
-func loadFeedsEnabled(cli string, file map[string]string) {
-	fileVal := ""
-	if v, ok := file["FEEDS_ENABLED"]; ok {
-		fileVal = v
-	}
-	feedsEnabled = resolveFeedsEnabled(cli, fileVal, os.Getenv(config.EnvFeedsEnabled))
 }

--- a/stats_config.go
+++ b/stats_config.go
@@ -1,13 +1,6 @@
 package main
 
-import (
-	"os"
-	"strconv"
-
-	"github.com/arran4/goa4web/config"
-)
-
-var statsStartYear int
+import "strconv"
 
 func parseInt(v string) (int, bool) {
 	if v == "" {
@@ -31,12 +24,4 @@ func resolveStatsStartYear(cli, file, env string) int {
 		return n
 	}
 	return 2005
-}
-
-func loadStatsStartYear(cli string, file map[string]string) {
-	fileVal := ""
-	if v, ok := file["STATS_START_YEAR"]; ok {
-		fileVal = v
-	}
-	statsStartYear = resolveStatsStartYear(cli, fileVal, os.Getenv(config.EnvStatsStartYear))
 }


### PR DESCRIPTION
## Summary
- add feeds and statistics fields to RuntimeConfig
- use config precedence to resolve FeedsEnabled and StatsStartYear
- remove feedsEnabled/statsStartYear globals and update handlers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6858d1d5f3a8832f8486f9d33e42d03a