### PR TITLE
Add spoiler CSS

### DIFF
--- a/a4code2html/a4code2html.go
+++ b/a4code2html/a4code2html.go
@@ -266,7 +266,7 @@ func (a *A4code2html) acomm() int {
 		case CTTableOfContents:
 		case CTTagStrip, CTWordsOnly:
 		default:
-			a.output.WriteString("<span onmouseover=\"this.style.color='#FFFFFF';\" onmouseout=\"this.style.color='#000000';\" style=\"color:#000000;background:#000000;\">")
+			a.output.WriteString("<span class=\"spoiler\">")
 			a.stack = append(a.stack, "</span>")
 		}
 	case "indent":
@@ -540,7 +540,7 @@ func (a *A4code2html) acommReader(r *bufio.Reader, w io.Writer) error {
 		switch a.CodeType {
 		case CTTableOfContents, CTTagStrip, CTWordsOnly:
 		default:
-			if _, err := io.WriteString(w, "<span onmouseover=\"this.style.color='#FFFFFF';\" onmouseout=\"this.style.color='#000000';\" style=\"color:#000000;background:#000000;\">"); err != nil {
+			if _, err := io.WriteString(w, "<span class=\"spoiler\">"); err != nil {
 				return err
 			}
 			a.stack = append(a.stack, "</span>")

--- a/a4code2html/a4code2html_test.go
+++ b/a4code2html/a4code2html_test.go
@@ -168,7 +168,7 @@ func TestSpoiler(t *testing.T) {
 	c := NewA4Code2HTML()
 	c.input = "[Spoiler secret]"
 	c.Process()
-	want := "<span onmouseover=\"this.style.color='#FFFFFF';\" onmouseout=\"this.style.color='#000000';\" style=\"color:#000000;background:#000000;\">secret</span>"
+	want := "<span class=\"spoiler\">secret</span>"
 	if got := c.Output(); got != want {
 		t.Errorf("got %q want %q", got, want)
 	}

--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -106,3 +106,12 @@ div.title {
         margin-bottom: 0.5em;
         background-color: #FFF6E0;
 }
+
+/* spoiler text hidden until hovered */
+.spoiler {
+        color: #000000;
+        background-color: #000000;
+}
+.spoiler:hover {
+        color: #FFFFFF;
+}

--- a/core/templates/spoiler_css_test.go
+++ b/core/templates/spoiler_css_test.go
@@ -1,0 +1,11 @@
+package templates
+
+import "strings"
+import "testing"
+
+func TestSpoilerCSS(t *testing.T) {
+	css := string(GetMainCSSData())
+	if !strings.Contains(css, ".spoiler:hover") {
+		t.Errorf("spoiler CSS rule missing")
+	}
+}

--- a/runtimeconfig/config.go
+++ b/runtimeconfig/config.go
@@ -240,7 +240,7 @@ func normalizeRuntimeConfig(cfg *RuntimeConfig) {
 	}
 	if cfg.EmailSMTPAuth == "" {
 		cfg.EmailSMTPAuth = "plain"
-  }
+	}
 	if cfg.EmailWorkerInterval == 0 {
 		cfg.EmailWorkerInterval = 60
 	}


### PR DESCRIPTION
## Summary
- add `.spoiler` style to main.css and update runtimeconfig formatting
- add unit test ensuring the spoiler rule is embedded

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b91e8f898832fbbbdaa2aa44388b2