### PR TITLE
Move template compile tests

### DIFF
--- a/core/templates/templates_compile_test.go
+++ b/core/templates/templates_compile_test.go
@@ -1,4 +1,4 @@
-package goa4web
+package templates
 
 import (
 	"embed"
@@ -11,17 +11,17 @@ import (
 	"testing"
 )
 
-//go:embed core/templates/templates/*.gohtml core/templates/templates/*/*.gohtml
+//go:embed templates/*.gohtml templates/*/*.gohtml
 var testTemplates embed.FS
 
 func TestCompileGoHTML(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
 	template.Must(template.New("").Funcs(corecommon.NewFuncs(r)).ParseFS(testTemplates,
-		"core/templates/templates/*.gohtml", "core/templates/templates/*/*.gohtml"))
+		"templates/*.gohtml", "templates/*/*.gohtml"))
 }
 
 func TestParseEachTemplate(t *testing.T) {
-	err := fs.WalkDir(testTemplates, "core/templates/templates", func(path string, d fs.DirEntry, err error) error {
+	err := fs.WalkDir(testTemplates, "templates", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- move `data_test.go` to `core/templates/`
- rename it `templates_compile_test.go`
- update package name and paths for embedding templates

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c8fd81904832f8ae5d908e6d9e6be