### PR TITLE
Add config management CLI

### DIFF
--- a/cmd/goa4web-admin/config.go
+++ b/cmd/goa4web-admin/config.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+// configCmd handles configuration management commands.
+type configCmd struct {
+	*rootCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseConfigCmd(parent *rootCmd, args []string) (*configCmd, error) {
+	c := &configCmd{rootCmd: parent}
+	fs := flag.NewFlagSet("config", flag.ContinueOnError)
+	c.fs = fs
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *configCmd) Run() error {
+	if len(c.args) == 0 {
+		c.fs.Usage()
+		return fmt.Errorf("missing config command")
+	}
+	switch c.args[0] {
+	case "show":
+		cmd, err := parseConfigShowCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("show: %w", err)
+		}
+		return cmd.Run()
+	case "set":
+		cmd, err := parseConfigSetCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("set: %w", err)
+		}
+		return cmd.Run()
+	default:
+		c.fs.Usage()
+		return fmt.Errorf("unknown config command %q", c.args[0])
+	}
+}
+
+// Usage prints command usage information with examples.
+func (c *configCmd) Usage() {
+	w := c.fs.Output()
+	fmt.Fprintf(w, "Usage:\n  %s config <command> [<args>]\n", c.rootCmd.fs.Name())
+	fmt.Fprintln(w, "\nCommands:")
+	fmt.Fprintln(w, "  show\tdisplay runtime configuration")
+	fmt.Fprintln(w, "  set\tupdate configuration file")
+	fmt.Fprintln(w, "\nExamples:")
+	fmt.Fprintf(w, "  %s config show\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s config set -key DB_HOST -value localhost\n\n", c.rootCmd.fs.Name())
+	c.fs.PrintDefaults()
+}

--- a/cmd/goa4web-admin/config_set.go
+++ b/cmd/goa4web-admin/config_set.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+)
+
+// configSetCmd implements "config set".
+type configSetCmd struct {
+	*configCmd
+	fs    *flag.FlagSet
+	Key   string
+	Value string
+	args  []string
+}
+
+func parseConfigSetCmd(parent *configCmd, args []string) (*configSetCmd, error) {
+	c := &configSetCmd{configCmd: parent}
+	fs := flag.NewFlagSet("set", flag.ContinueOnError)
+	fs.StringVar(&c.Key, "key", "", "configuration key")
+	fs.StringVar(&c.Value, "value", "", "configuration value")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *configSetCmd) Run() error {
+	if c.Key == "" {
+		return fmt.Errorf("key required")
+	}
+	path := c.rootCmd.configPath
+	if err := config.UpdateConfigKey(core.OSFS{}, path, c.Key, c.Value); err != nil {
+		return fmt.Errorf("update config: %w", err)
+	}
+	if c.rootCmd.Verbosity > 0 {
+		fmt.Printf("updated %s\n", c.Key)
+	}
+	return nil
+}

--- a/cmd/goa4web-admin/config_show.go
+++ b/cmd/goa4web-admin/config_show.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+)
+
+// configShowCmd implements "config show".
+type configShowCmd struct {
+	*configCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseConfigShowCmd(parent *configCmd, args []string) (*configShowCmd, error) {
+	c := &configShowCmd{configCmd: parent}
+	fs := flag.NewFlagSet("show", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *configShowCmd) Run() error {
+	b, err := json.MarshalIndent(c.rootCmd.cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	fmt.Println(string(b))
+	return nil
+}


### PR DESCRIPTION
## Summary
- add `config` command under `goa4web-admin` with `show` and `set` subcommands
- print runtime configuration with `config show`
- update configuration files using `config set`
- expose config file path in root command

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: apply: init schema_version: ExecQuery 'INSERT INTO schema_version (version) VALUES (1)', arguments do not match: expected 1, but got 0 arguments)*


------
https://chatgpt.com/codex/tasks/task_e_685d28cb2244832f95df98f65dac8813