### PR TITLE
Add admin CLI to Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,14 @@
 FROM golang:1.22-alpine AS build
 WORKDIR /src
 COPY . .
-RUN go build -o /goa4web ./cmd/goa4web
+RUN go build -o /goa4web ./cmd/goa4web \
+    && go build -o /goa4web-admin ./cmd/goa4web-admin
 
 FROM scratch
-COPY --from=build /goa4web /goa4web
+# Install both the main application and the admin CLI into the final image.
+ENV PATH=/usr/local/bin
+COPY --from=build /goa4web /usr/local/bin/goa4web
+COPY --from=build /goa4web-admin /usr/local/bin/goa4web-admin
 # Image uploads are stored under /data/imagebbs inside the container.
 VOLUME ["/data/imagebbs"]
-ENTRYPOINT ["/goa4web"]
+ENTRYPOINT ["/usr/local/bin/goa4web"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,8 +1,11 @@
 # This Dockerfile is used by GoReleaser to build container images.
 # GoReleaser builds the binary first and then copies it into the image,
 # so no build step is required here.
+# This image contains both the main server and the admin CLI binaries.
 FROM scratch
-COPY goa4web /goa4web
+ENV PATH=/usr/local/bin
+COPY goa4web /usr/local/bin/goa4web
+COPY goa4web-admin /usr/local/bin/goa4web-admin
 # Image uploads are stored under /data/imagebbs inside the container.
 VOLUME ["/data/imagebbs"]
-ENTRYPOINT ["/goa4web"]
+ENTRYPOINT ["/usr/local/bin/goa4web"]

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -8,6 +8,14 @@ builds:
     goos: [linux, darwin, windows]
     goarch: [amd64, arm64]
     flags: ["-trimpath"]
+  - id: goa4web-admin
+    main: ./cmd/goa4web-admin
+    binary: goa4web-admin
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+    flags: ["-trimpath"]
 archives:
   - format_overrides:
       - goos: windows

--- a/goreleaser_gitlab.yaml
+++ b/goreleaser_gitlab.yaml
@@ -8,6 +8,14 @@ builds:
     goos: [linux, darwin, windows]
     goarch: [amd64, arm64]
     flags: ["-trimpath"]
+  - id: goa4web-admin
+    main: ./cmd/goa4web-admin
+    binary: goa4web-admin
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+    flags: ["-trimpath"]
 archives:
   - format_overrides:
       - goos: windows

--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,10 @@ When reusing snippets from other projects be sure to update the image name or
 use the `$CI_REGISTRY_IMAGE` variable which already points to the correct
 registry path for this repository.
 
+The resulting container image also includes the `goa4web-admin` CLI installed at
+`/usr/local/bin/goa4web-admin`. Both `goa4web` and `goa4web-admin` are placed in
+`/usr/local/bin`, which is added to `PATH` inside the container.
+
 ## Application Configuration File
 
 The path to a general configuration file can be specified with the `--config-file`


### PR DESCRIPTION
## Summary
- bundle goa4web-admin in the main Docker image
- remove dedicated admin Dockerfiles and images
- keep GoReleaser building the admin CLI binary
- document location of the CLI inside the container
- install binaries into `/usr/local/bin` which is on PATH
- use absolute binary path in Docker ENTRYPOINT

## Testing
- `go vet ./...` *(fails: undefined types in handlers)*
- `golangci-lint run` *(fails: typecheck errors)*
- `go test ./...` *(fails to build handlers)*

------
https://chatgpt.com/codex/tasks/task_e_685ce52975d0832fb4314f6621d40f17