### PR TITLE
Fix email mock provider

### DIFF
--- a/internal/email/mock/mock.go
+++ b/internal/email/mock/mock.go
@@ -62,7 +62,7 @@ func (p *Provider) Send(_ context.Context, to mail.Address, rawEmailMessage []by
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.Messages = append(p.Messages, SentMail{To: to.Address, Subject: subject, Raw: rawEmailMessage, Text: textBody, HTML: htmlBody})
+	p.Messages = append(p.Messages, SentMail{To: to, Subject: subject, Raw: rawEmailMessage, Text: textBody, HTML: htmlBody})
 	return nil
 }
 

--- a/internal/emailutil/email_test.go
+++ b/internal/emailutil/email_test.go
@@ -137,7 +137,7 @@ func TestEmailQueueWorker(t *testing.T) {
 	rec := &mockemail.Provider{}
 	emailutil.ProcessPendingEmail(context.Background(), q, rec, nil)
 
-	if len(rec.Messages) != 1 || rec.Messages[0].To != "\"bob\" <e@>" {
+	if len(rec.Messages) != 1 || rec.Messages[0].To.String() != "\"bob\" <e@>" {
 		t.Fatalf("got %#v", rec.Messages)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
## Summary
- fix Send function in mock email provider to store full `mail.Address`
- update failing test to compare address via `String()`

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686d16ea4794832f8d6d2a4746cdc5f3