### PR TITLE
Implement flexible session secret file path

### DIFF
--- a/cmd/goa4web/config_as.go
+++ b/cmd/goa4web/config_as.go
@@ -92,7 +92,7 @@ func envMapFromConfig(cfg runtimeconfig.RuntimeConfig, cfgPath string) (map[stri
 	m[config.EnvSessionSecret] = first("", os.Getenv(config.EnvSessionSecret))
 	sessionFile := first(fileVals[config.EnvSessionSecretFile], os.Getenv(config.EnvSessionSecretFile))
 	if sessionFile == "" {
-		sessionFile = ".session_secret"
+		sessionFile = runtimeconfig.DefaultSessionSecretPath()
 	}
 	m[config.EnvSessionSecretFile] = sessionFile
 

--- a/cmd/goa4web/config_reload.go
+++ b/cmd/goa4web/config_reload.go
@@ -29,10 +29,7 @@ func parseConfigReloadCmd(parent *configCmd, args []string) (*configReloadCmd, e
 }
 
 func (c *configReloadCmd) Run() error {
-	cfgMap, err := admin.LoadAppConfigFile(core.OSFS{}, c.rootCmd.ConfigFile)
-	if err != nil {
-		return fmt.Errorf("load config: %w", err)
-	}
+	cfgMap := admin.LoadAppConfigFile(core.OSFS{}, c.rootCmd.ConfigFile)
 	admin.Srv.Config = runtimeconfig.GenerateRuntimeConfig(nil, cfgMap, os.Getenv)
 	if c.rootCmd.Verbosity > 0 {
 		fmt.Println("configuration reloaded")

--- a/cmd/goa4web/db_migrate.go
+++ b/cmd/goa4web/db_migrate.go
@@ -55,8 +55,7 @@ func parseDbMigrateCmd(parent *dbCmd, args []string) (*dbMigrateCmd, error) {
 
 func (c *dbMigrateCmd) Run() error {
 	if c.rootCmd.Verbosity >= 0 {
-		fmt.Printf("connecting to database at %s:%s\n", c.rootCmd.cfg.DBHost,
-			c.rootCmd.cfg.DBPort)
+		fmt.Printf("connecting to database using %s\n", c.rootCmd.cfg.DBConn)
 	}
 	db, err := openDB(c.rootCmd.cfg)
 	if err != nil {

--- a/config/appconfig.go
+++ b/config/appconfig.go
@@ -9,8 +9,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"github.com/arran4/goa4web/core"
 )
 
 // LoadAppConfigFile reads CONFIG_FILE style key=value pairs or JSON objects and
@@ -19,7 +17,7 @@ import (
 // other extension.
 // LoadAppConfigFile reads CONFIG_FILE style key=value pairs and returns them as a map.
 // Missing files return an empty map. Unknown keys are ignored.
-func LoadAppConfigFile(fs core.FileSystem, path string) (map[string]string, error) {
+func LoadAppConfigFile(fs FileSystem, path string) (map[string]string, error) {
 	values := make(map[string]string)
 	if path == "" {
 		log.Printf("config file not specified")
@@ -51,7 +49,7 @@ func LoadAppConfigFile(fs core.FileSystem, path string) (map[string]string, erro
 
 // UpdateConfigKey writes the given key/value pair to the config file.
 // Existing keys are replaced, new keys appended. Empty values remove the key.
-func UpdateConfigKey(fs core.FileSystem, path, key, value string) error {
+func UpdateConfigKey(fs FileSystem, path, key, value string) error {
 	if path == "" {
 		return nil
 	}
@@ -79,7 +77,7 @@ func UpdateConfigKey(fs core.FileSystem, path, key, value string) error {
 // AddMissingJSONOptions ensures all keys from values exist in the JSON file at
 // path. Missing keys are added with their values. The file is created when it
 // does not exist.
-func AddMissingJSONOptions(fs core.FileSystem, path string, values map[string]string) error {
+func AddMissingJSONOptions(fs FileSystem, path string, values map[string]string) error {
 	if path == "" {
 		return nil
 	}

--- a/config/env.go
+++ b/config/env.go
@@ -67,6 +67,9 @@ const (
 	// EnvSessionSecretFile specifies the file containing the session secret.
 	EnvSessionSecretFile = "SESSION_SECRET_FILE"
 
+	// EnvDocker indicates the application is running inside a Docker container.
+	EnvDocker = "GOA4WEB_DOCKER"
+
 	// EnvSendGridKey is the API key for the SendGrid email provider.
 	EnvSendGridKey = "SENDGRID_KEY"
 	// EnvAdminEmails is a comma-separated list of administrator email addresses.

--- a/config/fs.go
+++ b/config/fs.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"io/fs"
+	"os"
+)
+
+// FileSystem abstracts basic file operations for configuration helpers.
+type FileSystem interface {
+	ReadFile(name string) ([]byte, error)
+	WriteFile(name string, data []byte, perm fs.FileMode) error
+}
+
+// OSFS implements FileSystem using the os package.
+type OSFS struct{}
+
+func (OSFS) ReadFile(name string) ([]byte, error) { return os.ReadFile(name) }
+func (OSFS) WriteFile(name string, data []byte, perm fs.FileMode) error {
+	return os.WriteFile(name, data, perm)
+}

--- a/core/session_secret.go
+++ b/core/session_secret.go
@@ -6,13 +6,15 @@ import (
 	"errors"
 	"os"
 	"strings"
+
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 // LoadSessionSecret returns the session secret using the following priority:
 //  1. cliSecret if non-empty
 //  2. the environment variable named envSecret
 //  3. contents of the file at path. If path is empty it uses envSecretFile
-//     or a default file named ".session_secret" in the working directory.
+//     or runtimeconfig.DefaultSessionSecretPath().
 //
 // If the file does not exist, a new random secret is generated and saved.
 func LoadSessionSecret(fs FileSystem, cliSecret, path, envSecret, envSecretFile string) (string, error) {
@@ -27,7 +29,7 @@ func LoadSessionSecret(fs FileSystem, cliSecret, path, envSecret, envSecretFile 
 	if path == "" {
 		path = os.Getenv(envSecretFile)
 		if path == "" {
-			path = ".session_secret"
+			path = runtimeconfig.DefaultSessionSecretPath()
 		}
 	}
 

--- a/core/session_secret_test.go
+++ b/core/session_secret_test.go
@@ -1,10 +1,13 @@
 package core_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
+	common "github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestLoadSessionSecretCLI(t *testing.T) {
@@ -59,5 +62,35 @@ func TestLoadSessionSecretGenerate(t *testing.T) {
 	}
 	if string(b) != secret {
 		t.Fatalf("file secret mismatch: %s vs %s", b, secret)
+	}
+}
+
+func TestDefaultSessionSecretPathDev(t *testing.T) {
+	common.Version = "dev"
+	t.Setenv(config.EnvDocker, "")
+	got := runtimeconfig.DefaultSessionSecretPath()
+	if got != ".session_secret" {
+		t.Fatalf("want .session_secret got %s", got)
+	}
+}
+
+func TestDefaultSessionSecretPathDocker(t *testing.T) {
+	common.Version = "1"
+	t.Setenv(config.EnvDocker, "1")
+	t.Setenv("HOME", "/home/test")
+	got := runtimeconfig.DefaultSessionSecretPath()
+	if got != "/var/lib/goa4web/session_secret" {
+		t.Fatalf("want /var/lib/goa4web/session_secret got %s", got)
+	}
+}
+
+func TestDefaultSessionSecretPathUser(t *testing.T) {
+	common.Version = "1"
+	t.Setenv(config.EnvDocker, "")
+	t.Setenv("XDG_CONFIG_HOME", "/cfg")
+	got := runtimeconfig.DefaultSessionSecretPath()
+	want := filepath.Join("/cfg", "goa4web", "session_secret")
+	if got != want {
+		t.Fatalf("want %s got %s", want, got)
 	}
 }

--- a/examples/config.env
+++ b/examples/config.env
@@ -64,8 +64,8 @@ PAGE_SIZE_MIN=5
 SENDGRID_KEY=
 # session secret key (default: )
 SESSION_SECRET=
-# path to session secret file (default: .session_secret)
-SESSION_SECRET_FILE=.session_secret
+# path to session secret file (default: auto)
+#SESSION_SECRET_FILE=
 # SMTP host (default: )
 SMTP_HOST=
 # SMTP pass (default: )

--- a/examples/config.json
+++ b/examples/config.json
@@ -32,7 +32,6 @@
   "PAGE_SIZE_MIN": "5",
   "SENDGRID_KEY": "",
   "SESSION_SECRET": "",
-  "SESSION_SECRET_FILE": ".session_secret",
   "SMTP_HOST": "",
   "SMTP_PASS": "",
   "SMTP_PORT": "",

--- a/handlers/admin/adminReloadConfigPage.go
+++ b/handlers/admin/adminReloadConfigPage.go
@@ -25,10 +25,7 @@ func AdminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
 		Back:     "/admin",
 	}
 
-	cfgMap, err := LoadAppConfigFile(core.OSFS{}, ConfigFile)
-	if err != nil {
-		data.Errors = append(data.Errors, err.Error())
-	}
+	cfgMap := LoadAppConfigFile(core.OSFS{}, ConfigFile)
 	Srv.Config = runtimeconfig.GenerateRuntimeConfig(nil, cfgMap, os.Getenv)
 	if err := corelanguage.ValidateDefaultLanguage(r.Context(), db.New(DBPool), Srv.Config.DefaultLanguage); err != nil {
 		data.Errors = append(data.Errors, err.Error())

--- a/handlers/admin/config_file.go
+++ b/handlers/admin/config_file.go
@@ -1,6 +1,8 @@
 package admin
 
 import (
+	"log"
+
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 )

--- a/handlers/admin/config_update.go
+++ b/handlers/admin/config_update.go
@@ -1,6 +1,8 @@
 package admin
 
-import "github.com/arran4/goa4web/core"
+import (
+	"github.com/arran4/goa4web/config"
+)
 
 // updateConfigKey writes the given key/value pair to the config file.
 // Existing keys are replaced, new keys appended. Empty values remove the key.
@@ -8,5 +10,5 @@ func updateConfigKey(path, key, value string) error {
 	if UpdateConfigKeyFunc == nil {
 		return nil
 	}
-	return UpdateConfigKeyFunc(core.OSFS{}, path, key, value)
+	return UpdateConfigKeyFunc(config.OSFS{}, path, key, value)
 }

--- a/handlers/admin/email_helpers.go
+++ b/handlers/admin/email_helpers.go
@@ -1,0 +1,14 @@
+package admin
+
+import (
+	"context"
+
+	db "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/email"
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+// notifyAdmins sends a change notification to administrator addresses.
+func notifyAdmins(ctx context.Context, provider email.Provider, q *db.Queries, page string) {
+	notif.Notifier{EmailProvider: provider, Queries: q}.NotifyAdmins(ctx, page)
+}

--- a/handlers/admin/vars.go
+++ b/handlers/admin/vars.go
@@ -3,7 +3,7 @@ package admin
 import (
 	"database/sql"
 
-	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/pkg/server"
 )
 
@@ -18,4 +18,4 @@ var DBPool *sql.DB
 
 // UpdateConfigKeyFunc is used to persist configuration changes. It should be
 // set by the main application on startup.
-var UpdateConfigKeyFunc func(fs core.FileSystem, path, key, value string) error
+var UpdateConfigKeyFunc func(fs config.FileSystem, path, key, value string) error

--- a/handlers/news/helpers.go
+++ b/handlers/news/helpers.go
@@ -5,9 +5,7 @@ import (
 	"context"
 	"fmt"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/email"
 )
 
 func processCommentFullQuote(username, text string) string {

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,8 @@ The server relies on the MySQL instance and (optionally) AWS credentials for sen
 The secret used to sign these cookies is resolved in the following order:
 1. `--session-secret` flag
 2. `SESSION_SECRET` environment variable
-3. The file specified by `--session-secret-file` or `SESSION_SECRET_FILE` (defaults to `.session_secret`)
+3. The file specified by `--session-secret-file` or `SESSION_SECRET_FILE` (a default location is chosen when unset)
+   (`GOA4WEB_DOCKER` places it under `/var/lib/goa4web/`)
 
 If the file does not exist a new random secret is generated and written to it.
 
@@ -239,7 +240,8 @@ environment variables listed below.
 | `LISTEN` | `--listen` | No | `:8080` | Network address the HTTP server listens on. |
 | `HOSTNAME` | `--hostname` | No | `http://localhost:8080` | Base URL advertised by the HTTP server. |
 | `SESSION_SECRET` | `--session-secret` | No | generated | Secret used to encrypt session cookies. |
-| `SESSION_SECRET_FILE` | `--session-secret-file` | No | `.session_secret` | File containing the session secret. |
+| `SESSION_SECRET_FILE` | `--session-secret-file` | No | auto | File containing the session secret. |
+| `GOA4WEB_DOCKER` | n/a | No | - | Set when running inside Docker to adjust defaults. |
 | `SENDGRID_KEY` | `--sendgrid-key` | No | - | API key for the SendGrid email provider. |
 | `ADMIN_EMAILS` | n/a | No | - | Comma-separated list of administrator email addresses. |
 | `ADMIN_NOTIFY` | n/a | No | `true` | Toggles sending administrator notification emails. |

--- a/runtimeconfig/session_secret.go
+++ b/runtimeconfig/session_secret.go
@@ -1,0 +1,30 @@
+package runtimeconfig
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/arran4/goa4web/config"
+	common "github.com/arran4/goa4web/core/common"
+)
+
+const defaultSecretName = ".session_secret"
+
+// DefaultSessionSecretPath returns the default path for the session secret file
+// based on the execution environment.
+func DefaultSessionSecretPath() string {
+	if common.Version == "dev" {
+		return defaultSecretName
+	}
+	if os.Getenv(config.EnvDocker) != "" {
+		return "/var/lib/goa4web/session_secret"
+	}
+	if os.Getenv("HOME") == "" && os.Getenv("XDG_CONFIG_HOME") == "" {
+		return "/var/lib/goa4web/session_secret"
+	}
+	dir, err := os.UserConfigDir()
+	if err == nil && dir != "" {
+		return filepath.Join(dir, "goa4web", "session_secret")
+	}
+	return defaultSecretName
+}


### PR DESCRIPTION
## Summary
- provide default session secret path logic in runtimeconfig
- use the dynamic path in session secret loading and config commands
- document GOA4WEB_DOCKER variable
- update example configs
- fix build/test failures from missing notifyAdmins and outdated db info

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b4ea930f8832fa1d4f38ce7defc17