### PR TITLE
Embed migrations and verify version

### DIFF
--- a/handlers/common/constants.go
+++ b/handlers/common/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 9
+	ExpectedSchemaVersion = 11
 )

--- a/internal/dbstart/dbstart.go
+++ b/internal/dbstart/dbstart.go
@@ -121,7 +121,8 @@ func EnsureSchema(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("select schema_version: %w", err)
 	}
 	if version != hcommon.ExpectedSchemaVersion {
-		return fmt.Errorf("database schema version %d does not match expected %d", version, hcommon.ExpectedSchemaVersion)
+		msg := RenderSchemaMismatch(version, hcommon.ExpectedSchemaVersion)
+		return fmt.Errorf(msg)
 	}
 	return nil
 }

--- a/internal/dbstart/templates.go
+++ b/internal/dbstart/templates.go
@@ -1,0 +1,33 @@
+package dbstart
+
+import (
+	"bytes"
+	_ "embed"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+var (
+	// schemaMismatchTmpl is the CLI message shown when the database schema version is unexpected.
+	//
+	//go:embed templates/schema_mismatch.txt
+	schemaMismatchTmpl string
+
+	schemaMismatchTemplate = template.Must(template.New("schema").Parse(schemaMismatchTmpl))
+)
+
+// RenderSchemaMismatch returns the formatted schema mismatch message.
+func RenderSchemaMismatch(actual, expected int) string {
+	exe := filepath.Base(os.Args[0])
+	if !strings.HasSuffix(exe, "-admin") {
+		exe += "-admin"
+	}
+	var buf bytes.Buffer
+	_ = schemaMismatchTemplate.Execute(&buf, struct {
+		Actual, Expected int
+		Exe              string
+	}{actual, expected, exe})
+	return strings.TrimSpace(buf.String())
+}

--- a/internal/dbstart/templates/schema_mismatch.txt
+++ b/internal/dbstart/templates/schema_mismatch.txt
@@ -1,0 +1,2 @@
+Your database uses schema version {{.Actual}} but version {{.Expected}} is required.
+Run '{{.Exe}} db migrate' and restart the server.

--- a/internal/migrate/version_test.go
+++ b/internal/migrate/version_test.go
@@ -1,0 +1,38 @@
+package migrate
+
+import (
+	"io/fs"
+	"strconv"
+	"strings"
+	"testing"
+
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/migrations"
+)
+
+func TestExpectedSchemaVersionMatchesMigrations(t *testing.T) {
+	entries, err := fs.ReadDir(migrations.FS, ".")
+	if err != nil {
+		t.Fatalf("read migrations: %v", err)
+	}
+	max := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".sql") {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimSuffix(name, ".sql"))
+		if err != nil {
+			continue
+		}
+		if n > max {
+			max = n
+		}
+	}
+	if max != hcommon.ExpectedSchemaVersion {
+		t.Fatalf("schema version constant %d does not match latest migration %d", hcommon.ExpectedSchemaVersion, max)
+	}
+}

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -100,7 +100,9 @@ func renderMessage(ctx context.Context, q *dbpkg.Queries, action, path string, i
 		Path   string
 		Item   interface{}
 	}{Action: action, Path: path, Item: item})
-	return buf.String()
+	msg := buf.String()
+	msg = strings.TrimSuffix(msg, "\n")
+	return msg
 }
 
 // parseEvent identifies a subscription target from the request path.

--- a/migrations/embed.go
+++ b/migrations/embed.go
@@ -1,0 +1,8 @@
+package migrations
+
+import "embed"
+
+// FS contains the database migration SQL scripts.
+//
+//go:embed *.sql
+var FS embed.FS

--- a/startup_test.go
+++ b/startup_test.go
@@ -46,8 +46,13 @@ func TestEnsureSchemaVersionMismatch(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
 		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(hcommon.ExpectedSchemaVersion - 1))
 
-	if err := dbstart.EnsureSchema(context.Background(), db); err == nil {
+	err = dbstart.EnsureSchema(context.Background(), db)
+	if err == nil {
 		t.Fatalf("expected error")
+	}
+	expected := dbstart.RenderSchemaMismatch(hcommon.ExpectedSchemaVersion-1, hcommon.ExpectedSchemaVersion)
+	if err.Error() != expected {
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)


### PR DESCRIPTION
## Summary
- embed the migration SQL scripts using GoEmbed
- add a test that compares the latest migration against `ExpectedSchemaVersion`
- exit on startup if database schema version mismatches and hint to run migrations
- use a text template to format the schema mismatch error
- cache the schema mismatch template
- format the migration hint using the running binary name

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68677ca7150c832fae87c6530448a629