### PR TITLE
Remove obsolete forum tables

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -421,15 +421,3 @@ type Writingsearch struct {
 	SearchwordlistIdsearchwordlist int32
 	WritingID                      int32
 }
-
-type _1OldForumthread struct {
-	Idforumthread          int32
-	ForumtopicIdforumtopic int32
-}
-
-type _1OldForumtopic struct {
-	Idforumtopic                 int32
-	ForumcategoryIdforumcategory int32
-	Title                        sql.NullString
-	Description                  sql.NullString
-}

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1,19 +1,3 @@
-CREATE TABLE `1_old_forumthread` (
-  `idforumthread` int(10) NOT NULL AUTO_INCREMENT,
-  `forumtopic_idforumtopic` int(10) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`idforumthread`),
-  KEY `forumdiscussions_FKIndex1` (`forumtopic_idforumtopic`)
-);
-
-CREATE TABLE `1_old_forumtopic` (
-  `idforumtopic` int(10) NOT NULL AUTO_INCREMENT,
-  `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `title` tinytext DEFAULT NULL,
-  `description` mediumtext DEFAULT NULL,
-  PRIMARY KEY (`idforumtopic`),
-  KEY `forumtopic_FKIndex1` (`forumcategory_idforumcategory`)
-);
-
 CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,


### PR DESCRIPTION
## Summary
- drop deprecated `1_old_forumthread` and `1_old_forumtopic` from `schema.sql`
- regenerate sqlc models

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `sqlc generate`

------
https://chatgpt.com/codex/tasks/task_e_686db964bf28832fb1f127ae6b5b52c1