### PR TITLE
Add mock DLQ provider

### DIFF
--- a/internal/dlq/mock/mock.go
+++ b/internal/dlq/mock/mock.go
@@ -1,0 +1,34 @@
+package mock
+
+import (
+	"context"
+	"sync"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/dlq"
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+// Record stores a DLQ message recorded by the Provider.
+type Record struct{ Message string }
+
+// Provider records DLQ messages in memory for testing.
+type Provider struct {
+	mu      sync.Mutex
+	Records []Record
+}
+
+// Record appends the message to the in-memory slice.
+func (p *Provider) Record(_ context.Context, msg string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.Records = append(p.Records, Record{Message: msg})
+	return nil
+}
+
+func providerFromConfig(_ runtimeconfig.RuntimeConfig, _ *dbpkg.Queries) dlq.DLQ {
+	return &Provider{}
+}
+
+// Register registers the mock provider factory.
+func Register() { dlq.RegisterProvider("mock", providerFromConfig) }

--- a/internal/dlq/mock/mock_test.go
+++ b/internal/dlq/mock/mock_test.go
@@ -1,0 +1,19 @@
+package mock
+
+import (
+	"context"
+	"testing"
+)
+
+func TestProvider(t *testing.T) {
+	p := &Provider{}
+	if err := p.Record(context.Background(), "msg"); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if len(p.Records) != 1 {
+		t.Fatalf("records len=%d", len(p.Records))
+	}
+	if p.Records[0].Message != "msg" {
+		t.Fatalf("unexpected message: %q", p.Records[0].Message)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a memory-backed DLQ provider under `internal/dlq/mock`
- unit test the new provider

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686bc2b9eb20832f947b60a7f664cc63