### PR TITLE
Update docs for query file location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,10 @@ Tests must not interact with the real file system. Use in-memory file systems
 provided by the `io/fs` package or mocks when file access is required.
 
 SQL query files are compiled using `sqlc`. Do not manually edit the generated
-`*.sql.go` files; instead update the corresponding `.sql` file and run `sqlc generate`.
-The `.sql` files live at the repository root with names such as `queries-users.sql`.
+`*.sql.go` files; instead update the corresponding `.sql` file and run
+`sqlc generate`.
+The `.sql` files live under `internal/db/` with names such as
+`queries-users.sql`.
 
 All database schema changes must include a migration script in the `migrations/`
 directory so existing installations can be upgraded. Example migration files are

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ requests.
 ├── data_embedded.go     – embed templates and CSS for production builds
 ├── data_live.go         – load templates from disk in development
 ├── models.go            – sqlc generated data models
-└── queries-*.sql        – SQL queries consumed by sqlc
+└── internal/db/queries-*.sql        – SQL queries consumed by sqlc
 ```
 
 ## Testing


### PR DESCRIPTION
## Summary
- fix instructions about `internal/db/queries-*.sql` path in AGENTS
- mention new query path in README repository layout

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cb02054e4832f98cc096164fb195c