### PR TITLE
Check for existing administrator permission

### DIFF
--- a/cmd/goa4web-admin/user_make_admin.go
+++ b/cmd/goa4web-admin/user_make_admin.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
 
@@ -42,6 +43,14 @@ func (c *userMakeAdminCmd) Run() error {
 	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
+	}
+	if _, err := queries.GetAdministratorPermissionByUserId(ctx, u.Idusers); err == nil {
+		if c.rootCmd.Verbosity > 0 {
+			fmt.Printf("%s already administrator\n", c.Username)
+		}
+		return nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("check admin: %w", err)
 	}
 	if err := queries.PermissionUserAllow(ctx, dbpkg.PermissionUserAllowParams{
 		UsersIdusers: u.Idusers,

--- a/cmd/goa4web-admin/user_update.go
+++ b/cmd/goa4web-admin/user_update.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
 
@@ -58,7 +59,13 @@ func (c *userUpdateCmd) Run() error {
 		}
 	}
 	if c.MakeAdmin {
-		if err := queries.PermissionUserAllow(ctx, dbpkg.PermissionUserAllowParams{
+		if _, err := queries.GetAdministratorPermissionByUserId(ctx, u.Idusers); err == nil {
+			if c.rootCmd.Verbosity > 0 {
+				fmt.Printf("%s already administrator\n", c.Username)
+			}
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("check admin: %w", err)
+		} else if err := queries.PermissionUserAllow(ctx, dbpkg.PermissionUserAllowParams{
 			UsersIdusers: u.Idusers,
 			Section:      sql.NullString{String: "administrator", Valid: true},
 			Level:        sql.NullString{String: "administrator", Valid: true},

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -24,13 +24,14 @@ type Queries struct {
 	db DBTX
 }
 
-// DB exposes the underlying database handle.
-func (q *Queries) DB() DBTX {
-	return q.db
-}
-
 func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 	return &Queries{
 		db: tx,
 	}
+}
+
+// DB exposes the underlying *sql.DB if available.
+func (q *Queries) DB() *sql.DB {
+	db, _ := q.db.(*sql.DB)
+	return db
 }

--- a/internal/db/queries-permissions.sql
+++ b/internal/db/queries-permissions.sql
@@ -39,6 +39,11 @@ VALUES (?, ?, ?);
 DELETE FROM permissions
 WHERE idpermissions = ?;
 
+-- name: GetAdministratorPermissionByUserId :one
+SELECT *
+FROM permissions
+WHERE users_idusers = ? AND section = 'administrator' AND level = 'administrator';
+
 -- name: GetPermissionsByUserIdAndSectionAndSectionAll :one
 SELECT *
 FROM permissions

--- a/internal/db/queries-permissions.sql.go
+++ b/internal/db/queries-permissions.sql.go
@@ -53,6 +53,24 @@ func (q *Queries) DeleteTopicRestrictionsByForumTopicId(ctx context.Context, for
 	return err
 }
 
+const getAdministratorPermissionByUserId = `-- name: GetAdministratorPermissionByUserId :one
+SELECT idpermissions, users_idusers, section, level
+FROM permissions
+WHERE users_idusers = ? AND section = 'administrator' AND level = 'administrator'
+`
+
+func (q *Queries) GetAdministratorPermissionByUserId(ctx context.Context, usersIdusers int32) (*Permission, error) {
+	row := q.db.QueryRowContext(ctx, getAdministratorPermissionByUserId, usersIdusers)
+	var i Permission
+	err := row.Scan(
+		&i.Idpermissions,
+		&i.UsersIdusers,
+		&i.Section,
+		&i.Level,
+	)
+	return &i, err
+}
+
 const getAllForumTopicRestrictionsWithForumTopicTitle = `-- name: GetAllForumTopicRestrictionsWithForumTopicTitle :many
 SELECT t.idforumtopic, r.forumtopic_idforumtopic, r.viewlevel, r.replylevel, r.newthreadlevel, r.seelevel, r.invitelevel, r.readlevel, r.modlevel, r.adminlevel
 FROM forumtopic t


### PR DESCRIPTION
## Summary
- add GetAdministratorPermissionByUserId query
- return *sql.DB from Queries via DB method
- check for existing admin rights before granting permissions in CLI

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: apply: init schema_version: ExecQuery 'INSERT INTO schema_version (version) VALUES (1)', arguments do not match)*

------
https://chatgpt.com/codex/tasks/task_e_685d28d9b43c832fbe5d36a1c99fd640