### PR TITLE
Fix template conflict for category pages

### DIFF
--- a/core/templates/templates/linker/categoryPage.gohtml
+++ b/core/templates/templates/linker/categoryPage.gohtml
@@ -1,3 +1,5 @@
-{{ template "head" $ }}
-    {{ template "getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingLinks" $ }}
-{{ template "tail" $ }}
+{{ define "linkerCategoryPage" }}
+    {{ template "head" $ }}
+        {{ template "getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingLinks" $ }}
+    {{ template "tail" $ }}
+{{ end }}

--- a/core/templates/templates/writings/categoryPage.gohtml
+++ b/core/templates/templates/writings/categoryPage.gohtml
@@ -1,5 +1,7 @@
-{{ template "head" $ }}
-    {{ template "writingCategoryBreadcrumbs" $ }}
-    {{ template "listWritingCategories" $ }}
-    {{ template "listAbstracts" $ }}
-{{ template "tail" $ }}
+{{ define "writingsCategoryPage" }}
+    {{ template "head" $ }}
+        {{ template "writingCategoryBreadcrumbs" $ }}
+        {{ template "listWritingCategories" $ }}
+        {{ template "listAbstracts" $ }}
+    {{ template "tail" $ }}
+{{ end }}

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,7 @@ github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI6
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/handlers/linker/linkerCategoryPage.go
+++ b/handlers/linker/linkerCategoryPage.go
@@ -51,7 +51,7 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomLinkerIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "categoryPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "linkerCategoryPage", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -75,6 +75,25 @@ func TestPageTemplatesRender(t *testing.T) {
 			CategoryId                       int32
 			IsAdmin                          bool
 		}{&corecommon.CoreData{}, nil, 0, 0, false}},
+		{"linkerCategoryPage", struct {
+			*corecommon.CoreData
+			Offset      int
+			CatId       int
+			CommentOnId int
+			ReplyToId   int
+			Links       []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow
+		}{&corecommon.CoreData{}, 0, 0, 0, 0, nil}},
+		{"writingsCategoryPage", struct {
+			*corecommon.CoreData
+			Categories                       []*db.Writingcategory
+			CategoryBreadcrumbs              []*db.Writingcategory
+			EditingCategoryId                int32
+			CategoryId                       int32
+			WritingcategoryIdwritingcategory int32
+			IsAdmin                          bool
+			IsWriter                         bool
+			Abstracts                        []*db.GetPublicWritingsInCategoryRow
+		}{&corecommon.CoreData{}, nil, nil, 0, 0, 0, false, false, nil}},
 		{"searchPage", struct {
 			*corecommon.CoreData
 			SearchWords string

--- a/handlers/writings/writingsCategoryPage.go
+++ b/handlers/writings/writingsCategoryPage.go
@@ -92,7 +92,7 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 
 	CustomWritingsIndex(data.CoreData, r)
 
-	if err := templates.RenderTemplate(w, "categoryPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
+	if err := templates.RenderTemplate(w, "writingsCategoryPage", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Summary
- give the linker and writings category templates distinct names
- render the renamed templates in their handlers
- test that the new category page templates render correctly

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685df120edf4832f860f736f541d30c1