### PR TITLE
Refactor search word helpers

### DIFF
--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/arran4/goa4web/core"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	search "github.com/arran4/goa4web/handlers/search"
+	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -146,12 +146,12 @@ func BlogReplyPostPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if search.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -7,7 +7,7 @@ import (
 	corelanguage "github.com/arran4/goa4web/core/language"
 	blogs "github.com/arran4/goa4web/handlers/blogs"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	search "github.com/arran4/goa4web/handlers/search"
+	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"
 	"strconv"
@@ -93,12 +93,12 @@ func ThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if search.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/arran4/goa4web/core"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	search "github.com/arran4/goa4web/handlers/search"
+	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"
 	"strconv"
@@ -78,12 +78,12 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if search.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	search "github.com/arran4/goa4web/handlers/search"
 	db "github.com/arran4/goa4web/internal/db"
+	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"io"
 	"log"
 	"net/http"
@@ -199,12 +199,12 @@ func BoardPostImageActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if search.InsertWordsToImageSearch(w, r, wordIds, queries, pid) {
+	if searchutil.InsertWordsToImageSearch(w, r, wordIds, queries, pid) {
 		return
 	}
 

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	search "github.com/arran4/goa4web/handlers/search"
 	db "github.com/arran4/goa4web/internal/db"
+	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"
 	"strconv"
@@ -259,12 +259,12 @@ func BoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if search.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/linker/linkerAdminQueuePage.go
+++ b/handlers/linker/linkerAdminQueuePage.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	search "github.com/arran4/goa4web/handlers/search"
+	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -171,11 +171,11 @@ func AdminQueueApproveActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, text := range []string{link.Title.String, link.Description.String} {
-		wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
+		wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
 		if done {
 			return
 		}
-		if search.InsertWordsToLinkerSearch(w, r, wordIds, queries, lid) {
+		if searchutil.InsertWordsToLinkerSearch(w, r, wordIds, queries, lid) {
 			return
 		}
 	}
@@ -214,11 +214,11 @@ func AdminQueueBulkApproveActionPage(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		for _, text := range []string{link.Title.String, link.Description.String} {
-			wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
+			wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
 			if done {
 				return
 			}
-			if search.InsertWordsToLinkerSearch(w, r, wordIds, queries, lid) {
+			if searchutil.InsertWordsToLinkerSearch(w, r, wordIds, queries, lid) {
 				return
 			}
 		}

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -7,7 +7,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	search "github.com/arran4/goa4web/handlers/search"
+	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"
 	"strconv"
@@ -280,12 +280,12 @@ func CommentsReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if search.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -7,7 +7,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	search "github.com/arran4/goa4web/handlers/search"
+	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"
 	"strconv"
@@ -193,12 +193,12 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if search.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/news/searchResultNewsActionPage.go
+++ b/handlers/news/searchResultNewsActionPage.go
@@ -10,7 +10,6 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	search "github.com/arran4/goa4web/handlers/search"
 	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchutil"
 )
@@ -67,7 +66,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func NewsSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetNewsPostsByIdsWithWriterIdAndThreadCommentCountRow, bool, bool, error) {
-	searchWords := search.BreakupTextToWords(r.PostFormValue("searchwords"))
+	searchWords := searchutil.BreakupTextToWords(r.PostFormValue("searchwords"))
 	var newsIds []int32
 
 	if len(searchWords) == 0 {

--- a/handlers/search/search.go
+++ b/handlers/search/search.go
@@ -1,8 +1,6 @@
 package search
 
 import (
-	"database/sql"
-	"errors"
 	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
@@ -52,64 +50,4 @@ func SearchWordIdsFromText(w http.ResponseWriter, r *http.Request, text string, 
 		wordIds = append(wordIds, id)
 	}
 	return wordIds, false
-}
-
-func InsertWordsToLinkerSearch(w http.ResponseWriter, r *http.Request, wordIds []int64, queries *db.Queries, lid int64) bool {
-	for _, wid := range wordIds {
-		if err := queries.AddToLinkerSearch(r.Context(), db.AddToLinkerSearchParams{
-			LinkerIdlinker:                 int32(lid),
-			SearchwordlistIdsearchwordlist: int32(wid),
-		}); err != nil {
-			log.Printf("Error: addToLinkerSearch: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-			return true
-		}
-	}
-	return false
-}
-
-func InsertWordsToImageSearch(w http.ResponseWriter, r *http.Request, wordIds []int64, queries *db.Queries, pid int64) bool {
-	for _, wid := range wordIds {
-		if err := queries.AddToImagePostSearch(r.Context(), db.AddToImagePostSearchParams{
-			ImagepostIdimagepost:           int32(pid),
-			SearchwordlistIdsearchwordlist: int32(wid),
-		}); err != nil {
-			log.Printf("Error: addToImagePostSearch: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-			return true
-		}
-	}
-	return false
-}
-
-func InsertWordsToWritingSearch(w http.ResponseWriter, r *http.Request, wordIds []int64, queries *db.Queries, wacid int64) bool {
-	for _, wid := range wordIds {
-		if err := queries.AddToForumWritingSearch(r.Context(), db.AddToForumWritingSearchParams{
-			WritingIdwriting:               int32(wacid),
-			SearchwordlistIdsearchwordlist: int32(wid),
-		}); err != nil {
-			log.Printf("Error: addToForumWritingSearch: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-			return true
-		}
-	}
-	return false
-}
-
-func InsertWordsToForumSearch(w http.ResponseWriter, r *http.Request, wordIds []int64, queries *db.Queries, cid int64) bool {
-	for _, wid := range wordIds {
-		if err := queries.AddToForumCommentSearch(r.Context(), db.AddToForumCommentSearchParams{
-			CommentsIdcomments:             int32(cid),
-			SearchwordlistIdsearchwordlist: int32(wid),
-		}); err != nil {
-			switch {
-			case errors.Is(err, sql.ErrNoRows):
-			default:
-				log.Printf("Error: addToForumCommentSearch: %s", err)
-				http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -4,8 +4,8 @@ import (
 	"database/sql"
 	corecommon "github.com/arran4/goa4web/core/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	search "github.com/arran4/goa4web/handlers/search"
 	db "github.com/arran4/goa4web/internal/db"
+	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"
 	"strconv"
@@ -79,12 +79,12 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 		title,
 		body,
 	} {
-		wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
+		wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
 		if done {
 			return
 		}
 
-		if search.InsertWordsToWritingSearch(w, r, wordIds, queries, articleId) {
+		if searchutil.InsertWordsToWritingSearch(w, r, wordIds, queries, articleId) {
 			return
 		}
 	}

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -5,8 +5,8 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	search "github.com/arran4/goa4web/handlers/search"
 	db "github.com/arran4/goa4web/internal/db"
+	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"
 	"strconv"
@@ -107,12 +107,12 @@ func ArticleEditActionPage(w http.ResponseWriter, r *http.Request) {
 		title,
 		body,
 	} {
-		wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
+		wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
 		if done {
 			return
 		}
 
-		if search.InsertWordsToWritingSearch(w, r, wordIds, queries, int64(articleId)) {
+		if searchutil.InsertWordsToWritingSearch(w, r, wordIds, queries, int64(articleId)) {
 			return
 		}
 	}

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -6,8 +6,8 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	search "github.com/arran4/goa4web/handlers/search"
 	db "github.com/arran4/goa4web/internal/db"
+	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"
 	"strconv"
@@ -310,12 +310,12 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cid := int64(0)
-	wordIds, done := search.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if search.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 	//??? if _, done := SearchWordIdsFromText(w, r, text, queries); done {

--- a/internal/searchutil/insert.go
+++ b/internal/searchutil/insert.go
@@ -1,0 +1,23 @@
+package searchutil
+
+import (
+	"context"
+	"log"
+	"net/http"
+)
+
+// InsertFunc performs an insert operation for a single search word.
+type InsertFunc func(ctx context.Context, wordID int64) error
+
+// InsertWords executes insertFn for each word ID. It redirects on error and
+// returns true when a redirect has been issued.
+func InsertWords(w http.ResponseWriter, r *http.Request, wordIDs []int64, insertFn InsertFunc) bool {
+	for _, wid := range wordIDs {
+		if err := insertFn(r.Context(), wid); err != nil {
+			log.Printf("Error inserting search word: %s", err)
+			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			return true
+		}
+	}
+	return false
+}

--- a/internal/searchutil/tokenize.go
+++ b/internal/searchutil/tokenize.go
@@ -1,8 +1,7 @@
 package searchutil
 
 import (
-	"database/sql"
-	"errors"
+	"context"
 	"log"
 	"net/http"
 	"strings"
@@ -58,64 +57,40 @@ func SearchWordIdsFromText(w http.ResponseWriter, r *http.Request, text string, 
 
 // InsertWordsToLinkerSearch associates search words with a linker post.
 func InsertWordsToLinkerSearch(w http.ResponseWriter, r *http.Request, wordIds []int64, queries *db.Queries, lid int64) bool {
-	for _, wid := range wordIds {
-		if err := queries.AddToLinkerSearch(r.Context(), db.AddToLinkerSearchParams{
+	return InsertWords(w, r, wordIds, func(ctx context.Context, wid int64) error {
+		return queries.AddToLinkerSearch(ctx, db.AddToLinkerSearchParams{
 			LinkerIdlinker:                 int32(lid),
 			SearchwordlistIdsearchwordlist: int32(wid),
-		}); err != nil {
-			log.Printf("Error: addToLinkerSearch: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-			return true
-		}
-	}
-	return false
+		})
+	})
 }
 
 // InsertWordsToImageSearch associates search words with an image post.
 func InsertWordsToImageSearch(w http.ResponseWriter, r *http.Request, wordIds []int64, queries *db.Queries, pid int64) bool {
-	for _, wid := range wordIds {
-		if err := queries.AddToImagePostSearch(r.Context(), db.AddToImagePostSearchParams{
+	return InsertWords(w, r, wordIds, func(ctx context.Context, wid int64) error {
+		return queries.AddToImagePostSearch(ctx, db.AddToImagePostSearchParams{
 			ImagepostIdimagepost:           int32(pid),
 			SearchwordlistIdsearchwordlist: int32(wid),
-		}); err != nil {
-			log.Printf("Error: addToImagePostSearch: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-			return true
-		}
-	}
-	return false
+		})
+	})
 }
 
 // InsertWordsToWritingSearch associates search words with a writing post.
 func InsertWordsToWritingSearch(w http.ResponseWriter, r *http.Request, wordIds []int64, queries *db.Queries, wacid int64) bool {
-	for _, wid := range wordIds {
-		if err := queries.AddToForumWritingSearch(r.Context(), db.AddToForumWritingSearchParams{
+	return InsertWords(w, r, wordIds, func(ctx context.Context, wid int64) error {
+		return queries.AddToForumWritingSearch(ctx, db.AddToForumWritingSearchParams{
 			WritingIdwriting:               int32(wacid),
 			SearchwordlistIdsearchwordlist: int32(wid),
-		}); err != nil {
-			log.Printf("Error: addToForumWritingSearch: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-			return true
-		}
-	}
-	return false
+		})
+	})
 }
 
 // InsertWordsToForumSearch associates search words with a forum comment.
 func InsertWordsToForumSearch(w http.ResponseWriter, r *http.Request, wordIds []int64, queries *db.Queries, cid int64) bool {
-	for _, wid := range wordIds {
-		if err := queries.AddToForumCommentSearch(r.Context(), db.AddToForumCommentSearchParams{
+	return InsertWords(w, r, wordIds, func(ctx context.Context, wid int64) error {
+		return queries.AddToForumCommentSearch(ctx, db.AddToForumCommentSearchParams{
 			CommentsIdcomments:             int32(cid),
 			SearchwordlistIdsearchwordlist: int32(wid),
-		}); err != nil {
-			switch {
-			case errors.Is(err, sql.ErrNoRows):
-			default:
-				log.Printf("Error: addToForumCommentSearch: %s", err)
-				http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-				return true
-			}
-		}
-	}
-	return false
+		})
+	})
 }


### PR DESCRIPTION
## Summary
- centralize search word insertion helpers in internal package
- update handlers to use shared helpers
- remove duplicate implementations from search handler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ca7ebae54832f9d5ea3c49c0ba379