### PR TITLE
Fix GHCR push

### DIFF
--- a/.github/workflows/go_releaser.yaml
+++ b/.github/workflows/go_releaser.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   goreleaser:


### PR DESCRIPTION
## Summary
- allow docker push to GitHub packages by granting `packages: write` permission

## Testing
- `go mod tidy`
- `gofmt -w $(go list -f '{{.Dir}}' ./...)`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686db2fed67c832fa34880b2e16aedb3