### PR TITLE
Implement driver connector registry

### DIFF
--- a/cmd/goa4web/dbinit.go
+++ b/cmd/goa4web/dbinit.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/arran4/goa4web/internal/dbdrivers/allstable"
+)
+
+func init() {
+	allstable.Register()
+}

--- a/handlers/admin/adminHandler.go
+++ b/handlers/admin/adminHandler.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
-	_ "github.com/arran4/goa4web/internal/dbdrivers" // Register SQL drivers.
 )
 
 func AdminPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/forum/adminForumHandler.go
+++ b/handlers/forum/adminForumHandler.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
-	_ "github.com/arran4/goa4web/internal/dbdrivers" // Register SQL drivers.
 )
 
 func AdminForumPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/forum/adminForumWordListHandler.go
+++ b/handlers/forum/adminForumWordListHandler.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/templates"
-	_ "github.com/arran4/goa4web/internal/dbdrivers" // Register SQL drivers.
 )
 
 func AdminForumWordListPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/languages/admin.go
+++ b/handlers/languages/admin.go
@@ -12,7 +12,6 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	_ "github.com/arran4/goa4web/internal/dbdrivers" // Register SQL drivers.
 )
 
 func adminLanguageRedirect(w http.ResponseWriter, r *http.Request) {

--- a/handlers/search/admin_wordlist.go
+++ b/handlers/search/admin_wordlist.go
@@ -13,7 +13,6 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	common "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	_ "github.com/arran4/goa4web/internal/dbdrivers" // Register SQL drivers.
 )
 
 type PageLink struct {

--- a/internal/dbdrivers/allstable/allstable.go
+++ b/internal/dbdrivers/allstable/allstable.go
@@ -1,0 +1,14 @@
+package allstable
+
+import (
+	"github.com/arran4/goa4web/internal/dbdrivers/mysql"
+	"github.com/arran4/goa4web/internal/dbdrivers/postgres"
+	"github.com/arran4/goa4web/internal/dbdrivers/sqlite3"
+)
+
+// Register registers all stable database connectors.
+func Register() {
+	mysql.Register()
+	postgres.Register()
+	sqlite3.Register()
+}

--- a/internal/dbdrivers/drivers.go
+++ b/internal/dbdrivers/drivers.go
@@ -1,39 +1,15 @@
 package dbdrivers
 
 import (
-	"context"
 	"database/sql/driver"
 	"fmt"
-
-	"github.com/go-sql-driver/mysql"
-	"github.com/lib/pq"
-	"github.com/mattn/go-sqlite3"
 )
-
-type sqliteConnector struct {
-	dsn string
-}
-
-func (c sqliteConnector) Connect(context.Context) (driver.Conn, error) {
-	return (&sqlite3.SQLiteDriver{}).Open(c.dsn)
-}
-
-func (c sqliteConnector) Driver() driver.Driver { return &sqlite3.SQLiteDriver{} }
 
 // Connector returns a driver.Connector for the provided driver name and DSN.
 func Connector(driverName, dsn string) (driver.Connector, error) {
-	switch driverName {
-	case "mysql":
-		cfg, err := mysql.ParseDSN(dsn)
-		if err != nil {
-			return nil, err
-		}
-		return mysql.NewConnector(cfg)
-	case "postgres":
-		return pq.NewConnector(dsn)
-	case "sqlite3":
-		return sqliteConnector{dsn: dsn}, nil
-	default:
+	fn, ok := connectors[driverName]
+	if !ok {
 		return nil, fmt.Errorf("unsupported driver %s", driverName)
 	}
+	return fn(dsn)
 }

--- a/internal/dbdrivers/drivers_test.go
+++ b/internal/dbdrivers/drivers_test.go
@@ -1,0 +1,49 @@
+package dbdrivers_test
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/arran4/goa4web/internal/dbdrivers"
+	"github.com/arran4/goa4web/internal/dbdrivers/allstable"
+)
+
+type testConnector struct{}
+
+func (testConnector) Connect(context.Context) (driver.Conn, error) { return nil, nil }
+func (testConnector) Driver() driver.Driver                        { return nil }
+
+func TestConnectorUnknown(t *testing.T) {
+	if _, err := dbdrivers.Connector("unknown-driver", ""); err == nil {
+		t.Fatalf("expected error for unknown driver")
+	}
+}
+
+func TestRegisterConnector(t *testing.T) {
+	dbdrivers.RegisterConnector("testdriver", func(dsn string) (driver.Connector, error) {
+		if dsn != "dsn" {
+			return nil, fmt.Errorf("unexpected dsn: %s", dsn)
+		}
+		return testConnector{}, nil
+	})
+	c, err := dbdrivers.Connector("testdriver", "dsn")
+	if err != nil {
+		t.Fatalf("Connector returned error: %v", err)
+	}
+	if c == nil {
+		t.Fatalf("expected connector")
+	}
+}
+
+func TestAllstableRegister(t *testing.T) {
+	allstable.Register()
+	for _, n := range []string{"mysql", "postgres", "sqlite3"} {
+		_, err := dbdrivers.Connector(n, "")
+		if err != nil && strings.Contains(err.Error(), "unsupported driver") {
+			t.Fatalf("%s not registered", n)
+		}
+	}
+}

--- a/internal/dbdrivers/mysql/mysql.go
+++ b/internal/dbdrivers/mysql/mysql.go
@@ -1,0 +1,21 @@
+package mysql
+
+import (
+	"database/sql/driver"
+
+	"github.com/arran4/goa4web/internal/dbdrivers"
+	sqlmysql "github.com/go-sql-driver/mysql"
+)
+
+func connector(dsn string) (driver.Connector, error) {
+	cfg, err := sqlmysql.ParseDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return sqlmysql.NewConnector(cfg)
+}
+
+// Register registers the mysql connector with the dbdrivers registry.
+func Register() {
+	dbdrivers.RegisterConnector("mysql", connector)
+}

--- a/internal/dbdrivers/postgres/postgres.go
+++ b/internal/dbdrivers/postgres/postgres.go
@@ -1,0 +1,17 @@
+package postgres
+
+import (
+	"database/sql/driver"
+
+	"github.com/arran4/goa4web/internal/dbdrivers"
+	"github.com/lib/pq"
+)
+
+func connector(dsn string) (driver.Connector, error) {
+	return pq.NewConnector(dsn)
+}
+
+// Register registers the postgres connector with the dbdrivers registry.
+func Register() {
+	dbdrivers.RegisterConnector("postgres", connector)
+}

--- a/internal/dbdrivers/registry.go
+++ b/internal/dbdrivers/registry.go
@@ -1,0 +1,14 @@
+package dbdrivers
+
+import (
+	"database/sql/driver"
+)
+
+// connectors holds factories for creating driver connectors by name.
+var connectors = map[string]func(string) (driver.Connector, error){}
+
+// RegisterConnector registers a function to construct a driver.Connector for the
+// given name.
+func RegisterConnector(name string, fn func(string) (driver.Connector, error)) {
+	connectors[name] = fn
+}

--- a/internal/dbdrivers/sqlite3/sqlite3.go
+++ b/internal/dbdrivers/sqlite3/sqlite3.go
@@ -1,0 +1,26 @@
+package sqlite3
+
+import (
+	"context"
+	"database/sql/driver"
+
+	"github.com/arran4/goa4web/internal/dbdrivers"
+	"github.com/mattn/go-sqlite3"
+)
+
+type connector struct{ dsn string }
+
+func (c connector) Connect(ctx context.Context) (driver.Conn, error) {
+	return (&sqlite3.SQLiteDriver{}).Open(c.dsn)
+}
+
+func (c connector) Driver() driver.Driver { return &sqlite3.SQLiteDriver{} }
+
+func connectorFunc(dsn string) (driver.Connector, error) {
+	return connector{dsn: dsn}, nil
+}
+
+// Register registers the sqlite3 connector with the dbdrivers registry.
+func Register() {
+	dbdrivers.RegisterConnector("sqlite3", connectorFunc)
+}


### PR DESCRIPTION
## Summary
- create driver-specific packages for mysql, postgres and sqlite3
- expose Register functions and group them via allstable package
- init all stable connectors from cmd/goa4web
- adapt handlers and tests for new registration model

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b6e4396d4832fb719c06c1a45dde5