### PR TITLE
Implement runtimeconfig ToEnvMap helper

### DIFF
--- a/cmd/goa4web/config_as_test.go
+++ b/cmd/goa4web/config_as_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
-func TestEnvMapFromConfigLoops(t *testing.T) {
+func TestToEnvMapLoops(t *testing.T) {
 	cfg := runtimeconfig.RuntimeConfig{
 		EmailEnabled:         false,
 		NotificationsEnabled: false,
@@ -18,9 +18,9 @@ func TestEnvMapFromConfigLoops(t *testing.T) {
 		StatsStartYear:       2020,
 	}
 
-	m, err := envMapFromConfig(cfg, "")
+	m, err := runtimeconfig.ToEnvMap(cfg, "")
 	if err != nil {
-		t.Fatalf("envMapFromConfig: %v", err)
+		t.Fatalf("ToEnvMap: %v", err)
 	}
 	tests := map[string]string{
 		config.EnvEmailEnabled:         "false",

--- a/cmd/goa4web/config_json_add.go
+++ b/cmd/goa4web/config_json_add.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 // configJSONAddCmd implements "config add-json".
@@ -32,7 +33,7 @@ func (c *configJSONAddCmd) Run() error {
 	if c.File == "" {
 		return fmt.Errorf("file required")
 	}
-	values, err := envMapFromConfig(c.rootCmd.cfg, c.rootCmd.ConfigFile)
+	values, err := runtimeconfig.ToEnvMap(c.rootCmd.cfg, c.rootCmd.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}

--- a/runtimeconfig/envmap.go
+++ b/runtimeconfig/envmap.go
@@ -1,0 +1,44 @@
+package runtimeconfig
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/arran4/goa4web/config"
+)
+
+// ToEnvMap converts cfg into a map keyed by environment variable name.
+// The cfgPath argument sets the CONFIG_FILE entry and is used to
+// resolve SESSION_SECRET_FILE when empty.
+func ToEnvMap(cfg RuntimeConfig, cfgPath string) (map[string]string, error) {
+	m := make(map[string]string)
+
+	for _, o := range StringOptions {
+		m[o.Env] = *o.Target(&cfg)
+	}
+	for _, o := range IntOptions {
+		m[o.Env] = strconv.Itoa(*o.Target(&cfg))
+	}
+	for _, o := range BoolOptions {
+		m[o.Env] = strconv.FormatBool(*o.Target(&cfg))
+	}
+
+	fileVals, err := config.LoadAppConfigFile(config.OSFS{}, cfgPath)
+	if err != nil {
+		return nil, fmt.Errorf("load config file: %w", err)
+	}
+
+	m[config.EnvConfigFile] = cfgPath
+	m[config.EnvSessionSecret] = os.Getenv(config.EnvSessionSecret)
+	sessionFile := fileVals[config.EnvSessionSecretFile]
+	if sessionFile == "" {
+		sessionFile = os.Getenv(config.EnvSessionSecretFile)
+	}
+	if sessionFile == "" {
+		sessionFile = DefaultSessionSecretPath()
+	}
+	m[config.EnvSessionSecretFile] = sessionFile
+
+	return m, nil
+}

--- a/runtimeconfig/envmap_test.go
+++ b/runtimeconfig/envmap_test.go
@@ -1,0 +1,42 @@
+package runtimeconfig
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+)
+
+// TestToEnvMapIncludesAllKeys ensures that the helper returns entries for all
+// runtime options plus special config values.
+func TestToEnvMapIncludesAllKeys(t *testing.T) {
+	cfg := GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
+	m, err := ToEnvMap(cfg, "")
+	if err != nil {
+		t.Fatalf("ToEnvMap: %v", err)
+	}
+	want := len(StringOptions) + len(IntOptions) + len(BoolOptions) + 3
+	if len(m) != want {
+		t.Fatalf("got %d keys want %d", len(m), want)
+	}
+	for _, o := range StringOptions {
+		if _, ok := m[o.Env]; !ok {
+			t.Errorf("missing %s", o.Env)
+		}
+	}
+	for _, o := range IntOptions {
+		if _, ok := m[o.Env]; !ok {
+			t.Errorf("missing %s", o.Env)
+		}
+	}
+	for _, o := range BoolOptions {
+		if _, ok := m[o.Env]; !ok {
+			t.Errorf("missing %s", o.Env)
+		}
+	}
+	extras := []string{config.EnvConfigFile, config.EnvSessionSecret, config.EnvSessionSecretFile}
+	for _, k := range extras {
+		if _, ok := m[k]; !ok {
+			t.Errorf("missing %s", k)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `runtimeconfig.ToEnvMap` helper
- switch CLI commands to use the new helper
- test helper coverage

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686cb0a87068832fa3bc3175672f2b0b