### PR TITLE
Enhance news comment notifications

### DIFF
--- a/core/templates/templates/updateEmail.html
+++ b/core/templates/templates/updateEmail.html
@@ -2,10 +2,8 @@
 <html>
 <body>
 <p>Hello,</p>
-<p>{{.Action}} occurred at {{.Path}} on {{.Time}}.</p>
-{{if .URL}}
-<p>View details <a href="{{.URL}}">here</a>.</p>
-{{end}}
+<p>{{.Action}} occurred at <a href="{{.URL}}">{{.URL}}</a> on {{.Time}}.</p>
+{{/* URL always provided now */}}
 <p>If you no longer wish to receive these emails you can update your notification settings.</p>
 <p>Cheers,<br>The A4Web Team</p>
 </body>

--- a/core/templates/templates/updateEmail.txt
+++ b/core/templates/templates/updateEmail.txt
@@ -4,7 +4,7 @@ Subject: [A4] {{.Subject}}
 
 Hello,
 
-{{.Action}} occurred at {{.Path}} on {{.Time}}.
+{{.Action}} occurred at {{.URL}} on {{.Time}}.
 
 {{if .URL}}View details here:
 {{.URL}}

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gorilla/mux"
 
@@ -267,9 +268,21 @@ func NewsPostReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	languageId, _ := strconv.Atoi(r.PostFormValue("language"))
 	uid, _ := session.Values["UID"].(int32)
 
-	endUrl := fmt.Sprintf("/news/news/%d", pid)
+	base := "http://" + r.Host
+	if runtimeconfig.AppRuntimeConfig.HTTPHostname != "" {
+		base = strings.TrimRight(runtimeconfig.AppRuntimeConfig.HTTPHostname, "/")
+	}
+	endUrl := base + fmt.Sprintf("/news/news/%d", pid)
 
 	provider := email.ProviderFromConfig(runtimeconfig.AppRuntimeConfig)
+	var author string
+	if u, err := queries.GetUserById(r.Context(), uid); err == nil {
+		author = u.Username.String
+	}
+	action := "comment"
+	if author != "" {
+		action = fmt.Sprintf("comment by %s", author)
+	}
 
 	if rows, err := queries.ListUsersSubscribedToThread(r.Context(), db.ListUsersSubscribedToThreadParams{
 		ForumthreadIdforumthread: pthid,
@@ -278,7 +291,7 @@ func NewsPostReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Error: listUsersSubscribedToThread: %s", err)
 	} else if provider != nil {
 		for _, row := range rows {
-			if err := emailutil.NotifyChange(r.Context(), provider, row.Username.String, endUrl, "update", nil); err != nil {
+			if err := emailutil.NotifyChange(r.Context(), provider, row.Username.String, endUrl, action, nil); err != nil {
 				log.Printf("Error: notifyChange: %s", err)
 			}
 		}


### PR DESCRIPTION
## Summary
- craft fully qualified URLs when emailing news comment updates
- include commenter name in the email action description
- clarify update email templates

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: Provider does not implement email.Provider)*
- `golangci-lint run ./...` *(fails: typecheck errors in mock provider)*

------
https://chatgpt.com/codex/tasks/task_e_686bd606623c832fbda813d8e87a77f9