### PR TITLE
Implement language visibility preferences

### DIFF
--- a/blogsBloggerPage.go
+++ b/blogsBloggerPage.go
@@ -12,7 +12,7 @@ import (
 
 func blogsBloggerPage(w http.ResponseWriter, r *http.Request) {
 	type BlogRow struct {
-		*GetBlogEntriesForUserDescendingRow
+		*GetBlogEntriesForUserDescendingLanguagesRow
 		EditUrl string
 	}
 	type Data struct {
@@ -31,9 +31,7 @@ func blogsBloggerPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	userLanguagePref := 0
-
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+       queries := r.Context().Value(ContextValues("queries")).(*Queries)
 
 	bu, err := queries.GetUserByUsername(r.Context(), sql.NullString{
 		String: username,
@@ -52,12 +50,12 @@ func blogsBloggerPage(w http.ResponseWriter, r *http.Request) {
 
 	buid := bu.Idusers
 
-	rows, err := queries.GetBlogEntriesForUserDescending(r.Context(), GetBlogEntriesForUserDescendingParams{
-		UsersIdusers:       buid,
-		LanguageIdlanguage: int32(userLanguagePref),
-		Limit:              15,
-		Offset:             int32(offset),
-	})
+       rows, err := queries.GetBlogEntriesForUserDescendingLanguages(r.Context(), GetBlogEntriesForUserDescendingLanguagesParams{
+               UsersIdusers:  buid,
+               ViewerIdusers: uid,
+               Limit:         15,
+               Offset:        int32(offset),
+       })
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -80,8 +78,8 @@ func blogsBloggerPage(w http.ResponseWriter, r *http.Request) {
 			editUrl = fmt.Sprintf("/blogs/blog/%d/edit", row.Idblogs)
 		}
 		data.Rows = append(data.Rows, &BlogRow{
-			GetBlogEntriesForUserDescendingRow: row,
-			EditUrl:                            editUrl,
+			GetBlogEntriesForUserDescendingLanguagesRow: row,
+			EditUrl: editUrl,
 		})
 	}
 	CustomBlogIndex(data.CoreData, r)

--- a/blogsBloggerPage_test.go
+++ b/blogsBloggerPage_test.go
@@ -43,19 +43,19 @@ func TestBlogsBloggerPage(t *testing.T) {
 	ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{})
 	req = req.WithContext(ctx)
 
-	userRows := sqlmock.NewRows([]string{"idusers", "email", "passwd", "username"}).
-		AddRow(1, "e", "p", "bob")
-	mock.ExpectQuery(regexp.QuoteMeta(getUserByUsername)).
-		WithArgs(sqlmock.AnyArg()).
-		WillReturnRows(userRows)
+       userRows := sqlmock.NewRows([]string{"idusers", "email", "passwd", "username"}).
+               AddRow(1, "e", "p", "bob")
+       mock.ExpectQuery(regexp.QuoteMeta(getUserByUsername)).
+               WithArgs(sqlmock.AnyArg()).
+               WillReturnRows(userRows)
 
 	blogRows := sqlmock.NewRows([]string{
 		"idblogs", "forumthread_idforumthread", "users_idusers",
 		"language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)",
 	}).AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), "bob", 0)
-	mock.ExpectQuery(regexp.QuoteMeta(getBlogEntriesForUserDescending)).
-		WithArgs(int32(0), int32(0), int32(1), int32(1), int32(15), int32(0)).
-		WillReturnRows(blogRows)
+       mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).
+               WithArgs(int32(1), int32(1), int32(1), int32(1), int32(15), int32(0)).
+               WillReturnRows(blogRows)
 
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)

--- a/blogsPage.go
+++ b/blogsPage.go
@@ -14,7 +14,7 @@ import (
 
 func blogsPage(w http.ResponseWriter, r *http.Request) {
 	type BlogRow struct {
-		*GetBlogEntriesForUserDescendingRow
+		*GetBlogEntriesForUserDescendingLanguagesRow
 		EditUrl string
 	}
 	type Data struct {
@@ -33,15 +33,13 @@ func blogsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	userLanguagePref := 0
-
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	rows, err := queries.GetBlogEntriesForUserDescending(r.Context(), GetBlogEntriesForUserDescendingParams{
-		UsersIdusers:       int32(userId),
-		LanguageIdlanguage: int32(userLanguagePref),
-		Limit:              15,
-		Offset:             int32(offset),
-	})
+       queries := r.Context().Value(ContextValues("queries")).(*Queries)
+       rows, err := queries.GetBlogEntriesForUserDescendingLanguages(r.Context(), GetBlogEntriesForUserDescendingLanguagesParams{
+               UsersIdusers:  int32(userId),
+               ViewerIdusers: uid,
+               Limit:         15,
+               Offset:        int32(offset),
+       })
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -64,8 +62,8 @@ func blogsPage(w http.ResponseWriter, r *http.Request) {
 			editUrl = fmt.Sprintf("/blogs/blog/%d/edit", row.Idblogs)
 		}
 		data.Rows = append(data.Rows, &BlogRow{
-			GetBlogEntriesForUserDescendingRow: row,
-			EditUrl:                            editUrl,
+			GetBlogEntriesForUserDescendingLanguagesRow: row,
+			EditUrl: editUrl,
 		})
 	}
 
@@ -215,10 +213,12 @@ func FeedGen(r *http.Request, queries *Queries, uid int, username string) (*feed
 		Created:     time.Date(2005, 6, 25, 0, 0, 0, 0, time.UTC),
 	}
 
-	rows, err := queries.GetBlogEntriesForUserDescending(r.Context(), GetBlogEntriesForUserDescendingParams{
-		UsersIdusers: int32(uid),
-		Limit:        15,
-	})
+       rows, err := queries.GetBlogEntriesForUserDescendingLanguages(r.Context(), GetBlogEntriesForUserDescendingLanguagesParams{
+               UsersIdusers:  int32(uid),
+               ViewerIdusers: int32(uid),
+               Limit:         15,
+               Offset:        0,
+       })
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/blogsPage_test.go
+++ b/blogsPage_test.go
@@ -25,10 +25,10 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "passwd", "username"}).
 			AddRow(1, "e", "p", "bob"))
 
