### PR TITLE
Fix reply anchor markup

### DIFF
--- a/core/templates/templates/news/postPage.gohtml
+++ b/core/templates/templates/news/postPage.gohtml
@@ -2,7 +2,7 @@
     {{ template "newsPost" $.Post }}
     <hr><font size=4>Replies:</font>
     {{ template "threadComments" $ }}
-    <a id="reply">
+    <a id="reply"></a>
     {{ if or .IsReplyable }}
         <font size=4>Reply:</font>
         <form method="post" action="?#reply">


### PR DESCRIPTION
## Summary
- close the reply anchor in `news/postPage.gohtml`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: Provider does not implement email.Provider)*
- `golangci-lint run ./...` *(fails: Provider does not implement email.Provider)*
- `go test ./...` *(fails: build errors in internal/email/mock)*

------
https://chatgpt.com/codex/tasks/task_e_686bd4365f0c832fbdc5c8bb8a8a6858