### PR TITLE
Improve caching logic for self-hosted runners

### DIFF
--- a/.github/workflows/go_releaser.yaml
+++ b/.github/workflows/go_releaser.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: ${{ !contains(runner.labels, 'self-hosted') }}
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/go_test.yaml
+++ b/.github/workflows/go_test.yaml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache: true
+          cache: ${{ !contains(runner.labels, 'self-hosted') }}
       - name: Run tests
         run: go test ./...

--- a/.github/workflows/lint_vet.yaml
+++ b/.github/workflows/lint_vet.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache: true
+          cache: ${{ !contains(runner.labels, 'self-hosted') }}
       - name: Go Vet
         run: go vet ./...
       - name: Golangci Lint

--- a/.github/workflows/sqlc-update.yml
+++ b/.github/workflows/sqlc-update.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+          cache: ${{ !contains(runner.labels, 'self-hosted') }}
       - name: Install sqlc
         run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
       - name: Generate code


### PR DESCRIPTION
## Summary
- make all workflows disable Go cache on self-hosted runners by detecting the `self-hosted` label

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: undefined fmt.Eprintf)*
- `golangci-lint run` *(fails: various typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b458814b0832fbc27d84023716b37