### PR TITLE
Inject environment functions for config tests

### DIFF
--- a/adminReloadConfigPage.go
+++ b/adminReloadConfigPage.go
@@ -6,6 +6,7 @@ import (
 	common "github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/runtimeconfig"
@@ -23,7 +24,7 @@ func adminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cfgMap := LoadAppConfigFile(ConfigFile)
-	srv.Config = runtimeconfig.GenerateRuntimeConfig(nil, cfgMap)
+	srv.Config = runtimeconfig.GenerateRuntimeConfig(nil, cfgMap, os.Getenv)
 	if err := corelanguage.ValidateDefaultLanguage(r.Context(), New(dbPool), srv.Config.DefaultLanguage); err != nil {
 		data.Errors = append(data.Errors, err.Error())
 	}

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -49,7 +49,7 @@ func main() {
 		log.Fatalf("session secret: %v", err)
 	}
 
-	cfg := runtimeconfig.GenerateRuntimeConfig(fs, fileVals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, fileVals, os.Getenv)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/language_config_test.go
+++ b/language_config_test.go
@@ -2,7 +2,6 @@ package goa4web
 
 import (
 	"flag"
-	"os"
 	"testing"
 
 	"github.com/arran4/goa4web/config"
@@ -10,15 +9,14 @@ import (
 )
 
 func TestDefaultLanguageConfigPrecedence(t *testing.T) {
-	os.Setenv(config.EnvDefaultLanguage, "env")
-	defer os.Unsetenv(config.EnvDefaultLanguage)
+	env := map[string]string{config.EnvDefaultLanguage: "env"}
 
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	fs.String("default-language", "cli", "")
 	vals := map[string]string{config.EnvDefaultLanguage: "file"}
 	_ = fs.Parse([]string{"--default-language=cli"})
 
-	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals, func(k string) string { return env[k] })
 	if cfg.DefaultLanguage != "cli" {
 		t.Fatalf("merged %#v", cfg.DefaultLanguage)
 	}
@@ -27,7 +25,7 @@ func TestDefaultLanguageConfigPrecedence(t *testing.T) {
 func TestLoadDefaultLanguageFromFileValues(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	vals := map[string]string{config.EnvDefaultLanguage: "fileval"}
-	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals, func(string) string { return "" })
 	if cfg.DefaultLanguage != "fileval" {
 		t.Fatalf("want fileval got %q", cfg.DefaultLanguage)
 	}

--- a/pagination_config_test.go
+++ b/pagination_config_test.go
@@ -2,7 +2,6 @@ package goa4web
 
 import (
 	"flag"
-	"os"
 	"testing"
 
 	"github.com/arran4/goa4web/config"
@@ -10,12 +9,11 @@ import (
 )
 
 func TestPaginationConfigPrecedence(t *testing.T) {
-	os.Setenv(config.EnvPageSizeMin, "5")
-	os.Setenv(config.EnvPageSizeMax, "30")
-	os.Setenv(config.EnvPageSizeDefault, "25")
-	defer os.Unsetenv(config.EnvPageSizeMin)
-	defer os.Unsetenv(config.EnvPageSizeMax)
-	defer os.Unsetenv(config.EnvPageSizeDefault)
+	env := map[string]string{
+		config.EnvPageSizeMin:     "5",
+		config.EnvPageSizeMax:     "30",
+		config.EnvPageSizeDefault: "25",
+	}
 
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	fs.Int("page-size-min", 12, "")
@@ -26,7 +24,7 @@ func TestPaginationConfigPrecedence(t *testing.T) {
 		config.EnvPageSizeDefault: "18",
 	}
 	_ = fs.Parse([]string{"--page-size-min=12", "--page-size-default=15"})
-	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals, func(k string) string { return env[k] })
 	if cfg.PageSizeMin != 12 || cfg.PageSizeMax != 20 || cfg.PageSizeDefault != 15 {
 		t.Fatalf("merged %#v", cfg)
 	}
@@ -38,7 +36,7 @@ func TestLoadPaginationConfigFromFileValues(t *testing.T) {
 		config.EnvPageSizeMin:     "7",
 		config.EnvPageSizeDefault: "9",
 	}
-	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals)
+	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals, func(string) string { return "" })
 	if cfg.PageSizeMin != 7 || cfg.PageSizeDefault != 9 {
 		t.Fatalf("want 7/9 got %#v", cfg)
 	}

--- a/runtimeconfig/config.go
+++ b/runtimeconfig/config.go
@@ -97,7 +97,14 @@ func NewRuntimeFlagSet(name string) *flag.FlagSet {
 // GenerateRuntimeConfig builds the runtime configuration from a FlagSet,
 // optional config file values and environment variables following the
 // precedence rules from AGENTS.md.
-func GenerateRuntimeConfig(fs *flag.FlagSet, fileVals map[string]string) RuntimeConfig {
+// GenerateRuntimeConfig builds the runtime configuration from a FlagSet,
+// optional config file values and environment variables following the
+// precedence rules from AGENTS.md. The getenv function is used to
+// retrieve environment values and defaults to os.Getenv when nil.
+func GenerateRuntimeConfig(fs *flag.FlagSet, fileVals map[string]string, getenv func(string) string) RuntimeConfig {
+	if getenv == nil {
+		getenv = os.Getenv
+	}
 	setFlags := map[string]bool{}
 	if fs != nil {
 		fs.Visit(func(f *flag.Flag) { setFlags[f.Name] = true })
@@ -143,7 +150,7 @@ func GenerateRuntimeConfig(fs *flag.FlagSet, fileVals map[string]string) Runtime
 			*o.dst = v
 			continue
 		}
-		if v := os.Getenv(o.env); v != "" {
+		if v := getenv(o.env); v != "" {
 			*o.dst = v
 		}
 	}
@@ -167,7 +174,7 @@ func GenerateRuntimeConfig(fs *flag.FlagSet, fileVals map[string]string) Runtime
 			}
 		} else if v := fileVals[o.env]; v != "" {
 			val = v
-		} else if v := os.Getenv(o.env); v != "" {
+		} else if v := getenv(o.env); v != "" {
 			val = v
 		}
 		if val != "" {
@@ -188,12 +195,12 @@ func GenerateRuntimeConfig(fs *flag.FlagSet, fileVals map[string]string) Runtime
 	cfg.FeedsEnabled = resolveFeedsEnabled(
 		cliFeeds,
 		fileVals[config.EnvFeedsEnabled],
-		os.Getenv(config.EnvFeedsEnabled),
+		getenv(config.EnvFeedsEnabled),
 	)
 	cfg.StatsStartYear = resolveStatsStartYear(
 		cliStats,
 		fileVals[config.EnvStatsStartYear],
-		os.Getenv(config.EnvStatsStartYear),
+		getenv(config.EnvStatsStartYear),
 	)
 
 	normalizeRuntimeConfig(&cfg)


### PR DESCRIPTION
## Summary
- allow GenerateRuntimeConfig to take a getenv function for tests
- update runtime configuration call sites
- rewrite config tests to inject env values instead of modifying process env

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685bf05e4250832fbafc4ab9e3bcc471