### PR TITLE
Add default language configuration

### DIFF
--- a/adminReloadConfigPage.go
+++ b/adminReloadConfigPage.go
@@ -17,9 +17,14 @@ func adminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cfgMap := loadAppConfigFile(configFile)
-	srv.Config = loadRuntimeConfig(cfgMap)
-
-	data.Messages = append(data.Messages, "Configuration reloaded")
+	cfg := loadRuntimeConfig(cfgMap)
+	if err := validateDefaultLanguage(r.Context(), srv.DB, &cfg); err != nil {
+		data.Errors = append(data.Errors, err.Error())
+	} else {
+		appRuntimeConfig = cfg
+		srv.Config = cfg
+		data.Messages = append(data.Messages, "Configuration reloaded")
+	}
 
 	if err := renderTemplate(w, r, "adminRunTaskPage.gohtml", data); err != nil {
 		log.Printf("Template Error: %s", err)

--- a/adminSiteSettingsPage.go
+++ b/adminSiteSettingsPage.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 	"net/http"
+
+	"github.com/arran4/goa4web/config"
 )
 
 func adminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
@@ -12,18 +14,40 @@ func adminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		appRuntimeConfig.FeedsEnabled = r.PostFormValue("feeds_enabled") != ""
+		if lang := r.PostFormValue("default_language"); lang != "" {
+			tmp := appRuntimeConfig
+			tmp.DefaultLanguage = lang
+			if err := validateDefaultLanguage(r.Context(), srv.DB, &tmp); err == nil {
+				appRuntimeConfig.DefaultLanguage = lang
+				if configFile != "" {
+					_ = updateConfigKey(configFile, config.EnvDefaultLanguage, lang)
+				}
+			} else {
+				log.Printf("validate default language: %v", err)
+			}
+		}
+		if configFile != "" {
+			_ = updateConfigKey(configFile, config.EnvFeedsEnabled, r.PostFormValue("feeds_enabled"))
+		}
 		http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
 		return
 	}
 
 	type Data struct {
 		*CoreData
+		Languages       []*Language
+		DefaultLanguage string
 	}
 
 	data := Data{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 	data.CoreData.FeedsEnabled = appRuntimeConfig.FeedsEnabled
+	data.DefaultLanguage = appRuntimeConfig.DefaultLanguage
+	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	if rows, err := queries.FetchLanguages(r.Context()); err == nil {
+		data.Languages = rows
+	}
 
 	if err := renderTemplate(w, r, "adminSiteSettingsPage.gohtml", data); err != nil {
 		log.Printf("template error: %v", err)

--- a/app_config_write.go
+++ b/app_config_write.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bytes"
+	"sort"
+)
+
+// updateConfigKey rewrites the configuration file path with the provided key value.
+func updateConfigKey(path, key, value string) error {
+	m := loadAppConfigFile(path)
+	if m == nil {
+		m = make(map[string]string)
+	}
+	m[key] = value
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var buf bytes.Buffer
+	for _, k := range keys {
+		buf.WriteString(k + "=" + m[k] + "\n")
+	}
+	return writeFile(path, buf.Bytes(), 0644)
+}

--- a/blogsBlogAddPage.go
+++ b/blogsBlogAddPage.go
@@ -23,7 +23,7 @@ func blogsBlogAddPage(w http.ResponseWriter, r *http.Request) {
 
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: 1,
+		SelectedLanguageId: resolveDefaultLanguageID(r, 0),
 		Mode:               "Add",
 	}
 

--- a/blogsBlogEditPage.go
+++ b/blogsBlogEditPage.go
@@ -24,9 +24,8 @@ func blogsBlogEditPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData:           cd,
-		SelectedLanguageId: 1,
-		Mode:               "Edit",
+		CoreData: cd,
+		Mode:     "Edit",
 	}
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
@@ -47,6 +46,7 @@ func blogsBlogEditPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data.Blog = row
+	data.SelectedLanguageId = int(row.LanguageIdlanguage)
 
 	CustomBlogIndex(data.CoreData, r)
 

