### PR TITLE
Rename linker search column

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -249,7 +249,7 @@ type Linkerqueue struct {
 
 type Linkersearch struct {
 	SearchwordlistIdsearchwordlist int32
-	LinkerIdlinker                 int32
+	LinkerID                       int32
 }
 
 type LoginAttempt struct {
@@ -312,7 +312,7 @@ type Searchwordlist struct {
 
 type SearchwordlistHasLinker struct {
 	SearchwordlistIdsearchwordlist int32
-	LinkerIdlinker                 int32
+	LinkerID                       int32
 }
 
 type Session struct {

--- a/internal/db/queries-search.sql
+++ b/internal/db/queries-search.sql
@@ -68,8 +68,8 @@ FROM writing;
 
 -- name: RemakeLinkerSearch :exec
 -- This query selects data from the "linker" table and populates the "linkerSearch" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "linkerSearch" using the "linker_idlinker".
-INSERT INTO linkerSearch (text, linker_idlinker)
+-- Then, it iterates over the "queue" linked list to add each text and ID pair to the "linkerSearch" using the "linker_id".
+INSERT INTO linkerSearch (text, linker_id)
 SELECT CONCAT(title, ' ', description), idlinker
 FROM linker;
 
@@ -119,8 +119,8 @@ DELETE FROM writingSearch;
 
 -- name: RemakeLinkerSearchInsert :exec
 -- This query selects data from the "linker" table and populates the "linkerSearch" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "linkerSearch" using the "linker_idlinker".
-INSERT INTO linkerSearch (text, linker_idlinker)
+-- Then, it iterates over the "queue" linked list to add each text and ID pair to the "linkerSearch" using the "linker_id".
+INSERT INTO linkerSearch (text, linker_id)
 SELECT CONCAT(title, ' ', description), idlinker
 FROM linker;
 
@@ -193,7 +193,7 @@ VALUES (?, ?);
 
 -- name: AddToLinkerSearch :exec
 INSERT IGNORE INTO linkerSearch
-(linker_idlinker, searchwordlist_idsearchwordlist)
+(linker_id, searchwordlist_idsearchwordlist)
 VALUES (?, ?);
 
 
@@ -233,18 +233,18 @@ AND cs.site_news_id IN (sqlc.slice('ids'))
 ;
 
 -- name: LinkerSearchFirst :many
-SELECT DISTINCT cs.linker_idlinker
+SELECT DISTINCT cs.linker_id
 FROM linkerSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
 ;
 
 -- name: LinkerSearchNext :many
-SELECT DISTINCT cs.linker_idlinker
+SELECT DISTINCT cs.linker_id
 FROM linkerSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
-AND cs.linker_idlinker IN (sqlc.slice('ids'))
+AND cs.linker_id IN (sqlc.slice('ids'))
 ;
 
 -- name: AddToImagePostSearch :exec

--- a/internal/db/queries-search.sql.go
+++ b/internal/db/queries-search.sql.go
@@ -61,17 +61,17 @@ func (q *Queries) AddToImagePostSearch(ctx context.Context, arg AddToImagePostSe
 
 const addToLinkerSearch = `-- name: AddToLinkerSearch :exec
 INSERT IGNORE INTO linkerSearch
-(linker_idlinker, searchwordlist_idsearchwordlist)
+(linker_id, searchwordlist_idsearchwordlist)
 VALUES (?, ?)
 `
 
 type AddToLinkerSearchParams struct {
-	LinkerIdlinker                 int32
+	LinkerID                       int32
 	SearchwordlistIdsearchwordlist int32
 }
 
 func (q *Queries) AddToLinkerSearch(ctx context.Context, arg AddToLinkerSearchParams) error {
-	_, err := q.db.ExecContext(ctx, addToLinkerSearch, arg.LinkerIdlinker, arg.SearchwordlistIdsearchwordlist)
+	_, err := q.db.ExecContext(ctx, addToLinkerSearch, arg.LinkerID, arg.SearchwordlistIdsearchwordlist)
 	return err
 }
 
@@ -485,7 +485,7 @@ func (q *Queries) ImagePostSearchNext(ctx context.Context, arg ImagePostSearchNe
 }
 
 const linkerSearchFirst = `-- name: LinkerSearchFirst :many
-SELECT DISTINCT cs.linker_idlinker
+SELECT DISTINCT cs.linker_id
 FROM linkerSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
@@ -499,11 +499,11 @@ func (q *Queries) LinkerSearchFirst(ctx context.Context, word sql.NullString) ([
 	defer rows.Close()
 	var items []int32
 	for rows.Next() {
-		var linker_idlinker int32
-		if err := rows.Scan(&linker_idlinker); err != nil {
+		var linker_id int32
+		if err := rows.Scan(&linker_id); err != nil {
 			return nil, err
 		}
-		items = append(items, linker_idlinker)
+		items = append(items, linker_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -515,11 +515,11 @@ func (q *Queries) LinkerSearchFirst(ctx context.Context, word sql.NullString) ([
 }
 
 const linkerSearchNext = `-- name: LinkerSearchNext :many
-SELECT DISTINCT cs.linker_idlinker
+SELECT DISTINCT cs.linker_id
 FROM linkerSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
-AND cs.linker_idlinker IN (/*SLICE:ids*/?)
+AND cs.linker_id IN (/*SLICE:ids*/?)
 `
 
 type LinkerSearchNextParams struct {
@@ -546,11 +546,11 @@ func (q *Queries) LinkerSearchNext(ctx context.Context, arg LinkerSearchNextPara
 	defer rows.Close()
 	var items []int32
 	for rows.Next() {
-		var linker_idlinker int32
-		if err := rows.Scan(&linker_idlinker); err != nil {
+		var linker_id int32
+		if err := rows.Scan(&linker_id); err != nil {
 			return nil, err
 		}
-		items = append(items, linker_idlinker)
+		items = append(items, linker_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -625,26 +625,26 @@ func (q *Queries) RemakeImagePostSearchInsert(ctx context.Context) error {
 }
 
 const remakeLinkerSearch = `-- name: RemakeLinkerSearch :exec
-INSERT INTO linkerSearch (text, linker_idlinker)
+INSERT INTO linkerSearch (text, linker_id)
 SELECT CONCAT(title, ' ', description), idlinker
 FROM linker
 `
 
 // This query selects data from the "linker" table and populates the "linkerSearch" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "linkerSearch" using the "linker_idlinker".
+// Then, it iterates over the "queue" linked list to add each text and ID pair to the "linkerSearch" using the "linker_id".
 func (q *Queries) RemakeLinkerSearch(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, remakeLinkerSearch)
 	return err
 }
 
 const remakeLinkerSearchInsert = `-- name: RemakeLinkerSearchInsert :exec
-INSERT INTO linkerSearch (text, linker_idlinker)
+INSERT INTO linkerSearch (text, linker_id)
 SELECT CONCAT(title, ' ', description), idlinker
 FROM linker
 `
 
 // This query selects data from the "linker" table and populates the "linkerSearch" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "linkerSearch" using the "linker_idlinker".
+// Then, it iterates over the "queue" linked list to add each text and ID pair to the "linkerSearch" using the "linker_id".
 func (q *Queries) RemakeLinkerSearchInsert(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, remakeLinkerSearchInsert)
 	return err

--- a/internal/searchutil/tokenize.go
+++ b/internal/searchutil/tokenize.go
@@ -64,7 +64,7 @@ func SearchWordIdsFromText(w http.ResponseWriter, r *http.Request, text string, 
 func InsertWordsToLinkerSearch(w http.ResponseWriter, r *http.Request, wordIds []int64, queries *db.Queries, lid int64) bool {
 	return InsertWords(w, r, wordIds, func(ctx context.Context, wid int64) error {
 		return queries.AddToLinkerSearch(ctx, db.AddToLinkerSearchParams{
-			LinkerIdlinker:                 int32(lid),
+			LinkerID:                       int32(lid),
 			SearchwordlistIdsearchwordlist: int32(wid),
 		})
 	})

--- a/migrations/0020.sql
+++ b/migrations/0020.sql
@@ -1,0 +1,6 @@
+-- Rename linker search columns to snake_case
+ALTER TABLE linkerSearch CHANGE COLUMN linker_idlinker linker_id int(10) NOT NULL DEFAULT 0;
+ALTER TABLE searchwordlist_has_linker CHANGE COLUMN linker_idlinker linker_id int(10) NOT NULL DEFAULT 0;
+
+-- Record upgrade to schema version 20
+UPDATE schema_version SET version = 20 WHERE version = 19;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -206,10 +206,10 @@ CREATE TABLE `linkerQueue` (
 
 CREATE TABLE `linkerSearch` (
   `searchwordlist_idsearchwordlist` int(10) NOT NULL DEFAULT 0,
-  `linker_idlinker` int(10) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`searchwordlist_idsearchwordlist`,`linker_idlinker`),
+  `linker_id` int(10) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`searchwordlist_idsearchwordlist`,`linker_id`),
   KEY `searchwordlist_has_linker_FKIndex1` (`searchwordlist_idsearchwordlist`),
-  KEY `searchwordlist_has_linker_FKIndex2` (`linker_idlinker`)
+  KEY `searchwordlist_has_linker_FKIndex2` (`linker_id`)
 );
 
 CREATE TABLE `permissions` (
@@ -241,10 +241,10 @@ CREATE TABLE `searchwordlist` (
 
 CREATE TABLE `searchwordlist_has_linker` (
   `searchwordlist_idsearchwordlist` int(10) NOT NULL DEFAULT 0,
-  `linker_idlinker` int(10) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`searchwordlist_idsearchwordlist`,`linker_idlinker`),
+  `linker_id` int(10) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`searchwordlist_idsearchwordlist`,`linker_id`),
   KEY `searchwordlist_has_linker_FKIndex1` (`searchwordlist_idsearchwordlist`),
-  KEY `searchwordlist_has_linker_FKIndex2` (`linker_idlinker`)
+  KEY `searchwordlist_has_linker_FKIndex2` (`linker_id`)
 );
 
 CREATE TABLE `siteNews` (


### PR DESCRIPTION
## Summary
- rename `linker_idlinker` to `linker_id` in the schema
- add migration 0020 to rename the column
- adjust search queries and tokenizer code
- regenerate sqlc models and query helpers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`
- `sqlc generate`


------
https://chatgpt.com/codex/tasks/task_e_686da64dc1ec832f81cf12ca0438e927