### PR TITLE
Fix admin permission logic across project

### DIFF
--- a/cmd/goa4web/perm_grant.go
+++ b/cmd/goa4web/perm_grant.go
@@ -48,7 +48,7 @@ func (c *permGrantCmd) Run() error {
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}
-	if c.Section == "administrator" && c.Level == "administrator" {
+	if c.Section == "all" && c.Level == "administrator" {
 		if _, err := queries.GetAdministratorPermissionByUserId(ctx, u.Idusers); err == nil {
 			if c.rootCmd.Verbosity > 0 {
 				fmt.Printf("%s already administrator\n", c.User)

--- a/cmd/goa4web/user_add.go
+++ b/cmd/goa4web/user_add.go
@@ -90,7 +90,7 @@ func createUser(root *rootCmd, username, email, password string, admin bool) err
 			return fmt.Errorf("check admin: %w", err)
 		} else if err := queries.PermissionUserAllow(ctx, dbpkg.PermissionUserAllowParams{
 			UsersIdusers: int32(id),
-			Section:      sql.NullString{String: "administrator", Valid: true},
+			Section:      sql.NullString{String: "all", Valid: true},
 			Level:        sql.NullString{String: "administrator", Valid: true},
 		}); err != nil {
 			return fmt.Errorf("grant admin: %w", err)

--- a/cmd/goa4web/user_make_admin.go
+++ b/cmd/goa4web/user_make_admin.go
@@ -55,7 +55,7 @@ func (c *userMakeAdminCmd) Run() error {
 	}
 	if err := queries.PermissionUserAllow(ctx, dbpkg.PermissionUserAllowParams{
 		UsersIdusers: u.Idusers,
-		Section:      sql.NullString{String: "administrator", Valid: true},
+		Section:      sql.NullString{String: "all", Valid: true},
 		Level:        sql.NullString{String: "administrator", Valid: true},
 	}); err != nil {
 		return fmt.Errorf("grant admin: %w", err)

--- a/cmd/goa4web/user_update.go
+++ b/cmd/goa4web/user_update.go
@@ -68,7 +68,7 @@ func (c *userUpdateCmd) Run() error {
 			return fmt.Errorf("check admin: %w", err)
 		} else if err := queries.PermissionUserAllow(ctx, dbpkg.PermissionUserAllowParams{
 			UsersIdusers: u.Idusers,
-			Section:      sql.NullString{String: "administrator", Valid: true},
+			Section:      sql.NullString{String: "all", Valid: true},
 			Level:        sql.NullString{String: "administrator", Valid: true},
 		}); err != nil {
 			return fmt.Errorf("make admin: %w", err)
@@ -77,7 +77,7 @@ func (c *userUpdateCmd) Run() error {
 	if c.RemoveAdmin {
 		perm, err := queries.GetPermissionsByUserIdAndSectionAndSectionAll(ctx, dbpkg.GetPermissionsByUserIdAndSectionAndSectionAllParams{
 			UsersIdusers: u.Idusers,
-			Section:      sql.NullString{String: "administrator", Valid: true},
+			Section:      sql.NullString{String: "all", Valid: true},
 		})
 		if err == nil && perm != nil {
 			if err := queries.PermissionUserDisallow(ctx, perm.Idpermissions); err != nil {

--- a/internal/db/queries-permissions.sql
+++ b/internal/db/queries-permissions.sql
@@ -42,7 +42,7 @@ WHERE idpermissions = ?;
 -- name: GetAdministratorPermissionByUserId :one
 SELECT *
 FROM permissions
-WHERE users_idusers = ? AND section = 'administrator' AND level = 'administrator';
+WHERE users_idusers = ? AND section = 'all' AND level = 'administrator';
 
 -- name: GetPermissionsByUserIdAndSectionAndSectionAll :one
 SELECT *

--- a/internal/db/queries-permissions.sql.go
+++ b/internal/db/queries-permissions.sql.go
@@ -56,7 +56,7 @@ func (q *Queries) DeleteTopicRestrictionsByForumTopicId(ctx context.Context, for
 const getAdministratorPermissionByUserId = `-- name: GetAdministratorPermissionByUserId :one
 SELECT idpermissions, users_idusers, section, level
 FROM permissions
-WHERE users_idusers = ? AND section = 'administrator' AND level = 'administrator'
+WHERE users_idusers = ? AND section = 'all' AND level = 'administrator'
 `
 
 func (q *Queries) GetAdministratorPermissionByUserId(ctx context.Context, usersIdusers int32) (*Permission, error) {

--- a/internal/db/queries-users.sql.go
+++ b/internal/db/queries-users.sql.go
@@ -106,7 +106,7 @@ const listAdministratorEmails = `-- name: ListAdministratorEmails :many
 SELECT u.email
 FROM users u
 JOIN permissions p ON p.users_idusers = u.idusers
-WHERE p.section = 'administrator'
+WHERE p.section = 'all' and p.level = 'administrator'
 `
 
 func (q *Queries) ListAdministratorEmails(ctx context.Context) ([]sql.NullString, error) {

--- a/internal/db/queries_ext.go
+++ b/internal/db/queries_ext.go
@@ -809,7 +809,7 @@ func (q *Queries) ListUserInfo(ctx context.Context) ([]*UserInfoRow, error) {
                 IF(p.idpermissions IS NULL, 0, 1) AS admin,
                 MIN(s.created_at) AS created_at
                 FROM users u
-                LEFT JOIN permissions p ON p.users_idusers = u.idusers AND p.section = 'administrator'
+               LEFT JOIN permissions p ON p.users_idusers = u.idusers AND p.section = 'all' AND p.level = 'administrator'
                 LEFT JOIN sessions s ON s.users_idusers = u.idusers
                 GROUP BY u.idusers
                 ORDER BY u.idusers`)


### PR DESCRIPTION
## Summary
- update queries to treat administrators as `section='all'` and `level='administrator'`
- adjust CLI admin management commands accordingly
- regenerate sqlc code

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_686bb1cd2794832f8b9b4133e76a917a