### PR TITLE
Fix default registry paths

### DIFF
--- a/cmd/goa4web/dbhandlers/dbdefaults/allstable.go
+++ b/cmd/goa4web/dbhandlers/dbdefaults/allstable.go
@@ -1,4 +1,4 @@
-package allstable
+package dbdefaults
 
 import (
 	"github.com/arran4/goa4web/cmd/goa4web/dbhandlers/mysql"

--- a/cmd/goa4web/dbhandlers/registry_test.go
+++ b/cmd/goa4web/dbhandlers/registry_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/arran4/goa4web/cmd/goa4web/dbhandlers"
-	_ "github.com/arran4/goa4web/cmd/goa4web/dbhandlers/allstable"
+	_ "github.com/arran4/goa4web/cmd/goa4web/dbhandlers/dbdefaults"
 )
 
 func TestDefaultRegistrations(t *testing.T) {

--- a/cmd/goa4web/dbinit.go
+++ b/cmd/goa4web/dbinit.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/arran4/goa4web/internal/dbdrivers/allstable"
+	dbdefaults "github.com/arran4/goa4web/internal/dbdrivers/dbdefaults"
 )
 
 func init() {
-	allstable.Register()
+	dbdefaults.Register()
 }

--- a/cmd/goa4web/emailinit.go
+++ b/cmd/goa4web/emailinit.go
@@ -1,5 +1,5 @@
 package main
 
-import "github.com/arran4/goa4web/internal/email/builtin"
+import emaildefaults "github.com/arran4/goa4web/internal/email/emaildefaults"
 
-func init() { builtin.Register() }
+func init() { emaildefaults.Register() }

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -9,11 +9,11 @@ import (
 	"log"
 	"os"
 
-	_ "github.com/arran4/goa4web/cmd/goa4web/dbhandlers/allstable"
+	_ "github.com/arran4/goa4web/cmd/goa4web/dbhandlers/dbdefaults"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	dbstart "github.com/arran4/goa4web/internal/dbstart"
-	dlqreg "github.com/arran4/goa4web/internal/dlq/register/defaults"
+	dlqreg "github.com/arran4/goa4web/internal/dlq/dlqdefaults"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 

--- a/internal/dbdrivers/dbdefaults/allstable.go
+++ b/internal/dbdrivers/dbdefaults/allstable.go
@@ -1,4 +1,4 @@
-package allstable
+package dbdefaults
 
 import (
 	_ "github.com/arran4/goa4web/internal/dbdrivers/mysql"

--- a/internal/dlq/dlq_test.go
+++ b/internal/dlq/dlq_test.go
@@ -8,14 +8,14 @@ import (
 	dlq "github.com/arran4/goa4web/internal/dlq"
 	dbdlq "github.com/arran4/goa4web/internal/dlq/db"
 	dirdlq "github.com/arran4/goa4web/internal/dlq/dir"
+	dlqdefaults "github.com/arran4/goa4web/internal/dlq/dlqdefaults"
 	emaildlq "github.com/arran4/goa4web/internal/dlq/email"
 	filedlq "github.com/arran4/goa4web/internal/dlq/file"
-	defaults "github.com/arran4/goa4web/internal/dlq/register/defaults"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func TestProviderFromConfigRegistry(t *testing.T) {
-	defaults.Register()
+	dlqdefaults.Register()
 
 	cfg := runtimeconfig.RuntimeConfig{DLQProvider: "file", DLQFile: "p"}
 	if _, ok := dlq.ProviderFromConfig(cfg, nil).(*filedlq.DLQ); !ok {

--- a/internal/dlq/dlqdefaults/defaults.go
+++ b/internal/dlq/dlqdefaults/defaults.go
@@ -1,4 +1,4 @@
-package defaults
+package dlqdefaults
 
 import (
 	"github.com/arran4/goa4web/internal/dlq/db"

--- a/internal/email/emaildefaults/builtin.go
+++ b/internal/email/emaildefaults/builtin.go
@@ -1,4 +1,4 @@
-package builtin
+package emaildefaults
 
 import (
 	"github.com/arran4/goa4web/internal/email/jmap"


### PR DESCRIPTION
## Summary
- rename default registries to more specific names
- update imports and package names accordingly
- keep initialization using these new defaults

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686bc5671ee8832f92aee8efcfbe14ef