### PR TITLE
Remove html_body column

### DIFF
--- a/cmd/goa4web/email_queue_resend.go
+++ b/cmd/goa4web/email_queue_resend.go
@@ -45,7 +45,7 @@ func (c *emailQueueResendCmd) Run() error {
 	}
 	provider := email.ProviderFromConfig(c.rootCmd.cfg)
 	if provider != nil {
-		msg, err := email.BuildMessage(c.rootCmd.cfg.EmailFrom, e.ToEmail, e.Subject, e.Body, e.HtmlBody.String)
+		msg, err := email.BuildMessage(c.rootCmd.cfg.EmailFrom, e.ToEmail, e.Subject, e.Body, "")
 		if err != nil {
 			return fmt.Errorf("build message: %w", err)
 		}

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -50,7 +50,7 @@ func AdminEmailQueueResendActionPage(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		if provider != nil {
-			msg, err := email.BuildMessage(runtimeconfig.AppRuntimeConfig.EmailFrom, e.ToEmail, e.Subject, e.Body, e.HtmlBody.String)
+			msg, err := email.BuildMessage(runtimeconfig.AppRuntimeConfig.EmailFrom, e.ToEmail, e.Subject, e.Body, "")
 			if err != nil {
 				log.Printf("build message: %v", err)
 				continue

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -87,8 +87,8 @@ func TestListUnsentPendingEmails(t *testing.T) {
 	}
 	defer sqldb.Close()
 	q := db.New(sqldb)
-	rows := sqlmock.NewRows([]string{"id", "to_email", "subject", "body", "html_body", "error_count", "created_at"}).AddRow(1, "a@test", "s", "b", "h", 0, time.Now())
-	mock.ExpectQuery("SELECT id, to_email, subject, body, html_body, error_count, created_at FROM pending_emails WHERE sent_at IS NULL ORDER BY id").WillReturnRows(rows)
+	rows := sqlmock.NewRows([]string{"id", "to_email", "subject", "body", "error_count", "created_at"}).AddRow(1, "a@test", "s", "b", 0, time.Now())
+	mock.ExpectQuery("SELECT id, to_email, subject, body, error_count, created_at FROM pending_emails WHERE sent_at IS NULL ORDER BY id").WillReturnRows(rows)
 	if _, err := q.ListUnsentPendingEmails(context.Background()); err != nil {
 		t.Fatalf("list: %v", err)
 	}

--- a/handlers/common/constants.go
+++ b/handlers/common/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 15
+	ExpectedSchemaVersion = 16
 )

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -281,7 +281,6 @@ type PendingEmail struct {
 	ToEmail    string
 	Subject    string
 	Body       string
-	HtmlBody   sql.NullString
 	ErrorCount int32
 	CreatedAt  time.Time
 	SentAt     sql.NullTime

--- a/internal/db/queries_ext.go
+++ b/internal/db/queries_ext.go
@@ -108,20 +108,19 @@ func (q *Queries) UpdatePreference(ctx context.Context, arg UpdatePreferencePara
 
 // InsertPendingEmail adds an email to the sending queue.
 type InsertPendingEmailParams struct {
-	ToEmail  string
-	Subject  string
-	Body     string
-	HtmlBody string
+	ToEmail string
+	Subject string
+	Body    string
 }
 
 func (q *Queries) InsertPendingEmail(ctx context.Context, arg InsertPendingEmailParams) error {
-	_, err := q.db.ExecContext(ctx, "INSERT INTO pending_emails (to_email, subject, body, html_body) VALUES (?, ?, ?, ?)", arg.ToEmail, arg.Subject, arg.Body, arg.HtmlBody)
+	_, err := q.db.ExecContext(ctx, "INSERT INTO pending_emails (to_email, subject, body) VALUES (?, ?, ?)", arg.ToEmail, arg.Subject, arg.Body)
 	return err
 }
 
 // FetchPendingEmails returns unsent queued emails up to the provided limit.
 func (q *Queries) FetchPendingEmails(ctx context.Context, limit int32) ([]*PendingEmail, error) {
-	rows, err := q.db.QueryContext(ctx, "SELECT id, to_email, subject, body, html_body, error_count FROM pending_emails WHERE sent_at IS NULL ORDER BY id LIMIT ?", limit)
+	rows, err := q.db.QueryContext(ctx, "SELECT id, to_email, subject, body, error_count FROM pending_emails WHERE sent_at IS NULL ORDER BY id LIMIT ?", limit)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +128,7 @@ func (q *Queries) FetchPendingEmails(ctx context.Context, limit int32) ([]*Pendi
 	var items []*PendingEmail
 	for rows.Next() {
 		var p PendingEmail
-		if err := rows.Scan(&p.ID, &p.ToEmail, &p.Subject, &p.Body, &p.HtmlBody, &p.ErrorCount); err != nil {
+		if err := rows.Scan(&p.ID, &p.ToEmail, &p.Subject, &p.Body, &p.ErrorCount); err != nil {
 			return nil, err
 		}
 		items = append(items, &p)
@@ -145,7 +144,7 @@ func (q *Queries) MarkEmailSent(ctx context.Context, id int32) error {
 
 // ListUnsentPendingEmails returns all queued emails that have not been sent yet.
 func (q *Queries) ListUnsentPendingEmails(ctx context.Context) ([]*PendingEmail, error) {
-	rows, err := q.db.QueryContext(ctx, "SELECT id, to_email, subject, body, html_body, error_count, created_at FROM pending_emails WHERE sent_at IS NULL ORDER BY id")
+	rows, err := q.db.QueryContext(ctx, "SELECT id, to_email, subject, body, error_count, created_at FROM pending_emails WHERE sent_at IS NULL ORDER BY id")
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +152,7 @@ func (q *Queries) ListUnsentPendingEmails(ctx context.Context) ([]*PendingEmail,
 	var items []*PendingEmail
 	for rows.Next() {
 		var p PendingEmail
-		if err := rows.Scan(&p.ID, &p.ToEmail, &p.Subject, &p.Body, &p.HtmlBody, &p.ErrorCount, &p.CreatedAt); err != nil {
+		if err := rows.Scan(&p.ID, &p.ToEmail, &p.Subject, &p.Body, &p.ErrorCount, &p.CreatedAt); err != nil {
 			return nil, err
 		}
 		items = append(items, &p)
@@ -163,9 +162,9 @@ func (q *Queries) ListUnsentPendingEmails(ctx context.Context) ([]*PendingEmail,
 
 // GetPendingEmailByID returns a single pending email.
 func (q *Queries) GetPendingEmailByID(ctx context.Context, id int32) (*PendingEmail, error) {
-	row := q.db.QueryRowContext(ctx, "SELECT id, to_email, subject, body, html_body, error_count FROM pending_emails WHERE id = ?", id)
+	row := q.db.QueryRowContext(ctx, "SELECT id, to_email, subject, body, error_count FROM pending_emails WHERE id = ?", id)
 	var p PendingEmail
-	err := row.Scan(&p.ID, &p.ToEmail, &p.Subject, &p.Body, &p.HtmlBody, &p.ErrorCount)
+	err := row.Scan(&p.ID, &p.ToEmail, &p.Subject, &p.Body, &p.ErrorCount)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/email/mock/mock.go
+++ b/internal/email/mock/mock.go
@@ -12,8 +12,7 @@ import (
 type SentMail struct {
 	To      string
 	Subject string
-	Text    string
-	HTML    string
+	Raw     []byte
 }
 
 // Provider collects sent messages in memory for testing.
@@ -23,10 +22,10 @@ type Provider struct {
 }
 
 // Send appends the message to the Provider's Messages slice.
-func (p *Provider) Send(_ context.Context, to, subject, textBody, htmlBody string) error {
+func (p *Provider) Send(_ context.Context, to, subject string, rawEmailMessage []byte) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.Messages = append(p.Messages, SentMail{To: to, Subject: subject, Text: textBody, HTML: htmlBody})
+	p.Messages = append(p.Messages, SentMail{To: to, Subject: subject, Raw: rawEmailMessage})
 	return nil
 }
 

--- a/internal/email/mock/mock_test.go
+++ b/internal/email/mock/mock_test.go
@@ -7,14 +7,14 @@ import (
 
 func TestProvider(t *testing.T) {
 	p := &Provider{}
-	if err := p.Send(context.Background(), "to", "sub", "body", "html"); err != nil {
+	if err := p.Send(context.Background(), "to", "sub", []byte("msg")); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 	if len(p.Messages) != 1 {
 		t.Fatalf("messages len=%d", len(p.Messages))
 	}
 	msg := p.Messages[0]
-	if msg.To != "to" || msg.Subject != "sub" || msg.Text != "body" || msg.HTML != "html" {
+	if msg.To != "to" || msg.Subject != "sub" || string(msg.Raw) != "msg" {
 		t.Fatalf("unexpected message: %#v", msg)
 	}
 }

--- a/internal/emailutil/email.go
+++ b/internal/emailutil/email.go
@@ -117,7 +117,7 @@ func NotifyChange(ctx context.Context, provider email.Provider, emailAddr, page,
 	}
 
 	if q, ok := ctx.Value(hcommon.KeyQueries).(*db.Queries); ok {
-		if err := q.InsertPendingEmail(ctx, db.InsertPendingEmailParams{ToEmail: emailAddr, Subject: content.Subject, Body: textBody, HtmlBody: htmlBody}); err != nil {
+		if err := q.InsertPendingEmail(ctx, db.InsertPendingEmailParams{ToEmail: emailAddr, Subject: content.Subject, Body: textBody}); err != nil {
 			return err
 		}
 	} else if provider != nil {

--- a/internal/emailutil/email_queue.go
+++ b/internal/emailutil/email_queue.go
@@ -51,7 +51,7 @@ func ProcessPendingEmail(ctx context.Context, q *db.Queries, provider email.Prov
 		return
 	}
 	e := emails[0]
-	msg, err := email.BuildMessage(runtimeconfig.AppRuntimeConfig.EmailFrom, e.ToEmail, e.Subject, e.Body, e.HtmlBody.String)
+	msg, err := email.BuildMessage(runtimeconfig.AppRuntimeConfig.EmailFrom, e.ToEmail, e.Subject, e.Body, "")
 	if err != nil {
 		log.Printf("build message: %v", err)
 		return

--- a/migrations/0016.sql
+++ b/migrations/0016.sql
@@ -1,0 +1,5 @@
+-- Remove html_body column from pending_emails table
+ALTER TABLE pending_emails DROP COLUMN IF EXISTS html_body;
+
+-- Record upgrade to schema version 16
+UPDATE schema_version SET version = 16 WHERE version = 15;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -388,7 +388,6 @@ CREATE TABLE IF NOT EXISTS `pending_emails` (
   `to_email` text NOT NULL,
   `subject` text NOT NULL,
   `body` text NOT NULL,
-  `html_body` text,
   `error_count` int NOT NULL DEFAULT 0,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `sent_at` datetime DEFAULT NULL,


### PR DESCRIPTION
## Summary
- drop `html_body` from `pending_emails`
- update DB schema and add migration
- adjust email queue logic and tests
- update mock email provider
- bump expected schema version

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686bd3fa5214832fb5019b4d04a85d3b