### PR TITLE
Add explicit module registration

### DIFF
--- a/cmd/goa4web/modules.go
+++ b/cmd/goa4web/modules.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	admin "github.com/arran4/goa4web/handlers/admin"
+	auth "github.com/arran4/goa4web/handlers/auth"
+	blogs "github.com/arran4/goa4web/handlers/blogs"
+	bookmarks "github.com/arran4/goa4web/handlers/bookmarks"
+	faq "github.com/arran4/goa4web/handlers/faq"
+	forum "github.com/arran4/goa4web/handlers/forum"
+	imagebbs "github.com/arran4/goa4web/handlers/imagebbs"
+	information "github.com/arran4/goa4web/handlers/information"
+	languages "github.com/arran4/goa4web/handlers/languages"
+	linker "github.com/arran4/goa4web/handlers/linker"
+	news "github.com/arran4/goa4web/handlers/news"
+	search "github.com/arran4/goa4web/handlers/search"
+	user "github.com/arran4/goa4web/handlers/user"
+	writings "github.com/arran4/goa4web/handlers/writings"
+)
+
+// init registers all router modules used by the application.
+func init() {
+	admin.Register()
+	auth.Register()
+	blogs.Register()
+	bookmarks.Register()
+	faq.Register()
+	forum.Register()
+	imagebbs.Register()
+	information.Register()
+	languages.Register()
+	linker.Register()
+	news.Register()
+	search.Register()
+	user.Register()
+	writings.Register()
+}

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -12,6 +12,7 @@ import (
 	search "github.com/arran4/goa4web/handlers/search"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
 	writings "github.com/arran4/goa4web/handlers/writings"
+	router "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/internal/sections"
 )
 
@@ -80,4 +81,13 @@ func RegisterRoutes(ar *mux.Router) {
 
 	ar.HandleFunc("/reload", AdminReloadConfigPage).Methods("POST")
 	ar.HandleFunc("/shutdown", AdminShutdownPage).Methods("POST")
+}
+
+// Register registers the admin router module.
+func Register() {
+	router.RegisterModule("admin", []string{"faq", "forum", "languages", "linker", "news", "search", "user", "writings"}, func(r *mux.Router) {
+		ar := r.PathPrefix("/admin").Subrouter()
+		ar.Use(router.AdminCheckerMiddleware)
+		RegisterRoutes(ar)
+	})
 }

--- a/handlers/auth/routes.go
+++ b/handlers/auth/routes.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gorilla/mux"
 
 	hcommon "github.com/arran4/goa4web/handlers/common"
+	router "github.com/arran4/goa4web/internal/router"
 )
 
 // RegisterRoutes attaches the login and registration endpoints to r.
@@ -16,4 +17,9 @@ func RegisterRoutes(r *mux.Router) {
 	lr := r.PathPrefix("/login").Subrouter()
 	lr.HandleFunc("", LoginUserPassPage).Methods("GET").MatcherFunc(Not(RequiresAnAccount()))
 	lr.HandleFunc("", LoginActionPage).Methods("POST").MatcherFunc(Not(RequiresAnAccount())).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskLogin))
+}
+
+// Register registers the auth router module.
+func Register() {
+	router.RegisterModule("auth", nil, RegisterRoutes)
 }

--- a/handlers/blogs/routes.go
+++ b/handlers/blogs/routes.go
@@ -7,6 +7,7 @@ import (
 	auth "github.com/arran4/goa4web/handlers/auth"
 	comments "github.com/arran4/goa4web/handlers/comments"
 	hcommon "github.com/arran4/goa4web/handlers/common"
+	router "github.com/arran4/goa4web/internal/router"
 
 	"github.com/arran4/goa4web/internal/sections"
 )
