### PR TITLE
Fix failing envmap test and build issues

### DIFF
--- a/cmd/goa4web/config_as.go
+++ b/cmd/goa4web/config_as.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -58,13 +60,6 @@ func envMapFromConfig(cfg runtimeconfig.RuntimeConfig, cfgPath string) (map[stri
 	}
 
 	return m, nil
-}
-
-func defaultMap() map[string]string {
-	m := runtimeconfig.DefaultMap()
-	m[config.EnvConfigFile] = ""
-	m[config.EnvSessionSecretFile] = runtimeconfig.DefaultSessionSecretPath()
-	return m
 }
 
 func defaultMap() map[string]string {

--- a/cmd/goa4web/serve.go
+++ b/cmd/goa4web/serve.go
@@ -48,7 +48,7 @@ func (c *serveCmd) Run() error {
 	}
 	app.ConfigFile = c.rootCmd.ConfigFile
 	cfg := runtimeconfig.GenerateRuntimeConfig(c.fs, fileVals, os.Getenv)
-	secret, err := core.LoadSessionSecret(core.OSFS{}, cfg.SessionSecret, cfg.SessionSecretFile, config.EnvSessionSecret, config.EnvSessionSecretFile)
+	secret, err := runtimeconfig.LoadSessionSecret(core.OSFS{}, cfg.SessionSecret, cfg.SessionSecretFile, config.EnvSessionSecret, config.EnvSessionSecretFile)
 	if err != nil {
 		return fmt.Errorf("session secret: %w", err)
 	}

--- a/runtimeconfig/envmap_test.go
+++ b/runtimeconfig/envmap_test.go
@@ -14,7 +14,21 @@ func TestToEnvMapIncludesAllKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ToEnvMap: %v", err)
 	}
-	want := len(StringOptions) + len(IntOptions) + len(BoolOptions) + 3
+	keys := make(map[string]struct{})
+	for _, o := range StringOptions {
+		keys[o.Env] = struct{}{}
+	}
+	for _, o := range IntOptions {
+		keys[o.Env] = struct{}{}
+	}
+	for _, o := range BoolOptions {
+		keys[o.Env] = struct{}{}
+	}
+	extras := []string{config.EnvConfigFile, config.EnvSessionSecret, config.EnvSessionSecretFile}
+	for _, k := range extras {
+		keys[k] = struct{}{}
+	}
+	want := len(keys)
 	if len(m) != want {
 		t.Fatalf("got %d keys want %d", len(m), want)
 	}
@@ -33,7 +47,6 @@ func TestToEnvMapIncludesAllKeys(t *testing.T) {
 			t.Errorf("missing %s", o.Env)
 		}
 	}
-	extras := []string{config.EnvConfigFile, config.EnvSessionSecret, config.EnvSessionSecretFile}
 	for _, k := range extras {
 		if _, ok := m[k]; !ok {
 			t.Errorf("missing %s", k)


### PR DESCRIPTION
## Summary
- ensure `ToEnvMap` test counts unique keys only
- update config tooling to compile with the right imports
- fix server to use the runtimeconfig session secret loader

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686da3707eb8832fb4e062e6fc33eff2