### PR TITLE
Add config conversion commands

### DIFF
--- a/cmd/goa4web/config.go
+++ b/cmd/goa4web/config.go
@@ -36,6 +36,24 @@ func (c *configCmd) Run() error {
 			return fmt.Errorf("reload: %w", err)
 		}
 		return cmd.Run()
+	case "as-env":
+		cmd, err := parseConfigAsCmd(c, "as-env", c.args[1:])
+		if err != nil {
+			return fmt.Errorf("as-env: %w", err)
+		}
+		return cmd.asEnv()
+	case "as-json":
+		cmd, err := parseConfigAsCmd(c, "as-json", c.args[1:])
+		if err != nil {
+			return fmt.Errorf("as-json: %w", err)
+		}
+		return cmd.asJSON()
+	case "as-cli":
+		cmd, err := parseConfigAsCmd(c, "as-cli", c.args[1:])
+		if err != nil {
+			return fmt.Errorf("as-cli: %w", err)
+		}
+		return cmd.asCLI()
 	case "show":
 		cmd, err := parseConfigShowCmd(c, c.args[1:])
 		if err != nil {
@@ -60,12 +78,17 @@ func (c *configCmd) Usage() {
 	fmt.Fprintf(w, "Usage:\n  %s config <command> [<args>]\n", c.rootCmd.fs.Name())
 	fmt.Fprintln(w, "\nCommands:")
 	fmt.Fprintln(w, "  reload\treload configuration from file")
+	fmt.Fprintln(w, "  as-env\toutput configuration as env file")
+	fmt.Fprintln(w, "  as-json\toutput configuration as JSON")
+	fmt.Fprintln(w, "  as-cli\toutput configuration as CLI flags")
 	fmt.Fprintln(w, "\nExamples:")
 	fmt.Fprintf(w, "  %s config reload\n\n", c.rootCmd.fs.Name())
 	fmt.Fprintln(w, "  show\tdisplay runtime configuration")
 	fmt.Fprintln(w, "  set\tupdate configuration file")
 	fmt.Fprintln(w, "\nExamples:")
 	fmt.Fprintf(w, "  %s config show\n", c.rootCmd.fs.Name())
-	fmt.Fprintf(w, "  %s config set -key DB_HOST -value localhost\n\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s config set -key DB_HOST -value localhost\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s config as-env > config.env\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s config as-cli\n\n", c.rootCmd.fs.Name())
 	c.fs.PrintDefaults()
 }

--- a/cmd/goa4web/config_as.go
+++ b/cmd/goa4web/config_as.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+// configAsCmd implements "config as-*" commands.
+type configAsCmd struct {
+	*configCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseConfigAsCmd(parent *configCmd, name string, args []string) (*configAsCmd, error) {
+	c := &configAsCmd{configCmd: parent}
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func envMapFromConfig(cfg runtimeconfig.RuntimeConfig) map[string]string {
+	m := make(map[string]string)
+	v := reflect.ValueOf(cfg)
+	for _, o := range runtimeconfig.StringOptions {
+		m[o.Env] = v.FieldByName(o.Field).String()
+	}
+	for _, o := range runtimeconfig.IntOptions {
+		m[o.Env] = strconv.Itoa(int(v.FieldByName(o.Field).Int()))
+	}
+	m[config.EnvFeedsEnabled] = strconv.FormatBool(cfg.FeedsEnabled)
+	m[config.EnvStatsStartYear] = strconv.Itoa(cfg.StatsStartYear)
+	return m
+}
+
+func defaultMap() map[string]string {
+	def := runtimeconfig.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
+	return envMapFromConfig(def)
+}
+
+func (c *configAsCmd) asEnv() error {
+	current := envMapFromConfig(c.rootCmd.cfg)
+	def := defaultMap()
+	keys := make([]string, 0, len(current))
+	for k := range current {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	usage := usageMap()
+	for _, k := range keys {
+		u := usage[k]
+		d := def[k]
+		if u != "" {
+			fmt.Printf("# %s (default: %s)\n", u, d)
+		} else {
+			fmt.Printf("# default: %s\n", d)
+		}
+		fmt.Printf("%s=%s\n", k, current[k])
+	}
+	return nil
+}
+
+func (c *configAsCmd) asJSON() error {
+	m := envMapFromConfig(c.rootCmd.cfg)
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	fmt.Println(string(b))
+	return nil
+}
+
+func (c *configAsCmd) asCLI() error {
+	current := envMapFromConfig(c.rootCmd.cfg)
+	def := defaultMap()
+	var parts []string
+	nameMap := nameMap()
+	for env, val := range current {
+		if def[env] == val {
+			continue
+		}
+		n := nameMap[env]
+		if n == "" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("--%s=%s", n, val))
+	}
+	sort.Strings(parts)
+	fmt.Println(strings.Join(parts, " "))
+	return nil
+}
+
+func usageMap() map[string]string {
+	m := make(map[string]string)
+	for _, o := range runtimeconfig.StringOptions {
+		m[o.Env] = o.Usage
+	}
+	for _, o := range runtimeconfig.IntOptions {
+		m[o.Env] = o.Usage
+	}
+	m[config.EnvFeedsEnabled] = "enable or disable feeds"
+	m[config.EnvStatsStartYear] = "start year for usage stats"
+	return m
+}
+
+func nameMap() map[string]string {
+	m := make(map[string]string)
+	for _, o := range runtimeconfig.StringOptions {
+		m[o.Env] = o.Name
+	}
+	for _, o := range runtimeconfig.IntOptions {
+		m[o.Env] = o.Name
+	}
+	// feeds-enabled and stats-start-year only used for CLI
+	m[config.EnvFeedsEnabled] = "feeds-enabled"
+	m[config.EnvStatsStartYear] = "stats-start-year"
+	return m
+}

--- a/config/appconfig.go
+++ b/config/appconfig.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"sort"
-	"strings"
 )
 
 // FileSystem abstracts file operations. It matches the core.FileSystem
@@ -30,14 +29,7 @@ func LoadAppConfigFile(fs FileSystem, path string) map[string]string {
 		}
 		return values
 	}
-	for _, line := range strings.Split(string(b), "\n") {
-		if i := strings.IndexByte(line, '='); i > 0 {
-			key := strings.TrimSpace(line[:i])
-			val := strings.TrimSpace(line[i+1:])
-			values[key] = val
-		}
-	}
-	return values
+	return ParseEnvBytes(b)
 }
 
 // UpdateConfigKey writes the given key/value pair to the config file.

