### PR TITLE
Rename builtin register to defaults

### DIFF
--- a/cmd/goa4web/config_json_add.go
+++ b/cmd/goa4web/config_json_add.go
@@ -32,13 +32,13 @@ func (c *configJSONAddCmd) Run() error {
 	if c.File == "" {
 		return fmt.Errorf("file required")
 	}
-       values, err := envMapFromConfig(c.rootCmd.cfg, c.rootCmd.ConfigFile)
-       if err != nil {
-               return fmt.Errorf("load config: %w", err)
-       }
-       if err := config.AddMissingJSONOptions(core.OSFS{}, c.File, values); err != nil {
-               return fmt.Errorf("update json: %w", err)
-       }
+	values, err := envMapFromConfig(c.rootCmd.cfg, c.rootCmd.ConfigFile)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	if err := config.AddMissingJSONOptions(core.OSFS{}, c.File, values); err != nil {
+		return fmt.Errorf("update json: %w", err)
+	}
 	if c.rootCmd.Verbosity > 0 {
 		fmt.Printf("updated %s\n", c.File)
 	}

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -10,10 +10,15 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	dbstart "github.com/arran4/goa4web/internal/dbstart"
+	dlqreg "github.com/arran4/goa4web/internal/dlq/register/defaults"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 var version = "dev"
+
+func init() {
+	dlqreg.Register()
+}
 
 func main() {
 	root, err := parseRoot(os.Args)

--- a/internal/dlq/db/db.go
+++ b/internal/dlq/db/db.go
@@ -1,0 +1,28 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/dlq"
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+// DLQ stores messages in the database.
+type DLQ struct{ Queries *dbpkg.Queries }
+
+// Record inserts the message into the worker error table.
+func (d DLQ) Record(ctx context.Context, message string) error {
+	if d.Queries == nil {
+		return fmt.Errorf("no db")
+	}
+	return d.Queries.InsertWorkerError(ctx, message)
+}
+
+// Register registers the database provider.
+func Register() {
+	dlq.RegisterProvider("db", func(_ runtimeconfig.RuntimeConfig, q *dbpkg.Queries) dlq.DLQ {
+		return DLQ{Queries: q}
+	})
+}

--- a/internal/dlq/dir/dir.go
+++ b/internal/dlq/dir/dir.go
@@ -1,0 +1,37 @@
+package dir
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/dlq"
+	"github.com/arran4/goa4web/runtimeconfig"
+	"github.com/segmentio/ksuid"
+)
+
+// DLQ writes each message to a new file inside Dir using a KSUID filename.
+type DLQ struct {
+	Dir string
+}
+
+// Record writes the message to a unique file within the directory.
+func (d *DLQ) Record(_ context.Context, message string) error {
+	if d.Dir == "" {
+		d.Dir = "dlq"
+	}
+	if err := os.MkdirAll(d.Dir, 0o755); err != nil {
+		return err
+	}
+	name := ksuid.New().String() + ".txt"
+	path := filepath.Join(d.Dir, name)
+	return os.WriteFile(path, []byte(message+"\n"), 0o644)
+}
+
+// Register registers the directory provider.
+func Register() {
+	dlq.RegisterProvider("dir", func(cfg runtimeconfig.RuntimeConfig, _ *dbpkg.Queries) dlq.DLQ {
+		return &DLQ{Dir: cfg.DLQFile}
+	})
+}

--- a/internal/dlq/dlq.go
+++ b/internal/dlq/dlq.go
@@ -2,16 +2,10 @@ package dlq
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"os"
-	"path/filepath"
-	"sync"
 
 	dbpkg "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/email"
-	"github.com/arran4/goa4web/internal/emailutil"
-	"github.com/segmentio/ksuid"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 // DLQ records failed asynchronous operations.
@@ -27,68 +21,11 @@ func (LogDLQ) Record(_ context.Context, message string) error {
 	return nil
 }
 
-// FileDLQ appends messages to a file.
-type FileDLQ struct {
-	Path string
-	mu   sync.Mutex
+// RegisterLogDLQ registers the log provider.
+func RegisterLogDLQ() {
+	RegisterProvider("log", func(runtimeconfig.RuntimeConfig, *dbpkg.Queries) DLQ {
+		return LogDLQ{}
+	})
 }
 
-func (f *FileDLQ) Record(_ context.Context, message string) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.Path == "" {
-		f.Path = "dlq.log"
-	}
-	fh, err := os.OpenFile(f.Path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer fh.Close()
-	_, err = fmt.Fprintln(fh, message)
-	return err
-}
-
-// DBDLQ stores messages in the database.
-type DBDLQ struct{ Queries *dbpkg.Queries }
-
-func (d DBDLQ) Record(ctx context.Context, message string) error {
-	if d.Queries == nil {
-		return fmt.Errorf("no db")
-	}
-	return d.Queries.InsertWorkerError(ctx, message)
-}
-
-// DirDLQ writes each message to a new file inside Dir using a KSUID filename.
-type DirDLQ struct {
-	Dir string
-}
-
-func (d *DirDLQ) Record(_ context.Context, message string) error {
-	if d.Dir == "" {
-		d.Dir = "dlq"
-	}
-	if err := os.MkdirAll(d.Dir, 0o755); err != nil {
-		return err
-	}
-	name := ksuid.New().String() + ".txt"
-	path := filepath.Join(d.Dir, name)
-	return os.WriteFile(path, []byte(message+"\n"), 0o644)
-}
-
-// EmailDLQ sends DLQ messages to administrator emails using the given provider.
-type EmailDLQ struct {
-	Provider email.Provider
-	Queries  *dbpkg.Queries
-}
-
-func (e EmailDLQ) Record(ctx context.Context, message string) error {
-	if e.Provider == nil {
-		return fmt.Errorf("no email provider")
-	}
-	for _, addr := range emailutil.GetAdminEmails(ctx, e.Queries) {
-		if err := e.Provider.Send(ctx, addr, "DLQ message", message, ""); err != nil {
-			log.Printf("dlq email: %v", err)
-		}
-	}
-	return nil
-}
+func init() { RegisterLogDLQ() }

--- a/internal/dlq/dlq_test.go
+++ b/internal/dlq/dlq_test.go
@@ -1,0 +1,57 @@
+package dlq_test
+
+import (
+	"reflect"
+	"testing"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	dlq "github.com/arran4/goa4web/internal/dlq"
+	dbdlq "github.com/arran4/goa4web/internal/dlq/db"
+	dirdlq "github.com/arran4/goa4web/internal/dlq/dir"
+	emaildlq "github.com/arran4/goa4web/internal/dlq/email"
+	filedlq "github.com/arran4/goa4web/internal/dlq/file"
+	defaults "github.com/arran4/goa4web/internal/dlq/register/defaults"
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+func TestProviderFromConfigRegistry(t *testing.T) {
+	defaults.Register()
+
+	cfg := runtimeconfig.RuntimeConfig{DLQProvider: "file", DLQFile: "p"}
+	if _, ok := dlq.ProviderFromConfig(cfg, nil).(*filedlq.DLQ); !ok {
+		t.Fatalf("expected *file.DLQ")
+	}
+
+	cfg = runtimeconfig.RuntimeConfig{DLQProvider: "dir", DLQFile: "d"}
+	if _, ok := dlq.ProviderFromConfig(cfg, nil).(*dirdlq.DLQ); !ok {
+		t.Fatalf("expected *dir.DLQ")
+	}
+
+	cfg = runtimeconfig.RuntimeConfig{DLQProvider: "db"}
+	if _, ok := dlq.ProviderFromConfig(cfg, (&dbpkg.Queries{})).(dbdlq.DLQ); !ok {
+		t.Fatalf("expected db.DLQ")
+	}
+
+	cfg = runtimeconfig.RuntimeConfig{DLQProvider: "email"}
+	if p := dlq.ProviderFromConfig(cfg, nil); reflect.TypeOf(p) != reflect.TypeOf(emaildlq.DLQ{}) && reflect.TypeOf(p) != reflect.TypeOf(dlq.LogDLQ{}) {
+		t.Fatalf("unexpected type %T", p)
+	}
+
+	cfg = runtimeconfig.RuntimeConfig{DLQProvider: "db,log"}
+	if _, ok := dlq.ProviderFromConfig(cfg, (&dbpkg.Queries{})).(dlq.MultiDLQ); !ok {
+		t.Fatalf("expected MultiDLQ")
+	}
+}
+
+func TestRegisterProviderCustom(t *testing.T) {
+	called := false
+	dlq.RegisterProvider("custom", func(cfg runtimeconfig.RuntimeConfig, q *dbpkg.Queries) dlq.DLQ {
+		called = true
+		return dlq.LogDLQ{}
+	})
+
+	cfg := runtimeconfig.RuntimeConfig{DLQProvider: "custom"}
+	if _, ok := dlq.ProviderFromConfig(cfg, nil).(dlq.LogDLQ); !ok || !called {
+		t.Fatalf("custom provider not used")
+	}
+}

--- a/internal/dlq/email/email.go
+++ b/internal/dlq/email/email.go
@@ -1,0 +1,43 @@
+package email
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/dlq"
+	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/internal/emailutil"
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+// DLQ sends DLQ messages to administrator emails using the configured provider.
+type DLQ struct {
+	Provider email.Provider
+	Queries  *dbpkg.Queries
+}
+
+// Record emails the message to the configured recipients.
+func (e DLQ) Record(ctx context.Context, message string) error {
+	if e.Provider == nil {
+		return fmt.Errorf("no email provider")
+	}
+	for _, addr := range emailutil.GetAdminEmails(ctx, e.Queries) {
+		if err := e.Provider.Send(ctx, addr, "DLQ message", message, ""); err != nil {
+			log.Printf("dlq email: %v", err)
+		}
+	}
+	return nil
+}
+
+// Register registers the email provider.
+func Register() {
+	dlq.RegisterProvider("email", func(cfg runtimeconfig.RuntimeConfig, q *dbpkg.Queries) dlq.DLQ {
+		p := email.ProviderFromConfig(cfg)
+		if p == nil {
+			return dlq.LogDLQ{}
+		}
+		return DLQ{Provider: p, Queries: q}
+	})
+}

--- a/internal/dlq/file/file.go
+++ b/internal/dlq/file/file.go
@@ -1,0 +1,41 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/dlq"
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+// DLQ appends messages to a file.
+type DLQ struct {
+	Path string
+	mu   sync.Mutex
+}
+
+// Record writes the message to the configured file.
+func (f *DLQ) Record(_ context.Context, message string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.Path == "" {
+		f.Path = "dlq.log"
+	}
+	fh, err := os.OpenFile(f.Path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+	_, err = fmt.Fprintln(fh, message)
+	return err
+}
+
+// Register registers the file provider.
+func Register() {
+	dlq.RegisterProvider("file", func(cfg runtimeconfig.RuntimeConfig, _ *dbpkg.Queries) dlq.DLQ {
+		return &DLQ{Path: cfg.DLQFile}
+	})
+}

--- a/internal/dlq/multi.go
+++ b/internal/dlq/multi.go
@@ -1,0 +1,24 @@
+package dlq
+
+import (
+	"context"
+)
+
+// MultiDLQ records messages to multiple DLQs.
+type MultiDLQ struct{ providers []DLQ }
+
+// NewMulti returns a MultiDLQ using the provided DLQs.
+func NewMulti(providers ...DLQ) MultiDLQ {
+	return MultiDLQ{providers: providers}
+}
+
+// Record writes the message to all providers. It returns the first error encountered.
+func (m MultiDLQ) Record(ctx context.Context, msg string) error {
+	var first error
+	for _, p := range m.providers {
+		if err := p.Record(ctx, msg); err != nil && first == nil {
+			first = err
+		}
+	}
+	return first
+}

--- a/internal/dlq/provider_factory.go
+++ b/internal/dlq/provider_factory.go
@@ -1,32 +1,36 @@
 package dlq
 
 import (
+	"log"
 	"strings"
 
 	dbpkg "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 // ProviderFromConfig returns a DLQ implementation configured from cfg.
 func ProviderFromConfig(cfg runtimeconfig.RuntimeConfig, q *dbpkg.Queries) DLQ {
-	switch strings.ToLower(cfg.DLQProvider) {
-	case "file":
-		return &FileDLQ{Path: cfg.DLQFile}
-	case "dir":
-		return &DirDLQ{Dir: cfg.DLQFile}
-	case "db":
-		return DBDLQ{Queries: q}
-	case "email":
-		p := email.ProviderFromConfig(cfg)
-		if p != nil {
-			return EmailDLQ{Provider: p, Queries: q}
+	names := strings.Split(cfg.DLQProvider, ",")
+	var qs []DLQ
+	for _, name := range names {
+		n := strings.ToLower(strings.TrimSpace(name))
+		if n == "" {
+			continue
 		}
-		return LogDLQ{}
-	default:
-		if cfg.DLQProvider != "" && cfg.DLQProvider != "log" {
-			// unrecognised provider -> fallback to log
+		if f := lookupProvider(n); f != nil {
+			qs = append(qs, f(cfg, q))
+		} else {
+			if n != "log" {
+				log.Printf("unrecognised DLQ provider %q, falling back to log", n)
+			}
+			qs = append(qs, LogDLQ{})
 		}
+	}
+	if len(qs) == 0 {
 		return LogDLQ{}
 	}
+	if len(qs) == 1 {
+		return qs[0]
+	}
+	return NewMulti(qs...)
 }

--- a/internal/dlq/register/defaults/defaults.go
+++ b/internal/dlq/register/defaults/defaults.go
@@ -1,0 +1,16 @@
+package defaults
+
+import (
+	"github.com/arran4/goa4web/internal/dlq/db"
+	"github.com/arran4/goa4web/internal/dlq/dir"
+	"github.com/arran4/goa4web/internal/dlq/email"
+	"github.com/arran4/goa4web/internal/dlq/file"
+)
+
+// Register registers all stable DLQ providers.
+func Register() {
+	file.Register()
+	dir.Register()
+	db.Register()
+	email.Register()
+}

--- a/internal/dlq/registry.go
+++ b/internal/dlq/registry.go
@@ -1,0 +1,31 @@
+package dlq
+
+import (
+	"sync"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+// ProviderFactory creates a DLQ provider using runtime configuration.
+type ProviderFactory func(runtimeconfig.RuntimeConfig, *dbpkg.Queries) DLQ
+
+var (
+	regMu     sync.RWMutex
+	providers = make(map[string]ProviderFactory)
+)
+
+// RegisterProvider adds factory to the provider registry under name.
+func RegisterProvider(name string, factory ProviderFactory) {
+	regMu.Lock()
+	defer regMu.Unlock()
+	providers[name] = factory
+}
+
+// lookupProvider retrieves a factory by name.
+func lookupProvider(name string) ProviderFactory {
+	regMu.RLock()
+	f := providers[name]
+	regMu.RUnlock()
+	return f
+}

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -13,6 +13,7 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/dlq"
+	dbdlq "github.com/arran4/goa4web/internal/dlq/db"
 	"github.com/arran4/goa4web/internal/emailutil"
 	"github.com/arran4/goa4web/internal/eventbus"
 )
@@ -20,7 +21,7 @@ import (
 func recordAndNotify(ctx context.Context, q dlq.DLQ, n Notifier, msg string) {
 	if q != nil {
 		_ = q.Record(ctx, msg)
-		if dbq, ok := q.(dlq.DBDLQ); ok {
+		if dbq, ok := q.(dbdlq.DLQ); ok {
 			if count, err := dbq.Queries.CountWorkerErrors(ctx); err == nil {
 				if isPow10(count) {
 					n.NotifyAdmins(ctx, "/admin/dlq")


### PR DESCRIPTION
## Summary
- rename the built-in DLQ registry package to `defaults`
- update imports and tests to use the new path

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b6e3ccae4832f9c02ed86fd8538b5