### PR TITLE
Update favicon layout

### DIFF
--- a/core/templates/assets/favicon.svg
+++ b/core/templates/assets/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <radialGradient id="grad" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#FF9800"/>
+      <stop offset="100%" stop-color="#FF5722"/>
+    </radialGradient>
+  </defs>
+  <rect x="5" y="5" width="90" height="90" rx="10" fill="url(#grad)" stroke="#FFF" stroke-width="2"/>
+  <line x1="50" y1="10" x2="50" y2="90" stroke="#FFF" stroke-width="2"/>
+  <line x1="10" y1="50" x2="90" y2="50" stroke="#FFF" stroke-width="2"/>
+  <text x="25" y="40" font-size="36" text-anchor="middle" fill="#FFFFFF" font-family="Arial, sans-serif" font-weight="bold">g</text>
+  <text x="75" y="40" font-size="36" text-anchor="middle" fill="#FFFFFF" font-family="Arial, sans-serif" font-weight="bold">a</text>
+  <text x="25" y="85" font-size="36" text-anchor="middle" fill="#FFFFFF" font-family="Arial, sans-serif" font-weight="bold">4</text>
+  <text x="75" y="85" font-size="36" text-anchor="middle" fill="#FFFFFF" font-family="Arial, sans-serif" font-weight="bold">w</text>
+</svg>

--- a/core/templates/embedded.go
+++ b/core/templates/embedded.go
@@ -13,6 +13,8 @@ var (
 	templateFS embed.FS
 	//go:embed "assets/main.css"
 	mainCSSData []byte
+	//go:embed "assets/favicon.svg"
+	faviconData []byte
 )
 
 func GetCompiledTemplates(funcs template.FuncMap) *template.Template {
@@ -22,4 +24,9 @@ func GetCompiledTemplates(funcs template.FuncMap) *template.Template {
 
 func GetMainCSSData() []byte {
 	return mainCSSData
+}
+
+// GetFaviconData returns the site's favicon image data.
+func GetFaviconData() []byte {
+	return faviconData
 }

--- a/core/templates/live.go
+++ b/core/templates/live.go
@@ -21,3 +21,11 @@ func GetMainCSSData() []byte {
 	}
 	return b
 }
+
+func GetFaviconData() []byte {
+	b, err := os.ReadFile("core/templates/assets/favicon.svg")
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/core/templates/templates/head.gohtml
+++ b/core/templates/templates/head.gohtml
@@ -5,6 +5,7 @@
                 <title>{{$.Title}}</title>
                 {{template "headdata"}}
                 <link rel="stylesheet" href="/main.css">
+                <link rel="icon" href="/favicon.svg" type="image/svg+xml">
         {{ if $.AutoRefresh }}
             <meta http-equiv="refresh" content="1">
         {{ end }}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -30,6 +30,7 @@ import (
 // RegisterRoutes sets up all application routes on r.
 func RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/main.css", handlers.MainCSS).Methods("GET")
+	r.HandleFunc("/favicon.svg", handlers.Favicon).Methods("GET")
 
 	news.RegisterRoutes(r)
 	faq.RegisterRoutes(r)

--- a/pkg/handlers/common.go
+++ b/pkg/handlers/common.go
@@ -14,6 +14,12 @@ func MainCSS(w http.ResponseWriter, r *http.Request) {
 	http.ServeContent(w, r, "main.css", time.Time{}, bytes.NewReader(templates.GetMainCSSData()))
 }
 
+// Favicon serves the site's favicon image.
+func Favicon(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "image/svg+xml")
+	http.ServeContent(w, r, "favicon.svg", time.Time{}, bytes.NewReader(templates.GetFaviconData()))
+}
+
 // RedirectPermanent returns a handler that redirects to the provided path using StatusPermanentRedirect.
 func RedirectPermanent(to string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- redesign favicon so G, A, 4 and W each occupy their own quadrant

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b6d9fb7fc832fb5dfab58d5109f8b