### PR TITLE
Move helper code into internal packages

### DIFF
--- a/email_test.go
+++ b/email_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers/common"
 	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/internal/emailutil"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -75,7 +76,7 @@ func TestNotifyChange(t *testing.T) {
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs("a@b.com", sqlmock.AnyArg(), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 	ctx := context.WithValue(context.Background(), common.KeyQueries, q)
 	rec := &recordMail{}
-	if err := notifyChange(ctx, rec, "a@b.com", "http://host"); err != nil {
+	if err := emailutil.NotifyChange(ctx, rec, "a@b.com", "http://host"); err != nil {
 		t.Fatalf("notify error: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -85,7 +86,7 @@ func TestNotifyChange(t *testing.T) {
 
 func TestNotifyChangeErrors(t *testing.T) {
 	rec := &recordMail{}
-	if err := notifyChange(context.Background(), rec, "", "p"); err == nil {
+	if err := emailutil.NotifyChange(context.Background(), rec, "", "p"); err == nil {
 		t.Fatal("expected error for empty email")
 	}
 }
@@ -133,7 +134,7 @@ func TestEmailQueueWorker(t *testing.T) {
 	mock.ExpectExec("UPDATE pending_emails SET sent_at").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	rec := &emailRecordProvider{}
-	processPendingEmail(context.Background(), q, rec)
+	emailutil.ProcessPendingEmail(context.Background(), q, rec)
 
 	if rec.to != "a@test" {
 		t.Fatalf("got %q", rec.to)

--- a/internal/emailutil/email.go
+++ b/internal/emailutil/email.go
@@ -1,4 +1,4 @@
-package goa4web
+package emailutil
 
 import (
 	"bytes"
@@ -12,11 +12,12 @@ import (
 	"github.com/arran4/goa4web/config"
 
 	"github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
-func notifyChange(ctx context.Context, provider email.Provider, emailAddr string, page string) error {
+func NotifyChange(ctx context.Context, provider email.Provider, emailAddr string, page string) error {
 	if emailAddr == "" {
 		return fmt.Errorf("no email specified")
 	}
@@ -55,8 +56,8 @@ func notifyChange(ctx context.Context, provider email.Provider, emailAddr string
 		return fmt.Errorf("execute email template: %w", err)
 	}
 
-	if q, ok := ctx.Value(common.KeyQueries).(*Queries); ok {
-		if err := q.InsertPendingEmail(ctx, InsertPendingEmailParams{ToEmail: emailAddr, Subject: content.Subject, Body: notification.String()}); err != nil {
+	if q, ok := ctx.Value(common.KeyQueries).(*db.Queries); ok {
+		if err := q.InsertPendingEmail(ctx, db.InsertPendingEmailParams{ToEmail: emailAddr, Subject: content.Subject, Body: notification.String()}); err != nil {
 			return err
 		}
 	} else if provider != nil {
@@ -80,7 +81,7 @@ func getEmailProvider() email.Provider {
 // ADMIN_EMAILS environment variable is set, it takes precedence and is
 // interpreted as a comma-separated list. If not set and a Queries value is
 // provided, the database is queried for administrator accounts.
-func getAdminEmails(ctx context.Context, q *Queries) []string {
+func getAdminEmails(ctx context.Context, q *db.Queries) []string {
 	env := os.Getenv(config.EnvAdminEmails)
 	var emails []string
 	if env != "" {
@@ -134,23 +135,23 @@ func emailSendingEnabled() bool {
 	}
 }
 
-func notifyAdmins(ctx context.Context, provider email.Provider, q *Queries, page string) {
+func notifyAdmins(ctx context.Context, provider email.Provider, q *db.Queries, page string) {
 	if provider == nil || !adminNotificationsEnabled() {
 		return
 	}
 	for _, email := range getAdminEmails(ctx, q) {
-		if err := notifyChange(ctx, provider, email, page); err != nil {
-			log.Printf("Error: notifyChange: %s", err)
+		if err := NotifyChange(ctx, provider, email, page); err != nil {
+			log.Printf("Error: NotifyChange: %s", err)
 		}
 	}
 }
 
 // notifyThreadSubscribers emails users subscribed to the forum thread.
-func notifyThreadSubscribers(ctx context.Context, provider email.Provider, q *Queries, threadID, excludeUser int32, page string) {
+func NotifyThreadSubscribers(ctx context.Context, provider email.Provider, q *db.Queries, threadID, excludeUser int32, page string) {
 	if provider == nil {
 		return
 	}
-	rows, err := q.ListUsersSubscribedToThread(ctx, ListUsersSubscribedToThreadParams{
+	rows, err := q.ListUsersSubscribedToThread(ctx, db.ListUsersSubscribedToThreadParams{
 		ForumthreadIdforumthread: threadID,
 		Idusers:                  excludeUser,
 	})
@@ -159,8 +160,8 @@ func notifyThreadSubscribers(ctx context.Context, provider email.Provider, q *Qu
 		return
 	}
 	for _, row := range rows {
-		if err := notifyChange(ctx, provider, row.Username.String, page); err != nil {
-			log.Printf("Error: notifyChange: %s", err)
+		if err := NotifyChange(ctx, provider, row.Username.String, page); err != nil {
+			log.Printf("Error: NotifyChange: %s", err)
 		}
 	}
 }

--- a/internal/emailutil/email_queue.go
+++ b/internal/emailutil/email_queue.go
@@ -1,15 +1,16 @@
-package goa4web
+package emailutil
 
 import (
 	"context"
 	"log"
 	"time"
 
+	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
 )
 
 // emailQueueWorker periodically sends pending emails using the provided provider.
-func emailQueueWorker(ctx context.Context, q *Queries, provider email.Provider, interval time.Duration) {
+func EmailQueueWorker(ctx context.Context, q *db.Queries, provider email.Provider, interval time.Duration) {
 	if q == nil || provider == nil {
 		log.Printf("email queue worker disabled: missing queue or provider")
 		return
@@ -19,15 +20,15 @@ func emailQueueWorker(ctx context.Context, q *Queries, provider email.Provider, 
 	for {
 		select {
 		case <-ticker.C:
-			processPendingEmail(ctx, q, provider)
+			ProcessPendingEmail(ctx, q, provider)
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-// processPendingEmail sends a single queued email if available.
-func processPendingEmail(ctx context.Context, q *Queries, provider email.Provider) {
+// ProcessPendingEmail sends a single queued email if available.
+func ProcessPendingEmail(ctx context.Context, q *db.Queries, provider email.Provider) {
 	if q == nil || provider == nil {
 		return
 	}

--- a/internal/emailutil/updateEmail.go
+++ b/internal/emailutil/updateEmail.go
@@ -1,21 +1,23 @@
-package goa4web
+package emailutil
 
 import (
 	"context"
 	_ "embed"
+
 	"github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 // defaultUpdateEmailText contains the compiled-in notification email template.
 // Administrators may override it by saving a new body in the template_overrides table.
 //
-//go:embed core/templates/templates/updateEmail.txt
+//go:embed updateEmail.txt
 var defaultUpdateEmailText string
 
 // getUpdateEmailText returns the update email template body, preferring a database
 // override when available.
 func getUpdateEmailText(ctx context.Context) string {
-	if q, ok := ctx.Value(common.KeyQueries).(*Queries); ok && q != nil {
+	if q, ok := ctx.Value(common.KeyQueries).(*db.Queries); ok && q != nil {
 		if body, err := q.GetTemplateOverride(ctx, "updateEmail"); err == nil && body != "" {
 			return body
 		}

--- a/internal/emailutil/updateEmail.txt
+++ b/internal/emailutil/updateEmail.txt
@@ -1,0 +1,10 @@
+To: {{.To}}
+From: {{.To}}
+Subject: [A4] {{.Subject}}
+
+There has been an update on my site on some page you either requested to be notified
+or were directly involved with. Please visit the URL to find out in relation to what:
+{{.URL}}
+
+- Arran4
+.

--- a/internal/forumutil/postupdate.go
+++ b/internal/forumutil/postupdate.go
@@ -1,8 +1,10 @@
-package goa4web
+package forumutil
 
 import (
 	"context"
 	"fmt"
+
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 // PostUpdate refreshes metadata on the given forum thread and topic.
@@ -22,7 +24,7 @@ import (
 //
 // The same effect is achieved by calling RecalculateForumThreadByIdMetaData
 // and RebuildForumTopicByIdMetaColumns generated via sqlc.
-func PostUpdate(ctx context.Context, q *Queries, threadID, topicID int32) error {
+func PostUpdate(ctx context.Context, q *db.Queries, threadID, topicID int32) error {
 	if err := q.RecalculateForumThreadByIdMetaData(ctx, threadID); err != nil {
 		return fmt.Errorf("recalc thread metadata: %w", err)
 	}

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -1,4 +1,4 @@
-package goa4web
+package notifications
 
 import (
 	"context"
@@ -6,11 +6,12 @@ import (
 	"net/http"
 	"time"
 
+	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/feeds"
 )
 
-// notificationsFeed produces a feed from the notifications slice.
-func notificationsFeed(r *http.Request, notifications []*Notification) *feeds.Feed {
+// NotificationsFeed produces a feed from the notifications slice.
+func NotificationsFeed(r *http.Request, notifications []*db.Notification) *feeds.Feed {
 	feed := &feeds.Feed{
 		Title:       "Notifications",
 		Link:        &feeds.Link{Href: r.URL.Path},
@@ -39,7 +40,7 @@ func notificationsFeed(r *http.Request, notifications []*Notification) *feeds.Fe
 }
 
 // notificationPurgeWorker periodically removes old read notifications.
-func notificationPurgeWorker(ctx context.Context, q *Queries, interval time.Duration) {
+func NotificationPurgeWorker(ctx context.Context, q *db.Queries, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -9,6 +9,9 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/arran4/goa4web/internal/emailutil"
+	notif "github.com/arran4/goa4web/internal/notifications"
 )
 
 func TestNotificationsQueries(t *testing.T) {
@@ -47,7 +50,7 @@ func TestNotificationsQueries(t *testing.T) {
 func TestNotificationsFeed(t *testing.T) {
 	r := httptest.NewRequest("GET", "/notifications/rss", nil)
 	n := []*Notification{{ID: 1, Link: sql.NullString{String: "/l", Valid: true}, Message: sql.NullString{String: "m", Valid: true}}}
-	feed := notificationsFeed(r, n)
+	feed := notif.NotificationsFeed(r, n)
 	if len(feed.Items) != 1 || feed.Items[0].Link.Href != "/l" {
 		t.Fatalf("feed item incorrect")
 	}
@@ -77,7 +80,7 @@ func TestNotifyThreadSubscribers(t *testing.T) {
 		WithArgs(int32(2), int32(1)).
 		WillReturnRows(rows)
 	rec := &dummyProvider{}
-	notifyThreadSubscribers(context.Background(), rec, q, 2, 1, "/p")
+	emailutil.NotifyThreadSubscribers(context.Background(), rec, q, 2, 1, "/p")
 	if rec.to != "bob" {
 		t.Fatalf("expected mail to bob got %s", rec.to)
 	}

--- a/postupdate_test.go
+++ b/postupdate_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/internal/forumutil"
 )
 
 func TestPostUpdate(t *testing.T) {
@@ -22,7 +23,7 @@ func TestPostUpdate(t *testing.T) {
 		WithArgs(int32(2)).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
-	if err := PostUpdate(context.Background(), q, 1, 2); err != nil {
+	if err := forumutil.PostUpdate(context.Background(), q, 1, 2); err != nil {
 		t.Fatalf("PostUpdate: %v", err)
 	}
 

--- a/startup.go
+++ b/startup.go
@@ -14,6 +14,8 @@ import (
 	common "github.com/arran4/goa4web/core/common"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/internal/emailutil"
+	"github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/runtimeconfig"
 	"github.com/go-sql-driver/mysql"
 )
@@ -128,7 +130,7 @@ func ensureSchema(ctx context.Context, db *sql.DB) error {
 // startWorkers launches goroutines for email processing and notification cleanup.
 func startWorkers(ctx context.Context, db *sql.DB, provider email.Provider) {
 	log.Printf("Starting email worker")
-	safeGo(func() { emailQueueWorker(ctx, New(db), provider, time.Minute) })
+	safeGo(func() { emailutil.EmailQueueWorker(ctx, New(db), provider, time.Minute) })
 	log.Printf("Starting notification purger worker")
-	safeGo(func() { notificationPurgeWorker(ctx, New(db), time.Hour) })
+	safeGo(func() { notifications.NotificationPurgeWorker(ctx, New(db), time.Hour) })
 }


### PR DESCRIPTION
## Summary
- create `internal/emailutil` with email helpers
- create `internal/forumutil` for post update helper
- create `internal/notifications` for notification helpers
- update imports and tests to use the new packages

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c8f4ff5ec832fbb9d2b9f0debd8d9