### PR TITLE
Add embedded template and new DLQ providers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ All database schema changes must include a migration script in the `migrations/`
 
 Errors in critical functions like `main()` or `run()` must be logged or wrapped using `fmt.Errorf` with context. Prefer doing both when errors propagate.
 
+All default HTML or text templates must exist as standalone files and be embedded using `//go:embed` rather than inline string constants.
+
 When tackling bugs or missing features, check if the behaviour can be verified with tests. If so, write a test that fails before changing the implementation. Iterate on your fix until the new test passes.
 
 Before committing, run `go vet ./...` and `golangci-lint` to match the CI checks.

--- a/cmd/goa4web/config.go
+++ b/cmd/goa4web/config.go
@@ -54,6 +54,12 @@ func (c *configCmd) Run() error {
 			return fmt.Errorf("as-cli: %w", err)
 		}
 		return cmd.asCLI()
+	case "options":
+		cmd, err := parseConfigOptionsCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("options: %w", err)
+		}
+		return cmd.Run()
 	case "show":
 		cmd, err := parseConfigShowCmd(c, c.args[1:])
 		if err != nil {
@@ -81,6 +87,7 @@ func (c *configCmd) Usage() {
 	fmt.Fprintln(w, "  as-env\toutput configuration as env file")
 	fmt.Fprintln(w, "  as-json\toutput configuration as JSON")
 	fmt.Fprintln(w, "  as-cli\toutput configuration as CLI flags")
+	fmt.Fprintln(w, "  options\tlist available configuration options")
 	fmt.Fprintln(w, "\nExamples:")
 	fmt.Fprintf(w, "  %s config reload\n\n", c.rootCmd.fs.Name())
 	fmt.Fprintln(w, "  show\tdisplay runtime configuration")
@@ -90,5 +97,6 @@ func (c *configCmd) Usage() {
 	fmt.Fprintf(w, "  %s config set -key DB_HOST -value localhost\n", c.rootCmd.fs.Name())
 	fmt.Fprintf(w, "  %s config as-env > config.env\n", c.rootCmd.fs.Name())
 	fmt.Fprintf(w, "  %s config as-cli\n\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s config options\n", c.rootCmd.fs.Name())
 	c.fs.PrintDefaults()
 }

--- a/cmd/goa4web/config_options.go
+++ b/cmd/goa4web/config_options.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	_ "embed"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"text/template"
+)
+
+//go:embed templates/config_options.txt
+var configOptionsDefaultTemplate string
+
+// configOptionsCmd implements "config options".
+type configOptionsCmd struct {
+	*configCmd
+	fs       *flag.FlagSet
+	template string
+	args     []string
+}
+
+func parseConfigOptionsCmd(parent *configCmd, args []string) (*configOptionsCmd, error) {
+	c := &configOptionsCmd{configCmd: parent}
+	fs := flag.NewFlagSet("options", flag.ContinueOnError)
+	fs.StringVar(&c.template, "template", "", "template file")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+type option struct {
+	Env     string
+	Flag    string
+	Default string
+	Usage   string
+}
+
+func (c *configOptionsCmd) Run() error {
+	def := defaultMap()
+	usage := usageMap()
+	names := nameMap()
+	keys := make([]string, 0, len(def))
+	for k := range def {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	opts := make([]option, 0, len(keys))
+	for _, k := range keys {
+		opts = append(opts, option{
+			Env:     k,
+			Flag:    names[k],
+			Default: def[k],
+			Usage:   usage[k],
+		})
+	}
+	tmplText := configOptionsDefaultTemplate
+	if c.template != "" {
+		b, err := os.ReadFile(c.template)
+		if err != nil {
+			return fmt.Errorf("read template: %w", err)
+		}
+		tmplText = string(b)
+	}
+	t, err := template.New("options").Parse(tmplText)
+	if err != nil {
+		return fmt.Errorf("parse template: %w", err)
+	}
+	return t.Execute(os.Stdout, opts)
+}

--- a/cmd/goa4web/templates/config_options.txt
+++ b/cmd/goa4web/templates/config_options.txt
@@ -1,0 +1,3 @@
+{{printf "%s\t%s\t%s\t%s\n" "ENV" "FLAG" "DEFAULT" "DESCRIPTION"}}
+{{range .}}{{.Env}}\t{{.Flag}}\t{{.Default}}\t{{.Usage}}
+{{end}}

--- a/internal/dlq/dlq.go
+++ b/internal/dlq/dlq.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"sync"
 
 	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/internal/emailutil"
+	"github.com/segmentio/ksuid"
 )
 
 // DLQ records failed asynchronous operations.
@@ -52,4 +56,39 @@ func (d DBDLQ) Record(ctx context.Context, message string) error {
 		return fmt.Errorf("no db")
 	}
 	return d.Queries.InsertWorkerError(ctx, message)
+}
+
+// DirDLQ writes each message to a new file inside Dir using a KSUID filename.
+type DirDLQ struct {
+	Dir string
+}
+
+func (d *DirDLQ) Record(_ context.Context, message string) error {
+	if d.Dir == "" {
+		d.Dir = "dlq"
+	}
+	if err := os.MkdirAll(d.Dir, 0o755); err != nil {
+		return err
+	}
+	name := ksuid.New().String() + ".txt"
+	path := filepath.Join(d.Dir, name)
+	return os.WriteFile(path, []byte(message+"\n"), 0o644)
+}
+
+// EmailDLQ sends DLQ messages to administrator emails using the given provider.
+type EmailDLQ struct {
+	Provider email.Provider
+	Queries  *dbpkg.Queries
+}
+
+func (e EmailDLQ) Record(ctx context.Context, message string) error {
+	if e.Provider == nil {
+		return fmt.Errorf("no email provider")
+	}
+	for _, addr := range emailutil.GetAdminEmails(ctx, e.Queries) {
+		if err := e.Provider.Send(ctx, addr, "DLQ message", message, ""); err != nil {
+			log.Printf("dlq email: %v", err)
+		}
+	}
+	return nil
 }

--- a/internal/dlq/provider_factory.go
+++ b/internal/dlq/provider_factory.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -12,8 +13,16 @@ func ProviderFromConfig(cfg runtimeconfig.RuntimeConfig, q *dbpkg.Queries) DLQ {
 	switch strings.ToLower(cfg.DLQProvider) {
 	case "file":
 		return &FileDLQ{Path: cfg.DLQFile}
+	case "dir":
+		return &DirDLQ{Dir: cfg.DLQFile}
 	case "db":
 		return DBDLQ{Queries: q}
+	case "email":
+		p := email.ProviderFromConfig(cfg)
+		if p != nil {
+			return EmailDLQ{Provider: p, Queries: q}
+		}
+		return LogDLQ{}
 	default:
 		if cfg.DLQProvider != "" && cfg.DLQProvider != "log" {
 			// unrecognised provider -> fallback to log

--- a/readme.md
+++ b/readme.md
@@ -246,6 +246,18 @@ environment variables listed below.
 | `IMAGE_UPLOAD_DIR` | `--image-upload-dir` | No | `uploads/images` | Directory where uploaded images are stored. |
 | `IMAGE_MAX_BYTES` | `--image-max-bytes` | No | `5242880` | Maximum allowed size of uploaded images. |
 | `DEFAULT_LANGUAGE` | `--default-language` | No | - | Site's default language name. |
+| `DLQ_PROVIDER` | `--dlq-provider` | No | `log` | Dead letter queue provider. |
+| `DLQ_FILE` | `--dlq-file` | No | `dlq.log` | File path for the file or directory DLQ providers. |
+
+### Dead Letter Queue Providers
+
+The `DLQ_PROVIDER` setting selects how failed messages are recorded:
+
+* `log` – writes messages to the application log (default)
+* `file` – appends messages to a file in mbox/JSON lines format at `DLQ_FILE`
+* `dir` – creates one file per message under the directory `DLQ_FILE` using a KSUID name
+* `db` – stores messages in the database
+* `email` – sends messages to administrator addresses using the configured mail provider
 Example config file:
 
 ```conf


### PR DESCRIPTION
## Summary
- embed default template for `config options` command
- implement directory and email DLQ providers
- document available DLQ providers
- enforce template embedding rule in AGENTS guidelines

## Testing
- `go vet ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b15331fa8832fae10a2c5e46a037d