### PR TITLE
Move session helpers to core package

### DIFF
--- a/blogsBlogAddPage.go
+++ b/blogsBlogAddPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"strconv"
@@ -52,7 +53,7 @@ func blogsBlogAddActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	text := r.PostFormValue("text")
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/blogsBlogPage.go
+++ b/blogsBlogPage.go
@@ -2,6 +2,7 @@ package goa4web
 
 import (
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -54,7 +55,7 @@ func blogsBlogPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/blogsBlogReplyPage.go
+++ b/blogsBlogReplyPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -11,7 +12,7 @@ import (
 )
 
 func blogsBlogReplyPostPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/blogsBloggerPage.go
+++ b/blogsBloggerPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -25,7 +26,7 @@ func blogsBloggerPage(w http.ResponseWriter, r *http.Request) {
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	vars := mux.Vars(r)
 	username := vars["username"]
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/blogsBloggerPage_test.go
+++ b/blogsBloggerPage_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/core"
 )
 
 func TestBlogsBloggerPage(t *testing.T) {
@@ -22,6 +24,8 @@ func TestBlogsBloggerPage(t *testing.T) {
 
 	q := New(db)
 	store = sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = sessionName
 
 	r := mux.NewRouter()
 	br := r.PathPrefix("/blogs").Subrouter()

--- a/blogsCommentEditPage.go
+++ b/blogsCommentEditPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -23,7 +24,7 @@ func blogsCommentEditPostPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	blogId, _ := strconv.Atoi(vars["blog"])
 	commentId, _ := strconv.Atoi(vars["comment"])
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/blogsCommentPage.go
+++ b/blogsCommentPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -58,7 +59,7 @@ func blogsCommentPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/blogsPage.go
+++ b/blogsPage.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/arran4/goa4web/a4code2html"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/feeds"
 	"log"
 	"net/http"
@@ -28,7 +29,7 @@ func blogsPage(w http.ResponseWriter, r *http.Request) {
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	buid := r.URL.Query().Get("uid")
 	userId, _ := strconv.Atoi(buid)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/bookmarksEditPage.go
+++ b/bookmarksEditPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 )
@@ -19,7 +20,7 @@ func bookmarksEditPage(w http.ResponseWriter, r *http.Request) {
 		BookmarkContent: "Category: Example 1\nhttp://www.google.com.au Google\nColumn\nCategory: Example 2\nhttp://www.google.com.au Google\nhttp://www.google.com.au Google\n",
 	}
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -50,7 +51,7 @@ func bookmarksEditPage(w http.ResponseWriter, r *http.Request) {
 func bookmarksEditSaveActionPage(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("text")
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -74,7 +75,7 @@ func bookmarksEditSaveActionPage(w http.ResponseWriter, r *http.Request) {
 func bookmarksEditCreateActionPage(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("text")
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/bookmarksMinePage.go
+++ b/bookmarksMinePage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"strings"
@@ -72,7 +73,7 @@ func bookmarksMinePage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/bookmarksPage.go
+++ b/bookmarksPage.go
@@ -1,6 +1,7 @@
 package goa4web
 
 import (
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 )
@@ -10,7 +11,7 @@ func bookmarksPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 	}
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web"
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -43,7 +44,7 @@ func main() {
 			secretPath = v
 		}
 	}
-	secret, err := goa4web.LoadSessionSecret(sessionSecret, secretPath)
+	secret, err := core.LoadSessionSecret(sessionSecret, secretPath)
 	if err != nil {
 		log.Fatalf("session secret: %v", err)
 	}

--- a/core.go
+++ b/core.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -39,9 +40,9 @@ var indexItems = []IndexItem{
 
 func CoreAdderMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		session, err := GetSession(request)
+		session, err := core.GetSession(request)
 		if err != nil {
-			sessionErrorRedirect(writer, request, err)
+			core.SessionErrorRedirect(writer, request, err)
 			return
 		}
 		var uid int32
@@ -170,7 +171,8 @@ func X2c(what string) byte {
 	return d1*16 + d2
 }
 
-type ContextValues string
+// ContextValues is an alias to core.ContextValues for backward compatibility.
+type ContextValues = core.ContextValues
 
 func DBAdderMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {

--- a/core/memfs_test.go
+++ b/core/memfs_test.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"io/fs"
+	"os"
+	"testing"
+)
+
+type memFS struct{ files map[string]memFile }
+
+type memFile struct {
+	data []byte
+	mode fs.FileMode
+}
+
+func newMemFS() *memFS {
+	return &memFS{files: make(map[string]memFile)}
+}
+
+func (m *memFS) ReadFile(name string) ([]byte, error) {
+	f, ok := m.files[name]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return append([]byte(nil), f.data...), nil
+}
+
+func (m *memFS) WriteFile(name string, data []byte, perm fs.FileMode) error {
+	m.files[name] = memFile{data: append([]byte(nil), data...), mode: perm}
+	return nil
+}
+
+func useMemFS(t *testing.T) *memFS {
+	m := newMemFS()
+	origRead, origWrite := readFile, writeFile
+	readFile = m.ReadFile
+	writeFile = m.WriteFile
+	t.Cleanup(func() {
+		readFile = origRead
+		writeFile = origWrite
+	})
+	return m
+}

--- a/core/session_secret.go
+++ b/core/session_secret.go
@@ -1,4 +1,4 @@
-package goa4web
+package core
 
 import (
 	"crypto/rand"

--- a/core/session_secret_test.go
+++ b/core/session_secret_test.go
@@ -1,4 +1,4 @@
-package goa4web
+package core
 
 import "testing"
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -1,0 +1,11 @@
+package core
+
+import "os"
+
+// readFile is a wrapper around os.ReadFile so tests can swap it out
+// for an in-memory implementation.
+var readFile = os.ReadFile
+
+// writeFile is a wrapper around os.WriteFile so tests can swap it out
+// for an in-memory implementation.
+var writeFile = os.WriteFile

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -13,10 +13,14 @@ import (
 	"github.com/gorilla/csrf"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/core"
 )
 
 func TestCSRFLoginFlow(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("testsecret"))
+	core.Store = store
+	core.SessionName = sessionName
 	key := sha256.Sum256([]byte("testsecret"))
 
 	r := mux.NewRouter()
@@ -59,6 +63,8 @@ func TestCSRFLoginFlow(t *testing.T) {
 
 func TestCSRFMismatchedReferer(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("testsecret"))
+	core.Store = store
+	core.SessionName = sessionName
 	key := sha256.Sum256([]byte("testsecret"))
 
 	r := mux.NewRouter()
@@ -101,6 +107,8 @@ func TestCSRFMismatchedReferer(t *testing.T) {
 
 func TestCSRFDisabled(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("testsecret"))
+	core.Store = store
+	core.SessionName = sessionName
 
 	r := mux.NewRouter()
 	r.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {

--- a/faqAdminQuestionPage.go
+++ b/faqAdminQuestionPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"strconv"
@@ -111,7 +112,7 @@ func faqQuestionsCreateActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/faqAskPage.go
+++ b/faqAskPage.go
@@ -2,6 +2,7 @@ package goa4web
 
 import (
 	"database/sql"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"strconv"
@@ -44,7 +45,7 @@ func faqAskActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	text := r.PostFormValue("text")
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/forumFeed.go
+++ b/forumFeed.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/arran4/goa4web/a4code2html"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/feeds"
 	"github.com/gorilla/mux"
 	"log"
@@ -53,7 +54,7 @@ func forumTopicFeed(r *http.Request, title string, topicID int, rows []*GetForum
 }
 
 func forumTopicRssPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -93,7 +94,7 @@ func forumTopicRssPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func forumTopicAtomPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/forumPage.go
+++ b/forumPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -23,7 +24,7 @@ func forumPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/forumThreadNewPage.go
+++ b/forumThreadNewPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -42,7 +43,7 @@ func forumThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 	vars := mux.Vars(r)
 	topicId, err := strconv.Atoi(vars["topic"])
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/forumThreadPage.go
+++ b/forumThreadPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"strconv"
@@ -54,7 +55,7 @@ func forumThreadPage(w http.ResponseWriter, r *http.Request) {
 	threadRow := r.Context().Value(ContextValues("thread")).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
 	topicRow := r.Context().Value(ContextValues("topic")).(*GetForumTopicByIdForUserRow)
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/forumTopicPage.go
+++ b/forumTopicPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -23,7 +24,7 @@ func forumTopicsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/forumTopicThreadReplyPage.go
+++ b/forumTopicThreadReplyPage.go
@@ -3,13 +3,14 @@ package goa4web
 import (
 	"database/sql"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"strconv"
 )
 
 func forumTopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/imagebbsBoardPage.go
+++ b/imagebbsBoardPage.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"github.com/disintegration/imaging"
 	"github.com/gorilla/mux"
 	"io"
@@ -80,7 +81,7 @@ func imagebbsBoardPostImageActionPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bid, _ := strconv.Atoi(vars["boardno"])
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/imagebbsBoardThreadPage.go
+++ b/imagebbsBoardThreadPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -38,7 +39,7 @@ func imagebbsBoardThreadPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bid, _ := strconv.Atoi(vars["boardno"])
 	thid, _ := strconv.Atoi(vars["thread"])
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -136,7 +137,7 @@ func imagebbsBoardThreadPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func imagebbsBoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/linkerAdminAddPage.go
+++ b/linkerAdminAddPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"strconv"
@@ -53,7 +54,7 @@ func linkerAdminAddPage(w http.ResponseWriter, r *http.Request) {
 func linkerAdminAddActionPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/linkerCommentsPage.go
+++ b/linkerCommentsPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -48,7 +49,7 @@ func linkerCommentsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	vars := mux.Vars(r)
 	linkId, _ := strconv.Atoi(vars["link"])
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -141,7 +142,7 @@ func linkerCommentsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func linkerCommentsReplyPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/linkerShowPage.go
+++ b/linkerShowPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -54,7 +55,7 @@ func linkerShowPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func linkerShowReplyPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/linkerSuggestPage.go
+++ b/linkerSuggestPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"strconv"
@@ -53,7 +54,7 @@ func linkerSuggestPage(w http.ResponseWriter, r *http.Request) {
 func linkerSuggestActionPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/loginPage.go
+++ b/loginPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"net/url"
@@ -85,7 +86,7 @@ func loginActionPage(w http.ResponseWriter, r *http.Request) {
 
 	user := &User{Idusers: uid, Email: email}
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/newsPostPage.go
+++ b/newsPostPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -58,7 +59,7 @@ func newsPostPage(w http.ResponseWriter, r *http.Request) {
 	}
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -173,7 +174,7 @@ func newsPostPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func newsPostReplyActionPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -355,7 +356,7 @@ func newsPostNewActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	text := r.PostFormValue("text")
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/registerPage.go
+++ b/registerPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"strings"
@@ -101,7 +102,7 @@ func registerActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/run.go
+++ b/run.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -44,6 +45,8 @@ func init() {
 // session secret. The context controls the lifetime of the HTTP server.
 func RunWithConfig(ctx context.Context, cfg runtimeconfig.RuntimeConfig, sessionSecret string) error {
 	store = sessions.NewCookieStore([]byte(sessionSecret))
+	core.Store = store
+	core.SessionName = sessionName
 	store.Options = &sessions.Options{
 		Path:     "/",
 		HttpOnly: true,
@@ -171,7 +174,7 @@ func redirectPermanentPrefix(from, to string) http.HandlerFunc {
 // TODO we could do better
 func TargetUsersLevelNotHigherThanAdminsMax() mux.MatcherFunc {
 	return func(r *http.Request, match *mux.RouteMatch) bool {
-		session, err := GetSession(r)
+		session, err := core.GetSession(r)
 		if err != nil {
 			return false
 		}
@@ -212,7 +215,7 @@ func TargetUsersLevelNotHigherThanAdminsMax() mux.MatcherFunc {
 // TODO we could do better
 func AdminUsersMaxLevelNotLowerThanTargetLevel() mux.MatcherFunc {
 	return func(r *http.Request, match *mux.RouteMatch) bool {
-		session, err := GetSession(r)
+		session, err := core.GetSession(r)
 		if err != nil {
 			return false
 		}
@@ -252,7 +255,7 @@ func RequiredAccess(accessLevels ...string) mux.MatcherFunc {
 
 func RequiresAnAccount() mux.MatcherFunc {
 	return func(request *http.Request, match *mux.RouteMatch) bool {
-		session, err := GetSession(request)
+		session, err := core.GetSession(request)
 		if err != nil {
 			return false
 		}
@@ -266,7 +269,7 @@ func NewsPostAuthor() mux.MatcherFunc {
 		vars := mux.Vars(request)
 		newsPostId, _ := strconv.Atoi(vars["post"])
 		queries := request.Context().Value(ContextValues("queries")).(*Queries)
-		session, err := GetSession(request)
+		session, err := core.GetSession(request)
 		if err != nil {
 			return false
 		}
@@ -287,7 +290,7 @@ func BlogAuthor() mux.MatcherFunc {
 		vars := mux.Vars(request)
 		blogId, _ := strconv.Atoi(vars["blog"])
 		queries := request.Context().Value(ContextValues("queries")).(*Queries)
-		session, err := GetSession(request)
+		session, err := core.GetSession(request)
 		if err != nil {
 			return false
 		}
@@ -312,7 +315,7 @@ func WritingAuthor() mux.MatcherFunc {
 		vars := mux.Vars(request)
 		writingId, _ := strconv.Atoi(vars["writing"])
 		queries := request.Context().Value(ContextValues("queries")).(*Queries)
-		session, err := GetSession(request)
+		session, err := core.GetSession(request)
 		if err != nil {
 			return false
 		}
@@ -336,7 +339,7 @@ func CommentAuthor() mux.MatcherFunc {
 		vars := mux.Vars(request)
 		commentId, _ := strconv.Atoi(vars["comment"])
 		queries := request.Context().Value(ContextValues("queries")).(*Queries)
-		session, err := GetSession(request)
+		session, err := core.GetSession(request)
 		if err != nil {
 			return false
 		}
@@ -369,7 +372,7 @@ func GetThreadAndTopic() mux.MatcherFunc {
 
 		queries := r.Context().Value(ContextValues("queries")).(*Queries)
 
-		session, _ := GetSession(r)
+		session, _ := core.GetSession(r)
 		var uid int32
 		if session != nil {
 			uid, _ = session.Values["UID"].(int32)

--- a/searchResultBlogsActionPage.go
+++ b/searchResultBlogsActionPage.go
@@ -2,6 +2,7 @@ package goa4web
 
 import (
 	"database/sql"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 )
@@ -21,7 +22,7 @@ func searchResultBlogsActionPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/searchResultForumActionPage.go
+++ b/searchResultForumActionPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 )
@@ -19,7 +20,7 @@ func searchResultForumActionPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/searchResultLinkerActionPage.go
+++ b/searchResultLinkerActionPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 )
@@ -23,7 +24,7 @@ func searchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/searchResultNewsActionPage.go
+++ b/searchResultNewsActionPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 )
@@ -22,7 +23,7 @@ func searchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/searchResultWritingsActionPage.go
+++ b/searchResultWritingsActionPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 )
@@ -22,7 +23,7 @@ func searchResultWritingsActionPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -8,10 +8,14 @@ import (
 	"testing"
 
 	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/core"
 )
 
 func TestCoreAdderMiddlewareBadSession(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = sessionName
 	h := CoreAdderMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -32,10 +36,12 @@ func TestCoreAdderMiddlewareBadSession(t *testing.T) {
 
 func TestGetSessionOrFailBadSession(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = sessionName
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(&http.Cookie{Name: sessionName, Value: "bad"})
 	rr := httptest.NewRecorder()
-	sess, ok := GetSessionOrFail(rr, req)
+	sess, ok := core.GetSessionOrFail(rr, req)
 	if ok {
 		t.Fatalf("expected failure, got session %v", sess)
 	}

--- a/user.go
+++ b/user.go
@@ -10,14 +10,16 @@ import (
 	"time"
 
 	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/core"
 )
 
 func UserAdderMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		// Get the session.
-		session, err := GetSession(request)
+		session, err := core.GetSession(request)
 		if err != nil {
-			sessionError(writer, request, err)
+			core.SessionError(writer, request, err)
 		}
 
 		queries := request.Context().Value(ContextValues("queries")).(*Queries)

--- a/userEmailPage.go
+++ b/userEmailPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"net/url"
@@ -40,7 +41,7 @@ func userEmailPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 func userEmailSaveActionPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/userLangPage.go
+++ b/userLangPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"strconv"
@@ -132,7 +133,7 @@ func userLangSaveLanguagesActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -155,7 +156,7 @@ func userLangSaveLanguagePreferenceActionPage(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -178,7 +179,7 @@ func userLangSaveDefaultLanguageActionPage(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -201,7 +202,7 @@ func userLangSaveAllActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/userLangPage_test.go
+++ b/userLangPage_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/runtimeconfig"
 	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/core"
 )
 
 func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
@@ -24,6 +26,10 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 
 	queries := New(db)
 	store = sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = sessionName
+	core.Store = store
+	core.SessionName = sessionName
 
 	form := url.Values{}
 	form.Set("dothis", "Save all")
@@ -120,6 +126,8 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	queries := New(db)
 	runtimeconfig.AppRuntimeConfig.PageSizeDefault = 15
 	store = sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = sessionName
 
 	form := url.Values{}
 	form.Set("dothis", "Save language")

--- a/userLogoutPage.go
+++ b/userLogoutPage.go
@@ -3,6 +3,8 @@ package goa4web
 import (
 	"log"
 	"net/http"
+
+	"github.com/arran4/goa4web/core"
 )
 
 func userLogoutPage(w http.ResponseWriter, r *http.Request) {
@@ -15,9 +17,9 @@ func userLogoutPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 
-	session, err := GetSession(r)
+	session, err := core.GetSession(r)
 	if err != nil {
-		sessionError(w, r, err)
+		core.SessionError(w, r, err)
 	}
 	delete(session.Values, "UID")
 	delete(session.Values, "LoginTime")

--- a/userNotificationsPage.go
+++ b/userNotificationsPage.go
@@ -1,6 +1,7 @@
 package goa4web
 
 import (
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"strconv"
@@ -11,7 +12,7 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -42,7 +43,7 @@ func userNotificationsDismissActionPage(w http.ResponseWriter, r *http.Request) 
 		http.NotFound(w, r)
 		return
 	}
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -70,7 +71,7 @@ func notificationsRssPage(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/userPage.go
+++ b/userPage.go
@@ -3,6 +3,8 @@ package goa4web
 import (
 	"log"
 	"net/http"
+
+	"github.com/arran4/goa4web/core"
 )
 
 func userPage(w http.ResponseWriter, r *http.Request) {
@@ -15,7 +17,7 @@ func userPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if data.CoreData.UserID == 0 {
-		session, err := GetSession(r)
+		session, err := core.GetSession(r)
 		if err != nil {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return

--- a/userPagingPage.go
+++ b/userPagingPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"strconv"
@@ -39,7 +40,7 @@ func userPagingSaveActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/usr/paging", http.StatusSeeOther)
 		return
 	}
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/user_test.go
+++ b/user_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/core"
 )
 
 // helper to setup session cookie
@@ -30,6 +32,10 @@ func newRequestWithSession(method, target string, values map[string]interface{})
 
 func TestUserAdderMiddleware_ExpiredSession(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("test-key"))
+	core.Store = store
+	core.SessionName = sessionName
+	core.Store = store
+	core.SessionName = sessionName
 	req, rr := newRequestWithSession("GET", "/", map[string]interface{}{
 		"UID":        int32(1),
 		"ExpiryTime": time.Now().Add(-time.Hour).Unix(),

--- a/writingsArticleAddPage.go
+++ b/writingsArticleAddPage.go
@@ -2,6 +2,7 @@ package goa4web
 
 import (
 	"database/sql"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -38,7 +39,7 @@ func writingsArticleAddPage(w http.ResponseWriter, r *http.Request) {
 func writingsArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	categoryId, _ := strconv.Atoi(vars["category"])
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/writingsArticleEditPage.go
+++ b/writingsArticleEditPage.go
@@ -2,6 +2,7 @@ package goa4web
 
 import (
 	"database/sql"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -26,7 +27,7 @@ func writingsArticleEditPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	articleId, _ := strconv.Atoi(vars["article"])
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/writingsArticlePage.go
+++ b/writingsArticlePage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"golang.org/x/exp/slices"
 	"log"
@@ -53,7 +54,7 @@ func writingsArticlePage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	articleId, _ := strconv.Atoi(vars["article"])
 
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -181,7 +182,7 @@ func writingsArticlePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func writingsArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := GetSessionOrFail(w, r)
+	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}


### PR DESCRIPTION
## Summary
- relocate session management into new `core` package
- expose session store and name via exported variables
- adjust main program to use `core.LoadSessionSecret`
- update handlers and tests to reference `core` functions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685a613d1634832fb953275a5f7f0917