### PR TITLE
Refactor admin routes to feature packages

### DIFF
--- a/handlers/languages/admin.go
+++ b/handlers/languages/admin.go
@@ -1,16 +1,17 @@
-package goa4web
+package languages
 
 import (
 	"database/sql"
 	_ "embed"
 	"fmt"
-	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
 	"strconv"
 
+	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 	_ "github.com/go-sql-driver/mysql" // Import the MySQL driver.
 )
 
@@ -20,15 +21,15 @@ func adminLanguageRedirect(w http.ResponseWriter, r *http.Request) {
 
 func adminLanguagesPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*CoreData
-		Rows []*Language
+		*hcommon.CoreData
+		Rows []*db.Language
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 
 	rows, err := queries.FetchLanguages(r.Context())
 	if err != nil {
@@ -46,21 +47,21 @@ func adminLanguagesPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	cid := r.PostFormValue("cid")
 	cname := r.PostFormValue("cname")
 	data := struct {
-		*CoreData
+		*hcommon.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 		Back:     "/admin/languages",
 	}
 	if cidi, err := strconv.Atoi(cid); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("strconv.Atoi: %w", err).Error())
-	} else if err := queries.RenameLanguage(r.Context(), RenameLanguageParams{
+	} else if err := queries.RenameLanguage(r.Context(), db.RenameLanguageParams{
 		Nameof:     sql.NullString{Valid: true, String: cname},
 		Idlanguage: int32(cidi),
 	}); err != nil {
@@ -74,15 +75,15 @@ func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	cid := r.PostFormValue("cid")
 	data := struct {
-		*CoreData
+		*hcommon.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 		Back:     "/admin/languages",
 	}
 	if cidi, err := strconv.Atoi(cid); err != nil {
@@ -98,15 +99,15 @@ func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 func adminLanguagesCreatePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	cname := r.PostFormValue("cname")
 	data := struct {
-		*CoreData
+		*hcommon.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 		Back:     "/admin/languages",
 	}
 	if err := queries.CreateLanguage(r.Context(), sql.NullString{

--- a/handlers/languages/routes.go
+++ b/handlers/languages/routes.go
@@ -1,0 +1,16 @@
+package languages
+
+import (
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/handlers/common"
+)
+
+// RegisterAdminRoutes attaches the admin language endpoints to the router.
+func RegisterAdminRoutes(ar *mux.Router) {
+	ar.HandleFunc("/languages", adminLanguagesPage).Methods("GET")
+	ar.HandleFunc("/language", adminLanguageRedirect).Methods("GET")
+	ar.HandleFunc("/languages", adminLanguagesRenamePage).Methods("POST").MatcherFunc(common.TaskMatcher("Rename Language"))
+	ar.HandleFunc("/languages", adminLanguagesDeletePage).Methods("POST").MatcherFunc(common.TaskMatcher("Delete Language"))
+	ar.HandleFunc("/languages", adminLanguagesCreatePage).Methods("POST").MatcherFunc(common.TaskMatcher("Create Language"))
+}

--- a/handlers/search/admin.go
+++ b/handlers/search/admin.go
@@ -1,14 +1,15 @@
-package goa4web
+package search
 
 import (
 	"database/sql"
 	"fmt"
-	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
 
+	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 func adminSearchPage(w http.ResponseWriter, r *http.Request) {
@@ -25,15 +26,15 @@ func adminSearchPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type Data struct {
-		*CoreData
+		*hcommon.CoreData
 		Stats Stats
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	ctx := r.Context()
 	count := func(query string, dest *int64) {
 		if err := queries.DB().QueryRowContext(ctx, query).Scan(dest); err != nil && err != sql.ErrNoRows {
@@ -58,14 +59,14 @@ func adminSearchPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminSearchRemakeCommentsSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	data := struct {
-		*CoreData
+		*hcommon.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteCommentsSearch(r.Context()); err != nil {
@@ -82,14 +83,14 @@ func adminSearchRemakeCommentsSearchPage(w http.ResponseWriter, r *http.Request)
 	}
 }
 func adminSearchRemakeNewsSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	data := struct {
-		*CoreData
+		*hcommon.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteSiteNewsSearch(r.Context()); err != nil {
@@ -106,14 +107,14 @@ func adminSearchRemakeNewsSearchPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 func adminSearchRemakeBlogSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	data := struct {
-		*CoreData
+		*hcommon.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteBlogsSearch(r.Context()); err != nil {
@@ -130,14 +131,14 @@ func adminSearchRemakeBlogSearchPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 func adminSearchRemakeLinkerSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	data := struct {
-		*CoreData
+		*hcommon.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteLinkerSearch(r.Context()); err != nil {
@@ -154,14 +155,14 @@ func adminSearchRemakeLinkerSearchPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 func adminSearchRemakeWritingSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	data := struct {
-		*CoreData
+		*hcommon.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteWritingSearch(r.Context()); err != nil {
@@ -179,14 +180,14 @@ func adminSearchRemakeWritingSearchPage(w http.ResponseWriter, r *http.Request) 
 }
 
 func adminSearchRemakeImageSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	data := struct {
-		*CoreData
+		*hcommon.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteImagePostSearch(r.Context()); err != nil {

--- a/handlers/search/consts.go
+++ b/handlers/search/consts.go
@@ -8,3 +8,6 @@ const LinkerTopicName = "A LINKER TOPIC"
 
 // WritingTopicName is the default name for the hidden writing forum.
 const WritingTopicName = "A WRITING TOPIC"
+
+// Alphabet lists letters for search navigation.
+const Alphabet = "abcdefghijklmnopqrstuvwxyz"

--- a/handlers/search/routes_admin.go
+++ b/handlers/search/routes_admin.go
@@ -1,0 +1,21 @@
+package search
+
+import (
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/handlers/common"
+)
+
+// RegisterAdminRoutes attaches the admin search endpoints to the router.
+func RegisterAdminRoutes(ar *mux.Router) {
+	sr := ar.PathPrefix("/search").Subrouter()
+	sr.HandleFunc("", adminSearchPage).Methods("GET")
+	sr.HandleFunc("", adminSearchRemakeCommentsSearchPage).Methods("POST").MatcherFunc(common.TaskMatcher("Remake comments search"))
+	sr.HandleFunc("", adminSearchRemakeNewsSearchPage).Methods("POST").MatcherFunc(common.TaskMatcher("Remake news search"))
+	sr.HandleFunc("", adminSearchRemakeBlogSearchPage).Methods("POST").MatcherFunc(common.TaskMatcher("Remake blog search"))
+	sr.HandleFunc("", adminSearchRemakeLinkerSearchPage).Methods("POST").MatcherFunc(common.TaskMatcher("Remake linker search"))
+	sr.HandleFunc("", adminSearchRemakeWritingSearchPage).Methods("POST").MatcherFunc(common.TaskMatcher("Remake writing search"))
+	sr.HandleFunc("", adminSearchRemakeImageSearchPage).Methods("POST").MatcherFunc(common.TaskMatcher("Remake image search"))
+	sr.HandleFunc("/list", adminSearchWordListPage).Methods("GET")
+	sr.HandleFunc("/list.txt", adminSearchWordListDownloadPage).Methods("GET")
+}

--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -1,12 +1,14 @@
-package goa4web
+package user
 
 import (
 	"archive/zip"
 	"encoding/json"
 	"fmt"
-	"github.com/arran4/goa4web/handlers/common"
 	"net/http"
 	"strconv"
+
+	common "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 // gdprExportNote is included in exports to emphasise that the data is
@@ -16,7 +18,7 @@ const gdprExportNote = "# Personal data export - handle according to GDPR"
 // adminUsersExportPage streams all data for a single user in a zip archive for
 // admins. The user ID is provided via the "uid" query parameter.
 func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
 	uid, err := strconv.Atoi(r.URL.Query().Get("uid"))
 	if err != nil {
@@ -35,11 +37,11 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 	perms, _ := queries.GetPermissionsByUserID(r.Context(), int32(uid))
 
 	data := struct {
-		Note        string        `json:"note"`
-		User        *User         `json:"user"`
-		Preference  *Preference   `json:"preference,omitempty"`
-		Languages   []*Userlang   `json:"languages,omitempty"`
-		Permissions []*Permission `json:"permissions,omitempty"`
+		Note        string           `json:"note"`
+		User        *db.User         `json:"user"`
+		Preference  *db.Preference   `json:"preference,omitempty"`
+		Languages   []*db.Userlang   `json:"languages,omitempty"`
+		Permissions []*db.Permission `json:"permissions,omitempty"`
 	}{
 		Note:        gdprExportNote,
 		User:        user,
@@ -56,7 +58,7 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 
 	writings, _ := queries.GetAllWritingsByUser(r.Context(), int32(uid))
 	type writingExport struct {
-		*GetAllWritingsByUserRow
+		*db.GetAllWritingsByUserRow
 		Category string `json:"category"`
 	}
 	var ws []writingExport

--- a/handlers/user/admin_loginattempts.go
+++ b/handlers/user/admin_loginattempts.go
@@ -1,21 +1,22 @@
-package goa4web
+package user
 
 import (
-	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
 
+	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
+	common "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 func adminLoginAttemptsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*CoreData
-		Attempts []*LoginAttempt
+		*common.CoreData
+		Attempts []*db.LoginAttempt
 	}
-	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData)}
+	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	items, err := queries.ListLoginAttempts(r.Context())
 	if err != nil {
 		log.Printf("list login attempts: %v", err)

--- a/handlers/user/admin_sessions.go
+++ b/handlers/user/admin_sessions.go
@@ -1,21 +1,22 @@
-package goa4web
+package user
 
 import (
-	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
 
+	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
+	common "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 func adminSessionsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*CoreData
-		Sessions []*ListSessionsRow
+		*common.CoreData
+		Sessions []*db.ListSessionsRow
 	}
-	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData)}
+	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	items, err := queries.ListSessions(r.Context())
 	if err != nil {
 		log.Printf("list sessions: %v", err)
@@ -33,18 +34,18 @@ func adminSessionsPage(w http.ResponseWriter, r *http.Request) {
 func adminSessionsDeletePage(w http.ResponseWriter, r *http.Request) {
 	sid := r.PostFormValue("sid")
 	data := struct {
-		*CoreData
+		*common.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
 		Back:     "/admin/sessions",
 	}
 	if sid == "" {
 		data.Errors = append(data.Errors, "missing sid")
 	} else {
-		if err := r.Context().Value(common.KeyQueries).(*Queries).DeleteSessionByID(r.Context(), sid); err != nil {
+		if err := r.Context().Value(common.KeyQueries).(*db.Queries).DeleteSessionByID(r.Context(), sid); err != nil {
 			data.Errors = append(data.Errors, err.Error())
 		}
 	}

--- a/handlers/user/audit.go
+++ b/handlers/user/audit.go
@@ -1,0 +1,24 @@
+package user
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+// logAudit records an administrative action in the audit_log table.
+func logAudit(r *http.Request, action string) {
+	queries, qok := r.Context().Value(common.KeyQueries).(*db.Queries)
+	cd, cok := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	if !qok || !cok || cd == nil {
+		return
+	}
+	if err := queries.InsertAuditLog(r.Context(), db.InsertAuditLogParams{
+		UsersIdusers: cd.UserID,
+		Action:       action,
+	}); err != nil {
+		log.Printf("insert audit log: %v", err)
+	}
+}

--- a/handlers/user/password.go
+++ b/handlers/user/password.go
@@ -1,0 +1,23 @@
+package user
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+const passwordIterations = 10000
+
+// hashPassword returns a PBKDF2-SHA256 hash and algorithm descriptor.
+func hashPassword(pw string) (string, string, error) {
+	var salt [16]byte
+	if _, err := rand.Read(salt[:]); err != nil {
+		return "", "", err
+	}
+	hash := pbkdf2.Key([]byte(pw), salt[:], passwordIterations, 32, sha256.New)
+	alg := fmt.Sprintf("pbkdf2-sha256:%d:%s", passwordIterations, hex.EncodeToString(salt[:]))
+	return hex.EncodeToString(hash), alg, nil
+}

--- a/handlers/user/routes_admin.go
+++ b/handlers/user/routes_admin.go
@@ -1,0 +1,20 @@
+package user
+
+import (
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/handlers/common"
+)
+
+// RegisterAdminRoutes attaches user admin endpoints to the router.
+func RegisterAdminRoutes(ar *mux.Router) {
+	ar.HandleFunc("/users", adminUsersPage).Methods("GET")
+	ar.HandleFunc("/users/export", adminUsersExportPage).Methods("GET")
+	ar.HandleFunc("/sessions", adminSessionsPage).Methods("GET")
+	ar.HandleFunc("/sessions/delete", adminSessionsDeletePage).Methods("POST")
+	ar.HandleFunc("/login/attempts", adminLoginAttemptsPage).Methods("GET")
+	ar.HandleFunc("/users/permissions", adminUsersPermissionsPage).Methods("GET")
+	ar.HandleFunc("/users/permissions", adminUsersPermissionsPermissionUserAllowPage).Methods("POST").MatcherFunc(common.TaskMatcher("User Allow"))
+	ar.HandleFunc("/users/permissions", adminUsersPermissionsDisallowPage).Methods("POST").MatcherFunc(common.TaskMatcher("User Disallow"))
+	ar.HandleFunc("/users/permissions", adminUsersPermissionsUpdatePage).Methods("POST").MatcherFunc(common.TaskMatcher("Update"))
+}

--- a/routes.go
+++ b/routes.go
@@ -13,6 +13,7 @@ import (
 	faq "github.com/arran4/goa4web/handlers/faq"
 	forum "github.com/arran4/goa4web/handlers/forum"
 	imagebbs "github.com/arran4/goa4web/handlers/imagebbs"
+	languages "github.com/arran4/goa4web/handlers/languages"
 	linker "github.com/arran4/goa4web/handlers/linker"
 	news "github.com/arran4/goa4web/handlers/news"
 	search "github.com/arran4/goa4web/handlers/search"
@@ -173,11 +174,11 @@ func registerImagebbsRoutes(r *mux.Router) {
 func registerSearchRoutes(r *mux.Router) {
 	sr := r.PathPrefix("/search").Subrouter()
 	sr.HandleFunc("", search.Page).Methods("GET")
-	sr.HandleFunc("", search.SearchResultForumActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchForum))
-	sr.HandleFunc("", news.SearchResultNewsActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchNews))
-	sr.HandleFunc("", search.SearchResultLinkerActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchLinker))
-	sr.HandleFunc("", search.SearchResultBlogsActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchBlogs))
-	sr.HandleFunc("", search.SearchResultWritingsActionPage).Methods("POST").MatcherFunc(TaskMatcher(TaskSearchWritings))
+	sr.HandleFunc("", search.SearchResultForumActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskSearchForum))
+	sr.HandleFunc("", news.SearchResultNewsActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskSearchNews))
+	sr.HandleFunc("", search.SearchResultLinkerActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskSearchLinker))
+	sr.HandleFunc("", search.SearchResultBlogsActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskSearchBlogs))
+	sr.HandleFunc("", search.SearchResultWritingsActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskSearchWritings))
 }
 
 func registerWritingsRoutes(r *mux.Router) {
@@ -261,29 +262,15 @@ func registerAdminRoutes(r *mux.Router) {
 	ar.HandleFunc("/announcements", adminAnnouncementsPage).Methods("GET")
 	ar.HandleFunc("/announcements", adminAnnouncementsAddActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskAdd))
 	ar.HandleFunc("/announcements", adminAnnouncementsDeleteActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskDelete))
-	ar.HandleFunc("/sessions", adminSessionsPage).Methods("GET")
-	ar.HandleFunc("/sessions/delete", adminSessionsDeletePage).Methods("POST")
-	ar.HandleFunc("/login/attempts", adminLoginAttemptsPage).Methods("GET")
 	ar.HandleFunc("/ipbans", adminIPBanPage).Methods("GET")
 	ar.HandleFunc("/ipbans", adminIPBanAddActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskAdd))
 	ar.HandleFunc("/ipbans", adminIPBanDeleteActionPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskDelete))
-	ar.HandleFunc("/users", adminUsersPage).Methods("GET")
-	ar.HandleFunc("/users/export", adminUsersExportPage).Methods("GET")
 	ar.HandleFunc("/audit", adminAuditLogPage).Methods("GET")
 	ar.HandleFunc("/settings", adminSiteSettingsPage).Methods("GET", "POST")
 	ar.HandleFunc("/stats", adminServerStatsPage).Methods("GET")
 	ar.HandleFunc("/usage", adminUsageStatsPage).Methods("GET")
 
 	// search related
-	ar.HandleFunc("/search", adminSearchPage).Methods("GET")
-	ar.HandleFunc("/search", adminSearchRemakeCommentsSearchPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskRemakeCommentsSearch))
-	ar.HandleFunc("/search", adminSearchRemakeNewsSearchPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskRemakeNewsSearch))
-	ar.HandleFunc("/search", adminSearchRemakeBlogSearchPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskRemakeBlogSearch))
-	ar.HandleFunc("/search", adminSearchRemakeLinkerSearchPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskRemakeLinkerSearch))
-	ar.HandleFunc("/search", adminSearchRemakeWritingSearchPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskRemakeWritingSearch))
-	ar.HandleFunc("/search", adminSearchRemakeImageSearchPage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskRemakeImageSearch))
-	ar.HandleFunc("/search/list", adminSearchWordListPage).Methods("GET")
-	ar.HandleFunc("/search/list.txt", adminSearchWordListDownloadPage).Methods("GET")
 
 	// forum admin routes
 	far := ar.PathPrefix("/forum").Subrouter()
@@ -346,13 +333,9 @@ func registerAdminRoutes(r *mux.Router) {
 
 	// faq admin
 	faq.RegisterAdminRoutes(ar)
-
-	// languages
-	ar.HandleFunc("/languages", adminLanguagesPage).Methods("GET")
-	ar.HandleFunc("/language", adminLanguageRedirect).Methods("GET")
-	ar.HandleFunc("/languages", adminLanguagesRenamePage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskRenameLanguage))
-	ar.HandleFunc("/languages", adminLanguagesDeletePage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskDeleteLanguage))
-	ar.HandleFunc("/languages", adminLanguagesCreatePage).Methods("POST").MatcherFunc(common.TaskMatcher(TaskCreateLanguage))
+	search.RegisterAdminRoutes(ar)
+	userhandlers.RegisterAdminRoutes(ar)
+	languages.RegisterAdminRoutes(ar)
 
 	// news admin
 	nar := ar.PathPrefix("/news").Subrouter()


### PR DESCRIPTION
## Summary
- move language admin handlers into `handlers/languages`
- move search admin handlers into `handlers/search`
- move user admin handlers into `handlers/user`
- provide admin route registration per package
- wire the new admin routers from `routes.go`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685bfab09f0c832f9dba88a79bcebc0c