### PR TITLE
Add default name handling for mail.Address

### DIFF
--- a/cmd/goa4web/config_test_cmd.go
+++ b/cmd/goa4web/config_test_cmd.go
@@ -122,7 +122,12 @@ func (c *configTestEmailCmd) Run() error {
 		if err := ht.Execute(&buf, nil); err != nil {
 			return fmt.Errorf("exec html template: %w", err)
 		}
-		msg, err := email.BuildMessage(c.rootCmd.cfg.EmailFrom, addr, "Goa4Web Test Email", textBody, buf.String())
+		fromAddr := email.ParseAddress(c.rootCmd.cfg.EmailFrom)
+		if fromAddr.Name == "" {
+			fromAddr.Name = email.DefaultFromName
+		}
+		toAddr := email.ParseAddress(addr)
+		msg, err := email.BuildMessage(fromAddr, toAddr, "Goa4Web Test Email", textBody, buf.String())
 		if err != nil {
 			return fmt.Errorf("build message: %w", err)
 		}

--- a/cmd/goa4web/email_queue_resend.go
+++ b/cmd/goa4web/email_queue_resend.go
@@ -45,11 +45,7 @@ func (c *emailQueueResendCmd) Run() error {
 	}
 	provider := email.ProviderFromConfig(c.rootCmd.cfg)
 	if provider != nil {
-		msg, err := email.BuildMessage(c.rootCmd.cfg.EmailFrom, e.ToEmail, e.Subject, e.Body, e.HtmlBody.String)
-		if err != nil {
-			return fmt.Errorf("build message: %w", err)
-		}
-		if err := provider.Send(ctx, e.ToEmail, e.Subject, msg); err != nil {
+		if err := provider.Send(ctx, e.ToEmail, e.Subject, []byte(e.Body)); err != nil {
 			return fmt.Errorf("send email: %w", err)
 		}
 	}

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/arran4/goa4web/core"
 	dbstart "github.com/arran4/goa4web/internal/dbstart"
 	dlqreg "github.com/arran4/goa4web/internal/dlq/dlqdefaults"
+	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -98,6 +99,7 @@ func parseRoot(args []string) (*rootCmd, error) {
 	r.args = fs.Args()
 	r.ConfigFile = cfgPath
 	r.cfg = runtimeconfig.GenerateRuntimeConfig(fs, fileVals, os.Getenv)
+	email.SetDefaultFromName(r.cfg.EmailFrom)
 	return r, nil
 }
 

--- a/config/env.go
+++ b/config/env.go
@@ -20,7 +20,8 @@ const (
 	EnvSMTPAuth = "SMTP_AUTH"
 	// EnvSMTPStartTLS enables STARTTLS when sending SMTP mail.
 	EnvSMTPStartTLS = "SMTP_STARTTLS"
-	// EnvEmailFrom sets the default From address for outgoing mail.
+	// EnvEmailFrom sets the default From address for outgoing mail. The
+	// value must be a valid RFC 5322 address.
 	EnvEmailFrom = "EMAIL_FROM"
 	// EnvAWSRegion is the AWS region for the SES provider.
 	EnvAWSRegion = "AWS_REGION"

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -50,12 +50,7 @@ func AdminEmailQueueResendActionPage(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		if provider != nil {
-			msg, err := email.BuildMessage(runtimeconfig.AppRuntimeConfig.EmailFrom, e.ToEmail, e.Subject, e.Body, e.HtmlBody.String)
-			if err != nil {
-				log.Printf("build message: %v", err)
-				continue
-			}
-			if err := provider.Send(r.Context(), e.ToEmail, e.Subject, msg); err != nil {
+			if err := provider.Send(r.Context(), e.ToEmail, e.Subject, []byte(e.Body)); err != nil {
 				log.Printf("send email: %v", err)
 				continue
 			}

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -118,7 +118,12 @@ func AdminEmailTemplateTestActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	msg, err := email.BuildMessage(runtimeconfig.AppRuntimeConfig.EmailFrom, user.Email.String, content.Subject, buf.String(), "")
+	fromAddr := email.ParseAddress(runtimeconfig.AppRuntimeConfig.EmailFrom)
+	if fromAddr.Name == "" {
+		fromAddr.Name = email.DefaultFromName
+	}
+	toAddr := email.ParseAddress(user.Email.String)
+	msg, err := email.BuildMessage(fromAddr, toAddr, content.Subject, buf.String(), "")
 	if err != nil {
 		log.Printf("build message: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -74,6 +74,7 @@ func RunWithConfig(ctx context.Context, cfg runtimeconfig.RuntimeConfig, session
 		return fmt.Errorf("smtp fallback: %w", err)
 	}
 	runtimeconfig.AppRuntimeConfig = cfg
+	email.SetDefaultFromName(cfg.EmailFrom)
 
 	if dbPool != nil {
 		defer func() {

--- a/internal/dlq/email/email.go
+++ b/internal/dlq/email/email.go
@@ -24,7 +24,12 @@ func (e DLQ) Record(ctx context.Context, message string) error {
 		return fmt.Errorf("no email provider")
 	}
 	for _, addr := range emailutil.GetAdminEmails(ctx, e.Queries) {
-		msg, err := email.BuildMessage(runtimeconfig.AppRuntimeConfig.EmailFrom, addr, "DLQ message", message, "")
+		fromAddr := email.ParseAddress(runtimeconfig.AppRuntimeConfig.EmailFrom)
+		if fromAddr.Name == "" {
+			fromAddr.Name = email.DefaultFromName
+		}
+		toAddr := email.ParseAddress(addr)
+		msg, err := email.BuildMessage(fromAddr, toAddr, "DLQ message", message, "")
 		if err != nil {
 			log.Printf("build message: %v", err)
 			continue

--- a/internal/email/address.go
+++ b/internal/email/address.go
@@ -1,0 +1,17 @@
+package email
+
+import (
+	"log"
+	"net/mail"
+)
+
+// ParseAddress returns the mail.Address parsed from s. If parsing fails,
+// the returned Address has only the Address field set.
+func ParseAddress(s string) mail.Address {
+	a, err := mail.ParseAddress(s)
+	if err != nil {
+		log.Printf("parse mail address %q: %v", s, err)
+		return mail.Address{Address: s}
+	}
+	return *a
+}

--- a/internal/email/message.go
+++ b/internal/email/message.go
@@ -5,17 +5,49 @@ import (
 	"fmt"
 	"mime"
 	"mime/multipart"
+	"net/mail"
 	"net/textproto"
 	"strings"
 	"time"
 )
 
+// DefaultFromName is used when building messages without a specified sender
+// name. The value may be updated at runtime from configuration.
+var DefaultFromName = "Goa4Web"
+
+// SetDefaultFromName updates DefaultFromName based on the provided address.
+// When addr contains a name component, that name is stored. Otherwise the
+// default "Goa4Web" is used.
+func SetDefaultFromName(addr string) {
+	a, err := mail.ParseAddress(addr)
+	if err == nil && a.Name != "" {
+		DefaultFromName = a.Name
+	} else {
+		DefaultFromName = "Goa4Web"
+	}
+}
+
 // BuildMessage constructs a MIME email message with optional HTML content.
-func BuildMessage(from, to, subject, textBody, htmlBody string) ([]byte, error) {
+// The from and to parameters can include optional Name fields which will be
+// formatted as "Name <address>" in the resulting headers.
+func BuildMessage(from, to mail.Address, subject, textBody, htmlBody string) ([]byte, error) {
 	var msg bytes.Buffer
 	hdr := textproto.MIMEHeader{}
-	hdr.Set("From", from)
-	hdr.Set("To", to)
+	if from.Name == "" {
+		from.Name = DefaultFromName
+	}
+	if from.Name != "" {
+		enc := mail.Address{Name: mime.QEncoding.Encode("utf-8", from.Name), Address: from.Address}
+		hdr.Set("From", enc.String())
+	} else {
+		hdr.Set("From", from.Address)
+	}
+	if to.Name != "" {
+		enc := mail.Address{Name: mime.QEncoding.Encode("utf-8", to.Name), Address: to.Address}
+		hdr.Set("To", enc.String())
+	} else {
+		hdr.Set("To", to.Address)
+	}
 	hdr.Set("Subject", mime.QEncoding.Encode("utf-8", subject))
 	hdr.Set("MIME-Version", "1.0")
 

--- a/internal/email/mock/mock_test.go
+++ b/internal/email/mock/mock_test.go
@@ -3,11 +3,22 @@ package mock
 import (
 	"context"
 	"testing"
+
+	"github.com/arran4/goa4web/internal/email"
 )
 
 func TestProvider(t *testing.T) {
 	p := &Provider{}
-	if err := p.Send(context.Background(), "to", "sub", "body", "html"); err != nil {
+	fromAddr := email.ParseAddress("from@test")
+	if fromAddr.Name == "" {
+		fromAddr.Name = email.DefaultFromName
+	}
+	toAddr := email.ParseAddress("to")
+	raw, err := email.BuildMessage(fromAddr, toAddr, "sub", "body", "html")
+	if err != nil {
+		t.Fatalf("build message: %v", err)
+	}
+	if err := p.Send(context.Background(), "to", "sub", raw); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 	if len(p.Messages) != 1 {

--- a/internal/emailutil/email_queue.go
+++ b/internal/emailutil/email_queue.go
@@ -9,7 +9,6 @@ import (
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/dlq"
 	"github.com/arran4/goa4web/internal/email"
-	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 // emailQueueWorker periodically sends pending emails using the provided provider.
@@ -51,12 +50,7 @@ func ProcessPendingEmail(ctx context.Context, q *db.Queries, provider email.Prov
 		return
 	}
 	e := emails[0]
-	msg, err := email.BuildMessage(runtimeconfig.AppRuntimeConfig.EmailFrom, e.ToEmail, e.Subject, e.Body, e.HtmlBody.String)
-	if err != nil {
-		log.Printf("build message: %v", err)
-		return
-	}
-	if err := provider.Send(ctx, e.ToEmail, e.Subject, msg); err != nil {
+	if err := provider.Send(ctx, e.ToEmail, e.Subject, []byte(e.Body)); err != nil {
 		log.Printf("send queued mail: %v", err)
 		count, incErr := q.IncrementEmailError(ctx, e.ID)
 		if incErr != nil {

--- a/internal/emailutil/email_test.go
+++ b/internal/emailutil/email_test.go
@@ -144,7 +144,7 @@ func TestEmailQueueWorker(t *testing.T) {
 
 type errProvider struct{}
 
-func (errProvider) Send(context.Context, string, string, string, string) error {
+func (errProvider) Send(context.Context, string, string, []byte) error {
 	return fmt.Errorf("fail")
 }
 

--- a/readme.md
+++ b/readme.md
@@ -225,7 +225,7 @@ environment variables listed below.
 | `DB_CONN` | `--db-conn` | Yes | - | Database connection string. |
 | `DB_DRIVER` | `--db-driver` | Yes | `mysql` | Database driver name. |
 | `EMAIL_PROVIDER` | `--email-provider` | No | `ses` | Selects the mail sending backend. |
-| `EMAIL_FROM` | `--email-from` | No | - | Default From address for outgoing mail. |
+| `EMAIL_FROM` | `--email-from` | No | - | Default From address for outgoing mail. Must be a valid RFC 5322 address. |
 | `SMTP_HOST` | `--smtp-host` | No | - | SMTP server hostname. |
 | `SMTP_PORT` | `--smtp-port` | No | - | SMTP server port. |
 | `SMTP_USER` | `--smtp-user` | No | - | SMTP username. |


### PR DESCRIPTION
## Summary
- derive `DefaultFromName` from configuration
- log failures when parsing email addresses
- encode sender/recipient headers with mail.Address
- mention RFC 5322 requirement for `EMAIL_FROM`
- send queued emails without rebuilding messages

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686c6b303f28832f9f28948c667e6ad7