### PR TITLE
Move HTML helpers to internal package

### DIFF
--- a/internal/htmlutil/html.go
+++ b/internal/htmlutil/html.go
@@ -1,4 +1,4 @@
-package goa4web
+package htmlutil
 
 import (
 	"fmt"
@@ -7,15 +7,18 @@ import (
 	"github.com/arran4/goa4web/a4code2html"
 )
 
-func anchorLink(anchor, linkName string) string {
+// AnchorLink returns an anchor tag linking to the given section.
+func AnchorLink(anchor, linkName string) string {
 	return fmt.Sprintf("<a href=\"#%s\">%s</a><br>", anchor, linkName)
 }
 
-func pageLink(pagename, linkName string) string {
+// PageLink returns a link to the supplied page.
+func PageLink(pagename, linkName string) string {
 	return fmt.Sprintf("<a href=\"?page=%s\">%s</a><br>", pagename, linkName)
 }
 
-func categoryLevel(categoryName string, level int) string {
+// CategoryLevel formats a category heading at the given level.
+func CategoryLevel(categoryName string, level int) string {
 	span := ""
 	switch level {
 	case 0:
@@ -28,7 +31,8 @@ func categoryLevel(categoryName string, level int) string {
 	return fmt.Sprintf("<p><a name=\"%s\"><span style=\"%s\">%s</span></a><br>\n", categoryName, span, categoryName)
 }
 
-func externalLink(pagename, linkName string) string {
+// ExternalLink sanitizes pagename and returns a link that opens in a new window.
+func ExternalLink(pagename, linkName string) string {
 	safe, ok := a4code2html.SanitizeURL(pagename)
 	if ok {
 		return fmt.Sprintf("<a href=\"%s\" target=\"_blank\">%s</a>", safe, linkName)
@@ -36,7 +40,8 @@ func externalLink(pagename, linkName string) string {
 	return safe
 }
 
-func formatCategories(input string) string {
+// FormatCategories converts the markup used for category listings into HTML.
+func FormatCategories(input string) string {
 	var (
 		formatter          strings.Builder
 		currentLevel       uint
@@ -84,7 +89,7 @@ func formatCategories(input string) string {
 				if input[i+level+2] != '=' {
 					break
 				}
-				formatter.WriteString(anchorLink(categoryname.String(), categoryname.String()))
+				formatter.WriteString(AnchorLink(categoryname.String(), categoryname.String()))
 				i = i + level + 2 + func() int {
 					if input[i+level+3] == '\n' {
 						return 1
@@ -105,7 +110,8 @@ func formatCategories(input string) string {
 	return formatter.String()
 }
 
-func formatBlob(input string) string {
+// FormatBlob converts forum markup into HTML.
+func FormatBlob(input string) string {
 	var (
 		formatter          strings.Builder
 		strongToggle       bool
@@ -261,7 +267,7 @@ func formatBlob(input string) string {
 					if i+1 < len(input) && input[i+2] == '|' {
 						i++
 					}
-					formatter.WriteString(externalLink(linkaddr.String(), linkname.String()))
+					formatter.WriteString(ExternalLink(linkaddr.String(), linkname.String()))
 					i++
 					break
 				}

--- a/internal/htmlutil/html_test.go
+++ b/internal/htmlutil/html_test.go
@@ -1,9 +1,9 @@
-package goa4web
+package htmlutil
 
 import "testing"
 
 func TestAnchorLink(t *testing.T) {
-	got := anchorLink("section", "name")
+	got := AnchorLink("section", "name")
 	want := "<a href=\"#section\">name</a><br>"
 	if got != want {
 		t.Errorf("anchorLink=%q", got)
@@ -11,7 +11,7 @@ func TestAnchorLink(t *testing.T) {
 }
 
 func TestPageLink(t *testing.T) {
-	got := pageLink("home", "Home")
+	got := PageLink("home", "Home")
 	want := "<a href=\"?page=home\">Home</a><br>"
 	if got != want {
 		t.Errorf("pageLink=%q", got)
@@ -19,16 +19,16 @@ func TestPageLink(t *testing.T) {
 }
 
 func TestCategoryLevel(t *testing.T) {
-	if got := categoryLevel("cat", 1); got != "<p><a name=\"cat\"><span style=\"font-size: 16;\">cat</span></a><br>\n" {
+	if got := CategoryLevel("cat", 1); got != "<p><a name=\"cat\"><span style=\"font-size: 16;\">cat</span></a><br>\n" {
 		t.Errorf("categoryLevel=%q", got)
 	}
-	if got := categoryLevel("cat", 3); got != "<p><a name=\"cat\"><span style=\"\">cat</span></a><br>\n" {
+	if got := CategoryLevel("cat", 3); got != "<p><a name=\"cat\"><span style=\"\">cat</span></a><br>\n" {
 		t.Errorf("categoryLevel default=%q", got)
 	}
 }
 
 func TestExternalLink(t *testing.T) {
-	got := externalLink("http://x", "X")
+	got := ExternalLink("http://x", "X")
 	want := "<a href=\"http://x\" target=\"_blank\">X</a>"
 	if got != want {
 		t.Errorf("externalLink=%q", got)
@@ -36,7 +36,7 @@ func TestExternalLink(t *testing.T) {
 }
 
 func TestExternalLinkBadURL(t *testing.T) {
-	got := externalLink("javascript:alert(1)", "X")
+	got := ExternalLink("javascript:alert(1)", "X")
 	want := "javascript:alert(1)"
 	if got != want {
 		t.Errorf("externalLink bad=%q", got)
@@ -45,7 +45,7 @@ func TestExternalLinkBadURL(t *testing.T) {
 
 func TestFormatBlobComplex(t *testing.T) {
 	input := "\\</pre\\>line1\n#line2\n-line3\n\\*bold\\* text"
-	got := formatBlob(input)
+	got := FormatBlob(input)
 	want := "</pre>\nline1<br>\n<ol>\n<li>line2</ol>\n<br>\n<ul>\n<li>line3</ul>\n<br>\n<strong>bold</strong> text"
 	if got != want {
 		t.Errorf("unexpected output\n got: %q\nwant: %q", got, want)
@@ -54,7 +54,7 @@ func TestFormatBlobComplex(t *testing.T) {
 
 func TestFormatCategoriesSimple(t *testing.T) {
 	input := "==Cat==\n#item1\n-item2"
-	got := formatCategories(input)
+	got := FormatCategories(input)
 	want := "<ul>\n<a href=\"#Cat\">Cat</a><br><br>\n<br>\n</ul>\n"
 	if got != want {
 		t.Errorf("unexpected output\n got: %q\nwant: %q", got, want)


### PR DESCRIPTION
## Summary
- move html helper code into `internal/htmlutil`
- export HTML helper functions
- update tests

## Testing
- `go test ./...` *(fails: syntax errors in unrelated packages)*

------
https://chatgpt.com/codex/tasks/task_e_685cba6c4860832f9c031217d13c246a