### PR TITLE
Introduce section registry for dynamic navigation

### DIFF
--- a/core/templates/templates/admin/page.gohtml
+++ b/core/templates/templates/admin/page.gohtml
@@ -3,25 +3,9 @@
     [<a href="/admin">(This page/Refresh)</a>]<br />
 <p>Please select an option:</p>
 <ul>
-    <li><a href="/admin/blogs/user/permissions">Blogs</a></li>
-    <li><a href="/admin/categories">Categories</a></li>
-    <li><a href="/admin/faq/categories">FAQ</a></li>
-    <li><a href="/admin/forum">Forum</a></li>
-    <li><a href="/admin/imagebbs">ImageBBS</a></li>
-    <li><a href="/admin/languages">Languages</a></li>
-    <li><a href="/admin/linker/categories">Linker</a></li>
-    <li><a href="/admin/news/users/levels">News</a></li>
-    <li><a href="/admin/notifications">Notifications</a></li>
-    <li><a href="/admin/permissions/sections">Permission Sections</a></li>
-    <li><a href="/admin/email/queue">Queued Emails</a></li>
-    <li><a href="/admin/email/template">Email Template</a></li>
-    <li><a href="/admin/search">Search</a></li>
-    <li><a href="/admin/stats">Server Stats</a></li>
-    <li><a href="/admin/settings">Site Settings</a></li>
-    <li><a href="/admin/usage">Usage Stats</a></li>
-    <li><a href="/admin/users/permissions">User Permissions</a></li>
-    <li><a href="/admin/users">Users</a></li>
-    <li><a href="/admin/writings/categories">Writings</a></li>
+    {{- range $l := .AdminLinks }}
+    <li><a href="{{ $l.Link }}">{{ $l.Name }}</a></li>
+    {{- end }}
 </ul>
 
 <p>Site statistics:</p>

--- a/handlers/admin/adminHandler.go
+++ b/handlers/admin/adminHandler.go
@@ -6,6 +6,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/sections"
 	"log"
 	"net/http"
 
