### PR TITLE
Add unique indexes for users

### DIFF
--- a/cmd/goa4web/user_add.go
+++ b/cmd/goa4web/user_add.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"strings"
 
 	"golang.org/x/crypto/pbkdf2"
 
@@ -72,6 +73,9 @@ func createUser(root *rootCmd, username, email, password string, admin bool) err
 		username, email,
 	)
 	if err != nil {
+		if strings.Contains(err.Error(), "Duplicate entry") || strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return fmt.Errorf("user already exists")
+		}
 		return fmt.Errorf("insert user: %w", err)
 	}
 	id, err := res.LastInsertId()

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -104,6 +104,10 @@ func RegisterActionPage(w http.ResponseWriter, r *http.Request) {
 		username, email,
 	)
 	if err != nil {
+		if strings.Contains(err.Error(), "Duplicate entry") || strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			http.Error(w, "User already exists", http.StatusForbidden)
+			return
+		}
 		log.Printf("InsertUser Error: %s", err)
 		http.Error(w, "Can't create user", http.StatusForbidden)
 		return

--- a/handlers/common/constants.go
+++ b/handlers/common/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 20
+	ExpectedSchemaVersion = 21
 )

--- a/migrations/0021.sql
+++ b/migrations/0021.sql
@@ -1,0 +1,8 @@
+-- Add unique indexes to username and email
+ALTER TABLE users
+    ADD UNIQUE INDEX users_username_idx (username(255)),
+    ADD UNIQUE INDEX users_email_idx (email(255));
+
+-- Record upgrade to schema version 21
+UPDATE schema_version SET version = 21 WHERE version = 20;
+

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -295,7 +295,9 @@ CREATE TABLE `users` (
   `email` tinytext DEFAULT NULL,
   `username` tinytext DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
-  PRIMARY KEY (`idusers`)
+  PRIMARY KEY (`idusers`),
+  UNIQUE KEY `users_username_idx` (`username`(255)),
+  UNIQUE KEY `users_email_idx` (`email`(255))
 );
 
 CREATE TABLE `passwords` (


### PR DESCRIPTION
## Summary
- enforce unique usernames and emails at the DB level
- migrate existing installations to the new constraints
- handle duplicate user creation errors
- bump schema version

## Testing
- `go vet ./...` *(fails: context canceled)*
- `golangci-lint run ./...` *(fails: context canceled)*
- `go test -c ./...`

------
https://chatgpt.com/codex/tasks/task_e_686db95a5f18832fbbfc6c7839669849