### PR TITLE
Refactor core helpers into middleware package

### DIFF
--- a/core.go
+++ b/core.go
@@ -1,147 +1,18 @@
 package goa4web
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"database/sql"
 	"fmt"
-	common "github.com/arran4/goa4web/core/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
-	"strings"
 
-	"github.com/arran4/goa4web/core"
-	"github.com/arran4/goa4web/runtimeconfig"
+	common "github.com/arran4/goa4web/core/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
 )
-
-func handleDie(w http.ResponseWriter, message string) {
-	http.Error(w, message, http.StatusInternalServerError)
-}
-
-// IndexItem struct.
-type IndexItem = common.IndexItem
-
-// indexItems.
-var indexItems = []common.IndexItem{
-	{Name: "News", Link: "/"},
-	{Name: "FAQ", Link: "/faq"},
-	{Name: "Blogs", Link: "/blogs"},
-	{Name: "Forum", Link: "/forum"},
-	{Name: "Linker", Link: "/linker"},
-	{Name: "Bookmarks", Link: "/bookmarks"},
-	{Name: "ImageBBS", Link: "/imagebbs"},
-	{Name: "Search", Link: "/search"},
-	{Name: "Writings", Link: "/writings"},
-	{Name: "Information", Link: "/information"},
-}
-
-func CoreAdderMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		session, err := core.GetSession(request)
-		if err != nil {
-			core.SessionErrorRedirect(writer, request, err)
-			return
-		}
-		var uid int32
-		if err == nil {
-			uid, _ = session.Values["UID"].(int32)
-		}
-		queries := request.Context().Value(hcommon.KeyQueries).(*Queries)
-
-		level := "reader"
-		if uid != 0 {
-			perm, err := queries.GetPermissionsByUserIdAndSectionAndSectionAll(request.Context(), GetPermissionsByUserIdAndSectionAndSectionAllParams{
-				UsersIdusers: uid,
-				Section:      sql.NullString{String: "all", Valid: true},
-			})
-			if err == nil && perm.Level.Valid {
-				level = perm.Level.String
-			}
-		}
-
-		idx := make([]common.IndexItem, len(indexItems))
-		copy(idx, indexItems)
-		if uid != 0 {
-			idx = append(idx, common.IndexItem{Name: "Preferences", Link: "/usr"})
-		}
-		var count int32
-		if uid != 0 && hcommon.NotificationsEnabled() {
-			c, err := queries.CountUnreadNotifications(request.Context(), uid)
-			if err == nil {
-				count = c
-				idx = append(idx, common.IndexItem{Name: fmt.Sprintf("Notifications (%d)", c), Link: "/usr/notifications"})
-			}
-		}
-		var ann *GetActiveAnnouncementWithNewsRow
-		if queries.DB() != nil {
-			if a, err := queries.GetActiveAnnouncementWithNews(request.Context()); err == nil {
-				ann = a
-			}
-		}
-		ctx := context.WithValue(request.Context(), hcommon.KeyCoreData, &CoreData{
-			SecurityLevel:     level,
-			IndexItems:        idx,
-			UserID:            uid,
-			Title:             "Arran4's Website",
-			FeedsEnabled:      runtimeconfig.AppRuntimeConfig.FeedsEnabled,
-			NotificationCount: count,
-			Announcement:      ann,
-		})
-		next.ServeHTTP(writer, request.WithContext(ctx))
-	})
-}
 
 type CoreData = common.CoreData
 
