### PR TITLE
Add root Close helper

### DIFF
--- a/cmd/goa4web-admin/main.go
+++ b/cmd/goa4web-admin/main.go
@@ -19,6 +19,7 @@ func main() {
         log.Printf("%v", err)
         os.Exit(1)
     }
+    defer root.Close()
     if err := root.Run(); err != nil {
         log.Printf("%v", err)
         os.Exit(1)
@@ -43,6 +44,14 @@ func (r *rootCmd) DB() (*sql.DB, error) {
     }
     r.db = dbstart.GetDBPool()
     return r.db, nil
+}
+
+func (r *rootCmd) Close() {
+    if r.db != nil {
+        if err := r.db.Close(); err != nil {
+            log.Printf("close db: %v", err)
+        }
+    }
 }
 
 func parseRoot(args []string) (*rootCmd, error) {


### PR DESCRIPTION
## Summary
- add a Close method to `rootCmd`
- close the database on exit of goa4web-admin

## Testing
- `go vet ./...` *(fails: undefined functions in handler tests)*
- `go test ./...` *(fails: build errors in handler packages)*
- `golangci-lint run` *(fails: typecheck errors in handler tests)*

------
https://chatgpt.com/codex/tasks/task_e_685cebe64f74832fa7b2f1a42e3e6586