### PR TITLE
Add GitLab CI pipeline for container images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,24 @@
+image: docker:24
+
+services:
+  - docker:24-dind
+
+variables:
+  DOCKER_HOST: tcp://docker:2375
+  DOCKER_DRIVER: overlay2
+  DOCKER_TLS_CERTDIR: ""
+
+stages:
+  - release
+
+release:
+  stage: release
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
+      when: on_success
+    - when: never
+  script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+    - wget -O - https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_Linux_x86_64.tar.gz | tar -xz -C /tmp
+    - mv /tmp/goreleaser /usr/local/bin/
+    - goreleaser release --clean --config goreleaser_gitlab.yaml

--- a/goreleaser_gitlab.yaml
+++ b/goreleaser_gitlab.yaml
@@ -1,0 +1,59 @@
+version: 2
+project_name: goa4web
+builds:
+  - id: goa4web
+    binary: goa4web
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+    flags: ["-trimpath"]
+archives:
+  - format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+nfpms:
+  - vendor: Ubels Software Development
+    homepage: https://gitlab.arran.net.au/arran4/goa4web
+    maintainer: Arran Ubels <arran@ubels.com.au>
+    description: GOA4Web application
+    license: Private
+    formats:
+      - apk
+      - deb
+      - rpm
+      - termux.deb
+      - archlinux
+    release: 1
+    section: default
+    priority: extra
+dockers:
+  - image_templates:
+      - "registry-gitlab.arran.net.au/arran4/goa4web:{{ .Version }}-amd64"
+    dockerfile: Dockerfile.goreleaser
+    goos: linux
+    goarch: amd64
+  - image_templates:
+      - "registry-gitlab.arran.net.au/arran4/goa4web:{{ .Version }}-arm64"
+    dockerfile: Dockerfile.goreleaser
+    goos: linux
+    goarch: arm64
+docker_manifests:
+  - name_template: "registry-gitlab.arran.net.au/arran4/goa4web:{{ .Version }}"
+    image_templates:
+      - "registry-gitlab.arran.net.au/arran4/goa4web:{{ .Version }}-amd64"
+      - "registry-gitlab.arran.net.au/arran4/goa4web:{{ .Version }}-arm64"
+  - name_template: "registry-gitlab.arran.net.au/arran4/goa4web:latest"
+    image_templates:
+      - "registry-gitlab.arran.net.au/arran4/goa4web:{{ .Version }}-amd64"
+      - "registry-gitlab.arran.net.au/arran4/goa4web:{{ .Version }}-arm64"


### PR DESCRIPTION
## Summary
- build and publish Docker images on GitLab tags using GoReleaser
- create GitLab-specific GoReleaser config targeting registry-gitlab.arran.net.au

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a09d11844832fbe3321125bfea7a6