### PR TITLE
Refactor handler utilities into common package

### DIFF
--- a/a4code2html/a4code2html_test.go
+++ b/a4code2html/a4code2html_test.go
@@ -1,8 +1,9 @@
 package a4code2html
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestA4code2html_Process(t *testing.T) {

--- a/adminAnnouncementsPage.go
+++ b/adminAnnouncementsPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func adminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
@@ -24,7 +25,7 @@ func adminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data.Announcements = rows
-	if err := templates.RenderTemplate(w, "announcementsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "announcementsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminAuditLogPage.go
+++ b/adminAuditLogPage.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func copyValues(v url.Values) url.Values {
@@ -35,7 +36,7 @@ func adminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 		User:     r.URL.Query().Get("user"),
 		Action:   r.URL.Query().Get("action"),
-		PageSize: getPageSize(r),
+		PageSize: common.GetPageSize(r),
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
@@ -94,7 +95,7 @@ func adminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	if err := templates.RenderTemplate(w, "auditLogPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "auditLogPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminCategoriesPage.go
+++ b/adminCategoriesPage.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func adminCategoriesPage(w http.ResponseWriter, r *http.Request) {
@@ -52,7 +53,7 @@ func adminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 		data.LinkerCategories = rows
 	}
 
-	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminEmailQueuePage.go
+++ b/adminEmailQueuePage.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func adminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
@@ -24,7 +25,7 @@ func adminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data.Emails = items
-	if err := templates.RenderTemplate(w, "emailQueuePage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "emailQueuePage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminEmailTemplatePage.go
+++ b/adminEmailTemplatePage.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
@@ -42,7 +43,7 @@ func adminEmailTemplatePage(w http.ResponseWriter, r *http.Request) {
 		Error:    r.URL.Query().Get("error"),
 	}
 
-	if err := templates.RenderTemplate(w, "emailTemplatePage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "emailTemplatePage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminForumFlaggedPostsPage.go
+++ b/adminForumFlaggedPostsPage.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 // adminForumFlaggedPostsPage displays posts flagged for moderator review.
@@ -13,7 +14,7 @@ func adminForumFlaggedPostsPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 	}
 	data := Data{CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData)}
-	if err := templates.RenderTemplate(w, "forumFlaggedPostsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "forumFlaggedPostsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminForumHandler.go
+++ b/adminForumHandler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	_ "github.com/go-sql-driver/mysql" // Import the MySQL driver.
 )
 
@@ -19,7 +20,7 @@ func adminForumPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
-	err := templates.RenderTemplate(w, "page.gohtml", data, NewFuncs(r))
+	err := templates.RenderTemplate(w, "page.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -49,7 +50,7 @@ func adminForumRemakeForumThreadPage(w http.ResponseWriter, r *http.Request) {
 	} else {
 		data.Messages = append(data.Messages, "Thread metadata rebuild complete.")
 	}
-	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r))
+	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -78,7 +79,7 @@ func adminForumRemakeForumTopicPage(w http.ResponseWriter, r *http.Request) {
 	} else {
 		data.Messages = append(data.Messages, "Topic metadata rebuild complete.")
 	}
-	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r))
+	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/adminForumModeratorLogsPage.go
+++ b/adminForumModeratorLogsPage.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 // adminForumModeratorLogsPage displays recent moderator actions.
@@ -13,7 +14,7 @@ func adminForumModeratorLogsPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 	}
 	data := Data{CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData)}
-	if err := templates.RenderTemplate(w, "forumModeratorLogsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "forumModeratorLogsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminForumWordListHandler.go
+++ b/adminForumWordListHandler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	_ "github.com/go-sql-driver/mysql" // Import the MySQL driver.
 )
 
@@ -34,7 +35,7 @@ func adminForumWordListPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	err = templates.RenderTemplate(w, "forumWordListPage.gohtml", data, NewFuncs(r))
+	err = templates.RenderTemplate(w, "forumWordListPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/adminHandler.go
+++ b/adminHandler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	_ "github.com/go-sql-driver/mysql" // Import the MySQL driver.
 )
 
@@ -44,7 +45,7 @@ func adminPage(w http.ResponseWriter, r *http.Request) {
 	count("SELECT COUNT(*) FROM forumthread", &data.Stats.ForumThreads)
 	count("SELECT COUNT(*) FROM writing", &data.Stats.Writings)
 
-	err := templates.RenderTemplate(w, "page.gohtml", data, NewFuncs(r))
+	err := templates.RenderTemplate(w, "page.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/adminIPBanPage.go
+++ b/adminIPBanPage.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func adminIPBanPage(w http.ResponseWriter, r *http.Request) {
@@ -25,7 +26,7 @@ func adminIPBanPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data.Bans = rows
-	if err := templates.RenderTemplate(w, "iPBanPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "iPBanPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminLanguagesHandler.go
+++ b/adminLanguagesHandler.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	_ "github.com/go-sql-driver/mysql" // Import the MySQL driver.
 )
 
@@ -35,7 +36,7 @@ func adminLanguagesPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	err = templates.RenderTemplate(w, "languagesPage.gohtml", data, NewFuncs(r))
+	err = templates.RenderTemplate(w, "languagesPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -64,7 +65,7 @@ func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {
 	}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("RenameLanguage: %w", err).Error())
 	}
-	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r))
+	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -88,7 +89,7 @@ func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
 	} else if err := queries.DeleteLanguage(r.Context(), int32(cidi)); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("DeleteLanguage: %w", err).Error())
 	}
-	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r))
+	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -113,7 +114,7 @@ func adminLanguagesCreatePage(w http.ResponseWriter, r *http.Request) {
 	}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
 	}