-type Configuration struct {
-	data map[string]string
-}
-
-func NewConfiguration() *Configuration {
-	return &Configuration{
-		data: make(map[string]string),
-	}
-}
-
-func (c *Configuration) set(key, value string) {
-	c.data[key] = value
-}
-
-func (c *Configuration) get(key string) string {
-	return c.data[key]
-}
-
-func (c *Configuration) readConfiguration(fs core.FileSystem, filename string) {
-	b, err := fs.ReadFile(filename)
-	if err != nil {
-		return
-	}
-	scanner := bufio.NewScanner(bytes.NewReader(b))
-	for scanner.Scan() {
-		line := scanner.Text()
-		sep := strings.Index(line, "=")
-		if sep >= 0 {
-			key := line[:sep]
-			value := line[sep+1:]
-			c.set(key, value)
-		}
-	}
-}
-
-func X2c(what string) byte {
-	digit := func(c byte) byte {
-		if c >= 'A' {
-			return (c & 0xdf) - 'A' + 10
-		}
-		return c - '0'
-	}
-
-	d1 := digit(what[0])
-	d2 := digit(what[1])
-	return d1*16 + d2
-}
+// DBAdderMiddleware adds database handles and query helpers to the request context.
 func DBAdderMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if dbPool == nil {

--- a/handlers/admin/adminSiteSettingsPage.go
+++ b/handlers/admin/adminSiteSettingsPage.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"
@@ -33,7 +32,7 @@ func AdminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		runtimeconfig.AppRuntimeConfig.DefaultLanguage = name
-		if err := updateConfigKey(core.OSFS{}, ConfigFile, config.EnvDefaultLanguage, name); err != nil {
+		if err := updateConfigKey(ConfigFile, config.EnvDefaultLanguage, name); err != nil {
 			log.Printf("config write error: %v", err)
 		}
 		http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)

--- a/internal/middleware/core.go
+++ b/internal/middleware/core.go
@@ -1,0 +1,142 @@
+package middleware
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/arran4/goa4web/core"
+	common "github.com/arran4/goa4web/core/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+func handleDie(w http.ResponseWriter, message string) {
+	http.Error(w, message, http.StatusInternalServerError)
+}
+
+type IndexItem = common.IndexItem
+
+var indexItems = []common.IndexItem{
+	{Name: "News", Link: "/"},
+	{Name: "FAQ", Link: "/faq"},
+	{Name: "Blogs", Link: "/blogs"},
+	{Name: "Forum", Link: "/forum"},
+	{Name: "Linker", Link: "/linker"},
+	{Name: "Bookmarks", Link: "/bookmarks"},
+	{Name: "ImageBBS", Link: "/imagebbs"},
+	{Name: "Search", Link: "/search"},
+	{Name: "Writings", Link: "/writings"},
+	{Name: "Information", Link: "/information"},
+}
+
+func CoreAdderMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		session, err := core.GetSession(request)
+		if err != nil {
+			core.SessionErrorRedirect(writer, request, err)
+			return
+		}
+		var uid int32
+		if err == nil {
+			uid, _ = session.Values["UID"].(int32)
+		}
+		queries := request.Context().Value(hcommon.KeyQueries).(*db.Queries)
+
+		level := "reader"
+		if uid != 0 {
+			perm, err := queries.GetPermissionsByUserIdAndSectionAndSectionAll(request.Context(), db.GetPermissionsByUserIdAndSectionAndSectionAllParams{
+				UsersIdusers: uid,
+				Section:      sql.NullString{String: "all", Valid: true},
+			})
+			if err == nil && perm.Level.Valid {
+				level = perm.Level.String
+			}
+		}
+
+		idx := make([]common.IndexItem, len(indexItems))
+		copy(idx, indexItems)
+		if uid != 0 {
+			idx = append(idx, common.IndexItem{Name: "Preferences", Link: "/usr"})
+		}
+		var count int32
+		if uid != 0 && hcommon.NotificationsEnabled() {
+			c, err := queries.CountUnreadNotifications(request.Context(), uid)
+			if err == nil {
+				count = c
+				idx = append(idx, common.IndexItem{Name: fmt.Sprintf("Notifications (%d)", c), Link: "/usr/notifications"})
+			}
+		}
+		var ann *db.GetActiveAnnouncementWithNewsRow
+		if queries.DB() != nil {
+			if a, err := queries.GetActiveAnnouncementWithNews(request.Context()); err == nil {
+				ann = a
+			}
+		}
+		ctx := context.WithValue(request.Context(), hcommon.KeyCoreData, &CoreData{
+			SecurityLevel:     level,
+			IndexItems:        idx,
+			UserID:            uid,
+			Title:             "Arran4's Website",
+			FeedsEnabled:      runtimeconfig.AppRuntimeConfig.FeedsEnabled,
+			NotificationCount: count,
+			Announcement:      ann,
+		})
+		next.ServeHTTP(writer, request.WithContext(ctx))
+	})
+}
+
+type CoreData = common.CoreData
+
+type Configuration struct {
+	data map[string]string
+}
+
+func NewConfiguration() *Configuration {
+	return &Configuration{
+		data: make(map[string]string),
+	}
+}
+
+func (c *Configuration) set(key, value string) {
+	c.data[key] = value
+}
+
+func (c *Configuration) get(key string) string {
+	return c.data[key]
+}
+
+func (c *Configuration) readConfiguration(fs core.FileSystem, filename string) {
+	b, err := fs.ReadFile(filename)
+	if err != nil {
+		return
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	for scanner.Scan() {
+		line := scanner.Text()
+		sep := strings.Index(line, "=")
+		if sep >= 0 {
+			key := line[:sep]
+			value := line[sep+1:]
+			c.set(key, value)
+		}
+	}
+}
+
+func X2c(what string) byte {
+	digit := func(c byte) byte {
+		if c >= 'A' {
+			return (c & 0xdf) - 'A' + 10
+		}
+		return c - '0'
+	}
+
+	d1 := digit(what[0])
+	d2 := digit(what[1])
+	return d1*16 + d2
+}

--- a/internal/middleware/core_utils_test.go
+++ b/internal/middleware/core_utils_test.go
@@ -1,4 +1,4 @@
-package goa4web
+package middleware
 
 import (
 	"net/http"

--- a/run.go
+++ b/run.go
@@ -10,6 +10,7 @@ import (
 	news "github.com/arran4/goa4web/handlers/news"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
 	email "github.com/arran4/goa4web/internal/email"
+	middleware "github.com/arran4/goa4web/internal/middleware"
 	"log"
 	"net/http"
 	"os"
@@ -83,7 +84,7 @@ func RunWithConfig(ctx context.Context, cfg runtimeconfig.RuntimeConfig, session
 	handler = newMiddlewareChain(
 		DBAdderMiddleware,
 		userhandlers.UserAdderMiddleware,
-		CoreAdderMiddleware,
+		middleware.CoreAdderMiddleware,
 		RequestLoggerMiddleware,
 		SecurityHeadersMiddleware,
 	).Wrap(r)


### PR DESCRIPTION
## Summary
- move utility functions from `core.go` into new `internal/middleware` package
- adjust admin site settings to call `updateConfigKey` correctly
- update routes to use `middleware.CoreAdderMiddleware`
- relocate and update `core_utils_test.go`

## Testing
- `go test ./...` *(fails: `handlers/search` build errors)*

------
https://chatgpt.com/codex/tasks/task_e_685cb7484a80832f861da8cf57a9cfae