### PR TITLE
refactor context keys

### DIFF
--- a/adminAnnouncementsPage.go
+++ b/adminAnnouncementsPage.go
@@ -16,8 +16,8 @@ func adminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Announcements []*ListAnnouncementsWithNewsRow
 	}
-	data := Data{CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData)}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	rows, err := queries.ListAnnouncementsWithNews(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list announcements: %v", err)
@@ -33,7 +33,7 @@ func adminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminAnnouncementsAddActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	nid, err := strconv.Atoi(r.PostFormValue("news_id"))
 	if err != nil {
 		log.Printf("news id: %v", err)
@@ -47,7 +47,7 @@ func adminAnnouncementsAddActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminAnnouncementsDeleteActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm: %v", err)
 	}

--- a/adminAuditLogPage.go
+++ b/adminAuditLogPage.go
@@ -33,14 +33,14 @@ func adminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		User:     r.URL.Query().Get("user"),
 		Action:   r.URL.Query().Get("action"),
 		PageSize: common.GetPageSize(r),
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	usernameFilter := "%"
 	if strings.TrimSpace(data.User) != "" {

--- a/adminCategoriesPage.go
+++ b/adminCategoriesPage.go
@@ -20,10 +20,10 @@ func adminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Section:  r.URL.Query().Get("section"),
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if data.Section == "" || data.Section == "forum" {
 		rows, err := queries.GetAllForumCategoriesWithSubcategoryCount(r.Context())

--- a/adminEmailQueuePage.go
+++ b/adminEmailQueuePage.go
@@ -15,9 +15,9 @@ func adminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 		Emails []*PendingEmail
 	}
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	items, err := queries.ListUnsentPendingEmails(r.Context())
 	if err != nil {
 		log.Printf("list pending emails: %v", err)
@@ -33,7 +33,7 @@ func adminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminEmailQueueResendActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	provider := getEmailProvider()
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm: %v", err)
@@ -59,7 +59,7 @@ func adminEmailQueueResendActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminEmailQueueDeleteActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm: %v", err)
 	}

--- a/adminEmailTemplatePage.go
+++ b/adminEmailTemplatePage.go
@@ -37,7 +37,7 @@ func adminEmailTemplatePage(w http.ResponseWriter, r *http.Request) {
 		Preview string
 		Error   string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Body:     b,
 		Preview:  preview,
 		Error:    r.URL.Query().Get("error"),
@@ -56,7 +56,7 @@ func adminEmailTemplateSaveActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	body := r.PostFormValue("body")
-	q := r.Context().Value(ContextValues("queries")).(*Queries)
+	q := r.Context().Value(common.KeyQueries).(*Queries)
 	if err := q.SetTemplateOverride(r.Context(), "updateEmail", body); err != nil {
 		log.Printf("db save template: %v", err)
 	}
@@ -71,8 +71,8 @@ func adminEmailTemplateTestActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
 	user, err := queries.GetUserById(r.Context(), cd.UserID)
 	if err != nil {
 		log.Printf("get user: %v", err)

--- a/adminForumFlaggedPostsPage.go
+++ b/adminForumFlaggedPostsPage.go
@@ -13,7 +13,7 @@ func adminForumFlaggedPostsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*CoreData
 	}
-	data := Data{CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData)}
+	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
 	if err := templates.RenderTemplate(w, "forumFlaggedPostsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/adminForumHandler.go
+++ b/adminForumHandler.go
@@ -18,7 +18,7 @@ func adminForumPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 	err := templates.RenderTemplate(w, "page.gohtml", data, common.NewFuncs(r))
 	if err != nil {
@@ -29,14 +29,14 @@ func adminForumPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminForumRemakeForumThreadPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := struct {
 		*CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/forum",
 	}
 
@@ -59,14 +59,14 @@ func adminForumRemakeForumThreadPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminForumRemakeForumTopicPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := struct {
 		*CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/forum",
 	}
 

--- a/adminForumModeratorLogsPage.go
+++ b/adminForumModeratorLogsPage.go
@@ -13,7 +13,7 @@ func adminForumModeratorLogsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*CoreData
 	}
-	data := Data{CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData)}
+	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
 	if err := templates.RenderTemplate(w, "forumModeratorLogsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/adminForumWordListHandler.go
+++ b/adminForumWordListHandler.go
@@ -19,10 +19,10 @@ func adminForumWordListPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	rows, err := queries.CompleteWordList(r.Context())
 	if err != nil {

--- a/adminHandler.go
+++ b/adminHandler.go
@@ -28,9 +28,9 @@ func adminPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	ctx := r.Context()
 	count := func(query string, dest *int64) {
 		if err := queries.DB().QueryRowContext(ctx, query).Scan(dest); err != nil && err != sql.ErrNoRows {

--- a/adminIPBanPage.go
+++ b/adminIPBanPage.go
@@ -17,8 +17,8 @@ func adminIPBanPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Bans []*BannedIp
 	}
-	data := Data{CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData)}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	rows, err := queries.ListBannedIps(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list banned ips: %v", err)
@@ -34,7 +34,7 @@ func adminIPBanPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminIPBanAddActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	ipNet := strings.TrimSpace(r.PostFormValue("ip"))
 	ipNet = normalizeIPNet(ipNet)
 	reason := strings.TrimSpace(r.PostFormValue("reason"))
@@ -56,7 +56,7 @@ func adminIPBanAddActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminIPBanDeleteActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm: %v", err)
 	}

--- a/adminLanguagesHandler.go
+++ b/adminLanguagesHandler.go
@@ -24,10 +24,10 @@ func adminLanguagesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	rows, err := queries.FetchLanguages(r.Context())
 	if err != nil {
@@ -45,7 +45,7 @@ func adminLanguagesPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	cid := r.PostFormValue("cid")
 	cname := r.PostFormValue("cname")
 	data := struct {
@@ -54,7 +54,7 @@ func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/languages",
 	}
 	if cidi, err := strconv.Atoi(cid); err != nil {
@@ -73,7 +73,7 @@ func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	cid := r.PostFormValue("cid")
 	data := struct {
 		*CoreData
@@ -81,7 +81,7 @@ func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/languages",
 	}
 	if cidi, err := strconv.Atoi(cid); err != nil {
@@ -97,7 +97,7 @@ func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 func adminLanguagesCreatePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	cname := r.PostFormValue("cname")
 	data := struct {
 		*CoreData
@@ -105,7 +105,7 @@ func adminLanguagesCreatePage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/languages",
 	}
 	if err := queries.CreateLanguage(r.Context(), sql.NullString{

--- a/adminLoginAttemptsPage.go
+++ b/adminLoginAttemptsPage.go
@@ -13,8 +13,8 @@ func adminLoginAttemptsPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Attempts []*LoginAttempt
 	}
-	data := Data{CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData)}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	items, err := queries.ListLoginAttempts(r.Context())
 	if err != nil {
 		log.Printf("list login attempts: %v", err)

--- a/adminNotificationsPage.go
+++ b/adminNotificationsPage.go
@@ -19,9 +19,9 @@ func adminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		Unread        int
 	}
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	items, err := queries.RecentNotifications(r.Context(), 50)
 	if err != nil {
 		log.Printf("recent notifications: %v", err)
@@ -45,7 +45,7 @@ func adminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminNotificationsMarkReadActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm: %v", err)
 	}
@@ -59,7 +59,7 @@ func adminNotificationsMarkReadActionPage(w http.ResponseWriter, r *http.Request
 }
 
 func adminNotificationsPurgeActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	if err := queries.PurgeReadNotifications(r.Context()); err != nil {
 		log.Printf("purge notifications: %v", err)
 	}
@@ -67,7 +67,7 @@ func adminNotificationsPurgeActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminNotificationsSendActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	message := r.PostFormValue("message")
 	link := r.PostFormValue("link")
 	role := r.PostFormValue("role")

--- a/adminPermissionsSectionPage.go
+++ b/adminPermissionsSectionPage.go
@@ -20,10 +20,10 @@ func adminPermissionsSectionPage(w http.ResponseWriter, r *http.Request) {
 		Sections []*CountPermissionSectionsRow
 	}
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	rows, err := queries.CountPermissionSections(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("CountPermissionSections error: %s", err)
@@ -42,7 +42,7 @@ func adminPermissionsSectionPage(w http.ResponseWriter, r *http.Request) {
 // adminPermissionsSectionRenamePage converts one permission section value to
 // another. This can be used to normalise "writing" vs "writings" values.
 func adminPermissionsSectionRenamePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	from := r.PostFormValue("from")
 	to := r.PostFormValue("to")
 	data := struct {
@@ -51,7 +51,7 @@ func adminPermissionsSectionRenamePage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/permissions/sections",
 	}
 

--- a/adminPermissionsSectionViewPage.go
+++ b/adminPermissionsSectionViewPage.go
@@ -16,9 +16,9 @@ func adminPermissionsSectionViewPage(w http.ResponseWriter, r *http.Request) {
 		Section string
 		Rows    []*PermissionWithUser
 	}
-	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
 	section := r.URL.Query().Get("section")
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	rows, err := queries.GetPermissionsBySectionWithUsers(r.Context(), section)
 	if err != nil && err != sql.ErrNoRows {
 		log.Printf("GetPermissionsBySectionWithUsers error: %v", err)

--- a/adminReloadConfigPage.go
+++ b/adminReloadConfigPage.go
@@ -16,7 +16,7 @@ func adminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin",
 	}
 

--- a/adminSearchHandler.go
+++ b/adminSearchHandler.go
@@ -29,10 +29,10 @@ func adminSearchPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	ctx := r.Context()
 	count := func(query string, dest *int64) {
 		if err := queries.DB().QueryRowContext(ctx, query).Scan(dest); err != nil && err != sql.ErrNoRows {
@@ -57,14 +57,14 @@ func adminSearchPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminSearchRemakeCommentsSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := struct {
 		*CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteCommentsSearch(r.Context()); err != nil {
@@ -81,14 +81,14 @@ func adminSearchRemakeCommentsSearchPage(w http.ResponseWriter, r *http.Request)
 	}
 }
 func adminSearchRemakeNewsSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := struct {
 		*CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteSiteNewsSearch(r.Context()); err != nil {
@@ -105,14 +105,14 @@ func adminSearchRemakeNewsSearchPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 func adminSearchRemakeBlogSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := struct {
 		*CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteBlogsSearch(r.Context()); err != nil {
@@ -129,14 +129,14 @@ func adminSearchRemakeBlogSearchPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 func adminSearchRemakeLinkerSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := struct {
 		*CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteLinkerSearch(r.Context()); err != nil {
@@ -153,14 +153,14 @@ func adminSearchRemakeLinkerSearchPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 func adminSearchRemakeWritingSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := struct {
 		*CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteWritingSearch(r.Context()); err != nil {
@@ -178,14 +178,14 @@ func adminSearchRemakeWritingSearchPage(w http.ResponseWriter, r *http.Request) 
 }
 
 func adminSearchRemakeImageSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := struct {
 		*CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteImagePostSearch(r.Context()); err != nil {

--- a/adminSearchWordListHandler.go
+++ b/adminSearchWordListHandler.go
@@ -37,7 +37,7 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	letters := make([]string, len(Alphabet))
@@ -60,7 +60,7 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 
 	offset := (page - 1) * pageSize
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if r.URL.Query().Get("download") != "" {
 		rows, err := queries.CompleteWordList(r.Context())
@@ -151,7 +151,7 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 
 // adminSearchWordListDownloadPage sends the full word list as a text file.
 func adminSearchWordListDownloadPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	rows, err := queries.CompleteWordList(r.Context())
 	if err != nil {

--- a/adminServerStatsPage.go
+++ b/adminServerStatsPage.go
@@ -29,7 +29,7 @@ func adminServerStatsPage(w http.ResponseWriter, r *http.Request) {
 	runtime.ReadMemStats(&mem)
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Stats: Stats{
 			Goroutines: runtime.NumGoroutine(),
 			Alloc:      mem.Alloc,

--- a/adminSessionsPage.go
+++ b/adminSessionsPage.go
@@ -13,8 +13,8 @@ func adminSessionsPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Sessions []*ListSessionsRow
 	}
-	data := Data{CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData)}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	items, err := queries.ListSessions(r.Context())
 	if err != nil {
 		log.Printf("list sessions: %v", err)
@@ -37,13 +37,13 @@ func adminSessionsDeletePage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/sessions",
 	}
 	if sid == "" {
 		data.Errors = append(data.Errors, "missing sid")
 	} else {
-		if err := r.Context().Value(ContextValues("queries")).(*Queries).DeleteSessionByID(r.Context(), sid); err != nil {
+		if err := r.Context().Value(common.KeyQueries).(*Queries).DeleteSessionByID(r.Context(), sid); err != nil {
 			data.Errors = append(data.Errors, err.Error())
 		}
 	}

--- a/adminShutdownPage.go
+++ b/adminShutdownPage.go
@@ -17,7 +17,7 @@ func adminShutdownPage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin",
 	}
 

--- a/adminSiteSettingsPage.go
+++ b/adminSiteSettingsPage.go
@@ -12,7 +12,7 @@ import (
 )
 
 func adminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if r.Method == http.MethodPost {
 		if err := r.ParseForm(); err != nil {
@@ -44,7 +44,7 @@ func adminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		SelectedLanguageId: resolveDefaultLanguageID(r.Context(), queries),
 	}
 	data.CoreData.FeedsEnabled = runtimeconfig.AppRuntimeConfig.FeedsEnabled

--- a/adminUsageStatsPage.go
+++ b/adminUsageStatsPage.go
@@ -22,8 +22,8 @@ func adminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 		UserMonthly       []*UserMonthlyUsageRow
 		StartYear         int
 	}
-	data := Data{CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData)}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	var err error
 	if data.ForumTopics, err = queries.ForumTopicThreadCounts(r.Context()); err != nil {

--- a/adminUsersExportPage.go
+++ b/adminUsersExportPage.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"fmt"
+	"github.com/arran4/goa4web/handlers/common"
 	"net/http"
 	"strconv"
 )
@@ -15,7 +16,7 @@ const gdprExportNote = "# Personal data export - handle according to GDPR"
 // adminUsersExportPage streams all data for a single user in a zip archive for
 // admins. The user ID is provided via the "uid" query parameter.
 func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	uid, err := strconv.Atoi(r.URL.Query().Get("uid"))
 	if err != nil {

--- a/adminUsersHandler.go
+++ b/adminUsersHandler.go
@@ -34,7 +34,7 @@ func adminUsersPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Search:   r.URL.Query().Get("search"),
 		Role:     r.URL.Query().Get("role"),
 		Status:   r.URL.Query().Get("status"),
@@ -42,7 +42,7 @@ func adminUsersPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	pageSize := data.PageSize
 	var rows []*User
@@ -119,12 +119,12 @@ func adminUserDisablePage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/users",
 	}
 	if uidi, err := strconv.Atoi(uid); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("strconv.Atoi: %w", err).Error())
-	} else if _, err := r.Context().Value(ContextValues("queries")).(*Queries).DB().ExecContext(r.Context(), "DELETE FROM users WHERE idusers = ?", uidi); err != nil {
+	} else if _, err := r.Context().Value(common.KeyQueries).(*Queries).DB().ExecContext(r.Context(), "DELETE FROM users WHERE idusers = ?", uidi); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("delete user: %w", err).Error())
 	}
 	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r))
@@ -136,7 +136,7 @@ func adminUserDisablePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminUserEditFormPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	uid, _ := strconv.Atoi(r.URL.Query().Get("uid"))
 	user, err := queries.GetUserById(r.Context(), int32(uid))
 	if err != nil {
@@ -147,7 +147,7 @@ func adminUserEditFormPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		User *User
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		User:     user,
 	}
 	if err := templates.RenderTemplate(w, "userEditPage.gohtml", data, common.NewFuncs(r)); err != nil {
@@ -158,7 +158,7 @@ func adminUserEditFormPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminUserEditSavePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	uid := r.PostFormValue("uid")
 	username := r.PostFormValue("username")
 	email := r.PostFormValue("email")
@@ -168,7 +168,7 @@ func adminUserEditSavePage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/users",
 	}
 	if uidi, err := strconv.Atoi(uid); err != nil {
@@ -184,7 +184,7 @@ func adminUserEditSavePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminUserResetPasswordPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	uid := r.PostFormValue("uid")
 	data := struct {
 		*CoreData
@@ -193,7 +193,7 @@ func adminUserResetPasswordPage(w http.ResponseWriter, r *http.Request) {
 		Back     string
 		Password string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/users",
 	}
 	var buf [8]byte

--- a/adminUsersPermissionsHandler.go
+++ b/adminUsersPermissionsHandler.go
@@ -24,10 +24,10 @@ func adminUsersPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	rows, err := queries.GetPermissionsWithUsers(r.Context())
 	if err != nil {
@@ -63,7 +63,7 @@ func adminUsersPermissionsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	username := r.PostFormValue("username")
 	where := r.PostFormValue("where")
 	level := r.PostFormValue("level")
@@ -73,7 +73,7 @@ func adminUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/users/permissions",
 	}
 	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
@@ -102,7 +102,7 @@ func adminUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http
 }
 
 func adminUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	permid := r.PostFormValue("permid")
 	data := struct {
 		*CoreData
@@ -110,7 +110,7 @@ func adminUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/users/permissions",
 	}
 	if permidi, err := strconv.Atoi(permid); err != nil {
@@ -129,7 +129,7 @@ func adminUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminUsersPermissionsUpdatePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	permid := r.PostFormValue("permid")
 	level := r.PostFormValue("level")
 	where := r.PostFormValue("where")
@@ -140,7 +140,7 @@ func adminUsersPermissionsUpdatePage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/admin/users/permissions",
 	}
 

--- a/admin_test.go
+++ b/admin_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -20,7 +21,7 @@ func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 	runtimeconfig.AppRuntimeConfig.EmailProvider = ""
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{UserID: 1})
+	ctx := context.WithValue(req.Context(), common.KeyCoreData, &CoreData{UserID: 1})
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()
@@ -52,8 +53,8 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 		WithArgs(int32(1)).WillReturnRows(rows)
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{UserID: 1})
-	ctx = context.WithValue(ctx, ContextValues("queries"), q)
+	ctx := context.WithValue(req.Context(), common.KeyCoreData, &CoreData{UserID: 1})
+	ctx = context.WithValue(ctx, common.KeyQueries, q)
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()

--- a/audit_log.go
+++ b/audit_log.go
@@ -1,14 +1,15 @@
 package goa4web
 
 import (
+	"github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
 )
 
 // logAudit records an administrative action in the audit_log table.
 func logAudit(r *http.Request, action string) {
-	queries, qok := r.Context().Value(ContextValues("queries")).(*Queries)
-	cd, cok := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	queries, qok := r.Context().Value(common.KeyQueries).(*Queries)
+	cd, cok := r.Context().Value(common.KeyCoreData).(*CoreData)
 	if !qok || !cok || cd == nil {
 		return
 	}

--- a/blogsBlogAddPage.go
+++ b/blogsBlogAddPage.go
@@ -13,7 +13,7 @@ import (
 )
 
 func blogsBlogAddPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
 	if !(cd.HasRole("writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
@@ -25,7 +25,7 @@ func blogsBlogAddPage(w http.ResponseWriter, r *http.Request) {
 		Mode               string
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
 		CoreData:           cd,
 		SelectedLanguageId: int(resolveDefaultLanguageID(r.Context(), queries)),
@@ -55,7 +55,7 @@ func blogsBlogAddActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/blogsBlogEditPage.go
+++ b/blogsBlogEditPage.go
@@ -13,7 +13,7 @@ import (
 )
 
 func blogsBlogEditPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
 	if !(cd.HasRole("writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
@@ -26,7 +26,7 @@ func blogsBlogEditPage(w http.ResponseWriter, r *http.Request) {
 		Mode               string
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
 		CoreData:           cd,
 		SelectedLanguageId: int(resolveDefaultLanguageID(r.Context(), queries)),
@@ -66,7 +66,7 @@ func blogsBlogEditActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	blogId, _ := strconv.Atoi(vars["blog"])
 

--- a/blogsBlogPage.go
+++ b/blogsBlogPage.go
@@ -42,9 +42,9 @@ func blogsBlogPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	blogId, _ := strconv.Atoi(vars["blog"])
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
-		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		Offset:             offset,
 		IsReplyable:        true,
 		SelectedLanguageId: int(resolveDefaultLanguageID(r.Context(), queries)),

--- a/blogsBlogReplyPage.go
+++ b/blogsBlogReplyPage.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -30,7 +31,7 @@ func blogsBlogReplyPostPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	blog, err := queries.GetBlogEntryForUserById(r.Context(), int32(bid))
 	if err != nil {

--- a/blogsBloggerPage.go
+++ b/blogsBloggerPage.go
@@ -35,7 +35,7 @@ func blogsBloggerPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	bu, err := queries.GetUserByUsername(r.Context(), sql.NullString{
 		String: username,
@@ -71,7 +71,7 @@ func blogsBloggerPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		IsOffset: offset != 0,
 		UID:      strconv.Itoa(int(buid)),
 	}

--- a/blogsBloggersBloggerPage.go
+++ b/blogsBloggersBloggerPage.go
@@ -15,10 +15,10 @@ func blogsBloggersBloggerPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	//queries := r.Context().Name(ContextValues("queries")).(*Queries)
+	//queries := r.Context().Name(common.KeyQueries).(*Queries)
 	//
 	//rows, err := queries.GetCountOfBlogPostsByUser(r.Context())
 	//if err != nil {

--- a/blogsBloggersPage.go
+++ b/blogsBloggersPage.go
@@ -25,13 +25,13 @@ func blogsBloggersPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Search:   r.URL.Query().Get("search"),
 		PageSize: common.GetPageSize(r),
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	pageSize := common.GetPageSize(r)
 	var rows []*BloggerCountRow

--- a/blogsCommentEditPage.go
+++ b/blogsCommentEditPage.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -20,7 +21,7 @@ func blogsCommentEditPostPage(w http.ResponseWriter, r *http.Request) {
 	}
 	text := r.PostFormValue("replytext")
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	blogId, _ := strconv.Atoi(vars["blog"])
 	commentId, _ := strconv.Atoi(vars["comment"])

--- a/blogsCommentPage.go
+++ b/blogsCommentPage.go
@@ -46,9 +46,9 @@ func blogsCommentPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	blogId, _ := strconv.Atoi(vars["blog"])
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
-		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		Offset:             offset,
 		IsReplyable:        true,
 		SelectedLanguageId: int(resolveDefaultLanguageID(r.Context(), queries)),

--- a/blogsPage.go
+++ b/blogsPage.go
@@ -38,7 +38,7 @@ func blogsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	rows, err := queries.GetBlogEntriesForUserDescendingLanguages(r.Context(), GetBlogEntriesForUserDescendingLanguagesParams{
 		UsersIdusers:  int32(userId),
 		ViewerIdusers: uid,
@@ -56,7 +56,7 @@ func blogsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		IsOffset: offset != 0,
 		UID:      buid,
 	}
@@ -158,7 +158,7 @@ func CustomBlogIndex(data *CoreData, r *http.Request) {
 
 func blogsRssPage(w http.ResponseWriter, r *http.Request) {
 	username := r.URL.Query().Get("rss")
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{
 		String: username,
 		Valid:  true,
@@ -183,7 +183,7 @@ func blogsRssPage(w http.ResponseWriter, r *http.Request) {
 
 func blogsAtomPage(w http.ResponseWriter, r *http.Request) {
 	username := r.URL.Query().Get("rss")
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{
 		String: username,
 		Valid:  true,

--- a/blogsUserPermissionsPage.go
+++ b/blogsUserPermissionsPage.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
 	if !(cd.HasRole("writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
@@ -31,7 +31,7 @@ func getPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Re
 		Filter:   r.URL.Query().Get("level"),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	rows, err := queries.GetPermissionsByUserIdAndSectionBlogs(r.Context())
 	if err != nil {
@@ -65,7 +65,7 @@ func getPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Re
 }
 
 func blogsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	username := r.PostFormValue("username")
 	where := "blogs"
 	level := r.PostFormValue("level")
@@ -75,7 +75,7 @@ func blogsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/blogs/bloggers",
 	}
 	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
@@ -105,7 +105,7 @@ func blogsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http
 }
 
 func blogsUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	permid := r.PostFormValue("permid")
 	data := struct {
 		*CoreData
@@ -113,7 +113,7 @@ func blogsUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/blogs/bloggers",
 	}
 	if permidi, err := strconv.Atoi(permid); err != nil {
@@ -131,7 +131,7 @@ func blogsUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func blogsUsersPermissionsBulkAllowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	names := strings.FieldsFunc(r.PostFormValue("usernames"), func(r rune) bool { return r == ',' || r == '\n' || r == ' ' || r == '\t' })
 	level := r.PostFormValue("level")
 	data := struct {
@@ -140,7 +140,7 @@ func blogsUsersPermissionsBulkAllowPage(w http.ResponseWriter, r *http.Request) 
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/blogs/bloggers",
 	}
 
@@ -171,7 +171,7 @@ func blogsUsersPermissionsBulkAllowPage(w http.ResponseWriter, r *http.Request) 
 }
 
 func blogsUsersPermissionsBulkDisallowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	permids := r.PostForm["permid"]
 	data := struct {
 		*CoreData
@@ -179,7 +179,7 @@ func blogsUsersPermissionsBulkDisallowPage(w http.ResponseWriter, r *http.Reques
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/blogs/bloggers",
 	}
 

--- a/blogs_test.go
+++ b/blogs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gorilla/sessions"
 
 	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func TestBlogsBloggerPage(t *testing.T) {
@@ -43,9 +44,9 @@ func TestBlogsBloggerPage(t *testing.T) {
 		req.AddCookie(c)
 	}
 
-	ctx := context.WithValue(req.Context(), ContextValues("queries"), q)
-	ctx = context.WithValue(ctx, ContextValues("session"), sess)
-	ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{})
+	ctx := context.WithValue(req.Context(), common.KeyQueries, q)
+	ctx = context.WithValue(ctx, common.KeySession, sess)
+	ctx = context.WithValue(ctx, common.KeyCoreData, &CoreData{})
 	req = req.WithContext(ctx)
 
 	userRows := sqlmock.NewRows([]string{"idusers", "email", "passwd", "passwd_algorithm", "username"}).
@@ -93,7 +94,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 			AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), "bob", 0))
 
 	req := httptest.NewRequest("GET", "http://example.com/blogs/rss?rss=bob", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)
+	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 
@@ -117,7 +118,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 
 func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{SecurityLevel: "reader"})
+	ctx := context.WithValue(req.Context(), common.KeyCoreData, &CoreData{SecurityLevel: "reader"})
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	blogsBlogAddPage(rr, req)
@@ -128,7 +129,7 @@ func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
 
 func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/1/edit", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{SecurityLevel: "reader"})
+	ctx := context.WithValue(req.Context(), common.KeyCoreData, &CoreData{SecurityLevel: "reader"})
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	blogsBlogEditPage(rr, req)
@@ -139,7 +140,7 @@ func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 
 func TestGetPermissionsByUserIdAndSectionBlogsPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin/blogs/user/permissions", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{SecurityLevel: "reader"})
+	ctx := context.WithValue(req.Context(), common.KeyCoreData, &CoreData{SecurityLevel: "reader"})
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	getPermissionsByUserIdAndSectionBlogsPage(rr, req)

--- a/bookmarksEditPage.go
+++ b/bookmarksEditPage.go
@@ -19,10 +19,10 @@ func bookmarksEditPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData:        r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:        r.Context().Value(common.KeyCoreData).(*CoreData),
 		BookmarkContent: "Category: Example 1\nhttp://www.google.com.au Google\nColumn\nCategory: Example 2\nhttp://www.google.com.au Google\nhttp://www.google.com.au Google\n",
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -53,7 +53,7 @@ func bookmarksEditPage(w http.ResponseWriter, r *http.Request) {
 
 func bookmarksEditSaveActionPage(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -77,7 +77,7 @@ func bookmarksEditSaveActionPage(w http.ResponseWriter, r *http.Request) {
 
 func bookmarksEditCreateActionPage(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/bookmarksMinePage.go
+++ b/bookmarksMinePage.go
@@ -75,7 +75,7 @@ func bookmarksMinePage(w http.ResponseWriter, r *http.Request) {
 		Columns []*BookmarkColumn
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -94,7 +94,7 @@ func bookmarksMinePage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Columns:  preprocessBookmarks(bookmarks.List.String),
 	}
 	bookmarksCustomIndex(data.CoreData)

--- a/bookmarksPage.go
+++ b/bookmarksPage.go
@@ -21,7 +21,7 @@ func bookmarksPage(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	if uid == 0 {

--- a/core.go
+++ b/core.go
@@ -47,7 +47,7 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 		if err == nil {
 			uid, _ = session.Values["UID"].(int32)
 		}
-		queries := request.Context().Value(ContextValues("queries")).(*Queries)
+		queries := request.Context().Value(common.KeyQueries).(*Queries)
 
 		level := "reader"
 		if uid != 0 {
@@ -79,7 +79,7 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 				ann = a
 			}
 		}
-		ctx := context.WithValue(request.Context(), ContextValues("coreData"), &CoreData{
+		ctx := context.WithValue(request.Context(), common.KeyCoreData, &CoreData{
 			SecurityLevel:     level,
 			IndexItems:        idx,
 			UserID:            uid,
@@ -141,10 +141,6 @@ func X2c(what string) byte {
 	d2 := digit(what[1])
 	return d1*16 + d2
 }
-
-// ContextValues is an alias to core.ContextValues for backward compatibility.
-type ContextValues = core.ContextValues
-
 func DBAdderMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if dbPool == nil {
@@ -157,8 +153,8 @@ func DBAdderMiddleware(next http.Handler) http.Handler {
 			log.Printf("db pool stats: %+v", dbPool.Stats())
 		}
 		ctx := request.Context()
-		ctx = context.WithValue(ctx, ContextValues("sql.DB"), dbPool)
-		ctx = context.WithValue(ctx, ContextValues("queries"), New(dbPool))
+		ctx = context.WithValue(ctx, common.KeySQLDB, dbPool)
+		ctx = context.WithValue(ctx, common.KeyQueries, New(dbPool))
 		next.ServeHTTP(writer, request.WithContext(ctx))
 	})
 }

--- a/email.go
+++ b/email.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ses"
 
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
@@ -59,7 +60,7 @@ func notifyChange(ctx context.Context, provider email.Provider, emailAddr string
 		return fmt.Errorf("execute email template: %w", err)
 	}
 
-	if q, ok := ctx.Value(ContextValues("queries")).(*Queries); ok {
+	if q, ok := ctx.Value(common.KeyQueries).(*Queries); ok {
 		if err := q.InsertPendingEmail(ctx, InsertPendingEmailParams{ToEmail: emailAddr, Subject: content.Subject, Body: notification.String()}); err != nil {
 			return err
 		}

--- a/email_test.go
+++ b/email_test.go
@@ -9,6 +9,7 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
@@ -73,7 +74,7 @@ func TestNotifyChange(t *testing.T) {
 	defer db.Close()
 	q := New(db)
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs("a@b.com", sqlmock.AnyArg(), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-	ctx := context.WithValue(context.Background(), ContextValues("queries"), q)
+	ctx := context.WithValue(context.Background(), common.KeyQueries, q)
 	rec := &recordMail{}
 	if err := notifyChange(ctx, rec, "a@b.com", "http://host"); err != nil {
 		t.Fatalf("notify error: %v", err)

--- a/faqAdminAnswerPage.go
+++ b/faqAdminAnswerPage.go
@@ -19,10 +19,10 @@ func faqAdminAnswerPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	catrows, err := queries.GetAllFAQCategories(r.Context())
 	if err != nil {
@@ -70,7 +70,7 @@ func faqAnswerAnswerActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := queries.UpdateFAQQuestionAnswer(r.Context(), UpdateFAQQuestionAnswerParams{
 		Answer:                       sql.NullString{Valid: true, String: answer},
@@ -93,7 +93,7 @@ func faqAnswerRemoveActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := queries.DeleteFAQ(r.Context(), int32(faq)); err != nil {
 		log.Printf("Error: %s", err)

--- a/faqAdminCategoriesPage.go
+++ b/faqAdminCategoriesPage.go
@@ -18,10 +18,10 @@ func faqAdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	rows, err := queries.GetFAQCategoriesWithQuestionCount(r.Context())
 	if err != nil {
@@ -51,7 +51,7 @@ func faqCategoriesRenameActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := queries.RenameFAQCategory(r.Context(), RenameFAQCategoryParams{
 		Name: sql.NullString{
@@ -75,7 +75,7 @@ func faqCategoriesDeleteActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := queries.DeleteFAQCategory(r.Context(), int32(cid)); err != nil {
 		log.Printf("Error: %s", err)
@@ -88,7 +88,7 @@ func faqCategoriesDeleteActionPage(w http.ResponseWriter, r *http.Request) {
 
 func faqCategoriesCreateActionPage(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("cname")
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := queries.CreateFAQCategory(r.Context(), sql.NullString{
 		String: text,

--- a/faqAdminQuestionPage.go
+++ b/faqAdminQuestionPage.go
@@ -20,10 +20,10 @@ func faqAdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	catrows, err := queries.GetAllFAQCategories(r.Context())
 	if err != nil {
@@ -63,7 +63,7 @@ func faqQuestionsDeleteActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := queries.DeleteFAQ(r.Context(), int32(faq)); err != nil {
 		log.Printf("Error: %s", err)
@@ -89,7 +89,7 @@ func faqQuestionsEditActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := queries.UpdateFAQQuestionAnswer(r.Context(), UpdateFAQQuestionAnswerParams{
 		Answer:                       sql.NullString{Valid: true, String: answer},
@@ -114,7 +114,7 @@ func faqQuestionsCreateActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/faqAskPage.go
+++ b/faqAskPage.go
@@ -18,9 +18,9 @@ func faqAskPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int32
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
-		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		SelectedLanguageId: resolveDefaultLanguageID(r.Context(), queries),
 	}
 
@@ -47,7 +47,7 @@ func faqAskActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/faqPage.go
+++ b/faqPage.go
@@ -28,10 +28,10 @@ func faqPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	var currentCategoryFAQs CategoryFAQs
 

--- a/forumAdminCategoriesPage.go
+++ b/forumAdminCategoriesPage.go
@@ -17,10 +17,10 @@ func forumAdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Categories []*GetAllForumCategoriesWithSubcategoryCountRow
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	categoryRows, err := queries.GetAllForumCategoriesWithSubcategoryCount(r.Context())
@@ -53,7 +53,7 @@ func forumAdminCategoryEditPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	categoryId, _ := strconv.Atoi(vars["category"])
 
@@ -85,7 +85,7 @@ func forumAdminCategoryCreatePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	if err := queries.CreateForumCategory(r.Context(), CreateForumCategoryParams{
 		ForumcategoryIdforumcategory: int32(pcid),
 		Title: sql.NullString{
@@ -105,7 +105,7 @@ func forumAdminCategoryCreatePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func forumAdminCategoryDeletePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	cid, err := strconv.Atoi(r.PostFormValue("cid"))
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/forumAdminPage.go
+++ b/forumAdminPage.go
@@ -22,10 +22,10 @@ func forumAdminPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	ctx := r.Context()
 	count := func(q string, dest *int64) {
 		if err := queries.DB().QueryRowContext(ctx, q).Scan(dest); err != nil && err != sql.ErrNoRows {

--- a/forumAdminRestrictionsPage.go
+++ b/forumAdminRestrictionsPage.go
@@ -22,10 +22,10 @@ func forumAdminUsersRestrictionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	rows, err := queries.GetAllForumTopicsWithPermissionsAndTopic(r.Context())
 	if err != nil {
@@ -104,7 +104,7 @@ func forumAdminUsersRestrictionsUpdatePage(w http.ResponseWriter, r *http.Reques
 		}
 		expires = sql.NullTime{Time: t, Valid: true}
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := queries.UpsertUsersForumTopicLevelPermission(r.Context(), UpsertUsersForumTopicLevelPermissionParams{
 		Level: sql.NullInt32{
@@ -140,7 +140,7 @@ func forumAdminUsersRestrictionsDeletePage(w http.ResponseWriter, r *http.Reques
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := queries.DeleteUsersForumTopicLevelPermission(r.Context(), DeleteUsersForumTopicLevelPermissionParams{
 		ForumtopicIdforumtopic: int32(tid),

--- a/forumAdminThreadsPage.go
+++ b/forumAdminThreadsPage.go
@@ -21,7 +21,7 @@ func forumAdminThreadsPage(w http.ResponseWriter, r *http.Request) {
 		Order  []int32
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	rows, err := queries.GetAllForumThreadsWithTopic(r.Context())
 	if err != nil {
@@ -31,7 +31,7 @@ func forumAdminThreadsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Groups:   make(map[int32]*Group),
 	}
 
@@ -65,7 +65,7 @@ func forumAdminThreadDeletePage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	if err := ThreadDelete(r.Context(), queries, int32(threadID), int32(topicID)); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return

--- a/forumAdminTopicRestrictions.go
+++ b/forumAdminTopicRestrictions.go
@@ -19,10 +19,10 @@ func forumAdminTopicRestrictionLevelPage(w http.ResponseWriter, r *http.Request)
 		Restrictions []*GetForumTopicRestrictionsByForumTopicIdRow
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	data := &Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 	vars := mux.Vars(r)
 	topicId, _ := strconv.Atoi(vars["topic"])
@@ -92,7 +92,7 @@ func forumAdminTopicRestrictionLevelChangePage(w http.ResponseWriter, r *http.Re
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	// TODO fix query / schema to overwrite existing value
 	if err := queries.UpsertForumTopicRestrictions(r.Context(), UpsertForumTopicRestrictionsParams{
@@ -119,7 +119,7 @@ func forumAdminTopicRestrictionLevelDeletePage(w http.ResponseWriter, r *http.Re
 	vars := mux.Vars(r)
 	topicId, _ := strconv.Atoi(vars["topic"])
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := queries.DeleteTopicRestrictionsByForumTopicId(r.Context(), int32(topicId)); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
@@ -143,7 +143,7 @@ func forumAdminTopicRestrictionLevelCopyPage(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	src, err := queries.GetForumTopicRestrictionsByForumTopicId(r.Context(), int32(fromID))
 	if err != nil {

--- a/forumAdminTopicsPage.go
+++ b/forumAdminTopicsPage.go
@@ -18,10 +18,10 @@ func forumAdminTopicsPage(w http.ResponseWriter, r *http.Request) {
 		Categories []*GetAllForumCategoriesWithSubcategoryCountRow
 		Topics     []*Forumtopic
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	categoryRows, err := queries.GetAllForumCategoriesWithSubcategoryCount(r.Context())
@@ -67,7 +67,7 @@ func forumAdminTopicEditPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	topicId, _ := strconv.Atoi(vars["topic"])
 
@@ -99,7 +99,7 @@ func forumTopicCreatePage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if _, err := queries.CreateForumTopic(r.Context(), CreateForumTopicParams{
 		Title: sql.NullString{
@@ -121,7 +121,7 @@ func forumTopicCreatePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func forumAdminTopicDeletePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	topicId, _ := strconv.Atoi(vars["topic"])
 	if err := queries.DeleteForumTopic(r.Context(), int32(topicId)); err != nil {

--- a/forumAdminTopicsRestrictions.go
+++ b/forumAdminTopicsRestrictions.go
@@ -18,10 +18,10 @@ func forumAdminTopicsRestrictionLevelPage(w http.ResponseWriter, r *http.Request
 		Restrictions []*GetAllForumTopicRestrictionsWithForumTopicTitleRow
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	data := &Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	restrictions, err := queries.GetAllForumTopicRestrictionsWithForumTopicTitle(r.Context())
@@ -92,7 +92,7 @@ func forumAdminTopicsRestrictionLevelChangePage(w http.ResponseWriter, r *http.R
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := queries.UpsertForumTopicRestrictions(r.Context(), UpsertForumTopicRestrictionsParams{
 		ForumtopicIdforumtopic: int32(ftid),
@@ -120,7 +120,7 @@ func forumAdminTopicsRestrictionLevelDeletePage(w http.ResponseWriter, r *http.R
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := queries.DeleteTopicRestrictionsByForumTopicId(r.Context(), int32(ftid)); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
@@ -144,7 +144,7 @@ func forumAdminTopicsRestrictionLevelCopyPage(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	src, err := queries.GetForumTopicRestrictionsByForumTopicId(r.Context(), int32(fromID))
 	if err != nil {

--- a/forumAdminUserLevelPage.go
+++ b/forumAdminUserLevelPage.go
@@ -21,10 +21,10 @@ func forumAdminUserLevelPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	uid, _ := strconv.Atoi(vars["user"])
 
@@ -76,7 +76,7 @@ func forumAdminUserLevelUpdatePage(w http.ResponseWriter, r *http.Request) {
 		}
 		expires = sql.NullTime{Time: t, Valid: true}
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	uid, _ := strconv.Atoi(vars["user"])
 
@@ -109,7 +109,7 @@ func forumAdminUserLevelDeletePage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	uid, _ := strconv.Atoi(vars["user"])
 

--- a/forumAdminUserPage.go
+++ b/forumAdminUserPage.go
@@ -31,13 +31,13 @@ func forumAdminUserPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Search:   r.URL.Query().Get("search"),
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	users, err := queries.AllUsers(r.Context())
 	if err != nil {

--- a/forumFeed.go
+++ b/forumFeed.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/arran4/goa4web/a4code2html"
 	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/feeds"
 	"github.com/gorilla/mux"
 	"log"
@@ -61,7 +62,7 @@ func forumTopicRssPage(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 	vars := mux.Vars(r)
 	topicID, _ := strconv.Atoi(vars["topic"])
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	topic, err := queries.GetForumTopicByIdForUser(r.Context(), GetForumTopicByIdForUserParams{
 		UsersIdusers: uid,
@@ -101,7 +102,7 @@ func forumTopicAtomPage(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 	vars := mux.Vars(r)
 	topicID, _ := strconv.Atoi(vars["topic"])
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	topic, err := queries.GetForumTopicByIdForUser(r.Context(), GetForumTopicByIdForUserParams{
 		UsersIdusers: uid,

--- a/forumPage.go
+++ b/forumPage.go
@@ -26,7 +26,7 @@ func forumPage(w http.ResponseWriter, r *http.Request) {
 		Back                    bool
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -36,7 +36,7 @@ func forumPage(w http.ResponseWriter, r *http.Request) {
 	categoryId, _ := strconv.Atoi(vars["category"])
 
 	data := &Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Admin:    true,
 	}
 

--- a/forumThreadNewPage.go
+++ b/forumThreadNewPage.go
@@ -20,9 +20,9 @@ func forumThreadNewPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
-		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		SelectedLanguageId: int(resolveDefaultLanguageID(r.Context(), queries)),
 	}
 
@@ -43,7 +43,7 @@ func forumThreadNewPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func forumThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	topicId, err := strconv.Atoi(vars["topic"])
 	session, ok := core.GetSessionOrFail(w, r)

--- a/forumThreadPage.go
+++ b/forumThreadPage.go
@@ -40,9 +40,9 @@ func forumThreadPage(w http.ResponseWriter, r *http.Request) {
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
-		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		Offset:             offset,
 		IsReplyable:        true,
 		SelectedLanguageId: int(resolveDefaultLanguageID(r.Context(), queries)),
@@ -55,8 +55,8 @@ func forumThreadPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	threadRow := r.Context().Value(ContextValues("thread")).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
-	topicRow := r.Context().Value(ContextValues("topic")).(*GetForumTopicByIdForUserRow)
+	threadRow := r.Context().Value(common.KeyThread).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
+	topicRow := r.Context().Value(common.KeyTopic).(*GetForumTopicByIdForUserRow)
 
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {

--- a/forumTopicPage.go
+++ b/forumTopicPage.go
@@ -26,7 +26,7 @@ func forumTopicsPage(w http.ResponseWriter, r *http.Request) {
 		CopyDataToSubCategories func(rootCategory *ForumcategoryPlus) *Data
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -36,7 +36,7 @@ func forumTopicsPage(w http.ResponseWriter, r *http.Request) {
 	topicId, _ := strconv.Atoi(vars["topic"])
 
 	data := &Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Admin:    true,
 	}
 

--- a/forumTopicThreadCommentEditPage.go
+++ b/forumTopicThreadCommentEditPage.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"fmt"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -17,9 +18,9 @@ func forumTopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Reques
 	}
 	text := r.PostFormValue("replytext")
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
-	threadRow := r.Context().Value(ContextValues("thread")).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
-	topicRow := r.Context().Value(ContextValues("topic")).(*GetForumTopicByIdForUserRow)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	threadRow := r.Context().Value(common.KeyThread).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
+	topicRow := r.Context().Value(common.KeyTopic).(*GetForumTopicByIdForUserRow)
 	commentId, _ := strconv.Atoi(mux.Vars(r)["comment"])
 
 	err = queries.UpdateComment(r.Context(), UpdateCommentParams{
@@ -45,8 +46,8 @@ func forumTopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Reques
 }
 
 func forumTopicThreadCommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
-	threadRow := r.Context().Value(ContextValues("thread")).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
-	topicRow := r.Context().Value(ContextValues("topic")).(*GetForumTopicByIdForUserRow)
+	threadRow := r.Context().Value(common.KeyThread).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
+	topicRow := r.Context().Value(common.KeyTopic).(*GetForumTopicByIdForUserRow)
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
 

--- a/forumTopicThreadReplyPage.go
+++ b/forumTopicThreadReplyPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
 	"strconv"
@@ -15,10 +16,10 @@ func forumTopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	threadRow := r.Context().Value(ContextValues("thread")).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
-	topicRow := r.Context().Value(ContextValues("topic")).(*GetForumTopicByIdForUserRow)
+	threadRow := r.Context().Value(common.KeyThread).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
+	topicRow := r.Context().Value(common.KeyTopic).(*GetForumTopicByIdForUserRow)
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	text := r.PostFormValue("replytext")
 	languageId, _ := strconv.Atoi(r.PostFormValue("language"))
@@ -91,8 +92,8 @@ func forumTopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func forumTopicThreadReplyCancelPage(w http.ResponseWriter, r *http.Request) {
-	threadRow := r.Context().Value(ContextValues("thread")).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
-	topicRow := r.Context().Value(ContextValues("topic")).(*GetForumTopicByIdForUserRow)
+	threadRow := r.Context().Value(common.KeyThread).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
+	topicRow := r.Context().Value(common.KeyTopic).(*GetForumTopicByIdForUserRow)
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
 

--- a/handlers/common/auto_refresh.go
+++ b/handlers/common/auto_refresh.go
@@ -12,7 +12,7 @@ func TaskDoneAutoRefreshPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 	}
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(ContextKey("coreData")).(*CoreData),
 	}
 	data.AutoRefresh = true
 

--- a/handlers/common/funcs.go
+++ b/handlers/common/funcs.go
@@ -60,7 +60,7 @@ func NewFuncs(r *http.Request) template.FuncMap {
 				IsAdmin      bool
 			}
 			var result []*Post
-			queries := r.Context().Value(ContextValues("queries")).(*db.Queries)
+			queries := r.Context().Value(ContextKey("queries")).(*db.Queries)
 
 			offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
@@ -78,7 +78,7 @@ func NewFuncs(r *http.Request) template.FuncMap {
 
 			editingId, _ := strconv.Atoi(r.URL.Query().Get("reply"))
 
-			cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+			cd := r.Context().Value(ContextKey("coreData")).(*CoreData)
 			for _, post := range posts {
 				ann, err := queries.GetLatestAnnouncementByNewsID(r.Context(), post.Idsitenews)
 				if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/handlers/common/funcs_pagesize_test.go
+++ b/handlers/common/funcs_pagesize_test.go
@@ -33,7 +33,7 @@ func TestGetPageSize(t *testing.T) {
 			r := httptest.NewRequest("GET", "/", nil)
 			ctx := r.Context()
 			if tt.pref != nil {
-				ctx = context.WithValue(ctx, ContextValues("preference"), tt.pref)
+				ctx = context.WithValue(ctx, ContextKey("preference"), tt.pref)
 			}
 			r = r.WithContext(ctx)
 

--- a/handlers/common/pagesize.go
+++ b/handlers/common/pagesize.go
@@ -10,7 +10,7 @@ import (
 // GetPageSize returns the preferred page size within configured bounds.
 func GetPageSize(r *http.Request) int {
 	size := runtimeconfig.AppRuntimeConfig.PageSizeDefault
-	if pref, _ := r.Context().Value(ContextValues("preference")).(*db.Preference); pref != nil && pref.PageSize != 0 {
+	if pref, _ := r.Context().Value(ContextKey("preference")).(*db.Preference); pref != nil && pref.PageSize != 0 {
 		size = int(pref.PageSize)
 	}
 	if size < runtimeconfig.AppRuntimeConfig.PageSizeMin {

--- a/handlers/common/types.go
+++ b/handlers/common/types.go
@@ -8,3 +8,27 @@ type ContextValues = core.ContextValues
 
 // CoreData maps to core.CoreData for handler use.
 type CoreData = core.CoreData
+
+// Common context keys used across handlers.
+const (
+	// KeyCoreData provides access to CoreData.
+	KeyCoreData ContextKey = "coreData"
+	// KeyLanguages provides the user's language preferences.
+	KeyLanguages ContextKey = "languages"
+	// KeyPermissions stores user permissions.
+	KeyPermissions ContextKey = "permissions"
+	// KeyPreference stores a user's preferences.
+	KeyPreference ContextKey = "preference"
+	// KeyQueries holds the db.Queries pointer.
+	KeyQueries ContextKey = "queries"
+	// KeySession contains the session struct.
+	KeySession ContextKey = "session"
+	// KeySQLDB exposes the *sql.DB handle.
+	KeySQLDB ContextKey = "sql.DB"
+	// KeyThread holds the current thread information.
+	KeyThread ContextKey = "thread"
+	// KeyTopic holds the current topic information.
+	KeyTopic ContextKey = "topic"
+	// KeyUser references the authenticated user.
+	KeyUser ContextKey = "user"
+)

--- a/imagebbsAdminApprove.go
+++ b/imagebbsAdminApprove.go
@@ -11,7 +11,7 @@ import (
 func imagebbsAdminApprovePostPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	if err := queries.ApproveImagePost(r.Context(), int32(pid)); err != nil {
 		log.Printf("ApproveImagePost error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/imagebbsAdminBoardPage.go
+++ b/imagebbsAdminBoardPage.go
@@ -2,6 +2,7 @@ package goa4web
 
 import (
 	"database/sql"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -15,7 +16,7 @@ func imagebbsAdminBoardModifyBoardActionPage(w http.ResponseWriter, r *http.Requ
 	vars := mux.Vars(r)
 	bid, _ := strconv.Atoi(vars["board"])
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	err := queries.UpdateImageBoard(r.Context(), UpdateImageBoardParams{
 		ImageboardIdimageboard: int32(parentBoardId),

--- a/imagebbsAdminBoardsPage.go
+++ b/imagebbsAdminBoardsPage.go
@@ -24,9 +24,9 @@ func imagebbsAdminBoardsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	boardRows, err := queries.GetAllImageBoards(r.Context())
 	if err != nil {

--- a/imagebbsAdminFilesPage.go
+++ b/imagebbsAdminFilesPage.go
@@ -50,7 +50,7 @@ func imagebbsAdminFilesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Path:     cleaned,
 	}
 	if cleaned != "/" {

--- a/imagebbsAdminNewBoardPage.go
+++ b/imagebbsAdminNewBoardPage.go
@@ -18,9 +18,9 @@ func imagebbsAdminNewBoardPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	boardRows, err := queries.GetAllImageBoards(r.Context())
 	if err != nil {
@@ -49,7 +49,7 @@ func imagebbsAdminNewBoardMakePage(w http.ResponseWriter, r *http.Request) {
 	desc := r.PostFormValue("desc")
 	parentBoardId, _ := strconv.Atoi(r.PostFormValue("pbid"))
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	err := queries.CreateImageBoard(r.Context(), CreateImageBoardParams{
 		ImageboardIdimageboard: int32(parentBoardId),

--- a/imagebbsAdminPage.go
+++ b/imagebbsAdminPage.go
@@ -14,7 +14,7 @@ func imagebbsAdminPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	CustomImageBBSIndex(data.CoreData, r)

--- a/imagebbsBoardPage.go
+++ b/imagebbsBoardPage.go
@@ -36,12 +36,12 @@ func imagebbsBoardPage(w http.ResponseWriter, r *http.Request) {
 	bid, _ := strconv.Atoi(vars["boardno"])
 
 	data := Data{
-		CoreData:    r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:    r.Context().Value(common.KeyCoreData).(*CoreData),
 		IsSubBoard:  bid != 0,
 		BoardNumber: bid,
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	subBoardRows, err := queries.GetAllBoardsByParentBoardId(r.Context(), int32(bid))
 	if err != nil {
@@ -90,7 +90,7 @@ func imagebbsBoardPostImageActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	board, err := queries.GetImageBoardById(r.Context(), int32(bid))
 	if err != nil {

--- a/imagebbsBoardThreadPage.go
+++ b/imagebbsBoardThreadPage.go
@@ -48,9 +48,9 @@ func imagebbsBoardThreadPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
-		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		Replyable:          true,
 		BoardId:            bid,
 		ForumThreadId:      thid,
@@ -158,7 +158,7 @@ func imagebbsBoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	post, err := queries.GetAllImagePostsByIdWithAuthorUsernameAndThreadCommentCount(r.Context(), int32(bid))
 	if err != nil {

--- a/imagebbsFeed.go
+++ b/imagebbsFeed.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/arran4/goa4web/a4code2html"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/feeds"
 	"github.com/gorilla/mux"
 	"log"
@@ -60,7 +61,7 @@ func imagebbsFeed(r *http.Request, title string, boardID int, rows []*GetAllImag
 }
 
 func imagebbsRssPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	boards, err := queries.GetAllImageBoards(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query boards error: %s", err)
@@ -86,7 +87,7 @@ func imagebbsRssPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func imagebbsAtomPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	boards, err := queries.GetAllImageBoards(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query boards error: %s", err)
@@ -114,7 +115,7 @@ func imagebbsAtomPage(w http.ResponseWriter, r *http.Request) {
 func imagebbsBoardRssPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bid, _ := strconv.Atoi(vars["boardno"])
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	rows, err := queries.GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCount(r.Context(), int32(bid))
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
@@ -144,7 +145,7 @@ func imagebbsBoardRssPage(w http.ResponseWriter, r *http.Request) {
 func imagebbsBoardAtomPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bid, _ := strconv.Atoi(vars["boardno"])
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	rows, err := queries.GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCount(r.Context(), int32(bid))
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)

--- a/imagebbsPage.go
+++ b/imagebbsPage.go
@@ -19,12 +19,12 @@ func imagebbsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData:    r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:    r.Context().Value(common.KeyCoreData).(*CoreData),
 		IsSubBoard:  false,
 		BoardNumber: 0,
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	subBoardRows, err := queries.GetAllBoardsByParentBoardId(r.Context(), 0)
 	if err != nil {

--- a/imagebbsPosterPage.go
+++ b/imagebbsPosterPage.go
@@ -24,7 +24,7 @@ func imagebbsPosterPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	username := vars["username"]
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		switch {
@@ -49,7 +49,7 @@ func imagebbsPosterPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Posts:    rows,
 		Username: username,
 		IsOffset: offset != 0,

--- a/informationPage.go
+++ b/informationPage.go
@@ -27,7 +27,7 @@ func informationPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 	ld, err := load.Avg()
 	if err != nil {

--- a/linkerAdminAddPage.go
+++ b/linkerAdminAddPage.go
@@ -20,9 +20,9 @@ func linkerAdminAddPage(w http.ResponseWriter, r *http.Request) {
 		Categories         []*Linkercategory
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
-		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		SelectedLanguageId: int(resolveDefaultLanguageID(r.Context(), queries)),
 	}
 
@@ -55,7 +55,7 @@ func linkerAdminAddPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 func linkerAdminAddActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {

--- a/linkerAdminCategoriesPage.go
+++ b/linkerAdminCategoriesPage.go
@@ -18,10 +18,10 @@ func linkerAdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	categoryRows, err := queries.GetLinkerCategoryLinkCounts(r.Context())
 	if err != nil {
@@ -46,7 +46,7 @@ func linkerAdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func linkerAdminCategoriesUpdatePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
 	title := r.PostFormValue("title")
 	pos, _ := strconv.Atoi(r.PostFormValue("position"))
@@ -72,7 +72,7 @@ func linkerAdminCategoriesUpdatePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func linkerAdminCategoriesRenamePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
 	title := r.PostFormValue("title")
 	pos, _ := strconv.Atoi(r.PostFormValue("position"))
@@ -89,7 +89,7 @@ func linkerAdminCategoriesRenamePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func linkerAdminCategoriesDeletePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
 	rows, _ := queries.GetLinkerCategoryLinkCounts(r.Context())
 	for _, c := range rows {
@@ -117,7 +117,7 @@ func linkerAdminCategoriesDeletePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func linkerAdminCategoriesCreatePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	title := r.PostFormValue("title")
 	rows, _ := queries.GetLinkerCategoryLinkCounts(r.Context())
 	pos := len(rows) + 1

--- a/linkerAdminQueuePage.go
+++ b/linkerAdminQueuePage.go
@@ -30,14 +30,14 @@ func linkerAdminQueuePage(w http.ResponseWriter, r *http.Request) {
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Search:   r.URL.Query().Get("search"),
 		User:     r.URL.Query().Get("user"),
 		Category: r.URL.Query().Get("category"),
 		Offset:   offset,
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	queue, err := queries.GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails(r.Context())
 	if err != nil {
@@ -120,7 +120,7 @@ func linkerAdminQueuePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func linkerAdminQueueDeleteActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	qid, _ := strconv.Atoi(r.URL.Query().Get("qid"))
 	if err := queries.DeleteLinkerQueuedItem(r.Context(), int32(qid)); err != nil {
 		log.Printf("updateLinkerQueuedItem Error: %s", err)
@@ -131,7 +131,7 @@ func linkerAdminQueueDeleteActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func linkerAdminQueueUpdateActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	qid, _ := strconv.Atoi(r.URL.Query().Get("qid"))
 	title := r.URL.Query().Get("title")
 	URL := r.URL.Query().Get("URL")
@@ -152,7 +152,7 @@ func linkerAdminQueueUpdateActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func linkerAdminQueueApproveActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	qid, _ := strconv.Atoi(r.URL.Query().Get("qid"))
 	lid, err := queries.SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId(r.Context(), int32(qid))
 	if err != nil {
@@ -181,7 +181,7 @@ func linkerAdminQueueApproveActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func linkerAdminQueueBulkDeleteActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm Error: %s", err)
 	}
@@ -195,7 +195,7 @@ func linkerAdminQueueBulkDeleteActionPage(w http.ResponseWriter, r *http.Request
 }
 
 func linkerAdminQueueBulkApproveActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm Error: %s", err)
 	}

--- a/linkerAdminUserLevelsPage.go
+++ b/linkerAdminUserLevelsPage.go
@@ -26,11 +26,11 @@ func linkerAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Search:   r.URL.Query().Get("search"),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	rows, err := queries.GetUsersPermissions(r.Context())
 	if err != nil {
 		switch {
@@ -73,7 +73,7 @@ func linkerAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func linkerAdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	usernames := r.PostFormValue("usernames")
 	where := r.PostFormValue("where")
 	level := r.PostFormValue("level")
@@ -101,7 +101,7 @@ func linkerAdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request
 }
 
 func linkerAdminUserLevelsRemoveActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	r.ParseForm()
 	ids := r.Form["permids"]
 	if len(ids) == 0 {

--- a/linkerCategoriesPage.go
+++ b/linkerCategoriesPage.go
@@ -17,10 +17,10 @@ func linkerCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	categories, err := queries.GetAllLinkerCategories(r.Context())
 	if err != nil {

--- a/linkerCategoryPage.go
+++ b/linkerCategoryPage.go
@@ -23,7 +23,7 @@ func linkerCategoryPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	data.Offset, _ = strconv.Atoi(r.URL.Query().Get("offset"))
@@ -32,7 +32,7 @@ func linkerCategoryPage(w http.ResponseWriter, r *http.Request) {
 	data.CommentOnId, _ = strconv.Atoi(r.URL.Query().Get("comment"))
 	data.ReplyToId, _ = strconv.Atoi(r.URL.Query().Get("reply"))
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	linkerPosts, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(data.CatId)})
 	if err != nil {

--- a/linkerCommentsPage.go
+++ b/linkerCommentsPage.go
@@ -41,8 +41,8 @@ func linkerCommentsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
 		CoreData:           cd,
 		CanReply:           cd.UserID != 0,
@@ -59,7 +59,7 @@ func linkerCommentsPage(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 	data.UserId = uid
 
-	queries = r.Context().Value(ContextValues("queries")).(*Queries)
+	queries = r.Context().Value(common.KeyQueries).(*Queries)
 
 	languageRows, err := queries.FetchLanguages(r.Context())
 	if err != nil {
@@ -163,7 +163,7 @@ func linkerCommentsReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	link, err := queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(r.Context(), int32(linkId))
 	if err != nil {

--- a/linkerFeed.go
+++ b/linkerFeed.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/arran4/goa4web/a4code2html"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/feeds"
 	"net/http"
 	"strconv"
@@ -54,7 +55,7 @@ func linkerFeed(r *http.Request, rows []*GetAllLinkerItemsByCategoryIdWitherPost
 }
 
 func linkerRssPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
 	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(catID)})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -69,7 +70,7 @@ func linkerRssPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func linkerAtomPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
 	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(catID)})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/linkerLinkerPage.go
+++ b/linkerLinkerPage.go
@@ -24,7 +24,7 @@ func linkerLinkerPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	username := vars["username"]
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		switch {
@@ -49,7 +49,7 @@ func linkerLinkerPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Links:    rows,
 		Username: username,
 		IsOffset: offset != 0,

--- a/linkerPage.go
+++ b/linkerPage.go
@@ -26,7 +26,7 @@ func linkerPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	data.Offset, _ = strconv.Atoi(r.URL.Query().Get("offset"))
@@ -34,7 +34,7 @@ func linkerPage(w http.ResponseWriter, r *http.Request) {
 	data.CommentOnId, _ = strconv.Atoi(r.URL.Query().Get("comment"))
 	data.ReplyToId, _ = strconv.Atoi(r.URL.Query().Get("reply"))
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	linkerPosts, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(data.CatId)})
 	if err != nil {

--- a/linkerShowPage.go
+++ b/linkerShowPage.go
@@ -23,8 +23,8 @@ func linkerShowPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int
 	}
 
-	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
 		CoreData:           cd,
 		CanReply:           cd.UserID != 0,
@@ -76,7 +76,7 @@ func linkerShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	link, err := queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(r.Context(), int32(linkId))
 	if err != nil {

--- a/linkerSuggestPage.go
+++ b/linkerSuggestPage.go
@@ -20,9 +20,9 @@ func linkerSuggestPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
-		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		SelectedLanguageId: int(resolveDefaultLanguageID(r.Context(), queries)),
 	}
 
@@ -55,7 +55,7 @@ func linkerSuggestPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func linkerSuggestActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {

--- a/linker_test.go
+++ b/linker_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func TestLinkerFeed(t *testing.T) {
@@ -57,8 +58,8 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 	mock.ExpectExec("INSERT IGNORE INTO linkerSearch").WithArgs(int32(1), int32(2)).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	req := httptest.NewRequest("POST", "/admin/queue?qid=1", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)
-	ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{})
+	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
+	ctx = context.WithValue(ctx, common.KeyCoreData, &CoreData{})
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	linkerAdminQueueApproveActionPage(rr, req)

--- a/loginPage.go
+++ b/loginPage.go
@@ -20,7 +20,7 @@ func loginUserPassPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	if err := templates.RenderTemplate(w, "loginPage.gohtml", data, common.NewFuncs(r)); err != nil {
@@ -39,7 +39,7 @@ func loginActionPage(w http.ResponseWriter, r *http.Request) {
 	//
 	//hashedPassword := hex.EncodeToString(sum[:])
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	var (
 		uid    int32
@@ -125,7 +125,7 @@ func loginActionPage(w http.ResponseWriter, r *http.Request) {
 			Values  url.Values
 		}
 		data := Data{
-			CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+			CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 			BackURL:  backURL,
 			Method:   backMethod,
 			Values:   vals,

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
@@ -33,7 +34,7 @@ func TestGetThreadAndTopicTrue(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
-	ctx := context.WithValue(req.Context(), ContextValues("queries"), q)
+	ctx := context.WithValue(req.Context(), common.KeyQueries, q)
 	req = req.WithContext(ctx)
 
 	if !GetThreadAndTopic()(req, &mux.RouteMatch{}) {
@@ -67,7 +68,7 @@ func TestGetThreadAndTopicFalse(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
-	ctx := context.WithValue(req.Context(), ContextValues("queries"), q)
+	ctx := context.WithValue(req.Context(), common.KeyQueries, q)
 	req = req.WithContext(ctx)
 
 	if GetThreadAndTopic()(req, &mux.RouteMatch{}) {
@@ -93,7 +94,7 @@ func TestGetThreadAndTopicError(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
-	ctx := context.WithValue(req.Context(), ContextValues("queries"), q)
+	ctx := context.WithValue(req.Context(), common.KeyQueries, q)
 	req = req.WithContext(ctx)
 
 	if GetThreadAndTopic()(req, &mux.RouteMatch{}) {

--- a/newsAdminUserLevelsPage.go
+++ b/newsAdminUserLevelsPage.go
@@ -18,10 +18,10 @@ func newsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	rows, err := queries.GetUsersPermissions(r.Context())
 	if err != nil {
 		switch {
@@ -44,7 +44,7 @@ func newsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func newsAdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	username := r.PostFormValue("username")
 	where := r.PostFormValue("where")
 	level := r.PostFormValue("level")
@@ -75,7 +75,7 @@ func newsAdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) 
 }
 
 func newsAdminUserLevelsRemoveActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	permid, err := strconv.Atoi(r.PostFormValue("permid"))
 	if err != nil {
 		log.Printf("strconv.Atoi(permid) Error: %s", err)

--- a/newsAnnouncementHandlers.go
+++ b/newsAnnouncementHandlers.go
@@ -12,7 +12,7 @@ import (
 )
 
 func newsAnnouncementActivateActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
 
@@ -35,7 +35,7 @@ func newsAnnouncementActivateActionPage(w http.ResponseWriter, r *http.Request) 
 }
 
 func newsAnnouncementDeactivateActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
 

--- a/newsPostPage.go
+++ b/newsPostPage.go
@@ -53,9 +53,9 @@ func newsPostPage(w http.ResponseWriter, r *http.Request) {
 		ReplyText          string
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
-		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		IsReplying:         r.URL.Query().Has("comment"),
 		IsReplyable:        true,
 		SelectedLanguageId: resolveDefaultLanguageID(r.Context(), queries),
@@ -195,7 +195,7 @@ func newsPostReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	post, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(r.Context(), int32(pid))
 	if err != nil {
@@ -330,7 +330,7 @@ func newsPostEditActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	postId, _ := strconv.Atoi(vars["post"])
 
@@ -358,7 +358,7 @@ func newsPostNewActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/newsRssPage.go
+++ b/newsRssPage.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/arran4/goa4web/a4code2html"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/feeds"
 	"log"
 	"net/http"
@@ -12,7 +13,7 @@ import (
 )
 
 func newsRssPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	posts, err := queries.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(r.Context(), GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams{
 		Limit:  15,
 		Offset: 0,

--- a/newsUserPermissionsPage.go
+++ b/newsUserPermissionsPage.go
@@ -13,7 +13,7 @@ import (
 )
 
 func newsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
 	if !(cd.HasRole("writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
@@ -27,7 +27,7 @@ func newsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: cd,
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	rows, err := queries.GetPermissionsByUserIdAndSectionNews(r.Context())
 	if err != nil {
@@ -49,7 +49,7 @@ func newsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func newsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	username := r.PostFormValue("username")
 	where := "news"
 	level := r.PostFormValue("level")
@@ -59,7 +59,7 @@ func newsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/news",
 	}
 	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
@@ -88,7 +88,7 @@ func newsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.
 }
 
 func newsUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	permid := r.PostFormValue("permid")
 	data := struct {
 		*CoreData
@@ -96,7 +96,7 @@ func newsUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/news",
 	}
 	if permidi, err := strconv.Atoi(permid); err != nil {

--- a/registerPage.go
+++ b/registerPage.go
@@ -19,7 +19,7 @@ func registerPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	if err := templates.RenderTemplate(w, "registerPage.gohtml", data, common.NewFuncs(r)); err != nil {
@@ -51,7 +51,7 @@ func registerActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid email", http.StatusBadRequest)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if _, err := queries.UserByUsername(r.Context(), sql.NullString{
 		String: username,

--- a/required_access_test.go
+++ b/required_access_test.go
@@ -5,13 +5,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
 func TestRequiredAccessAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("user"), &User{Idusers: 1})
-	ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{SecurityLevel: "writer"})
+	ctx := context.WithValue(req.Context(), common.KeyUser, &User{Idusers: 1})
+	ctx = context.WithValue(ctx, common.KeyCoreData, &CoreData{SecurityLevel: "writer"})
 	req = req.WithContext(ctx)
 
 	if !RequiredAccess("writer")(req, &mux.RouteMatch{}) {
@@ -21,8 +22,8 @@ func TestRequiredAccessAllowed(t *testing.T) {
 
 func TestRequiredAccessDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("user"), &User{Idusers: 1})
-	ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{SecurityLevel: "reader"})
+	ctx := context.WithValue(req.Context(), common.KeyUser, &User{Idusers: 1})
+	ctx = context.WithValue(ctx, common.KeyCoreData, &CoreData{SecurityLevel: "reader"})
 	req = req.WithContext(ctx)
 
 	if RequiredAccess("writer")(req, &mux.RouteMatch{}) {

--- a/role_middleware_test.go
+++ b/role_middleware_test.go
@@ -2,6 +2,7 @@ package goa4web
 
 import (
 	"context"
+	"github.com/arran4/goa4web/handlers/common"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,7 +10,7 @@ import (
 
 func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{SecurityLevel: "administrator"})
+	ctx := context.WithValue(req.Context(), common.KeyCoreData, &CoreData{SecurityLevel: "administrator"})
 	req = req.WithContext(ctx)
 
 	called := false
@@ -30,7 +31,7 @@ func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 
 func TestRoleCheckerMiddlewareDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("coreData"), &CoreData{SecurityLevel: "reader"})
+	ctx := context.WithValue(req.Context(), common.KeyCoreData, &CoreData{SecurityLevel: "reader"})
 	req = req.WithContext(ctx)
 
 	called := false

--- a/run.go
+++ b/run.go
@@ -108,7 +108,7 @@ func runTemplate(template string) func(http.ResponseWriter, *http.Request) {
 		}
 
 		data := Data{
-			CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+			CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		}
 
 		CustomNewsIndex(data.CoreData, r)
@@ -125,7 +125,7 @@ func runTemplate(template string) func(http.ResponseWriter, *http.Request) {
 
 func AddNewsIndex(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+		cd := r.Context().Value(common.KeyCoreData).(*CoreData)
 		CustomNewsIndex(cd, r)
 		handler.ServeHTTP(w, r)
 	})
@@ -163,7 +163,7 @@ func TargetUsersLevelNotHigherThanAdminsMax() mux.MatcherFunc {
 			return false
 		}
 
-		queries := r.Context().Value(ContextValues("queries")).(*Queries)
+		queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 		targetUser, err := queries.GetUsersTopicLevelByUserIdAndThreadId(r.Context(), GetUsersTopicLevelByUserIdAndThreadIdParams{
 			ForumtopicIdforumtopic: int32(tid),
@@ -206,7 +206,7 @@ func AdminUsersMaxLevelNotLowerThanTargetLevel() mux.MatcherFunc {
 		if err != nil {
 			return false
 		}
-		queries := r.Context().Value(ContextValues("queries")).(*Queries)
+		queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 		adminUser, err := queries.GetUsersTopicLevelByUserIdAndThreadId(r.Context(), GetUsersTopicLevelByUserIdAndThreadIdParams{
 			ForumtopicIdforumtopic: int32(tid),
@@ -241,7 +241,7 @@ func NewsPostAuthor() mux.MatcherFunc {
 	return func(request *http.Request, match *mux.RouteMatch) bool {
 		vars := mux.Vars(request)
 		newsPostId, _ := strconv.Atoi(vars["post"])
-		queries := request.Context().Value(ContextValues("queries")).(*Queries)
+		queries := request.Context().Value(common.KeyQueries).(*Queries)
 		session, err := core.GetSession(request)
 		if err != nil {
 			return false
@@ -262,7 +262,7 @@ func BlogAuthor() mux.MatcherFunc {
 	return func(request *http.Request, match *mux.RouteMatch) bool {
 		vars := mux.Vars(request)
 		blogId, _ := strconv.Atoi(vars["blog"])
-		queries := request.Context().Value(ContextValues("queries")).(*Queries)
+		queries := request.Context().Value(common.KeyQueries).(*Queries)
 		session, err := core.GetSession(request)
 		if err != nil {
 			return false
@@ -287,7 +287,7 @@ func WritingAuthor() mux.MatcherFunc {
 	return func(request *http.Request, match *mux.RouteMatch) bool {
 		vars := mux.Vars(request)
 		writingId, _ := strconv.Atoi(vars["writing"])
-		queries := request.Context().Value(ContextValues("queries")).(*Queries)
+		queries := request.Context().Value(common.KeyQueries).(*Queries)
 		session, err := core.GetSession(request)
 		if err != nil {
 			return false
@@ -311,7 +311,7 @@ func CommentAuthor() mux.MatcherFunc {
 	return func(request *http.Request, match *mux.RouteMatch) bool {
 		vars := mux.Vars(request)
 		commentId, _ := strconv.Atoi(vars["comment"])
-		queries := request.Context().Value(ContextValues("queries")).(*Queries)
+		queries := request.Context().Value(common.KeyQueries).(*Queries)
 		session, err := core.GetSession(request)
 		if err != nil {
 			return false
@@ -343,7 +343,7 @@ func GetThreadAndTopic() mux.MatcherFunc {
 			return false
 		}
 
-		queries := r.Context().Value(ContextValues("queries")).(*Queries)
+		queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 		session, _ := core.GetSession(r)
 		var uid int32
@@ -373,8 +373,8 @@ func GetThreadAndTopic() mux.MatcherFunc {
 			return false
 		}
 
-		ctx := context.WithValue(r.Context(), ContextValues("thread"), threadRow)
-		ctx = context.WithValue(ctx, ContextValues("topic"), topicRow)
+		ctx := context.WithValue(r.Context(), common.KeyThread, threadRow)
+		ctx = context.WithValue(ctx, common.KeyTopic, topicRow)
 		*r = *r.WithContext(ctx)
 		return true
 	}

--- a/searchPage.go
+++ b/searchPage.go
@@ -15,7 +15,7 @@ func searchPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	if err := templates.RenderTemplate(w, "searchPage.gohtml", data, common.NewFuncs(r)); err != nil {

--- a/searchResultBlogsActionPage.go
+++ b/searchResultBlogsActionPage.go
@@ -22,9 +22,9 @@ func searchResultBlogsActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/searchResultForumActionPage.go
+++ b/searchResultForumActionPage.go
@@ -20,9 +20,9 @@ func searchResultForumActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/searchResultLinkerActionPage.go
+++ b/searchResultLinkerActionPage.go
@@ -24,9 +24,9 @@ func searchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/searchResultNewsActionPage.go
+++ b/searchResultNewsActionPage.go
@@ -23,9 +23,9 @@ func searchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/searchResultWritingsActionPage.go
+++ b/searchResultWritingsActionPage.go
@@ -23,9 +23,9 @@ func searchResultWritingsActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/security.go
+++ b/security.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/handlers/common"
 	"net"
 	"net/http"
 	"net/netip"
@@ -52,7 +53,7 @@ func requestIP(r *http.Request) string {
 func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ip := requestIP(r)
-		if queries, ok := r.Context().Value(ContextValues("queries")).(*Queries); ok {
+		if queries, ok := r.Context().Value(common.KeyQueries).(*Queries); ok {
 			bans, err := queries.ListActiveBans(r.Context())
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/session_test.go
+++ b/session_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/sessions"
 
 	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func TestCoreAdderMiddlewareBadSession(t *testing.T) {
@@ -21,7 +22,7 @@ func TestCoreAdderMiddlewareBadSession(t *testing.T) {
 	}))
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(&http.Cookie{Name: sessionName, Value: "bad"})
-	ctx := context.WithValue(req.Context(), ContextValues("queries"), New(nil))
+	ctx := context.WithValue(req.Context(), common.KeyQueries, New(nil))
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)

--- a/templatePage.go
+++ b/templatePage.go
@@ -14,7 +14,7 @@ func templatePage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	if err := templates.RenderTemplate(w, "templatePage.gohtml", data, common.NewFuncs(r)); err != nil {

--- a/updateEmail.go
+++ b/updateEmail.go
@@ -3,6 +3,7 @@ package goa4web
 import (
 	"context"
 	_ "embed"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 // defaultUpdateEmailText contains the compiled-in notification email template.
@@ -14,7 +15,7 @@ var defaultUpdateEmailText string
 // getUpdateEmailText returns the update email template body, preferring a database
 // override when available.
 func getUpdateEmailText(ctx context.Context) string {
-	if q, ok := ctx.Value(ContextValues("queries")).(*Queries); ok && q != nil {
+	if q, ok := ctx.Value(common.KeyQueries).(*Queries); ok && q != nil {
 		if body, err := q.GetTemplateOverride(ctx, "updateEmail"); err == nil && body != "" {
 			return body
 		}

--- a/user.go
+++ b/user.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/sessions"
 
 	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func UserAdderMiddleware(next http.Handler) http.Handler {
@@ -22,7 +23,7 @@ func UserAdderMiddleware(next http.Handler) http.Handler {
 			core.SessionError(writer, request, err)
 		}
 
-		queries := request.Context().Value(ContextValues("queries")).(*Queries)
+		queries := request.Context().Value(common.KeyQueries).(*Queries)
 		var (
 			user        *User
 			permissions []*Permission
@@ -79,11 +80,11 @@ func UserAdderMiddleware(next http.Handler) http.Handler {
 			}
 		}
 
-		ctx := context.WithValue(request.Context(), ContextValues("session"), session)
-		ctx = context.WithValue(ctx, ContextValues("user"), user)
-		ctx = context.WithValue(ctx, ContextValues("permissions"), permissions)
-		ctx = context.WithValue(ctx, ContextValues("preference"), preference)
-		ctx = context.WithValue(ctx, ContextValues("languages"), languages)
+		ctx := context.WithValue(request.Context(), common.KeySession, session)
+		ctx = context.WithValue(ctx, common.KeyUser, user)
+		ctx = context.WithValue(ctx, common.KeyPermissions, permissions)
+		ctx = context.WithValue(ctx, common.KeyPreference, preference)
+		ctx = context.WithValue(ctx, common.KeyLanguages, languages)
 		next.ServeHTTP(writer, request.WithContext(ctx))
 	})
 }

--- a/userEmailPage.go
+++ b/userEmailPage.go
@@ -25,11 +25,11 @@ func userEmailPage(w http.ResponseWriter, r *http.Request) {
 		Error           string
 	}
 
-	user, _ := r.Context().Value(ContextValues("user")).(*User)
-	pref, _ := r.Context().Value(ContextValues("preference")).(*Preference)
+	user, _ := r.Context().Value(common.KeyUser).(*User)
+	pref, _ := r.Context().Value(common.KeyPreference).(*Preference)
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		UserData: user,
 		Error:    r.URL.Query().Get("error"),
 	}
@@ -59,7 +59,7 @@ func userEmailSaveActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	updates := r.PostFormValue("emailupdates") != ""
 
 	_, err := queries.GetPreferenceByUserID(r.Context(), uid)
@@ -92,7 +92,7 @@ func userEmailSaveActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func userEmailTestActionPage(w http.ResponseWriter, r *http.Request) {
-	user, _ := r.Context().Value(ContextValues("user")).(*User)
+	user, _ := r.Context().Value(common.KeyUser).(*User)
 	if user == nil || !user.Email.Valid {
 		http.Error(w, "email unknown", http.StatusBadRequest)
 		return

--- a/userLangPage.go
+++ b/userLangPage.go
@@ -28,11 +28,11 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 		LanguageOptions []LanguageOption
 	}
 
-	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
-	pref, _ := r.Context().Value(ContextValues("preference")).(*Preference)
-	userLangs, _ := r.Context().Value(ContextValues("languages")).([]*Userlang)
+	pref, _ := r.Context().Value(common.KeyPreference).(*Preference)
+	userLangs, _ := r.Context().Value(common.KeyLanguages).([]*Userlang)
 
 	langs, err := queries.FetchLanguages(r.Context())
 	if err != nil {
@@ -141,7 +141,7 @@ func userLangSaveLanguagesActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := saveUserLanguages(r, queries, uid); err != nil {
 		log.Printf("Save languages Error: %s", err)
@@ -164,7 +164,7 @@ func userLangSaveLanguagePreferenceActionPage(w http.ResponseWriter, r *http.Req
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := saveUserLanguagePreference(r, queries, uid); err != nil {
 		log.Printf("Save language Error: %s", err)
@@ -187,7 +187,7 @@ func userLangSaveDefaultLanguageActionPage(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := saveDefaultLanguage(r, queries, uid); err != nil {
 		log.Printf("Save language Error: %s", err)
@@ -210,7 +210,7 @@ func userLangSaveAllActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := saveUserLanguages(r, queries, uid); err != nil {
 		log.Printf("Save languages Error: %s", err)

--- a/userLogoutPage.go
+++ b/userLogoutPage.go
@@ -16,7 +16,7 @@ func userLogoutPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	session, err := core.GetSession(r)
@@ -26,7 +26,7 @@ func userLogoutPage(w http.ResponseWriter, r *http.Request) {
 	delete(session.Values, "UID")
 	delete(session.Values, "LoginTime")
 	delete(session.Values, "ExpiryTime")
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	if session.ID != "" {
 		_ = queries.DeleteSessionByID(r.Context(), session.ID)
 	}

--- a/userNotificationsPage.go
+++ b/userNotificationsPage.go
@@ -20,7 +20,7 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	notifs, err := queries.GetUnreadNotifications(r.Context(), uid)
 	if err != nil {
 		log.Printf("get notifications: %v", err)
@@ -31,7 +31,7 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Notifications []*Notification
 	}{
-		CoreData:      r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:      r.Context().Value(common.KeyCoreData).(*CoreData),
 		Notifications: notifs,
 	}
 	if err := templates.RenderTemplate(w, "notifications.gohtml", data, common.NewFuncs(r)); err != nil {
@@ -56,7 +56,7 @@ func userNotificationsDismissActionPage(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	id, _ := strconv.Atoi(r.FormValue("id"))
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	n, err := queries.GetUnreadNotifications(r.Context(), uid)
 	if err == nil {
 		for _, no := range n {
@@ -79,7 +79,7 @@ func notificationsRssPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	notifs, err := queries.GetUnreadNotifications(r.Context(), uid)
 	if err != nil {
 		log.Printf("notify feed: %v", err)

--- a/userPage.go
+++ b/userPage.go
@@ -15,7 +15,7 @@ func userPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	if data.CoreData.UserID == 0 {

--- a/userPageSizePage.go
+++ b/userPageSizePage.go
@@ -27,7 +27,7 @@ func userPageSizePage(w http.ResponseWriter, r *http.Request) {
 		Max     int
 		Default int
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Min:      runtimeconfig.AppRuntimeConfig.PageSizeMin,
 		Max:      runtimeconfig.AppRuntimeConfig.PageSizeMax,
 		Default:  runtimeconfig.AppRuntimeConfig.PageSizeDefault,

--- a/userPagingPage.go
+++ b/userPagingPage.go
@@ -15,7 +15,7 @@ import (
 )
 
 func userPagingPage(w http.ResponseWriter, r *http.Request) {
-	pref, _ := r.Context().Value(ContextValues("preference")).(*Preference)
+	pref, _ := r.Context().Value(common.KeyPreference).(*Preference)
 	size := runtimeconfig.AppRuntimeConfig.PageSizeDefault
 	if pref != nil {
 		size = int(pref.PageSize)
@@ -26,7 +26,7 @@ func userPagingPage(w http.ResponseWriter, r *http.Request) {
 		Min  int
 		Max  int
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Size:     size,
 		Min:      runtimeconfig.AppRuntimeConfig.PageSizeMin,
 		Max:      runtimeconfig.AppRuntimeConfig.PageSizeMax,
@@ -55,7 +55,7 @@ func userPagingSaveActionPage(w http.ResponseWriter, r *http.Request) {
 	if size > runtimeconfig.AppRuntimeConfig.PageSizeMax {
 		size = runtimeconfig.AppRuntimeConfig.PageSizeMax
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	pref, err := queries.GetPreferenceByUserID(r.Context(), uid)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/writingsAdminCategoriesPage.go
+++ b/writingsAdminCategoriesPage.go
@@ -16,10 +16,10 @@ func writingsAdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Categories []*Writingcategory
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	categoryRows, err := queries.FetchAllCategories(r.Context())
@@ -52,7 +52,7 @@ func writingsAdminCategoriesModifyPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	categoryId, err := strconv.Atoi(r.PostFormValue("cid"))
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
@@ -87,7 +87,7 @@ func writingsAdminCategoriesCreatePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	if err := queries.InsertWritingCategory(r.Context(), InsertWritingCategoryParams{
 		WritingcategoryIdwritingcategory: int32(pcid),
 		Title: sql.NullString{

--- a/writingsAdminCategoriesPage_test.go
+++ b/writingsAdminCategoriesPage_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func TestWritingsAdminCategoriesPage(t *testing.T) {
@@ -24,8 +25,8 @@ func TestWritingsAdminCategoriesPage(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT wc.idwritingcategory, wc.writingcategory_idwritingcategory, wc.title, wc.description\nFROM writingCategory wc")).WillReturnRows(rows)
 
 	req := httptest.NewRequest("GET", "/admin/writings/categories", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)
-	ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{})
+	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
+	ctx = context.WithValue(ctx, common.KeyCoreData, &CoreData{})
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 

--- a/writingsAdminUserAccessPage.go
+++ b/writingsAdminUserAccessPage.go
@@ -18,10 +18,10 @@ func writingsAdminUserAccessPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	approvedUserRows, err := queries.GetAllWritingApprovals(r.Context())
 	if err != nil {
@@ -46,7 +46,7 @@ func writingsAdminUserAccessPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func writingsAdminUserAccessAllowActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	username := r.PostFormValue("username")
 	where := r.PostFormValue("where")
 	level := r.PostFormValue("level")
@@ -76,7 +76,7 @@ func writingsAdminUserAccessAllowActionPage(w http.ResponseWriter, r *http.Reque
 }
 
 func writingsAdminUserAccessAddActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	wid, _ := strconv.Atoi(r.PostFormValue("wid"))
 	username := r.PostFormValue("username")
 	readdoc, _ := strconv.ParseBool(r.PostFormValue("readdoc"))
@@ -101,7 +101,7 @@ func writingsAdminUserAccessAddActionPage(w http.ResponseWriter, r *http.Request
 	common.TaskDoneAutoRefreshPage(w, r)
 }
 func writingsAdminUserAccessUpdateActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	uid, _ := strconv.Atoi(r.PostFormValue("uid"))
 	wid, _ := strconv.Atoi(r.PostFormValue("wid"))
 	readdoc, _ := strconv.ParseBool(r.PostFormValue("readdoc"))
@@ -121,7 +121,7 @@ func writingsAdminUserAccessUpdateActionPage(w http.ResponseWriter, r *http.Requ
 }
 
 func writingsAdminUserAccessRemoveActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	uid, _ := strconv.Atoi(r.PostFormValue("uid"))
 	wid, _ := strconv.Atoi(r.PostFormValue("wid"))
 

--- a/writingsAdminUserLevelsPage.go
+++ b/writingsAdminUserLevelsPage.go
@@ -18,10 +18,10 @@ func writingsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	rows, err := queries.GetUsersPermissions(r.Context())
 	if err != nil {
 		switch {
@@ -44,7 +44,7 @@ func writingsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func writingsAdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	username := r.PostFormValue("username")
 	where := "writing"
 	level := r.PostFormValue("level")
@@ -74,7 +74,7 @@ func writingsAdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Reque
 }
 
 func writingsAdminUserLevelsRemoveActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	permid := r.PostFormValue("permid")
 	permidi, err := strconv.Atoi(permid)
 	if err != nil {

--- a/writingsArticleAddPage.go
+++ b/writingsArticleAddPage.go
@@ -19,10 +19,10 @@ func writingsArticleAddPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	languageRows, err := queries.FetchLanguages(r.Context())
 	if err != nil {
@@ -54,7 +54,7 @@ func writingsArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 	body := r.PostFormValue("body")
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	articleId, err := queries.InsertWriting(r.Context(), InsertWritingParams{
 		WritingcategoryIdwritingcategory: int32(categoryId),

--- a/writingsArticleEditPage.go
+++ b/writingsArticleEditPage.go
@@ -21,9 +21,9 @@ func writingsArticleEditPage(w http.ResponseWriter, r *http.Request) {
 		UserId             int32
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
-		CoreData:           r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		SelectedLanguageId: int(resolveDefaultLanguageID(r.Context(), queries)),
 	}
 
@@ -37,7 +37,7 @@ func writingsArticleEditPage(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 	data.UserId = uid
 
-	queries = r.Context().Value(ContextValues("queries")).(*Queries)
+	queries = r.Context().Value(common.KeyQueries).(*Queries)
 
 	writing, err := queries.GetWritingByIdForUserDescendingByPublishedDate(r.Context(), GetWritingByIdForUserDescendingByPublishedDateParams{
 		Userid:    uid,
@@ -77,7 +77,7 @@ func writingsArticleEditActionPage(w http.ResponseWriter, r *http.Request) {
 	abstract := r.PostFormValue("abstract")
 	body := r.PostFormValue("body")
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	if err := queries.UpdateWriting(r.Context(), UpdateWritingParams{
 		Title:              sql.NullString{Valid: true, String: title},

--- a/writingsArticlePage.go
+++ b/writingsArticlePage.go
@@ -45,8 +45,8 @@ func writingsArticlePage(w http.ResponseWriter, r *http.Request) {
 		CategoryBreadcrumbs []*Writingcategory
 	}
 
-	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	data := Data{
 		CoreData:           cd,
 		CanReply:           cd.UserID != 0,
@@ -63,7 +63,7 @@ func writingsArticlePage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 	data.UserId = uid
-	queries = r.Context().Value(ContextValues("queries")).(*Queries)
+	queries = r.Context().Value(common.KeyQueries).(*Queries)
 
 	writing, err := queries.GetWritingByIdForUserDescendingByPublishedDate(r.Context(), GetWritingByIdForUserDescendingByPublishedDateParams{
 		Userid:    uid,
@@ -203,7 +203,7 @@ func writingsArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	uid, _ := session.Values["UID"].(int32)
 
 	post, err := queries.GetWritingByIdForUserDescendingByPublishedDate(r.Context(), GetWritingByIdForUserDescendingByPublishedDateParams{

--- a/writingsCategoriesPage.go
+++ b/writingsCategoriesPage.go
@@ -24,7 +24,7 @@ func writingsCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	data.IsAdmin = data.CoreData.HasRole("administrator")
@@ -33,7 +33,7 @@ func writingsCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	data.EditingCategoryId = int32(editID)
 	data.WritingcategoryIdwritingcategory = 0
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	categoryRows, err := queries.FetchAllCategories(r.Context())
 	if err != nil {

--- a/writingsCategoryPage.go
+++ b/writingsCategoryPage.go
@@ -27,7 +27,7 @@ func writingsCategoryPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	data.IsAdmin = data.CoreData.HasRole("administrator")
@@ -40,7 +40,7 @@ func writingsCategoryPage(w http.ResponseWriter, r *http.Request) {
 	data.CategoryId = int32(categoryId)
 	data.WritingcategoryIdwritingcategory = data.CategoryId
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	categoryRows, err := queries.FetchAllCategories(r.Context())
 	if err != nil {

--- a/writingsCategoryPermissionsPage.go
+++ b/writingsCategoryPermissionsPage.go
@@ -18,10 +18,10 @@ func writingsCategoryPermissionsPage(w http.ResponseWriter, r *http.Request) {
 		CategoryID int32
 		UserLevels []*PermissionWithUser
 	}
-	cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
 	vars := mux.Vars(r)
 	cid, _ := strconv.Atoi(vars["category"])
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	rows, err := queries.GetPermissionsBySectionWithUsers(r.Context(), fmt.Sprintf("writing:%d", cid))
 	if err != nil && err != sql.ErrNoRows {
 		log.Printf("getPermissions Error: %s", err)
@@ -38,7 +38,7 @@ func writingsCategoryPermissionsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func writingsCategoryPermissionsAllowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	cid, _ := strconv.Atoi(vars["category"])
 	username := r.PostFormValue("username")
@@ -62,7 +62,7 @@ func writingsCategoryPermissionsAllowPage(w http.ResponseWriter, r *http.Request
 }
 
 func writingsCategoryPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	permid, _ := strconv.Atoi(r.PostFormValue("permid"))
 	if err := queries.PermissionUserDisallow(r.Context(), int32(permid)); err != nil {
 		log.Printf("permissionUserDisallow Error: %s", err)

--- a/writingsFeed.go
+++ b/writingsFeed.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/arran4/goa4web/a4code2html"
+	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/feeds"
 	"log"
 	"net/http"
@@ -58,7 +59,7 @@ func writingsFeedGen(r *http.Request, queries *Queries) (*feeds.Feed, error) {
 }
 
 func writingsRssPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	feed, err := writingsFeedGen(r, queries)
 	if err != nil {
 		log.Printf("FeedGen Error: %s", err)
@@ -73,7 +74,7 @@ func writingsRssPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func writingsAtomPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	feed, err := writingsFeedGen(r, queries)
 	if err != nil {
 		log.Printf("FeedGen Error: %s", err)

--- a/writingsPage.go
+++ b/writingsPage.go
@@ -25,7 +25,7 @@ func writingsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
 	data.IsAdmin = data.CoreData.HasRole("administrator")
@@ -34,7 +34,7 @@ func writingsPage(w http.ResponseWriter, r *http.Request) {
 	data.CategoryId = 0
 	data.WritingcategoryIdwritingcategory = data.CategoryId
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	categoryRows, err := queries.GetAllWritingCategories(r.Context(), data.CategoryId)
 	if err != nil {

--- a/writingsUserPermissionsPage.go
+++ b/writingsUserPermissionsPage.go
@@ -19,10 +19,10 @@ func writingsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 
 	rows, err := queries.GetPermissionsByUserIdAndSectionWritings(r.Context())
 	if err != nil {
@@ -44,7 +44,7 @@ func writingsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func writingsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	username := r.PostFormValue("username")
 	where := "writing"
 	level := r.PostFormValue("level")
@@ -54,7 +54,7 @@ func writingsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *h
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/writings",
 	}
 	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
@@ -83,7 +83,7 @@ func writingsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *h
 }
 
 func writingsUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	permid := r.PostFormValue("permid")
 	data := struct {
 		*CoreData
@@ -91,7 +91,7 @@ func writingsUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 		Back:     "/writings",
 	}
 	if permidi, err := strconv.Atoi(permid); err != nil {

--- a/writingsWriterPage.go
+++ b/writingsWriterPage.go
@@ -24,7 +24,7 @@ func writingsWriterPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	username := vars["username"]
 
-	queries := r.Context().Value(ContextValues("queries")).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*Queries)
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		switch {
@@ -49,7 +49,7 @@ func writingsWriterPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData:  r.Context().Value(ContextValues("coreData")).(*CoreData),
+		CoreData:  r.Context().Value(common.KeyCoreData).(*CoreData),
 		Abstracts: rows,
 		Username:  username,
 		IsOffset:  offset != 0,


### PR DESCRIPTION
## Summary
- migrate handlers to use `common.ContextKey` instead of `ContextValues`
- remove `ContextValues` alias from core
- introduce typed context key constants
- update imports for common package
- run `go vet` and `go test`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b63581908832fb8d0348af21d29da