### PR TITLE
Expose a4code2html package

### DIFF
--- a/a4code2html/a4code2html_test.go
+++ b/a4code2html/a4code2html_test.go
@@ -1,4 +1,4 @@
-package goa4web
+package a4code2html
 
 import (
 	"github.com/google/go-cmp/cmp"
@@ -44,11 +44,11 @@ func TestA4code2htmlEscape(t *testing.T) {
 	if got := c.Escape('\n'); got != "<br />\n" {
 		t.Errorf("newline %q", got)
 	}
-	c.codeType = ct_tagstrip
+	c.CodeType = CTTagStrip
 	if got := c.Escape('\n'); got != "\n" {
 		t.Errorf("tagstrip %q", got)
 	}
-	c.codeType = ct_wordsonly
+	c.CodeType = CTWordsOnly
 	if got := c.Escape('&'); got != " " {
 		t.Errorf("wordsonly %q", got)
 	}

--- a/blogsPage.go
+++ b/blogsPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/a4code2html"
 	"github.com/gorilla/feeds"
 	"log"
 	"net/http"
@@ -230,10 +231,10 @@ func FeedGen(r *http.Request, queries *Queries, uid int, username string) (*feed
 	for _, row := range rows {
 		u := r.URL
 		u.Query().Set("show", fmt.Sprintf("%d", row.Idblogs))
-		var text = &A4code2html{}
-		text.codeType = ct_tagstrip
-		text.input = row.Blog.String
-		text.Process()
+		conv := a4code2html.NewA4Code2HTML()
+		conv.CodeType = a4code2html.CTTagStrip
+		conv.SetInput(row.Blog.String)
+		conv.Process()
 		i := len(row.Blog.String)
 		if i > 255 {
 			i = 255
@@ -243,7 +244,7 @@ func FeedGen(r *http.Request, queries *Queries, uid int, username string) (*feed
 			Link: &feeds.Link{
 				Href: u.String(),
 			},
-			Description: fmt.Sprintf("%s\n-\n%s", text.output.String(), row.Username.String),
+			Description: fmt.Sprintf("%s\n-\n%s", conv.Output(), row.Username.String),
 		})
 	}
 	return feed, nil

--- a/forumFeed.go
+++ b/forumFeed.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/a4code2html"
 	"github.com/gorilla/feeds"
 	"github.com/gorilla/mux"
 	"log"
@@ -24,9 +25,9 @@ func forumTopicFeed(r *http.Request, title string, topicID int, rows []*GetForum
 			continue
 		}
 		text := row.Firstposttext.String
-		var conv = &A4code2html{}
-		conv.codeType = ct_tagstrip
-		conv.input = text
+		conv := a4code2html.NewA4Code2HTML()
+		conv.CodeType = a4code2html.CTTagStrip
+		conv.SetInput(text)
 		conv.Process()
 		i := len(text)
 		if i > 255 {
@@ -36,7 +37,7 @@ func forumTopicFeed(r *http.Request, title string, topicID int, rows []*GetForum
 			Title:   text[:i],
 			Link:    &feeds.Link{Href: fmt.Sprintf("/forum/topic/%d/thread/%d", topicID, row.Idforumthread)},
 			Created: time.Now(),
-			Description: fmt.Sprintf("%s\n-\n%s", conv.output.String(), func() string {
+			Description: fmt.Sprintf("%s\n-\n%s", conv.Output(), func() string {
 				if row.Firstpostusername.Valid {
 					return row.Firstpostusername.String
 				}

--- a/funcs.go
+++ b/funcs.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/arran4/goa4web/a4code2html"
 	"github.com/gorilla/csrf"
 )
 
@@ -21,18 +22,18 @@ func NewFuncs(r *http.Request) template.FuncMap {
 		"csrfField": func() template.HTML { return csrf.TemplateField(r) },
 		"version":   func() string { return version },
 		"a4code2html": func(s string) template.HTML {
-			c := NewA4Code2HTML()
-			c.codeType = ct_html
-			c.input = s
+			c := a4code2html.NewA4Code2HTML()
+			c.CodeType = a4code2html.CTHTML
+			c.SetInput(s)
 			c.Process()
-			return template.HTML(c.output.String())
+			return template.HTML(c.Output())
 		},
 		"a4code2string": func(s string) string {
-			c := NewA4Code2HTML()
-			c.codeType = ct_wordsonly
-			c.input = s
+			c := a4code2html.NewA4Code2HTML()
+			c.CodeType = a4code2html.CTWordsOnly
+			c.SetInput(s)
 			c.Process()
-			return c.output.String()
+			return c.Output()
 		},
 		"firstline": func(s string) string {
 			return strings.Split(s, "\n")[0]

--- a/html.go
+++ b/html.go
@@ -3,6 +3,8 @@ package goa4web
 import (
 	"fmt"
 	"strings"
+
+	"github.com/arran4/goa4web/a4code2html"
 )
 
 func anchorLink(anchor, linkName string) string {
@@ -27,7 +29,7 @@ func categoryLevel(categoryName string, level int) string {
 }
 
 func externalLink(pagename, linkName string) string {
-	safe, ok := sanitizeURL(pagename)
+	safe, ok := a4code2html.SanitizeURL(pagename)
 	if ok {
 		return fmt.Sprintf("<a href=\"%s\" target=\"_blank\">%s</a>", safe, linkName)
 	}

--- a/imagebbsFeed.go
+++ b/imagebbsFeed.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/a4code2html"
 	"github.com/gorilla/feeds"
 	"github.com/gorilla/mux"
 	"log"
@@ -31,7 +32,9 @@ func imagebbsFeed(r *http.Request, title string, boardID int, rows []*GetAllImag
 			continue
 		}
 		desc := row.Description.String
-		conv := &A4code2html{codeType: ct_tagstrip, input: desc}
+		conv := a4code2html.NewA4Code2HTML()
+		conv.CodeType = a4code2html.CTTagStrip
+		conv.SetInput(desc)
 		conv.Process()
 		i := len(desc)
 		if i > 255 {
@@ -41,7 +44,7 @@ func imagebbsFeed(r *http.Request, title string, boardID int, rows []*GetAllImag
 			Title:   desc[:i],
 			Link:    &feeds.Link{Href: fmt.Sprintf("/imagebbs/board/%d/thread/%d", boardID, row.ForumthreadIdforumthread)},
 			Created: time.Now(),
-			Description: fmt.Sprintf("%s\n-\n%s", conv.output.String(), func() string {
+			Description: fmt.Sprintf("%s\n-\n%s", conv.Output(), func() string {
 				if row.Username.Valid {
 					return row.Username.String
 				}

--- a/linkerFeed.go
+++ b/linkerFeed.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/a4code2html"
 	"github.com/gorilla/feeds"
 	"net/http"
 	"strconv"
@@ -23,11 +24,11 @@ func linkerFeed(r *http.Request, rows []*GetAllLinkerItemsByCategoryIdWitherPost
 		}
 		desc := ""
 		if row.Description.Valid {
-			var conv = &A4code2html{}
-			conv.codeType = ct_tagstrip
-			conv.input = row.Description.String
+			conv := a4code2html.NewA4Code2HTML()
+			conv.CodeType = a4code2html.CTTagStrip
+			conv.SetInput(row.Description.String)
 			conv.Process()
-			desc = conv.output.String()
+			desc = conv.Output()
 		}
 		href := fmt.Sprintf("/linker/show/%d", row.Idlinker)
 		if row.Url.Valid && row.Url.String != "" {

--- a/newsRssPage.go
+++ b/newsRssPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/a4code2html"
 	"github.com/gorilla/feeds"
 	"log"
 	"net/http"
@@ -31,9 +32,9 @@ func newsRssPage(w http.ResponseWriter, r *http.Request) {
 
 	for _, row := range posts {
 		text := row.News.String
-		conv := &A4code2html{}
-		conv.codeType = ct_tagstrip
-		conv.input = text
+		conv := a4code2html.NewA4Code2HTML()
+		conv.CodeType = a4code2html.CTTagStrip
+		conv.SetInput(text)
 		conv.Process()
 		i := len(text)
 		if i > 255 {
@@ -48,7 +49,7 @@ func newsRssPage(w http.ResponseWriter, r *http.Request) {
 				}
 				return time.Now()
 			}(),
-			Description: fmt.Sprintf("%s\n-\n%s", conv.output.String(), row.Writername.String),
+			Description: fmt.Sprintf("%s\n-\n%s", conv.Output(), row.Writername.String),
 		})
 	}
 

--- a/writingsFeed.go
+++ b/writingsFeed.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/a4code2html"
 	"github.com/gorilla/feeds"
 	"log"
 	"net/http"
@@ -30,7 +31,9 @@ func writingsFeedGen(r *http.Request, queries *Queries) (*feeds.Feed, error) {
 		if desc == "" {
 			desc = row.Writting.String
 		}
-		conv := &A4code2html{codeType: ct_tagstrip, input: desc}
+		conv := a4code2html.NewA4Code2HTML()
+		conv.CodeType = a4code2html.CTTagStrip
+		conv.SetInput(desc)
 		conv.Process()
 		title := row.Title.String
 		if title == "" {
@@ -44,7 +47,7 @@ func writingsFeedGen(r *http.Request, queries *Queries) (*feeds.Feed, error) {
 			Title:       title,
 			Link:        &feeds.Link{Href: fmt.Sprintf("/writings/article/%d", row.Idwriting)},
 			Created:     time.Now(),
-			Description: conv.output.String(),
+			Description: conv.Output(),
 		}
 		if row.Published.Valid {
 			item.Created = row.Published.Time


### PR DESCRIPTION
## Summary
- move `a4code2html` implementation to its own package and expose constants
- update call sites to use the new package API
- make sanitizeURL public and update helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a445a75f0832f8c89461a52256a46