@@ -41,4 +42,9 @@ func RegisterRoutes(r *mux.Router) {
 	br.HandleFunc("/users/permissions", UsersPermissionsDisallowPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskUserDisallow))
 	br.HandleFunc("/users/permissions", UsersPermissionsBulkAllowPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskUsersAllow))
 	br.HandleFunc("/users/permissions", UsersPermissionsBulkDisallowPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskUsersDisallow))
+}
+
+// Register registers the blogs router module.
+func Register() {
+	router.RegisterModule("blogs", nil, RegisterRoutes)
 }

--- a/handlers/bookmarks/routes.go
+++ b/handlers/bookmarks/routes.go
@@ -5,6 +5,7 @@ import (
 
 	auth "github.com/arran4/goa4web/handlers/auth"
 	hcommon "github.com/arran4/goa4web/handlers/common"
+	router "github.com/arran4/goa4web/internal/router"
 
 	"github.com/arran4/goa4web/internal/sections"
 )
@@ -19,4 +20,9 @@ func RegisterRoutes(r *mux.Router) {
 	br.HandleFunc("/edit", EditSaveActionPage).Methods("POST").MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskSave))
 	br.HandleFunc("/edit", EditCreateActionPage).Methods("POST").MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskCreate))
 	br.HandleFunc("/edit", hcommon.TaskDoneAutoRefreshPage).Methods("POST").MatcherFunc(auth.RequiresAnAccount())
+}
+
+// Register registers the bookmarks router module.
+func Register() {
+	router.RegisterModule("bookmarks", nil, RegisterRoutes)
 }

--- a/handlers/faq/routes.go
+++ b/handlers/faq/routes.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
+	router "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/internal/sections"
 )
 
@@ -63,4 +64,9 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	farq.HandleFunc("/questions", QuestionsEditActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskEdit))
 	farq.HandleFunc("/questions", QuestionsDeleteActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskRemoveRemove))
 	farq.HandleFunc("/questions", QuestionsCreateActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskCreate))
+}
+
+// Register registers the faq router module.
+func Register() {
+	router.RegisterModule("faq", nil, RegisterRoutes)
 }

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -6,6 +6,7 @@ import (
 
 	comments "github.com/arran4/goa4web/handlers/comments"
 	hcommon "github.com/arran4/goa4web/handlers/common"
+	router "github.com/arran4/goa4web/internal/router"
 
 	"github.com/arran4/goa4web/internal/sections"
 )
@@ -29,4 +30,9 @@ func RegisterRoutes(r *mux.Router) {
 	fr.Handle("/topic/{topic}/thread/{thread}/reply", RequireThreadAndTopic(http.HandlerFunc(TopicThreadReplyCancelPage))).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskCancel))
 	fr.Handle("/topic/{topic}/thread/{thread}/comment/{comment}", RequireThreadAndTopic(comments.RequireCommentAuthor(http.HandlerFunc(TopicThreadCommentEditActionPage)))).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskEditReply))
 	fr.Handle("/topic/{topic}/thread/{thread}/comment/{comment}", RequireThreadAndTopic(http.HandlerFunc(TopicThreadCommentEditActionCancelPage))).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskCancel))
+}
+
+// Register registers the forum router module.
+func Register() {
+	router.RegisterModule("forum", nil, RegisterRoutes)
 }

