### PR TITLE
Fix writing approval table name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,9 @@ go test ./...
 ```
 
 SQL query files are compiled using `sqlc`. Do not manually edit the generated `*.sql.go` files; instead edit the `.sql` files under `internal/db/` and run `sqlc generate`.
+Avoid using the `overrides` section in `sqlc.yaml`; prefer Go type aliases if a different struct name is required.
 
-All database schema changes must include a migration script in the `migrations/` directory (for example `0002.sql`, `0003.sql`).
+All database schema changes must include a new migration script in the `migrations/` directory (for example `0002.sql`, `0003.sql`). Never modify previously committed migration files so the history of changes remains intact.
 
 Errors in critical functions like `main()` or `run()` must be logged or wrapped using `fmt.Errorf` with context. Prefer doing both when errors propagate.
 

--- a/handlers/common/constants.go
+++ b/handlers/common/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 17
+	ExpectedSchemaVersion = 18
 )

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -276,8 +276,6 @@ type Password struct {
 	CreatedAt       time.Time
 }
 
-// PendingEmail represents a queued email message stored in full including
-// headers and MIME body. The message is addressed to the referenced user.
 type PendingEmail struct {
 	ID         int32
 	ToUserID   int32
@@ -405,6 +403,13 @@ type Writing struct {
 	DeletedAt                        sql.NullTime
 }
 
+type Writingapproveduser struct {
+	WritingIdwriting int32
+	UsersIdusers     int32
+	Readdoc          sql.NullBool
+	Editdoc          sql.NullBool
+}
+
 type Writingcategory struct {
 	Idwritingcategory                int32
 	WritingcategoryIdwritingcategory int32
@@ -415,13 +420,6 @@ type Writingcategory struct {
 type Writingsearch struct {
 	SearchwordlistIdsearchwordlist int32
 	WritingIdwriting               int32
-}
-
-type Writtingapproveduser struct {
-	WritingIdwriting int32
-	UsersIdusers     int32
-	Readdoc          sql.NullBool
-	Editdoc          sql.NullBool
 }
 
 type _1OldForumthread struct {

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -38,7 +38,7 @@ VALUES (?, ?, ?, ?, ?, ?, NOW(), ?);
 SELECT w.*, u.idusers AS WriterId, u.Username AS WriterUsername
 FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
-LEFT JOIN writtingApprovedUsers wau ON w.idwriting = wau.writing_idwriting AND wau.users_idusers = sqlc.arg(UserId)
+LEFT JOIN writingApprovedUsers wau ON w.idwriting = wau.writing_idwriting AND wau.users_idusers = sqlc.arg(UserId)
 WHERE w.idwriting = ? AND (w.private = 0 OR wau.readdoc = 1 OR w.users_idusers = sqlc.arg(UserId))
 ORDER BY w.published DESC
 ;
@@ -47,7 +47,7 @@ ORDER BY w.published DESC
 SELECT w.*, u.idusers AS WriterId, u.username AS WriterUsername
 FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
-LEFT JOIN writtingApprovedUsers wau ON w.idwriting = wau.writing_idwriting AND wau.users_idusers = sqlc.arg(userId)
+LEFT JOIN writingApprovedUsers wau ON w.idwriting = wau.writing_idwriting AND wau.users_idusers = sqlc.arg(userId)
 WHERE w.idwriting IN (sqlc.slice(writingIds)) AND (w.private = 0 OR wau.readdoc = 1 OR w.users_idusers = sqlc.arg(userId))
 ORDER BY w.published DESC
 ;
@@ -72,21 +72,21 @@ FROM writingCategory wc
 ;
 
 -- name: DeleteWritingApproval :exec
-DELETE FROM writtingApprovedUsers
+DELETE FROM writingApprovedUsers
 WHERE writing_idwriting = ? AND users_idusers = ?;
 
 -- name: CreateWritingApproval :exec
-INSERT INTO writtingApprovedUsers (writing_idwriting, users_idusers, readdoc, editdoc)
+INSERT INTO writingApprovedUsers (writing_idwriting, users_idusers, readdoc, editdoc)
 VALUES (?, ?, ?, ?);
 
 -- name: UpdateWritingApproval :exec
-UPDATE writtingApprovedUsers
+UPDATE writingApprovedUsers
 SET readdoc = ?, editdoc = ?
 WHERE writing_idwriting = ? AND users_idusers = ?;
 
 -- name: GetAllWritingApprovals :many
 SELECT idusers, u.username, wau.*
-FROM writtingApprovedUsers wau
+FROM writingApprovedUsers wau
 LEFT JOIN users u ON idusers = wau.users_idusers
 ;
 

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -26,7 +26,7 @@ func (q *Queries) AssignWritingThisThreadId(ctx context.Context, arg AssignWriti
 }
 
 const createWritingApproval = `-- name: CreateWritingApproval :exec
