### PR TITLE
Move generic handlers to common package

### DIFF
--- a/handlers/common/informationPage.go
+++ b/handlers/common/informationPage.go
@@ -1,8 +1,7 @@
-package goa4web
+package common
 
 import (
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
 	"time"
@@ -13,7 +12,7 @@ import (
 	"github.com/shirou/gopsutil/v3/load"
 )
 
-func informationPage(w http.ResponseWriter, r *http.Request) {
+func InformationPage(w http.ResponseWriter, r *http.Request) {
 
 	type SystemInformation struct {
 		Processors  []cpu.InfoStat
@@ -28,7 +27,7 @@ func informationPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(KeyCoreData).(*CoreData),
 	}
 	ld, err := load.Avg()
 	if err != nil {

--- a/handlers/common/password.go
+++ b/handlers/common/password.go
@@ -1,4 +1,4 @@
-package goa4web
+package common
 
 import (
 	"crypto/md5"

--- a/handlers/common/registerPage.go
+++ b/handlers/common/registerPage.go
@@ -1,10 +1,10 @@
-package goa4web
+package common
 
 import (
 	"database/sql"
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strings"
@@ -14,13 +14,13 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 )
 
-func registerPage(w http.ResponseWriter, r *http.Request) {
+func RegisterPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*CoreData
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(KeyCoreData).(*CoreData),
 	}
 
 	if err := templates.RenderTemplate(w, "registerPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
@@ -29,7 +29,7 @@ func registerPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 }
-func registerActionPage(w http.ResponseWriter, r *http.Request) {
+func RegisterActionPage(w http.ResponseWriter, r *http.Request) {
 	log.Printf("registration attempt %s", r.PostFormValue("username"))
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm Error: %s", err)
@@ -52,7 +52,7 @@ func registerActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid email", http.StatusBadRequest)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*Queries)
+	queries := r.Context().Value(KeyQueries).(*db.Queries)
 
 	if _, err := queries.UserByUsername(r.Context(), sql.NullString{
 		String: username,

--- a/handlers/common/registerPage_test.go
+++ b/handlers/common/registerPage_test.go
@@ -1,4 +1,4 @@
-package goa4web
+package common
 
 import (
 	"net/http"
@@ -22,7 +22,7 @@ func TestRegisterActionPageValidation(t *testing.T) {
 		req := httptest.NewRequest("POST", "/register", strings.NewReader(c.form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		rr := httptest.NewRecorder()
-		registerActionPage(rr, req)
+		RegisterActionPage(rr, req)
 		if rr.Result().StatusCode != http.StatusBadRequest {
 			t.Errorf("%s: status=%d", c.name, rr.Result().StatusCode)
 		}

--- a/handlers/common/templatePage.go
+++ b/handlers/common/templatePage.go
@@ -1,21 +1,20 @@
-package goa4web
+package common
 
 import (
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
 )
 
-func templatePage(w http.ResponseWriter, r *http.Request) {
+func TemplatePage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*CoreData
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(KeyCoreData).(*CoreData),
 	}
 
 	if err := templates.RenderTemplate(w, "templatePage.gohtml", data, corecommon.NewFuncs(r)); err != nil {

--- a/routes.go
+++ b/routes.go
@@ -225,19 +225,19 @@ func registerWritingsAdminRoutes(ar *mux.Router) {
 
 func registerInformationRoutes(r *mux.Router) {
 	ir := r.PathPrefix("/information").Subrouter()
-	ir.HandleFunc("", informationPage).Methods("GET")
+	ir.HandleFunc("", common.InformationPage).Methods("GET")
 }
 
 func registerRegisterRoutes(r *mux.Router) {
 	rr := r.PathPrefix("/register").Subrouter()
-	rr.HandleFunc("", registerPage).Methods("GET").MatcherFunc(Not(auth.RequiresAnAccount()))
-	rr.HandleFunc("", registerActionPage).Methods("POST").MatcherFunc(Not(auth.RequiresAnAccount())).MatcherFunc(common.TaskMatcher(TaskRegister))
+	rr.HandleFunc("", common.RegisterPage).Methods("GET").MatcherFunc(Not(auth.RequiresAnAccount()))
+	rr.HandleFunc("", common.RegisterActionPage).Methods("POST").MatcherFunc(Not(auth.RequiresAnAccount())).MatcherFunc(common.TaskMatcher(TaskRegister))
 }
 
 func registerLoginRoutes(r *mux.Router) {
 	ulr := r.PathPrefix("/login").Subrouter()
-	ulr.HandleFunc("", loginUserPassPage).Methods("GET").MatcherFunc(Not(auth.RequiresAnAccount()))
-	ulr.HandleFunc("", loginActionPage).Methods("POST").MatcherFunc(Not(auth.RequiresAnAccount())).MatcherFunc(common.TaskMatcher(TaskLogin))
+	ulr.HandleFunc("", common.LoginUserPassPage).Methods("GET").MatcherFunc(Not(auth.RequiresAnAccount()))
+	ulr.HandleFunc("", common.LoginActionPage).Methods("POST").MatcherFunc(Not(auth.RequiresAnAccount())).MatcherFunc(common.TaskMatcher(TaskLogin))
 }
 
 func registerAdminRoutes(r *mux.Router) {


### PR DESCRIPTION
## Summary
- relocate information, login, register, password and template pages under `handlers/common`
- update package names and imports
- adjust routes to point at the new handlers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c89ab6290832f9535b99a64f1f1c7