### PR TITLE
Implement admin mode with URL toggle

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -12,15 +12,17 @@ type IndexItem struct {
 }
 
 type CoreData struct {
-	IndexItems        []IndexItem
-	CustomIndexItems  []IndexItem
-	UserID            int32
-	SecurityLevel     string
-	Title             string
-	AutoRefresh       bool
-	FeedsEnabled      bool
-	RSSFeedUrl        string
-	AtomFeedUrl       string
+	IndexItems       []IndexItem
+	CustomIndexItems []IndexItem
+	UserID           int32
+	SecurityLevel    string
+	Title            string
+	AutoRefresh      bool
+	FeedsEnabled     bool
+	RSSFeedUrl       string
+	AtomFeedUrl      string
+	// AdminMode indicates whether admin-only UI elements should be displayed.
+	AdminMode         bool
 	NotificationCount int32
 	Announcement      *db.GetActiveAnnouncementWithNewsRow
 }

--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -47,6 +47,16 @@ func NewFuncs(r *http.Request) template.FuncMap {
 			}
 			return s[:l]
 		},
+		"addmode": func(u string) string {
+			cd, _ := r.Context().Value(ContextValues("coreData")).(*CoreData)
+			if cd == nil || !cd.AdminMode {
+				return u
+			}
+			if strings.Contains(u, "?") {
+				return u + "&mode=admin"
+			}
+			return u + "?mode=admin"
+		},
 		"LatestNews": func() (any, error) {
 			if LatestNews != nil {
 				return LatestNews, nil
@@ -90,7 +100,7 @@ func NewFuncs(r *http.Request) template.FuncMap {
 					ShowEdit:     cd.HasRole("writer"),
 					Editing:      editingId == int(post.Idsitenews),
 					Announcement: ann,
-					IsAdmin:      cd.HasRole("administrator"),
+					IsAdmin:      cd.HasRole("administrator") && cd.AdminMode,
 				})
 			}
 			LatestNews = result

--- a/core/templates/templates/index.gohtml
+++ b/core/templates/templates/index.gohtml
@@ -8,10 +8,15 @@
         <a href="/login">Login</a><br>
     {{ end }}
     {{ range $i := $.CustomIndexItems }}
-        <a href="{{ $i.Link }}">{{ $i.Name }}</a><br>
+        <a href="{{ addmode $i.Link }}">{{ $i.Name }}</a><br>
     {{ end }}
     {{ if eq $.SecurityLevel "administrator"}}
         <hr>
-        <a href="/admin">Control center</a><br>
+        <a href="{{ addmode "/admin" }}">Control center</a><br>
+        {{ if $.AdminMode }}
+            <a href="/">Disable admin mode</a><br>
+        {{ else }}
+            <a href="/?mode=admin">Enable admin mode</a><br>
+        {{ end }}
     {{ end }}
 {{- end}}

--- a/core/templates/templates/indexItems.gohtml
+++ b/core/templates/templates/indexItems.gohtml
@@ -1,5 +1,5 @@
 {{- define "indexItems"}}
     {{ range $i := $.IndexItems }}
-        <a href="{{ $i.Link }}">{{ $i.Name }}</a><br>
+        <a href="{{ addmode $i.Link }}">{{ $i.Name }}</a><br>
     {{ end }}
 {{- end}}

