### PR TITLE
Fix news feed route

### DIFF
--- a/handlers/imagebbs/routes.go
+++ b/handlers/imagebbs/routes.go
@@ -12,11 +12,11 @@ import (
 
 // RegisterRoutes attaches the public image board endpoints to r.
 func RegisterRoutes(r *mux.Router) {
+	r.HandleFunc("/imagebbs.rss", RssPage).Methods("GET")
 	ibr := r.PathPrefix("/imagebbs").Subrouter()
 	ibr.PathPrefix("/images/").Handler(http.StripPrefix("/imagebbs/images/", http.FileServer(http.Dir(runtimeconfig.AppRuntimeConfig.ImageUploadDir))))
-	ibr.HandleFunc(".rss", RssPage).Methods("GET")
 	ibr.HandleFunc("/board/{boardno:[0-9]+}.rss", BoardRssPage).Methods("GET")
-	ibr.HandleFunc(".atom", AtomPage).Methods("GET")
+	r.HandleFunc("/imagebbs.atom", AtomPage).Methods("GET")
 	ibr.HandleFunc("/board/{boardno:[0-9]+}.atom", BoardAtomPage).Methods("GET")
 	ibr.HandleFunc("/board/{boardno}", BoardPage).Methods("GET")
 	ibr.HandleFunc("/board/{boardno}", BoardPostImageActionPage).Methods("POST").MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskUploadImage))

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -47,9 +47,9 @@ func AddNewsIndex(handler http.Handler) http.Handler {
 func RegisterRoutes(r *mux.Router) {
 	r.Handle("/", AddNewsIndex(http.HandlerFunc(runTemplate("newsPage")))).Methods("GET")
 	r.HandleFunc("/", hcommon.TaskDoneAutoRefreshPage).Methods("POST")
+	r.HandleFunc("/news.rss", NewsRssPage).Methods("GET")
 	nr := r.PathPrefix("/news").Subrouter()
 	nr.Use(AddNewsIndex)
-	nr.HandleFunc(".rss", NewsRssPage).Methods("GET")
 	nr.HandleFunc("", runTemplate("newsPage")).Methods("GET")
 	nr.HandleFunc("", hcommon.TaskDoneAutoRefreshPage).Methods("POST")
 	nr.HandleFunc("/news/{post}", NewsPostPage).Methods("GET")


### PR DESCRIPTION
## Summary
- fix `/news.rss` path so it matches in gorilla/mux
- register image board RSS/Atom feeds directly on the root router

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685df1b8a97c832f9f48103fd5804bbe