--- a/config/envfile.go
+++ b/config/envfile.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+)
+
+// ParseEnvBytes parses key=value pairs from data.
+// Lines beginning with '#' or empty lines are ignored. Anything after a '#' is treated as a comment.
+func ParseEnvBytes(data []byte) map[string]string {
+	vals := make(map[string]string)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if idx := strings.IndexByte(line, '#'); idx >= 0 {
+			line = line[:idx]
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if i := strings.IndexByte(line, '='); i > 0 {
+			key := strings.TrimSpace(line[:i])
+			val := strings.TrimSpace(line[i+1:])
+			vals[key] = val
+		}
+	}
+	return vals
+}

--- a/config/envfile_test.go
+++ b/config/envfile_test.go
@@ -1,0 +1,18 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+)
+
+func TestParseEnvBytes(t *testing.T) {
+	data := []byte("DB_USER=user # comment\n# full comment\n\nDB_PASS=pass\n")
+	vals := config.ParseEnvBytes(data)
+	if vals["DB_USER"] != "user" || vals["DB_PASS"] != "pass" {
+		t.Fatalf("unexpected values: %#v", vals)
+	}
+	if len(vals) != 2 {
+		t.Fatalf("expected 2 values, got %d", len(vals))
+	}
+}

--- a/handlers/admin/config_file.go
+++ b/handlers/admin/config_file.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	iofs "io/fs"
 	"log"
-	"strings"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 )
 
@@ -23,12 +23,5 @@ func LoadAppConfigFile(fs core.FileSystem, path string) map[string]string {
 		}
 		return values
 	}
-	for _, line := range strings.Split(string(b), "\n") {
-		if i := strings.IndexByte(line, '='); i > 0 {
-			key := strings.TrimSpace(line[:i])
-			val := strings.TrimSpace(line[i+1:])
-			values[key] = val
-		}
-	}
-	return values
+	return config.ParseEnvBytes(b)
 }

