### PR TITLE
Relocate runtime config tests

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -173,11 +173,11 @@ func registerImagebbsRoutes(r *mux.Router) {
 func registerSearchRoutes(r *mux.Router) {
 	sr := r.PathPrefix("/search").Subrouter()
 	sr.HandleFunc("", search.Page).Methods("GET")
-	sr.HandleFunc("", search.SearchResultForumActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchForum))
-	sr.HandleFunc("", news.SearchResultNewsActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchNews))
-	sr.HandleFunc("", search.SearchResultLinkerActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchLinker))
-	sr.HandleFunc("", search.SearchResultBlogsActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchBlogs))
-	sr.HandleFunc("", search.SearchResultWritingsActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchWritings))
+	sr.HandleFunc("", search.SearchResultForumActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskSearchForum))
+	sr.HandleFunc("", news.SearchResultNewsActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskSearchNews))
+	sr.HandleFunc("", search.SearchResultLinkerActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskSearchLinker))
+	sr.HandleFunc("", search.SearchResultBlogsActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskSearchBlogs))
+	sr.HandleFunc("", search.SearchResultWritingsActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskSearchWritings))
 }
 
 func registerWritingsRoutes(r *mux.Router) {

--- a/runtimeconfig/db_config_test.go
+++ b/runtimeconfig/db_config_test.go
@@ -1,11 +1,10 @@
-package goa4web
+package runtimeconfig
 
 import (
 	"flag"
 	"testing"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestDBConfigPrecedence(t *testing.T) {
@@ -21,7 +20,7 @@ func TestDBConfigPrecedence(t *testing.T) {
 		config.EnvDBPort: "1",
 	}
 	_ = fs.Parse([]string{"--db-pass=cli"})
-	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals, func(k string) string { return env[k] })
+	cfg := GenerateRuntimeConfig(fs, vals, func(k string) string { return env[k] })
 	if cfg.DBUser != "file" || cfg.DBPass != "cli" || cfg.DBHost != "env" || cfg.DBPort != "1" {
 		t.Fatalf("merged %#v", cfg)
 	}
@@ -32,7 +31,7 @@ func TestLoadDBConfigFromFileValues(t *testing.T) {
 	vals := map[string]string{
 		config.EnvDBUser: "fileval",
 	}
-	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals, func(string) string { return "" })
+	cfg := GenerateRuntimeConfig(fs, vals, func(string) string { return "" })
 	if cfg.DBUser != "fileval" {
 		t.Fatalf("want fileval got %q", cfg.DBUser)
 	}

--- a/runtimeconfig/http_config_test.go
+++ b/runtimeconfig/http_config_test.go
@@ -1,11 +1,10 @@
-package goa4web
+package runtimeconfig
 
 import (
 	"flag"
 	"testing"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestHTTPConfigPrecedence(t *testing.T) {
@@ -22,7 +21,7 @@ func TestHTTPConfigPrecedence(t *testing.T) {
 		config.EnvHostname: "http://file",
 	}
 	_ = fs.Parse([]string{"--listen=:3", "--hostname=http://cli"})
-	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals, func(k string) string { return env[k] })
+	cfg := GenerateRuntimeConfig(fs, vals, func(k string) string { return env[k] })
 
 	if cfg.HTTPListen != ":3" || cfg.HTTPHostname != "http://cli" {
 		t.Fatalf("merged %#v", cfg)
@@ -34,7 +33,7 @@ func TestLoadHTTPConfigFromFileValues(t *testing.T) {
 	vals := map[string]string{
 		config.EnvListen: ":9",
 	}
-	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals, func(string) string { return "" })
+	cfg := GenerateRuntimeConfig(fs, vals, func(string) string { return "" })
 	if cfg.HTTPListen != ":9" {
 		t.Fatalf("want :9 got %q", cfg.HTTPListen)
 	}

--- a/runtimeconfig/language_config_test.go
+++ b/runtimeconfig/language_config_test.go
@@ -1,11 +1,10 @@
-package goa4web
+package runtimeconfig
 
 import (
 	"flag"
 	"testing"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestDefaultLanguageConfigPrecedence(t *testing.T) {
@@ -16,7 +15,7 @@ func TestDefaultLanguageConfigPrecedence(t *testing.T) {
 	vals := map[string]string{config.EnvDefaultLanguage: "file"}
 	_ = fs.Parse([]string{"--default-language=cli"})
 
-	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals, func(k string) string { return env[k] })
+	cfg := GenerateRuntimeConfig(fs, vals, func(k string) string { return env[k] })
 	if cfg.DefaultLanguage != "cli" {
 		t.Fatalf("merged %#v", cfg.DefaultLanguage)
 	}
@@ -25,7 +24,7 @@ func TestDefaultLanguageConfigPrecedence(t *testing.T) {
 func TestLoadDefaultLanguageFromFileValues(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	vals := map[string]string{config.EnvDefaultLanguage: "fileval"}
-	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals, func(string) string { return "" })
+	cfg := GenerateRuntimeConfig(fs, vals, func(string) string { return "" })
 	if cfg.DefaultLanguage != "fileval" {
 		t.Fatalf("want fileval got %q", cfg.DefaultLanguage)
 	}

--- a/runtimeconfig/pagination_config_test.go
+++ b/runtimeconfig/pagination_config_test.go
@@ -1,11 +1,10 @@
-package goa4web
+package runtimeconfig
 
 import (
 	"flag"
 	"testing"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestPaginationConfigPrecedence(t *testing.T) {
@@ -24,7 +23,7 @@ func TestPaginationConfigPrecedence(t *testing.T) {
 		config.EnvPageSizeDefault: "18",
 	}
 	_ = fs.Parse([]string{"--page-size-min=12", "--page-size-default=15"})
-	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals, func(k string) string { return env[k] })
+	cfg := GenerateRuntimeConfig(fs, vals, func(k string) string { return env[k] })
 	if cfg.PageSizeMin != 12 || cfg.PageSizeMax != 20 || cfg.PageSizeDefault != 15 {
 		t.Fatalf("merged %#v", cfg)
 	}
@@ -36,7 +35,7 @@ func TestLoadPaginationConfigFromFileValues(t *testing.T) {
 		config.EnvPageSizeMin:     "7",
 		config.EnvPageSizeDefault: "9",
 	}
-	cfg := runtimeconfig.GenerateRuntimeConfig(fs, vals, func(string) string { return "" })
+	cfg := GenerateRuntimeConfig(fs, vals, func(string) string { return "" })
 	if cfg.PageSizeMin != 7 || cfg.PageSizeDefault != 9 {
 		t.Fatalf("want 7/9 got %#v", cfg)
 	}


### PR DESCRIPTION
## Summary
- move runtime config tests into runtimeconfig package
- fix task matcher references in routes

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c735dd4c8832f96df03edd9330247