### PR TITLE
Add TaskErrorAcknowledgementPage

### DIFF
--- a/core/templates/templates/taskErrorAcknowledgementPage.gohtml
+++ b/core/templates/templates/taskErrorAcknowledgementPage.gohtml
@@ -1,0 +1,6 @@
+{{ template "head" $ }}
+{{- if $.Error }}
+<p style="color:red;">{{ $.Error }}</p>
+{{- end }}
+<button type="button" onclick="history.back()">Go Back</button>
+{{ template "tail" $ }}

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -70,7 +70,8 @@ func AdminEmailTemplateTestActionPage(w http.ResponseWriter, r *http.Request) {
 	provider := getEmailProvider()
 	if provider == nil {
 		q := url.QueryEscape(userhandlers.ErrMailNotConfigured)
-		http.Redirect(w, r, "/admin/email/template?error="+q, http.StatusTemporaryRedirect)
+		r.URL.RawQuery = "error=" + q
+		common.TaskErrorAcknowledgementPage(w, r)
 		return
 	}
 

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -30,12 +30,15 @@ func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 	rr := httptest.NewRecorder()
 	AdminEmailTemplateTestActionPage(rr, req)
 
-	if rr.Code != http.StatusTemporaryRedirect {
+	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d", rr.Code)
 	}
 	want := url.QueryEscape(userhandlers.ErrMailNotConfigured)
-	if loc := rr.Header().Get("Location"); !strings.Contains(loc, want) {
-		t.Fatalf("location=%q", loc)
+	if req.URL.RawQuery != "error="+want {
+		t.Fatalf("query=%q", req.URL.RawQuery)
+	}
+	if !strings.Contains(rr.Body.String(), "history.back()") {
+		t.Fatalf("body=%q", rr.Body.String())
 	}
 }
 

--- a/handlers/common/error_acknowledgement.go
+++ b/handlers/common/error_acknowledgement.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"log"
+	"net/http"
+
+	corecommon "github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/templates"
+)
+
+// TaskErrorAcknowledgementPage renders a page displaying an error message.
+func TaskErrorAcknowledgementPage(w http.ResponseWriter, r *http.Request) {
+	type Data struct {
+		*CoreData
+		Error string
+	}
+	data := Data{
+		CoreData: r.Context().Value(ContextKey("coreData")).(*CoreData),
+		Error:    r.URL.Query().Get("error"),
+	}
+	if data.Error == "" {
+		data.Error = r.PostFormValue("error")
+	}
+	if err := templates.RenderTemplate(w, "taskErrorAcknowledgementPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
+		log.Printf("Template Error: %s", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -107,11 +107,9 @@ func userEmailTestActionPage(w http.ResponseWriter, r *http.Request) {
 	provider := getEmailProvider()
 	if provider == nil {
 		q := url.QueryEscape(ErrMailNotConfigured)
-		// TaskDoneAutoRefreshPage triggers a client-side refresh to the
-		// same URL. By adjusting the query string we can show the error
-		// without an HTTP redirect that would repeat the POST.
+		// Display the error without redirecting so the POST isn't repeated.
 		r.URL.RawQuery = "error=" + q
-		common.TaskDoneAutoRefreshPage(w, r)
+		common.TaskErrorAcknowledgementPage(w, r)
 		return
 	}
 	if err := notifyChange(r.Context(), provider, user.Email.String, pageURL); err != nil {

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -153,8 +153,9 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	if req.URL.RawQuery != "error="+want {
 		t.Fatalf("query=%q", req.URL.RawQuery)
 	}
-	if !strings.Contains(rr.Body.String(), "meta http-equiv=\"refresh\"") {
-		t.Fatalf("body=%q", rr.Body.String())
+	body := rr.Body.String()
+	if !strings.Contains(body, "history.back()") {
+		t.Fatalf("body=%q", body)
 	}
 }
 


### PR DESCRIPTION
## Summary
- implement `TaskErrorAcknowledgementPage` handler
- add matching template for displaying errors
- integrate error page with email test actions
- update unit tests

## Testing
- `go vet ./...`
- `go test ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e0b334144832f80d17a193775447e