### PR TITLE
Add DB backup handler registry

### DIFF
--- a/cmd/goa4web/db_backup.go
+++ b/cmd/goa4web/db_backup.go
@@ -3,12 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net/url"
-	"os"
-	"os/exec"
-	"strings"
 
-	"github.com/go-sql-driver/mysql"
+	"github.com/arran4/goa4web/cmd/goa4web/dbhandlers"
 )
 
 // dbBackupCmd implements "db backup".
@@ -36,49 +32,12 @@ func (c *dbBackupCmd) Run() error {
 		return fmt.Errorf("file required")
 	}
 	cfg := c.rootCmd.cfg
-	var cmd *exec.Cmd
-	switch cfg.DBDriver {
-	case "mysql":
-		if cfg.DBConn == "" {
-			return fmt.Errorf("connection string required")
-		}
-		mcfg, err := mysql.ParseDSN(cfg.DBConn)
-		if err != nil {
-			return fmt.Errorf("parse DSN: %w", err)
-		}
-		host, port, _ := strings.Cut(mcfg.Addr, ":")
-		args := []string{
-			"-h", host,
-			"-P", port,
-			"-u", mcfg.User,
-			fmt.Sprintf("-p%s", mcfg.Passwd),
-			mcfg.DBName,
-		}
-		cmd = exec.Command("mysqldump", args...)
-	case "postgres":
-		if cfg.DBConn == "" {
-			return fmt.Errorf("connection string required")
-		}
-		cmd = exec.Command("pg_dump", "--dbname="+cfg.DBConn)
-	case "sqlite3":
-		path := cfg.DBConn
-		if strings.HasPrefix(path, "file:") {
-			if u, err := url.Parse(path); err == nil {
-				path = u.Path
-			}
-		}
-		cmd = exec.Command("sqlite3", path, ".dump")
-	default:
+	h := dbhandlers.BackupFor(cfg.DBDriver)
+	if h == nil {
 		return fmt.Errorf("backup not supported for driver %s", cfg.DBDriver)
 	}
-	outFile, err := os.Create(c.File)
-	if err != nil {
-		return fmt.Errorf("create file: %w", err)
-	}
-	defer outFile.Close()
-	cmd.Stdout = outFile
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("backup: %w", err)
+	if err := h.Backup(cfg, c.File); err != nil {
+		return err
 	}
 	if c.rootCmd.Verbosity > 0 {
 		fmt.Printf("database backup written to %s\n", c.File)

--- a/cmd/goa4web/dbhandlers/allstable/allstable.go
+++ b/cmd/goa4web/dbhandlers/allstable/allstable.go
@@ -1,0 +1,13 @@
+package allstable
+
+import (
+	"github.com/arran4/goa4web/cmd/goa4web/dbhandlers/mysql"
+	"github.com/arran4/goa4web/cmd/goa4web/dbhandlers/postgres"
+	"github.com/arran4/goa4web/cmd/goa4web/dbhandlers/sqlite"
+)
+
+func init() {
+	mysql.Register()
+	postgres.Register()
+	sqlite.Register()
+}

--- a/cmd/goa4web/dbhandlers/handlers.go
+++ b/cmd/goa4web/dbhandlers/handlers.go
@@ -1,0 +1,62 @@
+package dbhandlers
+
+import (
+	"sync"
+
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+// BackupHandler backs up a database to the provided file path.
+type BackupHandler interface {
+	Backup(cfg runtimeconfig.RuntimeConfig, file string) error
+}
+
+// RestoreHandler restores a database from the provided file path.
+type RestoreHandler interface {
+	Restore(cfg runtimeconfig.RuntimeConfig, file string) error
+}
+
+var (
+	mu              sync.RWMutex
+	backupRegistry  = map[string]BackupHandler{}
+	restoreRegistry = map[string]RestoreHandler{}
+)
+
+// RegisterBackup registers a handler for the given driver name.
+func RegisterBackup(driver string, h BackupHandler) {
+	mu.Lock()
+	backupRegistry[driver] = h
+	mu.Unlock()
+}
+
+// RegisterRestore registers a handler for the given driver name.
+func RegisterRestore(driver string, h RestoreHandler) {
+	mu.Lock()
+	restoreRegistry[driver] = h
+	mu.Unlock()
+}
+
+// BackupFor returns the BackupHandler for driver or nil if none registered.
+func BackupFor(driver string) BackupHandler {
+	mu.RLock()
+	h := backupRegistry[driver]
+	mu.RUnlock()
+	return h
+}
+
+// RestoreFor returns the RestoreHandler for driver or nil if none registered.
+func RestoreFor(driver string) RestoreHandler {
+	mu.RLock()
+	h := restoreRegistry[driver]
+	mu.RUnlock()
+	return h
+}
+
+// reset clears all registries. Used by tests.
+// Reset clears the internal registries. Used in tests.
+func Reset() {
+	mu.Lock()
+	backupRegistry = map[string]BackupHandler{}
+	restoreRegistry = map[string]RestoreHandler{}
+	mu.Unlock()
+}

--- a/cmd/goa4web/dbhandlers/mysql/mysql.go
+++ b/cmd/goa4web/dbhandlers/mysql/mysql.go
@@ -1,0 +1,67 @@
+package mysql
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/arran4/goa4web/cmd/goa4web/dbhandlers"
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+type handler struct{}
+
+func (handler) Backup(cfg runtimeconfig.RuntimeConfig, file string) error {
+	if cfg.DBConn == "" {
+		return fmt.Errorf("connection string required")
+	}
+	mcfg, err := mysql.ParseDSN(cfg.DBConn)
+	if err != nil {
+		return fmt.Errorf("parse DSN: %w", err)
+	}
+	host, port, _ := strings.Cut(mcfg.Addr, ":")
+	args := []string{"-h", host, "-P", port, "-u", mcfg.User, fmt.Sprintf("-p%s", mcfg.Passwd), mcfg.DBName}
+	cmd := exec.Command("mysqldump", args...)
+	outFile, err := os.Create(file)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer outFile.Close()
+	cmd.Stdout = outFile
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("backup: %w", err)
+	}
+	return nil
+}
+
+func (handler) Restore(cfg runtimeconfig.RuntimeConfig, file string) error {
+	if cfg.DBConn == "" {
+		return fmt.Errorf("connection string required")
+	}
+	inFile, err := os.Open(file)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer inFile.Close()
+	mcfg, err := mysql.ParseDSN(cfg.DBConn)
+	if err != nil {
+		return fmt.Errorf("parse DSN: %w", err)
+	}
+	host, port, _ := strings.Cut(mcfg.Addr, ":")
+	args := []string{"-h", host, "-P", port, "-u", mcfg.User, fmt.Sprintf("-p%s", mcfg.Passwd), mcfg.DBName}
+	cmd := exec.Command("mysql", args...)
+	cmd.Stdin = inFile
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("restore: %w", err)
+	}
+	return nil
+}
+
+// Register registers the mysql handlers with the default registry.
+func Register() {
+	dbhandlers.RegisterBackup("mysql", handler{})
+	dbhandlers.RegisterRestore("mysql", handler{})
+}

--- a/cmd/goa4web/dbhandlers/postgres/postgres.go
+++ b/cmd/goa4web/dbhandlers/postgres/postgres.go
@@ -1,0 +1,52 @@
+package postgres
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/arran4/goa4web/cmd/goa4web/dbhandlers"
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+type handler struct{}
+
+func (handler) Backup(cfg runtimeconfig.RuntimeConfig, file string) error {
+	if cfg.DBConn == "" {
+		return fmt.Errorf("connection string required")
+	}
+	cmd := exec.Command("pg_dump", "--dbname="+cfg.DBConn)
+	outFile, err := os.Create(file)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer outFile.Close()
+	cmd.Stdout = outFile
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("backup: %w", err)
+	}
+	return nil
+}
+
+func (handler) Restore(cfg runtimeconfig.RuntimeConfig, file string) error {
+	if cfg.DBConn == "" {
+		return fmt.Errorf("connection string required")
+	}
+	inFile, err := os.Open(file)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer inFile.Close()
+	cmd := exec.Command("psql", cfg.DBConn)
+	cmd.Stdin = inFile
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("restore: %w", err)
+	}
+	return nil
+}
+
+// Register registers the postgres handlers with the default registry.
+func Register() {
+	dbhandlers.RegisterBackup("postgres", handler{})
+	dbhandlers.RegisterRestore("postgres", handler{})
+}

