### PR TITLE
Refactor tests to avoid reflection

### DIFF
--- a/internal/dlq/dlq_test.go
+++ b/internal/dlq/dlq_test.go
@@ -1,7 +1,6 @@
 package dlq_test
 
 import (
-	"reflect"
 	"testing"
 
 	dbpkg "github.com/arran4/goa4web/internal/db"
@@ -33,8 +32,11 @@ func TestProviderFromConfigRegistry(t *testing.T) {
 	}
 
 	cfg = runtimeconfig.RuntimeConfig{DLQProvider: "email"}
-	if p := dlq.ProviderFromConfig(cfg, nil); reflect.TypeOf(p) != reflect.TypeOf(emaildlq.DLQ{}) && reflect.TypeOf(p) != reflect.TypeOf(dlq.LogDLQ{}) {
-		t.Fatalf("unexpected type %T", p)
+	p := dlq.ProviderFromConfig(cfg, nil)
+	if _, ok := p.(emaildlq.DLQ); !ok {
+		if _, ok := p.(dlq.LogDLQ); !ok {
+			t.Fatalf("unexpected type %T", p)
+		}
 	}
 
 	cfg = runtimeconfig.RuntimeConfig{DLQProvider: "db,log"}

--- a/internal/emailutil/email_test.go
+++ b/internal/emailutil/email_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"reflect"
 	"regexp"
 	"testing"
 
@@ -34,7 +33,8 @@ func init() {
 
 func TestGetEmailProviderLog(t *testing.T) {
 	cfg := runtimeconfig.RuntimeConfig{EmailProvider: "log"}
-	if p := email.ProviderFromConfig(cfg); reflect.TypeOf(p) != reflect.TypeOf(logProv.Provider{}) {
+	p := email.ProviderFromConfig(cfg)
+	if _, ok := p.(logProv.Provider); !ok {
 		t.Errorf("expected LogProvider, got %#v", p)
 	}
 }

--- a/internal/router/registry_test.go
+++ b/internal/router/registry_test.go
@@ -1,9 +1,9 @@
 package router
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
 )
 
@@ -35,7 +35,7 @@ func TestInitModulesDependencyOrder(t *testing.T) {
 	InitModules(r)
 
 	want := []string{"a", "b", "c"}
-	if !reflect.DeepEqual(order, want) {
-		t.Fatalf("order %+v want %+v", order, want)
+	if diff := cmp.Diff(want, order); diff != "" {
+		t.Fatalf("order mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
## Summary
- remove reflect-based type checks
- use type assertions for provider checks
- compare registry order with cmp.Diff

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686c6e46bc5c832f895e5d108be7667a