### PR TITLE
Organize user handlers

### DIFF
--- a/adminEmailTemplatePage.go
+++ b/adminEmailTemplatePage.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
+	userhandlers "github.com/arran4/goa4web/handlers/user"
 	"log"
 	"net/http"
 	"net/url"
@@ -67,7 +68,7 @@ func adminEmailTemplateSaveActionPage(w http.ResponseWriter, r *http.Request) {
 func adminEmailTemplateTestActionPage(w http.ResponseWriter, r *http.Request) {
 	provider := getEmailProvider()
 	if provider == nil {
-		q := url.QueryEscape(errMailNotConfigured)
+		q := url.QueryEscape(userhandlers.ErrMailNotConfigured)
 		http.Redirect(w, r, "/admin/email/template?error="+q, http.StatusTemporaryRedirect)
 		return
 	}

--- a/admin_test.go
+++ b/admin_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/handlers/common"
+	userhandlers "github.com/arran4/goa4web/handlers/user"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -30,7 +31,7 @@ func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 	if rr.Code != http.StatusTemporaryRedirect {
 		t.Fatalf("status=%d", rr.Code)
 	}
-	want := url.QueryEscape(errMailNotConfigured)
+	want := url.QueryEscape(userhandlers.ErrMailNotConfigured)
 	if loc := rr.Header().Get("Location"); !strings.Contains(loc, want) {
 		t.Fatalf("location=%q", loc)
 	}

--- a/handlers/user/email_util.go
+++ b/handlers/user/email_util.go
@@ -1,0 +1,26 @@
+package user
+
+import (
+	"context"
+	"strings"
+
+	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+func getEmailProvider() email.Provider {
+	switch strings.ToLower(runtimeconfig.AppRuntimeConfig.EmailProvider) {
+	case "log":
+		return email.LogProvider{}
+	default:
+		return nil
+	}
+}
+
+func notifyChange(ctx context.Context, provider email.Provider, to, page string) error {
+	if provider == nil {
+		return nil
+	}
+	subject := "Website Update Notification"
+	return provider.Send(ctx, to, subject, page)
+}

--- a/handlers/user/matchers.go
+++ b/handlers/user/matchers.go
@@ -1,0 +1,27 @@
+package user
+
+import (
+	"github.com/gorilla/mux"
+	"net/http"
+
+	"github.com/arran4/goa4web/core"
+)
+
+// RequiresAnAccount ensures the requester has a valid session.
+func RequiresAnAccount() mux.MatcherFunc {
+	return func(r *http.Request, m *mux.RouteMatch) bool {
+		session, err := core.GetSession(r)
+		if err != nil {
+			return false
+		}
+		uid, _ := session.Values["UID"].(int32)
+		return uid != 0
+	}
+}
+
+// TaskMatcher restricts requests to those specifying the provided task.
+func TaskMatcher(taskName string) mux.MatcherFunc {
+	return func(r *http.Request, m *mux.RouteMatch) bool {
+		return r.PostFormValue("task") == taskName
+	}
+}

--- a/handlers/user/notifications_feed.go
+++ b/handlers/user/notifications_feed.go
@@ -1,0 +1,37 @@
+package user
+
+import (
+	"net/http"
+	"time"
+
+	db "github.com/arran4/goa4web/internal/db"
+	"github.com/gorilla/feeds"
+)
+
+func notificationsFeed(r *http.Request, notifications []*db.Notification) *feeds.Feed {
+	feed := &feeds.Feed{
+		Title:       "Notifications",
+		Link:        &feeds.Link{Href: r.URL.Path},
+		Description: "recent notifications",
+		Created:     time.Now(),
+	}
+	for _, n := range notifications {
+		link := ""
+		if n.Link.Valid {
+			link = n.Link.String
+		}
+		msg := ""
+		if n.Message.Valid {
+			msg = n.Message.String
+		}
+		item := &feeds.Item{
+			Title:       msg,
+			Link:        &feeds.Link{Href: link},
+			Created:     time.Now(),
+			Description: msg,
+		}
+		item.Created = n.CreatedAt
+		feed.Items = append(feed.Items, item)
+	}
+	return feed
+}

--- a/handlers/user/routes.go
+++ b/handlers/user/routes.go
@@ -1,0 +1,33 @@
+package user
+
+import (
+	"github.com/gorilla/mux"
+	"net/http"
+
+	"github.com/arran4/goa4web/pkg/handlers"
+)
+
+// RegisterRoutes attaches user account endpoints to the router.
+func RegisterRoutes(r *mux.Router) {
+	ur := r.PathPrefix("/usr").Subrouter()
+	ur.HandleFunc("", userPage).Methods(http.MethodGet)
+	ur.HandleFunc("/logout", userLogoutPage).Methods(http.MethodGet)
+	ur.HandleFunc("/lang", userLangPage).Methods(http.MethodGet).MatcherFunc(RequiresAnAccount())
+	ur.HandleFunc("/lang", userLangSaveLanguagesActionPage).Methods(http.MethodPost).MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveLanguages))
+	ur.HandleFunc("/lang", userLangSaveLanguagePreferenceActionPage).Methods(http.MethodPost).MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveLanguage))
+	ur.HandleFunc("/lang", userLangSaveAllActionPage).Methods(http.MethodPost).MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveAll))
+	ur.HandleFunc("/email", userEmailPage).Methods(http.MethodGet).MatcherFunc(RequiresAnAccount())
+	ur.HandleFunc("/email", userEmailSaveActionPage).Methods(http.MethodPost).MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveAll))
+	ur.HandleFunc("/email", userEmailTestActionPage).Methods(http.MethodPost).MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskTestMail))
+	ur.HandleFunc("/paging", userPagingPage).Methods(http.MethodGet).MatcherFunc(RequiresAnAccount())
+	ur.HandleFunc("/paging", userPagingSaveActionPage).Methods(http.MethodPost).MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveAll))
+	ur.HandleFunc("/page-size", userPageSizePage).Methods(http.MethodGet).MatcherFunc(RequiresAnAccount())
+	ur.HandleFunc("/page-size", userPageSizeSaveActionPage).Methods(http.MethodPost).MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveAll))
+	ur.HandleFunc("/notifications", userNotificationsPage).Methods(http.MethodGet).MatcherFunc(RequiresAnAccount())
+	ur.HandleFunc("/notifications/dismiss", userNotificationsDismissActionPage).Methods(http.MethodPost).MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskDismiss))
+	ur.HandleFunc("/notifications/rss", notificationsRssPage).Methods(http.MethodGet).MatcherFunc(RequiresAnAccount())
+
+	// legacy redirects
+	r.HandleFunc("/user/lang", handlers.RedirectPermanent("/usr/lang"))
+	r.HandleFunc("/user/email", handlers.RedirectPermanent("/usr/email"))
+}

