### PR TITLE
Add version flag

### DIFF
--- a/cmd/goa4web-admin/main.go
+++ b/cmd/goa4web-admin/main.go
@@ -13,17 +13,19 @@ import (
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
+var version = "dev"
+
 func main() {
-  root, err := parseRoot(os.Args)
-  if err != nil {
-      log.Printf("%v", err)
-      os.Exit(1)
-  }
-  defer root.Close()
-  if err := root.Run(); err != nil {
-      log.Printf("%v", err)
-      os.Exit(1)
-  }
+	root, err := parseRoot(os.Args)
+	if err != nil {
+		log.Printf("%v", err)
+		os.Exit(1)
+	}
+	defer root.Close()
+	if err := root.Run(); err != nil {
+		log.Printf("%v", err)
+		os.Exit(1)
+	}
 }
 
 // rootCmd is the top-level command state.
@@ -47,21 +49,27 @@ func (r *rootCmd) DB() (*sql.DB, error) {
 }
 
 func (r *rootCmd) Close() {
-    if r.db != nil {
-        if err := r.db.Close(); err != nil {
-            log.Printf("close db: %v", err)
-        }
-    }
+	if r.db != nil {
+		if err := r.db.Close(); err != nil {
+			log.Printf("close db: %v", err)
+		}
+	}
 }
 
 func parseRoot(args []string) (*rootCmd, error) {
 	r := &rootCmd{}
 	early := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	var cfgPath string
+	var showVersion bool
 	early.StringVar(&cfgPath, "config-file", "", "path to config file")
+	early.BoolVar(&showVersion, "version", false, "print version and exit")
 	_ = early.Parse(args[1:])
 	if cfgPath == "" {
 		cfgPath = os.Getenv(config.EnvConfigFile)
+	}
+	if showVersion {
+		fmt.Println(version)
+		os.Exit(0)
 	}
 	fileVals := config.LoadAppConfigFile(core.OSFS{}, cfgPath)
 	fs := runtimeconfig.NewRuntimeFlagSet(args[0])

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -14,13 +15,22 @@ import (
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
+var version = "dev"
+
 func main() {
 	early := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	var cfgPath string
+	var showVersion bool
 	early.StringVar(&cfgPath, "config-file", "", "path to application configuration file")
+	early.BoolVar(&showVersion, "version", false, "print version and exit")
 	_ = early.Parse(os.Args[1:])
 	if cfgPath == "" {
 		cfgPath = os.Getenv(config.EnvConfigFile)
+	}
+
+	if showVersion {
+		fmt.Println(version)
+		return
 	}
 
 	fileVals := config.LoadAppConfigFile(core.OSFS{}, cfgPath)


### PR DESCRIPTION
## Summary
- make goa4web print version and exit
- add same version behaviour to goa4web-admin

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: apply: init schema_version: ExecQuery 'INSERT INTO schema_version (version) VALUES (1)', arguments do not match: expected 1, but got 0 arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685d28d095e8832f963bdb18da13b78a