### PR TITLE
Add GoDoc comment for redirect helper

### DIFF
--- a/autoRefreshPage.go
+++ b/autoRefreshPage.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 )
 
+// taskRedirectWithoutQueryArgs redirects the request to the same URL path
+// stripped of any query parameters using an HTTP 307 Temporary Redirect.
 func taskRedirectWithoutQueryArgs(w http.ResponseWriter, r *http.Request) {
 	u := r.URL
 	u.RawQuery = ""


### PR DESCRIPTION
## Summary
- add a GoDoc style comment explaining `taskRedirectWithoutQueryArgs`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cafd37600832f8e0980b7d9ca8a14