### PR TITLE
Fix LastPoster typo

### DIFF
--- a/handlers/blogs/blogsCommentEditPage.go
+++ b/handlers/blogs/blogsCommentEditPage.go
@@ -34,7 +34,7 @@ func CommentEditPostPage(w http.ResponseWriter, r *http.Request) {
 
 	comment := r.Context().Value(common.KeyComment).(*db.GetCommentByIdForUserRow)
 
-	thread, err := queries.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsParams{
+	thread, err := queries.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams{
 		UsersIdusers:  uid,
 		Idforumthread: comment.ForumthreadIdforumthread,
 	})
@@ -42,7 +42,7 @@ func CommentEditPostPage(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
-			log.Printf("Error: getThreadByIdForUserByIdWithLastPoserUserNameAndPermissions: %s", err)
+			log.Printf("Error: getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 			return
 		}

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -32,7 +32,7 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Category            *ForumcategoryPlus
 		Topic               *ForumtopicPlus
-		Thread              *db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow
+		Thread              *db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
 		Comments            []*CommentPlus
 		Offset              int
 		IsReplyable         bool
@@ -59,7 +59,7 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
+	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow)
 	topicRow := r.Context().Value(common.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
 	session, ok := core.GetSessionOrFail(w, r)

--- a/handlers/forum/forumTopicPage.go
+++ b/handlers/forum/forumTopicPage.go
@@ -104,7 +104,7 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
-			log.Printf("Error: getThreadByIdForUserByIdWithLastPoserUserNameAndPermissions: %s", err)
+			log.Printf("Error: getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 			return
 		}

--- a/handlers/forum/forumTopicThreadCommentEditPage.go
+++ b/handlers/forum/forumTopicThreadCommentEditPage.go
@@ -20,7 +20,7 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("replytext")
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
+	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow)
 	topicRow := r.Context().Value(common.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 	commentId, _ := strconv.Atoi(mux.Vars(r)["comment"])
 
@@ -47,7 +47,7 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func TopicThreadCommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
-	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
+	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow)
 	topicRow := r.Context().Value(common.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -26,7 +26,7 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	threadRow := r.Context().Value(hcommon.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
+	threadRow := r.Context().Value(hcommon.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow)
 	topicRow := r.Context().Value(hcommon.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
 	if evt, ok := r.Context().Value(hcommon.KeyBusEvent).(*eventbus.Event); ok && evt != nil {
@@ -106,7 +106,7 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func TopicThreadReplyCancelPage(w http.ResponseWriter, r *http.Request) {
-	threadRow := r.Context().Value(hcommon.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow)
+	threadRow := r.Context().Value(hcommon.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow)
 	topicRow := r.Context().Value(hcommon.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)

--- a/handlers/forum/matchers.go
+++ b/handlers/forum/matchers.go
@@ -39,7 +39,7 @@ func RequireThreadAndTopic(next http.Handler) http.Handler {
 			uid, _ = session.Values["UID"].(int32)
 		}
 
-		threadRow, err := queries.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsParams{
+		threadRow, err := queries.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams{
 			UsersIdusers:  uid,
 			Idforumthread: int32(threadID),
 		})

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -37,7 +37,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 		Comments           []*CommentPlus
 		BoardId            int
 		ImagePost          *db.GetAllImagePostsByIdWithAuthorUsernameAndThreadCommentCountRow
-		Thread             *db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow
+		Thread             *db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
 		Offset             int
 		IsReplyable        bool
 	}
@@ -73,7 +73,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	threadRow, err := queries.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsParams{
+	threadRow, err := queries.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams{
 		UsersIdusers:  uid,
 		Idforumthread: int32(thid),
 	})
@@ -81,7 +81,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
-			log.Printf("Error: getThreadByIdForUserByIdWithLastPoserUserNameAndPermissions: %s", err)
+			log.Printf("Error: getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 			return
 		}

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -45,7 +45,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		Text               string
 		CanEdit            bool
 		UserId             int32
-		Thread             *db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow
+		Thread             *db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
@@ -100,7 +100,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	threadRow, err := queries.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsParams{
+	threadRow, err := queries.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams{
 		UsersIdusers:  uid,
 		Idforumthread: link.ForumthreadIdforumthread,
 	})
@@ -108,7 +108,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
-			log.Printf("Error: getThreadByIdForUserByIdWithLastPoserUserNameAndPermissions: %s", err)
+			log.Printf("Error: getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 			return
 		}

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -60,7 +60,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		Offset             int
 		IsReplying         bool
 		IsReplyable        bool
-		Thread             *db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow
+		Thread             *db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
 		ReplyText          string
 	}
 
@@ -103,7 +103,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	threadRow, err := queries.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsParams{
+	threadRow, err := queries.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams{
 		UsersIdusers:  uid,
 		Idforumthread: int32(post.ForumthreadIdforumthread),
 	})
@@ -111,7 +111,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
-			log.Printf("Error: getThreadByIdForUserByIdWithLastPoserUserNameAndPermissions: %s", err)
+			log.Printf("Error: getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 			return
 		}

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -38,7 +38,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		UserId              int32
 		Languages           []*db.Language
 		SelectedLanguageId  int
-		Thread              *db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow
+		Thread              *db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
 		Comments            []*CommentPlus
 		IsReplyable         bool
 		IsAdmin             bool
@@ -151,7 +151,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	threadRow, err := queries.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsParams{
+	threadRow, err := queries.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams{
 		UsersIdusers:  uid,
 		Idforumthread: writing.ForumthreadIdforumthread,
 	})
@@ -159,7 +159,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
-			log.Printf("Error: getThreadByIdForUserByIdWithLastPoserUserNameAndPermissions: %s", err)
+			log.Printf("Error: getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 			return
 		}

--- a/internal/db/queries-threads.sql
+++ b/internal/db/queries-threads.sql
@@ -49,7 +49,7 @@ SET lastaddition = (
 )
 WHERE idforumthread = ?;
 
--- name: GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissions :one
+-- name: GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions :one
 SELECT th.*, lu.username AS LastPosterUsername, r.seelevel, u.level
 FROM forumthread th
 LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic

--- a/internal/db/queries-threads.sql.go
+++ b/internal/db/queries-threads.sql.go
@@ -30,7 +30,7 @@ func (q *Queries) GetForumTopicIdByThreadId(ctx context.Context, idforumthread i
 	return forumtopic_idforumtopic, err
 }
 
-const getThreadByIdForUserByIdWithLastPoserUserNameAndPermissions = `-- name: GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissions :one
+const getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions = `-- name: GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions :one
 SELECT th.idforumthread, th.firstpost, th.lastposter, th.forumtopic_idforumtopic, th.comments, th.lastaddition, th.locked, lu.username AS LastPosterUsername, r.seelevel, u.level
 FROM forumthread th
 LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
@@ -41,12 +41,12 @@ WHERE IF(r.seelevel IS NOT NULL, r.seelevel , 0) <= IF(u.level IS NOT NULL, u.le
 ORDER BY t.lastaddition DESC
 `
 
-type GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsParams struct {
+type GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams struct {
 	UsersIdusers  int32
 	Idforumthread int32
 }
 
-type GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow struct {
+type GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow struct {
 	Idforumthread          int32
 	Firstpost              int32
 	Lastposter             int32
@@ -59,9 +59,9 @@ type GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow struct {
 	Level                  sql.NullInt32
 }
 
-func (q *Queries) GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissions(ctx context.Context, arg GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsParams) (*GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow, error) {
-	row := q.db.QueryRowContext(ctx, getThreadByIdForUserByIdWithLastPoserUserNameAndPermissions, arg.UsersIdusers, arg.Idforumthread)
-	var i GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow
+func (q *Queries) GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(ctx context.Context, arg GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams) (*GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow, error) {
+	row := q.db.QueryRowContext(ctx, getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions, arg.UsersIdusers, arg.Idforumthread)
+	var i GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
 	err := row.Scan(
 		&i.Idforumthread,
 		&i.Firstpost,

--- a/internal/notifications/types.go
+++ b/internal/notifications/types.go
@@ -6,7 +6,7 @@ import "github.com/arran4/goa4web/internal/db"
 type ForumReplyInfo struct {
 	TopicTitle string
 	ThreadID   int32
-	Thread     *db.GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissionsRow
+	Thread     *db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
 }
 
 // ThreadInfo represents a newly created forum thread.


### PR DESCRIPTION
## Summary
- rename query `GetThreadByIdForUserByIdWithLastPoserUserNameAndPermissions` to `GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions`
- regenerate sqlc bindings
- update handlers and notification types to use the new query name

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686cb0bc8644832fb23d0f929da703c4