### PR TITLE
Move templatePage handler to new templates package

### DIFF
--- a/handlers/templates/template.go
+++ b/handlers/templates/template.go
@@ -1,21 +1,22 @@
-package goa4web
+package templates
 
 import (
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
 	"log"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
 )
 
-func templatePage(w http.ResponseWriter, r *http.Request) {
+// Page renders a simple template example.
+func Page(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*CoreData
+		*corecommon.CoreData
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData),
 	}
 
 	if err := templates.RenderTemplate(w, "templatePage.gohtml", data, corecommon.NewFuncs(r)); err != nil {

--- a/routes.go
+++ b/routes.go
@@ -19,6 +19,7 @@ import (
 	linker "github.com/arran4/goa4web/handlers/linker"
 	news "github.com/arran4/goa4web/handlers/news"
 	search "github.com/arran4/goa4web/handlers/search"
+	templatehandlers "github.com/arran4/goa4web/handlers/templates"
 	writings "github.com/arran4/goa4web/handlers/writings"
 
 	userhandlers "github.com/arran4/goa4web/handlers/user"
@@ -39,6 +40,7 @@ func registerRoutes(r *mux.Router) {
 	registerSearchRoutes(r)
 	registerWritingsRoutes(r)
 	registerInformationRoutes(r)
+	registerTemplatesRoutes(r)
 	userhandlers.RegisterRoutes(r)
 	registerRegisterRoutes(r)
 	registerLoginRoutes(r)
@@ -228,6 +230,11 @@ func registerWritingsAdminRoutes(ar *mux.Router) {
 func registerInformationRoutes(r *mux.Router) {
 	ir := r.PathPrefix("/information").Subrouter()
 	ir.HandleFunc("", information.Page).Methods("GET")
+}
+
+func registerTemplatesRoutes(r *mux.Router) {
+	tr := r.PathPrefix("/template").Subrouter()
+	tr.HandleFunc("", templatehandlers.Page).Methods(http.MethodGet)
 }
 
 func registerRegisterRoutes(r *mux.Router) {


### PR DESCRIPTION
## Summary
- add new `handlers/templates` package
- move old `templatePage` handler to `handlers/templates` as `Page`
- wire new template route in `routes.go`
- drop obsolete `templatePage.go`

## Testing
- `go test ./...` *(fails: syntax errors in internal/emailutil)*

------
https://chatgpt.com/codex/tasks/task_e_685cba634188832fb985938125264c8b