### PR TITLE
Protect email provider registry

### DIFF
--- a/internal/email/registry.go
+++ b/internal/email/registry.go
@@ -3,15 +3,21 @@ package email
 import (
 	"log"
 	"strings"
+	"sync"
 
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
-var providerRegistry = map[string]func(runtimeconfig.RuntimeConfig) Provider{}
+var (
+	regMu            sync.RWMutex
+	providerRegistry = map[string]func(runtimeconfig.RuntimeConfig) Provider{}
+)
 
 // RegisterProvider registers a factory for name.
 func RegisterProvider(name string, factory func(runtimeconfig.RuntimeConfig) Provider) {
 	n := strings.ToLower(name)
+	regMu.Lock()
+	defer regMu.Unlock()
 	if _, ok := providerRegistry[n]; ok {
 		log.Printf("email: provider %s already registered", n)
 	}
@@ -20,5 +26,8 @@ func RegisterProvider(name string, factory func(runtimeconfig.RuntimeConfig) Pro
 
 // providerFactory looks up the factory for name.
 func providerFactory(name string) func(runtimeconfig.RuntimeConfig) Provider {
-	return providerRegistry[strings.ToLower(name)]
+	regMu.RLock()
+	f := providerRegistry[strings.ToLower(name)]
+	regMu.RUnlock()
+	return f
 }


### PR DESCRIPTION
## Summary
- add `sync.RWMutex` `regMu` around the email provider registry
- lock reads/writes when registering or looking up providers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: TestNotifyAdminsEnv)*

------
https://chatgpt.com/codex/tasks/task_e_686bc11d94cc832fb9433a9212b03507