--- a/handlers/blogs/blogsIndexPermissions_test.go
+++ b/handlers/blogs/blogsIndexPermissions_test.go
@@ -10,7 +10,7 @@ import (
 func TestCustomBlogIndexRoles(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs", nil)
 
-	cd := &CoreData{SecurityLevel: "administrator"}
+	cd := &CoreData{SecurityLevel: "administrator", AdminMode: true}
 	CustomBlogIndex(cd, req)
 	if !corecommon.ContainsItem(cd.CustomIndexItems, "User Permissions") {
 		t.Errorf("admin should see user permissions")

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -113,7 +113,7 @@ func CustomBlogIndex(data *CoreData, r *http.Request) {
 		data.AtomFeedUrl = "/blogs/atom"
 	}
 
-	userHasAdmin := data.HasRole("administrator")
+	userHasAdmin := data.HasRole("administrator") && data.AdminMode
 	if userHasAdmin {
 		data.CustomIndexItems = append(data.CustomIndexItems, IndexItem{
 			Name: "User Permissions",

--- a/handlers/faq/page.go
+++ b/handlers/faq/page.go
@@ -72,7 +72,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 }
 
 func CustomFAQIndex(data *corecommon.CoreData) {
-	userHasAdmin := data.HasRole("administrator")
+	userHasAdmin := data.HasRole("administrator") && data.AdminMode
 	data.CustomIndexItems = append(data.CustomIndexItems, corecommon.IndexItem{
 		Name: "Ask",
 		Link: "/faq/ask",

--- a/handlers/faq/page_test.go
+++ b/handlers/faq/page_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestCustomFAQIndexRoles(t *testing.T) {
-	cd := &corecommon.CoreData{SecurityLevel: "administrator"}
+	cd := &corecommon.CoreData{SecurityLevel: "administrator", AdminMode: true}
 	CustomFAQIndex(cd)
 	if !corecommon.ContainsItem(cd.CustomIndexItems, "Question Qontrols") {
 		t.Errorf("admin should see question controls")

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -146,7 +146,7 @@ func CustomForumIndex(data *CoreData, r *http.Request) {
 			IndexItem{Name: "RSS Feed", Link: data.RSSFeedUrl},
 		)
 	}
-	userHasAdmin := data.HasRole("administrator")
+	userHasAdmin := data.HasRole("administrator") && data.AdminMode
 	if userHasAdmin {
 		data.CustomIndexItems = append(data.CustomIndexItems,
 			IndexItem{

--- a/handlers/imagebbs/imagebbsPage.go
+++ b/handlers/imagebbs/imagebbsPage.go
@@ -57,7 +57,7 @@ func CustomImageBBSIndex(data *common.CoreData, r *http.Request) {
 		data.AtomFeedUrl = "/imagebbs/atom"
 	}
 
-	userHasAdmin := data.HasRole("administrator")
+	userHasAdmin := data.HasRole("administrator") && data.AdminMode
 	if userHasAdmin {
 		data.CustomIndexItems = append(data.CustomIndexItems, corecommon.IndexItem{
 			Name: "Admin",

--- a/handlers/linker/linkerPage.go
+++ b/handlers/linker/linkerPage.go
@@ -79,7 +79,7 @@ func CustomLinkerIndex(data *corecommon.CoreData, r *http.Request) {
 		data.AtomFeedUrl = "/linker/atom"
 	}
 
-	userHasAdmin := data.HasRole("administrator")
+	userHasAdmin := data.HasRole("administrator") && data.AdminMode
 	if userHasAdmin {
 		data.CustomIndexItems = append(data.CustomIndexItems, IndexItem{
 			Name: "User Permissions",

--- a/handlers/news/newsIndexPermissions_test.go
+++ b/handlers/news/newsIndexPermissions_test.go
@@ -11,7 +11,7 @@ import (
 func TestCustomNewsIndexRoles(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 
-	cd := &hcommon.CoreData{SecurityLevel: "administrator"}
+	cd := &hcommon.CoreData{SecurityLevel: "administrator", AdminMode: true}
 	CustomNewsIndex(cd, req)
 	if !corecommon.ContainsItem(cd.CustomIndexItems, "User Permissions") {
 		t.Errorf("admin should see user permissions")

--- a/handlers/news/newsPage.go
+++ b/handlers/news/newsPage.go
@@ -17,7 +17,7 @@ func CustomNewsIndex(data *hcommon.CoreData, r *http.Request) {
 		Name: "RSS Feed",
 		Link: "/news.rss",
 	})
-	userHasAdmin := data.HasRole("administrator")
+	userHasAdmin := data.HasRole("administrator") && data.AdminMode
 	if userHasAdmin {
 		data.CustomIndexItems = append(data.CustomIndexItems, corecommon.IndexItem{
 			Name: "User Permissions",

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -164,7 +164,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		ShowEdit:     data.CoreData.HasRole("writer"),
 		Editing:      editingId == int(post.Idsitenews),
 		Announcement: ann,
-		IsAdmin:      data.CoreData.HasRole("administrator"),
+		IsAdmin:      data.CoreData.HasRole("administrator") && data.CoreData.AdminMode,
 	}
 
 	languageRows, err := queries.FetchLanguages(r.Context())

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -80,7 +80,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 
 	data.Writing = writing
 	data.IsAuthor = writing.UsersIdusers == uid
-	data.CanEdit = cd.HasRole("administrator") || (cd.HasRole("writer") && data.IsAuthor)
+	data.CanEdit = (cd.HasRole("administrator") && cd.AdminMode) || (cd.HasRole("writer") && data.IsAuthor)
 	data.CategoryId = writing.WritingcategoryIdwritingcategory
 
 	languageRows, err := queries.FetchLanguages(r.Context())

--- a/handlers/writings/writingsCategoriesPage.go
+++ b/handlers/writings/writingsCategoriesPage.go
@@ -29,7 +29,7 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
 	}
 
-	data.IsAdmin = data.CoreData.HasRole("administrator")
+	data.IsAdmin = data.CoreData.HasRole("administrator") && data.CoreData.AdminMode
 	data.IsWriter = data.CoreData.HasRole("writer") || data.IsAdmin
 	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
 	data.EditingCategoryId = int32(editID)

--- a/handlers/writings/writingsCategoryPage.go
+++ b/handlers/writings/writingsCategoryPage.go
@@ -32,7 +32,7 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
 	}
 
-	data.IsAdmin = data.CoreData.HasRole("administrator")
+	data.IsAdmin = data.CoreData.HasRole("administrator") && data.CoreData.AdminMode
 	data.IsWriter = data.CoreData.HasRole("writer") || data.IsAdmin
 	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
 	data.EditingCategoryId = int32(editID)

--- a/handlers/writings/writingsPage.go
+++ b/handlers/writings/writingsPage.go
@@ -30,7 +30,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
 	}
 
-	data.IsAdmin = data.CoreData.HasRole("administrator")
+	data.IsAdmin = data.CoreData.HasRole("administrator") && data.CoreData.AdminMode
 	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
 	data.EditingCategoryId = int32(editID)
 	data.CategoryId = 0
@@ -68,7 +68,7 @@ func CustomWritingsIndex(data *corecommon.CoreData, r *http.Request) {
 	data.RSSFeedUrl = "/writings/rss"
 	data.AtomFeedUrl = "/writings/atom"
 
-	userHasAdmin := data.HasRole("administrator")
+	userHasAdmin := data.HasRole("administrator") && data.AdminMode
 	if userHasAdmin && writingsPermissionsPageEnabled {
 		data.CustomIndexItems = append(data.CustomIndexItems, corecommon.IndexItem{
 			Name: "User Permissions",

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -75,6 +75,7 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 			UserID:            uid,
 			Title:             "Arran's Site",
 			FeedsEnabled:      runtimeconfig.AppRuntimeConfig.FeedsEnabled,
+			AdminMode:         r.URL.Query().Get("mode") == "admin",
 			NotificationCount: count,
 			Announcement:      ann,
 		}


### PR DESCRIPTION
## Summary
- add `AdminMode` flag on `CoreData`
- append mode to links via new `addmode` template function
- show admin features only when admin mode is active
- expose toggle link in index template
- update middleware to read `mode=admin`
- fix tests for admin mode

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e2d0a60f8832fb8b8ca2495a313d1