### PR TITLE
Add request log flags

### DIFF
--- a/cmd/goa4web-admin/config.go
+++ b/cmd/goa4web-admin/config.go
@@ -34,6 +34,8 @@ func (c *configCmd) Run() error {
 		cmd, err := parseConfigReloadCmd(c, c.args[1:])
 		if err != nil {
 			return fmt.Errorf("reload: %w", err)
+		}
+		return cmd.Run()
 	case "show":
 		cmd, err := parseConfigShowCmd(c, c.args[1:])
 		if err != nil {

--- a/cmd/goa4web-admin/config_set.go
+++ b/cmd/goa4web-admin/config_set.go
@@ -34,7 +34,7 @@ func (c *configSetCmd) Run() error {
 	if c.Key == "" {
 		return fmt.Errorf("key required")
 	}
-	path := c.rootCmd.configPath
+	path := c.rootCmd.ConfigFile
 	if err := config.UpdateConfigKey(core.OSFS{}, path, c.Key, c.Value); err != nil {
 		return fmt.Errorf("update config: %w", err)
 	}

--- a/cmd/goa4web-admin/main.go
+++ b/cmd/goa4web-admin/main.go
@@ -35,6 +35,7 @@ type rootCmd struct {
 	ConfigFile string
 	args       []string
 	db         *sql.DB
+	Verbosity  int
 }
 
 func (r *rootCmd) DB() (*sql.DB, error) {
@@ -117,22 +118,32 @@ func (r *rootCmd) Run() error {
 		c, err := parseBoardCmd(r, r.args[1:])
 		if err != nil {
 			return fmt.Errorf("board: %w", err)
+		}
+		return c.Run()
 	case "ipban":
 		c, err := parseIpBanCmd(r, r.args[1:])
 		if err != nil {
 			return fmt.Errorf("ipban: %w", err)
+		}
+		return c.Run()
 	case "audit":
 		c, err := parseAuditCmd(r, r.args[1:])
 		if err != nil {
 			return fmt.Errorf("audit: %w", err)
+		}
+		return c.Run()
 	case "lang":
 		c, err := parseLangCmd(r, r.args[1:])
 		if err != nil {
 			return fmt.Errorf("lang: %w", err)
+		}
+		return c.Run()
 	case "server":
 		c, err := parseServerCmd(r, r.args[1:])
 		if err != nil {
 			return fmt.Errorf("server: %w", err)
+		}
+		return c.Run()
 	case "config":
 		c, err := parseConfigCmd(r, r.args[1:])
 		if err != nil {

--- a/config/env.go
+++ b/config/env.go
@@ -61,6 +61,8 @@ const (
 
 	// EnvDBLogVerbosity controls the verbosity level of database logging.
 	EnvDBLogVerbosity = "DB_LOG_VERBOSITY"
+	// EnvLogFlags selects which HTTP request logs are emitted.
+	EnvLogFlags = "LOG_FLAGS"
 	// EnvListen is the network address the HTTP server listens on.
 	EnvListen = "LISTEN"
 	// EnvHostname is the base URL advertised by the HTTP server.

--- a/handlers/auth/loginPage.go
+++ b/handlers/auth/loginPage.go
@@ -14,6 +14,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
 	common "github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 // LoginUserPassPage serves the username/password login form.
@@ -35,7 +36,9 @@ func LoginUserPassPage(w http.ResponseWriter, r *http.Request) {
 
 // LoginActionPage processes the submitted login form.
 func LoginActionPage(w http.ResponseWriter, r *http.Request) {
-	log.Printf("login attempt for %s", r.PostFormValue("username"))
+	if runtimeconfig.AppRuntimeConfig.LogFlags&runtimeconfig.LogFlagAuth != 0 {
+		log.Printf("login attempt for %s", r.PostFormValue("username"))
+	}
 	username := r.PostFormValue("username")
 	password := r.PostFormValue("password")
 
@@ -114,7 +117,9 @@ func LoginActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("login success uid=%d", user.Idusers)
+	if runtimeconfig.AppRuntimeConfig.LogFlags&runtimeconfig.LogFlagAuth != 0 {
+		log.Printf("login success uid=%d", user.Idusers)
+	}
 
 	if backURL != "" {
 		if backMethod == "" || backMethod == http.MethodGet {

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -13,6 +13,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
 	common "github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 // RegisterPage renders the user registration form.
@@ -34,7 +35,9 @@ func RegisterPage(w http.ResponseWriter, r *http.Request) {
 
 // RegisterActionPage handles user creation from the registration form.
 func RegisterActionPage(w http.ResponseWriter, r *http.Request) {
-	log.Printf("registration attempt %s", r.PostFormValue("username"))
+	if runtimeconfig.AppRuntimeConfig.LogFlags&runtimeconfig.LogFlagAuth != 0 {
+		log.Printf("registration attempt %s", r.PostFormValue("username"))
+	}
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm Error: %s", err)
 		http.Error(w, "Bad Request", http.StatusBadRequest)
@@ -124,7 +127,9 @@ func RegisterActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("registration success uid=%d", lastInsertID)
+	if runtimeconfig.AppRuntimeConfig.LogFlags&runtimeconfig.LogFlagAuth != 0 {
+		log.Printf("registration success uid=%d", lastInsertID)
+	}
 
 	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 

--- a/handlers/forum/matchers.go
+++ b/handlers/forum/matchers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/arran4/goa4web/core"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 // GetThreadAndTopic retrieves thread and topic details for the request and stores them in the context.
@@ -39,7 +40,9 @@ func GetThreadAndTopic() mux.MatcherFunc {
 			Idforumthread: int32(threadID),
 		})
 		if err != nil {
-			log.Printf("GetThreadAndTopic thread: %v", err)
+			if runtimeconfig.AppRuntimeConfig.LogFlags&runtimeconfig.LogFlagAccess != 0 {
+				log.Printf("GetThreadAndTopic thread uid=%d topic=%d thread=%d: %v", uid, topicID, threadID, err)
+			}
 			return false
 		}
 
@@ -48,11 +51,16 @@ func GetThreadAndTopic() mux.MatcherFunc {
 			Idforumtopic: threadRow.ForumtopicIdforumtopic,
 		})
 		if err != nil {
-			log.Printf("GetThreadAndTopic topic: %v", err)
+			if runtimeconfig.AppRuntimeConfig.LogFlags&runtimeconfig.LogFlagAccess != 0 {
+				log.Printf("GetThreadAndTopic topic uid=%d topic=%d thread=%d: %v", uid, topicID, threadID, err)
+			}
 			return false
 		}
 
 		if int(topicRow.Idforumtopic) != topicID {
+			if runtimeconfig.AppRuntimeConfig.LogFlags&runtimeconfig.LogFlagAccess != 0 {
+				log.Printf("GetThreadAndTopic mismatch uid=%d urlTopic=%d threadTopic=%d", uid, topicID, topicRow.Idforumtopic)
+			}
 			return false
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,7 @@ environment variables listed below.
 | `PAGE_SIZE_DEFAULT` | `--page-size-default` | No | `15` | Default page size. |
 | `STATS_START_YEAR` | `--stats-start-year` | No | `2005` | First year displayed on the usage stats page. |
 | `DB_LOG_VERBOSITY` | `--db-log-verbosity` | No | `0` | Database logging verbosity. |
+| `LOG_FLAGS` | `--log-flags` | No | `0` | Bit mask selecting HTTP request logs. |
 | `LISTEN` | `--listen` | No | `:8080` | Network address the HTTP server listens on. |
 | `HOSTNAME` | `--hostname` | No | `http://localhost:8080` | Base URL advertised by the HTTP server. |
 | `SESSION_SECRET` | `--session-secret` | No | generated | Secret used to encrypt session cookies. |

--- a/runtimeconfig/config.go
+++ b/runtimeconfig/config.go
@@ -20,6 +20,7 @@ type RuntimeConfig struct {
 	DBPort         string
 	DBName         string
 	DBLogVerbosity int
+	LogFlags       int
 
 	HTTPListen   string
 	HTTPHostname string
@@ -64,6 +65,7 @@ func NewRuntimeFlagSet(name string) *flag.FlagSet {
 	fs.String("db-port", "", "database port")
 	fs.String("db-name", "", "database name")
 	fs.Int("db-log-verbosity", 0, "database logging verbosity")
+	fs.Int("log-flags", 0, "request logging flags")
 
 	fs.String("listen", ":8080", "server listen address")
 	fs.String("hostname", "", "server base URL")
@@ -161,6 +163,7 @@ func GenerateRuntimeConfig(fs *flag.FlagSet, fileVals map[string]string, getenv 
 		dst  *int
 	}{
 		{"db-log-verbosity", config.EnvDBLogVerbosity, &cfg.DBLogVerbosity},
+		{"log-flags", config.EnvLogFlags, &cfg.LogFlags},
 		{"page-size-min", config.EnvPageSizeMin, &cfg.PageSizeMin},
 		{"page-size-max", config.EnvPageSizeMax, &cfg.PageSizeMax},
 		{"page-size-default", config.EnvPageSizeDefault, &cfg.PageSizeDefault},

--- a/runtimeconfig/logflags.go
+++ b/runtimeconfig/logflags.go
@@ -1,0 +1,15 @@
+package runtimeconfig
+
+// Log flags for selectively enabling request logs.
+const (
+	// LogFlagAccess enables logging of access checks and permission issues.
+	LogFlagAccess = 1 << iota
+	// LogFlagDB enables verbose database access logs.
+	LogFlagDB
+	// LogFlagErrors enables extra error logs for debugging.
+	LogFlagErrors
+	// LogFlagDebug enables miscellaneous debug logs.
+	LogFlagDebug
+	// LogFlagAuth enables logging of authentication events.
+	LogFlagAuth
+)


### PR DESCRIPTION
## Summary
- replace LOG_VERBOSITY with LOG_FLAGS
- implement log flag constants and runtime config field
- log access and authentication events only when the matching flag is set

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685d36a47218832f92f963029a1dad78