### PR TITLE
Rename Offset field in linkerPage test struct

### DIFF
--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -46,7 +46,7 @@ func TestPageTemplatesRender(t *testing.T) {
 			*corecommon.CoreData
 			Categories any
 			Links      any
-			Offset     bool
+			HasOffset  bool
 			CatId      int32
 		}{&corecommon.CoreData{}, nil, nil, false, 0}},
 		{"forumPage", struct {


### PR DESCRIPTION
## Summary
- adjust linkerPage test struct in `template_render_test.go`
- rename `Offset` to `HasOffset`

## Testing
- `go fmt ./...`
- `go mod tidy`
- `go vet ./...` *(fails: cannot use to.Address as mail.Address in internal/email/mock)*
- `golangci-lint run` *(fails: typecheck error in internal/email/mock)*

------
https://chatgpt.com/codex/tasks/task_e_686d16e42d1c832f906a2bb7feda4408