### PR TITLE
Refactor helpers into internal packages

### DIFF
--- a/adminEmailQueuePage.go
+++ b/adminEmailQueuePage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/internal/emailutil"
 )
 
 func adminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +36,7 @@ func adminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 
 func adminEmailQueueResendActionPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(common.KeyQueries).(*Queries)
-	provider := getEmailProvider()
+	provider := emailutil.GetEmailProvider()
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm: %v", err)
 	}

--- a/adminEmailTemplatePage.go
+++ b/adminEmailTemplatePage.go
@@ -13,12 +13,13 @@ import (
 
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/internal/emailutil"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 // adminEmailTemplatePage allows administrators to edit the update email template.
 func adminEmailTemplatePage(w http.ResponseWriter, r *http.Request) {
-	b := getUpdateEmailText(r.Context())
+	b := emailutil.GetUpdateEmailText(r.Context())
 
 	var preview string
 	tmpl, err := template.New("email").Parse(b)
@@ -66,7 +67,7 @@ func adminEmailTemplateSaveActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminEmailTemplateTestActionPage(w http.ResponseWriter, r *http.Request) {
-	provider := getEmailProvider()
+	provider := emailutil.GetEmailProvider()
 	if provider == nil {
 		q := url.QueryEscape(userhandlers.ErrMailNotConfigured)
 		http.Redirect(w, r, "/admin/email/template?error="+q, http.StatusTemporaryRedirect)
@@ -93,7 +94,7 @@ func adminEmailTemplateTestActionPage(w http.ResponseWriter, r *http.Request) {
 	pageURL := base + r.URL.Path
 
 	var buf bytes.Buffer
-	tmpl, err := template.New("email").Parse(getUpdateEmailText(r.Context()))
+	tmpl, err := template.New("email").Parse(emailutil.GetUpdateEmailText(r.Context()))
 	if err != nil {
 		log.Printf("parse template: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/admin_test.go
+++ b/admin_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/handlers/common"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
+	"github.com/arran4/goa4web/internal/emailutil"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -117,7 +118,7 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	os.Setenv("ADMIN_EMAILS", "a@test.com,b@test.com")
 	defer os.Unsetenv("ADMIN_EMAILS")
 	rec := &recordAdminMail{}
-	notifyAdmins(context.Background(), rec, nil, "page")
+	emailutil.NotifyAdmins(context.Background(), rec, nil, "page")
 	if len(rec.to) != 2 {
 		t.Fatalf("expected 2 mails, got %d", len(rec.to))
 	}
@@ -129,7 +130,7 @@ func TestNotifyAdminsDisabled(t *testing.T) {
 	defer os.Unsetenv("ADMIN_EMAILS")
 	defer os.Unsetenv("ADMIN_NOTIFY")
 	rec := &recordAdminMail{}
-	notifyAdmins(context.Background(), rec, nil, "page")
+	emailutil.NotifyAdmins(context.Background(), rec, nil, "page")
 	if len(rec.to) != 0 {
 		t.Fatalf("expected 0 mails, got %d", len(rec.to))
 	}

--- a/internal/emailutil/email_queue.go
+++ b/internal/emailutil/email_queue.go
@@ -1,15 +1,16 @@
-package goa4web
+package emailutil
 
 import (
 	"context"
 	"log"
 	"time"
 
+	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
 )
 
 // emailQueueWorker periodically sends pending emails using the provided provider.
-func emailQueueWorker(ctx context.Context, q *Queries, provider email.Provider, interval time.Duration) {
+func EmailQueueWorker(ctx context.Context, q *db.Queries, provider email.Provider, interval time.Duration) {
 	if q == nil || provider == nil {
 		log.Printf("email queue worker disabled: missing queue or provider")
 		return
@@ -19,19 +20,19 @@ func emailQueueWorker(ctx context.Context, q *Queries, provider email.Provider, 
 	for {
 		select {
 		case <-ticker.C:
-			processPendingEmail(ctx, q, provider)
+			ProcessPendingEmail(ctx, q, provider)
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-// processPendingEmail sends a single queued email if available.
-func processPendingEmail(ctx context.Context, q *Queries, provider email.Provider) {
+// ProcessPendingEmail sends a single queued email if available.
+func ProcessPendingEmail(ctx context.Context, q *db.Queries, provider email.Provider) {
 	if q == nil || provider == nil {
 		return
 	}
-	if !emailSendingEnabled() {
+	if !EmailSendingEnabled() {
 		return
 	}
 	if provider == nil {

--- a/internal/emailutil/updateEmail.go
+++ b/internal/emailutil/updateEmail.go
@@ -1,21 +1,23 @@
-package goa4web
+package emailutil
 
 import (
 	"context"
 	_ "embed"
+
 	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/internal/db"
 )
 
 // defaultUpdateEmailText contains the compiled-in notification email template.
 // Administrators may override it by saving a new body in the template_overrides table.
 //
-//go:embed core/templates/templates/updateEmail.txt
+//go:embed updateEmail.txt
 var defaultUpdateEmailText string
 
 // getUpdateEmailText returns the update email template body, preferring a database
 // override when available.
-func getUpdateEmailText(ctx context.Context) string {
-	if q, ok := ctx.Value(common.KeyQueries).(*Queries); ok && q != nil {
+func GetUpdateEmailText(ctx context.Context) string {
+	if q, ok := ctx.Value(common.KeyQueries).(*db.Queries); ok && q != nil {
 		if body, err := q.GetTemplateOverride(ctx, "updateEmail"); err == nil && body != "" {
 			return body
 		}

--- a/internal/emailutil/updateEmail.txt
+++ b/internal/emailutil/updateEmail.txt
@@ -1,0 +1,10 @@
+To: {{.To}}
+From: {{.To}}
+Subject: [A4] {{.Subject}}
+
+There has been an update on my site on some page you either requested to be notified
+or were directly involved with. Please visit the URL to find out in relation to what:
+{{.URL}}
+
+- Arran4
+.

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -1,4 +1,4 @@
-package goa4web
+package notifications
 
 import (
 	"context"
@@ -7,10 +7,12 @@ import (
 	"time"
 
 	"github.com/gorilla/feeds"
+
+	"github.com/arran4/goa4web/internal/db"
 )
 
-// notificationsFeed produces a feed from the notifications slice.
-func notificationsFeed(r *http.Request, notifications []*Notification) *feeds.Feed {
+// Feed produces a feed from the notifications slice.
+func Feed(r *http.Request, notifications []*db.Notification) *feeds.Feed {
 	feed := &feeds.Feed{
 		Title:       "Notifications",
 		Link:        &feeds.Link{Href: r.URL.Path},
@@ -38,8 +40,8 @@ func notificationsFeed(r *http.Request, notifications []*Notification) *feeds.Fe
 	return feed
 }
 
-// notificationPurgeWorker periodically removes old read notifications.
-func notificationPurgeWorker(ctx context.Context, q *Queries, interval time.Duration) {
+// PurgeWorker periodically removes old read notifications.
+func PurgeWorker(ctx context.Context, q *db.Queries, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {

--- a/startup.go
+++ b/startup.go
@@ -14,6 +14,8 @@ import (
 	common "github.com/arran4/goa4web/core/common"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/internal/emailutil"
+	"github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/runtimeconfig"
 	"github.com/go-sql-driver/mysql"
 )
@@ -128,7 +130,7 @@ func ensureSchema(ctx context.Context, db *sql.DB) error {
 // startWorkers launches goroutines for email processing and notification cleanup.
 func startWorkers(ctx context.Context, db *sql.DB, provider email.Provider) {
 	log.Printf("Starting email worker")
-	safeGo(func() { emailQueueWorker(ctx, New(db), provider, time.Minute) })
+	safeGo(func() { emailutil.EmailQueueWorker(ctx, New(db), provider, time.Minute) })
 	log.Printf("Starting notification purger worker")
-	safeGo(func() { notificationPurgeWorker(ctx, New(db), time.Hour) })
+	safeGo(func() { notifications.PurgeWorker(ctx, New(db), time.Hour) })
 }


### PR DESCRIPTION
## Summary
- create `internal/emailutil` and `internal/notifications`
- move email and notification helpers out of repo root
- update all imports and function calls
- keep tests working with the new packages

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c8983b328832fb5edba4cf9e36a33