### PR TITLE
Use error variable

### DIFF
--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -70,7 +70,7 @@ func AdminEmailTemplateSaveActionPage(w http.ResponseWriter, r *http.Request) {
 func AdminEmailTemplateTestActionPage(w http.ResponseWriter, r *http.Request) {
 	provider := getEmailProvider()
 	if provider == nil {
-		q := url.QueryEscape(userhandlers.ErrMailNotConfigured)
+		q := url.QueryEscape(userhandlers.ErrMailNotConfigured.Error())
 		r.URL.RawQuery = "error=" + q
 		common.TaskErrorAcknowledgementPage(w, r)
 		return

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -33,7 +33,7 @@ func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d", rr.Code)
 	}
-	want := url.QueryEscape(userhandlers.ErrMailNotConfigured)
+	want := url.QueryEscape(userhandlers.ErrMailNotConfigured.Error())
 	if req.URL.RawQuery != "error="+want {
 		t.Fatalf("query=%q", req.URL.RawQuery)
 	}

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -17,7 +17,8 @@ import (
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
-const ErrMailNotConfigured = "mail isn't configured" // shown when Test mail has no provider
+// ErrMailNotConfigured is returned when test mail has no provider configured.
+var ErrMailNotConfigured = errors.New("mail isn't configured")
 
 func userEmailPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
@@ -106,7 +107,7 @@ func userEmailTestActionPage(w http.ResponseWriter, r *http.Request) {
 	pageURL := base + r.URL.Path
 	provider := getEmailProvider()
 	if provider == nil {
-		q := url.QueryEscape(ErrMailNotConfigured)
+		q := url.QueryEscape(ErrMailNotConfigured.Error())
 		// Display the error without redirecting so the POST isn't repeated.
 		r.URL.RawQuery = "error=" + q
 		common.TaskErrorAcknowledgementPage(w, r)

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -149,7 +149,7 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d", rr.Code)
 	}
-	want := url.QueryEscape(ErrMailNotConfigured)
+	want := url.QueryEscape(ErrMailNotConfigured.Error())
 	if req.URL.RawQuery != "error="+want {
 		t.Fatalf("query=%q", req.URL.RawQuery)
 	}


### PR DESCRIPTION
## Summary
- convert `ErrMailNotConfigured` constant to an exported error variable
- update references in handler and test files

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b391e28ac832fb991a60953fa67a9