### PR TITLE
Fix field mismatch in article edit template

### DIFF
--- a/core/templates/templates/writings/articleEditPage.gohtml
+++ b/core/templates/templates/writings/articleEditPage.gohtml
@@ -6,7 +6,7 @@
         {{ csrfField }}
             Title:<br><input name="title" value="{{ .Writing.Title.String }}"><br>
             Abstract:<br><textarea name="abstract" cols="60" rows="10">{{ .Writing.Abstract.String }}</textarea><br>
-            Writing:<br><textarea name="body" cols="60" rows="30">{{ .Writing.Writing.String }}</textarea><br>
+            Writing:<br><textarea name="body" cols="60" rows="30">{{ .Writing.Writting.String }}</textarea><br>
             Private writing: <input type="checkbox" name="isitprivate" {{ if .Writing.Private.Bool }}checked{{ end }}><br>
             {{ template "languageCombobox" $ }}
             <input type="submit" name="task" value="Update writing">


### PR DESCRIPTION
## Summary
- fix `articleEditPage.gohtml` to reference `Writting` field

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686b88d93b60832fa4c20600893546ee