### PR TITLE
Expose runtime config as separate package

### DIFF
--- a/adminEmailTemplatePage.go
+++ b/adminEmailTemplatePage.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 // adminEmailTemplatePage allows administrators to edit the update email template.
@@ -82,8 +83,8 @@ func adminEmailTemplateTestActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	base := "http://" + r.Host
-	if appRuntimeConfig.HTTPHostname != "" {
-		base = strings.TrimRight(appRuntimeConfig.HTTPHostname, "/")
+	if runtimeconfig.AppRuntimeConfig.HTTPHostname != "" {
+		base = strings.TrimRight(runtimeconfig.AppRuntimeConfig.HTTPHostname, "/")
 	}
 	pageURL := base + r.URL.Path
 

--- a/adminEmailTemplatePage_test.go
+++ b/adminEmailTemplatePage_test.go
@@ -11,11 +11,12 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 	os.Unsetenv("EMAIL_PROVIDER")
-	appRuntimeConfig.EmailProvider = ""
+	runtimeconfig.AppRuntimeConfig.EmailProvider = ""
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
 	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{UserID: 1})
@@ -35,7 +36,7 @@ func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 
 func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 	os.Setenv("EMAIL_PROVIDER", "log")
-	appRuntimeConfig.EmailProvider = "log"
+	runtimeconfig.AppRuntimeConfig.EmailProvider = "log"
 	defer os.Unsetenv("EMAIL_PROVIDER")
 
 	db, mock, err := sqlmock.New()

--- a/adminReloadConfigPage.go
+++ b/adminReloadConfigPage.go
@@ -3,6 +3,8 @@ package goa4web
 import (
 	"log"
 	"net/http"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func adminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
@@ -17,7 +19,7 @@ func adminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cfgMap := LoadAppConfigFile(ConfigFile)
-	srv.Config = GenerateRuntimeConfig(nil, cfgMap)
+	srv.Config = runtimeconfig.GenerateRuntimeConfig(nil, cfgMap)
 	if err := validateDefaultLanguage(r.Context(), New(dbPool), srv.Config.DefaultLanguage); err != nil {
 		data.Errors = append(data.Errors, err.Error())
 	}

--- a/adminSiteSettingsPage.go
+++ b/adminSiteSettingsPage.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func adminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
@@ -16,7 +17,7 @@ func adminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Bad Request", http.StatusBadRequest)
 			return
 		}
-		appRuntimeConfig.FeedsEnabled = r.PostFormValue("feeds_enabled") != ""
+		runtimeconfig.AppRuntimeConfig.FeedsEnabled = r.PostFormValue("feeds_enabled") != ""
 		langID, _ := strconv.Atoi(r.PostFormValue("default_language"))
 		langs, _ := queries.FetchLanguages(r.Context())
 		name := ""
@@ -26,7 +27,7 @@ func adminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 		}
-		appRuntimeConfig.DefaultLanguage = name
+		runtimeconfig.AppRuntimeConfig.DefaultLanguage = name
 		if err := updateConfigKey(ConfigFile, config.EnvDefaultLanguage, name); err != nil {
 			log.Printf("config write error: %v", err)
 		}
@@ -44,7 +45,7 @@ func adminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
 		SelectedLanguageId: resolveDefaultLanguageID(r.Context(), queries),
 	}
-	data.CoreData.FeedsEnabled = appRuntimeConfig.FeedsEnabled
+	data.CoreData.FeedsEnabled = runtimeconfig.AppRuntimeConfig.FeedsEnabled
 	if langs, err := queries.FetchLanguages(r.Context()); err == nil {
 		data.Languages = langs
 	}

