### PR TITLE
Use db package directly across handlers

### DIFF
--- a/handlers/admin/adminAnnouncementsPage.go
+++ b/handlers/admin/adminAnnouncementsPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/admin/adminAuditLogPage.go
+++ b/handlers/admin/adminAuditLogPage.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"net/url"

--- a/handlers/admin/adminCategoriesPage.go
+++ b/handlers/admin/adminCategoriesPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -3,7 +3,7 @@ package admin
 import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -5,7 +5,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"net/url"

--- a/handlers/admin/adminHandler.go
+++ b/handlers/admin/adminHandler.go
@@ -5,7 +5,7 @@ import (
 	_ "embed"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 

--- a/handlers/admin/adminIPBanPage.go
+++ b/handlers/admin/adminIPBanPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strings"

--- a/handlers/admin/adminNotificationsPage.go
+++ b/handlers/admin/adminNotificationsPage.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/admin/adminPermissionsSectionPage.go
+++ b/handlers/admin/adminPermissionsSectionPage.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 

--- a/handlers/admin/adminPermissionsSectionViewPage.go
+++ b/handlers/admin/adminPermissionsSectionViewPage.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 

--- a/handlers/admin/adminReloadConfigPage.go
+++ b/handlers/admin/adminReloadConfigPage.go
@@ -5,7 +5,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"os"

--- a/handlers/admin/adminSiteSettingsPage.go
+++ b/handlers/admin/adminSiteSettingsPage.go
@@ -4,7 +4,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/admin/adminUsageStatsPage.go
+++ b/handlers/admin/adminUsageStatsPage.go
@@ -3,7 +3,7 @@ package admin
 import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers/common"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
+	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -43,12 +44,12 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 	runtimeconfig.AppRuntimeConfig.EmailProvider = "log"
 	defer os.Unsetenv(config.EnvEmailProvider)
 
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer sqldb.Close()
+	q := db.New(sqldb)
 	rows := sqlmock.NewRows([]string{"idusers", "email", "passwd", "passwd_algorithm", "username"}).
 		AddRow(1, "u@example.com", "", "", "u")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT idusers, email, passwd, passwd_algorithm, username\nFROM users\nWHERE idusers = ?")).
@@ -74,12 +75,12 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 }
 
 func TestListUnsentPendingEmails(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer sqldb.Close()
+	q := db.New(sqldb)
 	rows := sqlmock.NewRows([]string{"id", "to_email", "subject", "body", "created_at"}).AddRow(1, "a@test", "s", "b", time.Now())
 	mock.ExpectQuery("SELECT id, to_email, subject, body, created_at FROM pending_emails WHERE sent_at IS NULL ORDER BY id").WillReturnRows(rows)
 	if _, err := q.ListUnsentPendingEmails(context.Background()); err != nil {
@@ -91,12 +92,12 @@ func TestListUnsentPendingEmails(t *testing.T) {
 }
 
 func TestRecentNotifications(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer sqldb.Close()
+	q := db.New(sqldb)
 	rows := sqlmock.NewRows([]string{"id", "users_idusers", "link", "message", "created_at", "read_at"}).AddRow(1, 1, "/l", "m", time.Now(), nil)
 	mock.ExpectQuery("SELECT id, users_idusers, link, message, created_at, read_at FROM notifications ORDER BY id DESC LIMIT ?").WithArgs(int32(5)).WillReturnRows(rows)
 	if _, err := q.RecentNotifications(context.Background(), 5); err != nil {

--- a/handlers/admin/email_helpers.go
+++ b/handlers/admin/email_helpers.go
@@ -2,7 +2,7 @@ package admin
 
 import (
 	"context"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/smtp"
 	"os"

--- a/handlers/auth/loginPage.go
+++ b/handlers/auth/loginPage.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"database/sql"
 	"errors"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"net/url"

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"database/sql"
 	"errors"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strings"

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -3,7 +3,7 @@ package blogs
 import (
 	"database/sql"
 	"fmt"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -3,7 +3,7 @@ package blogs
 import (
 	"database/sql"
 	"fmt"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"

--- a/handlers/blogs/blogsBlogPage.go
+++ b/handlers/blogs/blogsBlogPage.go
@@ -2,7 +2,7 @@ package blogs
 
 import (
 	"fmt"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/arran4/goa4web/core"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"github.com/gorilla/mux"
 	"log"

--- a/handlers/blogs/blogsBloggerPage.go
+++ b/handlers/blogs/blogsBloggerPage.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 
 	common "github.com/arran4/goa4web/handlers/common"
 	"log"

--- a/handlers/blogs/blogsBloggersPage.go
+++ b/handlers/blogs/blogsBloggersPage.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 
 	common "github.com/arran4/goa4web/handlers/common"
 	"log"

--- a/handlers/blogs/blogsCommentEditPage.go
+++ b/handlers/blogs/blogsCommentEditPage.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 
 	common "github.com/arran4/goa4web/handlers/common"
 	"log"

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 var (
@@ -23,13 +24,13 @@ var (
 )
 
 func TestBlogsBloggerPage(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer sqldb.Close()
 
-	q := New(db)
+	q := db.New(sqldb)
 	store = sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = sessionName
@@ -80,13 +81,13 @@ func TestBlogsBloggerPage(t *testing.T) {
 }
 
 func TestBlogsRssPageWritesRSS(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer sqldb.Close()
 
-	queries := New(db)
+	queries := db.New(sqldb)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT idusers, email, passwd, passwd_algorithm, username\nFROM users\nWHERE username = ?")).
 		WithArgs("bob").

--- a/handlers/blogs/blogsUserPermissionsPage.go
+++ b/handlers/blogs/blogsUserPermissionsPage.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 
 	common "github.com/arran4/goa4web/handlers/common"
 	"log"

--- a/handlers/blogs/email_helpers.go
+++ b/handlers/blogs/email_helpers.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/smtp"
 	"os"

--- a/handlers/blogs/postupdate.go
+++ b/handlers/blogs/postupdate.go
@@ -3,7 +3,7 @@ package blogs
 import (
 	"context"
 	"fmt"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 // PostUpdate refreshes thread and topic metadata.

--- a/handlers/forum/adminForumHandler.go
+++ b/handlers/forum/adminForumHandler.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 

--- a/handlers/forum/adminForumWordListHandler.go
+++ b/handlers/forum/adminForumWordListHandler.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 

--- a/handlers/forum/email_helpers.go
+++ b/handlers/forum/email_helpers.go
@@ -2,7 +2,7 @@ package forum
 
 import (
 	"context"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/internal/emailutil"

--- a/handlers/forum/forum.go
+++ b/handlers/forum/forum.go
@@ -2,7 +2,7 @@ package forum
 
 import (
 	"database/sql"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"golang.org/x/exp/slices"
 )
 

--- a/handlers/forum/forumAdminCategoriesPage.go
+++ b/handlers/forum/forumAdminCategoriesPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/forum/forumAdminPage.go
+++ b/handlers/forum/forumAdminPage.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 

--- a/handlers/forum/forumAdminRestrictionsPage.go
+++ b/handlers/forum/forumAdminRestrictionsPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/forum/forumAdminThreadsPage.go
+++ b/handlers/forum/forumAdminThreadsPage.go
@@ -3,7 +3,7 @@ package forum
 import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/forum/forumAdminTopicRestrictions.go
+++ b/handlers/forum/forumAdminTopicRestrictions.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/forum/forumAdminTopicsPage.go
+++ b/handlers/forum/forumAdminTopicsPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/forum/forumAdminTopicsRestrictions.go
+++ b/handlers/forum/forumAdminTopicsRestrictions.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/forum/forumAdminUserLevelPage.go
+++ b/handlers/forum/forumAdminUserLevelPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/forum/forumAdminUserPage.go
+++ b/handlers/forum/forumAdminUserPage.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"net/url"

--- a/handlers/forum/forumFeed.go
+++ b/handlers/forum/forumFeed.go
@@ -7,7 +7,7 @@ import (
 	"github.com/arran4/goa4web/a4code2html"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/feeds"
 	"github.com/gorilla/mux"
 	"log"

--- a/handlers/forum/forumFeed_test.go
+++ b/handlers/forum/forumFeed_test.go
@@ -5,10 +5,12 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 func TestForumTopicFeed(t *testing.T) {
-	rows := []*GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow{
+	rows := []*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow{
 		{
 			Idforumthread:     1,
 			Firstposttext:     sql.NullString{String: "hello world", Valid: true},

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -7,7 +7,7 @@ import (
 	corelanguage "github.com/arran4/goa4web/core/language"
 	blogs "github.com/arran4/goa4web/handlers/blogs"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -8,7 +8,7 @@ import (
 	corelanguage "github.com/arran4/goa4web/core/language"
 	blogs "github.com/arran4/goa4web/handlers/blogs"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/forum/forumTopicPage.go
+++ b/handlers/forum/forumTopicPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/forum/forumTopicThreadCommentEditPage.go
+++ b/handlers/forum/forumTopicThreadCommentEditPage.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/arran4/goa4web/core"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"

--- a/handlers/forum/matchers_test.go
+++ b/handlers/forum/matchers_test.go
@@ -8,17 +8,18 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/mux"
 )
 
 func TestGetThreadAndTopicTrue(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer sqldb.Close()
 
-	q := New(db)
+	q := db.New(sqldb)
 
 	mock.ExpectQuery("SELECT th.idforumthread").
 		WithArgs(int32(0), int32(2)).
@@ -46,13 +47,13 @@ func TestGetThreadAndTopicTrue(t *testing.T) {
 }
 
 func TestGetThreadAndTopicFalse(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer sqldb.Close()
 
-	q := New(db)
+	q := db.New(sqldb)
 
 	mock.ExpectQuery("SELECT th.idforumthread").
 		WithArgs(int32(0), int32(2)).
@@ -80,13 +81,13 @@ func TestGetThreadAndTopicFalse(t *testing.T) {
 }
 
 func TestGetThreadAndTopicError(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer sqldb.Close()
 
-	q := New(db)
+	q := db.New(sqldb)
 
 	mock.ExpectQuery("SELECT th.idforumthread").
 		WithArgs(int32(0), int32(2)).

--- a/handlers/forum/postupdate.go
+++ b/handlers/forum/postupdate.go
@@ -3,7 +3,7 @@ package forum
 import (
 	"context"
 	"fmt"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 // PostUpdate refreshes metadata on the given forum thread and topic.

--- a/handlers/forum/thread_delete.go
+++ b/handlers/forum/thread_delete.go
@@ -2,7 +2,7 @@ package forum
 
 import (
 	"context"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 // ThreadDelete removes a forum thread and updates topic statistics.

--- a/handlers/forum/thread_delete_test.go
+++ b/handlers/forum/thread_delete_test.go
@@ -5,16 +5,17 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 func TestThreadDelete(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer sqldb.Close()
 
-	q := New(db)
+	q := db.New(sqldb)
 	mock.ExpectExec("DeleteForumThread").
 		WithArgs(int32(1)).
 		WillReturnResult(sqlmock.NewResult(0, 0))

--- a/handlers/linker/email_helpers.go
+++ b/handlers/linker/email_helpers.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/smtp"
 	"os"

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -6,7 +6,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/linker/linkerAdminCategoriesPage.go
+++ b/handlers/linker/linkerAdminCategoriesPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/linker/linkerAdminQueuePage.go
+++ b/handlers/linker/linkerAdminQueuePage.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/linker/linkerCategoriesPage.go
+++ b/handlers/linker/linkerCategoriesPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 

--- a/handlers/linker/linkerCategoryPage.go
+++ b/handlers/linker/linkerCategoryPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -7,7 +7,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"

--- a/handlers/linker/linkerFeed.go
+++ b/handlers/linker/linkerFeed.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/arran4/goa4web/a4code2html"
 	"github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/feeds"
 	"net/http"
 	"strconv"

--- a/handlers/linker/linkerLinkerPage.go
+++ b/handlers/linker/linkerLinkerPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/linker/linkerPage.go
+++ b/handlers/linker/linkerPage.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 func TestLinkerFeed(t *testing.T) {
-	rows := []*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow{
+	rows := []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow{
 		{
 			Idlinker:       1,
 			Title:          sql.NullString{String: "Example", Valid: true},
@@ -36,13 +37,13 @@ func TestLinkerFeed(t *testing.T) {
 	}
 }
 func TestLinkerApproveAddsToSearch(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer sqldb.Close()
 
-	queries := New(db)
+	queries := db.New(sqldb)
 
 	// Approve item from queue id 1
 	mock.ExpectExec("INSERT INTO linker").

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -7,7 +7,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchutil"
 	"log"
 	"net/http"

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -6,7 +6,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"

--- a/handlers/linker/postupdate.go
+++ b/handlers/linker/postupdate.go
@@ -3,7 +3,7 @@ package linker
 import (
 	"context"
 	"fmt"
-	"github.com/arran4/goa4web/internal/db"
+	db "github.com/arran4/goa4web/internal/db"
 )
 
 // PostUpdate refreshes thread and topic metadata.


### PR DESCRIPTION
## Summary
- alias `github.com/arran4/goa4web/internal/db` as `db` in admin, auth, blogs, forum and linker handlers
- update tests to use `db.New` and db model types
- run `go vet` and `golangci-lint`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_685ceb44a170832facfac1e9f01c5c37