### PR TITLE
Add email worker interval option

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -72,6 +72,9 @@ const (
 
 	// EnvSendGridKey is the API key for the SendGrid email provider.
 	EnvSendGridKey = "SENDGRID_KEY"
+	// EnvEmailWorkerInterval controls how often the email worker processes
+	// pending messages in seconds.
+	EnvEmailWorkerInterval = "EMAIL_WORKER_INTERVAL"
 	// EnvAdminEmails is a comma-separated list of administrator email addresses.
 	EnvAdminEmails = "ADMIN_EMAILS"
 	// EnvAdminNotify toggles sending administrator notification emails.

--- a/examples/config.env
+++ b/examples/config.env
@@ -24,6 +24,8 @@ DLQ_PROVIDER=
 EMAIL_ENABLED=true
 # email provider (default: )
 EMAIL_PROVIDER=
+# interval in seconds between email worker runs (default: 60)
+EMAIL_WORKER_INTERVAL=60
 # enable or disable feeds (default: true)
 FEEDS_ENABLED=true
 # server base URL (default: http://localhost:8080)

--- a/examples/config.json
+++ b/examples/config.json
@@ -12,6 +12,7 @@
   "DLQ_PROVIDER": "",
   "EMAIL_ENABLED": "true",
   "EMAIL_PROVIDER": "",
+  "EMAIL_WORKER_INTERVAL": "60",
   "FEEDS_ENABLED": "true",
   "HOSTNAME": "bbd711bce6ea",
   "IMAGE_MAX_BYTES": "5242880",

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -102,7 +102,7 @@ func RunWithConfig(ctx context.Context, cfg runtimeconfig.RuntimeConfig, session
 	emailProvider := email.ProviderFromConfig(cfg)
 
 	dlqProvider := dlq.ProviderFromConfig(cfg, dbpkg.New(dbPool))
-	startWorkers(ctx, dbPool, emailProvider, dlqProvider)
+	startWorkers(ctx, dbPool, emailProvider, dlqProvider, cfg)
 
 	if err := server.Run(ctx, srv, cfg.HTTPListen); err != nil {
 		return fmt.Errorf("run server: %w", err)
@@ -124,9 +124,11 @@ func safeGo(fn func()) {
 	}()
 }
 
-func startWorkers(ctx context.Context, db *sql.DB, provider email.Provider, dlqProvider dlq.DLQ) {
+func startWorkers(ctx context.Context, db *sql.DB, provider email.Provider, dlqProvider dlq.DLQ, cfg runtimeconfig.RuntimeConfig) {
 	log.Printf("Starting email worker")
-	safeGo(func() { emailutil.EmailQueueWorker(ctx, dbpkg.New(db), provider, time.Minute) })
+	safeGo(func() {
+		emailutil.EmailQueueWorker(ctx, dbpkg.New(db), provider, time.Duration(cfg.EmailWorkerInterval)*time.Second)
+	})
 	log.Printf("Starting notification purger worker")
 	safeGo(func() { notifications.NotificationPurgeWorker(ctx, dbpkg.New(db), time.Hour) })
 	log.Printf("Starting event bus logger worker")

--- a/readme.md
+++ b/readme.md
@@ -244,6 +244,7 @@ environment variables listed below.
 | `SESSION_SECRET_FILE` | `--session-secret-file` | No | auto | File containing the session secret. |
 | `GOA4WEB_DOCKER` | n/a | No | - | Set when running inside Docker to adjust defaults. |
 | `SENDGRID_KEY` | `--sendgrid-key` | No | - | API key for the SendGrid email provider. |
+| `EMAIL_WORKER_INTERVAL` | `--email-worker-interval` | No | `60` | Interval in seconds between email worker runs. |
 | `ADMIN_EMAILS` | n/a | No | - | Comma-separated list of administrator email addresses. |
 | `ADMIN_NOTIFY` | n/a | No | `true` | Toggles sending administrator notification emails. |
 | `IMAGE_UPLOAD_DIR` | `--image-upload-dir` | No | `uploads/images` | Directory where uploaded images are stored. |

--- a/runtimeconfig/config.go
+++ b/runtimeconfig/config.go
@@ -36,6 +36,9 @@ type RuntimeConfig struct {
 	EmailJMAPPass     string
 	EmailSendGridKey  string
 
+	// EmailWorkerInterval sets how often the email worker runs in seconds.
+	EmailWorkerInterval int
+
 	PageSizeMin     int
 	PageSizeMax     int
 	PageSizeDefault int
@@ -222,6 +225,9 @@ func normalizeRuntimeConfig(cfg *RuntimeConfig) {
 	}
 	if cfg.ImageMaxBytes == 0 {
 		cfg.ImageMaxBytes = 5 * 1024 * 1024
+	}
+	if cfg.EmailWorkerInterval == 0 {
+		cfg.EmailWorkerInterval = 60
 	}
 }
 

--- a/runtimeconfig/config_email_worker_test.go
+++ b/runtimeconfig/config_email_worker_test.go
@@ -1,0 +1,32 @@
+package runtimeconfig
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+)
+
+func TestEmailWorkerIntervalPrecedence(t *testing.T) {
+	env := map[string]string{config.EnvEmailWorkerInterval: "30"}
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.Int("email-worker-interval", 15, "")
+	vals := map[string]string{config.EnvEmailWorkerInterval: "20"}
+	_ = fs.Parse([]string{"--email-worker-interval=15"})
+
+	cfg := GenerateRuntimeConfig(fs, vals, func(k string) string { return env[k] })
+	if cfg.EmailWorkerInterval != 15 {
+		t.Fatalf("merged %#v", cfg.EmailWorkerInterval)
+	}
+}
+
+func TestLoadEmailWorkerIntervalFromFileValues(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	vals := map[string]string{config.EnvEmailWorkerInterval: "25"}
+
+	cfg := GenerateRuntimeConfig(fs, vals, func(string) string { return "" })
+	if cfg.EmailWorkerInterval != 25 {
+		t.Fatalf("want 25 got %d", cfg.EmailWorkerInterval)
+	}
+}

--- a/runtimeconfig/options.go
+++ b/runtimeconfig/options.go
@@ -52,4 +52,5 @@ var IntOptions = []IntOption{
 	{"page-size-max", config.EnvPageSizeMax, "PageSizeMax", "maximum allowed page size", 0},
 	{"page-size-default", config.EnvPageSizeDefault, "PageSizeDefault", "default page size", 0},
 	{"image-max-bytes", config.EnvImageMaxBytes, "ImageMaxBytes", "maximum allowed upload size in bytes", 0},
+	{"email-worker-interval", config.EnvEmailWorkerInterval, "EmailWorkerInterval", "interval in seconds between email worker runs", 0},
 }


### PR DESCRIPTION
## Summary
- add `EMAIL_WORKER_INTERVAL` config option
- respect the interval in worker start logic
- update examples and documentation
- test configuration precedence

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b7438c32c832f9a3d08b3eab35ea4