### PR TITLE
Refactor startup routines

### DIFF
--- a/db_vars.go
+++ b/db_vars.go
@@ -1,0 +1,8 @@
+package goa4web
+
+import "database/sql"
+
+var (
+	dbPool         *sql.DB
+	dbLogVerbosity int
+)

--- a/handlers/admin/adminSiteSettingsPage.go
+++ b/handlers/admin/adminSiteSettingsPage.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"
@@ -33,7 +32,7 @@ func AdminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		runtimeconfig.AppRuntimeConfig.DefaultLanguage = name
-		if err := updateConfigKey(core.OSFS{}, ConfigFile, config.EnvDefaultLanguage, name); err != nil {
+		if err := updateConfigKey(ConfigFile, config.EnvDefaultLanguage, name); err != nil {
 			log.Printf("config write error: %v", err)
 		}
 		http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)

--- a/handlers/search/search_test.go
+++ b/handlers/search/search_test.go
@@ -24,7 +24,7 @@ func TestIsAlphanumericOrPunctuation(t *testing.T) {
 		{'!', false},
 	}
 	for _, c := range cases {
-		if got := isAlphanumericOrPunctuation(c.r); got != c.want {
+		if got := searchutil.IsAlphanumericOrPunctuation(c.r); got != c.want {
 			t.Errorf("%q got %v want %v", string(c.r), got, c.want)
 		}
 	}
@@ -43,7 +43,7 @@ func TestIsAlphanumericOrPunctuationExtra(t *testing.T) {
 		{'世', true},
 	}
 	for _, tt := range tests {
-		if got := isAlphanumericOrPunctuation(tt.r); got != tt.want {
+		if got := searchutil.IsAlphanumericOrPunctuation(tt.r); got != tt.want {
 			t.Errorf("%q got %v want %v", string(tt.r), got, tt.want)
 		}
 	}

--- a/internal/searchutil/tokenize.go
+++ b/internal/searchutil/tokenize.go
@@ -10,7 +10,9 @@ import (
 	db "github.com/arran4/goa4web/internal/db"
 )
 
-func isAlphanumericOrPunctuation(char rune) bool {
+// IsAlphanumericOrPunctuation reports whether the rune is a letter, digit or
+// one of the punctuation characters '-' or '\”. It is used by BreakupTextToWords.
+func IsAlphanumericOrPunctuation(char rune) bool {
 	return unicode.IsLetter(char) || unicode.IsDigit(char) || strings.ContainsRune("'-", char)
 }
 
@@ -20,7 +22,7 @@ func BreakupTextToWords(input string) []string {
 	var tokens []string
 	startIndex := -1
 	for i, char := range input {
-		if isAlphanumericOrPunctuation(char) {
+		if IsAlphanumericOrPunctuation(char) {
 			if startIndex == -1 {
 				startIndex = i
 			}

--- a/internal/startup/startup_test.go
+++ b/internal/startup/startup_test.go
@@ -1,4 +1,4 @@
-package goa4web
+package startup
 
 import (
 	"context"
@@ -20,7 +20,7 @@ func TestEnsureSchemaVersionMatch(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM schema_version")).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
-		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(ExpectedSchemaVersion))
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(expectedSchemaVersion))
 
 	if err := ensureSchema(context.Background(), db); err != nil {
 		t.Fatalf("ensureSchema: %v", err)
@@ -42,7 +42,7 @@ func TestEnsureSchemaVersionMismatch(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM schema_version")).
 		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
-		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(ExpectedSchemaVersion - 1))
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(expectedSchemaVersion - 1))
 
 	if err := ensureSchema(context.Background(), db); err == nil {
 		t.Fatalf("expected error")


### PR DESCRIPTION
## Summary
- move DB init and worker helpers to `internal/startup`
- update `RunWithConfig` to use new startup package
- keep db connection globals in `db_vars.go`
- adjust tests and utilities accordingly

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cb73a2e10832fb7060832643d8f70