--- a/handlers/imagebbs/routes.go
+++ b/handlers/imagebbs/routes.go
@@ -7,6 +7,7 @@ import (
 
 	auth "github.com/arran4/goa4web/handlers/auth"
 	hcommon "github.com/arran4/goa4web/handlers/common"
+	router "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/runtimeconfig"
 
 	"github.com/arran4/goa4web/internal/sections"
@@ -30,4 +31,9 @@ func RegisterRoutes(r *mux.Router) {
 	ibr.HandleFunc("/", Page).Methods("GET")
 	ibr.HandleFunc("/poster/{username}", PosterPage).Methods("GET")
 	ibr.HandleFunc("/poster/{username}/", PosterPage).Methods("GET")
+}
+
+// Register registers the imagebbs router module.
+func Register() {
+	router.RegisterModule("imagebbs", nil, RegisterRoutes)
 }

--- a/handlers/information/routes.go
+++ b/handlers/information/routes.go
@@ -3,6 +3,7 @@ package information
 import (
 	"github.com/gorilla/mux"
 
+	router "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/internal/sections"
 )
 
@@ -11,4 +12,9 @@ func RegisterRoutes(r *mux.Router) {
 	sections.RegisterIndexLink("Information", "/information", SectionWeight)
 	ir := r.PathPrefix("/information").Subrouter()
 	ir.HandleFunc("", Page).Methods("GET")
+}
+
+// Register registers the information router module.
+func Register() {
+	router.RegisterModule("information", nil, RegisterRoutes)
 }

--- a/handlers/languages/routes.go
+++ b/handlers/languages/routes.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/handlers/common"
+	router "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/internal/sections"
 )
 
@@ -15,4 +16,13 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	ar.HandleFunc("/languages", adminLanguagesRenamePage).Methods("POST").MatcherFunc(common.TaskMatcher("Rename Language"))
 	ar.HandleFunc("/languages", adminLanguagesDeletePage).Methods("POST").MatcherFunc(common.TaskMatcher("Delete Language"))
 	ar.HandleFunc("/languages", adminLanguagesCreatePage).Methods("POST").MatcherFunc(common.TaskMatcher("Create Language"))
+}
+
+// Register registers the languages router module.
+func Register() {
+	router.RegisterModule("languages", nil, func(r *mux.Router) {
+		ar := r.PathPrefix("/admin").Subrouter()
+		ar.Use(router.AdminCheckerMiddleware)
+		RegisterAdminRoutes(ar)
+	})
 }

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -4,6 +4,7 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 
+	router "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/internal/sections"
 )
 
@@ -25,4 +26,9 @@ func RegisterRoutes(r *mux.Router) {
 	lr.HandleFunc("/show/{link}", ShowReplyPage).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskReply))
 	lr.HandleFunc("/suggest", SuggestPage).Methods("GET")
 	lr.HandleFunc("/suggest", SuggestActionPage).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskSuggest))
+}
+
+// Register registers the linker router module.
+func Register() {
+	router.RegisterModule("linker", nil, RegisterRoutes)
 }

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -8,6 +8,7 @@ import (
 
 	auth "github.com/arran4/goa4web/handlers/auth"
 	hcommon "github.com/arran4/goa4web/handlers/common"
+	router "github.com/arran4/goa4web/internal/router"
 
 	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
@@ -66,4 +67,9 @@ func RegisterRoutes(r *mux.Router) {
 	nr.HandleFunc("/user/permissions", NewsUserPermissionsPage).Methods("GET").MatcherFunc(auth.RequiredAccess("administrator"))
 	nr.HandleFunc("/users/permissions", NewsUsersPermissionsPermissionUserAllowPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(hcommon.TaskMatcher("User Allow"))
 	nr.HandleFunc("/users/permissions", NewsUsersPermissionsDisallowPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(hcommon.TaskMatcher("User Disallow"))
+}
+
+// Register registers the news router module.
+func Register() {
+	router.RegisterModule("news", nil, RegisterRoutes)
 }

--- a/handlers/search/routes.go
+++ b/handlers/search/routes.go
@@ -5,6 +5,7 @@ import (
 
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	news "github.com/arran4/goa4web/handlers/news"
+	router "github.com/arran4/goa4web/internal/router"
 
 	"github.com/arran4/goa4web/internal/sections"
 )
@@ -20,4 +21,9 @@ func RegisterRoutes(r *mux.Router) {
 	sr.HandleFunc("", SearchResultLinkerActionPage).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskSearchLinker))
 	sr.HandleFunc("", SearchResultBlogsActionPage).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskSearchBlogs))
 	sr.HandleFunc("", SearchResultWritingsActionPage).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskSearchWritings))
