### PR TITLE
Enable comments on new writings

### DIFF
--- a/core/templates/templates/writings/articlePage.gohtml
+++ b/core/templates/templates/writings/articlePage.gohtml
@@ -12,21 +12,18 @@
         {{ .Writing.Abstract.String | a4code2html }}
         <hr>
         {{ .Writing.Writting.String | a4code2html }}
-        {{ if .Writing.ForumthreadIdforumthread }}
-            <hr>Comments:<br>
-            {{ template "threadComments" $ }}
-            {{ if .CanReply }}
-                <hr><font size="4">Reply:</font><br>
-                <form method="post">
+        <hr>Comments:<br>
+        {{ template "threadComments" $ }}
+        {{ if .CanReply }}
+            <hr><font size="4">Reply:</font><br>
+            <form method="post">
         {{ csrfField }}
-                    <input type="hidden" name="replyTo" value="{{ .Writing.ForumthreadIdforumthread }}">
-                    <textarea name="replytext" cols="40" rows="20">{{ .ReplyText }}</textarea><br>
-                    {{ template "languageCombobox" $ }}
-                    <input type="submit" name="task" value="Reply">
-                </form>
-            {{ else }}
-                Please sign-in (or sign-up) to write a reply.<br>
-            {{ end }}
+                <textarea name="replytext" cols="40" rows="20">{{ .ReplyText }}</textarea><br>
+                {{ template "languageCombobox" $ }}
+                <input type="submit" name="task" value="Reply">
+            </form>
+        {{ else }}
+            Please sign-in (or sign-up) to write a reply.<br>
         {{ end }}
     {{ else }}
         Article doesn't exist.<br>

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -80,6 +80,50 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if writing.ForumthreadIdforumthread == 0 && uid != 0 {
+		pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{
+			String: WritingTopicName,
+			Valid:  true,
+		})
+		var ptid int32
+		if errors.Is(err, sql.ErrNoRows) {
+			ptidi, err := queries.CreateForumTopic(r.Context(), db.CreateForumTopicParams{
+				ForumcategoryIdforumcategory: 0,
+				Title:                        sql.NullString{String: WritingTopicName, Valid: true},
+				Description:                  sql.NullString{String: WritingTopicDescription, Valid: true},
+			})
+			if err != nil {
+				log.Printf("Error: createForumTopic: %s", err)
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+			ptid = int32(ptidi)
+		} else if err != nil {
+			log.Printf("Error: findForumTopicByTitle: %s", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		} else {
+			ptid = pt.Idforumtopic
+		}
+
+		pthidi, err := queries.MakeThread(r.Context(), ptid)
+		if err != nil {
+			log.Printf("Error: makeThread: %s", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		pthid := int32(pthidi)
+		if err := queries.AssignWritingThisThreadId(r.Context(), db.AssignWritingThisThreadIdParams{
+			ForumthreadIdforumthread: pthid,
+			Idwriting:                writing.Idwriting,
+		}); err != nil {
+			log.Printf("Error: assign_article_to_thread: %s", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		writing.ForumthreadIdforumthread = pthid
+	}
+
 	data.Writing = writing
 	data.IsAuthor = writing.UsersIdusers == uid
 	data.CanEdit = (cd.HasRole("administrator") && cd.AdminMode) || (cd.HasRole("writer") && data.IsAuthor)


### PR DESCRIPTION
## Summary
- automatically create a forum thread for a writing when a logged in user views the article
- always render existing comments regardless of thread presence

## Testing
- `go vet ./...` *(fails: Provider does not implement email.Provider)*
- `golangci-lint run` *(fails: Provider does not implement email.Provider)*
- `go test ./...` *(fails: Provider does not implement email.Provider)*

------
https://chatgpt.com/codex/tasks/task_e_686bd4d0414c832f9f84554b8e6f037a