### PR TITLE
Handle [/code] closing for spoiler markup

### DIFF
--- a/a4code2html/a4code2html.go
+++ b/a4code2html/a4code2html.go
@@ -129,10 +129,11 @@ func (c *A4code2html) getNext(endAtEqual bool) string {
 	return result.String()
 }
 
-func (c *A4code2html) directOutput(terminator string) {
-	lensomething := len(terminator)
-	var last string
-
+func (c *A4code2html) directOutput(terminators ...string) {
+	lens := make([]int, len(terminators))
+	for i, t := range terminators {
+		lens[i] = len(t)
+	}
 	for len(c.input) > 0 {
 		ch := c.input[0]
 		c.input = c.input[1:]
@@ -146,11 +147,12 @@ func (c *A4code2html) directOutput(terminator string) {
 			c.output.WriteString(c.Escape(ch))
 		default:
 			c.output.WriteByte(ch)
-			if i := len(c.output.Bytes()) - lensomething; i >= 0 {
-				last = c.output.String()[i:]
-				if strings.EqualFold(terminator, last) {
-					c.output.Truncate(i)
-					return
+			for idx, term := range terminators {
+				if i := len(c.output.Bytes()) - lens[idx]; i >= 0 {
+					if strings.EqualFold(term, c.output.String()[i:]) {
+						c.output.Truncate(i)
+						return
+					}
 				}
 			}
 		}
@@ -230,7 +232,7 @@ func (a *A4code2html) acomm() int {
 		case CTTagStrip, CTWordsOnly:
 		default:
 			a.output.WriteString("<table width=90% align=center bgcolor=lightblue><tr><th>Code: <tr><td><pre>")
-			a.directOutput("code]")
+			a.directOutput("[/code]", "code]")
 			a.output.WriteString("</pre></table>")
 		}
 	case "quoteof":

--- a/a4code2html/a4code2html_test.go
+++ b/a4code2html/a4code2html_test.go
@@ -171,3 +171,13 @@ func TestSpoiler(t *testing.T) {
 		t.Errorf("got %q want %q", got, want)
 	}
 }
+
+func TestCodeSlashClose(t *testing.T) {
+	c := NewA4Code2HTML()
+	c.input = "[code]foo[/code]"
+	c.Process()
+	want := "<table width=90% align=center bgcolor=lightblue><tr><th>Code: <tr><td><pre>foo</pre></table>"
+	if got := c.Output(); got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- update directOutput to handle multiple terminators
- allow `[code]` blocks to end using `[/code]`
- add regression test for `[code]...[/code]`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b853e88e0832fb463420d02e7baa1