### PR TITLE
Use dedicated Dockerfile for GoReleaser

### DIFF
--- a/.github/workflows/go_releaser.yaml
+++ b/.github/workflows/go_releaser.yaml
@@ -18,6 +18,8 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# This Dockerfile is used by GoReleaser to build container images.
-# Keep the build stage in sync with goreleaser.yaml.
+# Build the goa4web binary and package it into a minimal image.
 FROM golang:1.22-alpine AS build
 WORKDIR /src
 COPY . .
@@ -8,6 +7,5 @@ RUN go build -o /goa4web ./cmd/goa4web
 FROM scratch
 COPY --from=build /goa4web /goa4web
 # Image uploads are stored under /data/imagebbs inside the container.
-# Future GoReleaser versions may build this image directly from the Dockerfile.
 VOLUME ["/data/imagebbs"]
 ENTRYPOINT ["/goa4web"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,8 @@
+# This Dockerfile is used by GoReleaser to build container images.
+# GoReleaser builds the binary first and then copies it into the image,
+# so no build step is required here.
+FROM scratch
+COPY goa4web /goa4web
+# Image uploads are stored under /data/imagebbs inside the container.
+VOLUME ["/data/imagebbs"]
+ENTRYPOINT ["/goa4web"]

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -40,12 +40,12 @@ nfpms:
 dockers:
   - image_templates:
       - "ghcr.io/arran4/goa4web:{{ .Version }}-amd64"
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.goreleaser
     goos: linux
     goarch: amd64
   - image_templates:
       - "ghcr.io/arran4/goa4web:{{ .Version }}-arm64"
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.goreleaser
     goos: linux
     goarch: arm64
 docker_manifests:


### PR DESCRIPTION
## Summary
- restore original Dockerfile with build stage
- add a Dockerfile.goreleaser that assumes binaries are prebuilt
- point GoReleaser to the new Dockerfile
- clean Dockerfile comments

## Testing
- `go test ./...` *(fails: expectations not met)*

------
https://chatgpt.com/codex/tasks/task_e_6859f99f25d0832fbd6d3302b5eb30ad