### PR TITLE
Remove unused middleware helpers

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -141,20 +141,3 @@ func startWorkers(ctx context.Context, db *sql.DB, provider email.Provider, dlqP
 		}, dlqProvider)
 	})
 }
-
-func newMiddlewareChain(mw ...func(http.Handler) http.Handler) routerWrapper {
-	return routerWrapperFunc(func(h http.Handler) http.Handler {
-		for i := len(mw) - 1; i >= 0; i-- {
-			h = mw[i](h)
-		}
-		return h
-	})
-}
-
-type routerWrapper interface {
-	Wrap(http.Handler) http.Handler
-}
-
-type routerWrapperFunc func(http.Handler) http.Handler
-
-func (f routerWrapperFunc) Wrap(h http.Handler) http.Handler { return f(h) }


### PR DESCRIPTION
## Summary
- remove the old router wrapper helpers from `internal/app/run.go`
- rely on `middleware.NewMiddlewareChain` from `router_utils.go`

## Testing
- `go vet ./...` *(fails: undefined fmt.Eprintf)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: undefined fmt.Eprintf)*

------
https://chatgpt.com/codex/tasks/task_e_686b45271640832f93322a353621367f