### PR TITLE
Update blogs timestamp default

### DIFF
--- a/handlers/common/constants.go
+++ b/handlers/common/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 22
+	ExpectedSchemaVersion = 23
 )

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -5,7 +5,7 @@ WHERE idblogs = ?;
 
 -- name: CreateBlogEntry :execlastid
 INSERT INTO blogs (users_idusers, language_idlanguage, blog, written)
-VALUES (?, ?, ?, NOW());
+VALUES (?, ?, ?, CURRENT_TIMESTAMP);
 
 -- name: AssignThreadIdToBlogEntry :exec
 UPDATE blogs

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -107,7 +107,7 @@ func (q *Queries) BlogsSearchNext(ctx context.Context, arg BlogsSearchNextParams
 
 const createBlogEntry = `-- name: CreateBlogEntry :execlastid
 INSERT INTO blogs (users_idusers, language_idlanguage, blog, written)
-VALUES (?, ?, ?, NOW())
+VALUES (?, ?, ?, CURRENT_TIMESTAMP)
 `
 
 type CreateBlogEntryParams struct {

--- a/migrations/0023.sql
+++ b/migrations/0023.sql
@@ -1,0 +1,6 @@
+-- Set default timestamp for blog posts
+ALTER TABLE blogs
+    MODIFY written DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- Record upgrade to schema version 23
+UPDATE schema_version SET version = 23 WHERE version = 22;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE `blogs` (
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `language_idlanguage` int(10) NOT NULL DEFAULT 0,
   `blog` longtext DEFAULT NULL,
-  `written` DATETIME NOT NULL DEFAULT NOW(),
+  `written` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `deleted_at` datetime DEFAULT NULL,
   PRIMARY KEY (`idblogs`),
   KEY `blogs_FKIndex1` (`language_idlanguage`),


### PR DESCRIPTION
## Summary
- set `blogs.written` column default to CURRENT_TIMESTAMP via new migration
- keep schema in sync
- update generated queries and schema version constant

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686dc88668ec832f9858c8443d685035