### PR TITLE
Update README CLI instructions

### DIFF
--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,0 +1,27 @@
+version: '3.8'
+services:
+  db:
+    image: mysql:8
+    restart: always
+    environment:
+      MYSQL_DATABASE: a4web
+      MYSQL_ROOT_PASSWORD: changeme
+    volumes:
+      - db-data:/var/lib/mysql
+
+  app:
+    build: ..
+    ports:
+      - "8080:8080"
+    environment:
+      DB_DRIVER: mysql
+      DB_CONN: root:changeme@tcp(db:3306)/a4web?parseTime=true
+      AUTO_MIGRATE: "true"
+    volumes:
+      - app-data:/data
+    depends_on:
+      - db
+
+volumes:
+  db-data:
+  app-data:


### PR DESCRIPTION
## Summary
- remove the GitLab section
- document extra CLI functionality such as migrations and config helpers
- add environment-based config example
- document docker deployment and compose config

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: Provider does not implement email.Provider)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: build errors in mock email provider)*
- `go mod tidy`


------
https://chatgpt.com/codex/tasks/task_e_686d01334724832f8bcc8c3eb0fd5aab