### PR TITLE
Rename ImageBBS constants

### DIFF
--- a/handlers/imagebbs/constants.go
+++ b/handlers/imagebbs/constants.go
@@ -1,7 +1,7 @@
 package imagebbs
 
-// ImagebbsTopicName is the default name for the hidden image BBS forum.
-const ImagebbsTopicName = "A IMAGE BBS TOPIC"
+// ImageBBSTopicName is the default name for the hidden image BBS forum.
+const ImageBBSTopicName = "A IMAGE BBS TOPIC"
 
-// ImagebbsTopicDescription describes the hidden image BBS forum.
-const ImagebbsTopicDescription = "THIS IS A HIDDEN FORUM FOR A IMAGE BBS"
+// ImageBBSTopicDescription describes the hidden image BBS forum.
+const ImageBBSTopicDescription = "THIS IS A HIDDEN FORUM FOR A IMAGE BBS"

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -171,7 +171,7 @@ func BoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
 
 	var pthid int32 = post.ForumthreadIdforumthread
 	pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{
-		String: ImagebbsTopicName,
+		String: ImageBBSTopicName,
 		Valid:  true,
 	})
 	var ptid int32
@@ -179,11 +179,11 @@ func BoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		ptidi, err := queries.CreateForumTopic(r.Context(), db.CreateForumTopicParams{
 			ForumcategoryIdforumcategory: 0,
 			Title: sql.NullString{
-				String: ImagebbsTopicName,
+				String: ImageBBSTopicName,
 				Valid:  true,
 			},
 			Description: sql.NullString{
-				String: ImagebbsTopicDescription,
+				String: ImageBBSTopicDescription,
 				Valid:  true,
 			},
 		})


### PR DESCRIPTION
## Summary
- rename ImagebbsTopicName and ImagebbsTopicDescription constants to ImageBBSTopicName/ImageBBSTopicDescription
- update usages in thread reply handling

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: cannot build internal/email/mock)*

------
https://chatgpt.com/codex/tasks/task_e_686d034c3678832fa5b4f9bd6cbc15b5