### PR TITLE
Move app config helpers to config package

### DIFF
--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -23,7 +23,7 @@ func main() {
 		cfgPath = os.Getenv(config.EnvConfigFile)
 	}
 
-	fileVals := goa4web.LoadAppConfigFile(core.OSFS{}, cfgPath)
+	fileVals := config.LoadAppConfigFile(core.OSFS{}, cfgPath)
 
 	fs := runtimeconfig.NewRuntimeFlagSet(os.Args[0])
 	var (

--- a/config/appconfig.go
+++ b/config/appconfig.go
@@ -1,18 +1,24 @@
-package goa4web
+package config
 
 import (
 	"bytes"
+	"io/fs"
 	"log"
 	"os"
 	"sort"
 	"strings"
-
-	"github.com/arran4/goa4web/core"
 )
+
+// FileSystem abstracts file operations. It matches the core.FileSystem
+// interface so core implementations can be passed in directly.
+type FileSystem interface {
+	ReadFile(name string) ([]byte, error)
+	WriteFile(name string, data []byte, perm fs.FileMode) error
+}
 
 // LoadAppConfigFile reads CONFIG_FILE style key=value pairs and returns them as a map.
 // Missing files return an empty map. Unknown keys are ignored.
-func LoadAppConfigFile(fs core.FileSystem, path string) map[string]string {
+func LoadAppConfigFile(fs FileSystem, path string) map[string]string {
 	values := make(map[string]string)
 	if path == "" {
 		return values
@@ -36,7 +42,7 @@ func LoadAppConfigFile(fs core.FileSystem, path string) map[string]string {
 
 // UpdateConfigKey writes the given key/value pair to the config file.
 // Existing keys are replaced, new keys appended. Empty values remove the key.
-func UpdateConfigKey(fs core.FileSystem, path, key, value string) error {
+func UpdateConfigKey(fs FileSystem, path, key, value string) error {
 	if path == "" {
 		return nil
 	}

--- a/config/appconfig_test.go
+++ b/config/appconfig_test.go
@@ -1,8 +1,9 @@
-package goa4web
+package config_test
 
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 )
 
@@ -13,7 +14,7 @@ func TestLoadAppConfigFile(t *testing.T) {
 	if err := fs.WriteFile(file, []byte(content), 0644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	m := LoadAppConfigFile(fs, file)
+	m := config.LoadAppConfigFile(fs, file)
 	if m["DB_USER"] != "dbuser" || m["EMAIL_PROVIDER"] != "smtp" {
 		t.Fatalf("unexpected map: %#v", m)
 	}
@@ -22,7 +23,7 @@ func TestLoadAppConfigFile(t *testing.T) {
 func TestLoadAppConfigFileMissing(t *testing.T) {
 	fs := core.UseMemFS(t)
 	file := "none.conf"
-	m := LoadAppConfigFile(fs, file)
+	m := config.LoadAppConfigFile(fs, file)
 	if len(m) != 0 {
 		t.Fatalf("expected empty map, got %#v", m)
 	}

--- a/handlers/admin/adminSiteSettingsPage.go
+++ b/handlers/admin/adminSiteSettingsPage.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"
@@ -33,7 +32,7 @@ func AdminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		runtimeconfig.AppRuntimeConfig.DefaultLanguage = name
-		if err := updateConfigKey(core.OSFS{}, ConfigFile, config.EnvDefaultLanguage, name); err != nil {
+		if err := updateConfigKey(ConfigFile, config.EnvDefaultLanguage, name); err != nil {
 			log.Printf("config write error: %v", err)
 		}
 		http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)

--- a/handlers/admin/vars.go
+++ b/handlers/admin/vars.go
@@ -3,7 +3,7 @@ package admin
 import (
 	"database/sql"
 
-	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/pkg/server"
 )
 
@@ -18,4 +18,4 @@ var DBPool *sql.DB
 
 // UpdateConfigKeyFunc is used to persist configuration changes. It should be
 // set by the main application on startup.
-var UpdateConfigKeyFunc func(fs core.FileSystem, path, key, value string) error
+var UpdateConfigKeyFunc func(fs config.FileSystem, path, key, value string) error

--- a/run.go
+++ b/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/pkg/server"
@@ -95,7 +96,7 @@ func RunWithConfig(ctx context.Context, cfg runtimeconfig.RuntimeConfig, session
 	adminhandlers.ConfigFile = ConfigFile
 	adminhandlers.Srv = srv
 	adminhandlers.DBPool = dbPool
-	adminhandlers.UpdateConfigKeyFunc = UpdateConfigKey
+	adminhandlers.UpdateConfigKeyFunc = config.UpdateConfigKey
 
 	provider := email.ProviderFromConfig(cfg)
 


### PR DESCRIPTION
## Summary
- relocate app config helpers into `config` package
- adjust admin helpers and runtime setup to use new location
- move associated tests

## Testing
- `go test ./...` *(fails: undefined isAlphanumericOrPunctuation in handlers/search)*

------
https://chatgpt.com/codex/tasks/task_e_685cb7066170832f86abe146213a4dac