### PR TITLE
Normalize search column names

### DIFF
--- a/handlers/common/constants.go
+++ b/handlers/common/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 18
+	ExpectedSchemaVersion = 19
 )

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -36,7 +36,7 @@ type Blog struct {
 }
 
 type Blogssearch struct {
-	BlogsIdblogs                   int32
+	BlogID                         int32
 	SearchwordlistIdsearchwordlist int32
 }
 
@@ -338,7 +338,7 @@ type Sitenews struct {
 }
 
 type Sitenewssearch struct {
-	SitenewsIdsitenews             int32
+	SiteNewsID                     int32
 	SearchwordlistIdsearchwordlist int32
 }
 

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -61,18 +61,18 @@ WHERE b.users_idusers = u.idusers
 GROUP BY u.idusers;
 
 -- name: BlogsSearchFirst :many
-SELECT DISTINCT cs.blogs_idblogs
+SELECT DISTINCT cs.blog_id
 FROM blogsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
 ;
 
 -- name: BlogsSearchNext :many
-SELECT DISTINCT cs.blogs_idblogs
+SELECT DISTINCT cs.blog_id
 FROM blogsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
-AND cs.blogs_idblogs IN (sqlc.slice('ids'))
+AND cs.blog_id IN (sqlc.slice('ids'))
 ;
 
 

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -29,7 +29,7 @@ func (q *Queries) AssignThreadIdToBlogEntry(ctx context.Context, arg AssignThrea
 }
 
 const blogsSearchFirst = `-- name: BlogsSearchFirst :many
-SELECT DISTINCT cs.blogs_idblogs
+SELECT DISTINCT cs.blog_id
 FROM blogsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
@@ -43,11 +43,11 @@ func (q *Queries) BlogsSearchFirst(ctx context.Context, word sql.NullString) ([]
 	defer rows.Close()
 	var items []int32
 	for rows.Next() {
-		var blogs_idblogs int32
-		if err := rows.Scan(&blogs_idblogs); err != nil {
+		var blog_id int32
+		if err := rows.Scan(&blog_id); err != nil {
 			return nil, err
 		}
-		items = append(items, blogs_idblogs)
+		items = append(items, blog_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -59,11 +59,11 @@ func (q *Queries) BlogsSearchFirst(ctx context.Context, word sql.NullString) ([]
 }
 
 const blogsSearchNext = `-- name: BlogsSearchNext :many
-SELECT DISTINCT cs.blogs_idblogs
+SELECT DISTINCT cs.blog_id
 FROM blogsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
-AND cs.blogs_idblogs IN (/*SLICE:ids*/?)
+AND cs.blog_id IN (/*SLICE:ids*/?)
 `
 
 type BlogsSearchNextParams struct {
@@ -90,11 +90,11 @@ func (q *Queries) BlogsSearchNext(ctx context.Context, arg BlogsSearchNextParams
 	defer rows.Close()
 	var items []int32
 	for rows.Next() {
-		var blogs_idblogs int32
-		if err := rows.Scan(&blogs_idblogs); err != nil {
+		var blog_id int32
+		if err := rows.Scan(&blog_id); err != nil {
 			return nil, err
 		}
-		items = append(items, blogs_idblogs)
+		items = append(items, blog_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err

--- a/internal/db/queries-search.sql
+++ b/internal/db/queries-search.sql
@@ -47,15 +47,15 @@ FROM comments;
 
 -- name: RemakeNewsSearch :exec
 -- This query selects data from the "siteNews" table and populates the "siteNewsSearch" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "siteNewsSearch" using the "siteNews_idsiteNews".
-INSERT INTO siteNewsSearch (text, siteNews_idsiteNews)
+-- Then, it iterates over the "queue" linked list to add each text and ID pair to the "siteNewsSearch" using the "site_news_id".
+INSERT INTO siteNewsSearch (text, site_news_id)
 SELECT news, idsiteNews
 FROM siteNews;
 
 -- name: RemakeBlogSearch :exec
 -- This query selects data from the "blogs" table and populates the "blogsSearch" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "blogsSearch" using the "blogs_idblogs".
-INSERT INTO blogsSearch (text, blogs_idblogs)
+-- Then, it iterates over the "queue" linked list to add each text and ID pair to the "blogsSearch" using the "blog_id".
+INSERT INTO blogsSearch (text, blog_id)
 SELECT blog, idblogs
 FROM blogs;
 
@@ -86,8 +86,8 @@ DELETE FROM commentsSearch;
 
 -- name: RemakeNewsSearchInsert :exec
 -- This query selects data from the "siteNews" table and populates the "siteNewsSearch" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "siteNewsSearch" using the "siteNews_idsiteNews".
-INSERT INTO siteNewsSearch (text, siteNews_idsiteNews)
+-- Then, it iterates over the "queue" linked list to add each text and ID pair to the "siteNewsSearch" using the "site_news_id".
+INSERT INTO siteNewsSearch (text, site_news_id)
 SELECT news, idsiteNews
 FROM siteNews;
 
@@ -97,8 +97,8 @@ DELETE FROM siteNewsSearch;
 
 -- name: RemakeBlogsSearchInsert :exec
 -- This query selects data from the "blogs" table and populates the "blogsSearch" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "blogsSearch" using the "blogs_idblogs".
-INSERT INTO blogsSearch (text, blogs_idblogs)
+-- Then, it iterates over the "queue" linked list to add each text and ID pair to the "blogsSearch" using the "blog_id".
+INSERT INTO blogsSearch (text, blog_id)
 SELECT blog, idblogs
 FROM blogs;
 
@@ -218,18 +218,18 @@ AND cs.writing_idwriting IN (sqlc.slice('ids'))
 ;
 
 -- name: SiteNewsSearchFirst :many
-SELECT DISTINCT cs.siteNews_idsiteNews
+SELECT DISTINCT cs.site_news_id
 FROM siteNewsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
 ;
 
 -- name: SiteNewsSearchNext :many
-SELECT DISTINCT cs.siteNews_idsiteNews
+SELECT DISTINCT cs.site_news_id
 FROM siteNewsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
-AND cs.siteNews_idsiteNews IN (sqlc.slice('ids'))
+AND cs.site_news_id IN (sqlc.slice('ids'))
 ;
 
 -- name: LinkerSearchFirst :many

--- a/internal/db/queries-search.sql.go
+++ b/internal/db/queries-search.sql.go
@@ -562,26 +562,26 @@ func (q *Queries) LinkerSearchNext(ctx context.Context, arg LinkerSearchNextPara
 }
 
 const remakeBlogSearch = `-- name: RemakeBlogSearch :exec
