### PR TITLE
Update dev guidelines to run go fmt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,4 +30,4 @@ All default HTML or text templates must exist as standalone files and be embedde
 
 When tackling bugs or missing features, check if the behaviour can be verified with tests. If so, write a test that fails before changing the implementation. Iterate on your fix until the new test passes.
 
-Before committing, run `go vet ./...` and `golangci-lint` to match the CI checks.
+Before committing, run `go fmt ./...`, `go vet ./...`, and `golangci-lint` to match the CI checks.


### PR DESCRIPTION
## Summary
- update AGENTS instructions to include `go fmt` in the pre-commit checks

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: undefined fmt.Eprintf)*
- `go test ./...` *(fails: build failures)*
- `golangci-lint run ./...` *(fails: typecheck issues)*

------
https://chatgpt.com/codex/tasks/task_e_686b3f8fd27c832f8e3bfa66c41fbd41