### PR TITLE
refactor auth handlers

### DIFF
--- a/handlers/auth/db_alias.go
+++ b/handlers/auth/db_alias.go
@@ -1,0 +1,10 @@
+package auth
+
+import db "github.com/arran4/goa4web/internal/db"
+
+type (
+	DBTX                     = db.DBTX                     // used
+	Queries                  = db.Queries                  // used
+	InsertLoginAttemptParams = db.InsertLoginAttemptParams // used
+	User                     = db.User                     // used
+)

--- a/handlers/auth/loginPage.go
+++ b/handlers/auth/loginPage.go
@@ -1,10 +1,8 @@
-package goa4web
+package auth
 
 import (
 	"database/sql"
 	"errors"
-	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
 	"net/url"
@@ -12,16 +10,19 @@ import (
 	"time"
 
 	"github.com/arran4/goa4web/core"
+	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
+	common "github.com/arran4/goa4web/handlers/common"
 )
 
-func loginUserPassPage(w http.ResponseWriter, r *http.Request) {
+// LoginUserPassPage serves the username/password login form.
+func LoginUserPassPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*CoreData
+		*corecommon.CoreData
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
 	}
 
 	if err := templates.RenderTemplate(w, "loginPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
@@ -31,7 +32,8 @@ func loginUserPassPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func loginActionPage(w http.ResponseWriter, r *http.Request) {
+// LoginActionPage processes the submitted login form.
+func LoginActionPage(w http.ResponseWriter, r *http.Request) {
 	log.Printf("login attempt for %s", r.PostFormValue("username"))
 	username := r.PostFormValue("username")
 	password := r.PostFormValue("password")
@@ -120,13 +122,13 @@ func loginActionPage(w http.ResponseWriter, r *http.Request) {
 		}
 		vals, _ := url.ParseQuery(backData)
 		type Data struct {
-			*CoreData
+			*corecommon.CoreData
 			BackURL string
 			Method  string
 			Values  url.Values
 		}
 		data := Data{
-			CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+			CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
 			BackURL:  backURL,
 			Method:   backMethod,
 			Values:   vals,

--- a/handlers/auth/password.go
+++ b/handlers/auth/password.go
@@ -1,4 +1,4 @@
-package goa4web
+package auth
 
 import (
 	"crypto/md5"

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -1,26 +1,27 @@
-package goa4web
+package auth
 
 import (
 	"database/sql"
 	"errors"
-	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/arran4/goa4web/core"
+	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
+	common "github.com/arran4/goa4web/handlers/common"
 )
 
-func registerPage(w http.ResponseWriter, r *http.Request) {
+// RegisterPage renders the user registration form.
+func RegisterPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*CoreData
+		*corecommon.CoreData
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
 	}
 
 	if err := templates.RenderTemplate(w, "registerPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
@@ -29,7 +30,9 @@ func registerPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 }
-func registerActionPage(w http.ResponseWriter, r *http.Request) {
+
+// RegisterActionPage handles user creation from the registration form.
+func RegisterActionPage(w http.ResponseWriter, r *http.Request) {
 	log.Printf("registration attempt %s", r.PostFormValue("username"))
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm Error: %s", err)

--- a/handlers/auth/registerPage_test.go
+++ b/handlers/auth/registerPage_test.go
@@ -1,4 +1,4 @@
-package goa4web
+package auth
 
 import (
 	"net/http"
@@ -22,7 +22,7 @@ func TestRegisterActionPageValidation(t *testing.T) {
 		req := httptest.NewRequest("POST", "/register", strings.NewReader(c.form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		rr := httptest.NewRecorder()
-		registerActionPage(rr, req)
+		RegisterActionPage(rr, req)
 		if rr.Result().StatusCode != http.StatusBadRequest {
 			t.Errorf("%s: status=%d", c.name, rr.Result().StatusCode)
 		}

--- a/routes.go
+++ b/routes.go
@@ -230,14 +230,14 @@ func registerInformationRoutes(r *mux.Router) {
 
 func registerRegisterRoutes(r *mux.Router) {
 	rr := r.PathPrefix("/register").Subrouter()
-	rr.HandleFunc("", registerPage).Methods("GET").MatcherFunc(Not(auth.RequiresAnAccount()))
-	rr.HandleFunc("", registerActionPage).Methods("POST").MatcherFunc(Not(auth.RequiresAnAccount())).MatcherFunc(common.TaskMatcher(TaskRegister))
+	rr.HandleFunc("", auth.RegisterPage).Methods("GET").MatcherFunc(Not(auth.RequiresAnAccount()))
+	rr.HandleFunc("", auth.RegisterActionPage).Methods("POST").MatcherFunc(Not(auth.RequiresAnAccount())).MatcherFunc(common.TaskMatcher(TaskRegister))
 }
 
 func registerLoginRoutes(r *mux.Router) {
 	ulr := r.PathPrefix("/login").Subrouter()
-	ulr.HandleFunc("", loginUserPassPage).Methods("GET").MatcherFunc(Not(auth.RequiresAnAccount()))
-	ulr.HandleFunc("", loginActionPage).Methods("POST").MatcherFunc(Not(auth.RequiresAnAccount())).MatcherFunc(common.TaskMatcher(TaskLogin))
+	ulr.HandleFunc("", auth.LoginUserPassPage).Methods("GET").MatcherFunc(Not(auth.RequiresAnAccount()))
+	ulr.HandleFunc("", auth.LoginActionPage).Methods("POST").MatcherFunc(Not(auth.RequiresAnAccount())).MatcherFunc(common.TaskMatcher(TaskLogin))
 }
 
 func registerAdminRoutes(r *mux.Router) {


### PR DESCRIPTION
## Summary
- move login/registration handlers to `handlers/auth`
- change package to `auth` with exported route functions
- update router to use new package paths
- provide DB model aliases for auth package

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c8990e110832fac76aa41c15a7359