### PR TITLE
Fix reply action for writings

### DIFF
--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -148,7 +148,7 @@ func BoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	vars := mux.Vars(r)
-	bid, err := strconv.Atoi(vars["board"])
+	bid, err := strconv.Atoi(vars["boardno"])
 
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -208,7 +208,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	vars := mux.Vars(r)
-	aid, err := strconv.Atoi(vars["post"])
+	aid, err := strconv.Atoi(vars["article"])
 
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/handlers/writings/writingsArticlePage_test.go
+++ b/handlers/writings/writingsArticlePage_test.go
@@ -1,0 +1,65 @@
+package writings
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/core"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+func TestArticleReplyActionPage_UsesArticleParam(t *testing.T) {
+	dbconn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer dbconn.Close()
+
+	queries := db.New(dbconn)
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test-session"
+
+	form := url.Values{}
+	form.Set("replytext", "hi")
+	form.Set("language", "1")
+	req := httptest.NewRequest("POST", "/writings/article/1", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = mux.SetURLVars(req, map[string]string{"article": "1"})
+
+	w := httptest.NewRecorder()
+	sess, _ := store.Get(req, core.SessionName)
+	sess.Values["UID"] = int32(1)
+	sess.Save(req, w)
+	for _, c := range w.Result().Cookies() {
+		req.AddCookie(c)
+	}
+
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
+	ctx = context.WithValue(ctx, hcommon.KeyCoreData, &hcommon.CoreData{})
+	req = req.WithContext(ctx)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT w.idwriting")).
+		WithArgs(int32(1), int32(1), int32(1)).
+		WillReturnError(sqlmock.ErrCancelled)
+
+	rr := httptest.NewRecorder()
+	ArticleReplyActionPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Result().StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- fix reply action parameter name when replying to a writing
- correct board thread reply handler to read the `boardno` route parameter
- add regression test ensuring the article reply handler uses the correct route variable

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: Provider does not implement email.Provider)*
- `golangci-lint run ./...` *(fails: Provider does not implement email.Provider)*
- `go mod tidy`
- `go test ./...` *(fails: Provider does not implement email.Provider)*

------
https://chatgpt.com/codex/tasks/task_e_686bd495ea14832fa48c549f45652215