### PR TITLE
Add admin CLI

### DIFF
--- a/cmd/goa4web-admin/main.go
+++ b/cmd/goa4web-admin/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+    "database/sql"
+    "flag"
+    "fmt"
+    "log"
+    "os"
+
+    "github.com/arran4/goa4web/config"
+    "github.com/arran4/goa4web/core"
+    dbstart "github.com/arran4/goa4web/internal/dbstart"
+    "github.com/arran4/goa4web/runtimeconfig"
+)
+
+func main() {
+    root, err := parseRoot(os.Args)
+    if err != nil {
+        log.Printf("%v", err)
+        os.Exit(1)
+    }
+    if err := root.Run(); err != nil {
+        log.Printf("%v", err)
+        os.Exit(1)
+    }
+}
+
+// rootCmd is the top-level command state.
+type rootCmd struct {
+    fs        *flag.FlagSet
+    cfg       runtimeconfig.RuntimeConfig
+    Verbosity int
+    args      []string
+    db        *sql.DB
+}
+
+func (r *rootCmd) DB() (*sql.DB, error) {
+    if r.db != nil {
+        return r.db, nil
+    }
+    if ue := dbstart.InitDB(r.cfg); ue != nil {
+        return nil, fmt.Errorf("init db: %w", ue.Err)
+    }
+    r.db = dbstart.GetDBPool()
+    return r.db, nil
+}
+
+func parseRoot(args []string) (*rootCmd, error) {
+    r := &rootCmd{}
+    early := flag.NewFlagSet(args[0], flag.ContinueOnError)
+    var cfgPath string
+    early.StringVar(&cfgPath, "config-file", "", "path to config file")
+    _ = early.Parse(args[1:])
+    if cfgPath == "" {
+        cfgPath = os.Getenv(config.EnvConfigFile)
+    }
+    fileVals := config.LoadAppConfigFile(core.OSFS{}, cfgPath)
+    fs := runtimeconfig.NewRuntimeFlagSet(args[0])
+    fs.StringVar(&cfgPath, "config-file", cfgPath, "path to config file")
+    fs.IntVar(&r.Verbosity, "verbosity", 0, "verbosity level")
+    _ = fs.Parse(args[1:])
+    r.fs = fs
+    r.args = fs.Args()
+    r.cfg = runtimeconfig.GenerateRuntimeConfig(fs, fileVals, os.Getenv)
+    return r, nil
+}
+
+func (r *rootCmd) Run() error {
+    if len(r.args) == 0 {
+        return fmt.Errorf("no command provided")
+    }
+    switch r.args[0] {
+    case "user":
+        c, err := parseUserCmd(r, r.args[1:])
+        if err != nil {
+            return fmt.Errorf("user: %w", err)
+        }
+        return c.Run()
+    case "perm":
+        c, err := parsePermCmd(r, r.args[1:])
+        if err != nil {
+            return fmt.Errorf("perm: %w", err)
+        }
+        return c.Run()
+    default:
+        return fmt.Errorf("unknown command %q", r.args[0])
+    }
+}

--- a/cmd/goa4web-admin/perm.go
+++ b/cmd/goa4web-admin/perm.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+type permCmd struct {
+	*rootCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parsePermCmd(parent *rootCmd, args []string) (*permCmd, error) {
+	fs := flag.NewFlagSet("perm", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return &permCmd{rootCmd: parent, fs: fs, args: fs.Args()}, nil
+}
+
+func (c *permCmd) Run() error {
+	if len(c.args) == 0 {
+		return fmt.Errorf("missing perm command")
+	}
+	switch c.args[0] {
+	case "grant":
+		cmd, err := parsePermGrantCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("grant: %w", err)
+		}
+		return cmd.Run()
+	case "revoke":
+		cmd, err := parsePermRevokeCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("revoke: %w", err)
+		}
+		return cmd.Run()
+	case "list":
+		cmd, err := parsePermListCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("list: %w", err)
+		}
+		return cmd.Run()
+	default:
+		return fmt.Errorf("unknown perm command %q", c.args[0])
+	}
+}

