### PR TITLE
Rename thread query to GetThreadLastPosterAndPerms

### DIFF
--- a/handlers/blogs/blogsCommentEditPage.go
+++ b/handlers/blogs/blogsCommentEditPage.go
@@ -34,7 +34,7 @@ func CommentEditPostPage(w http.ResponseWriter, r *http.Request) {
 
 	comment := r.Context().Value(common.KeyComment).(*db.GetCommentByIdForUserRow)
 
-	thread, err := queries.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams{
+	thread, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		UsersIdusers:  uid,
 		Idforumthread: comment.ForumthreadIdforumthread,
 	})

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -32,7 +32,7 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Category            *ForumcategoryPlus
 		Topic               *ForumtopicPlus
-		Thread              *db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
+		Thread              *db.GetThreadLastPosterAndPermsRow
 		Comments            []*CommentPlus
 		Offset              int
 		IsReplyable         bool
@@ -59,7 +59,7 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow)
+	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
 	topicRow := r.Context().Value(common.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
 	session, ok := core.GetSessionOrFail(w, r)

--- a/handlers/forum/forumTopicThreadCommentEditPage.go
+++ b/handlers/forum/forumTopicThreadCommentEditPage.go
@@ -20,7 +20,7 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("replytext")
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow)
+	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
 	topicRow := r.Context().Value(common.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 	commentId, _ := strconv.Atoi(mux.Vars(r)["comment"])
 
@@ -47,7 +47,7 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func TopicThreadCommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
-	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow)
+	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
 	topicRow := r.Context().Value(common.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -26,7 +26,7 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	threadRow := r.Context().Value(hcommon.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow)
+	threadRow := r.Context().Value(hcommon.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
 	topicRow := r.Context().Value(hcommon.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
 	if evt, ok := r.Context().Value(hcommon.KeyBusEvent).(*eventbus.Event); ok && evt != nil {
@@ -106,7 +106,7 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func TopicThreadReplyCancelPage(w http.ResponseWriter, r *http.Request) {
-	threadRow := r.Context().Value(hcommon.KeyThread).(*db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow)
+	threadRow := r.Context().Value(hcommon.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
 	topicRow := r.Context().Value(hcommon.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)

--- a/handlers/forum/matchers.go
+++ b/handlers/forum/matchers.go
@@ -39,7 +39,7 @@ func RequireThreadAndTopic(next http.Handler) http.Handler {
 			uid, _ = session.Values["UID"].(int32)
 		}
 
-		threadRow, err := queries.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams{
+		threadRow, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 			UsersIdusers:  uid,
 			Idforumthread: int32(threadID),
 		})

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -37,7 +37,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 		Comments           []*CommentPlus
 		BoardId            int
 		ImagePost          *db.GetAllImagePostsByIdWithAuthorUsernameAndThreadCommentCountRow
-		Thread             *db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
+		Thread             *db.GetThreadLastPosterAndPermsRow
 		Offset             int
 		IsReplyable        bool
 	}
@@ -73,7 +73,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	threadRow, err := queries.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams{
+	threadRow, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		UsersIdusers:  uid,
 		Idforumthread: int32(thid),
 	})

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -45,7 +45,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		Text               string
 		CanEdit            bool
 		UserId             int32
-		Thread             *db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
+		Thread             *db.GetThreadLastPosterAndPermsRow
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
@@ -100,7 +100,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	threadRow, err := queries.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams{
+	threadRow, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		UsersIdusers:  uid,
 		Idforumthread: link.ForumthreadIdforumthread,
 	})

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -60,7 +60,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		Offset             int
 		IsReplying         bool
 		IsReplyable        bool
-		Thread             *db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
+		Thread             *db.GetThreadLastPosterAndPermsRow
 		ReplyText          string
 	}
 
@@ -103,7 +103,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	threadRow, err := queries.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams{
+	threadRow, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		UsersIdusers:  uid,
 		Idforumthread: int32(post.ForumthreadIdforumthread),
 	})

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -38,7 +38,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		UserId              int32
 		Languages           []*db.Language
 		SelectedLanguageId  int
