### PR TITLE
Organize search handlers into new package

### DIFF
--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -5,7 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/arran4/goa4web/core"
-	"github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	search "github.com/arran4/goa4web/handlers/search"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -31,7 +32,7 @@ func BlogReplyPostPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*Queries)
 
 	blog, err := queries.GetBlogEntryForUserById(r.Context(), int32(bid))
 	if err != nil {
@@ -145,12 +146,12 @@ func BlogReplyPostPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := common.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if common.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if search.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -6,7 +6,8 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	blogs "github.com/arran4/goa4web/handlers/blogs"
-	common "github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	search "github.com/arran4/goa4web/handlers/search"
 	"log"
 	"net/http"
 	"strconv"
@@ -23,9 +24,9 @@ func ThreadNewPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*Queries)
 	data := Data{
-		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData:           r.Context().Value(hcommon.KeyCoreData).(*CoreData),
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries)),
 	}
 
@@ -46,7 +47,7 @@ func ThreadNewPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func ThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*Queries)
 	vars := mux.Vars(r)
 	topicId, err := strconv.Atoi(vars["topic"])
 	session, ok := core.GetSessionOrFail(w, r)
@@ -92,12 +93,12 @@ func ThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := common.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if common.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if search.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -4,7 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/arran4/goa4web/core"
-	"github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	search "github.com/arran4/goa4web/handlers/search"
 	"log"
 	"net/http"
 	"strconv"
@@ -16,10 +17,10 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	threadRow := r.Context().Value(common.KeyThread).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
-	topicRow := r.Context().Value(common.KeyTopic).(*GetForumTopicByIdForUserRow)
+	threadRow := r.Context().Value(hcommon.KeyThread).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
+	topicRow := r.Context().Value(hcommon.KeyTopic).(*GetForumTopicByIdForUserRow)
 
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*Queries)
 
 	text := r.PostFormValue("replytext")
 	languageId, _ := strconv.Atoi(r.PostFormValue("language"))
