### PR TITLE
Move sections registry to navigation package

### DIFF
--- a/handlers/admin/adminHandler.go
+++ b/handlers/admin/adminHandler.go
@@ -6,7 +6,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/sections"
+	nav "github.com/arran4/goa4web/internal/navigation"
 	"log"
 	"net/http"
 
@@ -32,7 +32,7 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 
 	data := Data{
 		CoreData:   r.Context().Value(common.KeyCoreData).(*CoreData),
-		AdminLinks: sections.AdminLinks(),
+		AdminLinks: nav.AdminLinks(),
 	}
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	ctx := r.Context()

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -12,22 +12,22 @@ import (
 	search "github.com/arran4/goa4web/handlers/search"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
 	writings "github.com/arran4/goa4web/handlers/writings"
+	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
-	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterRoutes attaches the admin endpoints to ar. The router is expected to
 // already have any required authentication middleware applied.
 func RegisterRoutes(ar *mux.Router) {
-	sections.RegisterAdminControlCenter("Categories", "/admin/categories", 20)
-	sections.RegisterAdminControlCenter("Notifications", "/admin/notifications", 90)
-	sections.RegisterAdminControlCenter("Permission Sections", "/admin/permissions/sections", 100)
-	sections.RegisterAdminControlCenter("Queued Emails", "/admin/email/queue", 110)
-	sections.RegisterAdminControlCenter("Email Template", "/admin/email/template", 120)
-	sections.RegisterAdminControlCenter("Dead Letter Queue", "/admin/dlq", 130)
-	sections.RegisterAdminControlCenter("Server Stats", "/admin/stats", 140)
-	sections.RegisterAdminControlCenter("Site Settings", "/admin/settings", 150)
-	sections.RegisterAdminControlCenter("Usage Stats", "/admin/usage", 160)
+	nav.RegisterAdminControlCenter("Categories", "/admin/categories", 20)
+	nav.RegisterAdminControlCenter("Notifications", "/admin/notifications", 90)
+	nav.RegisterAdminControlCenter("Permission Sections", "/admin/permissions/sections", 100)
+	nav.RegisterAdminControlCenter("Queued Emails", "/admin/email/queue", 110)
+	nav.RegisterAdminControlCenter("Email Template", "/admin/email/template", 120)
+	nav.RegisterAdminControlCenter("Dead Letter Queue", "/admin/dlq", 130)
+	nav.RegisterAdminControlCenter("Server Stats", "/admin/stats", 140)
+	nav.RegisterAdminControlCenter("Site Settings", "/admin/settings", 150)
+	nav.RegisterAdminControlCenter("Usage Stats", "/admin/usage", 160)
 
 	ar.HandleFunc("", AdminPage).Methods("GET")
 	ar.HandleFunc("/", AdminPage).Methods("GET")

--- a/handlers/blogs/routes.go
+++ b/handlers/blogs/routes.go
@@ -9,13 +9,13 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 
-	"github.com/arran4/goa4web/internal/sections"
+	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 // RegisterRoutes attaches the public blog endpoints to r.
 func RegisterRoutes(r *mux.Router) {
-	sections.RegisterIndexLink("Blogs", "/blogs", SectionWeight)
-	sections.RegisterAdminControlCenter("Blogs", "/admin/blogs/user/permissions", SectionWeight)
+	nav.RegisterIndexLink("Blogs", "/blogs", SectionWeight)
+	nav.RegisterAdminControlCenter("Blogs", "/admin/blogs/user/permissions", SectionWeight)
 	br := r.PathPrefix("/blogs").Subrouter()
 	br.HandleFunc("/rss", RssPage).Methods("GET")
 	br.HandleFunc("/atom", AtomPage).Methods("GET")

--- a/handlers/bookmarks/routes.go
+++ b/handlers/bookmarks/routes.go
@@ -7,12 +7,12 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 
-	"github.com/arran4/goa4web/internal/sections"
+	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 // RegisterRoutes attaches the bookmarks endpoints to r.
 func RegisterRoutes(r *mux.Router) {
-	sections.RegisterIndexLink("Bookmarks", "/bookmarks", SectionWeight)
+	nav.RegisterIndexLink("Bookmarks", "/bookmarks", SectionWeight)
 	br := r.PathPrefix("/bookmarks").Subrouter()
 	br.HandleFunc("", Page).Methods("GET")
 	br.HandleFunc("/mine", MinePage).Methods("GET").MatcherFunc(auth.RequiresAnAccount())

--- a/handlers/faq/routes.go
+++ b/handlers/faq/routes.go
@@ -4,8 +4,8 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
+	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
-	"github.com/arran4/goa4web/internal/sections"
 )
 
 // Task constants mirror the values used by the main package.
@@ -42,8 +42,8 @@ func noTask() mux.MatcherFunc {
 
 // RegisterRoutes attaches the public FAQ endpoints to the router.
 func RegisterRoutes(r *mux.Router) {
-	sections.RegisterIndexLink("FAQ", "/faq", SectionWeight)
-	sections.RegisterAdminControlCenter("FAQ", "/admin/faq/categories", SectionWeight)
+	nav.RegisterIndexLink("FAQ", "/faq", SectionWeight)
+	nav.RegisterAdminControlCenter("FAQ", "/admin/faq/categories", SectionWeight)
 	faqr := r.PathPrefix("/faq").Subrouter()
 	faqr.HandleFunc("", Page).Methods("GET", "POST")
 	faqr.HandleFunc("/ask", AskPage).Methods("GET")

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -8,13 +8,13 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 
-	"github.com/arran4/goa4web/internal/sections"
+	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 // RegisterRoutes attaches the public forum endpoints to r.
 func RegisterRoutes(r *mux.Router) {
-	sections.RegisterIndexLink("Forum", "/forum", SectionWeight)
-	sections.RegisterAdminControlCenter("Forum", "/admin/forum", SectionWeight)
+	nav.RegisterIndexLink("Forum", "/forum", SectionWeight)
+	nav.RegisterAdminControlCenter("Forum", "/admin/forum", SectionWeight)
 	fr := r.PathPrefix("/forum").Subrouter()
 	fr.HandleFunc("/topic/{topic}.rss", TopicRssPage).Methods("GET")
 	fr.HandleFunc("/topic/{topic}.atom", TopicAtomPage).Methods("GET")

--- a/handlers/imagebbs/routes.go
+++ b/handlers/imagebbs/routes.go
@@ -10,13 +10,13 @@ import (
 	router "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/runtimeconfig"
 
-	"github.com/arran4/goa4web/internal/sections"
+	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 // RegisterRoutes attaches the public image board endpoints to r.
 func RegisterRoutes(r *mux.Router) {
-	sections.RegisterIndexLink("ImageBBS", "/imagebbs", SectionWeight)
-	sections.RegisterAdminControlCenter("ImageBBS", "/admin/imagebbs", SectionWeight)
+	nav.RegisterIndexLink("ImageBBS", "/imagebbs", SectionWeight)
+	nav.RegisterAdminControlCenter("ImageBBS", "/admin/imagebbs", SectionWeight)
 	r.HandleFunc("/imagebbs.rss", RssPage).Methods("GET")
 	ibr := r.PathPrefix("/imagebbs").Subrouter()
 	ibr.PathPrefix("/images/").Handler(http.StripPrefix("/imagebbs/images/", http.FileServer(http.Dir(runtimeconfig.AppRuntimeConfig.ImageUploadDir))))

--- a/handlers/information/routes.go
+++ b/handlers/information/routes.go
@@ -3,13 +3,13 @@ package information
 import (
 	"github.com/gorilla/mux"
 
+	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
-	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterRoutes attaches the information endpoints to r.
 func RegisterRoutes(r *mux.Router) {
-	sections.RegisterIndexLink("Information", "/information", SectionWeight)
+	nav.RegisterIndexLink("Information", "/information", SectionWeight)
 	ir := r.PathPrefix("/information").Subrouter()
 	ir.HandleFunc("", Page).Methods("GET")
 }

--- a/handlers/languages/routes.go
+++ b/handlers/languages/routes.go
@@ -4,13 +4,13 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/handlers/common"
+	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
-	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterAdminRoutes attaches the admin language endpoints to the router.
 func RegisterAdminRoutes(ar *mux.Router) {
-	sections.RegisterAdminControlCenter("Languages", "/admin/languages", SectionWeight)
+	nav.RegisterAdminControlCenter("Languages", "/admin/languages", SectionWeight)
 	ar.HandleFunc("/languages", adminLanguagesPage).Methods("GET")
 	ar.HandleFunc("/language", adminLanguageRedirect).Methods("GET")
 	ar.HandleFunc("/languages", adminLanguagesRenamePage).Methods("POST").MatcherFunc(common.TaskMatcher("Rename Language"))

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -4,14 +4,14 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 
+	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
-	"github.com/arran4/goa4web/internal/sections"
 )
 
 // RegisterRoutes attaches the public linker endpoints to r.
 func RegisterRoutes(r *mux.Router) {
-	sections.RegisterIndexLink("Linker", "/linker", SectionWeight)
-	sections.RegisterAdminControlCenter("Linker", "/admin/linker/categories", SectionWeight)
+	nav.RegisterIndexLink("Linker", "/linker", SectionWeight)
+	nav.RegisterAdminControlCenter("Linker", "/admin/linker/categories", SectionWeight)
 	lr := r.PathPrefix("/linker").Subrouter()
 	lr.HandleFunc("/rss", RssPage).Methods("GET")
 	lr.HandleFunc("/atom", AtomPage).Methods("GET")

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -12,7 +12,7 @@ import (
 
 	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
-	"github.com/arran4/goa4web/internal/sections"
+	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 func runTemplate(tmpl string) func(http.ResponseWriter, *http.Request) {
@@ -47,8 +47,8 @@ func AddNewsIndex(handler http.Handler) http.Handler {
 
 // RegisterRoutes attaches the public news endpoints to r.
 func RegisterRoutes(r *mux.Router) {
-	sections.RegisterIndexLink("News", "/", SectionWeight)
-	sections.RegisterAdminControlCenter("News", "/admin/news/users/levels", SectionWeight)
+	nav.RegisterIndexLink("News", "/", SectionWeight)
+	nav.RegisterAdminControlCenter("News", "/admin/news/users/levels", SectionWeight)
 	r.Handle("/", AddNewsIndex(http.HandlerFunc(runTemplate("newsPage")))).Methods("GET")
 	r.HandleFunc("/", hcommon.TaskDoneAutoRefreshPage).Methods("POST")
 	r.HandleFunc("/news.rss", NewsRssPage).Methods("GET")

--- a/handlers/search/routes.go
+++ b/handlers/search/routes.go
@@ -7,13 +7,13 @@ import (
 	news "github.com/arran4/goa4web/handlers/news"
 	router "github.com/arran4/goa4web/internal/router"
 
-	"github.com/arran4/goa4web/internal/sections"
+	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 // RegisterRoutes attaches the search endpoints to r.
 func RegisterRoutes(r *mux.Router) {
-	sections.RegisterIndexLink("Search", "/search", SectionWeight)
-	sections.RegisterAdminControlCenter("Search", "/admin/search", SectionWeight)
+	nav.RegisterIndexLink("Search", "/search", SectionWeight)
+	nav.RegisterAdminControlCenter("Search", "/admin/search", SectionWeight)
 	sr := r.PathPrefix("/search").Subrouter()
 	sr.HandleFunc("", Page).Methods("GET")
 	sr.HandleFunc("", SearchResultForumActionPage).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskSearchForum))

--- a/handlers/user/routes_admin.go
+++ b/handlers/user/routes_admin.go
@@ -4,13 +4,13 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/handlers/common"
-	"github.com/arran4/goa4web/internal/sections"
+	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 // RegisterAdminRoutes attaches user admin endpoints to the router.
 func RegisterAdminRoutes(ar *mux.Router) {
-	sections.RegisterAdminControlCenter("User Permissions", "/admin/users/permissions", SectionWeight-10)
-	sections.RegisterAdminControlCenter("Users", "/admin/users", SectionWeight)
+	nav.RegisterAdminControlCenter("User Permissions", "/admin/users/permissions", SectionWeight-10)
+	nav.RegisterAdminControlCenter("Users", "/admin/users", SectionWeight)
 	ar.HandleFunc("/users", adminUsersPage).Methods("GET")
 	ar.HandleFunc("/users/export", adminUsersExportPage).Methods("GET")
 	ar.HandleFunc("/sessions", adminSessionsPage).Methods("GET")

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -9,13 +9,13 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 
-	"github.com/arran4/goa4web/internal/sections"
+	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 // RegisterRoutes attaches the public writings endpoints to r.
 func RegisterRoutes(r *mux.Router) {
-	sections.RegisterIndexLink("Writings", "/writings", SectionWeight)
-	sections.RegisterAdminControlCenter("Writings", "/admin/writings/categories", SectionWeight)
+	nav.RegisterIndexLink("Writings", "/writings", SectionWeight)
+	nav.RegisterAdminControlCenter("Writings", "/admin/writings/categories", SectionWeight)
 	wr := r.PathPrefix("/writings").Subrouter()
 	wr.HandleFunc("/rss", RssPage).Methods("GET")
 	wr.HandleFunc("/atom", AtomPage).Methods("GET")

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -14,7 +14,7 @@ import (
 	common "github.com/arran4/goa4web/core/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/sections"
+	nav "github.com/arran4/goa4web/internal/navigation"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -51,7 +51,7 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 			}
 		}
 
-		idx := sections.IndexItems()
+		idx := nav.IndexItems()
 		if uid != 0 {
 			idx = append(idx, common.IndexItem{Name: "Preferences", Link: "/usr"})
 		}

--- a/internal/navigation/registry.go
+++ b/internal/navigation/registry.go
@@ -1,4 +1,4 @@
-package sections
+package navigation
 
 import (
 	"sort"

--- a/internal/navigation/registry_test.go
+++ b/internal/navigation/registry_test.go
@@ -1,4 +1,4 @@
-package sections
+package navigation
 
 import (
 	"testing"

--- a/readme.md
+++ b/readme.md
@@ -89,9 +89,9 @@ requests.
 
 ### Section registration
 
-Site sections register their navigation items with the `sections` package so
-menus can be assembled dynamically. Use `sections.RegisterIndexLink` for public
-links and `sections.RegisterAdminControlCenter` for admin navigation. Each call
+Site sections register their navigation items with the `navigation` package so
+menus can be assembled dynamically. Use `navigation.RegisterIndexLink` for public
+links and `navigation.RegisterAdminControlCenter` for admin navigation. Each call
 accepts a weight value; lower numbers appear first.
 
 Example weights:


### PR DESCRIPTION
## Summary
- rename internal/sections/registry.go to internal/navigation/registry.go
- update all imports to use the new navigation package
- adjust README documentation

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686bc2fbc274832fb4c34dcff83aab9a