--- a/blogsBlogPage.go
+++ b/blogsBlogPage.go
@@ -42,7 +42,7 @@ func blogsBlogPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
 		Offset:             offset,
 		IsReplyable:        true,
-		SelectedLanguageId: 1,
+		SelectedLanguageId: resolveDefaultLanguageID(r, 0),
 		EditUrl:            fmt.Sprintf("/blogs/blog/%d/edit", blogId),
 	}
 

--- a/blogsCommentPage.go
+++ b/blogsCommentPage.go
@@ -46,7 +46,7 @@ func blogsCommentPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
 		Offset:             offset,
 		IsReplyable:        true,
-		SelectedLanguageId: 1,
+		SelectedLanguageId: resolveDefaultLanguageID(r, 0),
 		EditUrl:            fmt.Sprintf("/blogs/blog/%d/edit", blogId),
 	}
 

--- a/config/env.go
+++ b/config/env.go
@@ -56,6 +56,9 @@ const (
 	// EnvPageSizeDefault defines the default page size.
 	EnvPageSizeDefault = "PAGE_SIZE_DEFAULT"
 
+	// EnvDefaultLanguage sets the site's default language name.
+	EnvDefaultLanguage = "DEFAULT_LANGUAGE"
+
 	// EnvStatsStartYear sets the first year displayed by the usage stats page.
 	EnvStatsStartYear = "STATS_START_YEAR"
 

--- a/default_language.go
+++ b/default_language.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// validateLanguageName reports an error if name does not exist in the
+// language table.
+func validateLanguageName(ctx context.Context, db *sql.DB, name string) error {
+	if name == "" || db == nil {
+		return nil
+	}
+	q := &Queries{db: db}
+	if _, err := q.GetLanguageIDByName(ctx, sql.NullString{String: name, Valid: true}); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("language %s not found", name)
+		}
+		return err
+	}
+	return nil
+}
+
+// validateDefaultLanguage checks that cfg.DefaultLanguage exists in the language table.
+func validateDefaultLanguage(ctx context.Context, db *sql.DB, cfg *RuntimeConfig) error {
+	return validateLanguageName(ctx, db, cfg.DefaultLanguage)
+}
+
+// resolveDefaultLanguageID chooses the best language ID for new content.
+func resolveDefaultLanguageID(r *http.Request, contextLangID int32) int {
+	if contextLangID != 0 {
+		return int(contextLangID)
+	}
+	if pref, _ := r.Context().Value(ContextValues("preference")).(*Preference); pref != nil {
+		if pref.LanguageIdlanguage != 0 {
+			return int(pref.LanguageIdlanguage)
+		}
+	}
+	if appRuntimeConfig.DefaultLanguage != "" {
+		queries := r.Context().Value(ContextValues("queries")).(*Queries)
+		if queries != nil {
+			if id, err := queries.GetLanguageIDByName(r.Context(), sql.NullString{String: appRuntimeConfig.DefaultLanguage, Valid: true}); err == nil {
+				return int(id)
+			}
+		}
+	}
+	return 0
+}

--- a/faqAskPage.go
+++ b/faqAskPage.go
@@ -16,7 +16,7 @@ func faqAskPage(w http.ResponseWriter, r *http.Request) {
 
 	data := Data{
 		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
-		SelectedLanguageId: 1, // TODO user pref
+		SelectedLanguageId: int32(resolveDefaultLanguageID(r, 0)),
 	}
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)

--- a/forumThreadNewPage.go
+++ b/forumThreadNewPage.go
@@ -18,7 +18,7 @@ func forumThreadNewPage(w http.ResponseWriter, r *http.Request) {
 
 	data := Data{
 		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
-		SelectedLanguageId: 1, // TODO update these from user prefs and make it an optional filter
+		SelectedLanguageId: resolveDefaultLanguageID(r, 0),
 	}
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)

