### PR TITLE
Rename imagepost search column

### DIFF
--- a/handlers/common/constants.go
+++ b/handlers/common/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 19
+	ExpectedSchemaVersion = 20
 )

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -208,7 +208,7 @@ type Imagepost struct {
 }
 
 type Imagepostsearch struct {
-	ImagepostIdimagepost           int32
+	ImagePostID                    int32
 	SearchwordlistIdsearchwordlist int32
 }
 

--- a/internal/db/queries-search.sql
+++ b/internal/db/queries-search.sql
@@ -249,27 +249,27 @@ AND cs.linker_idlinker IN (sqlc.slice('ids'))
 
 -- name: AddToImagePostSearch :exec
 INSERT IGNORE INTO imagepostSearch
-(imagepost_idimagepost, searchwordlist_idsearchwordlist)
+(image_post_id, searchwordlist_idsearchwordlist)
 VALUES (?, ?);
 
 -- name: DeleteImagePostSearch :exec
 DELETE FROM imagepostSearch;
 
 -- name: RemakeImagePostSearchInsert :exec
-INSERT INTO imagepostSearch (text, imagepost_idimagepost)
+INSERT INTO imagepostSearch (text, image_post_id)
 SELECT description, idimagepost
 FROM imagepost;
 
 -- name: ImagePostSearchFirst :many
-SELECT DISTINCT cs.imagepost_idimagepost
+SELECT DISTINCT cs.image_post_id
 FROM imagepostSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?;
 
 -- name: ImagePostSearchNext :many
-SELECT DISTINCT cs.imagepost_idimagepost
+SELECT DISTINCT cs.image_post_id
 FROM imagepostSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
-AND cs.imagepost_idimagepost IN (sqlc.slice('ids'));
+AND cs.image_post_id IN (sqlc.slice('ids'));
 

