### PR TITLE
Fix history.back button blocked by CSP

### DIFF
--- a/core/templates/templates/taskErrorAcknowledgementPage.gohtml
+++ b/core/templates/templates/taskErrorAcknowledgementPage.gohtml
@@ -2,5 +2,7 @@
 {{- if $.Error }}
 <p style="color:red;">{{ $.Error }}</p>
 {{- end }}
-<button type="button" onclick="history.back()">Go Back</button>
+{{- if $.BackURL }}
+<a href="{{ $.BackURL }}">Go Back</a>
+{{- end }}
 {{ template "tail" $ }}

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -37,7 +37,7 @@ func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 	if req.URL.RawQuery != "error="+want {
 		t.Fatalf("query=%q", req.URL.RawQuery)
 	}
-	if !strings.Contains(rr.Body.String(), "history.back()") {
+	if !strings.Contains(rr.Body.String(), "<a href=") {
 		t.Fatalf("body=%q", rr.Body.String())
 	}
 }

--- a/handlers/common/error_acknowledgement.go
+++ b/handlers/common/error_acknowledgement.go
@@ -12,11 +12,13 @@ import (
 func TaskErrorAcknowledgementPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*CoreData
-		Error string
+		Error   string
+		BackURL string
 	}
 	data := Data{
 		CoreData: r.Context().Value(ContextKey("coreData")).(*CoreData),
 		Error:    r.URL.Query().Get("error"),
+		BackURL:  r.Referer(),
 	}
 	if data.Error == "" {
 		data.Error = r.PostFormValue("error")

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -154,7 +154,7 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 		t.Fatalf("query=%q", req.URL.RawQuery)
 	}
 	body := rr.Body.String()
-	if !strings.Contains(body, "history.back()") {
+	if !strings.Contains(body, "<a href=") {
 		t.Fatalf("body=%q", body)
 	}
 }


### PR DESCRIPTION
## Summary
- use a plain link to the HTTP referer instead of an inline JavaScript handler
- adjust tests to look for the link

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e2c16a608832f9ba76b40749531ae