### PR TITLE
Add admin emails configuration flag

### DIFF
--- a/cmd/goa4web/config_as.go
+++ b/cmd/goa4web/config_as.go
@@ -90,7 +90,6 @@ func envMapFromConfig(cfg runtimeconfig.RuntimeConfig, cfgPath string) (map[stri
 	m[config.EnvNotificationsEnabled] = boolVal(fileVals[config.EnvNotificationsEnabled], os.Getenv(config.EnvNotificationsEnabled), true)
 	m[config.EnvCSRFEnabled] = boolVal(fileVals[config.EnvCSRFEnabled], os.Getenv(config.EnvCSRFEnabled), true)
 	m[config.EnvAdminNotify] = boolVal(fileVals[config.EnvAdminNotify], os.Getenv(config.EnvAdminNotify), true)
-	m[config.EnvAdminEmails] = first(fileVals[config.EnvAdminEmails], os.Getenv(config.EnvAdminEmails))
 	m[config.EnvSessionSecret] = first("", os.Getenv(config.EnvSessionSecret))
 	sessionFile := first(fileVals[config.EnvSessionSecretFile], os.Getenv(config.EnvSessionSecretFile))
 	if sessionFile == "" {

--- a/internal/emailutil/email.go
+++ b/internal/emailutil/email.go
@@ -134,16 +134,13 @@ func NotifyChange(ctx context.Context, provider email.Provider, emailAddr, page,
 // loadEmailConfigFile reads EMAIL_* style configuration values from a simple
 // key=value file. Missing files return an empty configuration.
 
-// getAdminEmails returns a slice of administrator email addresses. If the
-// ADMIN_EMAILS environment variable is set, it takes precedence and is
-// interpreted as a comma-separated list. If not set and a Queries value is
-// provided, the database is queried for administrator accounts.
-// GetAdminEmails returns a slice of administrator email addresses. If the
-// ADMIN_EMAILS environment variable is set, it takes precedence and is
-// interpreted as a comma-separated list. If not set and a Queries value is
-// provided, the database is queried for administrator accounts.
+// getAdminEmails returns a slice of administrator email addresses. The
+// configuration option ADMIN_EMAILS may provide a comma-separated list. When
+// empty and a Queries value is supplied, the database is queried for
+// administrator accounts. GetAdminEmails returns a slice of administrator
+// addresses using this logic.
 func GetAdminEmails(ctx context.Context, q *db.Queries) []string {
-	env := os.Getenv(config.EnvAdminEmails)
+	env := runtimeconfig.AppRuntimeConfig.AdminEmails
 	var emails []string
 	if env != "" {
 		for _, e := range strings.Split(env, ",") {

--- a/readme.md
+++ b/readme.md
@@ -253,7 +253,7 @@ environment variables listed below.
 | `GOA4WEB_DOCKER` | n/a | No | - | Set when running inside Docker to adjust defaults. |
 | `SENDGRID_KEY` | `--sendgrid-key` | No | - | API key for the SendGrid email provider. |
 | `EMAIL_WORKER_INTERVAL` | `--email-worker-interval` | No | `60` | Interval in seconds between email worker runs. |
-| `ADMIN_EMAILS` | n/a | No | - | Comma-separated list of administrator email addresses. |
+| `ADMIN_EMAILS` | `--admin-emails` | No | - | Comma-separated list of administrator email addresses. |
 | `ADMIN_NOTIFY` | n/a | No | `true` | Toggles sending administrator notification emails. |
 | `IMAGE_UPLOAD_DIR` | `--image-upload-dir` | No | `uploads/images` | Directory where uploaded images are stored. |
 | `IMAGE_MAX_BYTES` | `--image-max-bytes` | No | `5242880` | Maximum allowed size of uploaded images. |

--- a/runtimeconfig/config.go
+++ b/runtimeconfig/config.go
@@ -39,6 +39,10 @@ type RuntimeConfig struct {
 	EmailJMAPPass     string
 	EmailSendGridKey  string
 
+	// AdminEmails holds a comma-separated list of administrator email
+	// addresses.
+	AdminEmails string
+
 	// EmailWorkerInterval sets how often the email worker runs in seconds.
 	EmailWorkerInterval int
 

--- a/runtimeconfig/options.go
+++ b/runtimeconfig/options.go
@@ -46,6 +46,7 @@ var StringOptions = []StringOption{
 	{"image-upload-dir", config.EnvImageUploadDir, "ImageUploadDir", "directory to store uploaded images", "", ""},
 	{"dlq-provider", config.EnvDLQProvider, "DLQProvider", "dead letter queue provider", "", ""},
 	{"dlq-file", config.EnvDLQFile, "DLQFile", "dead letter queue file path", "", ""},
+	{"admin-emails", config.EnvAdminEmails, "AdminEmails", "administrator email addresses", "", ""},
 }
 
 // IntOptions lists the integer runtime options shared by flag parsing and configuration generation.


### PR DESCRIPTION
## Summary
- support `ADMIN_EMAILS` via `--admin-emails` flag
- expose resolved admin emails to helpers
- document the new flag

## Testing
- `go mod tidy`
- `go vet ./...` *(fails: configTestCmd redeclared)*
- `golangci-lint run ./...` *(fails: configTestCmd redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_686bb1befcd0832f827e66cf43cbab86