### PR TITLE
Add JSON config fill command

### DIFF
--- a/cmd/goa4web/config.go
+++ b/cmd/goa4web/config.go
@@ -54,6 +54,12 @@ func (c *configCmd) Run() error {
 			return fmt.Errorf("as-cli: %w", err)
 		}
 		return cmd.asCLI()
+	case "add-json":
+		cmd, err := parseConfigJSONAddCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("add-json: %w", err)
+		}
+		return cmd.Run()
 	case "options":
 		cmd, err := parseConfigOptionsCmd(c, c.args[1:])
 		if err != nil {
@@ -87,6 +93,7 @@ func (c *configCmd) Usage() {
 	fmt.Fprintln(w, "  as-env\toutput configuration as env file")
 	fmt.Fprintln(w, "  as-json\toutput configuration as JSON")
 	fmt.Fprintln(w, "  as-cli\toutput configuration as CLI flags")
+	fmt.Fprintln(w, "  add-json\tadd missing options to JSON file")
 	fmt.Fprintln(w, "  options\tlist available configuration options")
 	fmt.Fprintln(w, "\nExamples:")
 	fmt.Fprintf(w, "  %s config reload\n\n", c.rootCmd.fs.Name())
@@ -98,5 +105,6 @@ func (c *configCmd) Usage() {
 	fmt.Fprintf(w, "  %s config as-env > config.env\n", c.rootCmd.fs.Name())
 	fmt.Fprintf(w, "  %s config as-cli\n\n", c.rootCmd.fs.Name())
 	fmt.Fprintf(w, "  %s config options\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s config add-json -file cfg.json\n", c.rootCmd.fs.Name())
 	c.fs.PrintDefaults()
 }

--- a/cmd/goa4web/config_json_add.go
+++ b/cmd/goa4web/config_json_add.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+)
+
+// configJSONAddCmd implements "config add-json".
+type configJSONAddCmd struct {
+	*configCmd
+	fs   *flag.FlagSet
+	File string
+	args []string
+}
+
+func parseConfigJSONAddCmd(parent *configCmd, args []string) (*configJSONAddCmd, error) {
+	c := &configJSONAddCmd{configCmd: parent}
+	fs := flag.NewFlagSet("add-json", flag.ContinueOnError)
+	fs.StringVar(&c.File, "file", "", "json file to update")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *configJSONAddCmd) Run() error {
+	if c.File == "" {
+		return fmt.Errorf("file required")
+	}
+	values := envMapFromConfig(c.rootCmd.cfg, c.rootCmd.ConfigFile)
+	if err := config.AddMissingJSONOptions(core.OSFS{}, c.File, values); err != nil {
+		return fmt.Errorf("update json: %w", err)
+	}
+	if c.rootCmd.Verbosity > 0 {
+		fmt.Printf("updated %s\n", c.File)
+	}
+	return nil
+}

--- a/config/json_add_test.go
+++ b/config/json_add_test.go
@@ -1,0 +1,56 @@
+package config_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+)
+
+func TestAddMissingJSONOptions(t *testing.T) {
+	fs := core.UseMemFS(t)
+	path := "cfg.json"
+	initial := `{"DB_USER":"user"}`
+	if err := fs.WriteFile(path, []byte(initial), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	err := config.AddMissingJSONOptions(fs, path, map[string]string{
+		"DB_USER": "user",
+		"DB_PASS": "pass",
+	})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	b, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["DB_USER"] != "user" || m["DB_PASS"] != "pass" {
+		t.Fatalf("unexpected map: %#v", m)
+	}
+}
+
+func TestAddMissingJSONOptionsCreate(t *testing.T) {
+	fs := core.UseMemFS(t)
+	path := "new.json"
+	err := config.AddMissingJSONOptions(fs, path, map[string]string{"DB_USER": "u"})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	b, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["DB_USER"] != "u" {
+		t.Fatalf("unexpected map: %#v", m)
+	}
+}


### PR DESCRIPTION
## Summary
- handle filling JSON configs via `config add-json`
- provide `AddMissingJSONOptions` helper
- cover JSON option filling with tests

## Testing
- `go vet ./...`
- `go test ./...`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_686b237e3874832face2671223377f69