-INSERT INTO writtingApprovedUsers (writing_idwriting, users_idusers, readdoc, editdoc)
+INSERT INTO writingApprovedUsers (writing_idwriting, users_idusers, readdoc, editdoc)
 VALUES (?, ?, ?, ?)
 `
 
@@ -48,7 +48,7 @@ func (q *Queries) CreateWritingApproval(ctx context.Context, arg CreateWritingAp
 }
 
 const deleteWritingApproval = `-- name: DeleteWritingApproval :exec
-DELETE FROM writtingApprovedUsers
+DELETE FROM writingApprovedUsers
 WHERE writing_idwriting = ? AND users_idusers = ?
 `
 
@@ -97,7 +97,7 @@ func (q *Queries) FetchAllCategories(ctx context.Context) ([]*Writingcategory, e
 
 const getAllWritingApprovals = `-- name: GetAllWritingApprovals :many
 SELECT idusers, u.username, wau.writing_idwriting, wau.users_idusers, wau.readdoc, wau.editdoc
-FROM writtingApprovedUsers wau
+FROM writingApprovedUsers wau
 LEFT JOIN users u ON idusers = wau.users_idusers
 `
 
@@ -426,7 +426,7 @@ const getWritingByIdForUserDescendingByPublishedDate = `-- name: GetWritingByIdF
 SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writingcategory_idwritingcategory, w.title, w.published, w.writting, w.abstract, w.private, w.deleted_at, u.idusers AS WriterId, u.Username AS WriterUsername
 FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
-LEFT JOIN writtingApprovedUsers wau ON w.idwriting = wau.writing_idwriting AND wau.users_idusers = ?
+LEFT JOIN writingApprovedUsers wau ON w.idwriting = wau.writing_idwriting AND wau.users_idusers = ?
 WHERE w.idwriting = ? AND (w.private = 0 OR wau.readdoc = 1 OR w.users_idusers = ?)
 ORDER BY w.published DESC
 `
@@ -477,7 +477,7 @@ const getWritingsByIdsForUserDescendingByPublishedDate = `-- name: GetWritingsBy
 SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writingcategory_idwritingcategory, w.title, w.published, w.writting, w.abstract, w.private, w.deleted_at, u.idusers AS WriterId, u.username AS WriterUsername
 FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
-LEFT JOIN writtingApprovedUsers wau ON w.idwriting = wau.writing_idwriting AND wau.users_idusers = ?
+LEFT JOIN writingApprovedUsers wau ON w.idwriting = wau.writing_idwriting AND wau.users_idusers = ?
 WHERE w.idwriting IN (/*SLICE:writingids*/?) AND (w.private = 0 OR wau.readdoc = 1 OR w.users_idusers = ?)
 ORDER BY w.published DESC
 `
@@ -627,7 +627,7 @@ func (q *Queries) UpdateWriting(ctx context.Context, arg UpdateWritingParams) er
 }
 
 const updateWritingApproval = `-- name: UpdateWritingApproval :exec
-UPDATE writtingApprovedUsers
+UPDATE writingApprovedUsers
 SET readdoc = ?, editdoc = ?
 WHERE writing_idwriting = ? AND users_idusers = ?
 `

--- a/migrations/0018.sql
+++ b/migrations/0018.sql
@@ -1,0 +1,6 @@
+-- Rename misnamed writtingApprovedUsers table
+RENAME TABLE writtingApprovedUsers TO writingApprovedUsers;
+
+-- Record upgrade to schema version 18
+UPDATE schema_version SET version = 18 WHERE version = 17;
+

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -355,7 +355,7 @@ CREATE TABLE `writingSearch` (
   KEY `searchwordlist_has_writing_FKIndex2` (`writing_idwriting`)
 );
 
-CREATE TABLE `writtingApprovedUsers` (
+CREATE TABLE `writingApprovedUsers` (
   `writing_idwriting` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `readdoc` tinyint(1) DEFAULT NULL,


### PR DESCRIPTION
## Summary
- rename `writtingApprovedUsers` table to `writingApprovedUsers`
- regenerate models and queries with sqlc
- bump expected schema version
- add migration for table rename
- drop rename map from sqlc.yaml and add type alias instead
- document that existing migration files must not be changed
- remove type alias and rename struct using sqlc overrides
- remove overrides and use type alias instead
- remove unused writing approved user alias

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: Provider does not implement email.Provider)*
- `golangci-lint run ./...` *(typecheck issues)*
- `go test ./...` *(build errors in internal/email/mock)*

------
https://chatgpt.com/codex/tasks/task_e_686d03808400832f918816765c6bb52a