### PR TITLE
Improve config file loading logs

### DIFF
--- a/config/appconfig.go
+++ b/config/appconfig.go
@@ -19,18 +19,23 @@ type FileSystem interface {
 // LoadAppConfigFile reads CONFIG_FILE style key=value pairs and returns them as a map.
 // Missing files return an empty map. Unknown keys are ignored.
 func LoadAppConfigFile(fs FileSystem, path string) map[string]string {
-	values := make(map[string]string)
-	if path == "" {
-		return values
-	}
-	b, err := fs.ReadFile(path)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			log.Printf("app config file error: %v", err)
-		}
-		return values
-	}
-	return ParseEnvBytes(b)
+        values := make(map[string]string)
+        if path == "" {
+                log.Printf("config file not specified")
+                return values
+        }
+        log.Printf("reading config file %s", path)
+        b, err := fs.ReadFile(path)
+        if err != nil {
+                if os.IsNotExist(err) {
+                        log.Printf("config file not found: %s", path)
+                } else {
+                        log.Printf("app config file error: %v", err)
+                }
+                return values
+        }
+        log.Printf("loaded config file %s", path)
+        return ParseEnvBytes(b)
 }
 
 // UpdateConfigKey writes the given key/value pair to the config file.

--- a/handlers/admin/config_file.go
+++ b/handlers/admin/config_file.go
@@ -12,16 +12,21 @@ import (
 // LoadAppConfigFile reads key=value pairs from the given path.
 // Missing files return an empty map and unknown keys are ignored.
 func LoadAppConfigFile(fs core.FileSystem, path string) map[string]string {
-	values := make(map[string]string)
-	if path == "" {
-		return values
-	}
-	b, err := fs.ReadFile(path)
-	if err != nil {
-		if !errors.Is(err, iofs.ErrNotExist) {
-			log.Printf("app config file error: %v", err)
-		}
-		return values
-	}
-	return config.ParseEnvBytes(b)
+        values := make(map[string]string)
+        if path == "" {
+                log.Printf("config file not specified")
+                return values
+        }
+        log.Printf("reading config file %s", path)
+        b, err := fs.ReadFile(path)
+        if err != nil {
+                if errors.Is(err, iofs.ErrNotExist) {
+                        log.Printf("config file not found: %s", path)
+                } else {
+                        log.Printf("app config file error: %v", err)
+                }
+                return values
+        }
+        log.Printf("loaded config file %s", path)
+        return config.ParseEnvBytes(b)
 }


### PR DESCRIPTION
## Summary
- improve LoadAppConfigFile logging
- log when admin config file is missing or loaded

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686b356ed250832f98761332574716f1