--- a/internal/db/queries-search.sql.go
+++ b/internal/db/queries-search.sql.go
@@ -45,17 +45,17 @@ func (q *Queries) AddToForumWritingSearch(ctx context.Context, arg AddToForumWri
 
 const addToImagePostSearch = `-- name: AddToImagePostSearch :exec
 INSERT IGNORE INTO imagepostSearch
-(imagepost_idimagepost, searchwordlist_idsearchwordlist)
+(image_post_id, searchwordlist_idsearchwordlist)
 VALUES (?, ?)
 `
 
 type AddToImagePostSearchParams struct {
-	ImagepostIdimagepost           int32
+	ImagePostID                    int32
 	SearchwordlistIdsearchwordlist int32
 }
 
 func (q *Queries) AddToImagePostSearch(ctx context.Context, arg AddToImagePostSearchParams) error {
-	_, err := q.db.ExecContext(ctx, addToImagePostSearch, arg.ImagepostIdimagepost, arg.SearchwordlistIdsearchwordlist)
+	_, err := q.db.ExecContext(ctx, addToImagePostSearch, arg.ImagePostID, arg.SearchwordlistIdsearchwordlist)
 	return err
 }
 
@@ -408,7 +408,7 @@ func (q *Queries) GetSearchWordByWordLowercased(ctx context.Context, lcase strin
 }
 
 const imagePostSearchFirst = `-- name: ImagePostSearchFirst :many
-SELECT DISTINCT cs.imagepost_idimagepost
+SELECT DISTINCT cs.image_post_id
 FROM imagepostSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
@@ -422,11 +422,11 @@ func (q *Queries) ImagePostSearchFirst(ctx context.Context, word sql.NullString)
 	defer rows.Close()
 	var items []int32
 	for rows.Next() {
-		var imagepost_idimagepost int32
-		if err := rows.Scan(&imagepost_idimagepost); err != nil {
+		var image_post_id int32
+		if err := rows.Scan(&image_post_id); err != nil {
 			return nil, err
 		}
-		items = append(items, imagepost_idimagepost)
+		items = append(items, image_post_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -438,11 +438,11 @@ func (q *Queries) ImagePostSearchFirst(ctx context.Context, word sql.NullString)
 }
 
 const imagePostSearchNext = `-- name: ImagePostSearchNext :many
-SELECT DISTINCT cs.imagepost_idimagepost
+SELECT DISTINCT cs.image_post_id
 FROM imagepostSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 WHERE swl.word=?
-AND cs.imagepost_idimagepost IN (/*SLICE:ids*/?)
+AND cs.image_post_id IN (/*SLICE:ids*/?)
 `
 
 type ImagePostSearchNextParams struct {
@@ -469,11 +469,11 @@ func (q *Queries) ImagePostSearchNext(ctx context.Context, arg ImagePostSearchNe
 	defer rows.Close()
 	var items []int32
 	for rows.Next() {
-		var imagepost_idimagepost int32
-		if err := rows.Scan(&imagepost_idimagepost); err != nil {
+		var image_post_id int32
+		if err := rows.Scan(&image_post_id); err != nil {
 			return nil, err
 		}
-		items = append(items, imagepost_idimagepost)
+		items = append(items, image_post_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -614,7 +614,7 @@ func (q *Queries) RemakeCommentsSearchInsert(ctx context.Context) error {
 }
 
 const remakeImagePostSearchInsert = `-- name: RemakeImagePostSearchInsert :exec
-INSERT INTO imagepostSearch (text, imagepost_idimagepost)
+INSERT INTO imagepostSearch (text, image_post_id)
 SELECT description, idimagepost
 FROM imagepost
 `

--- a/internal/searchutil/tokenize.go
+++ b/internal/searchutil/tokenize.go
@@ -74,7 +74,7 @@ func InsertWordsToLinkerSearch(w http.ResponseWriter, r *http.Request, wordIds [
 func InsertWordsToImageSearch(w http.ResponseWriter, r *http.Request, wordIds []int64, queries *db.Queries, pid int64) bool {
 	return InsertWords(w, r, wordIds, func(ctx context.Context, wid int64) error {
 		return queries.AddToImagePostSearch(ctx, db.AddToImagePostSearchParams{
-			ImagepostIdimagepost:           int32(pid),
+			ImagePostID:                    int32(pid),
 			SearchwordlistIdsearchwordlist: int32(wid),
 		})
 	})

--- a/migrations/0020.sql
+++ b/migrations/0020.sql
@@ -1,0 +1,5 @@
+-- Rename imagepost search column to snake_case
+ALTER TABLE imagepostSearch CHANGE COLUMN imagepost_idimagepost image_post_id int(10) NOT NULL DEFAULT 0;
+
+-- Record upgrade to schema version 20
+UPDATE schema_version SET version = 20 WHERE version = 19;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -151,10 +151,10 @@ CREATE TABLE `imagepost` (
 );
 
 CREATE TABLE `imagepostSearch` (
-  `imagepost_idimagepost` int(10) NOT NULL DEFAULT 0,
+  `image_post_id` int(10) NOT NULL DEFAULT 0,
   `searchwordlist_idsearchwordlist` int(10) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`imagepost_idimagepost`,`searchwordlist_idsearchwordlist`),
-  KEY `imagepostSearch_FKIndex1` (`imagepost_idimagepost`),
+  PRIMARY KEY (`image_post_id`,`searchwordlist_idsearchwordlist`),
+  KEY `imagepostSearch_FKIndex1` (`image_post_id`),
   KEY `imagepostSearch_FKIndex2` (`searchwordlist_idsearchwordlist`)
 );
 


### PR DESCRIPTION
## Summary
- migrate `imagepostSearch` column `imagepost_idimagepost` to `image_post_id`
- update schema to reflect the new column name
- regenerate sqlc code and refactor to new struct fields
- bump expected schema version to 20

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686da64e81bc832f9b48379db90b4963