### PR TITLE
Move router and startup tests to new packages

### DIFF
--- a/internal/app/startup.go
+++ b/internal/app/startup.go
@@ -1,4 +1,4 @@
-package goa4web
+package app
 
 import (
 	"context"

--- a/internal/app/startup_test.go
+++ b/internal/app/startup_test.go
@@ -1,4 +1,4 @@
-package goa4web
+package app
 
 import (
 	"context"

--- a/internal/router/middleware_roles_test.go
+++ b/internal/router/middleware_roles_test.go
@@ -1,21 +1,22 @@
-package goa4web
+package router
 
 import (
 	"context"
-	"github.com/arran4/goa4web/handlers/common"
-	routerpkg "github.com/arran4/goa4web/internal/router"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	corecommon "github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/handlers/common"
 )
 
 func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	ctx := context.WithValue(req.Context(), common.KeyCoreData, &CoreData{SecurityLevel: "administrator"})
+	ctx := context.WithValue(req.Context(), common.KeyCoreData, &corecommon.CoreData{SecurityLevel: "administrator"})
 	req = req.WithContext(ctx)
 
 	called := false
-	h := routerpkg.RoleCheckerMiddleware("administrator")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := RoleCheckerMiddleware("administrator")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -32,11 +33,11 @@ func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 
 func TestRoleCheckerMiddlewareDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	ctx := context.WithValue(req.Context(), common.KeyCoreData, &CoreData{SecurityLevel: "reader"})
+	ctx := context.WithValue(req.Context(), common.KeyCoreData, &corecommon.CoreData{SecurityLevel: "reader"})
 	req = req.WithContext(ctx)
 
 	called := false
-	h := routerpkg.RoleCheckerMiddleware("administrator")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := RoleCheckerMiddleware("administrator")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 	}))
 


### PR DESCRIPTION
## Summary
- relocate RoleCheckerMiddleware tests into router package
- move database startup tests into internal app package
- shift DB startup logic to `internal/app`
- update imports and references

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cd2fa4558832f8b2d63a816ba4248