-INSERT INTO blogsSearch (text, blogs_idblogs)
+INSERT INTO blogsSearch (text, blog_id)
 SELECT blog, idblogs
 FROM blogs
 `
 
 // This query selects data from the "blogs" table and populates the "blogsSearch" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "blogsSearch" using the "blogs_idblogs".
+// Then, it iterates over the "queue" linked list to add each text and ID pair to the "blogsSearch" using the "blog_id".
 func (q *Queries) RemakeBlogSearch(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, remakeBlogSearch)
 	return err
 }
 
 const remakeBlogsSearchInsert = `-- name: RemakeBlogsSearchInsert :exec
-INSERT INTO blogsSearch (text, blogs_idblogs)
+INSERT INTO blogsSearch (text, blog_id)
 SELECT blog, idblogs
 FROM blogs
 `
 
 // This query selects data from the "blogs" table and populates the "blogsSearch" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "blogsSearch" using the "blogs_idblogs".
+// Then, it iterates over the "queue" linked list to add each text and ID pair to the "blogsSearch" using the "blog_id".
 func (q *Queries) RemakeBlogsSearchInsert(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, remakeBlogsSearchInsert)
 	return err
@@ -651,26 +651,26 @@ func (q *Queries) RemakeLinkerSearchInsert(ctx context.Context) error {
 }
 
 const remakeNewsSearch = `-- name: RemakeNewsSearch :exec
-INSERT INTO siteNewsSearch (text, siteNews_idsiteNews)
+INSERT INTO siteNewsSearch (text, site_news_id)
 SELECT news, idsiteNews
 FROM siteNews
 `
 
 // This query selects data from the "siteNews" table and populates the "siteNewsSearch" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "siteNewsSearch" using the "siteNews_idsiteNews".
+// Then, it iterates over the "queue" linked list to add each text and ID pair to the "siteNewsSearch" using the "site_news_id".
 func (q *Queries) RemakeNewsSearch(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, remakeNewsSearch)
 	return err
 }
 
 const remakeNewsSearchInsert = `-- name: RemakeNewsSearchInsert :exec
-INSERT INTO siteNewsSearch (text, siteNews_idsiteNews)
+INSERT INTO siteNewsSearch (text, site_news_id)
 SELECT news, idsiteNews
 FROM siteNews
 `
 
 // This query selects data from the "siteNews" table and populates the "siteNewsSearch" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "siteNewsSearch" using the "siteNews_idsiteNews".
+// Then, it iterates over the "queue" linked list to add each text and ID pair to the "siteNewsSearch" using the "site_news_id".
 func (q *Queries) RemakeNewsSearchInsert(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, remakeNewsSearchInsert)
 	return err
@@ -703,7 +703,7 @@ func (q *Queries) RemakeWritingSearchInsert(ctx context.Context) error {
 }
 
 const siteNewsSearchFirst = `-- name: SiteNewsSearchFirst :many
