### PR TITLE
Refactor security middleware

### DIFF
--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -1,13 +1,15 @@
-package goa4web
+package middleware
 
 import (
 	"database/sql"
 	"errors"
-	"github.com/arran4/goa4web/handlers/common"
 	"net"
 	"net/http"
 	"net/netip"
 	"strings"
+
+	"github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 func normalizeIP(ip string) string {
@@ -50,10 +52,11 @@ func requestIP(r *http.Request) string {
 	return normalizeIP(host)
 }
 
+// SecurityHeadersMiddleware enforces IP bans and sets common security headers.
 func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ip := requestIP(r)
-		if queries, ok := r.Context().Value(common.KeyQueries).(*Queries); ok {
+		if queries, ok := r.Context().Value(common.KeyQueries).(*db.Queries); ok {
 			bans, err := queries.ListActiveBans(r.Context())
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/run.go
+++ b/run.go
@@ -10,6 +10,7 @@ import (
 	news "github.com/arran4/goa4web/handlers/news"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
 	email "github.com/arran4/goa4web/internal/email"
+	middleware "github.com/arran4/goa4web/internal/middleware"
 	"log"
 	"net/http"
 	"os"
@@ -85,7 +86,7 @@ func RunWithConfig(ctx context.Context, cfg runtimeconfig.RuntimeConfig, session
 		userhandlers.UserAdderMiddleware,
 		CoreAdderMiddleware,
 		RequestLoggerMiddleware,
-		SecurityHeadersMiddleware,
+		middleware.SecurityHeadersMiddleware,
 	).Wrap(r)
 	if csrfEnabled() {
 		handler = newCSRFMiddleware(sessionSecret, cfg.HTTPHostname, version).Wrap(handler)


### PR DESCRIPTION
## Summary
- move IP checking and headers into internal/middleware
- reference middleware.SecurityHeadersMiddleware in run.go
- remove old security.go

## Testing
- `go test ./...` *(fails: undefined: isAlphanumericOrPunctuation, too many arguments in call to updateConfigKey)*

------
https://chatgpt.com/codex/tasks/task_e_685cb736c9f4832f8bdd3609b7a6c64b