### PR TITLE
Rename news structs to SiteNews and SiteNewsSearch

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -330,7 +330,7 @@ type SiteAnnouncement struct {
 	CreatedAt  time.Time
 }
 
-type Sitenews struct {
+type SiteNews struct {
 	Idsitenews               int32
 	ForumthreadIdforumthread int32
 	LanguageIdlanguage       int32
@@ -339,7 +339,7 @@ type Sitenews struct {
 	Occurred                 sql.NullTime
 }
 
-type Sitenewssearch struct {
+type SiteNewsSearch struct {
 	SitenewsIdsitenews             int32
 	SearchwordlistIdsearchwordlist int32
 }


### PR DESCRIPTION
## Summary
- rename `Sitenews` struct to `SiteNews`
- rename `Sitenewssearch` struct to `SiteNewsSearch`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: Provider in email/mock does not implement email.Provider)*
- `golangci-lint run ./...` *(fails: typecheck errors in internal/email/mock)*
- `go test ./...` *(fails: build errors in internal/email/mock)*

------
https://chatgpt.com/codex/tasks/task_e_686d02fe6c20832fab1474e333c877d0