### PR TITLE
Add primary key to topicrestrictions

### DIFF
--- a/migrations/0021.sql
+++ b/migrations/0021.sql
@@ -1,0 +1,6 @@
+ALTER TABLE topicrestrictions
+    DROP INDEX threadrestrictions_FKIndex1,
+    ADD PRIMARY KEY (forumtopic_idforumtopic);
+
+-- Record upgrade to schema version 21
+UPDATE schema_version SET version = 21 WHERE version = 20;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -269,7 +269,7 @@ CREATE TABLE `siteNewsSearch` (
 );
 
 CREATE TABLE `topicrestrictions` (
-  `forumtopic_idforumtopic` int(10) NOT NULL DEFAULT 0, -- TODO Primary key this
+  `forumtopic_idforumtopic` int(10) NOT NULL DEFAULT 0,
   `viewlevel` int(10) DEFAULT NULL,
   `replylevel` int(10) DEFAULT NULL,
   `newthreadlevel` int(10) DEFAULT NULL,
@@ -278,7 +278,7 @@ CREATE TABLE `topicrestrictions` (
   `readlevel` int(10) DEFAULT NULL,
   `modlevel` int(10) DEFAULT NULL,
   `adminlevel` int(10) DEFAULT NULL,
-  KEY `threadrestrictions_FKIndex1` (`forumtopic_idforumtopic`)
+  PRIMARY KEY (`forumtopic_idforumtopic`)
 );
 
 CREATE TABLE `user_language` (


### PR DESCRIPTION
## Summary
- enforce a primary key on `topicrestrictions.forumtopic_idforumtopic`
- provide migration `0021.sql` to apply the new constraint and bump schema version

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_686db9563a10832f907e59ab774bc285