--- a/cmd/goa4web/dbhandlers/registry_test.go
+++ b/cmd/goa4web/dbhandlers/registry_test.go
@@ -1,0 +1,22 @@
+package dbhandlers_test
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/cmd/goa4web/dbhandlers"
+	_ "github.com/arran4/goa4web/cmd/goa4web/dbhandlers/allstable"
+)
+
+func TestDefaultRegistrations(t *testing.T) {
+	// reset after test to avoid affecting others
+	t.Cleanup(dbhandlers.Reset)
+	if dbhandlers.BackupFor("mysql") == nil {
+		t.Error("mysql backup handler not registered")
+	}
+	if dbhandlers.RestoreFor("postgres") == nil {
+		t.Error("postgres restore handler not registered")
+	}
+	if dbhandlers.BackupFor("sqlite3") == nil {
+		t.Error("sqlite backup handler not registered")
+	}
+}

--- a/cmd/goa4web/dbhandlers/sqlite/sqlite.go
+++ b/cmd/goa4web/dbhandlers/sqlite/sqlite.go
@@ -1,0 +1,60 @@
+package sqlite
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/arran4/goa4web/cmd/goa4web/dbhandlers"
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+type handler struct{}
+
+func pathFromConn(conn string) string {
+	path := conn
+	if strings.HasPrefix(path, "file:") {
+		if u, err := url.Parse(path); err == nil {
+			path = u.Path
+		}
+	}
+	return path
+}
+
+func (handler) Backup(cfg runtimeconfig.RuntimeConfig, file string) error {
+	path := pathFromConn(cfg.DBConn)
+	cmd := exec.Command("sqlite3", path, ".dump")
+	outFile, err := os.Create(file)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer outFile.Close()
+	cmd.Stdout = outFile
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("backup: %w", err)
+	}
+	return nil
+}
+
+func (handler) Restore(cfg runtimeconfig.RuntimeConfig, file string) error {
+	path := pathFromConn(cfg.DBConn)
+	inFile, err := os.Open(file)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer inFile.Close()
+	cmd := exec.Command("sqlite3", path)
+	cmd.Stdin = inFile
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("sqlite restore: %w", err)
+	}
+	return nil
+}
+
+// Register registers the sqlite handlers with the default registry.
+func Register() {
+	dbhandlers.RegisterBackup("sqlite3", handler{})
+	dbhandlers.RegisterRestore("sqlite3", handler{})
+}

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 
+	_ "github.com/arran4/goa4web/cmd/goa4web/dbhandlers/allstable"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	dbstart "github.com/arran4/goa4web/internal/dbstart"


### PR DESCRIPTION
## Summary
- add BackupHandler and RestoreHandler interfaces with registry
- implement MySQL, Postgres and SQLite backup/restore handlers
- register the handlers via an `allstable` package
- use registry lookups instead of switch statements
- test that default handlers are registered

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b6e5cdab0832f9a7c1b97adb42c20