-	mock.ExpectQuery(regexp.QuoteMeta(getBlogEntriesForUserDescending)).
-		WithArgs(int32(0), int32(0), int32(1), int32(1), int32(15), int32(0)).
-		WillReturnRows(sqlmock.NewRows([]string{"idblogs", "forumthread_idforumthread", "users_idusers", "language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)"}).
-			AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), "bob", 0))
+       mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).
+               WithArgs(int32(1), int32(1), int32(1), int32(1), int32(15), int32(0)).
+               WillReturnRows(sqlmock.NewRows([]string{"idblogs", "forumthread_idforumthread", "users_idusers", "language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)"}).
+                       AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), "bob", 0))
 
 	req := httptest.NewRequest("GET", "http://example.com/blogs/rss?rss=bob", nil)
 	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)

--- a/queries-blog.sql
+++ b/queries-blog.sql
@@ -22,6 +22,21 @@ AND (b.users_idusers = sqlc.arg(Users_idusers) OR sqlc.arg(Users_idusers) = 0)
 ORDER BY b.written DESC
 LIMIT ? OFFSET ?;
 
+-- name: GetBlogEntriesForUserDescendingLanguages :many
+SELECT b.*, u.username, coalesce(th.comments, 0)
+FROM blogs b
+LEFT JOIN users u ON b.users_idusers=u.idusers
+LEFT JOIN forumthread th ON b.forumthread_idforumthread = th.idforumthread
+WHERE (b.users_idusers = sqlc.arg(Users_idusers) OR sqlc.arg(Users_idusers) = 0)
+AND (
+    NOT EXISTS (SELECT 1 FROM userlang ul WHERE ul.users_idusers = sqlc.arg(Viewer_idusers))
+    OR b.language_idlanguage IN (
+        SELECT ul.language_idlanguage FROM userlang ul WHERE ul.users_idusers = sqlc.arg(Viewer_idusers)
+    )
+)
+ORDER BY b.written DESC
+LIMIT ? OFFSET ?;
+
 -- name: GetBlogEntriesByIdsDescending :many
 SELECT b.*
 FROM blogs b


### PR DESCRIPTION
## Summary
- refactor language filter to happen fully in SQL
- remove unused helper `getVisibleLanguageIDs`
- update blog listing and feed to call new query
- adjust unit tests for SQL-based filtering

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6859e45ee214832f9248d690cf8327f9