### PR TITLE
refactor alias exports into pkg directory

### DIFF
--- a/middleware_roles_test.go
+++ b/middleware_roles_test.go
@@ -2,17 +2,19 @@ package goa4web
 
 import (
 	"context"
-	"github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/middleware"
-	routerpkg "github.com/arran4/goa4web/internal/router"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/internal/middleware"
+	routerpkg "github.com/arran4/goa4web/internal/router"
+	"github.com/arran4/goa4web/pkg/coredata"
 )
 
 func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	ctx := context.WithValue(req.Context(), common.KeyCoreData, &CoreData{SecurityLevel: "administrator"})
+	ctx := context.WithValue(req.Context(), common.KeyCoreData, &coredata.CoreData{SecurityLevel: "administrator"})
 	req = req.WithContext(ctx)
 
 	called := false
@@ -35,7 +37,7 @@ func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 
 func TestRoleCheckerMiddlewareDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	ctx := context.WithValue(req.Context(), common.KeyCoreData, &CoreData{SecurityLevel: "reader"})
+	ctx := context.WithValue(req.Context(), common.KeyCoreData, &coredata.CoreData{SecurityLevel: "reader"})
 	req = req.WithContext(ctx)
 
 	called := false

--- a/pkg/coredata/coredata.go
+++ b/pkg/coredata/coredata.go
@@ -1,6 +1,6 @@
-package goa4web
+package coredata
 
 import common "github.com/arran4/goa4web/core/common"
 
-// CoreData exposes the common CoreData type at the top level package.
+// CoreData exposes the common CoreData type for external packages.
 type CoreData = common.CoreData

--- a/pkg/dbalias/dbalias.go
+++ b/pkg/dbalias/dbalias.go
@@ -1,7 +1,8 @@
-package goa4web
+package dbalias
 
 import db "github.com/arran4/goa4web/internal/db"
 
+// These aliases expose selected internal db types.
 type (
 	DBTX                                                = db.DBTX
 	Queries                                             = db.Queries
@@ -13,4 +14,5 @@ type (
 	User                                                = db.User
 )
 
+// New returns a new Queries instance using the given database.
 func New(d db.DBTX) *Queries { return db.New(d) }


### PR DESCRIPTION
## Summary
- move CoreData alias into `pkg/coredata`
- move DB alias types into `pkg/dbalias`
- update imports to use these new packages
- fix run.go compilation issues
- drop old alias files

## Testing
- `go vet ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cd8563258832f9587dd63d35ad219