### PR TITLE
Fix comment search column name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,7 @@ go test ./...
 SQL query files are compiled using `sqlc`. Do not manually edit the generated `*.sql.go` files; instead edit the `.sql` files under `internal/db/` and run `sqlc generate`.
 Avoid using the `overrides` section in `sqlc.yaml`; prefer Go type aliases if a different struct name is required.
 
-All database schema changes must include a new migration script in the `migrations/` directory (for example `0002.sql`, `0003.sql`). Never modify previously committed migration files so the history of changes remains intact.
-All database schema changes must include a new migration script in the `migrations/` directory (for example `0002.sql`, `0003.sql`). Never modify existing migration files as that would break deployments running older versions.
+All database schema changes must include a new migration script in the `migrations/` directory (for example `0002.sql`, `0003.sql`). Never modify existing migration files as that would break deployments running older versions. Every migration must also update the `schema_version` table so deployments can track the current schema state.
 
 Errors in critical functions like `main()` or `run()` must be logged or wrapped using `fmt.Errorf` with context. Prefer doing both when errors propagate.
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -58,7 +58,7 @@ type Comment struct {
 
 type Commentssearch struct {
 	SearchwordlistIdsearchwordlist int32
-	CommentsIdcomments             int32
+	CommentID                      int32
 }
 
 type DeactivatedBlog struct {

--- a/internal/db/queries-search.sql
+++ b/internal/db/queries-search.sql
@@ -40,8 +40,8 @@ LIMIT ? OFFSET ?;
 
 -- name: RemakeCommentsSearch :exec
 -- This query selects data from the "comments" table and populates the "commentsSearch" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "commentsSearch" using the "comments_idcomments".
-INSERT INTO commentsSearch (text, comments_idcomments)
+-- Then, it iterates over the "queue" linked list to add each text and ID pair to the "commentsSearch" using the "comment_id".
+INSERT INTO commentsSearch (text, comment_id)
 SELECT text, idcomments
 FROM comments;
 
@@ -75,8 +75,8 @@ FROM linker;
 
 -- name: RemakeCommentsSearchInsert :exec
 -- This query selects data from the "comments" table and populates the "commentsSearch" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "commentsSearch" using the "comments_idcomments".
-INSERT INTO commentsSearch (text, comments_idcomments)
+-- Then, it iterates over the "queue" linked list to add each text and ID pair to the "commentsSearch" using the "comment_id".
+INSERT INTO commentsSearch (text, comment_id)
 SELECT text, idcomments
 FROM comments;
 
@@ -139,14 +139,14 @@ VALUES (lcase(sqlc.arg(word)));
 
 -- name: AddToForumCommentSearch :exec
 INSERT IGNORE INTO commentsSearch
-(comments_idcomments, searchwordlist_idsearchwordlist)
+(comment_id, searchwordlist_idsearchwordlist)
 VALUES (?, ?);
 
 -- name: CommentsSearchFirstNotInRestrictedTopic :many
-SELECT DISTINCT cs.comments_idcomments
+SELECT DISTINCT cs.comment_id
 FROM commentsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
-LEFT JOIN comments c ON c.idcomments=cs.comments_idcomments
+LEFT JOIN comments c ON c.idcomments=cs.comment_id
 LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_idforumthread
 LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
 WHERE swl.word=?
@@ -154,35 +154,35 @@ AND ft.forumcategory_idforumcategory!=0
 ;
 
 -- name: CommentsSearchNextNotInRestrictedTopic :many
-SELECT DISTINCT cs.comments_idcomments
+SELECT DISTINCT cs.comment_id
 FROM commentsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
-LEFT JOIN comments c ON c.idcomments=cs.comments_idcomments
+LEFT JOIN comments c ON c.idcomments=cs.comment_id
 LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_idforumthread
 LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
 WHERE swl.word=?
-AND cs.comments_idcomments IN (sqlc.slice('ids'))
+AND cs.comment_id IN (sqlc.slice('ids'))
 AND ft.forumcategory_idforumcategory!=0
 ;
 
 -- name: CommentsSearchFirstInRestrictedTopic :many
-SELECT DISTINCT cs.comments_idcomments
+SELECT DISTINCT cs.comment_id
 FROM commentsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
-LEFT JOIN comments c ON c.idcomments=cs.comments_idcomments
+LEFT JOIN comments c ON c.idcomments=cs.comment_id
 LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_idforumthread
 WHERE swl.word=?
 AND fth.forumtopic_idforumtopic IN (sqlc.slice('ftids'))
 ;
 
 -- name: CommentsSearchNextInRestrictedTopic :many
-SELECT DISTINCT cs.comments_idcomments
+SELECT DISTINCT cs.comment_id
 FROM commentsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
-LEFT JOIN comments c ON c.idcomments=cs.comments_idcomments
+LEFT JOIN comments c ON c.idcomments=cs.comment_id
 LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_idforumthread
 WHERE swl.word=?
-AND cs.comments_idcomments IN (sqlc.slice('ids'))
+AND cs.comment_id IN (sqlc.slice('ids'))
 AND fth.forumtopic_idforumtopic IN (sqlc.slice('ftids'))
 ;
 

--- a/internal/db/queries-search.sql.go
+++ b/internal/db/queries-search.sql.go
@@ -13,17 +13,17 @@ import (
 
 const addToForumCommentSearch = `-- name: AddToForumCommentSearch :exec
 INSERT IGNORE INTO commentsSearch
-(comments_idcomments, searchwordlist_idsearchwordlist)
+(comment_id, searchwordlist_idsearchwordlist)
 VALUES (?, ?)
 `
 
 type AddToForumCommentSearchParams struct {
-	CommentsIdcomments             int32
+	CommentID                      int32
 	SearchwordlistIdsearchwordlist int32
 }
 
 func (q *Queries) AddToForumCommentSearch(ctx context.Context, arg AddToForumCommentSearchParams) error {
-	_, err := q.db.ExecContext(ctx, addToForumCommentSearch, arg.CommentsIdcomments, arg.SearchwordlistIdsearchwordlist)
+	_, err := q.db.ExecContext(ctx, addToForumCommentSearch, arg.CommentID, arg.SearchwordlistIdsearchwordlist)
 	return err
 }
 
@@ -76,10 +76,10 @@ func (q *Queries) AddToLinkerSearch(ctx context.Context, arg AddToLinkerSearchPa
 }
 
 const commentsSearchFirstInRestrictedTopic = `-- name: CommentsSearchFirstInRestrictedTopic :many
-SELECT DISTINCT cs.comments_idcomments
+SELECT DISTINCT cs.comment_id
 FROM commentsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
-LEFT JOIN comments c ON c.idcomments=cs.comments_idcomments
+LEFT JOIN comments c ON c.idcomments=cs.comment_id
 LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_idforumthread
 WHERE swl.word=?
 AND fth.forumtopic_idforumtopic IN (/*SLICE:ftids*/?)
@@ -109,11 +109,11 @@ func (q *Queries) CommentsSearchFirstInRestrictedTopic(ctx context.Context, arg 
 	defer rows.Close()
 	var items []int32
 	for rows.Next() {
-		var comments_idcomments int32
-		if err := rows.Scan(&comments_idcomments); err != nil {
+		var comment_id int32
+		if err := rows.Scan(&comment_id); err != nil {
 			return nil, err
 		}
-		items = append(items, comments_idcomments)
+		items = append(items, comment_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -125,10 +125,10 @@ func (q *Queries) CommentsSearchFirstInRestrictedTopic(ctx context.Context, arg 
 }
 
 const commentsSearchFirstNotInRestrictedTopic = `-- name: CommentsSearchFirstNotInRestrictedTopic :many
-SELECT DISTINCT cs.comments_idcomments
+SELECT DISTINCT cs.comment_id
 FROM commentsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
-LEFT JOIN comments c ON c.idcomments=cs.comments_idcomments
+LEFT JOIN comments c ON c.idcomments=cs.comment_id
 LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_idforumthread
 LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
 WHERE swl.word=?
@@ -143,11 +143,11 @@ func (q *Queries) CommentsSearchFirstNotInRestrictedTopic(ctx context.Context, w
 	defer rows.Close()
 	var items []int32
 	for rows.Next() {
-		var comments_idcomments int32
-		if err := rows.Scan(&comments_idcomments); err != nil {
+		var comment_id int32
+		if err := rows.Scan(&comment_id); err != nil {
 			return nil, err
 		}
-		items = append(items, comments_idcomments)
+		items = append(items, comment_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -159,13 +159,13 @@ func (q *Queries) CommentsSearchFirstNotInRestrictedTopic(ctx context.Context, w
 }
 
 const commentsSearchNextInRestrictedTopic = `-- name: CommentsSearchNextInRestrictedTopic :many
-SELECT DISTINCT cs.comments_idcomments
+SELECT DISTINCT cs.comment_id
 FROM commentsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
-LEFT JOIN comments c ON c.idcomments=cs.comments_idcomments
+LEFT JOIN comments c ON c.idcomments=cs.comment_id
 LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_idforumthread
 WHERE swl.word=?
-AND cs.comments_idcomments IN (/*SLICE:ids*/?)
+AND cs.comment_id IN (/*SLICE:ids*/?)
 AND fth.forumtopic_idforumtopic IN (/*SLICE:ftids*/?)
 `
 
@@ -202,11 +202,11 @@ func (q *Queries) CommentsSearchNextInRestrictedTopic(ctx context.Context, arg C
 	defer rows.Close()
 	var items []int32
 	for rows.Next() {
-		var comments_idcomments int32
-		if err := rows.Scan(&comments_idcomments); err != nil {
+		var comment_id int32
+		if err := rows.Scan(&comment_id); err != nil {
 			return nil, err
 		}
-		items = append(items, comments_idcomments)
+		items = append(items, comment_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -218,14 +218,14 @@ func (q *Queries) CommentsSearchNextInRestrictedTopic(ctx context.Context, arg C
 }
 
 const commentsSearchNextNotInRestrictedTopic = `-- name: CommentsSearchNextNotInRestrictedTopic :many
-SELECT DISTINCT cs.comments_idcomments
+SELECT DISTINCT cs.comment_id
 FROM commentsSearch cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
-LEFT JOIN comments c ON c.idcomments=cs.comments_idcomments
+LEFT JOIN comments c ON c.idcomments=cs.comment_id
 LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_idforumthread
 LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
 WHERE swl.word=?
-AND cs.comments_idcomments IN (/*SLICE:ids*/?)
+AND cs.comment_id IN (/*SLICE:ids*/?)
 AND ft.forumcategory_idforumcategory!=0
 `
 
@@ -253,11 +253,11 @@ func (q *Queries) CommentsSearchNextNotInRestrictedTopic(ctx context.Context, ar
 	defer rows.Close()
 	var items []int32
 	for rows.Next() {
-		var comments_idcomments int32
-		if err := rows.Scan(&comments_idcomments); err != nil {
+		var comment_id int32
+		if err := rows.Scan(&comment_id); err != nil {
 			return nil, err
 		}
-		items = append(items, comments_idcomments)
+		items = append(items, comment_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -588,26 +588,26 @@ func (q *Queries) RemakeBlogsSearchInsert(ctx context.Context) error {
 }
 
 const remakeCommentsSearch = `-- name: RemakeCommentsSearch :exec
-INSERT INTO commentsSearch (text, comments_idcomments)
+INSERT INTO commentsSearch (text, comment_id)
 SELECT text, idcomments
 FROM comments
 `
 
 // This query selects data from the "comments" table and populates the "commentsSearch" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "commentsSearch" using the "comments_idcomments".
+// Then, it iterates over the "queue" linked list to add each text and ID pair to the "commentsSearch" using the "comment_id".
 func (q *Queries) RemakeCommentsSearch(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, remakeCommentsSearch)
 	return err
 }
 
 const remakeCommentsSearchInsert = `-- name: RemakeCommentsSearchInsert :exec
-INSERT INTO commentsSearch (text, comments_idcomments)
+INSERT INTO commentsSearch (text, comment_id)
 SELECT text, idcomments
 FROM comments
 `
 
 // This query selects data from the "comments" table and populates the "commentsSearch" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "commentsSearch" using the "comments_idcomments".
+// Then, it iterates over the "queue" linked list to add each text and ID pair to the "commentsSearch" using the "comment_id".
 func (q *Queries) RemakeCommentsSearchInsert(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, remakeCommentsSearchInsert)
 	return err

--- a/internal/searchutil/tokenize.go
+++ b/internal/searchutil/tokenize.go
@@ -94,7 +94,7 @@ func InsertWordsToWritingSearch(w http.ResponseWriter, r *http.Request, wordIds 
 func InsertWordsToForumSearch(w http.ResponseWriter, r *http.Request, wordIds []int64, queries *db.Queries, cid int64) bool {
 	return InsertWords(w, r, wordIds, func(ctx context.Context, wid int64) error {
 		return queries.AddToForumCommentSearch(ctx, db.AddToForumCommentSearchParams{
-			CommentsIdcomments:             int32(cid),
+			CommentID:                      int32(cid),
 			SearchwordlistIdsearchwordlist: int32(wid),
 		})
 	})

--- a/migrations/0020.sql
+++ b/migrations/0020.sql
@@ -1,0 +1,4 @@
+ALTER TABLE commentsSearch CHANGE COLUMN comments_idcomments comment_id int(10) NOT NULL DEFAULT 0;
+
+-- Record upgrade to schema version 20
+UPDATE schema_version SET version = 20 WHERE version = 19;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -60,10 +60,10 @@ CREATE TABLE `comments` (
 
 CREATE TABLE `commentsSearch` (
   `searchwordlist_idsearchwordlist` int(10) NOT NULL DEFAULT 0,
-  `comments_idcomments` int(10) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`searchwordlist_idsearchwordlist`,`comments_idcomments`),
+  `comment_id` int(10) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`searchwordlist_idsearchwordlist`,`comment_id`),
   KEY `searchwordlist_has_comments_FKIndex1` (`searchwordlist_idsearchwordlist`),
-  KEY `searchwordlist_has_comments_FKIndex2` (`comments_idcomments`)
+  KEY `searchwordlist_has_comments_FKIndex2` (`comment_id`)
 );
 
 CREATE TABLE `faq` (


### PR DESCRIPTION
## Summary
- rename `comments_idcomments` to `comment_id` in schema and queries
- add migration for the rename and bump schema version
- regenerate SQLC models and fix Go code
- document that every migration must update `schema_version`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686da64983d4832f91217a835c26d102