### PR TITLE
Fix admin text typos

### DIFF
--- a/core/templates/templates/admin/forumPage.gohtml
+++ b/core/templates/templates/admin/forumPage.gohtml
@@ -6,7 +6,7 @@
                         <a href="/admin/forum/flagged">Flagged posts</a><br>
                         <a href="/admin/forum/modlog">Moderator logs</a><br>
 			<br>
-			Preform something:<br>
+                        Perform something:<br>
 			<form method="post">
         {{ csrfField }}
 				<input type="submit" name="task" value="Remake statistic information on forumthread"><br>

--- a/core/templates/templates/admin/searchPage.gohtml
+++ b/core/templates/templates/admin/searchPage.gohtml
@@ -18,7 +18,7 @@
                 <a href="/admin/search/list">Show complete word list</a><br>
                 <a href="/admin/search/list.txt">Download word list</a><br>
                 <br>
-                Preform something:<br>
+                Perform something:<br>
                 <form method="post">
         {{ csrfField }}
                         <input type="submit" name="task" value="Remake comments search"><br>


### PR DESCRIPTION
## Summary
- correct "Preform something" typos on admin forum and search pages

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: Provider does not implement email.Provider)*
- `golangci-lint run ./...` *(fails: typecheck issues in email mocks)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686d03153434832fab1ddb8287367327