@@ -26,11 +27,13 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 
 	type Data struct {
 		*CoreData
-		Stats Stats
+		AdminLinks []corecommon.IndexItem
+		Stats      Stats
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData:   r.Context().Value(common.KeyCoreData).(*CoreData),
+		AdminLinks: sections.AdminLinks(),
 	}
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	ctx := r.Context()

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -12,11 +12,21 @@ import (
 	search "github.com/arran4/goa4web/handlers/search"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
 	writings "github.com/arran4/goa4web/handlers/writings"
+	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterRoutes attaches the admin endpoints to ar. The router is expected to
 // already have any required authentication middleware applied.
 func RegisterRoutes(ar *mux.Router) {
+	sections.RegisterAdminControlCenter("Categories", "/admin/categories", 20)
+	sections.RegisterAdminControlCenter("Notifications", "/admin/notifications", 90)
+	sections.RegisterAdminControlCenter("Permission Sections", "/admin/permissions/sections", 100)
+	sections.RegisterAdminControlCenter("Queued Emails", "/admin/email/queue", 110)
+	sections.RegisterAdminControlCenter("Email Template", "/admin/email/template", 120)
+	sections.RegisterAdminControlCenter("Server Stats", "/admin/stats", 140)
+	sections.RegisterAdminControlCenter("Site Settings", "/admin/settings", 150)
+	sections.RegisterAdminControlCenter("Usage Stats", "/admin/usage", 160)
+
 	ar.HandleFunc("", AdminPage).Methods("GET")
 	ar.HandleFunc("/", AdminPage).Methods("GET")
 	ar.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")

--- a/handlers/blogs/routes.go
+++ b/handlers/blogs/routes.go
@@ -7,10 +7,14 @@ import (
 	auth "github.com/arran4/goa4web/handlers/auth"
 	comments "github.com/arran4/goa4web/handlers/comments"
 	hcommon "github.com/arran4/goa4web/handlers/common"
+
+	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterRoutes attaches the public blog endpoints to r.
 func RegisterRoutes(r *mux.Router) {
+	sections.RegisterIndexLink("Blogs", "/blogs", SectionWeight)
+	sections.RegisterAdminControlCenter("Blogs", "/admin/blogs/user/permissions", SectionWeight)
 	br := r.PathPrefix("/blogs").Subrouter()
 	br.HandleFunc("/rss", RssPage).Methods("GET")
 	br.HandleFunc("/atom", AtomPage).Methods("GET")

--- a/handlers/blogs/section.go
+++ b/handlers/blogs/section.go
@@ -1,0 +1,6 @@
+package blogs
+
+const (
+	// SectionWeight controls the order of the Blogs section in navigation.
+	SectionWeight = 30
+)

--- a/handlers/bookmarks/routes.go
+++ b/handlers/bookmarks/routes.go
@@ -5,10 +5,13 @@ import (
 
 	auth "github.com/arran4/goa4web/handlers/auth"
 	hcommon "github.com/arran4/goa4web/handlers/common"
+
+	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterRoutes attaches the bookmarks endpoints to r.
 func RegisterRoutes(r *mux.Router) {
+	sections.RegisterIndexLink("Bookmarks", "/bookmarks", SectionWeight)
 	br := r.PathPrefix("/bookmarks").Subrouter()
 	br.HandleFunc("", Page).Methods("GET")
 	br.HandleFunc("/mine", MinePage).Methods("GET").MatcherFunc(auth.RequiresAnAccount())

--- a/handlers/bookmarks/section.go
+++ b/handlers/bookmarks/section.go
@@ -1,0 +1,6 @@
+package bookmarks
+
+const (
+	// SectionWeight controls the order of the Bookmarks section in navigation.
+	SectionWeight = 60
+)

--- a/handlers/faq/routes.go
+++ b/handlers/faq/routes.go
@@ -3,6 +3,8 @@ package faq
 import (
 	"github.com/gorilla/mux"
 	"net/http"
+
+	"github.com/arran4/goa4web/internal/sections"
 )
 
 // Task constants mirror the values used by the main package.
@@ -39,6 +41,8 @@ func noTask() mux.MatcherFunc {
 
 // RegisterRoutes attaches the public FAQ endpoints to the router.
 func RegisterRoutes(r *mux.Router) {
+	sections.RegisterIndexLink("FAQ", "/faq", SectionWeight)
+	sections.RegisterAdminControlCenter("FAQ", "/admin/faq/categories", SectionWeight)
 	faqr := r.PathPrefix("/faq").Subrouter()
 	faqr.HandleFunc("", Page).Methods("GET", "POST")
 	faqr.HandleFunc("/ask", AskPage).Methods("GET")

--- a/handlers/faq/section.go
+++ b/handlers/faq/section.go
@@ -1,0 +1,6 @@
+package faq
+
+const (
+	// SectionWeight controls the order of the FAQ section in navigation.
+	SectionWeight = 20
+)

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -6,10 +6,14 @@ import (
 
 	comments "github.com/arran4/goa4web/handlers/comments"
 	hcommon "github.com/arran4/goa4web/handlers/common"
+
+	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterRoutes attaches the public forum endpoints to r.
 func RegisterRoutes(r *mux.Router) {
+	sections.RegisterIndexLink("Forum", "/forum", SectionWeight)
+	sections.RegisterAdminControlCenter("Forum", "/admin/forum", SectionWeight)
 	fr := r.PathPrefix("/forum").Subrouter()
 	fr.HandleFunc("/topic/{topic}.rss", TopicRssPage).Methods("GET")
 	fr.HandleFunc("/topic/{topic}.atom", TopicAtomPage).Methods("GET")

--- a/handlers/forum/section.go
+++ b/handlers/forum/section.go
@@ -1,0 +1,6 @@
+package forum
+
+const (
+	// SectionWeight controls the order of the Forum section in navigation.
+	SectionWeight = 40
+)

--- a/handlers/imagebbs/routes.go
+++ b/handlers/imagebbs/routes.go
@@ -8,10 +8,14 @@ import (
 	auth "github.com/arran4/goa4web/handlers/auth"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	"github.com/arran4/goa4web/runtimeconfig"
+
+	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterRoutes attaches the public image board endpoints to r.
 func RegisterRoutes(r *mux.Router) {
+	sections.RegisterIndexLink("ImageBBS", "/imagebbs", SectionWeight)
+	sections.RegisterAdminControlCenter("ImageBBS", "/admin/imagebbs", SectionWeight)
 	r.HandleFunc("/imagebbs.rss", RssPage).Methods("GET")
 	ibr := r.PathPrefix("/imagebbs").Subrouter()
 	ibr.PathPrefix("/images/").Handler(http.StripPrefix("/imagebbs/images/", http.FileServer(http.Dir(runtimeconfig.AppRuntimeConfig.ImageUploadDir))))

--- a/handlers/imagebbs/section.go
+++ b/handlers/imagebbs/section.go
@@ -1,0 +1,6 @@
+package imagebbs
+
+const (
+	// SectionWeight controls the order of the ImageBBS section in navigation.
+	SectionWeight = 70
+)

--- a/handlers/information/routes.go
+++ b/handlers/information/routes.go
@@ -1,9 +1,14 @@
 package information
 
-import "github.com/gorilla/mux"
+import (
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/internal/sections"
+)
 
 // RegisterRoutes attaches the information endpoints to r.
 func RegisterRoutes(r *mux.Router) {
+	sections.RegisterIndexLink("Information", "/information", SectionWeight)
 	ir := r.PathPrefix("/information").Subrouter()
 	ir.HandleFunc("", Page).Methods("GET")
 }

--- a/handlers/information/section.go
+++ b/handlers/information/section.go
@@ -1,0 +1,6 @@
+package information
+
+const (
+	// SectionWeight controls the order of the Information section in navigation.
+	SectionWeight = 100
+)

--- a/handlers/languages/routes.go
+++ b/handlers/languages/routes.go
@@ -4,10 +4,12 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterAdminRoutes attaches the admin language endpoints to the router.
 func RegisterAdminRoutes(ar *mux.Router) {
+	sections.RegisterAdminControlCenter("Languages", "/admin/languages", SectionWeight)
 	ar.HandleFunc("/languages", adminLanguagesPage).Methods("GET")
 	ar.HandleFunc("/language", adminLanguageRedirect).Methods("GET")
 	ar.HandleFunc("/languages", adminLanguagesRenamePage).Methods("POST").MatcherFunc(common.TaskMatcher("Rename Language"))

--- a/handlers/languages/section.go
+++ b/handlers/languages/section.go
@@ -1,0 +1,6 @@
+package languages
+
+const (
+	// SectionWeight controls the order of the Languages admin link in the control center.
+	SectionWeight = 60
+)

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -3,10 +3,14 @@ package linker
 import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterRoutes attaches the public linker endpoints to r.
 func RegisterRoutes(r *mux.Router) {
+	sections.RegisterIndexLink("Linker", "/linker", SectionWeight)
+	sections.RegisterAdminControlCenter("Linker", "/admin/linker/categories", SectionWeight)
 	lr := r.PathPrefix("/linker").Subrouter()
 	lr.HandleFunc("/rss", RssPage).Methods("GET")
 	lr.HandleFunc("/atom", AtomPage).Methods("GET")

--- a/handlers/linker/section.go
+++ b/handlers/linker/section.go
@@ -1,0 +1,6 @@
+package linker
+
+const (
+	// SectionWeight controls the order of the Linker section in navigation.
+	SectionWeight = 50
+)

--- a/handlers/news/consts.go
+++ b/handlers/news/consts.go
@@ -6,4 +6,7 @@ const (
 
 	// NewsTopicDescription describes the hidden news forum.
 	NewsTopicDescription = "THIS IS A HIDDEN FORUM FOR A NEWS TOPIC"
+
+	// SectionWeight controls the order of news in navigation menus.
+	SectionWeight = 10
 )

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -11,6 +11,7 @@ import (
 
 	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/internal/sections"
 )
 
 func runTemplate(tmpl string) func(http.ResponseWriter, *http.Request) {
@@ -45,6 +46,8 @@ func AddNewsIndex(handler http.Handler) http.Handler {
 
 // RegisterRoutes attaches the public news endpoints to r.
 func RegisterRoutes(r *mux.Router) {
+	sections.RegisterIndexLink("News", "/", SectionWeight)
+	sections.RegisterAdminControlCenter("News", "/admin/news/users/levels", SectionWeight)
 	r.Handle("/", AddNewsIndex(http.HandlerFunc(runTemplate("newsPage")))).Methods("GET")
 	r.HandleFunc("/", hcommon.TaskDoneAutoRefreshPage).Methods("POST")
 	r.HandleFunc("/news.rss", NewsRssPage).Methods("GET")

--- a/handlers/search/routes.go
+++ b/handlers/search/routes.go
@@ -5,10 +5,14 @@ import (
 
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	news "github.com/arran4/goa4web/handlers/news"
+
+	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterRoutes attaches the search endpoints to r.
 func RegisterRoutes(r *mux.Router) {
+	sections.RegisterIndexLink("Search", "/search", SectionWeight)
+	sections.RegisterAdminControlCenter("Search", "/admin/search", SectionWeight)
 	sr := r.PathPrefix("/search").Subrouter()
 	sr.HandleFunc("", Page).Methods("GET")
 	sr.HandleFunc("", SearchResultForumActionPage).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskSearchForum))

--- a/handlers/search/section.go
+++ b/handlers/search/section.go
@@ -1,0 +1,6 @@
+package search
+
+const (
+	// SectionWeight controls the order of the Search section in navigation.
+	SectionWeight = 80
+)

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -104,8 +104,9 @@ func TestPageTemplatesRender(t *testing.T) {
 		}{&corecommon.CoreData{}, struct{ Words, Comments, News, Blogs, Linker, Writing, Writings, Images int64 }{}}},
 		{"adminPage", struct {
 			*corecommon.CoreData
-			Stats adminStats
-		}{&corecommon.CoreData{}, adminStats{}}},
+			AdminLinks []corecommon.IndexItem
+			Stats      adminStats
+		}{&corecommon.CoreData{}, nil, adminStats{}}},
 		{"forumAdminPage", struct {
 			*corecommon.CoreData
 			Stats struct{ Categories, Topics, Threads int64 }

--- a/handlers/user/routes_admin.go
+++ b/handlers/user/routes_admin.go
@@ -4,10 +4,13 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterAdminRoutes attaches user admin endpoints to the router.
 func RegisterAdminRoutes(ar *mux.Router) {
+	sections.RegisterAdminControlCenter("User Permissions", "/admin/users/permissions", SectionWeight-10)
+	sections.RegisterAdminControlCenter("Users", "/admin/users", SectionWeight)
 	ar.HandleFunc("/users", adminUsersPage).Methods("GET")
 	ar.HandleFunc("/users/export", adminUsersExportPage).Methods("GET")
 	ar.HandleFunc("/sessions", adminSessionsPage).Methods("GET")

--- a/handlers/user/section.go
+++ b/handlers/user/section.go
@@ -1,0 +1,6 @@
+package user
+
+const (
+	// SectionWeight controls the order of the Users admin links in the control center.
+	SectionWeight = 180
+)

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -7,10 +7,14 @@ import (
 
 	auth "github.com/arran4/goa4web/handlers/auth"
 	hcommon "github.com/arran4/goa4web/handlers/common"
+
+	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterRoutes attaches the public writings endpoints to r.
 func RegisterRoutes(r *mux.Router) {
+	sections.RegisterIndexLink("Writings", "/writings", SectionWeight)
+	sections.RegisterAdminControlCenter("Writings", "/admin/writings/categories", SectionWeight)
 	wr := r.PathPrefix("/writings").Subrouter()
 	wr.HandleFunc("/rss", RssPage).Methods("GET")
 	wr.HandleFunc("/atom", AtomPage).Methods("GET")

--- a/handlers/writings/section.go
+++ b/handlers/writings/section.go
@@ -1,0 +1,6 @@
+package writings
+
+const (
+	// SectionWeight controls the order of the Writings section in navigation.
+	SectionWeight = 90
+)

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -14,6 +14,7 @@ import (
 	common "github.com/arran4/goa4web/core/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/sections"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -24,20 +25,6 @@ func handleDie(w http.ResponseWriter, message string) {
 
 // IndexItem exposes the core/common navigation item type.
 type IndexItem = common.IndexItem
-
-// indexItems are always present navigation links.
-var indexItems = []common.IndexItem{
-	{Name: "News", Link: "/"},
-	{Name: "FAQ", Link: "/faq"},
-	{Name: "Blogs", Link: "/blogs"},
-	{Name: "Forum", Link: "/forum"},
-	{Name: "Linker", Link: "/linker"},
-	{Name: "Bookmarks", Link: "/bookmarks"},
-	{Name: "ImageBBS", Link: "/imagebbs"},
-	{Name: "Search", Link: "/search"},
-	{Name: "Writings", Link: "/writings"},
-	{Name: "Information", Link: "/information"},
-}
 
 // CoreAdderMiddleware populates request context with CoreData for templates.
 func CoreAdderMiddleware(next http.Handler) http.Handler {
@@ -64,8 +51,7 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 			}
 		}
 
-		idx := make([]common.IndexItem, len(indexItems))
-		copy(idx, indexItems)
+		idx := sections.IndexItems()
 		if uid != 0 {
 			idx = append(idx, common.IndexItem{Name: "Preferences", Link: "/usr"})
 		}

--- a/internal/sections/registry.go
+++ b/internal/sections/registry.go
@@ -1,0 +1,53 @@
+package sections
+
+import (
+	"sort"
+
+	corecommon "github.com/arran4/goa4web/core/common"
+)
+
+// link represents a navigation item for either index or admin control center.
+type link struct {
+	name   string
+	link   string
+	weight int
+}
+
+var (
+	indexRegistry []link
+	adminRegistry []link
+)
+
+// RegisterIndexLink registers an entry for the site's index navigation.
+func RegisterIndexLink(name, url string, weight int) {
+	indexRegistry = append(indexRegistry, link{name: name, link: url, weight: weight})
+}
+
+// RegisterAdminControlCenter registers a link for the admin control center menu.
+func RegisterAdminControlCenter(name, url string, weight int) {
+	adminRegistry = append(adminRegistry, link{name: name, link: url, weight: weight})
+}
+
+// IndexItems returns navigation items sorted by weight.
+func IndexItems() []corecommon.IndexItem {
+	entries := make([]link, len(indexRegistry))
+	copy(entries, indexRegistry)
+	sort.Slice(entries, func(i, j int) bool { return entries[i].weight < entries[j].weight })
+	items := make([]corecommon.IndexItem, 0, len(entries))
+	for _, e := range entries {
+		items = append(items, corecommon.IndexItem{Name: e.name, Link: e.link})
+	}
+	return items
+}
+
+// AdminLinks returns admin navigation items sorted by weight.
+func AdminLinks() []corecommon.IndexItem {
+	entries := make([]link, len(adminRegistry))
+	copy(entries, adminRegistry)
+	sort.Slice(entries, func(i, j int) bool { return entries[i].weight < entries[j].weight })
+	items := make([]corecommon.IndexItem, 0, len(entries))
+	for _, e := range entries {
+		items = append(items, corecommon.IndexItem{Name: e.name, Link: e.link})
+	}
+	return items
+}

--- a/internal/sections/registry_test.go
+++ b/internal/sections/registry_test.go
@@ -1,0 +1,48 @@
+package sections
+
+import (
+	"testing"
+)
+
+func TestIndexItemsOrdering(t *testing.T) {
+	indexRegistry = nil
+	adminRegistry = nil
+	t.Cleanup(func() { indexRegistry = nil; adminRegistry = nil })
+
+	RegisterIndexLink("b", "/b", 20)
+	RegisterIndexLink("a", "/a", 10)
+	RegisterAdminControlCenter("b", "/admin/b", 20)
+	RegisterAdminControlCenter("a", "/admin/a", 10)
+
+	items := IndexItems()
+	if len(items) != 2 {
+		t.Fatalf("want 2 items got %d", len(items))
+	}
+	if items[0].Name != "a" {
+		t.Errorf("index 0 want a got %s", items[0].Name)
+	}
+
+	links := AdminLinks()
+	if len(links) != 2 {
+		t.Fatalf("want 2 links got %d", len(links))
+	}
+	if links[0].Name != "a" {
+		t.Errorf("admin link 0 want a got %s", links[0].Name)
+	}
+}
+
+func TestIndexItemsSkipEmpty(t *testing.T) {
+	indexRegistry = nil
+	adminRegistry = nil
+	t.Cleanup(func() { indexRegistry = nil; adminRegistry = nil })
+
+	RegisterAdminControlCenter("no", "/admin/no", 5)
+	items := IndexItems()
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items got %d", len(items))
+	}
+	links := AdminLinks()
+	if len(links) != 1 || links[0].Name != "no" {
+		t.Fatalf("unexpected admin links %#v", links)
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,28 @@ requests.
 └── internal/db/queries-*.sql        – SQL queries consumed by sqlc
 ```
 
+### Section registration
+
+Site sections register their navigation items with the `sections` package so
+menus can be assembled dynamically. Use `sections.RegisterIndexLink` for public
+links and `sections.RegisterAdminControlCenter` for admin navigation. Each call
+accepts a weight value; lower numbers appear first.
+
+Example weights:
+
+```
+News        10
+FAQ         20
+Blogs       30
+Forum       40
+Linker      50
+Bookmarks   60
+ImageBBS    70
+Search      80
+Writings    90
+Information 100
+```
+
 ## Testing
 
 Unit tests focus mainly on utility packages and template compilation. Execute all tests with:


### PR DESCRIPTION
## Summary
- add new `sections` package with registry helper
- replace global navigation links with `sections.IndexItems()`
- render admin links dynamically from `sections.AdminLinks()`
- register each site section with a weight for ordering
- register admin control center links for all pages so no links are lost
- document the registration system
- test registration ordering
- move admin link registration to section packages

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685df8a31898832f8f1a4ffe88c9f68e