-SELECT DISTINCT cs.siteNews_idsiteNews
+SELECT DISTINCT cs.site_news_id
 FROM siteNewsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
@@ -717,11 +717,11 @@ func (q *Queries) SiteNewsSearchFirst(ctx context.Context, word sql.NullString) 
 	defer rows.Close()
 	var items []int32
 	for rows.Next() {
-		var sitenews_idsitenews int32
-		if err := rows.Scan(&sitenews_idsitenews); err != nil {
+		var site_news_id int32
+		if err := rows.Scan(&site_news_id); err != nil {
 			return nil, err
 		}
-		items = append(items, sitenews_idsitenews)
+		items = append(items, site_news_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -733,11 +733,11 @@ func (q *Queries) SiteNewsSearchFirst(ctx context.Context, word sql.NullString) 
 }
 
 const siteNewsSearchNext = `-- name: SiteNewsSearchNext :many
-SELECT DISTINCT cs.siteNews_idsiteNews
+SELECT DISTINCT cs.site_news_id
 FROM siteNewsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
-AND cs.siteNews_idsiteNews IN (/*SLICE:ids*/?)
+AND cs.site_news_id IN (/*SLICE:ids*/?)
 `
 
 type SiteNewsSearchNextParams struct {
@@ -764,11 +764,11 @@ func (q *Queries) SiteNewsSearchNext(ctx context.Context, arg SiteNewsSearchNext
 	defer rows.Close()
 	var items []int32
 	for rows.Next() {
-		var sitenews_idsitenews int32
-		if err := rows.Scan(&sitenews_idsitenews); err != nil {
+		var site_news_id int32
+		if err := rows.Scan(&site_news_id); err != nil {
 			return nil, err
 		}
-		items = append(items, sitenews_idsitenews)
+		items = append(items, site_news_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err

--- a/migrations/0019.sql
+++ b/migrations/0019.sql
@@ -1,0 +1,6 @@
+-- Rename search columns to snake_case
+ALTER TABLE blogsSearch CHANGE COLUMN blogs_idblogs blog_id int(10) NOT NULL DEFAULT 0;
+ALTER TABLE siteNewsSearch CHANGE COLUMN siteNews_idsiteNews site_news_id int(10) NOT NULL DEFAULT 0;
+
+-- Record upgrade to schema version 19
+UPDATE schema_version SET version = 19 WHERE version = 18;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -29,10 +29,10 @@ CREATE TABLE `blogs` (
 );
 
 CREATE TABLE `blogsSearch` (
-  `blogs_idblogs` int(10) NOT NULL DEFAULT 0,
+  `blog_id` int(10) NOT NULL DEFAULT 0,
   `searchwordlist_idsearchwordlist` int(10) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`blogs_idblogs`,`searchwordlist_idsearchwordlist`),
-  KEY `blogs_has_searchwordlist_FKIndex1` (`blogs_idblogs`),
+  PRIMARY KEY (`blog_id`,`searchwordlist_idsearchwordlist`),
+  KEY `blogs_has_searchwordlist_FKIndex1` (`blog_id`),
   KEY `blogs_has_searchwordlist_FKIndex2` (`searchwordlist_idsearchwordlist`)
 );
 
@@ -261,10 +261,10 @@ CREATE TABLE `siteNews` (
 );
 
 CREATE TABLE `siteNewsSearch` (
-  `siteNews_idsiteNews` int(10) NOT NULL DEFAULT 0,
+  `site_news_id` int(10) NOT NULL DEFAULT 0,
   `searchwordlist_idsearchwordlist` int(10) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`siteNews_idsiteNews`,`searchwordlist_idsearchwordlist`),
-  KEY `siteNews_has_searchwordlist_FKIndex1` (`siteNews_idsiteNews`),
+  PRIMARY KEY (`site_news_id`,`searchwordlist_idsearchwordlist`),
+  KEY `siteNews_has_searchwordlist_FKIndex1` (`site_news_id`),
   KEY `siteNews_has_searchwordlist_FKIndex2` (`searchwordlist_idsearchwordlist`)
 );
 


### PR DESCRIPTION
## Summary
- rename `blogs_idblogs` to `blog_id` and `siteNews_idsiteNews` to `site_news_id`
- update queries and generated models
- bump expected schema version
- add migration 0019

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go mod tidy`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686d21e669e8832f8aa7445386fe1725