### PR TITLE
Move email tests to emailutil package

### DIFF
--- a/internal/emailutil/email_test.go
+++ b/internal/emailutil/email_test.go
@@ -1,4 +1,4 @@
-package goa4web
+package emailutil_test
 
 import (
 	"context"
@@ -73,7 +73,7 @@ func TestNotifyChange(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := New(db)
+	q := dbpkg.New(db)
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs("a@b.com", sqlmock.AnyArg(), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 	ctx := context.WithValue(context.Background(), common.KeyQueries, q)
 	rec := &recordMail{}
@@ -112,7 +112,7 @@ func TestInsertPendingEmail(t *testing.T) {
 	}
 	defer db.Close()
 
-	q := New(db)
+	q := dbpkg.New(db)
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs("t@test", "sub", "body").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	if err := q.InsertPendingEmail(context.Background(), dbpkg.InsertPendingEmailParams{ToEmail: "t@test", Subject: "sub", Body: "body"}); err != nil {
@@ -129,7 +129,7 @@ func TestEmailQueueWorker(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := New(db)
+	q := dbpkg.New(db)
 	rows := sqlmock.NewRows([]string{"id", "to_email", "subject", "body"}).AddRow(1, "a@test", "s", "b")
 	mock.ExpectQuery("SELECT id, to_email").WillReturnRows(rows)
 	mock.ExpectExec("UPDATE pending_emails SET sent_at").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))


### PR DESCRIPTION
## Summary
- move `email_test.go` into `internal/emailutil`
- set the test package to `emailutil_test`
- fix imports to use `dbpkg.New`

## Testing
- `go test ./...` *(fails: too many arguments in call to updateConfigKey)*

------
https://chatgpt.com/codex/tasks/task_e_685cb719adec832f805e75093792dfd4