### PR TITLE
Rename topic restriction structs

### DIFF
--- a/handlers/forum/forumAdminTopicRestrictions.go
+++ b/handlers/forum/forumAdminTopicRestrictions.go
@@ -20,7 +20,7 @@ func AdminTopicRestrictionLevelPage(w http.ResponseWriter, r *http.Request) {
 
 	type Data struct {
 		*CoreData
-		Restrictions []*db.GetForumTopicRestrictionsByForumTopicIdRow
+		Restrictions []*db.GetForumTopicRestrictionByForumTopicIdRow
 	}
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
@@ -31,7 +31,7 @@ func AdminTopicRestrictionLevelPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	topicId, _ := strconv.Atoi(vars["topic"])
 
-	restrictions, err := queries.GetForumTopicRestrictionsByForumTopicId(r.Context(), int32(topicId))
+	restrictions, err := queries.GetForumTopicRestrictionByForumTopicId(r.Context(), int32(topicId))
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -99,7 +99,7 @@ func AdminTopicRestrictionLevelChangePage(w http.ResponseWriter, r *http.Request
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
 	// TODO fix query / schema to overwrite existing value
-	if err := queries.UpsertForumTopicRestrictions(r.Context(), db.UpsertForumTopicRestrictionsParams{
+	if err := queries.UpsertForumTopicRestriction(r.Context(), db.UpsertForumTopicRestrictionParams{
 		ForumtopicIdforumtopic: int32(topicId),
 		Viewlevel:              sql.NullInt32{Valid: true, Int32: int32(view)},
 		Replylevel:             sql.NullInt32{Valid: true, Int32: int32(reply)},
@@ -125,7 +125,7 @@ func AdminTopicRestrictionLevelDeletePage(w http.ResponseWriter, r *http.Request
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
-	if err := queries.DeleteTopicRestrictionsByForumTopicId(r.Context(), int32(topicId)); err != nil {
+	if err := queries.DeleteTopicRestrictionByForumTopicId(r.Context(), int32(topicId)); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
@@ -149,20 +149,20 @@ func AdminTopicRestrictionLevelCopyPage(w http.ResponseWriter, r *http.Request) 
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
-	src, err := queries.GetForumTopicRestrictionsByForumTopicId(r.Context(), int32(fromID))
+	src, err := queries.GetForumTopicRestrictionByForumTopicId(r.Context(), int32(fromID))
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
 
 	if len(src) == 0 || !src[0].ForumtopicIdforumtopic.Valid {
-		if err := queries.DeleteTopicRestrictionsByForumTopicId(r.Context(), int32(toID)); err != nil {
+		if err := queries.DeleteTopicRestrictionByForumTopicId(r.Context(), int32(toID)); err != nil {
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 			return
 		}
 	} else {
 		row := src[0]
-		if err := queries.UpsertForumTopicRestrictions(r.Context(), db.UpsertForumTopicRestrictionsParams{
+		if err := queries.UpsertForumTopicRestriction(r.Context(), db.UpsertForumTopicRestrictionParams{
 			ForumtopicIdforumtopic: int32(toID),
 			Viewlevel:              row.Viewlevel,
 			Replylevel:             row.Replylevel,

--- a/handlers/forum/forumAdminTopicsRestrictions.go
+++ b/handlers/forum/forumAdminTopicsRestrictions.go
@@ -19,7 +19,7 @@ func AdminTopicsRestrictionLevelPage(w http.ResponseWriter, r *http.Request) {
 
 	type Data struct {
 		*CoreData
-		Restrictions []*db.GetAllForumTopicRestrictionsWithForumTopicTitleRow
+		Restrictions []*db.GetAllForumTopicRestrictionWithForumTopicTitleRow
 	}
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
@@ -28,7 +28,7 @@ func AdminTopicsRestrictionLevelPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
 	}
 
-	restrictions, err := queries.GetAllForumTopicRestrictionsWithForumTopicTitle(r.Context())
+	restrictions, err := queries.GetAllForumTopicRestrictionWithForumTopicTitle(r.Context())
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -98,7 +98,7 @@ func AdminTopicsRestrictionLevelChangePage(w http.ResponseWriter, r *http.Reques
 	}
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
-	if err := queries.UpsertForumTopicRestrictions(r.Context(), db.UpsertForumTopicRestrictionsParams{
+	if err := queries.UpsertForumTopicRestriction(r.Context(), db.UpsertForumTopicRestrictionParams{
 		ForumtopicIdforumtopic: int32(ftid),
 		Viewlevel:              sql.NullInt32{Valid: true, Int32: int32(view)},
 		Replylevel:             sql.NullInt32{Valid: true, Int32: int32(reply)},
@@ -126,7 +126,7 @@ func AdminTopicsRestrictionLevelDeletePage(w http.ResponseWriter, r *http.Reques
 	}
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
-	if err := queries.DeleteTopicRestrictionsByForumTopicId(r.Context(), int32(ftid)); err != nil {
+	if err := queries.DeleteTopicRestrictionByForumTopicId(r.Context(), int32(ftid)); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
@@ -150,20 +150,20 @@ func AdminTopicsRestrictionLevelCopyPage(w http.ResponseWriter, r *http.Request)
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
-	src, err := queries.GetForumTopicRestrictionsByForumTopicId(r.Context(), int32(fromID))
+	src, err := queries.GetForumTopicRestrictionByForumTopicId(r.Context(), int32(fromID))
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
 
 	if len(src) == 0 || !src[0].ForumtopicIdforumtopic.Valid {
-		if err := queries.DeleteTopicRestrictionsByForumTopicId(r.Context(), int32(toID)); err != nil {
+		if err := queries.DeleteTopicRestrictionByForumTopicId(r.Context(), int32(toID)); err != nil {
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 			return
 		}
 	} else {
 		row := src[0]
-		if err := queries.UpsertForumTopicRestrictions(r.Context(), db.UpsertForumTopicRestrictionsParams{
+		if err := queries.UpsertForumTopicRestriction(r.Context(), db.UpsertForumTopicRestrictionParams{
 			ForumtopicIdforumtopic: int32(toID),
 			Viewlevel:              row.Viewlevel,
 			Replylevel:             row.Replylevel,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -276,8 +276,6 @@ type Password struct {
 	CreatedAt       time.Time
 }
 
-// PendingEmail represents a queued email message stored in full including
-// headers and MIME body. The message is addressed to the referenced user.
 type PendingEmail struct {
 	ID         int32
 	ToUserID   int32
@@ -358,7 +356,7 @@ type TemplateOverride struct {
 	UpdatedAt time.Time
 }
 
-type Topicrestriction struct {
+type TopicRestriction struct {
 	ForumtopicIdforumtopic int32
 	Viewlevel              sql.NullInt32
 	Replylevel             sql.NullInt32

--- a/internal/db/queries-permissions.sql
+++ b/internal/db/queries-permissions.sql
@@ -78,10 +78,10 @@ FROM userstopiclevel utl
 WHERE utl.users_idusers = ? AND utl.forumtopic_idforumtopic = ?
 ;
 
--- name: DeleteTopicRestrictionsByForumTopicId :exec
+-- name: DeleteTopicRestrictionByForumTopicId :exec
 DELETE FROM topicrestrictions WHERE forumtopic_idforumtopic = ?;
 
--- name: UpsertForumTopicRestrictions :exec
+-- name: UpsertForumTopicRestriction :exec
 INSERT INTO topicrestrictions (forumtopic_idforumtopic, viewlevel, replylevel, newthreadlevel, seelevel, invitelevel, readlevel, modlevel, adminlevel)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON DUPLICATE KEY UPDATE
@@ -94,13 +94,13 @@ ON DUPLICATE KEY UPDATE
     modlevel = VALUES(modlevel),
     adminlevel = VALUES(adminlevel);
 
--- name: GetForumTopicRestrictionsByForumTopicId :many
+-- name: GetForumTopicRestrictionByForumTopicId :many
 SELECT t.idforumtopic, r.*
 FROM forumtopic t
 LEFT JOIN topicrestrictions r ON t.idforumtopic = r.forumtopic_idforumtopic
 WHERE idforumtopic = ?;
 
--- name: GetAllForumTopicRestrictionsWithForumTopicTitle :many
+-- name: GetAllForumTopicRestrictionWithForumTopicTitle :many
 SELECT t.idforumtopic, r.*
 FROM forumtopic t
 LEFT JOIN topicrestrictions r ON t.idforumtopic = r.forumtopic_idforumtopic;

--- a/internal/db/queries-permissions.sql.go
+++ b/internal/db/queries-permissions.sql.go
@@ -44,12 +44,12 @@ func (q *Queries) CountPermissionSections(ctx context.Context) ([]*CountPermissi
 	return items, nil
 }
 
-const deleteTopicRestrictionsByForumTopicId = `-- name: DeleteTopicRestrictionsByForumTopicId :exec
+const deleteTopicRestrictionByForumTopicId = `-- name: DeleteTopicRestrictionByForumTopicId :exec
 DELETE FROM topicrestrictions WHERE forumtopic_idforumtopic = ?
 `
 
-func (q *Queries) DeleteTopicRestrictionsByForumTopicId(ctx context.Context, forumtopicIdforumtopic int32) error {
-	_, err := q.db.ExecContext(ctx, deleteTopicRestrictionsByForumTopicId, forumtopicIdforumtopic)
+func (q *Queries) DeleteTopicRestrictionByForumTopicId(ctx context.Context, forumtopicIdforumtopic int32) error {
+	_, err := q.db.ExecContext(ctx, deleteTopicRestrictionByForumTopicId, forumtopicIdforumtopic)
 	return err
 }
 
@@ -71,13 +71,13 @@ func (q *Queries) GetAdministratorPermissionByUserId(ctx context.Context, usersI
 	return &i, err
 }
 
-const getAllForumTopicRestrictionsWithForumTopicTitle = `-- name: GetAllForumTopicRestrictionsWithForumTopicTitle :many
+const getAllForumTopicRestrictionWithForumTopicTitle = `-- name: GetAllForumTopicRestrictionWithForumTopicTitle :many
 SELECT t.idforumtopic, r.forumtopic_idforumtopic, r.viewlevel, r.replylevel, r.newthreadlevel, r.seelevel, r.invitelevel, r.readlevel, r.modlevel, r.adminlevel
 FROM forumtopic t
 LEFT JOIN topicrestrictions r ON t.idforumtopic = r.forumtopic_idforumtopic
 `
 
-type GetAllForumTopicRestrictionsWithForumTopicTitleRow struct {
+type GetAllForumTopicRestrictionWithForumTopicTitleRow struct {
 	Idforumtopic           int32
 	ForumtopicIdforumtopic sql.NullInt32
 	Viewlevel              sql.NullInt32
@@ -90,15 +90,15 @@ type GetAllForumTopicRestrictionsWithForumTopicTitleRow struct {
 	Adminlevel             sql.NullInt32
 }
 
-func (q *Queries) GetAllForumTopicRestrictionsWithForumTopicTitle(ctx context.Context) ([]*GetAllForumTopicRestrictionsWithForumTopicTitleRow, error) {
-	rows, err := q.db.QueryContext(ctx, getAllForumTopicRestrictionsWithForumTopicTitle)
+func (q *Queries) GetAllForumTopicRestrictionWithForumTopicTitle(ctx context.Context) ([]*GetAllForumTopicRestrictionWithForumTopicTitleRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllForumTopicRestrictionWithForumTopicTitle)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*GetAllForumTopicRestrictionsWithForumTopicTitleRow
+	var items []*GetAllForumTopicRestrictionWithForumTopicTitleRow
 	for rows.Next() {
-		var i GetAllForumTopicRestrictionsWithForumTopicTitleRow
+		var i GetAllForumTopicRestrictionWithForumTopicTitleRow
 		if err := rows.Scan(
 			&i.Idforumtopic,
 			&i.ForumtopicIdforumtopic,
@@ -124,14 +124,14 @@ func (q *Queries) GetAllForumTopicRestrictionsWithForumTopicTitle(ctx context.Co
 	return items, nil
 }
 
-const getForumTopicRestrictionsByForumTopicId = `-- name: GetForumTopicRestrictionsByForumTopicId :many
+const getForumTopicRestrictionByForumTopicId = `-- name: GetForumTopicRestrictionByForumTopicId :many
 SELECT t.idforumtopic, r.forumtopic_idforumtopic, r.viewlevel, r.replylevel, r.newthreadlevel, r.seelevel, r.invitelevel, r.readlevel, r.modlevel, r.adminlevel
 FROM forumtopic t
 LEFT JOIN topicrestrictions r ON t.idforumtopic = r.forumtopic_idforumtopic
 WHERE idforumtopic = ?
 `
 
-type GetForumTopicRestrictionsByForumTopicIdRow struct {
+type GetForumTopicRestrictionByForumTopicIdRow struct {
 	Idforumtopic           int32
 	ForumtopicIdforumtopic sql.NullInt32
 	Viewlevel              sql.NullInt32
@@ -144,15 +144,15 @@ type GetForumTopicRestrictionsByForumTopicIdRow struct {
 	Adminlevel             sql.NullInt32
 }
 
-func (q *Queries) GetForumTopicRestrictionsByForumTopicId(ctx context.Context, idforumtopic int32) ([]*GetForumTopicRestrictionsByForumTopicIdRow, error) {
-	rows, err := q.db.QueryContext(ctx, getForumTopicRestrictionsByForumTopicId, idforumtopic)
+func (q *Queries) GetForumTopicRestrictionByForumTopicId(ctx context.Context, idforumtopic int32) ([]*GetForumTopicRestrictionByForumTopicIdRow, error) {
+	rows, err := q.db.QueryContext(ctx, getForumTopicRestrictionByForumTopicId, idforumtopic)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*GetForumTopicRestrictionsByForumTopicIdRow
+	var items []*GetForumTopicRestrictionByForumTopicIdRow
 	for rows.Next() {
-		var i GetForumTopicRestrictionsByForumTopicIdRow
+		var i GetForumTopicRestrictionByForumTopicIdRow
 		if err := rows.Scan(
 			&i.Idforumtopic,
 			&i.ForumtopicIdforumtopic,
@@ -495,7 +495,7 @@ func (q *Queries) RenamePermissionSection(ctx context.Context, arg RenamePermiss
 	return err
 }
 
-const upsertForumTopicRestrictions = `-- name: UpsertForumTopicRestrictions :exec
+const upsertForumTopicRestriction = `-- name: UpsertForumTopicRestriction :exec
 INSERT INTO topicrestrictions (forumtopic_idforumtopic, viewlevel, replylevel, newthreadlevel, seelevel, invitelevel, readlevel, modlevel, adminlevel)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON DUPLICATE KEY UPDATE
@@ -509,7 +509,7 @@ ON DUPLICATE KEY UPDATE
     adminlevel = VALUES(adminlevel)
 `
 
-type UpsertForumTopicRestrictionsParams struct {
+type UpsertForumTopicRestrictionParams struct {
 	ForumtopicIdforumtopic int32
 	Viewlevel              sql.NullInt32
 	Replylevel             sql.NullInt32
@@ -521,8 +521,8 @@ type UpsertForumTopicRestrictionsParams struct {
 	Adminlevel             sql.NullInt32
 }
 
-func (q *Queries) UpsertForumTopicRestrictions(ctx context.Context, arg UpsertForumTopicRestrictionsParams) error {
-	_, err := q.db.ExecContext(ctx, upsertForumTopicRestrictions,
+func (q *Queries) UpsertForumTopicRestriction(ctx context.Context, arg UpsertForumTopicRestrictionParams) error {
+	_, err := q.db.ExecContext(ctx, upsertForumTopicRestriction,
 		arg.ForumtopicIdforumtopic,
 		arg.Viewlevel,
 		arg.Replylevel,

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -1,4 +1,8 @@
 version: 2
+overrides:
+    go:
+        rename:
+            topicrestriction: TopicRestriction
 sql:
     - engine: "mysql"
       schema: "schema/schema.sql"


### PR DESCRIPTION
## Summary
- rename TopicRestriction struct via sqlc rename
- update related query names and handlers
- regenerate sqlc code

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: Provider does not implement email.Provider)*
- `golangci-lint run` *(fails: typecheck errors)*
- `sqlc generate`

------
https://chatgpt.com/codex/tasks/task_e_686d03008c48832f96707a0041521c6c