### PR TITLE
Add optional AWS SES provider

### DIFF
--- a/internal/email/provider.go
+++ b/internal/email/provider.go
@@ -11,10 +11,6 @@ import (
 	"os/exec"
 	"strings"
 	"time"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ses"
-	"github.com/aws/aws-sdk-go/service/ses/sesiface"
 )
 
 const (
@@ -26,24 +22,6 @@ const (
 // Only the fields necessary for sending basic notification emails are included.
 type Provider interface {
 	Send(ctx context.Context, to, subject, textBody, htmlBody string) error
-}
-
-// SESProvider wraps the AWS SES client.
-type SESProvider struct{ Client sesiface.SESAPI }
-
-func (s SESProvider) Send(ctx context.Context, to, subject, textBody, htmlBody string) error {
-	dest := &ses.Destination{ToAddresses: []*string{aws.String(to)}}
-	msg := &ses.Message{
-		Subject: &ses.Content{Charset: aws.String("UTF-8"), Data: aws.String(subject)},
-		Body:    &ses.Body{},
-	}
-	msg.Body.Text = &ses.Content{Charset: aws.String("UTF-8"), Data: aws.String(textBody)}
-	if htmlBody != "" {
-		msg.Body.Html = &ses.Content{Charset: aws.String("UTF-8"), Data: aws.String(htmlBody)}
-	}
-	input := &ses.SendEmailInput{Destination: dest, Message: msg, Source: aws.String(SourceEmail)}
-	_, err := s.Client.SendEmailWithContext(ctx, input)
-	return err
 }
 
 // SMTPProvider uses the standard net/smtp package.

--- a/internal/email/provider_factory.go
+++ b/internal/email/provider_factory.go
@@ -5,10 +5,6 @@ import (
 	"net/smtp"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ses"
-
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
@@ -38,23 +34,7 @@ func ProviderFromConfig(cfg runtimeconfig.RuntimeConfig) Provider {
 		return SMTPProvider{Addr: addr, Auth: auth, From: SourceEmail}
 
 	case "ses":
-		awsCfg := aws.NewConfig()
-		if region := cfg.EmailAWSRegion; region != "" {
-			awsCfg = awsCfg.WithRegion(region)
-		}
-		sess, err := session.NewSession(awsCfg)
-		if err != nil {
-			log.Printf("Email disabled: cannot initialise AWS session: %v", err)
-			if mode == "ses" {
-				return nil
-			}
-			return nil
-		}
-		if _, err := sess.Config.Credentials.Get(); err != nil {
-			log.Printf("Email disabled: no AWS credentials: %v", err)
-			return nil
-		}
-		return SESProvider{Client: ses.New(sess)}
+		return SESProviderFromConfig(cfg)
 
 	case "local":
 		return LocalProvider{}

--- a/internal/email/provider_ses.go
+++ b/internal/email/provider_ses.go
@@ -1,0 +1,56 @@
+//go:build ses
+// +build ses
+
+package email
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/aws/aws-sdk-go/service/ses/sesiface"
+
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+// SESBuilt indicates whether the SES provider is compiled in.
+const SESBuilt = true
+
+// SESProvider wraps the AWS SES client.
+type SESProvider struct{ Client sesiface.SESAPI }
+
+// Send delivers an email using AWS SES.
+func (s SESProvider) Send(ctx context.Context, to, subject, textBody, htmlBody string) error {
+	dest := &ses.Destination{ToAddresses: []*string{aws.String(to)}}
+	msg := &ses.Message{
+		Subject: &ses.Content{Charset: aws.String("UTF-8"), Data: aws.String(subject)},
+		Body:    &ses.Body{},
+	}
+	msg.Body.Text = &ses.Content{Charset: aws.String("UTF-8"), Data: aws.String(textBody)}
+	if htmlBody != "" {
+		msg.Body.Html = &ses.Content{Charset: aws.String("UTF-8"), Data: aws.String(htmlBody)}
+	}
+	input := &ses.SendEmailInput{Destination: dest, Message: msg, Source: aws.String(SourceEmail)}
+	_, err := s.Client.SendEmailWithContext(ctx, input)
+	return err
+}
+
+// SESProviderFromConfig constructs an SESProvider using cfg.
+func SESProviderFromConfig(cfg runtimeconfig.RuntimeConfig) Provider {
+	awsCfg := aws.NewConfig()
+	if region := cfg.EmailAWSRegion; region != "" {
+		awsCfg = awsCfg.WithRegion(region)
+	}
+	sess, err := session.NewSession(awsCfg)
+	if err != nil {
+		log.Printf("Email disabled: cannot initialise AWS session: %v", err)
+		return nil
+	}
+	if _, err := sess.Config.Credentials.Get(); err != nil {
+		log.Printf("Email disabled: no AWS credentials: %v", err)
+		return nil
+	}
+	return SESProvider{Client: ses.New(sess)}
+}

--- a/internal/email/provider_ses_stub.go
+++ b/internal/email/provider_ses_stub.go
@@ -1,0 +1,24 @@
+//go:build !ses
+// +build !ses
+
+package email
+
+import (
+	"context"
+
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+// SESBuilt indicates whether the SES provider is compiled in.
+const SESBuilt = false
+
+// SESProvider is a stub implementation used when SES support is disabled.
+type SESProvider struct{}
+
+// Send implements the Provider interface but performs no action.
+func (SESProvider) Send(ctx context.Context, to, subject, textBody, htmlBody string) error {
+	return nil
+}
+
+// SESProviderFromConfig returns nil when SES support is disabled.
+func SESProviderFromConfig(cfg runtimeconfig.RuntimeConfig) Provider { return nil }


### PR DESCRIPTION
## Summary
- split the SES email provider into a separate build-tagged file
- add stub provider when the `ses` build tag isn't set
- update provider factory to use the new constructor

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b6aa75990832fa0356eaa20645377