### PR TITLE
Fix session middleware early return

### DIFF
--- a/core.go
+++ b/core.go
@@ -40,6 +40,7 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 		session, err := GetSession(request)
 		if err != nil {
 			sessionErrorRedirect(writer, request, err)
+			return
 		}
 		var uid int32
 		if err == nil {


### PR DESCRIPTION
## Summary
- return early in CoreAdderMiddleware when session retrieval fails

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685a364daba4832f9b11e38344cd5810