+}
+
+// Register registers the search router module.
+func Register() {
+	router.RegisterModule("search", []string{"news"}, RegisterRoutes)
 }

--- a/handlers/user/routes.go
+++ b/handlers/user/routes.go
@@ -6,6 +6,7 @@ import (
 
 	auth "github.com/arran4/goa4web/handlers/auth"
 	"github.com/arran4/goa4web/handlers/common"
+	router "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/pkg/handlers"
 )
 
@@ -38,4 +39,9 @@ func RegisterRoutes(r *mux.Router) {
 	// legacy redirects
 	r.HandleFunc("/user/lang", handlers.RedirectPermanent("/usr/lang"))
 	r.HandleFunc("/user/email", handlers.RedirectPermanent("/usr/email"))
+}
+
+// Register registers the user router module.
+func Register() {
+	router.RegisterModule("user", nil, RegisterRoutes)
 }

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -7,6 +7,7 @@ import (
 
 	auth "github.com/arran4/goa4web/handlers/auth"
 	hcommon "github.com/arran4/goa4web/handlers/common"
+	router "github.com/arran4/goa4web/internal/router"
 
 	"github.com/arran4/goa4web/internal/sections"
 )
@@ -34,4 +35,9 @@ func RegisterRoutes(r *mux.Router) {
 	wr.HandleFunc("/category/{category}", CategoryPage).Methods("GET")
 	wr.HandleFunc("/category/{category}/add", ArticleAddPage).Methods("GET").MatcherFunc(Or(auth.RequiredAccess("writer"), auth.RequiredAccess("administrator")))
 	wr.HandleFunc("/category/{category}/add", ArticleAddActionPage).Methods("POST").MatcherFunc(Or(auth.RequiredAccess("writer"), auth.RequiredAccess("administrator"))).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskSubmitWriting))
+}
+
+// Register registers the writings router module.
+func Register() {
+	router.RegisterModule("writings", nil, RegisterRoutes)
 }

--- a/internal/router/registry.go
+++ b/internal/router/registry.go
@@ -1,0 +1,68 @@
+package router
+
+import (
+	"sync"
+
+	"github.com/gorilla/mux"
+)
+
+// Module represents a router module and its setup function.
+type Module struct {
+	Name  string
+	Deps  []string
+	Setup func(*mux.Router)
+	once  sync.Once
+}
+
+var (
+	modules = map[string]*Module{}
+	mu      sync.Mutex
+)
+
+// RegisterModule registers a router module with optional dependencies. A module
+// is stored only on the first call.
+func RegisterModule(name string, deps []string, setup func(*mux.Router)) {
+	mu.Lock()
+	defer mu.Unlock()
+	if _, ok := modules[name]; ok {
+		return
+	}
+	modules[name] = &Module{Name: name, Deps: deps, Setup: setup}
+}
+
+// InitModules initialises all registered modules by resolving their
+// dependencies and invoking their Setup function once.
+func InitModules(r *mux.Router) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	visited := make(map[string]bool)
+	var order []*Module
+
+	var visit func(string)
+	visit = func(name string) {
+		if visited[name] {
+			return
+		}
+		visited[name] = true
+		m := modules[name]
+		if m == nil {
+			return
+		}
+		for _, dep := range m.Deps {
+			visit(dep)
+		}
+		order = append(order, m)
+	}
+
+	for name := range modules {
+		visit(name)
+	}
+
+	for _, m := range order {
+		if m.Setup == nil {
+			continue
+		}
+		m.once.Do(func() { m.Setup(r) })
+	}
+}

