### PR TITLE
Show logged in user in header

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -15,12 +15,14 @@ type CoreData struct {
 	IndexItems       []IndexItem
 	CustomIndexItems []IndexItem
 	UserID           int32
-	SecurityLevel    string
-	Title            string
-	AutoRefresh      bool
-	FeedsEnabled     bool
-	RSSFeedUrl       string
-	AtomFeedUrl      string
+	// Username is the currently logged in user.
+	Username      string
+	SecurityLevel string
+	Title         string
+	AutoRefresh   bool
+	FeedsEnabled  bool
+	RSSFeedUrl    string
+	AtomFeedUrl   string
 	// AdminMode indicates whether admin-only UI elements should be displayed.
 	AdminMode         bool
 	NotificationCount int32

--- a/core/templates/templates/header.gohtml
+++ b/core/templates/templates/header.gohtml
@@ -1,5 +1,8 @@
 {{define "header"}}
 <strong>Arran's Site</strong>
+{{ if $.Username }}<br>
+Logged in as {{ $.Username }}
+{{ end }}
 {{ if $.Announcement }}<br>
 <a href="/news/news/{{ $.Announcement.Idsitenews }}"><strong>{{ $.Announcement.News.String }}</strong></a>
 {{ end }}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -63,6 +63,12 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 				idx = append(idx, common.IndexItem{Name: fmt.Sprintf("Notifications (%d)", c), Link: "/usr/notifications"})
 			}
 		}
+		var username string
+		if u, ok := r.Context().Value(hcommon.KeyUser).(*dbpkg.User); ok {
+			if u != nil && u.Username.Valid {
+				username = u.Username.String
+			}
+		}
 		var ann *dbpkg.GetActiveAnnouncementWithNewsRow
 		if queries.DB() != nil {
 			if a, err := queries.GetActiveAnnouncementWithNews(r.Context()); err == nil {
@@ -73,6 +79,7 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 			SecurityLevel:     level,
 			IndexItems:        idx,
 			UserID:            uid,
+			Username:          username,
 			Title:             "Arran's Site",
 			FeedsEnabled:      runtimeconfig.AppRuntimeConfig.FeedsEnabled,
 			AdminMode:         r.URL.Query().Get("mode") == "admin",


### PR DESCRIPTION
## Summary
- add Username field to CoreData
- propagate username from middleware
- show logged in username in the header

## Testing
- `go vet ./...` *(fails: cannot use &Provider{} as email.Provider)*
- `golangci-lint run ./...` *(fails: typecheck errors in internal/email/mock)*
- `go test ./...` *(fails: build errors in internal/email/mock)*

------
https://chatgpt.com/codex/tasks/task_e_686bd6c90208832f8d2573396713b481