### PR TITLE
Replace fmt.Print* with log.Printf

### DIFF
--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -2,7 +2,7 @@ package notifications
 
 import (
 	"context"
-	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -47,7 +47,7 @@ func NotificationPurgeWorker(ctx context.Context, q *db.Queries, interval time.D
 		select {
 		case <-ticker.C:
 			if err := q.PurgeReadNotifications(ctx); err != nil {
-				fmt.Println("purge notifications:", err)
+				log.Printf("purge notifications: %v", err)
 			}
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
## Summary
- swap fmt.Println with log.Printf in NotificationPurgeWorker
- use log package in notifications code

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cb00c6eb4832fbcafcf4bbb4af848