### PR TITLE
Improve DLQ provider registry

### DIFF
--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -124,6 +124,9 @@ func (r *recordAdminMail) Send(ctx context.Context, to, subject, textBody, htmlB
 func TestNotifyAdminsEnv(t *testing.T) {
 	os.Setenv(config.EnvAdminEmails, "a@test.com,b@test.com")
 	defer os.Unsetenv(config.EnvAdminEmails)
+	orig := runtimeconfig.AppRuntimeConfig.AdminEmails
+	runtimeconfig.AppRuntimeConfig.AdminEmails = "a@test.com,b@test.com"
+	defer func() { runtimeconfig.AppRuntimeConfig.AdminEmails = orig }()
 	rec := &recordAdminMail{}
 	notifyAdmins(context.Background(), rec, nil, "page")
 	if len(rec.to) != 2 {
@@ -136,6 +139,9 @@ func TestNotifyAdminsDisabled(t *testing.T) {
 	os.Setenv(config.EnvAdminNotify, "false")
 	defer os.Unsetenv(config.EnvAdminEmails)
 	defer os.Unsetenv(config.EnvAdminNotify)
+	orig := runtimeconfig.AppRuntimeConfig.AdminEmails
+	runtimeconfig.AppRuntimeConfig.AdminEmails = "a@test.com"
+	defer func() { runtimeconfig.AppRuntimeConfig.AdminEmails = orig }()
 	rec := &recordAdminMail{}
 	notifyAdmins(context.Background(), rec, nil, "page")
 	if len(rec.to) != 0 {

--- a/internal/dlq/registry.go
+++ b/internal/dlq/registry.go
@@ -1,6 +1,8 @@
 package dlq
 
 import (
+	"log"
+	"strings"
 	"sync"
 
 	dbpkg "github.com/arran4/goa4web/internal/db"
@@ -19,13 +21,17 @@ var (
 func RegisterProvider(name string, factory ProviderFactory) {
 	regMu.Lock()
 	defer regMu.Unlock()
-	providers[name] = factory
+	n := strings.ToLower(name)
+	if _, ok := providers[n]; ok {
+		log.Printf("dlq: provider %s already registered", n)
+	}
+	providers[n] = factory
 }
 
 // lookupProvider retrieves a factory by name.
 func lookupProvider(name string) ProviderFactory {
 	regMu.RLock()
-	f := providers[name]
+	f := providers[strings.ToLower(name)]
 	regMu.RUnlock()
 	return f
 }


### PR DESCRIPTION
## Summary
- normalize provider names on registration and lookups
- warn if a DLQ provider is registered twice
- make admin email tests update runtime configuration

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686bc11b253c832f8531dcef03528e1e