--- a/internal/router/registry_test.go
+++ b/internal/router/registry_test.go
@@ -1,0 +1,41 @@
+package router
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestInitModulesOnce(t *testing.T) {
+	modules = map[string]*Module{}
+	t.Cleanup(func() { modules = map[string]*Module{} })
+	r := mux.NewRouter()
+	count := 0
+	RegisterModule("a", nil, func(*mux.Router) { count++ })
+
+	InitModules(r)
+	InitModules(r)
+
+	if count != 1 {
+		t.Fatalf("expected setup to run once, got %d", count)
+	}
+}
+
+func TestInitModulesDependencyOrder(t *testing.T) {
+	modules = map[string]*Module{}
+	t.Cleanup(func() { modules = map[string]*Module{} })
+	r := mux.NewRouter()
+	order := []string{}
+
+	RegisterModule("a", nil, func(*mux.Router) { order = append(order, "a") })
+	RegisterModule("b", []string{"a"}, func(*mux.Router) { order = append(order, "b") })
+	RegisterModule("c", []string{"b"}, func(*mux.Router) { order = append(order, "c") })
+
+	InitModules(r)
+
+	want := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(order, want) {
+		t.Fatalf("order %+v want %+v", order, want)
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -6,23 +6,9 @@ import (
 
 	"github.com/gorilla/mux"
 
-	adminhandlers "github.com/arran4/goa4web/handlers/admin"
-	auth "github.com/arran4/goa4web/handlers/auth"
-	blogs "github.com/arran4/goa4web/handlers/blogs"
-	bookmarks "github.com/arran4/goa4web/handlers/bookmarks"
-	hcommon "github.com/arran4/goa4web/handlers/common"
-	faq "github.com/arran4/goa4web/handlers/faq"
-	forum "github.com/arran4/goa4web/handlers/forum"
-	imagebbs "github.com/arran4/goa4web/handlers/imagebbs"
-	information "github.com/arran4/goa4web/handlers/information"
-	linker "github.com/arran4/goa4web/handlers/linker"
-	news "github.com/arran4/goa4web/handlers/news"
-	search "github.com/arran4/goa4web/handlers/search"
-	writings "github.com/arran4/goa4web/handlers/writings"
-
 	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
-	userhandlers "github.com/arran4/goa4web/handlers/user"
+	hcommon "github.com/arran4/goa4web/handlers/common"
 	"github.com/arran4/goa4web/internal/permissions"
 	handlers "github.com/arran4/goa4web/pkg/handlers"
 )
@@ -31,19 +17,7 @@ import (
 func RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/main.css", handlers.MainCSS).Methods("GET")
 
-	news.RegisterRoutes(r)
-	faq.RegisterRoutes(r)
-	blogs.RegisterRoutes(r)
-	forum.RegisterRoutes(r)
-	linker.RegisterRoutes(r)
-	bookmarks.RegisterRoutes(r)
-	imagebbs.RegisterRoutes(r)
-	search.RegisterRoutes(r)
-	writings.RegisterRoutes(r)
-	information.RegisterRoutes(r)
-	userhandlers.RegisterRoutes(r)
-	auth.RegisterRoutes(r)
-	registerAdminRoutes(r)
+	InitModules(r)
 
 	// legacy redirects
 	r.PathPrefix("/writing").HandlerFunc(handlers.RedirectPermanentPrefix("/writing", "/writings"))
@@ -70,10 +44,4 @@ func RoleCheckerMiddleware(roles ...string) func(http.Handler) http.Handler {
 // AdminCheckerMiddleware ensures the requester has administrator rights.
 func AdminCheckerMiddleware(next http.Handler) http.Handler {
 	return RoleCheckerMiddleware("administrator")(next)
-}
-
-func registerAdminRoutes(r *mux.Router) {
-	ar := r.PathPrefix("/admin").Subrouter()
-	ar.Use(AdminCheckerMiddleware)
-	adminhandlers.RegisterRoutes(ar)
 }


### PR DESCRIPTION
## Summary
- add `cmd/goa4web/modules.go` to register router modules
- expose `Register` functions in each handler instead of using `init`
- keep router initialization through `InitModules`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b709f5b48832fb214c2ccc7592cf6