### PR TITLE
Add verbose output to db migrate

### DIFF
--- a/cmd/goa4web/db_migrate.go
+++ b/cmd/goa4web/db_migrate.go
@@ -70,6 +70,10 @@ func parseDbMigrateCmd(parent *dbCmd, args []string) (*dbMigrateCmd, error) {
 }
 
 func (c *dbMigrateCmd) Run() error {
+	if c.rootCmd.Verbosity >= 0 {
+		fmt.Printf("connecting to database at %s:%s\n", c.rootCmd.cfg.DBHost,
+			c.rootCmd.cfg.DBPort)
+	}
 	db, err := openDB(c.rootCmd.cfg)
 	if err != nil {
 		return fmt.Errorf("open db: %w", err)
@@ -77,7 +81,10 @@ func (c *dbMigrateCmd) Run() error {
 	defer db.Close()
 	ctx := context.Background()
 	fsys := os.DirFS(c.Dir)
-	if err := migrate.Apply(ctx, db, fsys); err != nil {
+	if c.rootCmd.Verbosity >= 0 {
+		fmt.Printf("applying migrations from %s\n", c.Dir)
+	}
+	if err := migrate.Apply(ctx, db, fsys, c.rootCmd.Verbosity >= 0); err != nil {
 		return err
 	}
 	return nil

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -15,13 +15,25 @@ import (
 // Apply reads SQL migration files from the provided filesystem and
 // executes each one in order, updating the schema_version table after
 // every successful script.
-func Apply(ctx context.Context, db *sql.DB, f fs.FS) error {
+// Apply reads SQL migration files from the provided filesystem and executes
+// each one in order, updating the schema_version table after every successful
+// script. When verbose is true, progress information is printed to stdout.
+func Apply(ctx context.Context, db *sql.DB, f fs.FS, verbose bool) error {
+	if verbose {
+		fmt.Println("ensuring schema_version table")
+	}
 	if _, err := db.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)"); err != nil {
 		return fmt.Errorf("create schema_version: %w", err)
+	}
+	if verbose {
+		fmt.Println("checking current schema version")
 	}
 	var version int
 	err := db.QueryRowContext(ctx, "SELECT version FROM schema_version").Scan(&version)
 	if err == sql.ErrNoRows {
+		if verbose {
+			fmt.Println("initialising schema_version to 1")
+		}
 		if _, err := db.ExecContext(ctx, "INSERT INTO schema_version (version) VALUES (?)", 1); err != nil {
 			return fmt.Errorf("init schema_version: %w", err)
 		}
@@ -50,22 +62,37 @@ func Apply(ctx context.Context, db *sql.DB, f fs.FS) error {
 		nums = append(nums, n)
 	}
 	sort.Ints(nums)
+	applied := false
 	for _, n := range nums {
 		if n <= version {
 			continue
 		}
 		path := fmt.Sprintf("%04d.sql", n)
-		if err := executeFile(ctx, db, f, path); err != nil {
+		if verbose {
+			fmt.Printf("applying %s\n", path)
+		}
+		if err := executeFile(ctx, db, f, path, verbose); err != nil {
 			return fmt.Errorf("execute %s: %w", path, err)
 		}
 		if _, err := db.ExecContext(ctx, "UPDATE schema_version SET version = ?", n); err != nil {
 			return fmt.Errorf("update schema_version: %w", err)
 		}
+		if verbose {
+			fmt.Printf("schema version updated to %d\n", n)
+		}
+		applied = true
+	}
+	if verbose {
+		if applied {
+			fmt.Println("migration complete")
+		} else {
+			fmt.Println("database schema already up to date")
+		}
 	}
 	return nil
 }
 
-func executeFile(ctx context.Context, db *sql.DB, f fs.FS, path string) error {
+func executeFile(ctx context.Context, db *sql.DB, f fs.FS, path string, verbose bool) error {
 	data, err := fs.ReadFile(f, path)
 	if err != nil {
 		return err
@@ -80,6 +107,9 @@ func executeFile(ctx context.Context, db *sql.DB, f fs.FS, path string) error {
 		stmt.WriteString(line)
 		if strings.HasSuffix(line, ";") {
 			sqlStmt := strings.TrimSuffix(stmt.String(), ";")
+			if verbose {
+				fmt.Printf("  %s\n", sqlStmt)
+			}
 			if _, err := db.ExecContext(ctx, sqlStmt); err != nil {
 				return err
 			}
@@ -92,6 +122,9 @@ func executeFile(ctx context.Context, db *sql.DB, f fs.FS, path string) error {
 		return err
 	}
 	if s := strings.TrimSpace(stmt.String()); s != "" {
+		if verbose {
+			fmt.Printf("  %s\n", s)
+		}
 		if _, err := db.ExecContext(ctx, s); err != nil {
 			return err
 		}

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -31,7 +31,7 @@ func TestApply(t *testing.T) {
 	mock.ExpectExec("UPDATE schema_version SET version = ?").WithArgs(2).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	if err := Apply(context.Background(), db, mfs); err != nil {
+	if err := Apply(context.Background(), db, mfs, false); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
## Summary
- expand `db migrate` to show progress
- allow migrations to print SQL statements when verbosity is enabled
- show migration info even at default verbosity

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b341f35fc832faa0072f51d1fa5ab