### PR TITLE
Improve DLQ handling for email failures

### DIFF
--- a/internal/dlq/file/file.go
+++ b/internal/dlq/file/file.go
@@ -17,6 +17,9 @@ type DLQ struct {
 	mu   sync.Mutex
 }
 
+// fileSeparator marks the boundary around each recorded message.
+const fileSeparator = "-----"
+
 // Record writes the message to the configured file.
 func (f *DLQ) Record(_ context.Context, message string) error {
 	f.mu.Lock()
@@ -29,7 +32,7 @@ func (f *DLQ) Record(_ context.Context, message string) error {
 		return err
 	}
 	defer fh.Close()
-	_, err = fmt.Fprintln(fh, message)
+	_, err = fmt.Fprintf(fh, "%s\n%s\n%s\n", fileSeparator, message, fileSeparator)
 	return err
 }
 

--- a/internal/emailutil/email_queue.go
+++ b/internal/emailutil/email_queue.go
@@ -70,7 +70,8 @@ func ProcessPendingEmail(ctx context.Context, q *db.Queries, provider email.Prov
 		}
 		if count > 4 {
 			if dlqProvider != nil {
-				_ = dlqProvider.Record(ctx, fmt.Sprintf("email %d to %s failed: %v", e.ID, user.Email.String, err))
+				msg := fmt.Sprintf("email %d to %s failed: %v\n%s", e.ID, user.Email.String, err, e.Body)
+				_ = dlqProvider.Record(ctx, msg)
 			}
 			if delErr := q.DeletePendingEmail(ctx, e.ID); delErr != nil {
 				log.Printf("delete email: %v", delErr)

--- a/internal/emailutil/email_test.go
+++ b/internal/emailutil/email_test.go
@@ -22,6 +22,7 @@ import (
 	smtpProv "github.com/arran4/goa4web/internal/email/smtp"
 	"github.com/arran4/goa4web/internal/emailutil"
 	"github.com/arran4/goa4web/runtimeconfig"
+	"strings"
 )
 
 func init() {
@@ -172,6 +173,10 @@ func TestProcessPendingEmailDLQ(t *testing.T) {
 
 	if len(dlqRec.Records) != 1 {
 		t.Fatalf("dlq records=%d", len(dlqRec.Records))
+	}
+	msg := dlqRec.Records[0].Message
+	if !strings.Contains(msg, "b") || !strings.Contains(msg, "fail") {
+		t.Fatalf("unexpected dlq message: %s", msg)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)

--- a/readme.md
+++ b/readme.md
@@ -265,10 +265,12 @@ environment variables listed below.
 The `DLQ_PROVIDER` setting selects how failed messages are recorded:
 
 * `log` – writes messages to the application log (default)
-* `file` – appends messages to a file in mbox/JSON lines format at `DLQ_FILE`
+* `file` – appends messages to a file using separator lines at `DLQ_FILE`
 * `dir` – creates one file per message under the directory `DLQ_FILE` using a KSUID name
 * `db` – stores messages in the database
 * `email` – sends messages to administrator addresses using the configured mail provider
+
+Messages include any error details and full email contents when available.
 Example config file:
 
 ```conf


### PR DESCRIPTION
## Summary
- log full email message and error to DLQ
- clearly separate entries when using file DLQ
- update DLQ tests
- document DLQ separator behaviour

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686dc3d91534832f8e5bfec075d36cc6