### PR TITLE
Add filtering flags to perm list

### DIFF
--- a/handlers/user/admin_permissions.go
+++ b/handlers/user/admin_permissions.go
@@ -31,7 +31,7 @@ func adminUsersPermissionsPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
-	rows, err := queries.GetPermissionsWithUsers(r.Context())
+	rows, err := queries.GetPermissionsWithUsers(r.Context(), sql.NullString{}, sql.NullString{})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):


### PR DESCRIPTION
## Summary
- add `--user` and `--section` flags to `perm list`
- allow querying permissions filtered by username or section
- adapt admin permissions page call

## Testing
- `go vet ./...` *(fails: undefined functions in tests)*
- `golangci-lint run ./...` *(fails: typecheck issues)*
- `go test ./...` *(fails: build errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_685cec7bb970832f9d2531dd5fef4d61