### PR TITLE
Update GitHub workflows to self-hosted runners

### DIFF
--- a/.github/workflows/go_releaser.yaml
+++ b/.github/workflows/go_releaser.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/go_test.yaml
+++ b/.github/workflows/go_test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint_vet.yaml
+++ b/.github/workflows/lint_vet.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint-vet:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sqlc-update.yml
+++ b/.github/workflows/sqlc-update.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   generate:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Summary
- switch `runs-on` from `ubuntu-latest` to `self-hosted` for all workflows

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6867bf776530832fb2c41e9a1ce53985