### PR TITLE
Improve notification styling

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -100,3 +100,9 @@ div.title {
 	color: #800000;
 	background-color: transparent;
 }
+.notification {
+        border: 1px solid #808000;
+        padding: 0.5em;
+        margin-bottom: 0.5em;
+        background-color: #FFF6E0;
+}

--- a/core/templates/templates/user/notifications.gohtml
+++ b/core/templates/templates/user/notifications.gohtml
@@ -1,9 +1,9 @@
 {{ template "head" $ }}
 {{ range .Notifications }}
-    <div>
+    <div class="notification">
         {{ if .Link.Valid }}<a href="{{ .Link.String }}">{{ end }}{{ .Message.String }}{{ if .Link.Valid }}</a>{{ end }}
-        <form method="post" action="/usr/notifications/dismiss">
-        {{ csrfField }}
+        <form method="post" action="/usr/notifications/dismiss" style="display:inline">
+            {{ csrfField }}
             <input type="hidden" name="id" value="{{ .ID }}">
             <input type="submit" name="task" value="Dismiss">
         </form>


### PR DESCRIPTION
## Summary
- add CSS for `.notification` blocks
- wrap user notifications in styled divs for better separation

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e155b6b5c832fa1bd7cf77a7b3d92