### PR TITLE
add as-env-file and adjust as-env output

### DIFF
--- a/cmd/goa4web/config.go
+++ b/cmd/goa4web/config.go
@@ -42,6 +42,12 @@ func (c *configCmd) Run() error {
 			return fmt.Errorf("as-env: %w", err)
 		}
 		return cmd.asEnv()
+	case "as-env-file":
+		cmd, err := parseConfigAsCmd(c, "as-env-file", c.args[1:])
+		if err != nil {
+			return fmt.Errorf("as-env-file: %w", err)
+		}
+		return cmd.asEnvFile()
 	case "as-json":
 		cmd, err := parseConfigAsCmd(c, "as-json", c.args[1:])
 		if err != nil {
@@ -90,7 +96,8 @@ func (c *configCmd) Usage() {
 	fmt.Fprintf(w, "Usage:\n  %s config <command> [<args>]\n", c.rootCmd.fs.Name())
 	fmt.Fprintln(w, "\nCommands:")
 	fmt.Fprintln(w, "  reload\treload configuration from file")
-	fmt.Fprintln(w, "  as-env\toutput configuration as env file")
+	fmt.Fprintln(w, "  as-env\toutput configuration as export statements")
+	fmt.Fprintln(w, "  as-env-file\toutput configuration as env file")
 	fmt.Fprintln(w, "  as-json\toutput configuration as JSON")
 	fmt.Fprintln(w, "  as-cli\toutput configuration as CLI flags")
 	fmt.Fprintln(w, "  add-json\tadd missing options to JSON file")
@@ -102,7 +109,7 @@ func (c *configCmd) Usage() {
 	fmt.Fprintln(w, "\nExamples:")
 	fmt.Fprintf(w, "  %s config show\n", c.rootCmd.fs.Name())
 	fmt.Fprintf(w, "  %s config set -key DB_HOST -value localhost\n", c.rootCmd.fs.Name())
-	fmt.Fprintf(w, "  %s config as-env > config.env\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s config as-env-file > config.env\n", c.rootCmd.fs.Name())
 	fmt.Fprintf(w, "  %s config as-cli\n\n", c.rootCmd.fs.Name())
 	fmt.Fprintf(w, "  %s config options\n", c.rootCmd.fs.Name())
 	fmt.Fprintf(w, "  %s config add-json -file cfg.json\n", c.rootCmd.fs.Name())

--- a/cmd/goa4web/config_as.go
+++ b/cmd/goa4web/config_as.go
@@ -101,7 +101,7 @@ func defaultMap() map[string]string {
 	return envMapFromConfig(def, "")
 }
 
-func (c *configAsCmd) asEnv() error {
+func (c *configAsCmd) asEnvFile() error {
 	current := envMapFromConfig(c.rootCmd.cfg, c.rootCmd.ConfigFile)
 	def := defaultMap()
 	keys := make([]string, 0, len(current))
@@ -119,6 +119,28 @@ func (c *configAsCmd) asEnv() error {
 			fmt.Printf("# default: %s\n", d)
 		}
 		fmt.Printf("%s=%s\n", k, current[k])
+	}
+	return nil
+}
+
+func (c *configAsCmd) asEnv() error {
+	current := envMapFromConfig(c.rootCmd.cfg, c.rootCmd.ConfigFile)
+	def := defaultMap()
+	keys := make([]string, 0, len(current))
+	for k := range current {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	usage := usageMap()
+	for _, k := range keys {
+		u := usage[k]
+		d := def[k]
+		if u != "" {
+			fmt.Printf("# %s (default: %s)\n", u, d)
+		} else {
+			fmt.Printf("# default: %s\n", d)
+		}
+		fmt.Printf("export %s=%s\n", k, current[k])
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- add new `as-env-file` subcommand to `config`
- change `as-env` to print `export` statements
- update usage examples

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b36ba0364832fabe158557486bffe