### PR TITLE
Move main test to forum pkg

### DIFF
--- a/handlers/forum/matchers_getthread_test.go
+++ b/handlers/forum/matchers_getthread_test.go
@@ -1,4 +1,4 @@
-package goa4web
+package forum
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/handlers/common"
-	forum "github.com/arran4/goa4web/handlers/forum"
 	"github.com/gorilla/mux"
 )
 
@@ -38,7 +37,7 @@ func TestGetThreadAndTopicTrue(t *testing.T) {
 	ctx := context.WithValue(req.Context(), common.KeyQueries, q)
 	req = req.WithContext(ctx)
 
-	if !forum.GetThreadAndTopic()(req, &mux.RouteMatch{}) {
+	if !GetThreadAndTopic()(req, &mux.RouteMatch{}) {
 		t.Errorf("expected match")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -72,7 +71,7 @@ func TestGetThreadAndTopicFalse(t *testing.T) {
 	ctx := context.WithValue(req.Context(), common.KeyQueries, q)
 	req = req.WithContext(ctx)
 
-	if forum.GetThreadAndTopic()(req, &mux.RouteMatch{}) {
+	if GetThreadAndTopic()(req, &mux.RouteMatch{}) {
 		t.Errorf("expected no match")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -98,7 +97,7 @@ func TestGetThreadAndTopicError(t *testing.T) {
 	ctx := context.WithValue(req.Context(), common.KeyQueries, q)
 	req = req.WithContext(ctx)
 
-	if forum.GetThreadAndTopic()(req, &mux.RouteMatch{}) {
+	if GetThreadAndTopic()(req, &mux.RouteMatch{}) {
 		t.Errorf("expected no match on error")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
## Summary
- move matcher tests into handlers/forum
- rename to `matchers_getthread_test.go`
- adapt imports and package name

## Testing
- `go test ./handlers/forum`


------
https://chatgpt.com/codex/tasks/task_e_685c80ebb41c832f98522cbd5bea6e03