### PR TITLE
Reference env constants in tests

### DIFF
--- a/core/session_secret_test.go
+++ b/core/session_secret_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"testing"
+
+	"github.com/arran4/goa4web/config"
 )
 
 func TestLoadSessionSecretCLI(t *testing.T) {
@@ -15,7 +17,7 @@ func TestLoadSessionSecretCLI(t *testing.T) {
 }
 
 func TestLoadSessionSecretEnv(t *testing.T) {
-	t.Setenv("SESSION_SECRET", "env")
+	t.Setenv(config.EnvSessionSecret, "env")
 	secret, err := LoadSessionSecret(OSFS{}, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -12,13 +12,14 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers/common"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
-	os.Unsetenv("EMAIL_PROVIDER")
+	os.Unsetenv(config.EnvEmailProvider)
 	runtimeconfig.AppRuntimeConfig.EmailProvider = ""
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
@@ -38,9 +39,9 @@ func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 }
 
 func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
-	os.Setenv("EMAIL_PROVIDER", "log")
+	os.Setenv(config.EnvEmailProvider, "log")
 	runtimeconfig.AppRuntimeConfig.EmailProvider = "log"
-	defer os.Unsetenv("EMAIL_PROVIDER")
+	defer os.Unsetenv(config.EnvEmailProvider)
 
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -114,8 +115,8 @@ func (r *recordAdminMail) Send(ctx context.Context, to, subject, body string) er
 }
 
 func TestNotifyAdminsEnv(t *testing.T) {
-	os.Setenv("ADMIN_EMAILS", "a@test.com,b@test.com")
-	defer os.Unsetenv("ADMIN_EMAILS")
+	os.Setenv(config.EnvAdminEmails, "a@test.com,b@test.com")
+	defer os.Unsetenv(config.EnvAdminEmails)
 	rec := &recordAdminMail{}
 	notifyAdmins(context.Background(), rec, nil, "page")
 	if len(rec.to) != 2 {
@@ -124,10 +125,10 @@ func TestNotifyAdminsEnv(t *testing.T) {
 }
 
 func TestNotifyAdminsDisabled(t *testing.T) {
-	os.Setenv("ADMIN_EMAILS", "a@test.com")
-	os.Setenv("ADMIN_NOTIFY", "false")
-	defer os.Unsetenv("ADMIN_EMAILS")
-	defer os.Unsetenv("ADMIN_NOTIFY")
+	os.Setenv(config.EnvAdminEmails, "a@test.com")
+	os.Setenv(config.EnvAdminNotify, "false")
+	defer os.Unsetenv(config.EnvAdminEmails)
+	defer os.Unsetenv(config.EnvAdminNotify)
 	rec := &recordAdminMail{}
 	notifyAdmins(context.Background(), rec, nil, "page")
 	if len(rec.to) != 0 {

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/arran4/goa4web/config"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/sessions"
 
@@ -134,7 +136,7 @@ func TestUserAdderMiddleware_AttachesPrefs(t *testing.T) {
 }
 
 func TestUserEmailTestAction_NoProvider(t *testing.T) {
-	os.Unsetenv("EMAIL_PROVIDER")
+	os.Unsetenv(config.EnvEmailProvider)
 	runtimeconfig.AppRuntimeConfig.EmailProvider = ""
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := context.WithValue(req.Context(), common.KeyUser, &dbpkg.User{Email: sql.NullString{String: "u@example.com", Valid: true}})
@@ -154,9 +156,9 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 }
 
 func TestUserEmailTestAction_WithProvider(t *testing.T) {
-	os.Setenv("EMAIL_PROVIDER", "log")
+	os.Setenv(config.EnvEmailProvider, "log")
 	runtimeconfig.AppRuntimeConfig.EmailProvider = "log"
-	defer os.Unsetenv("EMAIL_PROVIDER")
+	defer os.Unsetenv(config.EnvEmailProvider)
 
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := context.WithValue(req.Context(), common.KeyUser, &dbpkg.User{Email: sql.NullString{String: "u@example.com", Valid: true}})


### PR DESCRIPTION
## Summary
- update tests to reference configuration constants for environment vars
- import config package in updated tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cafcbd100832f8233f8e5f5895448