### PR TITLE
Fix CI lint configuration for golangci-lint v2

### DIFF
--- a/.github/workflows/lint_vet.yaml
+++ b/.github/workflows/lint_vet.yaml
@@ -19,6 +19,6 @@ jobs:
       - name: Go Vet
         run: go vet ./...
       - name: Golangci Lint
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.2.1


### PR DESCRIPTION
## Summary
- use golangci-lint-action v8 to support v2 configuration
- pin golangci-lint version to v2.2.1

## Testing
- `go vet ./...`
- `golangci-lint run ./...`

------
https://chatgpt.com/codex/tasks/task_e_68677c2f0dbc832fb788eea71c5503b3