### PR TITLE
Fix runtimeconfig FS types and update email mock

### DIFF
--- a/internal/email/mock/mock.go
+++ b/internal/email/mock/mock.go
@@ -30,9 +30,11 @@ type Provider struct {
 }
 
 // Send appends the message to the Provider's Messages slice.
-func (p *Provider) Send(_ context.Context, to, subject string, rawEmailMessage []byte) error {
-	var textBody, htmlBody string
+func (p *Provider) Send(_ context.Context, to mail.Address, rawEmailMessage []byte) error {
+	var subject, textBody, htmlBody string
+
 	if m, err := mail.ReadMessage(bytes.NewReader(rawEmailMessage)); err == nil {
+		subject = m.Header.Get("Subject")
 		ct := m.Header.Get("Content-Type")
 		mediaType, params, _ := mime.ParseMediaType(ct)
 		if strings.HasPrefix(mediaType, "multipart/") {
@@ -61,7 +63,7 @@ func (p *Provider) Send(_ context.Context, to, subject string, rawEmailMessage [
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.Messages = append(p.Messages, SentMail{To: to, Subject: subject, Raw: rawEmailMessage, Text: textBody, HTML: htmlBody})
+	p.Messages = append(p.Messages, SentMail{To: to.String(), Subject: subject, Raw: rawEmailMessage, Text: textBody, HTML: htmlBody})
 	return nil
 }
 

--- a/internal/email/mock/mock_test.go
+++ b/internal/email/mock/mock_test.go
@@ -17,14 +17,14 @@ func TestProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
-	if err := p.Send(context.Background(), to.Address, "sub", msg); err != nil {
+	if err := p.Send(context.Background(), to, msg); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 	if len(p.Messages) != 1 {
 		t.Fatalf("messages len=%d", len(p.Messages))
 	}
 	rec := p.Messages[0]
-	if rec.To != to.Address || rec.Subject != "sub" {
+	if rec.To != to.String() || rec.Subject != "sub" {
 		t.Fatalf("unexpected message: %#v", rec)
 	}
 	if rec.Text != "body" || rec.HTML != "html" {

--- a/internal/emailutil/email_test.go
+++ b/internal/emailutil/email_test.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"net/mail"
-	"reflect"
 	"regexp"
 	"testing"
 
@@ -138,7 +137,7 @@ func TestEmailQueueWorker(t *testing.T) {
 	rec := &mockemail.Provider{}
 	emailutil.ProcessPendingEmail(context.Background(), q, rec, nil)
 
-	if len(rec.Messages) != 1 || rec.Messages[0].To.Address != "e" {
+	if len(rec.Messages) != 1 || rec.Messages[0].To != "\"bob\" <e@>" {
 		t.Fatalf("got %#v", rec.Messages)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/runtimeconfig/envmap.go
+++ b/runtimeconfig/envmap.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
 )
 
 // ToEnvMap converts cfg into a map keyed by environment variable name.
@@ -24,7 +25,7 @@ func ToEnvMap(cfg RuntimeConfig, cfgPath string) (map[string]string, error) {
 		m[o.Env] = strconv.FormatBool(*o.Target(&cfg))
 	}
 
-	fileVals, err := config.LoadAppConfigFile(config.OSFS{}, cfgPath)
+	fileVals, err := config.LoadAppConfigFile(core.OSFS{}, cfgPath)
 	if err != nil {
 		return nil, fmt.Errorf("load config file: %w", err)
 	}

--- a/runtimeconfig/session_secret.go
+++ b/runtimeconfig/session_secret.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
 	common "github.com/arran4/goa4web/core/common"
 )
 
@@ -16,7 +17,7 @@ import (
 const defaultSecretName = ".session_secret"
 
 // FileSystem abstracts file operations for loading and storing the secret.
-type FileSystem = config.FileSystem
+type FileSystem = core.FileSystem
 
 // DefaultSessionSecretPath returns the default path for the session secret file
 // based on the execution environment.


### PR DESCRIPTION
## Summary
- fix incorrect references to `config.OSFS` and `config.FileSystem`
- update the mock email provider to use `mail.Address`
- update tests for new provider signature

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686d0b798ef0832f890389b05f65cde8