### PR TITLE
Add perm update subcommand

### DIFF
--- a/cmd/goa4web-admin/perm.go
+++ b/cmd/goa4web-admin/perm.go
@@ -36,6 +36,12 @@ func (c *permCmd) Run() error {
 			return fmt.Errorf("revoke: %w", err)
 		}
 		return cmd.Run()
+	case "update":
+		cmd, err := parsePermUpdateCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("update: %w", err)
+		}
+		return cmd.Run()
 	case "list":
 		cmd, err := parsePermListCmd(c, c.args[1:])
 		if err != nil {

--- a/cmd/goa4web-admin/perm_update.go
+++ b/cmd/goa4web-admin/perm_update.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// permUpdateCmd implements "perm update".
+type permUpdateCmd struct {
+	*permCmd
+	fs      *flag.FlagSet
+	ID      int
+	Section string
+	Level   string
+	args    []string
+}
+
+func parsePermUpdateCmd(parent *permCmd, args []string) (*permUpdateCmd, error) {
+	c := &permUpdateCmd{permCmd: parent}
+	fs := flag.NewFlagSet("update", flag.ContinueOnError)
+	fs.IntVar(&c.ID, "id", 0, "permission id")
+	fs.StringVar(&c.Section, "section", "", "permission section")
+	fs.StringVar(&c.Level, "level", "", "permission level")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *permUpdateCmd) Run() error {
+	if c.ID == 0 || c.Section == "" || c.Level == "" {
+		return fmt.Errorf("id, section and level required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	if err := queries.UpdatePermission(ctx, dbpkg.UpdatePermissionParams{
+		ID:      int32(c.ID),
+		Section: sql.NullString{String: c.Section, Valid: true},
+		Level:   sql.NullString{String: c.Level, Valid: true},
+	}); err != nil {
+		return fmt.Errorf("update permission: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add `perm update` subcommand in admin CLI
- wire the new command into permission CLI

## Testing
- `go vet ./...` *(fails: undefined symbols in admin and blogs packages)*
- `golangci-lint run ./...` *(fails: typecheck issues in several packages)*
- `go test ./...` *(fails: build errors in admin, blogs, forum and linker packages)*

------
https://chatgpt.com/codex/tasks/task_e_685cec77c89c832fa0e443098b0a6a15