### PR TITLE
Add FAQ CLI with tree and read commands

### DIFF
--- a/cmd/goa4web/blog.go
+++ b/cmd/goa4web/blog.go
@@ -42,6 +42,18 @@ func (c *blogCmd) Run() error {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
+	case "read":
+		cmd, err := parseBlogReadCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("read: %w", err)
+		}
+		return cmd.Run()
+	case "comments":
+		cmd, err := parseBlogCommentsCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("comments: %w", err)
+		}
+		return cmd.Run()
 	case "update":
 		cmd, err := parseBlogUpdateCmd(c, c.args[1:])
 		if err != nil {
@@ -66,11 +78,15 @@ func (c *blogCmd) Usage() {
 	fmt.Fprintln(w, "\nCommands:")
 	fmt.Fprintln(w, "  create\tcreate a blog entry")
 	fmt.Fprintln(w, "  list\tlist blog entries")
+	fmt.Fprintln(w, "  read\tread a blog entry")
+	fmt.Fprintln(w, "  comments\tmanage blog comments")
 	fmt.Fprintln(w, "  update\tupdate a blog entry")
 	fmt.Fprintln(w, "  deactivate\tdeactivate a blog entry")
 	fmt.Fprintln(w, "\nExamples:")
 	fmt.Fprintf(w, "  %s blog create -user 1 -lang 1 -text 'hi'\n", c.rootCmd.fs.Name())
 	fmt.Fprintf(w, "  %s blog list -user 1\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s blog read 1\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s blog comments list 1\n", c.rootCmd.fs.Name())
 	fmt.Fprintf(w, "  %s blog update -id 1 -text 'changed'\n", c.rootCmd.fs.Name())
 	fmt.Fprintf(w, "  %s blog deactivate -id 1\n\n", c.rootCmd.fs.Name())
 	c.fs.PrintDefaults()

--- a/cmd/goa4web/blog_comments.go
+++ b/cmd/goa4web/blog_comments.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+// blogCommentsCmd handles "blog comments".
+type blogCommentsCmd struct {
+	*blogCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseBlogCommentsCmd(parent *blogCmd, args []string) (*blogCommentsCmd, error) {
+	c := &blogCommentsCmd{blogCmd: parent}
+	fs := flag.NewFlagSet("comments", flag.ContinueOnError)
+	c.fs = fs
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *blogCommentsCmd) Run() error {
+	if len(c.args) == 0 {
+		c.fs.Usage()
+		return fmt.Errorf("missing comments command")
+	}
+	switch c.args[0] {
+	case "list":
+		cmd, err := parseBlogCommentsListCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("list: %w", err)
+		}
+		return cmd.Run()
+	case "read":
+		cmd, err := parseBlogCommentsReadCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("read: %w", err)
+		}
+		return cmd.Run()
+	default:
+		c.fs.Usage()
+		return fmt.Errorf("unknown comments command %q", c.args[0])
+	}
+}
+
+func (c *blogCommentsCmd) Usage() {
+	w := c.fs.Output()
+	fmt.Fprintf(w, "Usage:\n  %s blog comments <command> [<args>]\n", c.rootCmd.fs.Name())
+	fmt.Fprintln(w, "\nCommands:")
+	fmt.Fprintln(w, "  list\tlist comments for a blog")
+	fmt.Fprintln(w, "  read\tread a comment or all comments")
+	fmt.Fprintln(w, "\nExamples:")
+	fmt.Fprintf(w, "  %s blog comments list 3\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s blog comments read 3 1\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s blog comments read 3 all\n", c.rootCmd.fs.Name())
+	c.fs.PrintDefaults()
+}

--- a/cmd/goa4web/blog_comments_list.go
+++ b/cmd/goa4web/blog_comments_list.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strconv"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// blogCommentsListCmd implements "blog comments list".
+type blogCommentsListCmd struct {
+	*blogCommentsCmd
+	fs   *flag.FlagSet
+	ID   int
+	args []string
+}
+
+func parseBlogCommentsListCmd(parent *blogCommentsCmd, args []string) (*blogCommentsListCmd, error) {
+	c := &blogCommentsListCmd{blogCommentsCmd: parent}
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	fs.IntVar(&c.ID, "id", 0, "blog id")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	if c.ID == 0 && len(c.args) > 0 {
+		if id, err := strconv.Atoi(c.args[0]); err == nil {
+			c.ID = id
+			c.args = c.args[1:]
+		}
+	}
+	return c, nil
+}
+
+func (c *blogCommentsListCmd) Run() error {
+	if c.ID == 0 {
+		return fmt.Errorf("id required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	b, err := queries.GetBlogEntryForUserById(ctx, int32(c.ID))
+	if err != nil {
+		return fmt.Errorf("get blog: %w", err)
+	}
+	rows, err := queries.GetCommentsByThreadIdForUser(ctx, dbpkg.GetCommentsByThreadIdForUserParams{UsersIdusers: 0, ForumthreadIdforumthread: b.ForumthreadIdforumthread})
+	if err != nil {
+		return fmt.Errorf("list comments: %w", err)
+	}
+	for _, cm := range rows {
+		fmt.Printf("%d\t%s\n", cm.Idcomments, cm.Text.String)
+	}
+	return nil
+}

--- a/cmd/goa4web/blog_comments_read.go
+++ b/cmd/goa4web/blog_comments_read.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strconv"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// blogCommentsReadCmd implements "blog comments read".
+type blogCommentsReadCmd struct {
+	*blogCommentsCmd
+	fs        *flag.FlagSet
+	BlogID    int
+	CommentID int
+	All       bool
+	args      []string
+}
+
+func parseBlogCommentsReadCmd(parent *blogCommentsCmd, args []string) (*blogCommentsReadCmd, error) {
+	c := &blogCommentsReadCmd{blogCommentsCmd: parent}
+	fs := flag.NewFlagSet("read", flag.ContinueOnError)
+	fs.IntVar(&c.BlogID, "id", 0, "blog id")
+	fs.IntVar(&c.CommentID, "comment", 0, "comment id")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	if c.BlogID == 0 && len(c.args) > 0 {
+		if id, err := strconv.Atoi(c.args[0]); err == nil {
+			c.BlogID = id
+			c.args = c.args[1:]
+		}
+	}
+	if len(c.args) > 0 {
+		if c.args[0] == "all" {
+			c.All = true
+			c.args = c.args[1:]
+		} else if id, err := strconv.Atoi(c.args[0]); err == nil {
+			c.CommentID = id
+			c.args = c.args[1:]
+		}
+	}
+	return c, nil
+}
+
+func (c *blogCommentsReadCmd) Run() error {
+	if c.BlogID == 0 {
+		return fmt.Errorf("blog id required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	b, err := queries.GetBlogEntryForUserById(ctx, int32(c.BlogID))
+	if err != nil {
+		return fmt.Errorf("get blog: %w", err)
+	}
+	if c.All {
+		rows, err := queries.GetCommentsByThreadIdForUser(ctx, dbpkg.GetCommentsByThreadIdForUserParams{UsersIdusers: 0, ForumthreadIdforumthread: b.ForumthreadIdforumthread})
+		if err != nil {
+			return fmt.Errorf("get comments: %w", err)
+		}
+		for _, cm := range rows {
+			fmt.Printf("%d\t%s\n", cm.Idcomments, cm.Text.String)
+		}
+		return nil
+	}
+	if c.CommentID == 0 {
+		return fmt.Errorf("comment id required")
+	}
+	cm, err := queries.GetCommentByIdForUser(ctx, dbpkg.GetCommentByIdForUserParams{UsersIdusers: 0, Idcomments: int32(c.CommentID)})
+	if err != nil {
+		return fmt.Errorf("get comment: %w", err)
+	}
+	fmt.Printf("%d\t%s\n", cm.Idcomments, cm.Text.String)
+	return nil
+}

--- a/cmd/goa4web/blog_read.go
+++ b/cmd/goa4web/blog_read.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strconv"
+	"time"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// blogReadCmd implements "blog read".
+type blogReadCmd struct {
+	*blogCmd
+	fs   *flag.FlagSet
+	ID   int
+	args []string
+}
+
+func parseBlogReadCmd(parent *blogCmd, args []string) (*blogReadCmd, error) {
+	c := &blogReadCmd{blogCmd: parent}
+	fs := flag.NewFlagSet("read", flag.ContinueOnError)
+	fs.IntVar(&c.ID, "id", 0, "blog id")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	if c.ID == 0 && len(c.args) > 0 {
+		if id, err := strconv.Atoi(c.args[0]); err == nil {
+			c.ID = id
+			c.args = c.args[1:]
+		}
+	}
+	return c, nil
+}
+
+func (c *blogReadCmd) Run() error {
+	if c.ID == 0 {
+		return fmt.Errorf("id required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	row, err := queries.GetBlogEntryForUserById(ctx, int32(c.ID))
+	if err != nil {
+		return fmt.Errorf("get blog: %w", err)
+	}
+	fmt.Printf("Written: %s\n", row.Written.Format(time.RFC3339))
+	fmt.Println(row.Blog.String)
+	return nil
+}

--- a/cmd/goa4web/faq.go
+++ b/cmd/goa4web/faq.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+// faqCmd handles FAQ management subcommands.
+type faqCmd struct {
+	*rootCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseFaqCmd(parent *rootCmd, args []string) (*faqCmd, error) {
+	c := &faqCmd{rootCmd: parent}
+	fs := flag.NewFlagSet("faq", flag.ContinueOnError)
+	c.fs = fs
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *faqCmd) Run() error {
+	if len(c.args) == 0 {
+		c.fs.Usage()
+		return fmt.Errorf("missing faq command")
+	}
+	switch c.args[0] {
+	case "tree":
+		cmd, err := parseFaqTreeCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("tree: %w", err)
+		}
+		return cmd.Run()
+	case "read":
+		cmd, err := parseFaqReadCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("read: %w", err)
+		}
+		return cmd.Run()
+	default:
+		c.fs.Usage()
+		return fmt.Errorf("unknown faq command %q", c.args[0])
+	}
+}
+
+func (c *faqCmd) Usage() {
+	w := c.fs.Output()
+	fmt.Fprintf(w, "Usage:\n  %s faq <command> [<args>]\n", c.rootCmd.fs.Name())
+	fmt.Fprintln(w, "\nCommands:")
+	fmt.Fprintln(w, "  tree\tshow FAQ categories and questions")
+	fmt.Fprintln(w, "  read\tread a FAQ question")
+	fmt.Fprintln(w, "\nExamples:")
+	fmt.Fprintf(w, "  %s faq tree\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s faq read 1\n", c.rootCmd.fs.Name())
+	c.fs.PrintDefaults()
+}

--- a/cmd/goa4web/faq_read.go
+++ b/cmd/goa4web/faq_read.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strconv"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// faqReadCmd implements "faq read".
+type faqReadCmd struct {
+	*faqCmd
+	fs   *flag.FlagSet
+	ID   int
+	args []string
+}
+
+func parseFaqReadCmd(parent *faqCmd, args []string) (*faqReadCmd, error) {
+	c := &faqReadCmd{faqCmd: parent}
+	fs := flag.NewFlagSet("read", flag.ContinueOnError)
+	fs.IntVar(&c.ID, "id", 0, "faq id")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	if c.ID == 0 && len(c.args) > 0 {
+		if id, err := strconv.Atoi(c.args[0]); err == nil {
+			c.ID = id
+			c.args = c.args[1:]
+		}
+	}
+	return c, nil
+}
+
+func (c *faqReadCmd) Run() error {
+	if c.ID == 0 {
+		return fmt.Errorf("id required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	rows, err := queries.GetAllFAQQuestions(ctx)
+	if err != nil {
+		return fmt.Errorf("get faq: %w", err)
+	}
+	for _, q := range rows {
+		if int(q.Idfaq) == c.ID {
+			fmt.Printf("Q: %s\n", q.Question.String)
+			fmt.Printf("A: %s\n", q.Answer.String)
+			return nil
+		}
+	}
+	return fmt.Errorf("faq not found")
+}

--- a/cmd/goa4web/faq_tree.go
+++ b/cmd/goa4web/faq_tree.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// faqTreeCmd implements "faq tree".
+type faqTreeCmd struct {
+	*faqCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseFaqTreeCmd(parent *faqCmd, args []string) (*faqTreeCmd, error) {
+	c := &faqTreeCmd{faqCmd: parent}
+	fs := flag.NewFlagSet("tree", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *faqTreeCmd) Run() error {
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	rows, err := queries.GetAllAnsweredFAQWithFAQCategories(ctx)
+	if err != nil {
+		return fmt.Errorf("tree: %w", err)
+	}
+	var lastCat int32 = -1
+	for _, r := range rows {
+		if r.Idfaqcategories.Valid && r.Idfaqcategories.Int32 != lastCat {
+			fmt.Printf("%d\t%s\n", r.Idfaqcategories.Int32, r.Name.String)
+			lastCat = r.Idfaqcategories.Int32
+		}
+		fmt.Printf("  %d\t%s\n", r.Idfaq, r.Question.String)
+	}
+	return nil
+}

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -135,10 +135,28 @@ func (r *rootCmd) Run() error {
 			return fmt.Errorf("board: %w", err)
 		}
 		return c.Run()
-	case "blog":
+	case "blog", "blogs":
 		c, err := parseBlogCmd(r, r.args[1:])
 		if err != nil {
 			return fmt.Errorf("blog: %w", err)
+		}
+		return c.Run()
+	case "writing", "writings":
+		c, err := parseWritingCmd(r, r.args[1:])
+		if err != nil {
+			return fmt.Errorf("writing: %w", err)
+		}
+		return c.Run()
+	case "news":
+		c, err := parseNewsCmd(r, r.args[1:])
+		if err != nil {
+			return fmt.Errorf("news: %w", err)
+		}
+		return c.Run()
+	case "faq":
+		c, err := parseFaqCmd(r, r.args[1:])
+		if err != nil {
+			return fmt.Errorf("faq: %w", err)
 		}
 		return c.Run()
 	case "ipban":
@@ -192,8 +210,15 @@ func (r *rootCmd) Usage() {
 	fmt.Fprintf(w, "  %s config reload\n\n", r.fs.Name())
 	fmt.Fprintln(w, "  board\tmanage image boards")
 	fmt.Fprintln(w, "  blog\tmanage blog entries")
+	fmt.Fprintln(w, "  news\tmanage news posts")
+	fmt.Fprintln(w, "  faq\tmanage frequently asked questions")
+	fmt.Fprintln(w, "  writing\tmanage writings")
 	fmt.Fprintln(w, "\nExamples:")
 	fmt.Fprintf(w, "  %s board list\n", r.fs.Name())
+	fmt.Fprintf(w, "  %s blog read 1\n", r.fs.Name())
+	fmt.Fprintf(w, "  %s news list\n", r.fs.Name())
+	fmt.Fprintf(w, "  %s writing tree\n", r.fs.Name())
+	fmt.Fprintf(w, "  %s faq tree\n", r.fs.Name())
 	fmt.Fprintln(w, "  ipban\tmanage IP bans")
 	fmt.Fprintf(w, "  %s ipban list\n\n", r.fs.Name())
 	fmt.Fprintln(w, "  audit\tshow recent audit log entries")

--- a/cmd/goa4web/news.go
+++ b/cmd/goa4web/news.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+// newsCmd handles news management subcommands.
+type newsCmd struct {
+	*rootCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseNewsCmd(parent *rootCmd, args []string) (*newsCmd, error) {
+	c := &newsCmd{rootCmd: parent}
+	fs := flag.NewFlagSet("news", flag.ContinueOnError)
+	c.fs = fs
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *newsCmd) Run() error {
+	if len(c.args) == 0 {
+		c.fs.Usage()
+		return fmt.Errorf("missing news command")
+	}
+	switch c.args[0] {
+	case "list":
+		cmd, err := parseNewsListCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("list: %w", err)
+		}
+		return cmd.Run()
+	case "read":
+		cmd, err := parseNewsReadCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("read: %w", err)
+		}
+		return cmd.Run()
+	case "comments":
+		cmd, err := parseNewsCommentsCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("comments: %w", err)
+		}
+		return cmd.Run()
+	default:
+		c.fs.Usage()
+		return fmt.Errorf("unknown news command %q", c.args[0])
+	}
+}
+
+// Usage prints command usage information with examples.
+func (c *newsCmd) Usage() {
+	w := c.fs.Output()
+	fmt.Fprintf(w, "Usage:\n  %s news <command> [<args>]\n", c.rootCmd.fs.Name())
+	fmt.Fprintln(w, "\nCommands:")
+	fmt.Fprintln(w, "  list\tlist news posts")
+	fmt.Fprintln(w, "  read\tread a news post")
+	fmt.Fprintln(w, "  comments\tmanage news comments")
+	fmt.Fprintln(w, "\nExamples:")
+	fmt.Fprintf(w, "  %s news list\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s news read 1\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s news comments list 1\n", c.rootCmd.fs.Name())
+	c.fs.PrintDefaults()
+}

--- a/cmd/goa4web/news_comments.go
+++ b/cmd/goa4web/news_comments.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+// newsCommentsCmd handles "news comments".
+type newsCommentsCmd struct {
+	*newsCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseNewsCommentsCmd(parent *newsCmd, args []string) (*newsCommentsCmd, error) {
+	c := &newsCommentsCmd{newsCmd: parent}
+	fs := flag.NewFlagSet("comments", flag.ContinueOnError)
+	c.fs = fs
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *newsCommentsCmd) Run() error {
+	if len(c.args) == 0 {
+		c.fs.Usage()
+		return fmt.Errorf("missing comments command")
+	}
+	switch c.args[0] {
+	case "list":
+		cmd, err := parseNewsCommentsListCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("list: %w", err)
+		}
+		return cmd.Run()
+	case "read":
+		cmd, err := parseNewsCommentsReadCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("read: %w", err)
+		}
+		return cmd.Run()
+	default:
+		c.fs.Usage()
+		return fmt.Errorf("unknown comments command %q", c.args[0])
+	}
+}
+
+func (c *newsCommentsCmd) Usage() {
+	w := c.fs.Output()
+	fmt.Fprintf(w, "Usage:\n  %s news comments <command> [<args>]\n", c.rootCmd.fs.Name())
+	fmt.Fprintln(w, "\nCommands:")
+	fmt.Fprintln(w, "  list\tlist comments for a news post")
+	fmt.Fprintln(w, "  read\tread a comment or all comments")
+	fmt.Fprintln(w, "\nExamples:")
+	fmt.Fprintf(w, "  %s news comments list 3\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s news comments read 3 1\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s news comments read 3 all\n", c.rootCmd.fs.Name())
+	c.fs.PrintDefaults()
+}

--- a/cmd/goa4web/news_comments_list.go
+++ b/cmd/goa4web/news_comments_list.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strconv"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// newsCommentsListCmd implements "news comments list".
+type newsCommentsListCmd struct {
+	*newsCommentsCmd
+	fs   *flag.FlagSet
+	ID   int
+	args []string
+}
+
+func parseNewsCommentsListCmd(parent *newsCommentsCmd, args []string) (*newsCommentsListCmd, error) {
+	c := &newsCommentsListCmd{newsCommentsCmd: parent}
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	fs.IntVar(&c.ID, "id", 0, "news id")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	if c.ID == 0 && len(c.args) > 0 {
+		if id, err := strconv.Atoi(c.args[0]); err == nil {
+			c.ID = id
+			c.args = c.args[1:]
+		}
+	}
+	return c, nil
+}
+
+func (c *newsCommentsListCmd) Run() error {
+	if c.ID == 0 {
+		return fmt.Errorf("id required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	n, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx, int32(c.ID))
+	if err != nil {
+		return fmt.Errorf("get news: %w", err)
+	}
+	rows, err := queries.GetCommentsByThreadIdForUser(ctx, dbpkg.GetCommentsByThreadIdForUserParams{UsersIdusers: 0, ForumthreadIdforumthread: n.ForumthreadIdforumthread})
+	if err != nil {
+		return fmt.Errorf("list comments: %w", err)
+	}
+	for _, cm := range rows {
+		fmt.Printf("%d\t%s\n", cm.Idcomments, cm.Text.String)
+	}
+	return nil
+}

--- a/cmd/goa4web/news_comments_read.go
+++ b/cmd/goa4web/news_comments_read.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strconv"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// newsCommentsReadCmd implements "news comments read".
+type newsCommentsReadCmd struct {
+	*newsCommentsCmd
+	fs        *flag.FlagSet
+	NewsID    int
+	CommentID int
+	All       bool
+	args      []string
+}
+
+func parseNewsCommentsReadCmd(parent *newsCommentsCmd, args []string) (*newsCommentsReadCmd, error) {
+	c := &newsCommentsReadCmd{newsCommentsCmd: parent}
+	fs := flag.NewFlagSet("read", flag.ContinueOnError)
+	fs.IntVar(&c.NewsID, "id", 0, "news id")
+	fs.IntVar(&c.CommentID, "comment", 0, "comment id")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	if c.NewsID == 0 && len(c.args) > 0 {
+		if id, err := strconv.Atoi(c.args[0]); err == nil {
+			c.NewsID = id
+			c.args = c.args[1:]
+		}
+	}
+	if len(c.args) > 0 {
+		if c.args[0] == "all" {
+			c.All = true
+			c.args = c.args[1:]
+		} else if id, err := strconv.Atoi(c.args[0]); err == nil {
+			c.CommentID = id
+			c.args = c.args[1:]
+		}
+	}
+	return c, nil
+}
+
+func (c *newsCommentsReadCmd) Run() error {
+	if c.NewsID == 0 {
+		return fmt.Errorf("news id required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	n, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx, int32(c.NewsID))
+	if err != nil {
+		return fmt.Errorf("get news: %w", err)
+	}
+	if c.All {
+		rows, err := queries.GetCommentsByThreadIdForUser(ctx, dbpkg.GetCommentsByThreadIdForUserParams{UsersIdusers: 0, ForumthreadIdforumthread: n.ForumthreadIdforumthread})
+		if err != nil {
+			return fmt.Errorf("get comments: %w", err)
+		}
+		for _, cm := range rows {
+			fmt.Printf("%d\t%s\n", cm.Idcomments, cm.Text.String)
+		}
+		return nil
+	}
+	if c.CommentID == 0 {
+		return fmt.Errorf("comment id required")
+	}
+	cm, err := queries.GetCommentByIdForUser(ctx, dbpkg.GetCommentByIdForUserParams{UsersIdusers: 0, Idcomments: int32(c.CommentID)})
+	if err != nil {
+		return fmt.Errorf("get comment: %w", err)
+	}
+	fmt.Printf("%d\t%s\n", cm.Idcomments, cm.Text.String)
+	return nil
+}

--- a/cmd/goa4web/news_list.go
+++ b/cmd/goa4web/news_list.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// newsListCmd implements "news list".
+type newsListCmd struct {
+	*newsCmd
+	fs     *flag.FlagSet
+	Limit  int
+	Offset int
+	args   []string
+}
+
+func parseNewsListCmd(parent *newsCmd, args []string) (*newsListCmd, error) {
+	c := &newsListCmd{newsCmd: parent}
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	fs.IntVar(&c.Limit, "limit", 10, "limit")
+	fs.IntVar(&c.Offset, "offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *newsListCmd) Run() error {
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	rows, err := queries.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(ctx, dbpkg.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams{
+		Limit:  int32(c.Limit),
+		Offset: int32(c.Offset),
+	})
+	if err != nil {
+		return fmt.Errorf("list news: %w", err)
+	}
+	for _, n := range rows {
+		fmt.Printf("%d\t%s\n", n.Idsitenews, n.News.String)
+	}
+	return nil
+}

--- a/cmd/goa4web/news_read.go
+++ b/cmd/goa4web/news_read.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strconv"
+	"time"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// newsReadCmd implements "news read".
+type newsReadCmd struct {
+	*newsCmd
+	fs   *flag.FlagSet
+	ID   int
+	args []string
+}
+
+func parseNewsReadCmd(parent *newsCmd, args []string) (*newsReadCmd, error) {
+	c := &newsReadCmd{newsCmd: parent}
+	fs := flag.NewFlagSet("read", flag.ContinueOnError)
+	fs.IntVar(&c.ID, "id", 0, "news id")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	if c.ID == 0 && len(c.args) > 0 {
+		if id, err := strconv.Atoi(c.args[0]); err == nil {
+			c.ID = id
+			c.args = c.args[1:]
+		}
+	}
+	return c, nil
+}
+
+func (c *newsReadCmd) Run() error {
+	if c.ID == 0 {
+		return fmt.Errorf("id required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	row, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx, int32(c.ID))
+	if err != nil {
+		return fmt.Errorf("get news: %w", err)
+	}
+	if row.Occured.Valid {
+		fmt.Printf("Posted: %s\n", row.Occured.Time.Format(time.RFC3339))
+	}
+	fmt.Println(row.News.String)
+	return nil
+}

--- a/cmd/goa4web/writing.go
+++ b/cmd/goa4web/writing.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+// writingCmd handles writing management subcommands.
+type writingCmd struct {
+	*rootCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseWritingCmd(parent *rootCmd, args []string) (*writingCmd, error) {
+	c := &writingCmd{rootCmd: parent}
+	fs := flag.NewFlagSet("writing", flag.ContinueOnError)
+	c.fs = fs
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *writingCmd) Run() error {
+	if len(c.args) == 0 {
+		c.fs.Usage()
+		return fmt.Errorf("missing writing command")
+	}
+	switch c.args[0] {
+	case "tree":
+		cmd, err := parseWritingTreeCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("tree: %w", err)
+		}
+		return cmd.Run()
+	case "list":
+		cmd, err := parseWritingListCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("list: %w", err)
+		}
+		return cmd.Run()
+	case "read":
+		cmd, err := parseWritingReadCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("read: %w", err)
+		}
+		return cmd.Run()
+	case "comments":
+		cmd, err := parseWritingCommentsCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("comments: %w", err)
+		}
+		return cmd.Run()
+	default:
+		c.fs.Usage()
+		return fmt.Errorf("unknown writing command %q", c.args[0])
+	}
+}
+
+// Usage prints command usage information with examples.
+func (c *writingCmd) Usage() {
+	w := c.fs.Output()
+	fmt.Fprintf(w, "Usage:\n  %s writing <command> [<args>]\n", c.rootCmd.fs.Name())
+	fmt.Fprintln(w, "\nCommands:")
+	fmt.Fprintln(w, "  tree\tshow writing categories")
+	fmt.Fprintln(w, "  list\tlist writings")
+	fmt.Fprintln(w, "  read\tread a writing")
+	fmt.Fprintln(w, "  comments\tmanage comments for a writing")
+	fmt.Fprintln(w, "\nExamples:")
+	fmt.Fprintf(w, "  %s writing tree\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s writing list\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s writing read 1\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s writing comments list 1\n", c.rootCmd.fs.Name())
+	c.fs.PrintDefaults()
+}

--- a/cmd/goa4web/writing_comments.go
+++ b/cmd/goa4web/writing_comments.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+// writingCommentsCmd handles "writing comments".
+type writingCommentsCmd struct {
+	*writingCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseWritingCommentsCmd(parent *writingCmd, args []string) (*writingCommentsCmd, error) {
+	c := &writingCommentsCmd{writingCmd: parent}
+	fs := flag.NewFlagSet("comments", flag.ContinueOnError)
+	c.fs = fs
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *writingCommentsCmd) Run() error {
+	if len(c.args) == 0 {
+		c.fs.Usage()
+		return fmt.Errorf("missing comments command")
+	}
+	switch c.args[0] {
+	case "list":
+		cmd, err := parseWritingCommentsListCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("list: %w", err)
+		}
+		return cmd.Run()
+	case "read":
+		cmd, err := parseWritingCommentsReadCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("read: %w", err)
+		}
+		return cmd.Run()
+	default:
+		c.fs.Usage()
+		return fmt.Errorf("unknown comments command %q", c.args[0])
+	}
+}
+
+func (c *writingCommentsCmd) Usage() {
+	w := c.fs.Output()
+	fmt.Fprintf(w, "Usage:\n  %s writing comments <command> [<args>]\n", c.rootCmd.fs.Name())
+	fmt.Fprintln(w, "\nCommands:")
+	fmt.Fprintln(w, "  list\tlist comments for a writing")
+	fmt.Fprintln(w, "  read\tread a comment or all comments")
+	fmt.Fprintln(w, "\nExamples:")
+	fmt.Fprintf(w, "  %s writing comments list 3\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s writing comments read 3 1\n", c.rootCmd.fs.Name())
+	fmt.Fprintf(w, "  %s writing comments read 3 all\n", c.rootCmd.fs.Name())
+	c.fs.PrintDefaults()
+}

--- a/cmd/goa4web/writing_comments_list.go
+++ b/cmd/goa4web/writing_comments_list.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strconv"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// writingCommentsListCmd implements "writing comments list".
+type writingCommentsListCmd struct {
+	*writingCommentsCmd
+	fs   *flag.FlagSet
+	ID   int
+	args []string
+}
+
+func parseWritingCommentsListCmd(parent *writingCommentsCmd, args []string) (*writingCommentsListCmd, error) {
+	c := &writingCommentsListCmd{writingCommentsCmd: parent}
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	fs.IntVar(&c.ID, "id", 0, "writing id")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	if c.ID == 0 && len(c.args) > 0 {
+		if id, err := strconv.Atoi(c.args[0]); err == nil {
+			c.ID = id
+			c.args = c.args[1:]
+		}
+	}
+	return c, nil
+}
+
+func (c *writingCommentsListCmd) Run() error {
+	if c.ID == 0 {
+		return fmt.Errorf("id required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	w, err := queries.GetWritingByIdForUserDescendingByPublishedDate(ctx, dbpkg.GetWritingByIdForUserDescendingByPublishedDateParams{Userid: 0, Idwriting: int32(c.ID)})
+	if err != nil {
+		return fmt.Errorf("get writing: %w", err)
+	}
+	rows, err := queries.GetCommentsByThreadIdForUser(ctx, dbpkg.GetCommentsByThreadIdForUserParams{UsersIdusers: 0, ForumthreadIdforumthread: w.ForumthreadIdforumthread})
+	if err != nil {
+		return fmt.Errorf("list comments: %w", err)
+	}
+	for _, cm := range rows {
+		fmt.Printf("%d\t%s\n", cm.Idcomments, cm.Text.String)
+	}
+	return nil
+}

--- a/cmd/goa4web/writing_comments_read.go
+++ b/cmd/goa4web/writing_comments_read.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strconv"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// writingCommentsReadCmd implements "writing comments read".
+type writingCommentsReadCmd struct {
+	*writingCommentsCmd
+	fs        *flag.FlagSet
+	WritingID int
+	CommentID int
+	All       bool
+	args      []string
+}
+
+func parseWritingCommentsReadCmd(parent *writingCommentsCmd, args []string) (*writingCommentsReadCmd, error) {
+	c := &writingCommentsReadCmd{writingCommentsCmd: parent}
+	fs := flag.NewFlagSet("read", flag.ContinueOnError)
+	fs.IntVar(&c.WritingID, "id", 0, "writing id")
+	fs.IntVar(&c.CommentID, "comment", 0, "comment id")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	if c.WritingID == 0 && len(c.args) > 0 {
+		if id, err := strconv.Atoi(c.args[0]); err == nil {
+			c.WritingID = id
+			c.args = c.args[1:]
+		}
+	}
+	if len(c.args) > 0 {
+		if c.args[0] == "all" {
+			c.All = true
+			c.args = c.args[1:]
+		} else if id, err := strconv.Atoi(c.args[0]); err == nil {
+			c.CommentID = id
+			c.args = c.args[1:]
+		}
+	}
+	return c, nil
+}
+
+func (c *writingCommentsReadCmd) Run() error {
+	if c.WritingID == 0 {
+		return fmt.Errorf("writing id required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	w, err := queries.GetWritingByIdForUserDescendingByPublishedDate(ctx, dbpkg.GetWritingByIdForUserDescendingByPublishedDateParams{Userid: 0, Idwriting: int32(c.WritingID)})
+	if err != nil {
+		return fmt.Errorf("get writing: %w", err)
+	}
+	if c.All {
+		rows, err := queries.GetCommentsByThreadIdForUser(ctx, dbpkg.GetCommentsByThreadIdForUserParams{UsersIdusers: 0, ForumthreadIdforumthread: w.ForumthreadIdforumthread})
+		if err != nil {
+			return fmt.Errorf("get comments: %w", err)
+		}
+		for _, cm := range rows {
+			fmt.Printf("%d\t%s\n", cm.Idcomments, cm.Text.String)
+		}
+		return nil
+	}
+	if c.CommentID == 0 {
+		return fmt.Errorf("comment id required")
+	}
+	cm, err := queries.GetCommentByIdForUser(ctx, dbpkg.GetCommentByIdForUserParams{UsersIdusers: 0, Idcomments: int32(c.CommentID)})
+	if err != nil {
+		return fmt.Errorf("get comment: %w", err)
+	}
+	fmt.Printf("%d\t%s\n", cm.Idcomments, cm.Text.String)
+	return nil
+}

--- a/cmd/goa4web/writing_list.go
+++ b/cmd/goa4web/writing_list.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// writingListCmd implements "writing list".
+type writingListCmd struct {
+	*writingCmd
+	fs       *flag.FlagSet
+	UserID   int
+	Category int
+	Limit    int
+	Offset   int
+	args     []string
+}
+
+func parseWritingListCmd(parent *writingCmd, args []string) (*writingListCmd, error) {
+	c := &writingListCmd{writingCmd: parent}
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	fs.IntVar(&c.UserID, "user", 0, "user id")
+	fs.IntVar(&c.Category, "category", 0, "category id")
+	fs.IntVar(&c.Limit, "limit", 10, "limit")
+	fs.IntVar(&c.Offset, "offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *writingListCmd) Run() error {
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	if c.UserID != 0 {
+		rows, err := queries.GetPublicWritingsByUser(ctx, dbpkg.GetPublicWritingsByUserParams{
+			UsersIdusers: int32(c.UserID),
+			Limit:        int32(c.Limit),
+			Offset:       int32(c.Offset),
+		})
+		if err != nil {
+			return fmt.Errorf("list writings: %w", err)
+		}
+		for _, w := range rows {
+			fmt.Printf("%d\t%s\n", w.Idwriting, w.Title.String)
+		}
+		return nil
+	}
+	if c.Category != 0 {
+		rows, err := queries.GetPublicWritingsInCategory(ctx, dbpkg.GetPublicWritingsInCategoryParams{
+			WritingcategoryIdwritingcategory: int32(c.Category),
+			Limit:                            int32(c.Limit),
+			Offset:                           int32(c.Offset),
+		})
+		if err != nil {
+			return fmt.Errorf("list writings: %w", err)
+		}
+		for _, w := range rows {
+			fmt.Printf("%d\t%s\n", w.Idwriting, w.Title.String)
+		}
+		return nil
+	}
+	rows, err := queries.GetPublicWritings(ctx, dbpkg.GetPublicWritingsParams{
+		Limit:  int32(c.Limit),
+		Offset: int32(c.Offset),
+	})
+	if err != nil {
+		return fmt.Errorf("list writings: %w", err)
+	}
+	for _, w := range rows {
+		fmt.Printf("%d\t%s\n", w.Idwriting, w.Title.String)
+	}
+	return nil
+}

--- a/cmd/goa4web/writing_read.go
+++ b/cmd/goa4web/writing_read.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strconv"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// writingReadCmd implements "writing read".
+type writingReadCmd struct {
+	*writingCmd
+	fs   *flag.FlagSet
+	ID   int
+	args []string
+}
+
+func parseWritingReadCmd(parent *writingCmd, args []string) (*writingReadCmd, error) {
+	c := &writingReadCmd{writingCmd: parent}
+	fs := flag.NewFlagSet("read", flag.ContinueOnError)
+	fs.IntVar(&c.ID, "id", 0, "writing id")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	if c.ID == 0 && len(c.args) > 0 {
+		if id, err := strconv.Atoi(c.args[0]); err == nil {
+			c.ID = id
+			c.args = c.args[1:]
+		}
+	}
+	return c, nil
+}
+
+func (c *writingReadCmd) Run() error {
+	if c.ID == 0 {
+		return fmt.Errorf("id required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	row, err := queries.GetWritingByIdForUserDescendingByPublishedDate(ctx, dbpkg.GetWritingByIdForUserDescendingByPublishedDateParams{
+		Userid:    0,
+		Idwriting: int32(c.ID),
+	})
+	if err != nil {
+		return fmt.Errorf("get writing: %w", err)
+	}
+	fmt.Printf("Title: %s\n", row.Title.String)
+	fmt.Println(row.Writting.String)
+	return nil
+}

--- a/cmd/goa4web/writing_tree.go
+++ b/cmd/goa4web/writing_tree.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// writingTreeCmd implements "writing tree".
+type writingTreeCmd struct {
+	*writingCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseWritingTreeCmd(parent *writingCmd, args []string) (*writingTreeCmd, error) {
+	c := &writingTreeCmd{writingCmd: parent}
+	fs := flag.NewFlagSet("tree", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *writingTreeCmd) Run() error {
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	rows, err := queries.FetchAllCategories(ctx)
+	if err != nil {
+		return fmt.Errorf("tree: %w", err)
+	}
+	children := map[int32][]*dbpkg.Writingcategory{}
+	for _, cat := range rows {
+		parent := cat.WritingcategoryIdwritingcategory
+		children[parent] = append(children[parent], cat)
+	}
+	var printTree func(parent int32, prefix string)
+	printTree = func(parent int32, prefix string) {
+		for _, cat := range children[parent] {
+			fmt.Printf("%s%d\t%s\n", prefix, cat.Idwritingcategory, cat.Title.String)
+			printTree(cat.Idwritingcategory, prefix+"  ")
+		}
+	}
+	printTree(0, "")
+	return nil
+}


### PR DESCRIPTION
## Summary
- implement `faq` command with tree and read subcommands
- wire faq command into root CLI usage and command switch
- add `writing tree` command to display category hierarchy

## Testing
- `go mod tidy`
- `go fmt ./cmd/goa4web/...`
- `go vet ./cmd/goa4web/...`
- `golangci-lint run` *(failed: process timed out)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b91757cc8832fb6ee55785e17b8dc