--- a/cmd/goa4web-admin/perm_grant.go
+++ b/cmd/goa4web-admin/perm_grant.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// permGrantCmd implements "perm grant".
+type permGrantCmd struct {
+	*permCmd
+	fs      *flag.FlagSet
+	User    string
+	Section string
+	Level   string
+	args    []string
+}
+
+func parsePermGrantCmd(parent *permCmd, args []string) (*permGrantCmd, error) {
+	c := &permGrantCmd{permCmd: parent}
+	fs := flag.NewFlagSet("grant", flag.ContinueOnError)
+	fs.StringVar(&c.User, "user", "", "username")
+	fs.StringVar(&c.Section, "section", "", "permission section")
+	fs.StringVar(&c.Level, "level", "", "permission level")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *permGrantCmd) Run() error {
+	if c.User == "" || c.Section == "" || c.Level == "" {
+		return fmt.Errorf("user, section and level required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.User, Valid: true})
+	if err != nil {
+		return fmt.Errorf("get user: %w", err)
+	}
+	if err := queries.PermissionUserAllow(ctx, dbpkg.PermissionUserAllowParams{
+		UsersIdusers: u.Idusers,
+		Section:      sql.NullString{String: c.Section, Valid: true},
+		Level:        sql.NullString{String: c.Level, Valid: true},
+	}); err != nil {
+		return fmt.Errorf("grant: %w", err)
+	}
+	return nil
+}

--- a/cmd/goa4web-admin/perm_revoke.go
+++ b/cmd/goa4web-admin/perm_revoke.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// permRevokeCmd implements "perm revoke".
+type permRevokeCmd struct {
+	*permCmd
+	fs   *flag.FlagSet
+	ID   int
+	args []string
+}
+
+func parsePermRevokeCmd(parent *permCmd, args []string) (*permRevokeCmd, error) {
+	c := &permRevokeCmd{permCmd: parent}
+	fs := flag.NewFlagSet("revoke", flag.ContinueOnError)
+	fs.IntVar(&c.ID, "id", 0, "permission id")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *permRevokeCmd) Run() error {
+	if c.ID == 0 {
+		return fmt.Errorf("id required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	if err := queries.PermissionUserDisallow(ctx, int32(c.ID)); err != nil {
+		return fmt.Errorf("revoke: %w", err)
+	}
+	return nil
+}

--- a/cmd/goa4web-admin/user.go
+++ b/cmd/goa4web-admin/user.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+type userCmd struct {
+	*rootCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseUserCmd(parent *rootCmd, args []string) (*userCmd, error) {
+	fs := flag.NewFlagSet("user", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return &userCmd{rootCmd: parent, fs: fs, args: fs.Args()}, nil
+}
+
+func (c *userCmd) Run() error {
+	if len(c.args) == 0 {
+		return fmt.Errorf("missing user command")
+	}
+	switch c.args[0] {
+	case "add":
+		cmd, err := parseUserAddCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("add: %w", err)
+		}
+		return cmd.Run()
+	case "add-admin":
+		cmd, err := parseUserAddAdminCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("add-admin: %w", err)
+		}
+		return cmd.Run()
+	case "make-admin":
+		cmd, err := parseUserMakeAdminCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("make-admin: %w", err)
+		}
+		return cmd.Run()
+	case "list":
+		cmd, err := parseUserListCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("list: %w", err)
+		}
+		return cmd.Run()
+	default:
+		return fmt.Errorf("unknown user command %q", c.args[0])
+	}
+}

--- a/cmd/goa4web-admin/user_add.go
+++ b/cmd/goa4web-admin/user_add.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"flag"
+	"fmt"
+
+	"golang.org/x/crypto/pbkdf2"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// userAddCmd implements the "user add" command.
+type userAddCmd struct {
+	*userCmd
+	fs       *flag.FlagSet
+	Username string
+	Email    string
+	Password string
+	Admin    bool
+	args     []string
+}
+
+func parseUserAddCmd(parent *userCmd, args []string) (*userAddCmd, error) {
+	c := &userAddCmd{userCmd: parent}
+	fs := flag.NewFlagSet("add", flag.ContinueOnError)
+	fs.StringVar(&c.Username, "username", "", "username")
+	fs.StringVar(&c.Email, "email", "", "email address")
+	fs.StringVar(&c.Password, "password", "", "password")
+	fs.BoolVar(&c.Admin, "admin", false, "grant administrator rights")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *userAddCmd) Run() error {
+	return createUser(c.userCmd.rootCmd, c.Username, c.Email, c.Password, c.Admin)
+}
+
+func createUser(root *rootCmd, username, email, password string, admin bool) error {
+	if username == "" || password == "" {
+		return fmt.Errorf("username and password required")
+	}
+	db, err := root.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	hash, alg, err := hashPassword(password)
+	if err != nil {
+		return fmt.Errorf("hash password: %w", err)
+	}
+	res, err := queries.DB().ExecContext(ctx,
+		"INSERT INTO users (username, passwd, passwd_algorithm, email) VALUES (?, ?, ?, ?)",
+		username, hash, alg, email,
+	)
+	if err != nil {
+		return fmt.Errorf("insert user: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("last insert id: %w", err)
+	}
+	if admin {
+		if err := queries.PermissionUserAllow(ctx, dbpkg.PermissionUserAllowParams{
+			UsersIdusers: int32(id),
+			Section:      sql.NullString{String: "administrator", Valid: true},
+			Level:        sql.NullString{String: "administrator", Valid: true},
+		}); err != nil {
+			return fmt.Errorf("grant admin: %w", err)
+		}
+	}
+	if root.Verbosity > 0 {
+		fmt.Printf("created user %s (id %d)\n", username, id)
+	}
+	return nil
+}
+
+// hashPassword creates a PBKDF2-SHA256 hash and algorithm string.
+func hashPassword(pw string) (string, string, error) {
+	const iterations = 10000
+	var salt [16]byte
+	if _, err := rand.Read(salt[:]); err != nil {
+		return "", "", err
+	}
+	hash := pbkdf2.Key([]byte(pw), salt[:], iterations, 32, sha256.New)
+	alg := fmt.Sprintf("pbkdf2-sha256:%d:%x", iterations, salt)
+	return hex.EncodeToString(hash), alg, nil
+}

--- a/cmd/goa4web-admin/user_add_admin.go
+++ b/cmd/goa4web-admin/user_add_admin.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"flag"
+)
+
+// userAddAdminCmd implements "user add-admin".
+type userAddAdminCmd struct {
+	*userCmd
+	fs       *flag.FlagSet
+	Username string
+	Email    string
+	Password string
+	args     []string
+}
+
+func parseUserAddAdminCmd(parent *userCmd, args []string) (*userAddAdminCmd, error) {
+	c := &userAddAdminCmd{userCmd: parent}
+	fs := flag.NewFlagSet("add-admin", flag.ContinueOnError)
+	fs.StringVar(&c.Username, "username", "", "username")
+	fs.StringVar(&c.Email, "email", "", "email address")
+	fs.StringVar(&c.Password, "password", "", "password")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *userAddAdminCmd) Run() error {
+	return createUser(c.userCmd.rootCmd, c.Username, c.Email, c.Password, true)
+}

--- a/cmd/goa4web-admin/user_list.go
+++ b/cmd/goa4web-admin/user_list.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// userListCmd implements "user list".
+type userListCmd struct {
+	*userCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseUserListCmd(parent *userCmd, args []string) (*userListCmd, error) {
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return &userListCmd{userCmd: parent, fs: fs, args: fs.Args()}, nil
+}
+
+func (c *userListCmd) Run() error {
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	users, err := queries.AllUsers(ctx)
+	if err != nil {
+		return fmt.Errorf("list users: %w", err)
+	}
+	for _, u := range users {
+		fmt.Printf("%d\t%s\t%s\n", u.Idusers, u.Username.String, u.Email.String)
+	}
+	return nil
+}

--- a/cmd/goa4web-admin/user_make_admin.go
+++ b/cmd/goa4web-admin/user_make_admin.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// userMakeAdminCmd grants administrator rights to an existing user.
+type userMakeAdminCmd struct {
+	*userCmd
+	fs       *flag.FlagSet
+	Username string
+	args     []string
+}
+
+func parseUserMakeAdminCmd(parent *userCmd, args []string) (*userMakeAdminCmd, error) {
+	c := &userMakeAdminCmd{userCmd: parent}
+	fs := flag.NewFlagSet("make-admin", flag.ContinueOnError)
+	fs.StringVar(&c.Username, "username", "", "username")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *userMakeAdminCmd) Run() error {
+	if c.Username == "" {
+		return fmt.Errorf("username required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+	if err != nil {
+		return fmt.Errorf("get user: %w", err)
+	}
+	if err := queries.PermissionUserAllow(ctx, dbpkg.PermissionUserAllowParams{
+		UsersIdusers: u.Idusers,
+		Section:      sql.NullString{String: "administrator", Valid: true},
+		Level:        sql.NullString{String: "administrator", Valid: true},
+	}); err != nil {
+		return fmt.Errorf("grant admin: %w", err)
+	}
+	if c.rootCmd.Verbosity > 0 {
+		fmt.Printf("granted administrator to %s\n", c.Username)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add a new command `goa4web-admin`
- implement nested flag-set based commands for user and permission management
- split subcommands into individual files

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cddf32ae8832f8f8d571f92cf01a5