### PR TITLE
Refactor runtime config parsing

### DIFF
--- a/adminReloadConfigPage.go
+++ b/adminReloadConfigPage.go
@@ -17,7 +17,7 @@ func adminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cfgMap := loadAppConfigFile(configFile)
-	srv.Config = loadRuntimeConfig(cfgMap)
+	srv.Config = generateRuntimeConfig(nil, cfgMap)
 
 	data.Messages = append(data.Messages, "Configuration reloaded")
 

--- a/db_config_test.go
+++ b/db_config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"testing"
 
@@ -13,23 +14,25 @@ func TestDBConfigPrecedence(t *testing.T) {
 	defer os.Unsetenv(config.EnvDBUser)
 	defer os.Unsetenv(config.EnvDBHost)
 
-	cliRuntimeConfig = RuntimeConfig{DBPass: "cli"}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("db-pass", "cli", "")
 	vals := map[string]string{
 		config.EnvDBUser: "file",
 		config.EnvDBPort: "1",
 	}
-	cfg := loadRuntimeConfig(vals)
+	_ = fs.Parse([]string{"--db-pass=cli"})
+	cfg := generateRuntimeConfig(fs, vals)
 	if cfg.DBUser != "file" || cfg.DBPass != "cli" || cfg.DBHost != "env" || cfg.DBPort != "1" {
 		t.Fatalf("merged %#v", cfg)
 	}
 }
 
 func TestLoadDBConfigFromFileValues(t *testing.T) {
-	cliRuntimeConfig = RuntimeConfig{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	vals := map[string]string{
 		config.EnvDBUser: "fileval",
 	}
-	cfg := loadRuntimeConfig(vals)
+	cfg := generateRuntimeConfig(fs, vals)
 	if cfg.DBUser != "fileval" {
 		t.Fatalf("want fileval got %q", cfg.DBUser)
 	}

--- a/email_config_test.go
+++ b/email_config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"testing"
 
@@ -13,26 +14,26 @@ func TestEmailConfigPrecedence(t *testing.T) {
 	defer os.Unsetenv(config.EnvEmailProvider)
 	defer os.Unsetenv(config.EnvSMTPHost)
 
-	cliRuntimeConfig = RuntimeConfig{
-		EmailProvider: "smtp",
-		EmailSMTPPort: "25",
-	}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("email-provider", "smtp", "")
+	fs.String("smtp-port", "25", "")
 	vals := map[string]string{
 		config.EnvEmailProvider: "log",
 		config.EnvSMTPHost:      "file",
 	}
-	cfg := loadRuntimeConfig(vals)
+	_ = fs.Parse([]string{"--email-provider=smtp", "--smtp-port=25"})
+	cfg := generateRuntimeConfig(fs, vals)
 	if cfg.EmailProvider != "smtp" || cfg.EmailSMTPHost != "file" || cfg.EmailSMTPPort != "25" {
 		t.Fatalf("merged %#v", cfg)
 	}
 }
 
 func TestLoadEmailConfigFromFileValues(t *testing.T) {
-	cliRuntimeConfig = RuntimeConfig{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	vals := map[string]string{
 		config.EnvEmailProvider: "log",
 	}
-	cfg := loadRuntimeConfig(vals)
+	cfg := generateRuntimeConfig(fs, vals)
 	if cfg.EmailProvider != "log" {
 		t.Fatalf("want log got %q", cfg.EmailProvider)
 	}

--- a/http_config_test.go
+++ b/http_config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"testing"
 
@@ -13,12 +14,15 @@ func TestHTTPConfigPrecedence(t *testing.T) {
 	defer os.Unsetenv(config.EnvListen)
 	defer os.Unsetenv(config.EnvHostname)
 
-	cliRuntimeConfig = RuntimeConfig{HTTPListen: ":3", HTTPHostname: "http://cli"}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("listen", ":3", "")
+	fs.String("hostname", "http://cli", "")
 	vals := map[string]string{
 		config.EnvListen:   ":2",
 		config.EnvHostname: "http://file",
 	}
-	cfg := loadRuntimeConfig(vals)
+	_ = fs.Parse([]string{"--listen=:3", "--hostname=http://cli"})
+	cfg := generateRuntimeConfig(fs, vals)
 
 	if cfg.HTTPListen != ":3" || cfg.HTTPHostname != "http://cli" {
 		t.Fatalf("merged %#v", cfg)
@@ -26,11 +30,11 @@ func TestHTTPConfigPrecedence(t *testing.T) {
 }
 
 func TestLoadHTTPConfigFromFileValues(t *testing.T) {
-	cliRuntimeConfig = RuntimeConfig{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	vals := map[string]string{
 		config.EnvListen: ":9",
 	}
-	cfg := loadRuntimeConfig(vals)
+	cfg := generateRuntimeConfig(fs, vals)
 	if cfg.HTTPListen != ":9" {
 		t.Fatalf("want :9 got %q", cfg.HTTPListen)
 	}

--- a/pagination_config_test.go
+++ b/pagination_config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"testing"
 
@@ -15,25 +16,28 @@ func TestPaginationConfigPrecedence(t *testing.T) {
 	defer os.Unsetenv(config.EnvPageSizeMax)
 	defer os.Unsetenv(config.EnvPageSizeDefault)
 
-	cliRuntimeConfig = RuntimeConfig{PageSizeMin: 12, PageSizeDefault: 15}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.Int("page-size-min", 12, "")
+	fs.Int("page-size-default", 15, "")
 	vals := map[string]string{
 		config.EnvPageSizeMin:     "8",
 		config.EnvPageSizeMax:     "20",
 		config.EnvPageSizeDefault: "18",
 	}
-	cfg := loadRuntimeConfig(vals)
+	_ = fs.Parse([]string{"--page-size-min=12", "--page-size-default=15"})
+	cfg := generateRuntimeConfig(fs, vals)
 	if cfg.PageSizeMin != 12 || cfg.PageSizeMax != 20 || cfg.PageSizeDefault != 15 {
 		t.Fatalf("merged %#v", cfg)
 	}
 }
 
 func TestLoadPaginationConfigFromFileValues(t *testing.T) {
-	cliRuntimeConfig = RuntimeConfig{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	vals := map[string]string{
 		config.EnvPageSizeMin:     "7",
 		config.EnvPageSizeDefault: "9",
 	}
-	cfg := loadRuntimeConfig(vals)
+	cfg := generateRuntimeConfig(fs, vals)
 	if cfg.PageSizeMin != 7 || cfg.PageSizeDefault != 9 {
 		t.Fatalf("want 7/9 got %#v", cfg)
 	}


### PR DESCRIPTION
## Summary
- rewrite `generateRuntimeConfig` to reduce duplication
- iterate over config options instead of large switch blocks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6858e4017780832f95141c24007cff81