### PR TITLE
Rename writingCategory table

### DIFF
--- a/cmd/goa4web/writing_tree.go
+++ b/cmd/goa4web/writing_tree.go
@@ -37,7 +37,7 @@ func (c *writingTreeCmd) Run() error {
 	if err != nil {
 		return fmt.Errorf("tree: %w", err)
 	}
-	children := map[int32][]*dbpkg.Writingcategory{}
+	children := map[int32][]*dbpkg.WritingCategory{}
 	for _, cat := range rows {
 		parent := cat.WritingcategoryIdwritingcategory
 		children[parent] = append(children[parent], cat)

--- a/handlers/admin/adminCategoriesPage.go
+++ b/handlers/admin/adminCategoriesPage.go
@@ -17,7 +17,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Section           string
 		ForumCategories   []*db.GetAllForumCategoriesWithSubcategoryCountRow
-		WritingCategories []*db.Writingcategory
+		WritingCategories []*db.WritingCategory
 		LinkerCategories  []*db.GetLinkerCategoryLinkCountsRow
 	}
 

--- a/handlers/common/constants.go
+++ b/handlers/common/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 20
+	ExpectedSchemaVersion = 22
 )

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -70,7 +70,7 @@ func TestPageTemplatesRender(t *testing.T) {
 		}{&corecommon.CoreData{}, nil, false, "", []struct{ Username string }{{"test"}}}},
 		{"writingsPage", struct {
 			*corecommon.CoreData
-			Categories                       []*db.Writingcategory
+			Categories                       []*db.WritingCategory
 			WritingcategoryIdwritingcategory int32
 			CategoryId                       int32
 			IsAdmin                          bool
@@ -86,8 +86,8 @@ func TestPageTemplatesRender(t *testing.T) {
 		}{&corecommon.CoreData{}, 0, false, 0, 0, 0, nil}},
 		{"writingsCategoryPage", struct {
 			*corecommon.CoreData
-			Categories                       []*db.Writingcategory
-			CategoryBreadcrumbs              []*db.Writingcategory
+			Categories                       []*db.WritingCategory
+			CategoryBreadcrumbs              []*db.WritingCategory
 			EditingCategoryId                int32
 			CategoryId                       int32
 			WritingcategoryIdwritingcategory int32

--- a/handlers/writings/writingsAdminCategoriesPage.go
+++ b/handlers/writings/writingsAdminCategoriesPage.go
@@ -16,7 +16,7 @@ import (
 func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*corecommon.CoreData
-		Categories []*db.Writingcategory
+		Categories []*db.WritingCategory
 	}
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 

--- a/handlers/writings/writingsAdminCategoriesPage_test.go
+++ b/handlers/writings/writingsAdminCategoriesPage_test.go
@@ -24,7 +24,7 @@ func TestWritingsAdminCategoriesPage(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writingcategory_idwritingcategory", "title", "description"}).
 		AddRow(1, 0, "a", "b")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT wc.idwritingcategory, wc.writingcategory_idwritingcategory, wc.title, wc.description\nFROM writingCategory wc")).WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT wc.idwritingcategory, wc.writingcategory_idwritingcategory, wc.title, wc.description\nFROM writing_category wc")).WillReturnRows(rows)
 
 	req := httptest.NewRequest("GET", "/admin/writings/categories", nil)
 	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -43,10 +43,10 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		Comments            []*CommentPlus
 		IsReplyable         bool
 		IsAdmin             bool
-		Categories          []*db.Writingcategory
+		Categories          []*db.WritingCategory
 		CategoryId          int32
 		Offset              int32
-		CategoryBreadcrumbs []*db.Writingcategory
+		CategoryBreadcrumbs []*db.WritingCategory
 		ReplyText           string
 	}
 
@@ -177,7 +177,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	categoryMap := map[int32]*db.Writingcategory{}
+	categoryMap := map[int32]*db.WritingCategory{}
 	for _, cat := range categoryRows {
 		categoryMap[cat.Idwritingcategory] = cat
 		if cat.WritingcategoryIdwritingcategory == data.CategoryId {

--- a/handlers/writings/writingsCategoriesPage.go
+++ b/handlers/writings/writingsCategoriesPage.go
@@ -16,8 +16,8 @@ import (
 func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*corecommon.CoreData
-		Categories                       []*db.Writingcategory
-		CategoryBreadcrumbs              []*db.Writingcategory
+		Categories                       []*db.WritingCategory
+		CategoryBreadcrumbs              []*db.WritingCategory
 		EditingCategoryId                int32
 		IsAdmin                          bool
 		IsWriter                         bool
@@ -63,7 +63,7 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	categoryMap := map[int32]*db.Writingcategory{}
+	categoryMap := map[int32]*db.WritingCategory{}
 	for _, cat := range categoryRows {
 		categoryMap[cat.Idwritingcategory] = cat
 		if cat.WritingcategoryIdwritingcategory == 0 {

--- a/handlers/writings/writingsCategoryPage.go
+++ b/handlers/writings/writingsCategoryPage.go
@@ -18,8 +18,8 @@ import (
 func CategoryPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*corecommon.CoreData
-		Categories                       []*db.Writingcategory
-		CategoryBreadcrumbs              []*db.Writingcategory
+		Categories                       []*db.WritingCategory
+		CategoryBreadcrumbs              []*db.WritingCategory
 		EditingCategoryId                int32
 		CategoryId                       int32
 		WritingcategoryIdwritingcategory int32
@@ -71,7 +71,7 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	categoryMap := map[int32]*db.Writingcategory{}
+	categoryMap := map[int32]*db.WritingCategory{}
 	for _, cat := range categoryRows {
 		categoryMap[cat.Idwritingcategory] = cat
 		if cat.WritingcategoryIdwritingcategory == data.CategoryId {

--- a/handlers/writings/writingsPage.go
+++ b/handlers/writings/writingsPage.go
@@ -19,7 +19,7 @@ var writingsPermissionsPageEnabled = true
 func Page(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*corecommon.CoreData
-		Categories                       []*db.Writingcategory
+		Categories                       []*db.WritingCategory
 		EditingCategoryId                int32
 		CategoryId                       int32
 		WritingcategoryIdwritingcategory int32

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -403,18 +403,18 @@ type Writing struct {
 	DeletedAt                        sql.NullTime
 }
 
+type WritingCategory struct {
+	Idwritingcategory                int32
+	WritingcategoryIdwritingcategory int32
+	Title                            sql.NullString
+	Description                      sql.NullString
+}
+
 type Writingapproveduser struct {
 	WritingID    int32
 	UsersIdusers int32
 	Readdoc      sql.NullBool
 	Editdoc      sql.NullBool
-}
-
-type Writingcategory struct {
-	Idwritingcategory                int32
-	WritingcategoryIdwritingcategory int32
-	Title                            sql.NullString
-	Description                      sql.NullString
 }
 
 type Writingsearch struct {

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -53,22 +53,22 @@ ORDER BY w.published DESC
 ;
 
 -- name: InsertWritingCategory :exec
-INSERT INTO writingCategory (writingCategory_idwritingCategory, title, description)
+INSERT INTO writing_category (writingCategory_idwritingCategory, title, description)
 VALUES (?, ?, ?);
 
 -- name: UpdateWritingCategory :exec
-UPDATE writingCategory
+UPDATE writing_category
 SET title = ?, description = ?, writingCategory_idwritingCategory = ?
 WHERE idwritingCategory = ?;
 
 -- name: GetAllWritingCategories :many
 SELECT *
-FROM writingCategory
+FROM writing_category
 WHERE writingCategory_idwritingCategory = ?;
 
 -- name: FetchAllCategories :many
 SELECT wc.*
-FROM writingCategory wc
+FROM writing_category wc
 ;
 
 -- name: DeleteWritingApproval :exec

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -64,18 +64,18 @@ func (q *Queries) DeleteWritingApproval(ctx context.Context, arg DeleteWritingAp
 
 const fetchAllCategories = `-- name: FetchAllCategories :many
 SELECT wc.idwritingcategory, wc.writingcategory_idwritingcategory, wc.title, wc.description
-FROM writingCategory wc
+FROM writing_category wc
 `
 
-func (q *Queries) FetchAllCategories(ctx context.Context) ([]*Writingcategory, error) {
+func (q *Queries) FetchAllCategories(ctx context.Context) ([]*WritingCategory, error) {
 	rows, err := q.db.QueryContext(ctx, fetchAllCategories)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*Writingcategory
+	var items []*WritingCategory
 	for rows.Next() {
-		var i Writingcategory
+		var i WritingCategory
 		if err := rows.Scan(
 			&i.Idwritingcategory,
 			&i.WritingcategoryIdwritingcategory,
@@ -142,19 +142,19 @@ func (q *Queries) GetAllWritingApprovals(ctx context.Context) ([]*GetAllWritingA
 
 const getAllWritingCategories = `-- name: GetAllWritingCategories :many
 SELECT idwritingcategory, writingcategory_idwritingcategory, title, description
-FROM writingCategory
+FROM writing_category
 WHERE writingCategory_idwritingCategory = ?
 `
 
-func (q *Queries) GetAllWritingCategories(ctx context.Context, writingcategoryIdwritingcategory int32) ([]*Writingcategory, error) {
+func (q *Queries) GetAllWritingCategories(ctx context.Context, writingcategoryIdwritingcategory int32) ([]*WritingCategory, error) {
 	rows, err := q.db.QueryContext(ctx, getAllWritingCategories, writingcategoryIdwritingcategory)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*Writingcategory
+	var items []*WritingCategory
 	for rows.Next() {
-		var i Writingcategory
+		var i WritingCategory
 		if err := rows.Scan(
 			&i.Idwritingcategory,
 			&i.WritingcategoryIdwritingcategory,
@@ -584,7 +584,7 @@ func (q *Queries) InsertWriting(ctx context.Context, arg InsertWritingParams) (i
 }
 
 const insertWritingCategory = `-- name: InsertWritingCategory :exec
-INSERT INTO writingCategory (writingCategory_idwritingCategory, title, description)
+INSERT INTO writing_category (writingCategory_idwritingCategory, title, description)
 VALUES (?, ?, ?)
 `
 
@@ -650,7 +650,7 @@ func (q *Queries) UpdateWritingApproval(ctx context.Context, arg UpdateWritingAp
 }
 
 const updateWritingCategory = `-- name: UpdateWritingCategory :exec
-UPDATE writingCategory
+UPDATE writing_category
 SET title = ?, description = ?, writingCategory_idwritingCategory = ?
 WHERE idwritingCategory = ?
 `

--- a/migrations/0022.sql
+++ b/migrations/0022.sql
@@ -1,0 +1,4 @@
+RENAME TABLE writingCategory TO writing_category;
+
+-- Record upgrade to schema version 22
+UPDATE schema_version SET version = 22 WHERE version = 21;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -322,7 +322,7 @@ CREATE TABLE `writing` (
   KEY `writing_FKIndex4` (`users_idusers`)
 );
 
-CREATE TABLE `writingCategory` (
+CREATE TABLE `writing_category` (
   `idwritingCategory` int(10) NOT NULL AUTO_INCREMENT,
   `writingCategory_idwritingCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,


### PR DESCRIPTION
## Summary
- rename `writingCategory` to `writing_category` in the schema
- update SQL queries and Go code to reference the new table name
- bump `ExpectedSchemaVersion` to 22
- add migration for renaming the table

## Testing
- `sqlc generate`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686dbd1388f8832fa0753742e6490a82