### PR TITLE
Improve sqlc regen branch detection

### DIFF
--- a/.github/workflows/sqlc-update.yml
+++ b/.github/workflows/sqlc-update.yml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore(sqlc): regenerate code'
           branch: sqlc-autogen-${{ github.run_id }}
-          base: ${{ github.ref_name }}
+          base: ${{ github.head_ref || github.ref_name }}
           title: 'Update sqlc generated files'
           body: |
             This PR updates generated code after SQL file changes.


### PR DESCRIPTION
## Summary
- allow sqlc regen action to work when triggered on a PR

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686d10cac8c4832f80c29eb3527c101d