--- a/forumThreadPage.go
+++ b/forumThreadPage.go
@@ -40,7 +40,7 @@ func forumThreadPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
 		Offset:             offset,
 		IsReplyable:        true,
-		SelectedLanguageId: 1,
+		SelectedLanguageId: resolveDefaultLanguageID(r, 0),
 	}
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)

--- a/language_config_test.go
+++ b/language_config_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+)
+
+func TestLanguageConfigPrecedence(t *testing.T) {
+	os.Setenv(config.EnvDefaultLanguage, "env")
+	defer os.Unsetenv(config.EnvDefaultLanguage)
+
+	cliRuntimeConfig = RuntimeConfig{DefaultLanguage: "cli"}
+	vals := map[string]string{config.EnvDefaultLanguage: "file"}
+	cfg := loadRuntimeConfig(vals)
+	if cfg.DefaultLanguage != "cli" {
+		t.Fatalf("merged %#v", cfg)
+	}
+}
+
+func TestLoadLanguageConfigFromFileValues(t *testing.T) {
+	cliRuntimeConfig = RuntimeConfig{}
+	vals := map[string]string{config.EnvDefaultLanguage: "file"}
+	cfg := loadRuntimeConfig(vals)
+	if cfg.DefaultLanguage != "file" {
+		t.Fatalf("want file got %q", cfg.DefaultLanguage)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ var (
 	hostnameFlag        = flag.String("hostname", "", "server base URL")
 	feedsEnabledFlag    = flag.String("feeds-enabled", "", "enable or disable feeds")
 	statsStartYearFlag  = flag.String("stats-start-year", "", "start year for usage stats")
+	defaultLanguageFlag = flag.String("default-language", "", "site default language")
 	pageSizeMinFlag     = flag.Int("page-size-min", 0, "minimum allowed page size")
 	pageSizeMaxFlag     = flag.Int("page-size-max", 0, "maximum allowed page size")
 	pageSizeDefaultFlag = flag.Int("page-size-default", 0, "default page size")
@@ -162,6 +163,7 @@ func run() error {
 	cliRuntimeConfig.PageSizeMin = *pageSizeMinFlag
 	cliRuntimeConfig.PageSizeMax = *pageSizeMaxFlag
 	cliRuntimeConfig.PageSizeDefault = *pageSizeDefaultFlag
+	cliRuntimeConfig.DefaultLanguage = *defaultLanguageFlag
 
 	if feedsFlagSet {
 		cliFeedsEnabled = *feedsEnabledFlag
@@ -175,6 +177,11 @@ func run() error {
 	if err := performStartupChecks(cfg); err != nil {
 		return fmt.Errorf("startup checks: %w", err)
 	}
+
+	if err := validateDefaultLanguage(context.Background(), dbPool, &cfg); err != nil {
+		return fmt.Errorf("validate default language: %w", err)
+	}
+	appRuntimeConfig = cfg
 
 	if dbPool != nil {
 		defer func() {

--- a/newsPostPage.go
+++ b/newsPostPage.go
@@ -50,9 +50,10 @@ func newsPostPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData:    r.Context().Value(ContextValues("coreData")).(*CoreData),
-		IsReplying:  r.URL.Query().Has("comment"),
-		IsReplyable: true,
+		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		IsReplying:         r.URL.Query().Has("comment"),
+		IsReplyable:        true,
+		SelectedLanguageId: int32(resolveDefaultLanguageID(r, 0)),
 	}
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])

--- a/queries-languages.sql
+++ b/queries-languages.sql
@@ -25,3 +25,6 @@ VALUES (?);
 SELECT *
 FROM language;
 
+-- name: GetLanguageIDByName :one
+SELECT idlanguage FROM language WHERE nameof = ?;
+

--- a/queries-languages.sql.go
+++ b/queries-languages.sql.go
@@ -66,6 +66,17 @@ func (q *Queries) FetchLanguages(ctx context.Context) ([]*Language, error) {
 	return items, nil
 }
 
+const getLanguageIDByName = `-- name: GetLanguageIDByName :one
+SELECT idlanguage FROM language WHERE nameof = ?
+`
+
+func (q *Queries) GetLanguageIDByName(ctx context.Context, nameof sql.NullString) (int32, error) {
+	row := q.db.QueryRowContext(ctx, getLanguageIDByName, nameof)
+	var idlanguage int32
+	err := row.Scan(&idlanguage)
+	return idlanguage, err
+}
+
 const renameLanguage = `-- name: RenameLanguage :exec
 UPDATE language
 SET nameof = ?

--- a/runtime_config.go
+++ b/runtime_config.go
@@ -37,6 +37,8 @@ type RuntimeConfig struct {
 	PageSizeMax     int
 	PageSizeDefault int
 
+	DefaultLanguage string
+
 	FeedsEnabled   bool
 	StatsStartYear int
 }
@@ -70,6 +72,7 @@ func loadRuntimeConfig(fileVals map[string]string) RuntimeConfig {
 		EmailJMAPUser:     os.Getenv(config.EnvJMAPUser),
 		EmailJMAPPass:     os.Getenv(config.EnvJMAPPass),
 		EmailSendGridKey:  os.Getenv(config.EnvSendGridKey),
+		DefaultLanguage:   os.Getenv(config.EnvDefaultLanguage),
 	}
 	if v := os.Getenv(config.EnvDBLogVerbosity); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
@@ -112,6 +115,7 @@ func loadRuntimeConfig(fileVals map[string]string) RuntimeConfig {
 		EmailJMAPUser:     fileVals[config.EnvJMAPUser],
 		EmailJMAPPass:     fileVals[config.EnvJMAPPass],
 		EmailSendGridKey:  fileVals[config.EnvSendGridKey],
+		DefaultLanguage:   fileVals[config.EnvDefaultLanguage],
 	}
 	if v := fileVals[config.EnvDBLogVerbosity]; v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
@@ -151,7 +155,6 @@ func loadRuntimeConfig(fileVals map[string]string) RuntimeConfig {
 	)
 
 	normalizeRuntimeConfig(&cfg)
-	appRuntimeConfig = cfg
 	return cfg
 }
 

--- a/templates/adminSiteSettingsPage.gohtml
+++ b/templates/adminSiteSettingsPage.gohtml
@@ -6,6 +6,14 @@
         Enable Feeds
     </label>
     <br>
+    Default language:
+    <select name="default_language">
+        <option value="">None</option>
+        {{ range $.Languages }}
+            <option value="{{ .Nameof.String }}"{{ if eq $.DefaultLanguage .Nameof.String }} selected{{ end }}>{{ .Nameof.String }}</option>
+        {{ end }}
+    </select>
+    <br>
     <input type="submit" value="Save">
 </form>
 {{ template "tail" $ }}

--- a/writingsArticleAddPage.go
+++ b/writingsArticleAddPage.go
@@ -11,11 +11,13 @@ import (
 func writingsArticleAddPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*CoreData
-		Languages []*Language
+		Languages          []*Language
+		SelectedLanguageId int
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		SelectedLanguageId: resolveDefaultLanguageID(r, 0),
 	}
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)

--- a/writingsArticleEditPage.go
+++ b/writingsArticleEditPage.go
@@ -44,6 +44,7 @@ func writingsArticleEditPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data.Writing = writing
+	data.SelectedLanguageId = int(writing.LanguageIdlanguage)
 
 	languageRows, err := queries.FetchLanguages(r.Context())
 	if err != nil {


### PR DESCRIPTION
## Summary
- manage default language via env var, config file, or CLI flag
- validate site default language against DB
- expose helper to resolve the best language ID
- persist default language through app_config updates
- show language dropdown in site settings template
- preselect user preferred language across forms
- add tests for default language config precedence
- generalize language validation helper

## Testing
- `sqlc generate`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6859391ad134832fb036badc1778a7b3