--- a/handlers/user/tasks.go
+++ b/handlers/user/tasks.go
@@ -1,0 +1,15 @@
+package user
+
+// Task constants mirror values used by the main package.
+const (
+	// TaskSaveLanguages saves multiple languages at once.
+	TaskSaveLanguages = "Save languages"
+	// TaskSaveLanguage saves updates to a single language.
+	TaskSaveLanguage = "Save language"
+	// TaskSaveAll saves all changes in bulk.
+	TaskSaveAll = "Save all"
+	// TaskTestMail sends a test email to the current user.
+	TaskTestMail = "Test mail"
+	// TaskDismiss marks a notification as read.
+	TaskDismiss = "Dismiss"
+)

--- a/handlers/user/user.go
+++ b/handlers/user/user.go
@@ -1,4 +1,4 @@
-package goa4web
+package user
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 func UserAdderMiddleware(next http.Handler) http.Handler {
@@ -23,12 +24,12 @@ func UserAdderMiddleware(next http.Handler) http.Handler {
 			core.SessionError(writer, request, err)
 		}
 
-		queries := request.Context().Value(common.KeyQueries).(*Queries)
+		queries := request.Context().Value(common.KeyQueries).(*db.Queries)
 		var (
-			user        *User
-			permissions []*Permission
-			preference  *Preference
-			languages   []*Userlang
+			user        *db.User
+			permissions []*db.Permission
+			preference  *db.Preference
+			languages   []*db.Userlang
 			uid         int32
 		)
 		if uidi, ok := session.Values["UID"]; ok {
@@ -74,7 +75,7 @@ func UserAdderMiddleware(next http.Handler) http.Handler {
 
 		if session.ID != "" {
 			if uid != 0 {
-				_ = queries.InsertSession(request.Context(), InsertSessionParams{SessionID: session.ID, UsersIdusers: uid})
+				_ = queries.InsertSession(request.Context(), db.InsertSessionParams{SessionID: session.ID, UsersIdusers: uid})
 			} else {
 				_ = queries.DeleteSessionByID(request.Context(), session.ID)
 			}

--- a/handlers/user/userLogoutPage.go
+++ b/handlers/user/userLogoutPage.go
@@ -1,4 +1,4 @@
-package goa4web
+package user
 
 import (
 	corecommon "github.com/arran4/goa4web/core/common"
@@ -8,16 +8,17 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 func userLogoutPage(w http.ResponseWriter, r *http.Request) {
 	log.Printf("logout request")
 	type Data struct {
-		*CoreData
+		*common.CoreData
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
 	}
 
 	session, err := core.GetSession(r)
@@ -27,7 +28,7 @@ func userLogoutPage(w http.ResponseWriter, r *http.Request) {
 	delete(session.Values, "UID")
 	delete(session.Values, "LoginTime")
 	delete(session.Values, "ExpiryTime")
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	if session.ID != "" {
 		_ = queries.DeleteSessionByID(r.Context(), session.ID)
 	}

--- a/handlers/user/userNotificationsPage.go
+++ b/handlers/user/userNotificationsPage.go
@@ -1,4 +1,4 @@
-package goa4web
+package user
 
 import (
 	corecommon "github.com/arran4/goa4web/core/common"
@@ -9,6 +9,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
@@ -21,7 +22,7 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	notifs, err := queries.GetUnreadNotifications(r.Context(), uid)
 	if err != nil {
 		log.Printf("get notifications: %v", err)
@@ -29,10 +30,10 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data := struct {
-		*CoreData
-		Notifications []*Notification
+		*common.CoreData
+		Notifications []*db.Notification
 	}{
-		CoreData:      r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData:      r.Context().Value(common.KeyCoreData).(*common.CoreData),
 		Notifications: notifs,
 	}
 	if err := templates.RenderTemplate(w, "notifications.gohtml", data, corecommon.NewFuncs(r)); err != nil {
@@ -57,7 +58,7 @@ func userNotificationsDismissActionPage(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	id, _ := strconv.Atoi(r.FormValue("id"))
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	n, err := queries.GetUnreadNotifications(r.Context(), uid)
 	if err == nil {
 		for _, no := range n {
@@ -80,7 +81,7 @@ func notificationsRssPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	notifs, err := queries.GetUnreadNotifications(r.Context(), uid)
 	if err != nil {
 		log.Printf("notify feed: %v", err)

--- a/handlers/user/userPage.go
+++ b/handlers/user/userPage.go
@@ -1,4 +1,4 @@
-package goa4web
+package user
 
 import (
 	corecommon "github.com/arran4/goa4web/core/common"
@@ -12,11 +12,11 @@ import (
 
 func userPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*CoreData
+		*common.CoreData
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
 	}
 
 	if data.CoreData.UserID == 0 {

--- a/handlers/user/userPageSizePage.go
+++ b/handlers/user/userPageSizePage.go
@@ -1,4 +1,4 @@
-package goa4web
+package user
 
 import (
 	corecommon "github.com/arran4/goa4web/core/common"
@@ -23,12 +23,12 @@ func userPageSizePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data := struct {
-		*CoreData
+		*common.CoreData
 		Min     int
 		Max     int
 		Default int
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
 		Min:      runtimeconfig.AppRuntimeConfig.PageSizeMin,
 		Max:      runtimeconfig.AppRuntimeConfig.PageSizeMax,
 		Default:  runtimeconfig.AppRuntimeConfig.PageSizeDefault,

--- a/handlers/user/userPagingPage.go
+++ b/handlers/user/userPagingPage.go
@@ -1,4 +1,4 @@
-package goa4web
+package user
 
 import (
 	"database/sql"
@@ -11,23 +11,24 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
+	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func userPagingPage(w http.ResponseWriter, r *http.Request) {
-	pref, _ := r.Context().Value(common.KeyPreference).(*Preference)
+	pref, _ := r.Context().Value(common.KeyPreference).(*db.Preference)
 	size := runtimeconfig.AppRuntimeConfig.PageSizeDefault
 	if pref != nil {
 		size = int(pref.PageSize)
 	}
 	data := struct {
-		*CoreData
+		*common.CoreData
 		Size int
 		Min  int
 		Max  int
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
 		Size:     size,
 		Min:      runtimeconfig.AppRuntimeConfig.PageSizeMin,
 		Max:      runtimeconfig.AppRuntimeConfig.PageSizeMax,
@@ -56,11 +57,11 @@ func userPagingSaveActionPage(w http.ResponseWriter, r *http.Request) {
 	if size > runtimeconfig.AppRuntimeConfig.PageSizeMax {
 		size = runtimeconfig.AppRuntimeConfig.PageSizeMax
 	}
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	pref, err := queries.GetPreferenceByUserID(r.Context(), uid)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			err = queries.InsertPreference(r.Context(), InsertPreferenceParams{
+			err = queries.InsertPreference(r.Context(), db.InsertPreferenceParams{
 				LanguageIdlanguage: 0,
 				UsersIdusers:       uid,
 				PageSize:           int32(size),
@@ -68,7 +69,7 @@ func userPagingSaveActionPage(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		pref.PageSize = int32(size)
-		err = queries.UpdatePreference(r.Context(), UpdatePreferenceParams{
+		err = queries.UpdatePreference(r.Context(), db.UpdatePreferenceParams{
 			LanguageIdlanguage: pref.LanguageIdlanguage,
 			UsersIdusers:       uid,
 			PageSize:           pref.PageSize,

--- a/routes.go
+++ b/routes.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arran4/goa4web/handlers/common"
 	faq "github.com/arran4/goa4web/sections/faq"
 
+	userhandlers "github.com/arran4/goa4web/handlers/user"
 	"github.com/arran4/goa4web/pkg/handlers"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
@@ -25,7 +26,7 @@ func registerRoutes(r *mux.Router) {
 	registerSearchRoutes(r)
 	registerWritingsRoutes(r)
 	registerInformationRoutes(r)
-	registerUserRoutes(r)
+	userhandlers.RegisterRoutes(r)
 	registerRegisterRoutes(r)
 	registerLoginRoutes(r)
 	registerAdminRoutes(r)
@@ -195,30 +196,6 @@ func registerWritingsRoutes(r *mux.Router) {
 func registerInformationRoutes(r *mux.Router) {
 	ir := r.PathPrefix("/information").Subrouter()
 	ir.HandleFunc("", informationPage).Methods("GET")
-}
-
-func registerUserRoutes(r *mux.Router) {
-	ur := r.PathPrefix("/usr").Subrouter()
-	ur.HandleFunc("", userPage).Methods("GET")
-	ur.HandleFunc("/logout", userLogoutPage).Methods("GET")
-	ur.HandleFunc("/lang", userLangPage).Methods("GET").MatcherFunc(RequiresAnAccount())
-	ur.HandleFunc("/lang", userLangSaveLanguagesActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveLanguages))
-	ur.HandleFunc("/lang", userLangSaveLanguagePreferenceActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveLanguage))
-	ur.HandleFunc("/lang", userLangSaveAllActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveAll))
-	ur.HandleFunc("/email", userEmailPage).Methods("GET").MatcherFunc(RequiresAnAccount())
-	ur.HandleFunc("/email", userEmailSaveActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveAll))
-	ur.HandleFunc("/email", userEmailTestActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskTestMail))
-	ur.HandleFunc("/paging", userPagingPage).Methods("GET").MatcherFunc(RequiresAnAccount())
-	ur.HandleFunc("/paging", userPagingSaveActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveAll))
-	ur.HandleFunc("/page-size", userPageSizePage).Methods("GET").MatcherFunc(RequiresAnAccount())
-	ur.HandleFunc("/page-size", userPageSizeSaveActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskSaveAll))
-	ur.HandleFunc("/notifications", userNotificationsPage).Methods("GET").MatcherFunc(RequiresAnAccount())
-	ur.HandleFunc("/notifications/dismiss", userNotificationsDismissActionPage).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher(TaskDismiss))
-	ur.HandleFunc("/notifications/rss", notificationsRssPage).Methods("GET").MatcherFunc(RequiresAnAccount())
-
-	// legacy redirects
-	r.HandleFunc("/user/lang", handlers.RedirectPermanent("/usr/lang"))
-	r.HandleFunc("/user/email", handlers.RedirectPermanent("/usr/email"))
 }
 
 func registerRegisterRoutes(r *mux.Router) {

--- a/run.go
+++ b/run.go
@@ -8,6 +8,7 @@ import (
 	common "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	hcommon "github.com/arran4/goa4web/handlers/common"
+	userhandlers "github.com/arran4/goa4web/handlers/user"
 	"log"
 	"net/http"
 	"os"
@@ -81,7 +82,7 @@ func RunWithConfig(ctx context.Context, cfg runtimeconfig.RuntimeConfig, session
 
 	handler = newMiddlewareChain(
 		DBAdderMiddleware,
-		UserAdderMiddleware,
+		userhandlers.UserAdderMiddleware,
 		CoreAdderMiddleware,
 		RequestLoggerMiddleware,
 		SecurityHeadersMiddleware,


### PR DESCRIPTION
## Summary
- move user handler code to new `handlers/user` package
- introduce helper matchers, tasks, and email utils
- expose RegisterRoutes for user-related routes
- update routes and middleware usage
- relocate and adjust tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685bac8e6074832fa4bc6e673334f488