### PR TITLE
Add AUTO_MIGRATE feature toggle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN go build -o /goa4web ./cmd/goa4web
 FROM scratch
 # Install the application into the final image.
 ENV PATH=/usr/local/bin
+ENV AUTO_MIGRATE=false
 COPY --from=build /goa4web /usr/local/bin/goa4web
 # Image uploads are stored under /data/imagebbs inside the container.
 VOLUME ["/data/imagebbs"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -4,6 +4,7 @@
 # This image contains the goa4web binary.
 FROM scratch
 ENV PATH=/usr/local/bin
+ENV AUTO_MIGRATE=false
 COPY goa4web /usr/local/bin/goa4web
 # Image uploads are stored under /data/imagebbs inside the container.
 VOLUME ["/data/imagebbs"]

--- a/config/env.go
+++ b/config/env.go
@@ -98,4 +98,7 @@ const (
 	EnvDLQProvider = "DLQ_PROVIDER"
 	// EnvDLQFile is the file path used by the file DLQ provider.
 	EnvDLQFile = "DLQ_FILE"
+
+	// EnvAutoMigrate toggles automatic database migrations on startup.
+	EnvAutoMigrate = "AUTO_MIGRATE"
 )

--- a/examples/config.env
+++ b/examples/config.env
@@ -78,3 +78,5 @@ SMTP_PORT=
 SMTP_USER=
 # start year for usage stats (default: 2005)
 STATS_START_YEAR=2005
+# run migrations automatically on startup (default: false)
+AUTO_MIGRATE=false

--- a/examples/config.json
+++ b/examples/config.json
@@ -38,5 +38,6 @@
   "SMTP_STARTTLS": "true",
   "SMTP_PORT": "",
   "SMTP_USER": "",
-  "STATS_START_YEAR": "2005"
+  "STATS_START_YEAR": "2005",
+  "AUTO_MIGRATE": "false"
 }

--- a/internal/dbstart/automigrate.go
+++ b/internal/dbstart/automigrate.go
@@ -1,0 +1,59 @@
+package dbstart
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/arran4/goa4web/config"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	dbdrivers "github.com/arran4/goa4web/internal/dbdrivers"
+	"github.com/arran4/goa4web/internal/migrate"
+	"github.com/arran4/goa4web/runtimeconfig"
+)
+
+// autoMigrateEnabled reports whether automatic migrations should run.
+func autoMigrateEnabled() bool {
+	v := strings.ToLower(os.Getenv(config.EnvAutoMigrate))
+	switch v {
+	case "1", "true", "on", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+// applyMigrations connects to the database and executes SQL migrations.
+func applyMigrations(ctx context.Context, cfg runtimeconfig.RuntimeConfig) error {
+	conn := cfg.DBConn
+	if conn == "" {
+		return fmt.Errorf("connection string required")
+	}
+	c, err := dbdrivers.Connector(cfg.DBDriver, conn)
+	if err != nil {
+		return err
+	}
+	var connector driver.Connector = dbpkg.NewLoggingConnector(c)
+	db := sql.OpenDB(connector)
+	defer db.Close()
+	if err := db.PingContext(ctx); err != nil {
+		return err
+	}
+	fsys := os.DirFS("migrations")
+	return migrate.Apply(ctx, db, fsys, false)
+}
+
+// maybeAutoMigrate runs migrations when enabled via AUTO_MIGRATE.
+func maybeAutoMigrate(cfg runtimeconfig.RuntimeConfig) error {
+	if !autoMigrateEnabled() {
+		return nil
+	}
+	ctx := context.Background()
+	if err := applyMigrations(ctx, cfg); err != nil {
+		return fmt.Errorf("auto-migrate: %w", err)
+	}
+	return nil
+}

--- a/internal/dbstart/dbstart.go
+++ b/internal/dbstart/dbstart.go
@@ -56,6 +56,9 @@ func InitDB(cfg runtimeconfig.RuntimeConfig) *common.UserError {
 
 // PerformStartupChecks checks the database and upload directory configuration.
 func PerformStartupChecks(cfg runtimeconfig.RuntimeConfig) error {
+	if err := maybeAutoMigrate(cfg); err != nil {
+		return err
+	}
 	if ue := InitDB(cfg); ue != nil {
 		return fmt.Errorf("%s: %w", ue.ErrorMessage, ue.Err)
 	}

--- a/readme.md
+++ b/readme.md
@@ -263,6 +263,7 @@ environment variables listed below.
 | `DEFAULT_LANGUAGE` | `--default-language` | No | - | Site's default language name. |
 | `DLQ_PROVIDER` | `--dlq-provider` | No | `log` | Dead letter queue provider. |
 | `DLQ_FILE` | `--dlq-file` | No | `dlq.log` | File path for the file or directory DLQ providers. |
+| `AUTO_MIGRATE` | n/a | No | `false` | Run database migrations on startup. |
 
 ### Dead Letter Queue Providers
 


### PR DESCRIPTION
## Summary
- add `AUTO_MIGRATE` env var constant
- run migrations automatically from `dbstart` when `AUTO_MIGRATE` is enabled
- set `AUTO_MIGRATE=false` in the Docker images
- document the new variable and add examples

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686c6da42aa4832fb7fa4de31ca820cc