### PR TITLE
Move user middleware to core package

### DIFF
--- a/context_alias.go
+++ b/context_alias.go
@@ -1,0 +1,5 @@
+package goa4web
+
+import "github.com/arran4/goa4web/core"
+
+type ContextValues = core.ContextValues

--- a/core.go
+++ b/core.go
@@ -170,8 +170,6 @@ func X2c(what string) byte {
 	return d1*16 + d2
 }
 
-type ContextValues string
-
 func DBAdderMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if dbPool == nil {

--- a/core/context.go
+++ b/core/context.go
@@ -1,0 +1,3 @@
+package core
+
+type ContextValues string

--- a/core/session.go
+++ b/core/session.go
@@ -1,0 +1,49 @@
+package core
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/sessions"
+)
+
+const sessionName = "my-session"
+
+var store *sessions.CookieStore
+
+// SetSessionStore configures the session store used by GetSession.
+func SetSessionStore(s *sessions.CookieStore) {
+	store = s
+}
+
+// GetSession returns the session from the request context if present,
+// otherwise it retrieves the session from the session store.
+func GetSession(r *http.Request) (*sessions.Session, error) {
+	if sessVal := r.Context().Value(ContextValues("session")); sessVal != nil {
+		sess, ok := sessVal.(*sessions.Session)
+		if !ok {
+			return nil, fmt.Errorf("invalid session in context")
+		}
+		return sess, nil
+	}
+	sess, err := store.Get(r, sessionName)
+	if err != nil {
+		log.Printf("get session: %v", err)
+	}
+	return sess, err
+}
+
+func clearSession(w http.ResponseWriter, r *http.Request) {
+	sess, _ := store.New(r, sessionName)
+	sess.Options.MaxAge = -1
+	if err := sess.Save(r, w); err != nil {
+		log.Printf("clear session: %v", err)
+	}
+}
+
+// sessionError logs the error and clears the session cookie.
+func sessionError(w http.ResponseWriter, r *http.Request, err error) {
+	log.Printf("session error: %v", err)
+	clearSession(w, r)
+}

--- a/run.go
+++ b/run.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -50,6 +51,7 @@ func RunWithConfig(ctx context.Context, cfg runtimeconfig.RuntimeConfig, session
 		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	}
+	core.SetSessionStore(store)
 
 	var handler http.Handler
 
@@ -74,7 +76,7 @@ func RunWithConfig(ctx context.Context, cfg runtimeconfig.RuntimeConfig, session
 
 	handler = newMiddlewareChain(
 		DBAdderMiddleware,
-		UserAdderMiddleware,
+		core.UserAdderMiddleware,
 		CoreAdderMiddleware,
 		RequestLoggerMiddleware,
 		SecurityHeadersMiddleware,

--- a/userPage.go
+++ b/userPage.go
@@ -3,6 +3,8 @@ package goa4web
 import (
 	"log"
 	"net/http"
+
+	"github.com/arran4/goa4web/core"
 )
 
 func userPage(w http.ResponseWriter, r *http.Request) {
@@ -20,7 +22,7 @@ func userPage(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
-		redirectToLogin(w, r, session)
+		core.RedirectToLogin(w, r, session)
 		return
 	}
 

--- a/user_test.go
+++ b/user_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/sessions"
 )
 
@@ -30,6 +31,7 @@ func newRequestWithSession(method, target string, values map[string]interface{})
 
 func TestUserAdderMiddleware_ExpiredSession(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("test-key"))
+	core.SetSessionStore(store)
 	req, rr := newRequestWithSession("GET", "/", map[string]interface{}{
 		"UID":        int32(1),
 		"ExpiryTime": time.Now().Add(-time.Hour).Unix(),
@@ -38,7 +40,7 @@ func TestUserAdderMiddleware_ExpiredSession(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	called := false
-	handler := UserAdderMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := core.UserAdderMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 	}))
 
@@ -61,6 +63,7 @@ func TestUserAdderMiddleware_AttachesPrefs(t *testing.T) {
 	}
 	defer db.Close()
 	store = sessions.NewCookieStore([]byte("test-key"))
+	core.SetSessionStore(store)
 
 	req, rr := newRequestWithSession("GET", "/", map[string]interface{}{
 		"UID":        int32(1),
@@ -89,7 +92,7 @@ func TestUserAdderMiddleware_AttachesPrefs(t *testing.T) {
 	var gotPref *Preference
 	var gotLangs []*Userlang
 
-	handler := UserAdderMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := core.UserAdderMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPerms, _ = r.Context().Value(ContextValues("permissions")).([]*Permission)
 		gotPref, _ = r.Context().Value(ContextValues("preference")).(*Preference)
 		gotLangs, _ = r.Context().Value(ContextValues("languages")).([]*Userlang)


### PR DESCRIPTION
## Summary
- migrate `UserAdderMiddleware` and its redirect helper to new `core` package
- add session helpers and context alias
- wire up core middleware in `run.go`
- update tests and user page to reference new package

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a8199ac34832fb533360b273bcb17