### PR TITLE
Fix spoiler tag and add test

### DIFF
--- a/a4code2html/a4code2html.go
+++ b/a4code2html/a4code2html.go
@@ -158,7 +158,7 @@ func (c *A4code2html) directOutput(terminator string) {
 }
 
 func (a *A4code2html) acomm() int {
-	command := a.getNext(true)
+	command := strings.ToLower(a.getNext(true))
 	switch command {
 	case "*", "b", "bold":
 		switch a.CodeType {
@@ -254,7 +254,7 @@ func (a *A4code2html) acomm() int {
 		case CTTableOfContents:
 		case CTTagStrip, CTWordsOnly:
 		default:
-			a.output.WriteString("<span onmouseover=\"this.style.color='#FFFFFF';\" onmouseout=\"this.style.color=this.style.backgroundColor='#000000'\" style=\"color: rgb(0, 0, 0); background: rgb(0, 0, 0);\">")
+			a.output.WriteString("<span onmouseover=\"this.style.color='#FFFFFF';\" onmouseout=\"this.style.color='#000000';\" style=\"color:#000000;background:#000000;\">")
 			a.stack = append(a.stack, "</span>")
 		}
 	case "indent":

--- a/a4code2html/a4code2html_test.go
+++ b/a4code2html/a4code2html_test.go
@@ -161,3 +161,13 @@ func TestA4code2htmlBadURL(t *testing.T) {
 		t.Errorf("got %q want %q", got, want)
 	}
 }
+
+func TestSpoiler(t *testing.T) {
+	c := NewA4Code2HTML()
+	c.input = "[Spoiler secret]"
+	c.Process()
+	want := "<span onmouseover=\"this.style.color='#FFFFFF';\" onmouseout=\"this.style.color='#000000';\" style=\"color:#000000;background:#000000;\">secret</span>"
+	if got := c.Output(); got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- correct the spoiler tag markup to use consistent colors
- ensure commands are case-insensitive by lowercasing the command name
- add a unit test verifying spoiler tag output

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b78d988d8832fb9d8c26b004db78b