### PR TITLE
Use core filesystem in admin config utilities

### DIFF
--- a/handlers/admin/adminReloadConfigPage.go
+++ b/handlers/admin/adminReloadConfigPage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"
@@ -23,7 +24,7 @@ func AdminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
 		Back:     "/admin",
 	}
 
-	cfgMap := LoadAppConfigFile(ConfigFile)
+	cfgMap := LoadAppConfigFile(core.OSFS{}, ConfigFile)
 	Srv.Config = runtimeconfig.GenerateRuntimeConfig(nil, cfgMap, os.Getenv)
 	if err := corelanguage.ValidateDefaultLanguage(r.Context(), New(DBPool), Srv.Config.DefaultLanguage); err != nil {
 		data.Errors = append(data.Errors, err.Error())

--- a/handlers/admin/adminSiteSettingsPage.go
+++ b/handlers/admin/adminSiteSettingsPage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"
@@ -32,7 +33,7 @@ func AdminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		runtimeconfig.AppRuntimeConfig.DefaultLanguage = name
-		if err := updateConfigKey(ConfigFile, config.EnvDefaultLanguage, name); err != nil {
+		if err := updateConfigKey(core.OSFS{}, ConfigFile, config.EnvDefaultLanguage, name); err != nil {
 			log.Printf("config write error: %v", err)
 		}
 		http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)

--- a/handlers/admin/config_file.go
+++ b/handlers/admin/config_file.go
@@ -1,21 +1,24 @@
 package admin
 
 import (
+	"errors"
+	iofs "io/fs"
 	"log"
-	"os"
 	"strings"
+
+	"github.com/arran4/goa4web/core"
 )
 
 // LoadAppConfigFile reads key=value pairs from the given path.
 // Missing files return an empty map and unknown keys are ignored.
-func LoadAppConfigFile(path string) map[string]string {
+func LoadAppConfigFile(fs core.FileSystem, path string) map[string]string {
 	values := make(map[string]string)
 	if path == "" {
 		return values
 	}
-	b, err := os.ReadFile(path)
+	b, err := fs.ReadFile(path)
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, iofs.ErrNotExist) {
 			log.Printf("app config file error: %v", err)
 		}
 		return values

--- a/handlers/admin/config_update.go
+++ b/handlers/admin/config_update.go
@@ -2,17 +2,18 @@ package admin
 
 import (
 	"bytes"
-	"os"
 	"sort"
+
+	"github.com/arran4/goa4web/core"
 )
 
 // updateConfigKey writes the given key/value pair to the config file.
 // Existing keys are replaced, new keys appended. Empty values remove the key.
-func updateConfigKey(path, key, value string) error {
+func updateConfigKey(fs core.FileSystem, path, key, value string) error {
 	if path == "" {
 		return nil
 	}
-	cfg := LoadAppConfigFile(path)
+	cfg := LoadAppConfigFile(fs, path)
 	if value == "" {
 		delete(cfg, key)
 	} else {
@@ -27,5 +28,5 @@ func updateConfigKey(path, key, value string) error {
 	for _, k := range keys {
 		buf.WriteString(k + "=" + cfg[k] + "\n")
 	}
-	return os.WriteFile(path, buf.Bytes(), 0644)
+	return fs.WriteFile(path, buf.Bytes(), 0644)
 }


### PR DESCRIPTION
## Summary
- use `core.FileSystem` in admin config helpers
- pass `core.OSFS{}` to settings and reload pages

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cafda7cb0832f9ab1039d3d44c388