### PR TITLE
Refactor DB startup logic

### DIFF
--- a/startup_test.go
+++ b/startup_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	hcommon "github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/internal/dbstart"
 )
 
 func TestEnsureSchemaVersionMatch(t *testing.T) {
@@ -23,7 +24,7 @@ func TestEnsureSchemaVersionMatch(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
 		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(hcommon.ExpectedSchemaVersion))
 
-	if err := ensureSchema(context.Background(), db); err != nil {
+	if err := dbstart.EnsureSchema(context.Background(), db); err != nil {
 		t.Fatalf("ensureSchema: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -45,7 +46,7 @@ func TestEnsureSchemaVersionMismatch(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
 		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(hcommon.ExpectedSchemaVersion - 1))
 
-	if err := ensureSchema(context.Background(), db); err == nil {
+	if err := dbstart.EnsureSchema(context.Background(), db); err == nil {
 		t.Fatalf("expected error")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
## Summary
- move DB bootstrap helpers into internal/dbstart
- call the new package from application startup
- adapt tests to the new package

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cd2f5ce40832fb4c0aaee0a2ee5e0