### PR TITLE
Add user update command

### DIFF
--- a/cmd/goa4web-admin/user.go
+++ b/cmd/goa4web-admin/user.go
@@ -42,6 +42,12 @@ func (c *userCmd) Run() error {
 			return fmt.Errorf("make-admin: %w", err)
 		}
 		return cmd.Run()
+	case "update":
+		cmd, err := parseUserUpdateCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("update: %w", err)
+		}
+		return cmd.Run()
 	case "list":
 		cmd, err := parseUserListCmd(c, c.args[1:])
 		if err != nil {

--- a/cmd/goa4web-admin/user_update.go
+++ b/cmd/goa4web-admin/user_update.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// userUpdateCmd implements the "user update" command.
+type userUpdateCmd struct {
+	*userCmd
+	fs          *flag.FlagSet
+	Username    string
+	Email       string
+	MakeAdmin   bool
+	RemoveAdmin bool
+	args        []string
+}
+
+func parseUserUpdateCmd(parent *userCmd, args []string) (*userUpdateCmd, error) {
+	c := &userUpdateCmd{userCmd: parent}
+	fs := flag.NewFlagSet("update", flag.ContinueOnError)
+	fs.StringVar(&c.Username, "username", "", "username")
+	fs.StringVar(&c.Email, "email", "", "email address")
+	fs.BoolVar(&c.MakeAdmin, "make-admin", false, "grant administrator rights")
+	fs.BoolVar(&c.RemoveAdmin, "remove-admin", false, "revoke administrator rights")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *userUpdateCmd) Run() error {
+	if c.Username == "" {
+		return fmt.Errorf("username required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+	if err != nil {
+		return fmt.Errorf("get user: %w", err)
+	}
+	if c.Email != "" {
+		if err := queries.UpdateUserEmail(ctx, dbpkg.UpdateUserEmailParams{
+			Email:   sql.NullString{String: c.Email, Valid: true},
+			Idusers: u.Idusers,
+		}); err != nil {
+			return fmt.Errorf("update email: %w", err)
+		}
+	}
+	if c.MakeAdmin {
+		if err := queries.PermissionUserAllow(ctx, dbpkg.PermissionUserAllowParams{
+			UsersIdusers: u.Idusers,
+			Section:      sql.NullString{String: "administrator", Valid: true},
+			Level:        sql.NullString{String: "administrator", Valid: true},
+		}); err != nil {
+			return fmt.Errorf("make admin: %w", err)
+		}
+	}
+	if c.RemoveAdmin {
+		perm, err := queries.GetPermissionsByUserIdAndSectionAndSectionAll(ctx, dbpkg.GetPermissionsByUserIdAndSectionAndSectionAllParams{
+			UsersIdusers: u.Idusers,
+			Section:      sql.NullString{String: "administrator", Valid: true},
+		})
+		if err == nil && perm != nil {
+			if err := queries.PermissionUserDisallow(ctx, perm.Idpermissions); err != nil {
+				return fmt.Errorf("remove admin: %w", err)
+			}
+		}
+	}
+	if c.rootCmd.Verbosity > 0 {
+		fmt.Printf("updated user %s\n", c.Username)
+	}
+	return nil
+}

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -67,3 +67,8 @@ SELECT u.email
 FROM users u
 JOIN permissions p ON p.users_idusers = u.idusers
 WHERE p.section = 'administrator';
+
+-- name: UpdateUserEmail :exec
+UPDATE users
+SET email = ?
+WHERE idusers = ?;

--- a/internal/db/queries-users.sql.go
+++ b/internal/db/queries-users.sql.go
@@ -456,6 +456,22 @@ func (q *Queries) Login(ctx context.Context, arg LoginParams) (*User, error) {
 	return &i, err
 }
 
+const updateUserEmail = `-- name: UpdateUserEmail :exec
+UPDATE users
+SET email = ?
+WHERE idusers = ?
+`
+
+type UpdateUserEmailParams struct {
+	Email   sql.NullString
+	Idusers int32
+}
+
+func (q *Queries) UpdateUserEmail(ctx context.Context, arg UpdateUserEmailParams) error {
+	_, err := q.db.ExecContext(ctx, updateUserEmail, arg.Email, arg.Idusers)
+	return err
+}
+
 const userByEmail = `-- name: UserByEmail :one
 SELECT idusers, email, passwd, passwd_algorithm, username
 FROM users


### PR DESCRIPTION
## Summary
- add `user update` CLI command
- allow updating user email
- allow granting or removing admin rights
- support via `--username`, `--email`, `--make-admin` and `--remove-admin` flags
- regenerate sqlc code for new query

## Testing
- `go vet ./...` *(fails: undefined references)*
- `golangci-lint run` *(fails: undefined references)*
- `go test ./...` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_685cec700460832fa6884b7af20974ae