### PR TITLE
Fix lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 run:
   issues-exit-code: 1
 linters:


### PR DESCRIPTION
## Summary
- fix `.golangci.yml` version to a string so configuration verification passes

## Testing
- `golangci-lint config verify`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68691cdeb6d0832fbd443dbfb25202ab