### PR TITLE
Support custom runtime flags

### DIFF
--- a/cmd/goa4web/serve.go
+++ b/cmd/goa4web/serve.go
@@ -25,14 +25,18 @@ type serveCmd struct {
 
 func parseServeCmd(parent *rootCmd, args []string) (*serveCmd, error) {
 	c := &serveCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
-	fs.StringVar(&c.sessionSecret, "session-secret", "", "session secret key")
-	fs.StringVar(&c.sessionSecretFile, "session-secret-file", "", "path to session secret file")
+	sopts := []runtimeconfig.StringOption{
+		{Name: "session-secret", Env: config.EnvSessionSecret, Usage: "session secret key"},
+		{Name: "session-secret-file", Env: config.EnvSessionSecretFile, Usage: "path to session secret file"},
+	}
+	fs := runtimeconfig.NewRuntimeFlagSetWithOptions("serve", sopts, nil)
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return nil, err
 	}
 	c.fs = fs
+	c.sessionSecret = fs.Lookup("session-secret").Value.String()
+	c.sessionSecretFile = fs.Lookup("session-secret-file").Value.String()
 	c.args = fs.Args()
 	return c, nil
 }

--- a/runtimeconfig/with_options_test.go
+++ b/runtimeconfig/with_options_test.go
@@ -1,0 +1,44 @@
+package runtimeconfig
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+)
+
+func TestGenerateRuntimeConfigWithInjectedOptions(t *testing.T) {
+	env := map[string]string{
+		config.EnvDBUser:         "env",
+		config.EnvDBLogVerbosity: "2",
+	}
+
+	strOpt := StringOption{Name: "db-user-alt", Env: config.EnvDBUser, Field: "DBUser", Usage: ""}
+	intOpt := IntOption{Name: "db-verb-alt", Env: config.EnvDBLogVerbosity, Field: "DBLogVerbosity", Usage: ""}
+	fs := NewRuntimeFlagSetWithOptions("test", []StringOption{strOpt}, []IntOption{intOpt})
+	_ = fs.Parse([]string{"--db-user-alt=cli", "--db-verb-alt=5"})
+
+	vals := map[string]string{
+		config.EnvDBUser:         "file",
+		config.EnvDBLogVerbosity: "3",
+	}
+
+	cfg := GenerateRuntimeConfigWithOptions(fs, vals, func(k string) string { return env[k] }, []StringOption{strOpt}, []IntOption{intOpt})
+
+	if cfg.DBUser != "cli" || cfg.DBLogVerbosity != 5 {
+		t.Fatalf("merged %#v", cfg)
+	}
+}
+
+func TestGenerateRuntimeConfigWithInjectedFileValue(t *testing.T) {
+	strOpt := StringOption{Name: "db-user-alt", Env: config.EnvDBUser, Field: "DBUser", Usage: ""}
+	fs := NewRuntimeFlagSetWithOptions("test", []StringOption{strOpt}, nil)
+	_ = fs.Parse(nil)
+
+	vals := map[string]string{config.EnvDBUser: "file"}
+
+	cfg := GenerateRuntimeConfigWithOptions(fs, vals, func(string) string { return "" }, []StringOption{strOpt}, nil)
+
+	if cfg.DBUser != "file" {
+		t.Fatalf("want file got %q", cfg.DBUser)
+	}
+}


### PR DESCRIPTION
## Summary
- allow runtimeconfig flagset and config generation to accept extra options
- use new helpers in `serve` command to support session secret flags
- test runtimeconfig option injection logic

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b2346e380832f963d0bbbb8251755