-		Thread              *db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
+		Thread              *db.GetThreadLastPosterAndPermsRow
 		Comments            []*CommentPlus
 		IsReplyable         bool
 		IsAdmin             bool
@@ -151,7 +151,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	threadRow, err := queries.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(r.Context(), db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams{
+	threadRow, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		UsersIdusers:  uid,
 		Idforumthread: writing.ForumthreadIdforumthread,
 	})

--- a/internal/db/queries-threads.sql
+++ b/internal/db/queries-threads.sql
@@ -49,7 +49,7 @@ SET lastaddition = (
 )
 WHERE idforumthread = ?;
 
--- name: GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions :one
+-- name: GetThreadLastPosterAndPerms :one
 SELECT th.*, lu.username AS LastPosterUsername, r.seelevel, u.level
 FROM forumthread th
 LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic

--- a/internal/db/queries-threads.sql.go
+++ b/internal/db/queries-threads.sql.go
@@ -30,7 +30,7 @@ func (q *Queries) GetForumTopicIdByThreadId(ctx context.Context, idforumthread i
 	return forumtopic_idforumtopic, err
 }
 
-const getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions = `-- name: GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions :one
+const getThreadLastPosterAndPerms = `-- name: GetThreadLastPosterAndPerms :one
 SELECT th.idforumthread, th.firstpost, th.lastposter, th.forumtopic_idforumtopic, th.comments, th.lastaddition, th.locked, lu.username AS LastPosterUsername, r.seelevel, u.level
 FROM forumthread th
 LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
@@ -41,12 +41,12 @@ WHERE IF(r.seelevel IS NOT NULL, r.seelevel , 0) <= IF(u.level IS NOT NULL, u.le
 ORDER BY t.lastaddition DESC
 `
 
-type GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams struct {
+type GetThreadLastPosterAndPermsParams struct {
 	UsersIdusers  int32
 	Idforumthread int32
 }
 
-type GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow struct {
+type GetThreadLastPosterAndPermsRow struct {
 	Idforumthread          int32
 	Firstpost              int32
 	Lastposter             int32
@@ -59,9 +59,9 @@ type GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow struct {
 	Level                  sql.NullInt32
 }
 
-func (q *Queries) GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissions(ctx context.Context, arg GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsParams) (*GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow, error) {
-	row := q.db.QueryRowContext(ctx, getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions, arg.UsersIdusers, arg.Idforumthread)
-	var i GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
+func (q *Queries) GetThreadLastPosterAndPerms(ctx context.Context, arg GetThreadLastPosterAndPermsParams) (*GetThreadLastPosterAndPermsRow, error) {
+	row := q.db.QueryRowContext(ctx, getThreadLastPosterAndPerms, arg.UsersIdusers, arg.Idforumthread)
+	var i GetThreadLastPosterAndPermsRow
 	err := row.Scan(
 		&i.Idforumthread,
 		&i.Firstpost,

--- a/internal/notifications/types.go
+++ b/internal/notifications/types.go
@@ -6,7 +6,7 @@ import "github.com/arran4/goa4web/internal/db"
 type ForumReplyInfo struct {
 	TopicTitle string
 	ThreadID   int32
-	Thread     *db.GetThreadByIdForUserByIdWithLastPosterUserNameAndPermissionsRow
+	Thread     *db.GetThreadLastPosterAndPermsRow
 }
 
 // ThreadInfo represents a newly created forum thread.


### PR DESCRIPTION
## Summary
- shorten query name related to last poster details
- adjust Go code to use the new identifier

## Testing
- `go vet ./...` *(fails: Provider does not implement email.Provider)*
- `golangci-lint run ./...` *(fails: typecheck errors in mock email provider)*
- `go test ./...` *(fails: build errors in email/mock)*

------
https://chatgpt.com/codex/tasks/task_e_686d037b0c68832fb41ca8a2842d03e1