--- a/runtimeconfig/options.go
+++ b/runtimeconfig/options.go
@@ -1,0 +1,58 @@
+package runtimeconfig
+
+import "github.com/arran4/goa4web/config"
+
+// StringOption describes a string based runtime configuration flag.
+type StringOption struct {
+	Name    string
+	Env     string
+	Field   string
+	Usage   string
+	Default string
+}
+
+// IntOption describes an integer runtime configuration flag.
+type IntOption struct {
+	Name    string
+	Env     string
+	Field   string
+	Usage   string
+	Default int
+}
+
+// StringOptions lists the string runtime options shared by flag parsing and configuration generation.
+var StringOptions = []StringOption{
+	{"db-user", config.EnvDBUser, "DBUser", "database user", ""},
+	{"db-pass", config.EnvDBPass, "DBPass", "database password", ""},
+	{"db-host", config.EnvDBHost, "DBHost", "database host", ""},
+	{"db-port", config.EnvDBPort, "DBPort", "database port", ""},
+	{"db-name", config.EnvDBName, "DBName", "database name", ""},
+	{"listen", config.EnvListen, "HTTPListen", "server listen address", ":8080"},
+	{"hostname", config.EnvHostname, "HTTPHostname", "server base URL", ""},
+	{"email-provider", config.EnvEmailProvider, "EmailProvider", "email provider", ""},
+	{"smtp-host", config.EnvSMTPHost, "EmailSMTPHost", "SMTP host", ""},
+	{"smtp-port", config.EnvSMTPPort, "EmailSMTPPort", "SMTP port", ""},
+	{"smtp-user", config.EnvSMTPUser, "EmailSMTPUser", "SMTP user", ""},
+	{"smtp-pass", config.EnvSMTPPass, "EmailSMTPPass", "SMTP pass", ""},
+	{"aws-region", config.EnvAWSRegion, "EmailAWSRegion", "AWS region", ""},
+	{"jmap-endpoint", config.EnvJMAPEndpoint, "EmailJMAPEndpoint", "JMAP endpoint", ""},
+	{"jmap-account", config.EnvJMAPAccount, "EmailJMAPAccount", "JMAP account", ""},
+	{"jmap-identity", config.EnvJMAPIdentity, "EmailJMAPIdentity", "JMAP identity", ""},
+	{"jmap-user", config.EnvJMAPUser, "EmailJMAPUser", "JMAP user", ""},
+	{"jmap-pass", config.EnvJMAPPass, "EmailJMAPPass", "JMAP pass", ""},
+	{"sendgrid-key", config.EnvSendGridKey, "EmailSendGridKey", "SendGrid API key", ""},
+	{"default-language", config.EnvDefaultLanguage, "DefaultLanguage", "default language name", ""},
+	{"image-upload-dir", config.EnvImageUploadDir, "ImageUploadDir", "directory to store uploaded images", ""},
+	{"dlq-provider", config.EnvDLQProvider, "DLQProvider", "dead letter queue provider", ""},
+	{"dlq-file", config.EnvDLQFile, "DLQFile", "dead letter queue file path", ""},
+}
+
+// IntOptions lists the integer runtime options shared by flag parsing and configuration generation.
+var IntOptions = []IntOption{
+	{"db-log-verbosity", config.EnvDBLogVerbosity, "DBLogVerbosity", "database logging verbosity", 0},
+	{"log-flags", config.EnvLogFlags, "LogFlags", "request logging flags", 0},
+	{"page-size-min", config.EnvPageSizeMin, "PageSizeMin", "minimum allowed page size", 0},
+	{"page-size-max", config.EnvPageSizeMax, "PageSizeMax", "maximum allowed page size", 0},
+	{"page-size-default", config.EnvPageSizeDefault, "PageSizeDefault", "default page size", 0},
+	{"image-max-bytes", config.EnvImageMaxBytes, "ImageMaxBytes", "maximum allowed upload size in bytes", 0},
+}


### PR DESCRIPTION
## Summary
- add env file parsing with comment support
- refactor runtime options into shared lists
- generate runtime flags from shared options
- implement `config as-env`, `config as-json` and `config as-cli`
- show new commands in `config` usage
- add tests for env parser

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686b0dd13b10832fa306dd5d2a0d84d8