-	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r))
+	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/adminLoginAttemptsPage.go
+++ b/adminLoginAttemptsPage.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func adminLoginAttemptsPage(w http.ResponseWriter, r *http.Request) {
@@ -21,7 +22,7 @@ func adminLoginAttemptsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data.Attempts = items
-	if err := templates.RenderTemplate(w, "loginAttemptsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "loginAttemptsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminNotificationsPage.go
+++ b/adminNotificationsPage.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func adminNotificationsPage(w http.ResponseWriter, r *http.Request) {
@@ -36,7 +37,7 @@ func adminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 	data.Notifications = items
 	data.Total = len(items)
 	data.Unread = unread
-	if err := templates.RenderTemplate(w, "notificationsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "notificationsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminPermissionsSectionPage.go
+++ b/adminPermissionsSectionPage.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 // adminPermissionsSectionPage displays the current distinct permission sections
@@ -31,7 +32,7 @@ func adminPermissionsSectionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Sections = rows
 
-	if err := templates.RenderTemplate(w, "permissionsSectionPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "permissionsSectionPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -63,7 +64,7 @@ func adminPermissionsSectionRenamePage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("RenamePermissionSection: %w", err).Error())
 	}
 
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminPermissionsSectionViewPage.go
+++ b/adminPermissionsSectionViewPage.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 // adminPermissionsSectionViewPage lists all permissions for a specific section.
@@ -25,7 +26,7 @@ func adminPermissionsSectionViewPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data := Data{CoreData: cd, Section: section, Rows: rows}
-	if err := templates.RenderTemplate(w, "permissionsSectionViewPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "permissionsSectionViewPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminReloadConfigPage.go
+++ b/adminReloadConfigPage.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -27,7 +28,7 @@ func adminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Messages = append(data.Messages, "Configuration reloaded")
 
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminSearchHandler.go
+++ b/adminSearchHandler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func adminSearchPage(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +49,7 @@ func adminSearchPage(w http.ResponseWriter, r *http.Request) {
 	count("SELECT COUNT(*) FROM writingSearch", &data.Stats.Writings)
 	count("SELECT COUNT(*) FROM imagepostSearch", &data.Stats.Images)
 
-	if err := templates.RenderTemplate(w, "searchPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "searchPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -73,7 +74,7 @@ func adminSearchRemakeCommentsSearchPage(w http.ResponseWriter, r *http.Request)
 		data.Errors = append(data.Errors, fmt.Errorf("RemakeCommentsSearchInsert: %w", err).Error())
 	}
 
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -97,7 +98,7 @@ func adminSearchRemakeNewsSearchPage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("RemakeNewsSearchInsert: %w", err).Error())
 	}
 
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -121,7 +122,7 @@ func adminSearchRemakeBlogSearchPage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("RemakeBlogsSearchInsert: %w", err).Error())
 	}
 
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -145,7 +146,7 @@ func adminSearchRemakeLinkerSearchPage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("RemakeLinkerSearchInsert: %w", err).Error())
 	}
 
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -169,7 +170,7 @@ func adminSearchRemakeWritingSearchPage(w http.ResponseWriter, r *http.Request) 
 		data.Errors = append(data.Errors, fmt.Errorf("RemakeWritingSearchInsert: %w", err).Error())
 	}
 
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -194,7 +195,7 @@ func adminSearchRemakeImageSearchPage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("RemakeImagePostSearchInsert: %w", err).Error())
 	}
 
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminSearchWordListHandler.go
+++ b/adminSearchWordListHandler.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	_ "github.com/go-sql-driver/mysql" // Import the MySQL driver.
 )
 
@@ -141,7 +142,7 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 		data.PrevLink = base + "?" + vals.Encode()
 	}
 
