### PR TITLE
Add flag helper and reduce parser boilerplate

### DIFF
--- a/cmd/goa4web/board_update.go
+++ b/cmd/goa4web/board_update.go
@@ -23,17 +23,18 @@ type boardUpdateCmd struct {
 
 func parseBoardUpdateCmd(parent *boardCmd, args []string) (*boardUpdateCmd, error) {
 	c := &boardUpdateCmd{boardCmd: parent}
-	fs := flag.NewFlagSet("update", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "board id")
-	fs.IntVar(&c.Parent, "parent", 0, "parent board id")
-	fs.StringVar(&c.Name, "name", "", "board name")
-	fs.StringVar(&c.Description, "description", "", "board description")
-	fs.BoolVar(&c.ApprovalNeeded, "approval", false, "require approval")
-	if err := fs.Parse(args); err != nil {
+	fs, rest, err := parseFlags("update", args, func(fs *flag.FlagSet) {
+		fs.IntVar(&c.ID, "id", 0, "board id")
+		fs.IntVar(&c.Parent, "parent", 0, "parent board id")
+		fs.StringVar(&c.Name, "name", "", "board name")
+		fs.StringVar(&c.Description, "description", "", "board description")
+		fs.BoolVar(&c.ApprovalNeeded, "approval", false, "require approval")
+	})
+	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = fs.Args()
+	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/flagutil.go
+++ b/cmd/goa4web/flagutil.go
@@ -1,0 +1,17 @@
+package main
+
+import "flag"
+
+// parseFlags builds a FlagSet with the provided name, applies flag
+// registrations via fn, parses args and returns the FlagSet with any
+// remaining positional arguments.
+func parseFlags(name string, args []string, fn func(*flag.FlagSet)) (*flag.FlagSet, []string, error) {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	if fn != nil {
+		fn(fs)
+	}
+	if err := fs.Parse(args); err != nil {
+		return nil, nil, err
+	}
+	return fs, fs.Args(), nil
+}

--- a/cmd/goa4web/ipban_add.go
+++ b/cmd/goa4web/ipban_add.go
@@ -22,15 +22,16 @@ type ipBanAddCmd struct {
 
 func parseIpBanAddCmd(parent *ipBanCmd, args []string) (*ipBanAddCmd, error) {
 	c := &ipBanAddCmd{ipBanCmd: parent}
-	fs := flag.NewFlagSet("add", flag.ContinueOnError)
-	fs.StringVar(&c.IP, "ip", "", "ip or cidr")
-	fs.StringVar(&c.Reason, "reason", "", "ban reason")
-	fs.StringVar(&c.Expires, "expires", "", "expiry date YYYY-MM-DD")
-	if err := fs.Parse(args); err != nil {
+	fs, rest, err := parseFlags("add", args, func(fs *flag.FlagSet) {
+		fs.StringVar(&c.IP, "ip", "", "ip or cidr")
+		fs.StringVar(&c.Reason, "reason", "", "ban reason")
+		fs.StringVar(&c.Expires, "expires", "", "expiry date YYYY-MM-DD")
+	})
+	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = fs.Args()
+	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/ipban_delete.go
+++ b/cmd/goa4web/ipban_delete.go
@@ -18,13 +18,14 @@ type ipBanDeleteCmd struct {
 
 func parseIpBanDeleteCmd(parent *ipBanCmd, args []string) (*ipBanDeleteCmd, error) {
 	c := &ipBanDeleteCmd{ipBanCmd: parent}
-	fs := flag.NewFlagSet("delete", flag.ContinueOnError)
-	fs.StringVar(&c.IP, "ip", "", "ip or cidr")
-	if err := fs.Parse(args); err != nil {
+	fs, rest, err := parseFlags("delete", args, func(fs *flag.FlagSet) {
+		fs.StringVar(&c.IP, "ip", "", "ip or cidr")
+	})
+	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = fs.Args()
+	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/ipban_list.go
+++ b/cmd/goa4web/ipban_list.go
@@ -17,12 +17,12 @@ type ipBanListCmd struct {
 
 func parseIpBanListCmd(parent *ipBanCmd, args []string) (*ipBanListCmd, error) {
 	c := &ipBanListCmd{ipBanCmd: parent}
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	if err := fs.Parse(args); err != nil {
+	fs, rest, err := parseFlags("list", args, nil)
+	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = fs.Args()
+	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/ipban_update.go
+++ b/cmd/goa4web/ipban_update.go
@@ -22,15 +22,16 @@ type ipBanUpdateCmd struct {
 
 func parseIpBanUpdateCmd(parent *ipBanCmd, args []string) (*ipBanUpdateCmd, error) {
 	c := &ipBanUpdateCmd{ipBanCmd: parent}
-	fs := flag.NewFlagSet("update", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "ban id")
-	fs.StringVar(&c.Reason, "reason", "", "ban reason")
-	fs.StringVar(&c.Expires, "expires", "", "expiry date YYYY-MM-DD")
-	if err := fs.Parse(args); err != nil {
+	fs, rest, err := parseFlags("update", args, func(fs *flag.FlagSet) {
+		fs.IntVar(&c.ID, "id", 0, "ban id")
+		fs.StringVar(&c.Reason, "reason", "", "ban reason")
+		fs.StringVar(&c.Expires, "expires", "", "expiry date YYYY-MM-DD")
+	})
+	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = fs.Args()
+	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_activate.go
+++ b/cmd/goa4web/user_activate.go
@@ -20,14 +20,15 @@ type userActivateCmd struct {
 
 func parseUserActivateCmd(parent *userCmd, args []string) (*userActivateCmd, error) {
 	c := &userActivateCmd{userCmd: parent}
-	fs := flag.NewFlagSet("activate", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "user id")
-	fs.StringVar(&c.Username, "username", "", "username")
-	if err := fs.Parse(args); err != nil {
+	fs, rest, err := parseFlags("activate", args, func(fs *flag.FlagSet) {
+		fs.IntVar(&c.ID, "id", 0, "user id")
+		fs.StringVar(&c.Username, "username", "", "username")
+	})
+	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = fs.Args()
+	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_add.go
+++ b/cmd/goa4web/user_add.go
@@ -28,16 +28,17 @@ type userAddCmd struct {
 
 func parseUserAddCmd(parent *userCmd, args []string) (*userAddCmd, error) {
 	c := &userAddCmd{userCmd: parent}
-	fs := flag.NewFlagSet("add", flag.ContinueOnError)
-	fs.StringVar(&c.Username, "username", "", "username")
-	fs.StringVar(&c.Email, "email", "", "email address")
-	fs.StringVar(&c.Password, "password", "", "password (leave empty to prompt)")
-	fs.BoolVar(&c.Admin, "admin", false, "grant administrator rights")
-	if err := fs.Parse(args); err != nil {
+	fs, rest, err := parseFlags("add", args, func(fs *flag.FlagSet) {
+		fs.StringVar(&c.Username, "username", "", "username")
+		fs.StringVar(&c.Email, "email", "", "email address")
+		fs.StringVar(&c.Password, "password", "", "password (leave empty to prompt)")
+		fs.BoolVar(&c.Admin, "admin", false, "grant administrator rights")
+	})
+	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = fs.Args()
+	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_add_admin.go
+++ b/cmd/goa4web/user_add_admin.go
@@ -18,15 +18,16 @@ type userAddAdminCmd struct {
 
 func parseUserAddAdminCmd(parent *userCmd, args []string) (*userAddAdminCmd, error) {
 	c := &userAddAdminCmd{userCmd: parent}
-	fs := flag.NewFlagSet("add-admin", flag.ContinueOnError)
-	fs.StringVar(&c.Username, "username", "", "username")
-	fs.StringVar(&c.Email, "email", "", "email address")
-	fs.StringVar(&c.Password, "password", "", "password (leave empty to prompt)")
-	if err := fs.Parse(args); err != nil {
+	fs, rest, err := parseFlags("add-admin", args, func(fs *flag.FlagSet) {
+		fs.StringVar(&c.Username, "username", "", "username")
+		fs.StringVar(&c.Email, "email", "", "email address")
+		fs.StringVar(&c.Password, "password", "", "password (leave empty to prompt)")
+	})
+	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = fs.Args()
+	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -20,13 +20,14 @@ type userDeactivateCmd struct {
 
 func parseUserDeactivateCmd(parent *userCmd, args []string) (*userDeactivateCmd, error) {
 	c := &userDeactivateCmd{userCmd: parent}
-	fs := flag.NewFlagSet("deactivate", flag.ContinueOnError)
-	fs.StringVar(&c.Username, "username", "", "username")
-	if err := fs.Parse(args); err != nil {
+	fs, rest, err := parseFlags("deactivate", args, func(fs *flag.FlagSet) {
+		fs.StringVar(&c.Username, "username", "", "username")
+	})
+	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = fs.Args()
+	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_list.go
+++ b/cmd/goa4web/user_list.go
@@ -22,15 +22,16 @@ type userListCmd struct {
 
 func parseUserListCmd(parent *userCmd, args []string) (*userListCmd, error) {
 	c := &userListCmd{userCmd: parent}
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	fs.BoolVar(&c.showAdmin, "admin", false, "include admin status")
-	fs.BoolVar(&c.showCreated, "created", false, "include creation date")
-	fs.BoolVar(&c.jsonOut, "json", false, "machine-readable JSON output")
-	if err := fs.Parse(args); err != nil {
+	fs, rest, err := parseFlags("list", args, func(fs *flag.FlagSet) {
+		fs.BoolVar(&c.showAdmin, "admin", false, "include admin status")
+		fs.BoolVar(&c.showCreated, "created", false, "include creation date")
+		fs.BoolVar(&c.jsonOut, "json", false, "machine-readable JSON output")
+	})
+	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = fs.Args()
+	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_make_admin.go
+++ b/cmd/goa4web/user_make_admin.go
@@ -20,13 +20,14 @@ type userMakeAdminCmd struct {
 
 func parseUserMakeAdminCmd(parent *userCmd, args []string) (*userMakeAdminCmd, error) {
 	c := &userMakeAdminCmd{userCmd: parent}
-	fs := flag.NewFlagSet("make-admin", flag.ContinueOnError)
-	fs.StringVar(&c.Username, "username", "", "username")
-	if err := fs.Parse(args); err != nil {
+	fs, rest, err := parseFlags("make-admin", args, func(fs *flag.FlagSet) {
+		fs.StringVar(&c.Username, "username", "", "username")
+	})
+	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = fs.Args()
+	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_update.go
+++ b/cmd/goa4web/user_update.go
@@ -23,16 +23,17 @@ type userUpdateCmd struct {
 
 func parseUserUpdateCmd(parent *userCmd, args []string) (*userUpdateCmd, error) {
 	c := &userUpdateCmd{userCmd: parent}
-	fs := flag.NewFlagSet("update", flag.ContinueOnError)
-	fs.StringVar(&c.Username, "username", "", "username")
-	fs.StringVar(&c.Email, "email", "", "email address")
-	fs.BoolVar(&c.MakeAdmin, "make-admin", false, "grant administrator rights")
-	fs.BoolVar(&c.RemoveAdmin, "remove-admin", false, "revoke administrator rights")
-	if err := fs.Parse(args); err != nil {
+	fs, rest, err := parseFlags("update", args, func(fs *flag.FlagSet) {
+		fs.StringVar(&c.Username, "username", "", "username")
+		fs.StringVar(&c.Email, "email", "", "email address")
+		fs.BoolVar(&c.MakeAdmin, "make-admin", false, "grant administrator rights")
+		fs.BoolVar(&c.RemoveAdmin, "remove-admin", false, "revoke administrator rights")
+	})
+	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = fs.Args()
+	c.args = rest
 	return c, nil
 }
 


### PR DESCRIPTION
## Summary
- centralize command flag parsing via `parseFlags`
- use `parseFlags` in user and ipban commands to drop repetitive setup

## Testing
- `go vet ./...` *(fails: undefined fmt.Eprintf)*
- `golangci-lint run ./...` *(fails: undefined fmt.Eprintf)*
- `go test ./...` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_686b45519098832fb5a23bcff2832ff5