### PR TITLE
Switch CI back to GitHub hosted runners

### DIFF
--- a/.github/workflows/config-examples-update.yml
+++ b/.github/workflows/config-examples-update.yml
@@ -7,13 +7,15 @@ on:
 
 jobs:
   generate:
-    runs-on: self-hosted
-    container:
-      image: ghcr.io/openai/codex-universal:latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
       - name: Generate examples
         run: |
           go run ./cmd/goa4web config as-env-file > examples/config.env

--- a/.github/workflows/go_releaser.yaml
+++ b/.github/workflows/go_releaser.yaml
@@ -10,14 +10,16 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: self-hosted
-    container:
-      image: ghcr.io/openai/codex-universal:latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/go_test.yaml
+++ b/.github/workflows/go_test.yaml
@@ -8,11 +8,13 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
-    container:
-      image: ghcr.io/openai/codex-universal:latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
       - name: Run tests
         run: go test ./...

--- a/.github/workflows/lint_vet.yaml
+++ b/.github/workflows/lint_vet.yaml
@@ -7,12 +7,14 @@ on:
 
 jobs:
   lint-vet:
-    runs-on: self-hosted
-    container:
-      image: ghcr.io/openai/codex-universal:latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
       - name: Go Vet
         run: go vet ./...
       - name: Golangci Lint

--- a/.github/workflows/sqlc-update.yml
+++ b/.github/workflows/sqlc-update.yml
@@ -11,13 +11,15 @@ on:
 
 jobs:
   generate:
-    runs-on: self-hosted
-    container:
-      image: ghcr.io/openai/codex-universal:latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
       - name: Install sqlc
         run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
       - name: Generate code

--- a/cmd/goa4web/config_test_cmd.go
+++ b/cmd/goa4web/config_test_cmd.go
@@ -130,13 +130,13 @@ func (c *configTestEmailCmd) Run() error {
 		} else {
 			fromAddr = mail.Address{Address: c.rootCmd.cfg.EmailFrom}
 		}
-	    msg, err := email.BuildMessage(fromAddr, toAddr, "Goa4Web Test Email", textBody, buf.String())
-	    if err != nil {
-	 		   return fmt.Errorf("build message: %w", err)
-	    }
-	    if err := provider.Send(ctx, toAddr, msg); err != nil {
-	 		   return fmt.Errorf("send email: %w", err)
-	    }
+		msg, err := email.BuildMessage(fromAddr, toAddr, "Goa4Web Test Email", textBody, buf.String())
+		if err != nil {
+			return fmt.Errorf("build message: %w", err)
+		}
+		if err := provider.Send(ctx, toAddr, msg); err != nil {
+			return fmt.Errorf("send email: %w", err)
+		}
 	}
 	return nil
 }

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -85,8 +85,8 @@ func TestListUnsentPendingEmails(t *testing.T) {
 	}
 	defer sqldb.Close()
 	q := db.New(sqldb)
-       rows := sqlmock.NewRows([]string{"id", "to_user_id", "body", "error_count", "created_at"}).AddRow(1, 2, "b", 0, time.Now())
-       mock.ExpectQuery("SELECT id, to_user_id, body, error_count, created_at FROM pending_emails WHERE sent_at IS NULL ORDER BY id").WillReturnRows(rows)
+	rows := sqlmock.NewRows([]string{"id", "to_user_id", "body", "error_count", "created_at"}).AddRow(1, 2, "b", 0, time.Now())
+	mock.ExpectQuery("SELECT id, to_user_id, body, error_count, created_at FROM pending_emails WHERE sent_at IS NULL ORDER BY id").WillReturnRows(rows)
 	if _, err := q.ListUnsentPendingEmails(context.Background()); err != nil {
 		t.Fatalf("list: %v", err)
 	}

--- a/internal/emailutil/email_test.go
+++ b/internal/emailutil/email_test.go
@@ -86,7 +86,7 @@ func TestNotifyChange(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-       mock.ExpectExec("INSERT INTO pending_emails").WithArgs(int32(2), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(int32(2), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 	ctx := context.WithValue(context.Background(), common.KeyQueries, q)
 	rec := &mockemail.Provider{}
 	if err := emailutil.NotifyChange(ctx, rec, 2, "a@b.com", "http://host", "update", nil); err != nil {


### PR DESCRIPTION
## Summary
- move CI off the self-hosted container runner
- run workflows on `ubuntu-latest`
- install Go using `actions/setup-go`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: Provider does not implement email.Provider)*

------
https://chatgpt.com/codex/tasks/task_e_686d0141f08c832f920c6d7da10bd2cd