-	if err = templates.RenderTemplate(w, "searchWordListPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err = templates.RenderTemplate(w, "searchWordListPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminServerStatsPage.go
+++ b/adminServerStatsPage.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func adminServerStatsPage(w http.ResponseWriter, r *http.Request) {
@@ -40,7 +41,7 @@ func adminServerStatsPage(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	if err := templates.RenderTemplate(w, "serverStatsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "serverStatsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminSessionsPage.go
+++ b/adminSessionsPage.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func adminSessionsPage(w http.ResponseWriter, r *http.Request) {
@@ -21,7 +22,7 @@ func adminSessionsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data.Sessions = items
-	if err := templates.RenderTemplate(w, "sessionsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "sessionsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -46,7 +47,7 @@ func adminSessionsDeletePage(w http.ResponseWriter, r *http.Request) {
 			data.Errors = append(data.Errors, err.Error())
 		}
 	}
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminShutdownPage.go
+++ b/adminShutdownPage.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func adminShutdownPage(w http.ResponseWriter, r *http.Request) {
@@ -28,7 +29,7 @@ func adminShutdownPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminSiteSettingsPage.go
+++ b/adminSiteSettingsPage.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -51,7 +52,7 @@ func adminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 		data.Languages = langs
 	}
 
-	if err := templates.RenderTemplate(w, "siteSettingsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "siteSettingsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminUsageStatsPage.go
+++ b/adminUsageStatsPage.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -51,7 +52,7 @@ func adminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.StartYear = runtimeconfig.AppRuntimeConfig.StatsStartYear
 
-	if err := templates.RenderTemplate(w, "usageStatsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "usageStatsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminUsersHandler.go
+++ b/adminUsersHandler.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func cloneValues(v url.Values) url.Values {
@@ -37,7 +38,7 @@ func adminUsersPage(w http.ResponseWriter, r *http.Request) {
 		Search:   r.URL.Query().Get("search"),
 		Role:     r.URL.Query().Get("role"),
 		Status:   r.URL.Query().Get("status"),
-		PageSize: getPageSize(r),
+		PageSize: common.GetPageSize(r),
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
@@ -102,7 +103,7 @@ func adminUsersPage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	err = templates.RenderTemplate(w, "usersPage.gohtml", data, NewFuncs(r))
+	err = templates.RenderTemplate(w, "usersPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -126,7 +127,7 @@ func adminUserDisablePage(w http.ResponseWriter, r *http.Request) {
 	} else if _, err := r.Context().Value(ContextValues("queries")).(*Queries).DB().ExecContext(r.Context(), "DELETE FROM users WHERE idusers = ?", uidi); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("delete user: %w", err).Error())
 	}
-	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r))
+	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -149,7 +150,7 @@ func adminUserEditFormPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 		User:     user,
 	}
-	if err := templates.RenderTemplate(w, "userEditPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "userEditPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -175,7 +176,7 @@ func adminUserEditSavePage(w http.ResponseWriter, r *http.Request) {
 	} else if _, err := queries.DB().ExecContext(r.Context(), "UPDATE users SET username=?, email=? WHERE idusers=?", username, email, uidi); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("update user: %w", err).Error())
 	}
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -209,7 +210,7 @@ func adminUserResetPasswordPage(w http.ResponseWriter, r *http.Request) {
 	} else {
 		data.Password = newPass
 	}
-	if err := templates.RenderTemplate(w, "userResetPasswordPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "userResetPasswordPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/adminUsersPermissionsHandler.go
+++ b/adminUsersPermissionsHandler.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func adminUsersPermissionsPage(w http.ResponseWriter, r *http.Request) {
@@ -53,7 +54,7 @@ func adminUsersPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Sections = groups
 
-	err = templates.RenderTemplate(w, "usersPermissionsPage.gohtml", data, NewFuncs(r))
+	err = templates.RenderTemplate(w, "usersPermissionsPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -92,7 +93,7 @@ func adminUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http
 	} else {
 		logAudit(r, "Permission allow")
 	}
-	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r))
+	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -119,7 +120,7 @@ func adminUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 	} else {
 		logAudit(r, "Permission disallow")
 	}
-	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r))
+	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -155,7 +156,7 @@ func adminUsersPermissionsUpdatePage(w http.ResponseWriter, r *http.Request) {
 		logAudit(r, "Permission update")
 	}
 
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/autoRefreshPage.go
+++ b/autoRefreshPage.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func taskDoneAutoRefreshPage(w http.ResponseWriter, r *http.Request) {
@@ -18,7 +19,7 @@ func taskDoneAutoRefreshPage(w http.ResponseWriter, r *http.Request) {
 
 	data.AutoRefresh = true
 
-	if err := templates.RenderTemplate(w, "taskDoneAutoRefreshPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "taskDoneAutoRefreshPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/blogsBlogAddPage.go
+++ b/blogsBlogAddPage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func blogsBlogAddPage(w http.ResponseWriter, r *http.Request) {
@@ -40,7 +41,7 @@ func blogsBlogAddPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomBlogIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "blogAddPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "blogAddPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/blogsBlogEditPage.go
+++ b/blogsBlogEditPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -51,7 +52,7 @@ func blogsBlogEditPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomBlogIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "blogEditPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "blogEditPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/blogsBlogPage.go
+++ b/blogsBlogPage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -83,7 +84,7 @@ func blogsBlogPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomBlogIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "blogPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "blogPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/blogsBlogReplyPage.go
+++ b/blogsBlogReplyPage.go
@@ -4,11 +4,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/core"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/arran4/goa4web/core"
+	"github.com/gorilla/mux"
 )
 
 func blogsBlogReplyPostPage(w http.ResponseWriter, r *http.Request) {

--- a/blogsBloggerPage.go
+++ b/blogsBloggerPage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -87,7 +88,7 @@ func blogsBloggerPage(w http.ResponseWriter, r *http.Request) {
 	}
 	CustomBlogIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "bloggerPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "bloggerPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/blogsBloggersBloggerPage.go
+++ b/blogsBloggersBloggerPage.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func blogsBloggersBloggerPage(w http.ResponseWriter, r *http.Request) {
@@ -32,7 +33,7 @@ func blogsBloggersBloggerPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomBlogIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "bloggersBloggerPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "bloggersBloggerPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/blogsBloggersPage.go
+++ b/blogsBloggersPage.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func blogsBloggersPage(w http.ResponseWriter, r *http.Request) {
@@ -26,13 +27,13 @@ func blogsBloggersPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 		Search:   r.URL.Query().Get("search"),
-		PageSize: getPageSize(r),
+		PageSize: common.GetPageSize(r),
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	queries := r.Context().Value(ContextValues("queries")).(*Queries)
 
-	pageSize := getPageSize(r)
+	pageSize := common.GetPageSize(r)
 	var rows []*BloggerCountRow
 	var err error
 	if data.Search != "" {
@@ -91,7 +92,7 @@ func blogsBloggersPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomBlogIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "bloggersPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "bloggersPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/blogsCommentEditPage.go
+++ b/blogsCommentEditPage.go
@@ -4,11 +4,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/core"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/arran4/goa4web/core"
+	"github.com/gorilla/mux"
 )
 
 func blogsCommentEditPostPage(w http.ResponseWriter, r *http.Request) {

--- a/blogsCommentPage.go
+++ b/blogsCommentPage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -147,7 +148,7 @@ func blogsCommentPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomBlogIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "commentPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "commentPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/blogsPage.go
+++ b/blogsPage.go
@@ -13,6 +13,7 @@ import (
 	"github.com/arran4/goa4web/a4code2html"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/feeds"
 )
 
@@ -73,7 +74,7 @@ func blogsPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomBlogIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "page.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "page.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/blogsUserPermissionsPage.go
+++ b/blogsUserPermissionsPage.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func getPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Request) {
@@ -55,7 +56,7 @@ func getPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Re
 	data.Rows = rows
 
 	CustomBlogIndex(data.CoreData, r)
-	err = templates.RenderTemplate(w, "userPermissionsPage.gohtml", data, NewFuncs(r))
+	err = templates.RenderTemplate(w, "userPermissionsPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -95,7 +96,7 @@ func blogsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http
 
 	CustomBlogIndex(data.CoreData, r)
 
-	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r))
+	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -121,7 +122,7 @@ func blogsUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
 	}
 	CustomBlogIndex(data.CoreData, r)
-	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r))
+	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -162,7 +163,7 @@ func blogsUsersPermissionsBulkAllowPage(w http.ResponseWriter, r *http.Request) 
 	}
 
 	CustomBlogIndex(data.CoreData, r)
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -197,7 +198,7 @@ func blogsUsersPermissionsBulkDisallowPage(w http.ResponseWriter, r *http.Reques
 	}
 
 	CustomBlogIndex(data.CoreData, r)
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/bookmarksEditPage.go
+++ b/bookmarksEditPage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func bookmarksEditPage(w http.ResponseWriter, r *http.Request) {
@@ -43,7 +44,7 @@ func bookmarksEditPage(w http.ResponseWriter, r *http.Request) {
 	}
 	bookmarksCustomIndex(data.CoreData)
 
-	if err := templates.RenderTemplate(w, "editPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "editPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/bookmarksMinePage.go
+++ b/bookmarksMinePage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 type BookmarkEntry struct {
@@ -98,7 +99,7 @@ func bookmarksMinePage(w http.ResponseWriter, r *http.Request) {
 	}
 	bookmarksCustomIndex(data.CoreData)
 
-	if err := templates.RenderTemplate(w, "minePage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "minePage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/bookmarksMinePage_test.go
+++ b/bookmarksMinePage_test.go
@@ -1,8 +1,9 @@
 package goa4web
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func Test_preprocessBookmarks(t *testing.T) {

--- a/bookmarksPage.go
+++ b/bookmarksPage.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func bookmarksPage(w http.ResponseWriter, r *http.Request) {
@@ -24,7 +25,7 @@ func bookmarksPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if uid == 0 {
-		if err := templates.RenderTemplate(w, "infoPage.gohtml", data, NewFuncs(r)); err != nil {
+		if err := templates.RenderTemplate(w, "infoPage.gohtml", data, common.NewFuncs(r)); err != nil {
 			log.Printf("Template Error: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
@@ -34,7 +35,7 @@ func bookmarksPage(w http.ResponseWriter, r *http.Request) {
 
 	bookmarksCustomIndex(data.CoreData)
 
-	if err := templates.RenderTemplate(w, "page.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "page.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/core.go
+++ b/core.go
@@ -161,18 +161,3 @@ func DBAdderMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(writer, request.WithContext(ctx))
 	})
 }
-
-// getPageSize returns the preferred page size within configured bounds.
-func getPageSize(r *http.Request) int {
-	size := runtimeconfig.AppRuntimeConfig.PageSizeDefault
-	if pref, _ := r.Context().Value(ContextValues("preference")).(*Preference); pref != nil && pref.PageSize != 0 {
-		size = int(pref.PageSize)
-	}
-	if size < runtimeconfig.AppRuntimeConfig.PageSizeMin {
-		size = runtimeconfig.AppRuntimeConfig.PageSizeMin
-	}
-	if size > runtimeconfig.AppRuntimeConfig.PageSizeMax {
-		size = runtimeconfig.AppRuntimeConfig.PageSizeMax
-	}
-	return size
-}

--- a/data_test.go
+++ b/data_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 //go:embed core/templates/templates/*.gohtml core/templates/templates/*/*.gohtml
@@ -15,7 +17,7 @@ var testTemplates embed.FS
 
 func TestCompileGoHTML(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
-	template.Must(template.New("").Funcs(NewFuncs(r)).ParseFS(testTemplates,
+	template.Must(template.New("").Funcs(common.NewFuncs(r)).ParseFS(testTemplates,
 		"core/templates/templates/*.gohtml", "core/templates/templates/*/*.gohtml"))
 }
 
@@ -29,7 +31,7 @@ func TestParseEachTemplate(t *testing.T) {
 		}
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			r := httptest.NewRequest("GET", "/", nil)
-			if _, err := template.New("").Funcs(NewFuncs(r)).ParseFS(testTemplates, path); err != nil {
+			if _, err := template.New("").Funcs(common.NewFuncs(r)).ParseFS(testTemplates, path); err != nil {
 				t.Errorf("failed to parse %s: %v", path, err)
 			}
 		})

--- a/faqAdminAnswerPage.go
+++ b/faqAdminAnswerPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func faqAdminAnswerPage(w http.ResponseWriter, r *http.Request) {
@@ -47,7 +48,7 @@ func faqAdminAnswerPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomFAQIndex(data.CoreData)
 
-	if err := templates.RenderTemplate(w, "adminAnswerPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminAnswerPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/faqAdminCategoriesPage.go
+++ b/faqAdminCategoriesPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func faqAdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +36,7 @@ func faqAdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomFAQIndex(data.CoreData)
 
-	if err := templates.RenderTemplate(w, "adminCategoriesPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminCategoriesPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/faqAdminQuestionPage.go
+++ b/faqAdminQuestionPage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func faqAdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +49,7 @@ func faqAdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomFAQIndex(data.CoreData)
 
-	if err := templates.RenderTemplate(w, "adminQuestionPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminQuestionPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/faqAskPage.go
+++ b/faqAskPage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func faqAskPage(w http.ResponseWriter, r *http.Request) {
@@ -32,7 +33,7 @@ func faqAskPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomFAQIndex(data.CoreData)
 
-	if err := templates.RenderTemplate(w, "askPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "askPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/faqPage.go
+++ b/faqPage.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func faqPage(w http.ResponseWriter, r *http.Request) {
@@ -61,7 +62,7 @@ func faqPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomFAQIndex(data.CoreData)
 
-	if err := templates.RenderTemplate(w, "page.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "page.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forum.go
+++ b/forum.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
+
 	"golang.org/x/exp/slices"
 )
 

--- a/forumAdminCategoriesPage.go
+++ b/forumAdminCategoriesPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -37,7 +38,7 @@ func forumAdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomForumIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminCategoriesPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminCategoriesPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forumAdminPage.go
+++ b/forumAdminPage.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func forumAdminPage(w http.ResponseWriter, r *http.Request) {
@@ -38,7 +39,7 @@ func forumAdminPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomForumIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forumAdminRestrictionsPage.go
+++ b/forumAdminRestrictionsPage.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func forumAdminUsersRestrictionsPage(w http.ResponseWriter, r *http.Request) {
@@ -65,7 +66,7 @@ func forumAdminUsersRestrictionsPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomForumIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminUsersRestrictionsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminUsersRestrictionsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forumAdminThreadsPage.go
+++ b/forumAdminThreadsPage.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -46,7 +47,7 @@ func forumAdminThreadsPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomForumIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminThreadsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminThreadsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forumAdminTopicRestrictions.go
+++ b/forumAdminTopicRestrictions.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -41,7 +42,7 @@ func forumAdminTopicRestrictionLevelPage(w http.ResponseWriter, r *http.Request)
 
 	CustomForumIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminTopicRestrictionLevelPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminTopicRestrictionLevelPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forumAdminTopicsPage.go
+++ b/forumAdminTopicsPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -51,7 +52,7 @@ func forumAdminTopicsPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomForumIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminTopicsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminTopicsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forumAdminTopicsRestrictions.go
+++ b/forumAdminTopicsRestrictions.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func forumAdminTopicsRestrictionLevelPage(w http.ResponseWriter, r *http.Request) {
@@ -38,7 +39,7 @@ func forumAdminTopicsRestrictionLevelPage(w http.ResponseWriter, r *http.Request
 
 	CustomForumIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminTopicsRestrictionLevelPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminTopicsRestrictionLevelPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forumAdminUserLevelPage.go
+++ b/forumAdminUserLevelPage.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -42,7 +43,7 @@ func forumAdminUserLevelPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomForumIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminUserLevelPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminUserLevelPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forumAdminUserPage.go
+++ b/forumAdminUserPage.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func forumAdminUserPage(w http.ResponseWriter, r *http.Request) {
@@ -70,7 +71,7 @@ func forumAdminUserPage(w http.ResponseWriter, r *http.Request) {
 		users = filtered
 	}
 
-	pageSize := getPageSize(r)
+	pageSize := common.GetPageSize(r)
 	if offset < 0 {
 		offset = 0
 	}
@@ -119,7 +120,7 @@ func forumAdminUserPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomForumIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminUserPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminUserPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forumFeed.go
+++ b/forumFeed.go
@@ -4,14 +4,15 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/a4code2html"
-	"github.com/arran4/goa4web/core"
-	"github.com/gorilla/feeds"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/arran4/goa4web/a4code2html"
+	"github.com/arran4/goa4web/core"
+	"github.com/gorilla/feeds"
+	"github.com/gorilla/mux"
 )
 
 func forumTopicFeed(r *http.Request, title string, topicID int, rows []*GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow) *feeds.Feed {

--- a/forumPage.go
+++ b/forumPage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -123,7 +124,7 @@ func forumPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomForumIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "page.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "page.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forumThreadNewPage.go
+++ b/forumThreadNewPage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -34,7 +35,7 @@ func forumThreadNewPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomBlogIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "threadNewPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "threadNewPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forumThreadPage.go
+++ b/forumThreadPage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func forumThreadPage(w http.ResponseWriter, r *http.Request) {
@@ -170,7 +171,7 @@ func forumThreadPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomBlogIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "threadPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "threadPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forumTopicPage.go
+++ b/forumTopicPage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -110,7 +111,7 @@ func forumTopicsPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomForumIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "topicsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "topicsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/forumTopicThreadCommentEditPage.go
+++ b/forumTopicThreadCommentEditPage.go
@@ -3,10 +3,11 @@ package goa4web
 import (
 	"database/sql"
 	"fmt"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/gorilla/mux"
 )
 
 func forumTopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {

--- a/forumTopicThreadReplyPage.go
+++ b/forumTopicThreadReplyPage.go
@@ -3,10 +3,11 @@ package goa4web
 import (
 	"database/sql"
 	"fmt"
-	"github.com/arran4/goa4web/core"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/arran4/goa4web/core"
 )
 
 func forumTopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/common/funcs.go
+++ b/handlers/common/funcs.go
@@ -1,4 +1,4 @@
-package goa4web
+package common
 
 import (
 	"database/sql"
@@ -11,16 +11,21 @@ import (
 	"time"
 
 	"github.com/arran4/goa4web/a4code2html"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/runtimeconfig"
 	"github.com/gorilla/csrf"
 )
 
+// Version identifies the running build for template display.
+var Version = "dev"
+
+// NewFuncs returns template helpers used by multiple handlers.
 func NewFuncs(r *http.Request) template.FuncMap {
 	var LatestNews any
 	return map[string]any{
-		//"getPermissionsByUserIdAndSectionAndSectionAll":
 		"now":       func() time.Time { return time.Now() },
 		"csrfField": func() template.HTML { return csrf.TemplateField(r) },
-		"version":   func() string { return version },
+		"version":   func() string { return Version },
 		"a4code2html": func(s string) template.HTML {
 			c := a4code2html.NewA4Code2HTML()
 			c.CodeType = a4code2html.CTHTML
@@ -50,19 +55,19 @@ func NewFuncs(r *http.Request) template.FuncMap {
 				return LatestNews, nil
 			}
 			type Post struct {
-				*GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow
+				*db.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow
 				ShowReply    bool
 				ShowEdit     bool
 				Editing      bool
-				Announcement *SiteAnnouncement
+				Announcement *db.SiteAnnouncement
 				IsAdmin      bool
 			}
 			var result []*Post
-			queries := r.Context().Value(ContextValues("queries")).(*Queries)
+			queries := r.Context().Value(ContextKey("queries")).(*db.Queries)
 
 			offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
-			posts, err := queries.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(r.Context(), GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams{
+			posts, err := queries.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(r.Context(), db.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams{
 				Limit:  15,
 				Offset: int32(offset),
 			})
@@ -76,7 +81,7 @@ func NewFuncs(r *http.Request) template.FuncMap {
 
 			editingId, _ := strconv.Atoi(r.URL.Query().Get("reply"))
 
-			cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+			cd := r.Context().Value(ContextKey("coreData")).(*CoreData)
 			for _, post := range posts {
 				ann, err := queries.GetLatestAnnouncementByNewsID(r.Context(), post.Idsitenews)
 				if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -95,4 +100,19 @@ func NewFuncs(r *http.Request) template.FuncMap {
 			return result, nil
 		},
 	}
+}
+
+// GetPageSize returns the preferred page size within configured bounds.
+func GetPageSize(r *http.Request) int {
+	size := runtimeconfig.AppRuntimeConfig.PageSizeDefault
+	if pref, _ := r.Context().Value(ContextKey("preference")).(*db.Preference); pref != nil && pref.PageSize != 0 {
+		size = int(pref.PageSize)
+	}
+	if size < runtimeconfig.AppRuntimeConfig.PageSizeMin {
+		size = runtimeconfig.AppRuntimeConfig.PageSizeMin
+	}
+	if size > runtimeconfig.AppRuntimeConfig.PageSizeMax {
+		size = runtimeconfig.AppRuntimeConfig.PageSizeMax
+	}
+	return size
 }

--- a/handlers/common/funcs_test.go
+++ b/handlers/common/funcs_test.go
@@ -1,4 +1,4 @@
-package goa4web
+package common
 
 import (
 	"net/http/httptest"

--- a/handlers/common/types.go
+++ b/handlers/common/types.go
@@ -1,0 +1,9 @@
+package common
+
+import "github.com/arran4/goa4web/core"
+
+// ContextKey maps to core.ContextValues.
+type ContextKey = core.ContextValues
+
+// CoreData maps to core.CoreData for handler use.
+type CoreData = core.CoreData

--- a/imagebbsAdminApprove.go
+++ b/imagebbsAdminApprove.go
@@ -1,10 +1,11 @@
 package goa4web
 
 import (
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/gorilla/mux"
 )
 
 func imagebbsAdminApprovePostPage(w http.ResponseWriter, r *http.Request) {

--- a/imagebbsAdminBoardPage.go
+++ b/imagebbsAdminBoardPage.go
@@ -2,10 +2,11 @@ package goa4web
 
 import (
 	"database/sql"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/gorilla/mux"
 )
 
 func imagebbsAdminBoardModifyBoardActionPage(w http.ResponseWriter, r *http.Request) {

--- a/imagebbsAdminBoardsPage.go
+++ b/imagebbsAdminBoardsPage.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func imagebbsAdminBoardsPage(w http.ResponseWriter, r *http.Request) {
@@ -55,7 +56,7 @@ func imagebbsAdminBoardsPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomImageBBSIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminBoardsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminBoardsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/imagebbsAdminFilesPage.go
+++ b/imagebbsAdminFilesPage.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -67,7 +68,7 @@ func imagebbsAdminFilesPage(w http.ResponseWriter, r *http.Request) {
 	}
 	sort.Slice(data.Entries, func(i, j int) bool { return data.Entries[i].Name < data.Entries[j].Name })
 
-	if err := templates.RenderTemplate(w, "adminFilesPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminFilesPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/imagebbsAdminNewBoardPage.go
+++ b/imagebbsAdminNewBoardPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func imagebbsAdminNewBoardPage(w http.ResponseWriter, r *http.Request) {
@@ -36,7 +37,7 @@ func imagebbsAdminNewBoardPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomImageBBSIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminNewBoardPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminNewBoardPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/imagebbsAdminPage.go
+++ b/imagebbsAdminPage.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func imagebbsAdminPage(w http.ResponseWriter, r *http.Request) {
@@ -18,7 +19,7 @@ func imagebbsAdminPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomImageBBSIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/imagebbsBoardPage.go
+++ b/imagebbsBoardPage.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/disintegration/imaging"
 	"github.com/gorilla/mux"
 
@@ -70,7 +71,7 @@ func imagebbsBoardPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomImageBBSIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "boardPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "boardPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/imagebbsBoardThreadPage.go
+++ b/imagebbsBoardThreadPage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -131,7 +132,7 @@ func imagebbsBoardThreadPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomImageBBSIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "boardThreadPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "boardThreadPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/imagebbsFeed.go
+++ b/imagebbsFeed.go
@@ -4,14 +4,15 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/a4code2html"
-	"github.com/gorilla/feeds"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/arran4/goa4web/a4code2html"
+	"github.com/gorilla/feeds"
+	"github.com/gorilla/mux"
 )
 
 func imagebbsFeed(r *http.Request, title string, boardID int, rows []*GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCountRow) *feeds.Feed {

--- a/imagebbsPage.go
+++ b/imagebbsPage.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func imagebbsPage(w http.ResponseWriter, r *http.Request) {
@@ -40,7 +41,7 @@ func imagebbsPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomImageBBSIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "page.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "page.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/imagebbsPosterPage.go
+++ b/imagebbsPosterPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -56,7 +57,7 @@ func imagebbsPosterPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomImageBBSIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "posterPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "posterPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/informationPage.go
+++ b/informationPage.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/host"
 	"github.com/shirou/gopsutil/v3/load"
@@ -59,7 +60,7 @@ func informationPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.System.Processors = cpuInfo
 
-	if err := templates.RenderTemplate(w, "informationPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "informationPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/linkerAdminAddPage.go
+++ b/linkerAdminAddPage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func linkerAdminAddPage(w http.ResponseWriter, r *http.Request) {
@@ -47,7 +48,7 @@ func linkerAdminAddPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomLinkerIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminAddPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminAddPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/linkerAdminCategoriesPage.go
+++ b/linkerAdminCategoriesPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func linkerAdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +38,7 @@ func linkerAdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomLinkerIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/linkerAdminQueuePage.go
+++ b/linkerAdminQueuePage.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func linkerAdminQueuePage(w http.ResponseWriter, r *http.Request) {
@@ -68,7 +69,7 @@ func linkerAdminQueuePage(w http.ResponseWriter, r *http.Request) {
 		filtered = append(filtered, &QueueRow{q, fetchPageTitle(r.Context(), q.Url.String)})
 	}
 
-	pageSize := getPageSize(r)
+	pageSize := common.GetPageSize(r)
 	if data.Offset < 0 {
 		data.Offset = 0
 	}
@@ -111,7 +112,7 @@ func linkerAdminQueuePage(w http.ResponseWriter, r *http.Request) {
 
 	CustomLinkerIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminQueuePage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminQueuePage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/linkerAdminUserLevelsPage.go
+++ b/linkerAdminUserLevelsPage.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func linkerAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
@@ -64,7 +65,7 @@ func linkerAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	data.UserLevels = perms
 
 	CustomLinkerIndex(data.CoreData, r)
-	if err := templates.RenderTemplate(w, "adminUserLevelsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminUserLevelsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/linkerCategoriesPage.go
+++ b/linkerCategoriesPage.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func linkerCategoriesPage(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +36,7 @@ func linkerCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	data.Categories = categories
 
 	CustomLinkerIndex(data.CoreData, r)
-	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/linkerCategoryPage.go
+++ b/linkerCategoryPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -48,7 +49,7 @@ func linkerCategoryPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomLinkerIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "categoryPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "categoryPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/linkerCommentsPage.go
+++ b/linkerCommentsPage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -136,7 +137,7 @@ func linkerCommentsPage(w http.ResponseWriter, r *http.Request) {
 	data.Thread = threadRow
 
 	CustomLinkerIndex(data.CoreData, r)
-	if err := templates.RenderTemplate(w, "commentsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "commentsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/linkerFeed.go
+++ b/linkerFeed.go
@@ -4,11 +4,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/a4code2html"
-	"github.com/gorilla/feeds"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/arran4/goa4web/a4code2html"
+	"github.com/gorilla/feeds"
 )
 
 func linkerFeed(r *http.Request, rows []*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow) *feeds.Feed {

--- a/linkerLinkerPage.go
+++ b/linkerLinkerPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -56,7 +57,7 @@ func linkerLinkerPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomLinkerIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "linkerPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "linkerPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/linkerPage.go
+++ b/linkerPage.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -63,7 +64,7 @@ func linkerPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomLinkerIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "page.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "page.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/linkerShowPage.go
+++ b/linkerShowPage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -49,7 +50,7 @@ func linkerShowPage(w http.ResponseWriter, r *http.Request) {
 	data.Link = link
 
 	CustomLinkerIndex(data.CoreData, r)
-	if err := templates.RenderTemplate(w, "showPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "showPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/linkerSuggestPage.go
+++ b/linkerSuggestPage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func linkerSuggestPage(w http.ResponseWriter, r *http.Request) {
@@ -46,7 +47,7 @@ func linkerSuggestPage(w http.ResponseWriter, r *http.Request) {
 	data.Languages = languageRows
 
 	CustomLinkerIndex(data.CoreData, r)
-	if err := templates.RenderTemplate(w, "suggestPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "suggestPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/loginPage.go
+++ b/loginPage.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func loginUserPassPage(w http.ResponseWriter, r *http.Request) {
@@ -22,7 +23,7 @@ func loginUserPassPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 
-	if err := templates.RenderTemplate(w, "loginPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "loginPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -129,7 +130,7 @@ func loginActionPage(w http.ResponseWriter, r *http.Request) {
 			Method:   backMethod,
 			Values:   vals,
 		}
-		if err := templates.GetCompiledTemplates(NewFuncs(r)).ExecuteTemplate(w, "redirectBackPage.gohtml", data); err != nil {
+		if err := templates.GetCompiledTemplates(common.NewFuncs(r)).ExecuteTemplate(w, "redirectBackPage.gohtml", data); err != nil {
 			log.Printf("Template Error: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		}

--- a/middleware.go
+++ b/middleware.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 // routerWrapper wraps a router with additional middleware.
@@ -86,7 +87,7 @@ func RoleCheckerMiddleware(roles ...string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !roleAllowed(r, roles...) {
-				err := templates.GetCompiledTemplates(NewFuncs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", r.Context().Value(ContextValues("coreData")).(*CoreData))
+				err := templates.GetCompiledTemplates(common.NewFuncs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", r.Context().Value(ContextValues("coreData")).(*CoreData))
 				if err != nil {
 					log.Printf("Template Error: %s", err)
 					http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/newsAdminUserLevelsPage.go
+++ b/newsAdminUserLevelsPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func newsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +36,7 @@ func newsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomNewsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminUserLevelsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminUserLevelsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/newsPage.go
+++ b/newsPage.go
@@ -2,9 +2,10 @@ package goa4web
 
 import (
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
 	"strconv"
+
+	"github.com/gorilla/mux"
 )
 
 func CustomNewsIndex(data *CoreData, r *http.Request) {

--- a/newsPostPage.go
+++ b/newsPostPage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -168,7 +169,7 @@ func newsPostPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomNewsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "postPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "postPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/newsRssPage.go
+++ b/newsRssPage.go
@@ -4,11 +4,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/a4code2html"
-	"github.com/gorilla/feeds"
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/arran4/goa4web/a4code2html"
+	"github.com/gorilla/feeds"
 )
 
 func newsRssPage(w http.ResponseWriter, r *http.Request) {

--- a/newsUserPermissionsPage.go
+++ b/newsUserPermissionsPage.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func newsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
@@ -40,7 +41,7 @@ func newsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	data.Rows = rows
 
 	CustomNewsIndex(data.CoreData, r)
-	if err := templates.RenderTemplate(w, "userPermissionsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "userPermissionsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -79,7 +80,7 @@ func newsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.
 
 	CustomNewsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -104,7 +105,7 @@ func newsUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
 	}
 	CustomNewsIndex(data.CoreData, r)
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/registerPage.go
+++ b/registerPage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func registerPage(w http.ResponseWriter, r *http.Request) {
@@ -21,7 +22,7 @@ func registerPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 
-	if err := templates.RenderTemplate(w, "registerPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "registerPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/routes.go
+++ b/routes.go
@@ -1,9 +1,10 @@
 package goa4web
 
 import (
+	"net/http"
+
 	. "github.com/arran4/gorillamuxlogic"
 	"github.com/gorilla/mux"
-	"net/http"
 
 	"github.com/arran4/goa4web/runtimeconfig"
 )

--- a/run.go
+++ b/run.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -35,8 +36,6 @@ var (
 	sessionName = "my-session"
 	store       *sessions.CookieStore
 	srv         *Server
-
-	version = "dev"
 )
 
 func init() {
@@ -85,7 +84,7 @@ func RunWithConfig(ctx context.Context, cfg runtimeconfig.RuntimeConfig, session
 		SecurityHeadersMiddleware,
 	).Wrap(r)
 	if csrfEnabled() {
-		handler = newCSRFMiddleware(sessionSecret, cfg.HTTPHostname, version).Wrap(handler)
+		handler = newCSRFMiddleware(sessionSecret, cfg.HTTPHostname, common.Version).Wrap(handler)
 	}
 
 	srv = newServer(handler, store, dbPool, cfg)
@@ -115,7 +114,7 @@ func runTemplate(template string) func(http.ResponseWriter, *http.Request) {
 
 		log.Printf("rendering template %s", template)
 
-		if err := templates.RenderTemplate(w, template, data, NewFuncs(r)); err != nil {
+		if err := templates.RenderTemplate(w, template, data, common.NewFuncs(r)); err != nil {
 			log.Printf("Template Error: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return

--- a/searchPage.go
+++ b/searchPage.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func searchPage(w http.ResponseWriter, r *http.Request) {
@@ -17,7 +18,7 @@ func searchPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 
-	if err := templates.RenderTemplate(w, "searchPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "searchPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/searchResultBlogsActionPage.go
+++ b/searchResultBlogsActionPage.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func searchResultBlogsActionPage(w http.ResponseWriter, r *http.Request) {
@@ -53,7 +54,7 @@ func searchResultBlogsActionPage(w http.ResponseWriter, r *http.Request) {
 		data.EmptyWords = noResults
 	}
 
-	if err := templates.RenderTemplate(w, "resultBlogsActionPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "resultBlogsActionPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/searchResultForumActionPage.go
+++ b/searchResultForumActionPage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func searchResultForumActionPage(w http.ResponseWriter, r *http.Request) {
@@ -36,7 +37,7 @@ func searchResultForumActionPage(w http.ResponseWriter, r *http.Request) {
 		data.CommentsEmptyWords = noResults
 	}
 
-	if err := templates.RenderTemplate(w, "resultForumActionPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "resultForumActionPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/searchResultLinkerActionPage.go
+++ b/searchResultLinkerActionPage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func searchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
@@ -55,7 +56,7 @@ func searchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
 		data.EmptyWords = noResults
 	}
 
-	if err := templates.RenderTemplate(w, "resultLinkerActionPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "resultLinkerActionPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/searchResultNewsActionPage.go
+++ b/searchResultNewsActionPage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func searchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +55,7 @@ func searchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 		data.EmptyWords = noResults
 	}
 
-	if err := templates.RenderTemplate(w, "resultNewsActionPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "resultNewsActionPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/searchResultWritingsActionPage.go
+++ b/searchResultWritingsActionPage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func searchResultWritingsActionPage(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +55,7 @@ func searchResultWritingsActionPage(w http.ResponseWriter, r *http.Request) {
 		data.EmptyWords = noResults
 	}
 
-	if err := templates.RenderTemplate(w, "resultWritingsActionPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "resultWritingsActionPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/server.go
+++ b/server.go
@@ -5,11 +5,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/gorilla/sessions"
 	"log"
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/gorilla/sessions"
 
 	"github.com/arran4/goa4web/runtimeconfig"
 )

--- a/templatePage.go
+++ b/templatePage.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func templatePage(w http.ResponseWriter, r *http.Request) {
@@ -16,7 +17,7 @@ func templatePage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
 	}
 
-	if err := templates.RenderTemplate(w, "templatePage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "templatePage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template page: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/userEmailPage.go
+++ b/userEmailPage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 
 	"github.com/arran4/goa4web/runtimeconfig"
 )
@@ -36,7 +37,7 @@ func userEmailPage(w http.ResponseWriter, r *http.Request) {
 		data.UserPreferences.EmailUpdates = pref.Emailforumupdates.Bool
 	}
 
-	if err := templates.RenderTemplate(w, "emailPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "emailPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("user email page: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/userLangPage.go
+++ b/userLangPage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 
 	"github.com/arran4/goa4web/runtimeconfig"
 )
@@ -61,7 +62,7 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 		LanguageOptions: opts,
 	}
 
-	if err := templates.RenderTemplate(w, "langPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "langPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/userLogoutPage.go
+++ b/userLogoutPage.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func userLogoutPage(w http.ResponseWriter, r *http.Request) {
@@ -41,7 +42,7 @@ func userLogoutPage(w http.ResponseWriter, r *http.Request) {
 	data.CoreData.UserID = 0
 	data.CoreData.SecurityLevel = ""
 
-	if err := templates.RenderTemplate(w, "logoutPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "logoutPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/userNotificationsPage.go
+++ b/userNotificationsPage.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
@@ -33,7 +34,7 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:      r.Context().Value(ContextValues("coreData")).(*CoreData),
 		Notifications: notifs,
 	}
-	if err := templates.RenderTemplate(w, "notifications.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "notifications.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/userPage.go
+++ b/userPage.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func userPage(w http.ResponseWriter, r *http.Request) {
@@ -27,7 +28,7 @@ func userPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := templates.RenderTemplate(w, "page.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "page.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/userPageSizePage.go
+++ b/userPageSizePage.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -31,7 +32,7 @@ func userPageSizePage(w http.ResponseWriter, r *http.Request) {
 		Max:      runtimeconfig.AppRuntimeConfig.PageSizeMax,
 		Default:  runtimeconfig.AppRuntimeConfig.PageSizeDefault,
 	}
-	if err := templates.RenderTemplate(w, "pageSizePage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "pageSizePage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/userPagingPage.go
+++ b/userPagingPage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 
 	"github.com/arran4/goa4web/runtimeconfig"
 )
@@ -30,7 +31,7 @@ func userPagingPage(w http.ResponseWriter, r *http.Request) {
 		Min:      runtimeconfig.AppRuntimeConfig.PageSizeMin,
 		Max:      runtimeconfig.AppRuntimeConfig.PageSizeMax,
 	}
-	if err := templates.RenderTemplate(w, "pagingPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "pagingPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("template error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/writingsAdminCategoriesPage.go
+++ b/writingsAdminCategoriesPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func writingsAdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
@@ -36,7 +37,7 @@ func writingsAdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomWritingsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/writingsAdminUserAccessPage.go
+++ b/writingsAdminUserAccessPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func writingsAdminUserAccessPage(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +38,7 @@ func writingsAdminUserAccessPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomWritingsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminUserAccessPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminUserAccessPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/writingsAdminUserLevelsPage.go
+++ b/writingsAdminUserLevelsPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func writingsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +36,7 @@ func writingsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomWritingsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "adminUserLevelsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "adminUserLevelsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/writingsArticleAddPage.go
+++ b/writingsArticleAddPage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -32,7 +33,7 @@ func writingsArticleAddPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomWritingsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "articleAddPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "articleAddPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/writingsArticleEditPage.go
+++ b/writingsArticleEditPage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -59,7 +60,7 @@ func writingsArticleEditPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomWritingsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "articleEditPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "articleEditPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/writingsArticlePage.go
+++ b/writingsArticlePage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 	"golang.org/x/exp/slices"
 )
@@ -176,7 +177,7 @@ func writingsArticlePage(w http.ResponseWriter, r *http.Request) {
 
 	CustomWritingsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "articlePage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "articlePage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/writingsCategoriesPage.go
+++ b/writingsCategoriesPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func writingsCategoriesPage(w http.ResponseWriter, r *http.Request) {
@@ -72,7 +73,7 @@ func writingsCategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomWritingsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/writingsCategoryPage.go
+++ b/writingsCategoryPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 	"golang.org/x/exp/slices"
 )
@@ -89,7 +90,7 @@ func writingsCategoryPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomWritingsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "categoryPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "categoryPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/writingsCategoryPermissionsPage.go
+++ b/writingsCategoryPermissionsPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -29,7 +30,7 @@ func writingsCategoryPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data := Data{CoreData: cd, CategoryID: int32(cid), UserLevels: rows}
 	CustomWritingsIndex(cd, r)
-	if err := templates.RenderTemplate(w, "categoryPermissionsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "categoryPermissionsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/writingsFeed.go
+++ b/writingsFeed.go
@@ -4,11 +4,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/a4code2html"
-	"github.com/gorilla/feeds"
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/arran4/goa4web/a4code2html"
+	"github.com/gorilla/feeds"
 )
 
 func writingsFeedGen(r *http.Request, queries *Queries) (*feeds.Feed, error) {

--- a/writingsPage.go
+++ b/writingsPage.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 var writingsPermissionsPageEnabled = true
@@ -50,7 +51,7 @@ func writingsPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomWritingsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "page.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "page.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/writingsUserPermissionsPage.go
+++ b/writingsUserPermissionsPage.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func writingsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +36,7 @@ func writingsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	data.Rows = rows
 
 	CustomWritingsIndex(data.CoreData, r)
-	if err := templates.RenderTemplate(w, "usersPermissionsPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "usersPermissionsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -74,7 +75,7 @@ func writingsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *h
 
 	CustomWritingsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -99,7 +100,7 @@ func writingsUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request
 		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
 	}
 	CustomWritingsIndex(data.CoreData, r)
-	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/writingsWriterPage.go
+++ b/writingsWriterPage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -56,7 +57,7 @@ func writingsWriterPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomWritingsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "writerPage.gohtml", data, NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "writerPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Summary
- add `handlers/common` package with shared types and utilities
- move template helper funcs and page-size logic into `handlers/common`
- use `common.NewFuncs` and `common.GetPageSize` throughout handlers
- expose `common.Version` for build metadata
- move `funcs_test.go` into the new package

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b46cab5e0832fad6ac9400e611c2e