### PR TITLE
Move task matcher tests

### DIFF
--- a/handlers/common/matchers_test.go
+++ b/handlers/common/matchers_test.go
@@ -1,24 +1,23 @@
-package goa4web
+package common
 
 import (
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 )
 
 func TestTaskMatcher(t *testing.T) {
-	req := httptest.NewRequest("POST", "/", strings.NewReader("task="+TaskCreate))
+	req := httptest.NewRequest("POST", "/", strings.NewReader("task=Create"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	if err := req.ParseForm(); err != nil {
 		t.Fatalf("parse form: %v", err)
 	}
-	if !common.TaskMatcher(TaskCreate)(req, &mux.RouteMatch{}) {
+	if !TaskMatcher("Create")(req, &mux.RouteMatch{}) {
 		t.Errorf("expected task matcher to pass")
 	}
-	if common.TaskMatcher(TaskEdit)(req, &mux.RouteMatch{}) {
+	if TaskMatcher("Edit")(req, &mux.RouteMatch{}) {
 		t.Errorf("unexpected match")
 	}
 }
@@ -29,7 +28,7 @@ func TestNoTask(t *testing.T) {
 	if err := req.ParseForm(); err != nil {
 		t.Fatalf("parse form: %v", err)
 	}
-	if !common.NoTask()(req, &mux.RouteMatch{}) {
+	if !NoTask()(req, &mux.RouteMatch{}) {
 		t.Errorf("expected match when no task")
 	}
 
@@ -38,7 +37,7 @@ func TestNoTask(t *testing.T) {
 	if err := req.ParseForm(); err != nil {
 		t.Fatalf("parse form: %v", err)
 	}
-	if common.NoTask()(req, &mux.RouteMatch{}) {
+	if NoTask()(req, &mux.RouteMatch{}) {
 		t.Errorf("unexpected match when task provided")
 	}
 }


### PR DESCRIPTION
## Summary
- move `taskmatcher_test.go` into `handlers/common` as `matchers_test.go`
- adjust the test package and imports so it builds in that directory

## Testing
- `go test ./handlers/common`


------
https://chatgpt.com/codex/tasks/task_e_685c77a63dbc832f9c603736cf794656