@@ -77,12 +78,12 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := common.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if common.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if search.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 
@@ -92,8 +93,8 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func TopicThreadReplyCancelPage(w http.ResponseWriter, r *http.Request) {
-	threadRow := r.Context().Value(common.KeyThread).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
-	topicRow := r.Context().Value(common.KeyTopic).(*GetForumTopicByIdForUserRow)
+	threadRow := r.Context().Value(hcommon.KeyThread).(*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
+	topicRow := r.Context().Value(hcommon.KeyTopic).(*GetForumTopicByIdForUserRow)
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
 

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -6,7 +6,8 @@ import (
 	"errors"
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	search "github.com/arran4/goa4web/handlers/search"
 	db "github.com/arran4/goa4web/internal/db"
 	"io"
 	"log"
@@ -27,7 +28,7 @@ import (
 
 func BoardPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*common.CoreData
+		*hcommon.CoreData
 		Boards      []*db.Imageboard
 		IsSubBoard  bool
 		BoardNumber int
@@ -38,12 +39,12 @@ func BoardPage(w http.ResponseWriter, r *http.Request) {
 	bid, _ := strconv.Atoi(vars["boardno"])
 
 	data := Data{
-		CoreData:    r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData:    r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 		IsSubBoard:  bid != 0,
 		BoardNumber: bid,
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 
 	subBoardRows, err := queries.GetAllBoardsByParentBoardId(r.Context(), int32(bid))
 	if err != nil {
@@ -92,7 +93,7 @@ func BoardPostImageActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 
 	board, err := queries.GetImageBoardById(r.Context(), int32(bid))
 	if err != nil {
@@ -198,14 +199,14 @@ func BoardPostImageActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := common.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if common.InsertWordsToImageSearch(w, r, wordIds, queries, pid) {
+	if search.InsertWordsToImageSearch(w, r, wordIds, queries, pid) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	hcommon.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -5,7 +5,8 @@ import (
 	"errors"
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	search "github.com/arran4/goa4web/handlers/search"
 	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
@@ -28,7 +29,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 		EditSaveUrl        string
 	}
 	type Data struct {
-		*common.CoreData
+		*hcommon.CoreData
 		Replyable          bool
 		Languages          []*db.Language
 		SelectedLanguageId int
@@ -50,9 +51,9 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	data := Data{
-		CoreData:      r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData:      r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 		Replyable:     true,
 		BoardId:       bid,
 		ForumThreadId: thid,
@@ -159,7 +160,7 @@ func BoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 
 	post, err := queries.GetAllImagePostsByIdWithAuthorUsernameAndThreadCommentCount(r.Context(), int32(bid))
 	if err != nil {
@@ -252,18 +253,18 @@ func BoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := common.PostUpdate(r.Context(), queries, pthid, ptid); err != nil {
+	if err := hcommon.PostUpdate(r.Context(), queries, pthid, ptid); err != nil {
 		log.Printf("Error: postUpdate: %s", err)
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
 
-	wordIds, done := common.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if common.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if search.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
-	"github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	search "github.com/arran4/goa4web/handlers/search"
 	"log"
 	"net/http"
 	"strconv"
@@ -43,8 +44,8 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-	cd := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	cd := r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)
+	queries := r.Context().Value(hcommon.KeyQueries).(*Queries)
 	data := Data{
 		CoreData:           cd,
 		CanReply:           cd.UserID != 0,
@@ -61,7 +62,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 	data.UserId = uid
 
-	queries = r.Context().Value(common.KeyQueries).(*Queries)
+	queries = r.Context().Value(hcommon.KeyQueries).(*Queries)
 
 	languageRows, err := queries.FetchLanguages(r.Context())
 	if err != nil {
@@ -165,7 +166,7 @@ func CommentsReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*Queries)
 
 	link, err := queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(r.Context(), int32(linkId))
 	if err != nil {
@@ -279,12 +280,12 @@ func CommentsReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := common.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if common.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if search.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
-	"github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	search "github.com/arran4/goa4web/handlers/search"
 	"log"
 	"net/http"
 	"strconv"
@@ -25,8 +26,8 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int
 	}
 
-	cd := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	cd := r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)
+	queries := r.Context().Value(hcommon.KeyQueries).(*Queries)
 	data := Data{
 		CoreData:           cd,
 		CanReply:           cd.UserID != 0,
@@ -78,7 +79,7 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*Queries)
 
 	link, err := queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(r.Context(), int32(linkId))
 	if err != nil {
@@ -192,12 +193,12 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := common.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if common.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if search.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/news/searchResultNewsActionPage.go
+++ b/handlers/news/searchResultNewsActionPage.go
@@ -10,6 +10,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
 	hcommon "github.com/arran4/goa4web/handlers/common"
+	search "github.com/arran4/goa4web/handlers/search"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -65,7 +66,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func NewsSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetNewsPostsByIdsWithWriterIdAndThreadCommentCountRow, bool, bool, error) {
-	searchWords := hcommon.BreakupTextToWords(r.PostFormValue("searchwords"))
+	searchWords := search.BreakupTextToWords(r.PostFormValue("searchwords"))
 	var newsIds []int32
 
 	if len(searchWords) == 0 {

--- a/handlers/search/consts.go
+++ b/handlers/search/consts.go
@@ -1,0 +1,10 @@
+package search
+
+// BloggerTopicName is the default name for the hidden blogger forum.
+const BloggerTopicName = "A BLOGGER TOPIC"
+
+// LinkerTopicName is the default name for the hidden linker forum.
+const LinkerTopicName = "A LINKER TOPIC"
+
+// WritingTopicName is the default name for the hidden writing forum.
+const WritingTopicName = "A WRITING TOPIC"

--- a/handlers/search/search.go
+++ b/handlers/search/search.go
@@ -1,4 +1,4 @@
-package common
+package search
 
 import (
 	"database/sql"

--- a/handlers/search/searchPage.go
+++ b/handlers/search/searchPage.go
@@ -1,22 +1,22 @@
-package goa4web
+package search
 
 import (
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
 )
 
-func searchPage(w http.ResponseWriter, r *http.Request) {
+func Page(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*CoreData
+		*hcommon.CoreData
 		SearchWords string
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 	}
 
 	if err := templates.RenderTemplate(w, "searchPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {

--- a/handlers/search/searchResultBlogsActionPage.go
+++ b/handlers/search/searchResultBlogsActionPage.go
@@ -1,9 +1,10 @@
-package goa4web
+package search
 
 import (
 	"database/sql"
 	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 
@@ -11,11 +12,11 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 )
 
-func searchResultBlogsActionPage(w http.ResponseWriter, r *http.Request) {
+func SearchResultBlogsActionPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*CoreData
-		Comments           []*GetCommentsByIdsForUserWithThreadInfoRow
-		Blogs              []*Blog
+		*hcommon.CoreData
+		Comments           []*db.GetCommentsByIdsForUserWithThreadInfoRow
+		Blogs              []*db.Blog
 		CommentsNoResults  bool
 		CommentsEmptyWords bool
 		NoResults          bool
@@ -23,9 +24,9 @@ func searchResultBlogsActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 	}
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -62,8 +63,8 @@ func searchResultBlogsActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func BlogSearch(w http.ResponseWriter, r *http.Request, queries *Queries, uid int32) ([]*Blog, bool, bool, error) {
-	searchWords := common.BreakupTextToWords(r.PostFormValue("searchwords"))
+func BlogSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.Blog, bool, bool, error) {
+	searchWords := BreakupTextToWords(r.PostFormValue("searchwords"))
 	var blogIds []int32
 
 	if len(searchWords) == 0 {
@@ -83,7 +84,7 @@ func BlogSearch(w http.ResponseWriter, r *http.Request, queries *Queries, uid in
 			}
 			blogIds = ids
 		} else {
-			ids, err := queries.BlogsSearchNext(r.Context(), BlogsSearchNextParams{
+			ids, err := queries.BlogsSearchNext(r.Context(), db.BlogsSearchNextParams{
 				Word: sql.NullString{
 					String: word,
 					Valid:  true,

--- a/handlers/search/searchResultLinkerActionPage.go
+++ b/handlers/search/searchResultLinkerActionPage.go
@@ -1,10 +1,11 @@
-package goa4web
+package search
 
 import (
 	"database/sql"
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 
@@ -12,11 +13,11 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 )
 
-func searchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
+func SearchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*CoreData
-		Comments                         []*GetCommentsByIdsForUserWithThreadInfoRow
-		Links                            []*GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow
+		*hcommon.CoreData
+		Comments                         []*db.GetCommentsByIdsForUserWithThreadInfoRow
+		Links                            []*db.GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow
 		CommentsNoResults                bool
 		CommentsEmptyWords               bool
 		NoResults                        bool
@@ -25,9 +26,9 @@ func searchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 	}
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -64,8 +65,8 @@ func searchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func LinkerSearch(w http.ResponseWriter, r *http.Request, queries *Queries, uid int32) ([]*GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow, bool, bool, error) {
-	searchWords := common.BreakupTextToWords(r.PostFormValue("searchwords"))
+func LinkerSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow, bool, bool, error) {
+	searchWords := BreakupTextToWords(r.PostFormValue("searchwords"))
 	var LinkerIds []int32
 
 	if len(searchWords) == 0 {
@@ -89,7 +90,7 @@ func LinkerSearch(w http.ResponseWriter, r *http.Request, queries *Queries, uid 
 			}
 			LinkerIds = ids
 		} else {
-			ids, err := queries.LinkerSearchNext(r.Context(), LinkerSearchNextParams{
+			ids, err := queries.LinkerSearchNext(r.Context(), db.LinkerSearchNextParams{
 				Word: sql.NullString{
 					String: word,
 					Valid:  true,

--- a/handlers/search/search_test.go
+++ b/handlers/search/search_test.go
@@ -1,4 +1,4 @@
-package common
+package search
 
 import (
 	"context"

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -3,7 +3,8 @@ package writings
 import (
 	"database/sql"
 	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	search "github.com/arran4/goa4web/handlers/search"
 	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
@@ -21,10 +22,10 @@ func ArticleAddPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 
 	languageRows, err := queries.FetchLanguages(r.Context())
 	if err != nil {
@@ -56,7 +57,7 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 	body := r.PostFormValue("body")
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 
 	articleId, err := queries.InsertWriting(r.Context(), db.InsertWritingParams{
 		WritingcategoryIdwritingcategory: int32(categoryId),
@@ -78,12 +79,12 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 		title,
 		body,
 	} {
-		wordIds, done := common.SearchWordIdsFromText(w, r, text, queries)
+		wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
 		if done {
 			return
 		}
 
-		if common.InsertWordsToWritingSearch(w, r, wordIds, queries, articleId) {
+		if search.InsertWordsToWritingSearch(w, r, wordIds, queries, articleId) {
 			return
 		}
 	}

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -4,7 +4,8 @@ import (
 	"database/sql"
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
-	"github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	search "github.com/arran4/goa4web/handlers/search"
 	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
@@ -24,9 +25,9 @@ func ArticleEditPage(w http.ResponseWriter, r *http.Request) {
 		UserId             int32
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	data := Data{
-		CoreData:           r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData:           r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData),
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries)),
 	}
 
@@ -40,7 +41,7 @@ func ArticleEditPage(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 	data.UserId = uid
 
-	queries = r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries = r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 
 	writing, err := queries.GetWritingByIdForUserDescendingByPublishedDate(r.Context(), db.GetWritingByIdForUserDescendingByPublishedDateParams{
 		Userid:    uid,
@@ -80,7 +81,7 @@ func ArticleEditActionPage(w http.ResponseWriter, r *http.Request) {
 	abstract := r.PostFormValue("abstract")
 	body := r.PostFormValue("body")
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 
 	if err := queries.UpdateWriting(r.Context(), db.UpdateWritingParams{
 		Title:              sql.NullString{Valid: true, String: title},
@@ -106,12 +107,12 @@ func ArticleEditActionPage(w http.ResponseWriter, r *http.Request) {
 		title,
 		body,
 	} {
-		wordIds, done := common.SearchWordIdsFromText(w, r, text, queries)
+		wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
 		if done {
 			return
 		}
 
-		if common.InsertWordsToWritingSearch(w, r, wordIds, queries, int64(articleId)) {
+		if search.InsertWordsToWritingSearch(w, r, wordIds, queries, int64(articleId)) {
 			return
 		}
 	}

--- a/routes.go
+++ b/routes.go
@@ -13,6 +13,7 @@ import (
 	imagebbs "github.com/arran4/goa4web/handlers/imagebbs"
 	linker "github.com/arran4/goa4web/handlers/linker"
 	news "github.com/arran4/goa4web/handlers/news"
+	search "github.com/arran4/goa4web/handlers/search"
 	writings "github.com/arran4/goa4web/handlers/writings"
 
 	userhandlers "github.com/arran4/goa4web/handlers/user"
@@ -169,12 +170,12 @@ func registerImagebbsRoutes(r *mux.Router) {
 
 func registerSearchRoutes(r *mux.Router) {
 	sr := r.PathPrefix("/search").Subrouter()
-	sr.HandleFunc("", searchPage).Methods("GET")
-	sr.HandleFunc("", searchResultForumActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchForum))
+	sr.HandleFunc("", search.Page).Methods("GET")
+	sr.HandleFunc("", search.SearchResultForumActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchForum))
 	sr.HandleFunc("", news.SearchResultNewsActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchNews))
-	sr.HandleFunc("", searchResultLinkerActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchLinker))
-	sr.HandleFunc("", searchResultBlogsActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchBlogs))
-	sr.HandleFunc("", searchResultWritingsActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchWritings))
+	sr.HandleFunc("", search.SearchResultLinkerActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchLinker))
+	sr.HandleFunc("", search.SearchResultBlogsActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchBlogs))
+	sr.HandleFunc("", search.SearchResultWritingsActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchWritings))
 }
 
 func registerWritingsRoutes(r *mux.Router) {


### PR DESCRIPTION
## Summary
- move search handler files into `handlers/search`
- expose search helpers via new `search` package
- update routes and imports to use new handlers
- add constants for hidden topic names

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685befe98cb0832fa4f0b3bd79f31593