--- a/adminUsageStatsPage.go
+++ b/adminUsageStatsPage.go
@@ -3,6 +3,8 @@ package goa4web
 import (
 	"log"
 	"net/http"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func adminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
@@ -40,13 +42,13 @@ func adminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 	if data.LinkerCategories, err = queries.GetLinkerCategoryLinkCounts(r.Context()); err != nil {
 		log.Printf("linker category counts: %v", err)
 	}
-	if data.Monthly, err = queries.MonthlyUsageCounts(r.Context(), int32(appRuntimeConfig.StatsStartYear)); err != nil {
+	if data.Monthly, err = queries.MonthlyUsageCounts(r.Context(), int32(runtimeconfig.AppRuntimeConfig.StatsStartYear)); err != nil {
 		log.Printf("monthly usage counts: %v", err)
 	}
-	if data.UserMonthly, err = queries.UserMonthlyUsageCounts(r.Context(), int32(appRuntimeConfig.StatsStartYear)); err != nil {
+	if data.UserMonthly, err = queries.UserMonthlyUsageCounts(r.Context(), int32(runtimeconfig.AppRuntimeConfig.StatsStartYear)); err != nil {
 		log.Printf("user monthly usage counts: %v", err)
 	}
-	data.StartYear = appRuntimeConfig.StatsStartYear
+	data.StartYear = runtimeconfig.AppRuntimeConfig.StatsStartYear
 
 	if err := renderTemplate(w, r, "usageStatsPage.gohtml", data); err != nil {
 		log.Printf("template error: %v", err)

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web"
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func main() {
@@ -23,7 +24,7 @@ func main() {
 
 	fileVals := goa4web.LoadAppConfigFile(cfgPath)
 
-	fs := goa4web.NewRuntimeFlagSet(os.Args[0])
+	fs := runtimeconfig.NewRuntimeFlagSet(os.Args[0])
 	var (
 		sessionSecret     string
 		sessionSecretFile string
@@ -47,7 +48,7 @@ func main() {
 		log.Fatalf("session secret: %v", err)
 	}
 
-	cfg := goa4web.GenerateRuntimeConfig(fs, fileVals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, fileVals)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/consts.go
+++ b/consts.go
@@ -31,9 +31,6 @@ const (
 	// LinkerTopicDescription describes the hidden linker forum.
 	LinkerTopicDescription = "THIS IS A HIDDEN FORUM FOR A LINKER TOPIC"
 
-	// DefaultPageSize defines the number of items shown per page.
-	DefaultPageSize = 15
-
 	// Alphabet lists letters for search navigation.
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 

--- a/core.go
+++ b/core.go
@@ -9,6 +9,8 @@ import (
 	"log"
 	"net/http"
 	"strings"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func handleDie(w http.ResponseWriter, message string) {
@@ -83,7 +85,7 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 			IndexItems:        idx,
 			UserID:            uid,
 			Title:             "Arran4's Website",
-			FeedsEnabled:      appRuntimeConfig.FeedsEnabled,
+			FeedsEnabled:      runtimeconfig.AppRuntimeConfig.FeedsEnabled,
 			NotificationCount: count,
 			Announcement:      ann,
 		})
@@ -190,15 +192,15 @@ func DBAdderMiddleware(next http.Handler) http.Handler {
 
 // getPageSize returns the preferred page size within configured bounds.
 func getPageSize(r *http.Request) int {
-	size := appRuntimeConfig.PageSizeDefault
+	size := runtimeconfig.AppRuntimeConfig.PageSizeDefault
 	if pref, _ := r.Context().Value(ContextValues("preference")).(*Preference); pref != nil && pref.PageSize != 0 {
 		size = int(pref.PageSize)
 	}
-	if size < appRuntimeConfig.PageSizeMin {
-		size = appRuntimeConfig.PageSizeMin
+	if size < runtimeconfig.AppRuntimeConfig.PageSizeMin {
+		size = runtimeconfig.AppRuntimeConfig.PageSizeMin
 	}
-	if size > appRuntimeConfig.PageSizeMax {
-		size = appRuntimeConfig.PageSizeMax
+	if size > runtimeconfig.AppRuntimeConfig.PageSizeMax {
+		size = runtimeconfig.AppRuntimeConfig.PageSizeMax
 	}
 	return size
 }

--- a/db_config_test.go
+++ b/db_config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestDBConfigPrecedence(t *testing.T) {
@@ -21,7 +22,7 @@ func TestDBConfigPrecedence(t *testing.T) {
 		config.EnvDBPort: "1",
 	}
 	_ = fs.Parse([]string{"--db-pass=cli"})
-	cfg := GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
 	if cfg.DBUser != "file" || cfg.DBPass != "cli" || cfg.DBHost != "env" || cfg.DBPort != "1" {
 		t.Fatalf("merged %#v", cfg)
 	}
@@ -32,7 +33,7 @@ func TestLoadDBConfigFromFileValues(t *testing.T) {
 	vals := map[string]string{
 		config.EnvDBUser: "fileval",
 	}
-	cfg := GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
 	if cfg.DBUser != "fileval" {
 		t.Fatalf("want fileval got %q", cfg.DBUser)
 	}

--- a/default_language.go
+++ b/default_language.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"unicode"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 // validateLanguageName ensures the provided language name contains only
@@ -36,10 +38,10 @@ func validateDefaultLanguage(ctx context.Context, q *Queries, name string) error
 
 // resolveDefaultLanguageID converts the configured language name to its ID.
 func resolveDefaultLanguageID(ctx context.Context, q *Queries) int32 {
-	if appRuntimeConfig.DefaultLanguage == "" {
+	if runtimeconfig.AppRuntimeConfig.DefaultLanguage == "" {
 		return 0
 	}
-	id, err := q.GetLanguageIDByName(ctx, sql.NullString{String: appRuntimeConfig.DefaultLanguage, Valid: true})
+	id, err := q.GetLanguageIDByName(ctx, sql.NullString{String: runtimeconfig.AppRuntimeConfig.DefaultLanguage, Valid: true})
 	if err != nil {
 		return 0
 	}

--- a/email.go
+++ b/email.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ses"
 
 	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func notifyChange(ctx context.Context, provider email.Provider, emailAddr string, page string) error {
@@ -70,7 +71,7 @@ func notifyChange(ctx context.Context, provider email.Provider, emailAddr string
 	return nil
 }
 
-func providerFromConfig(cfg RuntimeConfig) email.Provider {
+func providerFromConfig(cfg runtimeconfig.RuntimeConfig) email.Provider {
 	mode := strings.ToLower(cfg.EmailProvider)
 
 	switch mode {
@@ -156,7 +157,7 @@ func providerFromConfig(cfg RuntimeConfig) email.Provider {
 // getEmailProvider returns the mail provider configured by environment variables.
 // Production code uses this, while tests can call providerFromConfig directly.
 func getEmailProvider() email.Provider {
-	return providerFromConfig(appRuntimeConfig)
+	return providerFromConfig(runtimeconfig.AppRuntimeConfig)
 }
 
 // loadEmailConfigFile reads EMAIL_* style configuration values from a simple

--- a/email_provider_extra_test.go
+++ b/email_provider_extra_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 
 	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestGetEmailProviderSMTP(t *testing.T) {
-	p := providerFromConfig(RuntimeConfig{
+	p := providerFromConfig(runtimeconfig.RuntimeConfig{
 		EmailProvider: "smtp",
 		EmailSMTPHost: "localhost",
 		EmailSMTPPort: "25",
@@ -22,13 +23,13 @@ func TestGetEmailProviderSMTP(t *testing.T) {
 }
 
 func TestGetEmailProviderLocal(t *testing.T) {
-	if _, ok := providerFromConfig(RuntimeConfig{EmailProvider: "local"}).(email.LocalProvider); !ok {
+	if _, ok := providerFromConfig(runtimeconfig.RuntimeConfig{EmailProvider: "local"}).(email.LocalProvider); !ok {
 		t.Fatalf("expected LocalProvider")
 	}
 }
 
 func TestGetEmailProviderJMAP(t *testing.T) {
-	p := providerFromConfig(RuntimeConfig{
+	p := providerFromConfig(runtimeconfig.RuntimeConfig{
 		EmailProvider:     "jmap",
 		EmailJMAPEndpoint: "http://example.com",
 		EmailJMAPAccount:  "acct",
@@ -44,7 +45,7 @@ func TestGetEmailProviderJMAP(t *testing.T) {
 }
 
 func TestGetEmailProviderSESNoCreds(t *testing.T) {
-	if p := providerFromConfig(RuntimeConfig{EmailProvider: "ses", EmailAWSRegion: "us-east-1"}); p != nil {
+	if p := providerFromConfig(runtimeconfig.RuntimeConfig{EmailProvider: "ses", EmailAWSRegion: "us-east-1"}); p != nil {
 		t.Errorf("expected nil provider, got %#v", p)
 	}
 }

--- a/email_test.go
+++ b/email_test.go
@@ -10,17 +10,18 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestGetEmailProviderLog(t *testing.T) {
-	cfg := RuntimeConfig{EmailProvider: "log"}
+	cfg := runtimeconfig.RuntimeConfig{EmailProvider: "log"}
 	if p := providerFromConfig(cfg); reflect.TypeOf(p) != reflect.TypeOf(email.LogProvider{}) {
 		t.Errorf("expected LogProvider, got %#v", p)
 	}
 }
 
 func TestGetEmailProviderUnknown(t *testing.T) {
-	cfg := RuntimeConfig{EmailProvider: "unknown"}
+	cfg := runtimeconfig.RuntimeConfig{EmailProvider: "unknown"}
 	if p := providerFromConfig(cfg); p != nil {
 		t.Errorf("expected nil for unknown provider, got %#v", p)
 	}
@@ -40,7 +41,7 @@ func TestEmailConfigPrecedence(t *testing.T) {
 		config.EnvSMTPHost:      "file",
 	}
 	_ = fs.Parse([]string{"--email-provider=smtp", "--smtp-port=25"})
-	cfg := GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
 	if cfg.EmailProvider != "smtp" || cfg.EmailSMTPHost != "file" || cfg.EmailSMTPPort != "25" {
 		t.Fatalf("merged %#v", cfg)
 	}
@@ -51,7 +52,7 @@ func TestLoadEmailConfigFromFileValues(t *testing.T) {
 	vals := map[string]string{
 		config.EnvEmailProvider: "log",
 	}
-	cfg := GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
 	if cfg.EmailProvider != "log" {
 		t.Fatalf("want log got %q", cfg.EmailProvider)
 	}
@@ -143,7 +144,7 @@ func TestEmailQueueWorker(t *testing.T) {
 }
 
 func TestSendGridProviderFromConfig(t *testing.T) {
-	p := providerFromConfig(RuntimeConfig{EmailProvider: "sendgrid", EmailSendGridKey: "k"})
+	p := providerFromConfig(runtimeconfig.RuntimeConfig{EmailProvider: "sendgrid", EmailSendGridKey: "k"})
 	if email.SendgridBuilt {
 		if _, ok := p.(email.SendGridProvider); !ok {
 			t.Fatalf("expected SendGridProvider, got %#v", p)

--- a/http_config_test.go
+++ b/http_config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestHTTPConfigPrecedence(t *testing.T) {
@@ -22,7 +23,7 @@ func TestHTTPConfigPrecedence(t *testing.T) {
 		config.EnvHostname: "http://file",
 	}
 	_ = fs.Parse([]string{"--listen=:3", "--hostname=http://cli"})
-	cfg := GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
 
 	if cfg.HTTPListen != ":3" || cfg.HTTPHostname != "http://cli" {
 		t.Fatalf("merged %#v", cfg)
@@ -34,7 +35,7 @@ func TestLoadHTTPConfigFromFileValues(t *testing.T) {
 	vals := map[string]string{
 		config.EnvListen: ":9",
 	}
-	cfg := GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
 	if cfg.HTTPListen != ":9" {
 		t.Fatalf("want :9 got %q", cfg.HTTPListen)
 	}

--- a/imagebbsAdminFilesPage.go
+++ b/imagebbsAdminFilesPage.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func imagebbsAdminFilesPage(w http.ResponseWriter, r *http.Request) {
@@ -23,7 +25,7 @@ func imagebbsAdminFilesPage(w http.ResponseWriter, r *http.Request) {
 		Entries []Entry
 	}
 
-	base := appRuntimeConfig.ImageUploadDir
+	base := runtimeconfig.AppRuntimeConfig.ImageUploadDir
 	reqPath := r.URL.Query().Get("path")
 	cleaned := filepath.Clean("/" + reqPath)
 	abs := filepath.Join(base, cleaned)

--- a/language_config_test.go
+++ b/language_config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestDefaultLanguageConfigPrecedence(t *testing.T) {
@@ -17,7 +18,7 @@ func TestDefaultLanguageConfigPrecedence(t *testing.T) {
 	vals := map[string]string{config.EnvDefaultLanguage: "file"}
 	_ = fs.Parse([]string{"--default-language=cli"})
 
-	cfg := GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
 	if cfg.DefaultLanguage != "cli" {
 		t.Fatalf("merged %#v", cfg.DefaultLanguage)
 	}
@@ -26,7 +27,7 @@ func TestDefaultLanguageConfigPrecedence(t *testing.T) {
 func TestLoadDefaultLanguageFromFileValues(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	vals := map[string]string{config.EnvDefaultLanguage: "fileval"}
-	cfg := GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
 	if cfg.DefaultLanguage != "fileval" {
 		t.Fatalf("want fileval got %q", cfg.DefaultLanguage)
 	}

--- a/pagination_config_test.go
+++ b/pagination_config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestPaginationConfigPrecedence(t *testing.T) {
@@ -25,7 +26,7 @@ func TestPaginationConfigPrecedence(t *testing.T) {
 		config.EnvPageSizeDefault: "18",
 	}
 	_ = fs.Parse([]string{"--page-size-min=12", "--page-size-default=15"})
-	cfg := GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
 	if cfg.PageSizeMin != 12 || cfg.PageSizeMax != 20 || cfg.PageSizeDefault != 15 {
 		t.Fatalf("merged %#v", cfg)
 	}
@@ -37,7 +38,7 @@ func TestLoadPaginationConfigFromFileValues(t *testing.T) {
 		config.EnvPageSizeMin:     "7",
 		config.EnvPageSizeDefault: "9",
 	}
-	cfg := GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
 	if cfg.PageSizeMin != 7 || cfg.PageSizeDefault != 9 {
 		t.Fatalf("want 7/9 got %#v", cfg)
 	}

--- a/routes.go
+++ b/routes.go
@@ -4,6 +4,8 @@ import (
 	. "github.com/arran4/gorillamuxlogic"
 	"github.com/gorilla/mux"
 	"net/http"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func registerRoutes(r *mux.Router) {
@@ -135,7 +137,7 @@ func registerBookmarksRoutes(r *mux.Router) {
 
 func registerImagebbsRoutes(r *mux.Router) {
 	ibr := r.PathPrefix("/imagebbs").Subrouter()
-	ibr.PathPrefix("/images/").Handler(http.StripPrefix("/imagebbs/images/", http.FileServer(http.Dir(appRuntimeConfig.ImageUploadDir))))
+	ibr.PathPrefix("/images/").Handler(http.StripPrefix("/imagebbs/images/", http.FileServer(http.Dir(runtimeconfig.AppRuntimeConfig.ImageUploadDir))))
 	ibr.HandleFunc(".rss", imagebbsRssPage).Methods("GET")
 	ibr.HandleFunc("/board/{boardno:[0-9]+}.rss", imagebbsBoardRssPage).Methods("GET")
 	ibr.HandleFunc(".atom", imagebbsAtomPage).Methods("GET")

--- a/run.go
+++ b/run.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 // ConfigFile stores the path to the configuration file if provided on the
@@ -40,7 +42,7 @@ func init() {
 
 // RunWithConfig starts the application using the provided configuration and
 // session secret. The context controls the lifetime of the HTTP server.
-func RunWithConfig(ctx context.Context, cfg RuntimeConfig, sessionSecret string) error {
+func RunWithConfig(ctx context.Context, cfg runtimeconfig.RuntimeConfig, sessionSecret string) error {
 	store = sessions.NewCookieStore([]byte(sessionSecret))
 	store.Options = &sessions.Options{
 		Path:     "/",

--- a/runtimeconfig/config.go
+++ b/runtimeconfig/config.go
@@ -1,4 +1,4 @@
-package goa4web
+package runtimeconfig
 
 import (
 	"flag"
@@ -7,6 +7,9 @@ import (
 
 	"github.com/arran4/goa4web/config"
 )
+
+// DefaultPageSize defines the number of items shown per page.
+const DefaultPageSize = 15
 
 // RuntimeConfig stores configuration values resolved from environment
 // variables, optional files and command line flags.
@@ -46,7 +49,8 @@ type RuntimeConfig struct {
 	ImageMaxBytes  int
 }
 
-var appRuntimeConfig RuntimeConfig
+// AppRuntimeConfig stores the current application configuration.
+var AppRuntimeConfig RuntimeConfig
 
 // NewRuntimeFlagSet returns a FlagSet containing all runtime configuration
 // options. The returned FlagSet uses ContinueOnError to allow tests to supply
@@ -193,7 +197,7 @@ func GenerateRuntimeConfig(fs *flag.FlagSet, fileVals map[string]string) Runtime
 	)
 
 	normalizeRuntimeConfig(&cfg)
-	appRuntimeConfig = cfg
+	AppRuntimeConfig = cfg
 	return cfg
 }
 
@@ -234,9 +238,9 @@ func normalizeRuntimeConfig(cfg *RuntimeConfig) {
 	}
 }
 
-// updatePaginationConfig adjusts the pagination fields of cfg and enforces
+// UpdatePaginationConfig adjusts the pagination fields of cfg and enforces
 // valid limits.
-func updatePaginationConfig(cfg *RuntimeConfig, min, max, def int) {
+func UpdatePaginationConfig(cfg *RuntimeConfig, min, max, def int) {
 	if min != 0 {
 		cfg.PageSizeMin = min
 	}

--- a/runtimeconfig/site_config.go
+++ b/runtimeconfig/site_config.go
@@ -1,4 +1,4 @@
-package goa4web
+package runtimeconfig
 
 import "strings"
 

--- a/runtimeconfig/site_config_test.go
+++ b/runtimeconfig/site_config_test.go
@@ -1,4 +1,4 @@
-package goa4web
+package runtimeconfig
 
 import "testing"
 

--- a/runtimeconfig/stats_config.go
+++ b/runtimeconfig/stats_config.go
@@ -1,4 +1,4 @@
-package goa4web
+package runtimeconfig
 
 import "strconv"
 

--- a/server.go
+++ b/server.go
@@ -10,11 +10,13 @@ import (
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 // Server bundles the application's configuration, router and runtime dependencies.
 type Server struct {
-	Config RuntimeConfig
+	Config runtimeconfig.RuntimeConfig
 	Router http.Handler
 	Store  *sessions.CookieStore
 	DB     *sql.DB
@@ -54,7 +56,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 }
 
 // newServer returns a Server with the supplied dependencies.
-func newServer(handler http.Handler, store *sessions.CookieStore, db *sql.DB, cfg RuntimeConfig) *Server {
+func newServer(handler http.Handler, store *sessions.CookieStore, db *sql.DB, cfg runtimeconfig.RuntimeConfig) *Server {
 	return &Server{
 		Config: cfg,
 		Router: handler,

--- a/startup.go
+++ b/startup.go
@@ -13,6 +13,7 @@ import (
 
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/runtimeconfig"
 	"github.com/go-sql-driver/mysql"
 )
 
@@ -23,7 +24,7 @@ var (
 
 // InitDB opens the database connection using the provided configuration
 // and ensures the schema exists.
-func InitDB(cfg RuntimeConfig) *UserError {
+func InitDB(cfg runtimeconfig.RuntimeConfig) *UserError {
 	dbLogVerbosity = cfg.DBLogVerbosity
 	db.LogVerbosity = cfg.DBLogVerbosity
 	if cfg.DBUser == "" {
@@ -65,11 +66,11 @@ func InitDB(cfg RuntimeConfig) *UserError {
 }
 
 // checkDatabase attempts to connect and ping the configured database.
-func checkDatabase(cfg RuntimeConfig) *UserError {
+func checkDatabase(cfg runtimeconfig.RuntimeConfig) *UserError {
 	return InitDB(cfg)
 }
 
-func performStartupChecks(cfg RuntimeConfig) error {
+func performStartupChecks(cfg runtimeconfig.RuntimeConfig) error {
 	if ue := checkDatabase(cfg); ue != nil {
 		return fmt.Errorf("%s: %w", ue.ErrorMessage, ue.Err)
 	}
@@ -79,7 +80,7 @@ func performStartupChecks(cfg RuntimeConfig) error {
 	return nil
 }
 
-func checkUploadDir(cfg RuntimeConfig) *UserError {
+func checkUploadDir(cfg runtimeconfig.RuntimeConfig) *UserError {
 	if cfg.ImageUploadDir == "" {
 		return &UserError{Err: fmt.Errorf("dir empty"), ErrorMessage: "image upload directory not set"}
 	}

--- a/userEmailPage.go
+++ b/userEmailPage.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 const errMailNotConfigured = "mail isn't configured" // shown when Test mail has no provider
@@ -92,8 +94,8 @@ func userEmailTestActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	base := "http://" + r.Host
-	if appRuntimeConfig.HTTPHostname != "" {
-		base = strings.TrimRight(appRuntimeConfig.HTTPHostname, "/")
+	if runtimeconfig.AppRuntimeConfig.HTTPHostname != "" {
+		base = strings.TrimRight(runtimeconfig.AppRuntimeConfig.HTTPHostname, "/")
 	}
 	pageURL := base + r.URL.Path
 	provider := getEmailProvider()

--- a/userEmailPage_test.go
+++ b/userEmailPage_test.go
@@ -9,11 +9,13 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	os.Unsetenv("EMAIL_PROVIDER")
-	appRuntimeConfig.EmailProvider = ""
+	runtimeconfig.AppRuntimeConfig.EmailProvider = ""
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := context.WithValue(req.Context(), ContextValues("user"), &User{Email: sql.NullString{String: "u@example.com", Valid: true}})
 	ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{})
@@ -33,7 +35,7 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 
 func TestUserEmailTestAction_WithProvider(t *testing.T) {
 	os.Setenv("EMAIL_PROVIDER", "log")
-	appRuntimeConfig.EmailProvider = "log"
+	runtimeconfig.AppRuntimeConfig.EmailProvider = "log"
 	defer os.Unsetenv("EMAIL_PROVIDER")
 
 	req := httptest.NewRequest("POST", "/email", nil)

--- a/userLangPage.go
+++ b/userLangPage.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func userLangPage(w http.ResponseWriter, r *http.Request) {
@@ -95,7 +97,7 @@ func saveUserLanguagePreference(r *http.Request, queries *Queries, uid int32) er
 			return queries.InsertPreference(r.Context(), InsertPreferenceParams{
 				LanguageIdlanguage: int32(langID),
 				UsersIdusers:       uid,
-				PageSize:           int32(appRuntimeConfig.PageSizeDefault),
+				PageSize:           int32(runtimeconfig.AppRuntimeConfig.PageSizeDefault),
 			})
 		}
 		return err
@@ -114,7 +116,7 @@ func saveDefaultLanguage(r *http.Request, queries *Queries, uid int32) error {
 	pref, err := queries.GetPreferenceByUserID(r.Context(), uid)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			_, err = queries.DB().ExecContext(r.Context(), "INSERT INTO preferences (language_idlanguage, users_idusers, page_size) VALUES (?, ?, ?)", langID, uid, appRuntimeConfig.PageSizeDefault)
+			_, err = queries.DB().ExecContext(r.Context(), "INSERT INTO preferences (language_idlanguage, users_idusers, page_size) VALUES (?, ?, ?)", langID, uid, runtimeconfig.AppRuntimeConfig.PageSizeDefault)
 			return err
 		}
 		return err

--- a/userLangPage_test.go
+++ b/userLangPage_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/runtimeconfig"
 	"github.com/gorilla/sessions"
 )
 
@@ -50,8 +51,8 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language")).WillReturnRows(rows)
 	mock.ExpectExec("INSERT INTO userlang").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectQuery("SELECT idpreferences").WithArgs(int32(1)).WillReturnError(sql.ErrNoRows)
-	appRuntimeConfig.PageSizeDefault = 15
-	mock.ExpectExec("INSERT INTO preferences").WithArgs(int32(2), int32(1), int32(appRuntimeConfig.PageSizeDefault)).WillReturnResult(sqlmock.NewResult(1, 1))
+	runtimeconfig.AppRuntimeConfig.PageSizeDefault = 15
+	mock.ExpectExec("INSERT INTO preferences").WithArgs(int32(2), int32(1), int32(runtimeconfig.AppRuntimeConfig.PageSizeDefault)).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	userLangSaveAllActionPage(rr, req)
 
@@ -117,7 +118,7 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	defer db.Close()
 
 	queries := New(db)
-	appRuntimeConfig.PageSizeDefault = 15
+	runtimeconfig.AppRuntimeConfig.PageSizeDefault = 15
 	store = sessions.NewCookieStore([]byte("test"))
 
 	form := url.Values{}
@@ -142,9 +143,9 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates", "page_size"}).
-		AddRow(1, 1, 1, nil, appRuntimeConfig.PageSizeDefault)
+		AddRow(1, 1, 1, nil, runtimeconfig.AppRuntimeConfig.PageSizeDefault)
 	mock.ExpectQuery("SELECT idpreferences").WithArgs(int32(1)).WillReturnRows(prefRows)
-	mock.ExpectExec("UPDATE preferences").WithArgs(int32(2), int32(appRuntimeConfig.PageSizeDefault), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("UPDATE preferences").WithArgs(int32(2), int32(runtimeconfig.AppRuntimeConfig.PageSizeDefault), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	userLangSaveLanguagePreferenceActionPage(rr, req)
 

--- a/userPageSizePage.go
+++ b/userPageSizePage.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func userPageSizePage(w http.ResponseWriter, r *http.Request) {
@@ -12,7 +14,7 @@ func userPageSizePage(w http.ResponseWriter, r *http.Request) {
 			min, _ := strconv.Atoi(r.PostFormValue("min"))
 			max, _ := strconv.Atoi(r.PostFormValue("max"))
 			def, _ := strconv.Atoi(r.PostFormValue("default"))
-			updatePaginationConfig(&appRuntimeConfig, min, max, def)
+			runtimeconfig.UpdatePaginationConfig(&runtimeconfig.AppRuntimeConfig, min, max, def)
 		}
 		http.Redirect(w, r, "/usr/page-size", http.StatusSeeOther)
 		return
@@ -24,9 +26,9 @@ func userPageSizePage(w http.ResponseWriter, r *http.Request) {
 		Default int
 	}{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
-		Min:      appRuntimeConfig.PageSizeMin,
-		Max:      appRuntimeConfig.PageSizeMax,
-		Default:  appRuntimeConfig.PageSizeDefault,
+		Min:      runtimeconfig.AppRuntimeConfig.PageSizeMin,
+		Max:      runtimeconfig.AppRuntimeConfig.PageSizeMax,
+		Default:  runtimeconfig.AppRuntimeConfig.PageSizeDefault,
 	}
 	if err := renderTemplate(w, r, "pageSizePage.gohtml", data); err != nil {
 		log.Printf("template error: %v", err)

--- a/userPagingPage.go
+++ b/userPagingPage.go
@@ -6,11 +6,13 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func userPagingPage(w http.ResponseWriter, r *http.Request) {
 	pref, _ := r.Context().Value(ContextValues("preference")).(*Preference)
-	size := appRuntimeConfig.PageSizeDefault
+	size := runtimeconfig.AppRuntimeConfig.PageSizeDefault
 	if pref != nil {
 		size = int(pref.PageSize)
 	}
@@ -22,8 +24,8 @@ func userPagingPage(w http.ResponseWriter, r *http.Request) {
 	}{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 		Size:     size,
-		Min:      appRuntimeConfig.PageSizeMin,
-		Max:      appRuntimeConfig.PageSizeMax,
+		Min:      runtimeconfig.AppRuntimeConfig.PageSizeMin,
+		Max:      runtimeconfig.AppRuntimeConfig.PageSizeMax,
 	}
 	if err := renderTemplate(w, r, "pagingPage.gohtml", data); err != nil {
 		log.Printf("template error: %v", err)
@@ -43,11 +45,11 @@ func userPagingSaveActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 	size, _ := strconv.Atoi(r.FormValue("size"))
-	if size < appRuntimeConfig.PageSizeMin {
-		size = appRuntimeConfig.PageSizeMin
+	if size < runtimeconfig.AppRuntimeConfig.PageSizeMin {
+		size = runtimeconfig.AppRuntimeConfig.PageSizeMin
 	}
-	if size > appRuntimeConfig.PageSizeMax {
-		size = appRuntimeConfig.PageSizeMax
+	if size > runtimeconfig.AppRuntimeConfig.PageSizeMax {
+		size = runtimeconfig.AppRuntimeConfig.PageSizeMax
 	}
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	pref, err := queries.GetPreferenceByUserID(r.Context(), uid)


### PR DESCRIPTION
## Summary
- move runtime configuration helpers to new `runtimeconfig` package
- expose `AppRuntimeConfig` and `UpdatePaginationConfig`
- update imports and tests to use the new package
- remove unused constant from `consts.go`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a45f6a020832f92dbf9c3cd5db087