### PR TITLE
Rename IsOffset fields to HasOffset

### DIFF
--- a/core/templates/templates/blogs/bloggerPage.gohtml
+++ b/core/templates/templates/blogs/bloggerPage.gohtml
@@ -19,7 +19,7 @@
 				{{end}}
 			</table><br>
 		{{else}}
-			{{if .IsOffset}}
+                       {{if .HasOffset}}
 				{{if .UID}}
 					There are no more blogs under this user.<br>
 				{{else}}

--- a/core/templates/templates/blogs/page.gohtml
+++ b/core/templates/templates/blogs/page.gohtml
@@ -20,7 +20,7 @@
 				{{end}}
 			</table><br>
 		{{else}}
-			{{if .IsOffset}}
+                       {{if .HasOffset}}
 				{{if .UID}}
 					There are no more blogs under this user.<br>
 				{{else}}

--- a/handlers/blogs/blogsBloggerPage.go
+++ b/handlers/blogs/blogsBloggerPage.go
@@ -23,9 +23,9 @@ func BloggerPage(w http.ResponseWriter, r *http.Request) {
 	}
 	type Data struct {
 		*CoreData
-		Rows     []*BlogRow
-		IsOffset bool
-		UID      string
+		Rows      []*BlogRow
+		HasOffset bool
+		UID       string
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
@@ -73,9 +73,9 @@ func BloggerPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
-		IsOffset: offset != 0,
-		UID:      strconv.Itoa(int(buid)),
+		CoreData:  r.Context().Value(common.KeyCoreData).(*CoreData),
+		HasOffset: offset != 0,
+		UID:       strconv.Itoa(int(buid)),
 	}
 
 	for _, row := range rows {

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -26,9 +26,9 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 	type Data struct {
 		*CoreData
-		Rows     []*BlogRow
-		IsOffset bool
-		UID      string
+		Rows      []*BlogRow
+		HasOffset bool
+		UID       string
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
@@ -58,9 +58,9 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
-		IsOffset: offset != 0,
-		UID:      buid,
+		CoreData:  r.Context().Value(common.KeyCoreData).(*CoreData),
+		HasOffset: offset != 0,
+		UID:       buid,
 	}
 
 	for _, row := range rows {

--- a/handlers/linker/linkerLinkerPage.go
+++ b/handlers/linker/linkerLinkerPage.go
@@ -17,9 +17,9 @@ import (
 func LinkerPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*corecommon.CoreData
-		Links    []*db.GetLinkerItemsByUserDescendingRow
-		Username string
-		IsOffset bool
+		Links     []*db.GetLinkerItemsByUserDescendingRow
+		Username  string
+		HasOffset bool
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
@@ -51,10 +51,10 @@ func LinkerPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
-		Links:    rows,
-		Username: username,
-		IsOffset: offset != 0,
+		CoreData:  r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		Links:     rows,
+		Username:  username,
+		HasOffset: offset != 0,
 	}
 
 	CustomLinkerIndex(data.CoreData, r)

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -63,10 +63,10 @@ func TestPageTemplatesRender(t *testing.T) {
 		}{&corecommon.CoreData{}, nil}},
 		{"blogsPage", struct {
 			*corecommon.CoreData
-			Rows     any
-			IsOffset bool
-			UID      string
-			Blogs    []struct{ Username string }
+			Rows      any
+			HasOffset bool
+			UID       string
+			Blogs     []struct{ Username string }
 		}{&corecommon.CoreData{}, nil, false, "", []struct{ Username string }{{"test"}}}},
 		{"writingsPage", struct {
 			*corecommon.CoreData

--- a/handlers/writings/writingsWriterPage.go
+++ b/handlers/writings/writingsWriterPage.go
@@ -19,7 +19,7 @@ func WriterPage(w http.ResponseWriter, r *http.Request) {
 		*corecommon.CoreData
 		Abstracts []*db.GetPublicWritingsByUserRow
 		Username  string
-		IsOffset  bool
+		HasOffset bool
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
@@ -54,7 +54,7 @@ func WriterPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:  r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
 		Abstracts: rows,
 		Username:  username,
-		IsOffset:  offset != 0,
+		HasOffset: offset != 0,
 	}
 
 	CustomWritingsIndex(data.CoreData, r)


### PR DESCRIPTION
## Summary
- rename `IsOffset` struct fields to `HasOffset`
- update blogs templates to reference `HasOffset`
- adjust template rendering tests

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: Provider type mismatch)*
- `golangci-lint run` *(fails: typecheck issues)*
- `go test ./...` *(fails: build failure in internal/email/mock)*

------
https://chatgpt.com/codex/tasks/task_e_686d03829fa0832fad5680848f3f93a1