### PR TITLE
Remove obsolete permissions function

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -25,10 +25,6 @@ type CoreData struct {
 	Announcement      *db.GetActiveAnnouncementWithNewsRow
 }
 
-func (cd *CoreData) GetPermissionsByUserIdAndSectionAndSectionAll() string {
-	return cd.SecurityLevel
-}
-
 var rolePriority = map[string]int{
 	"reader":        1,
 	"writer":        2,

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,7 @@ github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI6
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=


### PR DESCRIPTION
## Summary
- drop unused `GetPermissionsByUserIdAndSectionAndSectionAll` method
- add missing checksum for google/go-cmp

## Testing
- `go vet ./...`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_685df43e2834832fbdbd49f3b8da2ce4