### PR TITLE
Rename writing category ID column

### DIFF
--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -96,16 +96,16 @@ func (c *userDeactivateCmd) Run() error {
 	}
 	for _, w := range writings {
 		if err := qtx.ArchiveWriting(ctx, dbpkg.ArchiveWritingParams{
-			Idwriting:                        w.Idwriting,
-			UsersIdusers:                     w.UsersIdusers,
-			ForumthreadIdforumthread:         w.ForumthreadIdforumthread,
-			LanguageIdlanguage:               w.LanguageIdlanguage,
-			WritingcategoryIdwritingcategory: w.WritingcategoryIdwritingcategory,
-			Title:                            w.Title,
-			Published:                        w.Published,
-			Writing:                          w.Writing,
-			Abstract:                         w.Abstract,
-			Private:                          w.Private,
+			Idwriting:                w.Idwriting,
+			UsersIdusers:             w.UsersIdusers,
+			ForumthreadIdforumthread: w.ForumthreadIdforumthread,
+			LanguageIdlanguage:       w.LanguageIdlanguage,
+			WritingCategoryID:        w.WritingCategoryID,
+			Title:                    w.Title,
+			Published:                w.Published,
+			Writing:                  w.Writing,
+			Abstract:                 w.Abstract,
+			Private:                  w.Private,
 		}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("archive writing: %w", err)

--- a/cmd/goa4web/writing_list.go
+++ b/cmd/goa4web/writing_list.go
@@ -57,9 +57,9 @@ func (c *writingListCmd) Run() error {
 	}
 	if c.Category != 0 {
 		rows, err := queries.GetPublicWritingsInCategory(ctx, dbpkg.GetPublicWritingsInCategoryParams{
-			WritingcategoryIdwritingcategory: int32(c.Category),
-			Limit:                            int32(c.Limit),
-			Offset:                           int32(c.Offset),
+			WritingCategoryID: int32(c.Category),
+			Limit:             int32(c.Limit),
+			Offset:            int32(c.Offset),
 		})
 		if err != nil {
 			return fmt.Errorf("list writings: %w", err)

--- a/cmd/goa4web/writing_tree.go
+++ b/cmd/goa4web/writing_tree.go
@@ -39,7 +39,7 @@ func (c *writingTreeCmd) Run() error {
 	}
 	children := map[int32][]*dbpkg.WritingCategory{}
 	for _, cat := range rows {
-		parent := cat.WritingcategoryIdwritingcategory
+		parent := cat.WritingCategoryID
 		children[parent] = append(children[parent], cat)
 	}
 	var printTree func(parent int32, prefix string)

--- a/core/templates/templates/admin/categoriesPage.gohtml
+++ b/core/templates/templates/admin/categoriesPage.gohtml
@@ -70,7 +70,7 @@
         <form method="post" action="/admin/writings/categories">
         {{ csrfField }}
             <td><input type="hidden" name="wcid" value="{{ .Idwritingcategory }}"><a id="wc{{ .Idwritingcategory }}" href="/writings/category/{{ .Idwritingcategory }}">{{ .Idwritingcategory }}</a></td>
-            <td>{{ $fcid := .WritingcategoryIdwritingcategory }} <a href="#wc{{ $fcid }}">{{ $fcid }}</a> <select name="pcid" value="{{ .WritingcategoryIdwritingcategory }}"><option value="0">None</option>{{ range $.WritingCategories }}<option value="{{.Idwritingcategory}}" {{if eq $fcid .Idwritingcategory}}selected{{end}}>{{.Title.String}}</option>{{ end }}</select></td>
+            <td>{{ $fcid := .WritingCategoryID }} <a href="#wc{{ $fcid }}">{{ $fcid }}</a> <select name="pcid" value="{{ .WritingCategoryID }}"><option value="0">None</option>{{ range $.WritingCategories }}<option value="{{.Idwritingcategory}}" {{if eq $fcid .Idwritingcategory}}selected{{end}}>{{.Title.String}}</option>{{ end }}</select></td>
             <td><input name="name" value="{{ .Title.String }}"></td>
             <td><textarea name="desc" rows="3" cols="60">{{ .Description.String }}</textarea></td>
             <td>

--- a/core/templates/templates/listWritingCategories.gohtml
+++ b/core/templates/templates/listWritingCategories.gohtml
@@ -1,5 +1,5 @@
 {{ define "listWritingCategories" }}
-    <font size="4">{{ if $.WritingcategoryIdwritingcategory }}Sub-{{ end }}Categories:</font><br>
+    <font size="4">{{ if $.WritingCategoryID }}Sub-{{ end }}Categories:</font><br>
     <table>
         {{ range .Categories }}
             {{ $title := .Title.String }}

--- a/core/templates/templates/writings/adminCategoriesPage.gohtml
+++ b/core/templates/templates/writings/adminCategoriesPage.gohtml
@@ -12,7 +12,7 @@
                 <form method="post" action="/admin/writings/categories">
         {{ csrfField }}
                     <td><input type="hidden" name="wcid" value="{{ .Idwritingcategory }}"><a id="wc{{ .Idwritingcategory }}" href="/writings/category/{{ .Idwritingcategory }}">{{ .Idwritingcategory }}</a>
-                    <td>{{ $fcid := .WritingcategoryIdwritingcategory }} <a href="#wc{{ $fcid }}">{{ $fcid }}</a> <select name="pcid" value="{{ .WritingcategoryIdwritingcategory }}"><option value="0">None</option>{{ range $.Categories }}<option value="{{.Idwritingcategory}}" {{if eq $fcid .Idwritingcategory}}selected{{end}}>{{.Title.String}}</option>  {{ end }}</select>
+                    <td>{{ $fcid := .WritingCategoryID }} <a href="#wc{{ $fcid }}">{{ $fcid }}</a> <select name="pcid" value="{{ .WritingCategoryID }}"><option value="0">None</option>{{ range $.Categories }}<option value="{{.Idwritingcategory}}" {{if eq $fcid .Idwritingcategory}}selected{{end}}>{{.Title.String}}</option>  {{ end }}</select>
                     <td><input name="name" value="{{ .Title.String }}">
                     <td><textarea name="desc">{{ .Description.String }}</textarea>
                     <td>
@@ -35,5 +35,4 @@
                 </td>
             </form>
         </tr>
-    </table>
-{{ template "tail" $ }}
+    </table>{{ template "tail" $ }}

--- a/core/templates/templates/writings/articlePage.gohtml
+++ b/core/templates/templates/writings/articlePage.gohtml
@@ -5,7 +5,7 @@
         {{ if .Writing.Private.Bool }} (Restricted access) {{ end }}
         {{ if or .CanEdit .IsAuthor }}
             [<a href="/writings/article/{{ .Writing.Idwriting }}/edit">EDIT</a>]
-            {{ if .IsAuthor }} [<a href="/admin/writings/users/access?category={{ .Writing.WritingcategoryIdwritingcategory }}&article={{ .Writing.Idwriting }}">APPROVED USERS</a>] {{ end }}
+            {{ if .IsAuthor }} [<a href="/admin/writings/users/access?category={{ .Writing.WritingCategoryID }}&article={{ .Writing.Idwriting }}">APPROVED USERS</a>] {{ end }}
         {{ end }}
         <br>
         <strong>Abstract:</strong><br>
@@ -28,5 +28,4 @@
     {{ else }}
         Article doesn't exist.<br>
     {{ end }}
-
 {{ template "tail" $ }}

--- a/handlers/common/constants.go
+++ b/handlers/common/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 22
+	ExpectedSchemaVersion = 23
 )

--- a/handlers/search/searchResultLinkerActionPage.go
+++ b/handlers/search/searchResultLinkerActionPage.go
@@ -18,13 +18,13 @@ import (
 func SearchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*hcommon.CoreData
-		Comments                         []*db.GetCommentsByIdsForUserWithThreadInfoRow
-		Links                            []*db.GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow
-		CommentsNoResults                bool
-		CommentsEmptyWords               bool
-		NoResults                        bool
-		EmptyWords                       bool
-		WritingcategoryIdwritingcategory int32
+		Comments           []*db.GetCommentsByIdsForUserWithThreadInfoRow
+		Links              []*db.GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow
+		CommentsNoResults  bool
+		CommentsEmptyWords bool
+		NoResults          bool
+		EmptyWords         bool
+		WritingCategoryID  int32
 	}
 
 	data := Data{

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -70,10 +70,10 @@ func TestPageTemplatesRender(t *testing.T) {
 		}{&corecommon.CoreData{}, nil, false, "", []struct{ Username string }{{"test"}}}},
 		{"writingsPage", struct {
 			*corecommon.CoreData
-			Categories                       []*db.WritingCategory
-			WritingcategoryIdwritingcategory int32
-			CategoryId                       int32
-			IsAdmin                          bool
+			Categories        []*db.WritingCategory
+			WritingCategoryID int32
+			CategoryId        int32
+			IsAdmin           bool
 		}{&corecommon.CoreData{}, nil, 0, 0, false}},
 		{"linkerCategoryPage", struct {
 			*corecommon.CoreData
@@ -86,14 +86,14 @@ func TestPageTemplatesRender(t *testing.T) {
 		}{&corecommon.CoreData{}, 0, false, 0, 0, 0, nil}},
 		{"writingsCategoryPage", struct {
 			*corecommon.CoreData
-			Categories                       []*db.WritingCategory
-			CategoryBreadcrumbs              []*db.WritingCategory
-			EditingCategoryId                int32
-			CategoryId                       int32
-			WritingcategoryIdwritingcategory int32
-			IsAdmin                          bool
-			IsWriter                         bool
-			Abstracts                        []*db.GetPublicWritingsInCategoryRow
+			Categories          []*db.WritingCategory
+			CategoryBreadcrumbs []*db.WritingCategory
+			EditingCategoryId   int32
+			CategoryId          int32
+			WritingCategoryID   int32
+			IsAdmin             bool
+			IsWriter            bool
+			Abstracts           []*db.GetPublicWritingsInCategoryRow
 		}{&corecommon.CoreData{}, nil, nil, 0, 0, 0, false, false, nil}},
 		{"searchPage", struct {
 			*corecommon.CoreData

--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -64,7 +64,7 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 	}
 	var ws []writingExport
 	for _, wrow := range writings {
-		ws = append(ws, writingExport{wrow, catMap[wrow.WritingcategoryIdwritingcategory]})
+		ws = append(ws, writingExport{wrow, catMap[wrow.WritingCategoryID]})
 	}
 
 	blogs, _ := queries.GetAllBlogEntriesByUser(r.Context(), int32(uid))

--- a/handlers/writings/matchers_test.go
+++ b/handlers/writings/matchers_test.go
@@ -40,7 +40,7 @@ func TestRequireWritingAuthorArticleVar(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	rows := sqlmock.NewRows([]string{
-		"idwriting", "users_idusers", "forumthread_idforumthread", "language_idlanguage", "writingcategory_idwritingcategory", "title", "published", "writing", "abstract", "private", "deleted_at", "WriterId", "WriterUsername",
+		"idwriting", "users_idusers", "forumthread_idforumthread", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "WriterId", "WriterUsername",
 	}).AddRow(2, 1, 0, 1, 1, sql.NullString{}, sql.NullTime{}, sql.NullString{}, sql.NullString{}, sql.NullBool{}, sql.NullTime{}, 1, sql.NullString{})
 	mock.ExpectQuery("SELECT w.idwriting").
 		WithArgs(int32(1), int32(2), int32(1)).

--- a/handlers/writings/writingsAdminCategoriesPage.go
+++ b/handlers/writings/writingsAdminCategoriesPage.go
@@ -70,8 +70,8 @@ func AdminCategoriesModifyPage(w http.ResponseWriter, r *http.Request) {
 			Valid:  true,
 			String: desc,
 		},
-		Idwritingcategory:                int32(categoryId),
-		WritingcategoryIdwritingcategory: int32(wcid),
+		Idwritingcategory: int32(categoryId),
+		WritingCategoryID: int32(wcid),
 	}); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
@@ -91,7 +91,7 @@ func AdminCategoriesCreatePage(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	if err := queries.InsertWritingCategory(r.Context(), db.InsertWritingCategoryParams{
-		WritingcategoryIdwritingcategory: int32(pcid),
+		WritingCategoryID: int32(pcid),
 		Title: sql.NullString{
 			Valid:  true,
 			String: name,

--- a/handlers/writings/writingsAdminCategoriesPage_test.go
+++ b/handlers/writings/writingsAdminCategoriesPage_test.go
@@ -22,9 +22,9 @@ func TestWritingsAdminCategoriesPage(t *testing.T) {
 
 	queries := db.New(sqlDB)
 
-	rows := sqlmock.NewRows([]string{"idwritingcategory", "writingcategory_idwritingcategory", "title", "description"}).
+	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
 		AddRow(1, 0, "a", "b")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT wc.idwritingcategory, wc.writingcategory_idwritingcategory, wc.title, wc.description\nFROM writing_category wc")).WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT wc.idwritingcategory, wc.writing_category_id, wc.title, wc.description\nFROM writing_category wc")).WillReturnRows(rows)
 
 	req := httptest.NewRequest("GET", "/admin/writings/categories", nil)
 	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -62,13 +62,13 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 
 	articleId, err := queries.InsertWriting(r.Context(), db.InsertWritingParams{
-		WritingcategoryIdwritingcategory: int32(categoryId),
-		Title:                            sql.NullString{Valid: true, String: title},
-		Abstract:                         sql.NullString{Valid: true, String: abstract},
-		Writing:                          sql.NullString{Valid: true, String: body},
-		Private:                          sql.NullBool{Valid: true, Bool: private},
-		LanguageIdlanguage:               int32(languageId),
-		UsersIdusers:                     uid,
+		WritingCategoryID:  int32(categoryId),
+		Title:              sql.NullString{Valid: true, String: title},
+		Abstract:           sql.NullString{Valid: true, String: abstract},
+		Writing:            sql.NullString{Valid: true, String: body},
+		Private:            sql.NullBool{Valid: true, Bool: private},
+		LanguageIdlanguage: int32(languageId),
+		UsersIdusers:       uid,
 	})
 	if err != nil {
 		log.Printf("insertWriting Error: %s", err)

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -128,7 +128,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 	data.Writing = writing
 	data.IsAuthor = writing.UsersIdusers == uid
 	data.CanEdit = (cd.HasRole("administrator") && cd.AdminMode) || (cd.HasRole("writer") && data.IsAuthor)
-	data.CategoryId = writing.WritingcategoryIdwritingcategory
+	data.CategoryId = writing.WritingCategoryID
 
 	languageRows, err := queries.FetchLanguages(r.Context())
 	if err != nil {
@@ -180,7 +180,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 	categoryMap := map[int32]*db.WritingCategory{}
 	for _, cat := range categoryRows {
 		categoryMap[cat.Idwritingcategory] = cat
-		if cat.WritingcategoryIdwritingcategory == data.CategoryId {
+		if cat.WritingCategoryID == data.CategoryId {
 			data.Categories = append(data.Categories, cat)
 		}
 	}
@@ -188,7 +188,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		cat, ok := categoryMap[cid]
 		if ok {
 			data.CategoryBreadcrumbs = append(data.CategoryBreadcrumbs, cat)
-			cid = cat.WritingcategoryIdwritingcategory
+			cid = cat.WritingCategoryID
 		} else {
 			break
 		}

--- a/handlers/writings/writingsCategoriesPage.go
+++ b/handlers/writings/writingsCategoriesPage.go
@@ -16,13 +16,13 @@ import (
 func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*corecommon.CoreData
-		Categories                       []*db.WritingCategory
-		CategoryBreadcrumbs              []*db.WritingCategory
-		EditingCategoryId                int32
-		IsAdmin                          bool
-		IsWriter                         bool
-		Abstracts                        []*db.GetPublicWritingsInCategoryRow
-		WritingcategoryIdwritingcategory int32
+		Categories          []*db.WritingCategory
+		CategoryBreadcrumbs []*db.WritingCategory
+		EditingCategoryId   int32
+		IsAdmin             bool
+		IsWriter            bool
+		Abstracts           []*db.GetPublicWritingsInCategoryRow
+		WritingCategoryID   int32
 	}
 
 	data := Data{
@@ -33,7 +33,7 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 	data.IsWriter = data.CoreData.HasRole("writer") || data.IsAdmin
 	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
 	data.EditingCategoryId = int32(editID)
-	data.WritingcategoryIdwritingcategory = 0
+	data.WritingCategoryID = 0
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
@@ -49,9 +49,9 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writingsRows, err := queries.GetPublicWritingsInCategory(r.Context(), db.GetPublicWritingsInCategoryParams{
-		WritingcategoryIdwritingcategory: 0,
-		Limit:                            15,
-		Offset:                           0,
+		WritingCategoryID: 0,
+		Limit:             15,
+		Offset:            0,
 	})
 	if err != nil {
 		switch {
@@ -66,7 +66,7 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 	categoryMap := map[int32]*db.WritingCategory{}
 	for _, cat := range categoryRows {
 		categoryMap[cat.Idwritingcategory] = cat
-		if cat.WritingcategoryIdwritingcategory == 0 {
+		if cat.WritingCategoryID == 0 {
 			data.Categories = append(data.Categories, cat)
 		}
 	}

--- a/handlers/writings/writingsCategoryPage.go
+++ b/handlers/writings/writingsCategoryPage.go
@@ -18,14 +18,14 @@ import (
 func CategoryPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*corecommon.CoreData
-		Categories                       []*db.WritingCategory
-		CategoryBreadcrumbs              []*db.WritingCategory
-		EditingCategoryId                int32
-		CategoryId                       int32
-		WritingcategoryIdwritingcategory int32
-		IsAdmin                          bool
-		IsWriter                         bool
-		Abstracts                        []*db.GetPublicWritingsInCategoryRow
+		Categories          []*db.WritingCategory
+		CategoryBreadcrumbs []*db.WritingCategory
+		EditingCategoryId   int32
+		CategoryId          int32
+		WritingCategoryID   int32
+		IsAdmin             bool
+		IsWriter            bool
+		Abstracts           []*db.GetPublicWritingsInCategoryRow
 	}
 
 	data := Data{
@@ -40,7 +40,7 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	categoryId, _ := strconv.Atoi(vars["category"])
 	data.CategoryId = int32(categoryId)
-	data.WritingcategoryIdwritingcategory = data.CategoryId
+	data.WritingCategoryID = data.CategoryId
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
@@ -56,9 +56,9 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writingsRows, err := queries.GetPublicWritingsInCategory(r.Context(), db.GetPublicWritingsInCategoryParams{
-		WritingcategoryIdwritingcategory: data.CategoryId,
-		Limit:                            15,
-		Offset:                           0,
+		WritingCategoryID: data.CategoryId,
+		Limit:             15,
+		Offset:            0,
 	})
 	if err != nil {
 		switch {
@@ -74,7 +74,7 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 	categoryMap := map[int32]*db.WritingCategory{}
 	for _, cat := range categoryRows {
 		categoryMap[cat.Idwritingcategory] = cat
-		if cat.WritingcategoryIdwritingcategory == data.CategoryId {
+		if cat.WritingCategoryID == data.CategoryId {
 			data.Categories = append(data.Categories, cat)
 		}
 	}
@@ -82,7 +82,7 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 		cat, ok := categoryMap[cid]
 		if ok {
 			data.CategoryBreadcrumbs = append(data.CategoryBreadcrumbs, cat)
-			cid = cat.WritingcategoryIdwritingcategory
+			cid = cat.WritingCategoryID
 		} else {
 			break
 		}

--- a/handlers/writings/writingsPage.go
+++ b/handlers/writings/writingsPage.go
@@ -19,11 +19,11 @@ var writingsPermissionsPageEnabled = true
 func Page(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*corecommon.CoreData
-		Categories                       []*db.WritingCategory
-		EditingCategoryId                int32
-		CategoryId                       int32
-		WritingcategoryIdwritingcategory int32
-		IsAdmin                          bool
+		Categories        []*db.WritingCategory
+		EditingCategoryId int32
+		CategoryId        int32
+		WritingCategoryID int32
+		IsAdmin           bool
 	}
 
 	data := Data{
@@ -34,7 +34,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
 	data.EditingCategoryId = int32(editID)
 	data.CategoryId = 0
-	data.WritingcategoryIdwritingcategory = data.CategoryId
+	data.WritingCategoryID = data.CategoryId
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -123,18 +123,18 @@ type DeactivatedUser struct {
 }
 
 type DeactivatedWriting struct {
-	Idwriting                        int32
-	UsersIdusers                     int32
-	ForumthreadIdforumthread         int32
-	LanguageIdlanguage               int32
-	WritingcategoryIdwritingcategory int32
-	Title                            sql.NullString
-	Published                        sql.NullTime
-	Writing                          sql.NullString
-	Abstract                         sql.NullString
-	Private                          sql.NullBool
-	DeletedAt                        sql.NullTime
-	RestoredAt                       sql.NullTime
+	Idwriting                int32
+	UsersIdusers             int32
+	ForumthreadIdforumthread int32
+	LanguageIdlanguage       int32
+	WritingCategoryID        int32
+	Title                    sql.NullString
+	Published                sql.NullTime
+	Writing                  sql.NullString
+	Abstract                 sql.NullString
+	Private                  sql.NullBool
+	DeletedAt                sql.NullTime
+	RestoredAt               sql.NullTime
 }
 
 type DeadLetter struct {
@@ -390,24 +390,24 @@ type Userstopiclevel struct {
 }
 
 type Writing struct {
-	Idwriting                        int32
-	UsersIdusers                     int32
-	ForumthreadIdforumthread         int32
-	LanguageIdlanguage               int32
-	WritingcategoryIdwritingcategory int32
-	Title                            sql.NullString
-	Published                        sql.NullTime
-	Writing                          sql.NullString
-	Abstract                         sql.NullString
-	Private                          sql.NullBool
-	DeletedAt                        sql.NullTime
+	Idwriting                int32
+	UsersIdusers             int32
+	ForumthreadIdforumthread int32
+	LanguageIdlanguage       int32
+	WritingCategoryID        int32
+	Title                    sql.NullString
+	Published                sql.NullTime
+	Writing                  sql.NullString
+	Abstract                 sql.NullString
+	Private                  sql.NullBool
+	DeletedAt                sql.NullTime
 }
 
 type WritingCategory struct {
-	Idwritingcategory                int32
-	WritingcategoryIdwritingcategory int32
-	Title                            sql.NullString
-	Description                      sql.NullString
+	Idwritingcategory int32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Description       sql.NullString
 }
 
 type Writingapproveduser struct {

--- a/internal/db/queries-deactivation.sql
+++ b/internal/db/queries-deactivation.sql
@@ -27,7 +27,7 @@ UPDATE comments SET text = ?, deleted_at = NULL WHERE idcomments = ?;
 UPDATE deactivated_comments SET restored_at = NOW() WHERE idcomments = ?;
 
 -- name: ArchiveWriting :exec
-INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_idforumthread, language_idlanguage, writingCategory_idwritingCategory, title, published, writing, abstract, private, deleted_at)
+INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_idforumthread, language_idlanguage, writing_category_id, title, published, writing, abstract, private, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
 
 -- name: ScrubWriting :exec

--- a/internal/db/queries-deactivation.sql.go
+++ b/internal/db/queries-deactivation.sql.go
@@ -142,21 +142,21 @@ func (q *Queries) ArchiveUser(ctx context.Context, idusers int32) error {
 }
 
 const archiveWriting = `-- name: ArchiveWriting :exec
-INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_idforumthread, language_idlanguage, writingCategory_idwritingCategory, title, published, writing, abstract, private, deleted_at)
+INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_idforumthread, language_idlanguage, writing_category_id, title, published, writing, abstract, private, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
 type ArchiveWritingParams struct {
-	Idwriting                        int32
-	UsersIdusers                     int32
-	ForumthreadIdforumthread         int32
-	LanguageIdlanguage               int32
-	WritingcategoryIdwritingcategory int32
-	Title                            sql.NullString
-	Published                        sql.NullTime
-	Writing                          sql.NullString
-	Abstract                         sql.NullString
-	Private                          sql.NullBool
+	Idwriting                int32
+	UsersIdusers             int32
+	ForumthreadIdforumthread int32
+	LanguageIdlanguage       int32
+	WritingCategoryID        int32
+	Title                    sql.NullString
+	Published                sql.NullTime
+	Writing                  sql.NullString
+	Abstract                 sql.NullString
+	Private                  sql.NullBool
 }
 
 func (q *Queries) ArchiveWriting(ctx context.Context, arg ArchiveWritingParams) error {
@@ -165,7 +165,7 @@ func (q *Queries) ArchiveWriting(ctx context.Context, arg ArchiveWritingParams) 
 		arg.UsersIdusers,
 		arg.ForumthreadIdforumthread,
 		arg.LanguageIdlanguage,
-		arg.WritingcategoryIdwritingcategory,
+		arg.WritingCategoryID,
 		arg.Title,
 		arg.Published,
 		arg.Writing,

--- a/internal/db/queries-users.sql.go
+++ b/internal/db/queries-users.sql.go
@@ -356,7 +356,7 @@ func (q *Queries) ListUsersSubscribedToThread(ctx context.Context, arg ListUsers
 }
 
 const listUsersSubscribedToWriting = `-- name: ListUsersSubscribedToWriting :many
-SELECT idwriting, t.users_idusers, forumthread_idforumthread, t.language_idlanguage, writingcategory_idwritingcategory, title, published, writing, abstract, private, t.deleted_at, idusers, email, username, u.deleted_at, idpreferences, p.language_idlanguage, p.users_idusers, emailforumupdates, page_size, auto_subscribe_replies
+SELECT idwriting, t.users_idusers, forumthread_idforumthread, t.language_idlanguage, writing_category_id, title, published, writing, abstract, private, t.deleted_at, idusers, email, username, u.deleted_at, idpreferences, p.language_idlanguage, p.users_idusers, emailforumupdates, page_size, auto_subscribe_replies
 FROM writing t, users u, preferences p
 WHERE t.idwriting=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=t.users_idusers AND u.idusers!=?
 GROUP BY u.idusers
@@ -368,27 +368,27 @@ type ListUsersSubscribedToWritingParams struct {
 }
 
 type ListUsersSubscribedToWritingRow struct {
-	Idwriting                        int32
-	UsersIdusers                     int32
-	ForumthreadIdforumthread         int32
-	LanguageIdlanguage               int32
-	WritingcategoryIdwritingcategory int32
-	Title                            sql.NullString
-	Published                        sql.NullTime
-	Writing                          sql.NullString
-	Abstract                         sql.NullString
-	Private                          sql.NullBool
-	DeletedAt                        sql.NullTime
-	Idusers                          int32
-	Email                            sql.NullString
-	Username                         sql.NullString
-	DeletedAt_2                      sql.NullTime
-	Idpreferences                    int32
-	LanguageIdlanguage_2             int32
-	UsersIdusers_2                   int32
-	Emailforumupdates                sql.NullBool
-	PageSize                         int32
-	AutoSubscribeReplies             bool
+	Idwriting                int32
+	UsersIdusers             int32
+	ForumthreadIdforumthread int32
+	LanguageIdlanguage       int32
+	WritingCategoryID        int32
+	Title                    sql.NullString
+	Published                sql.NullTime
+	Writing                  sql.NullString
+	Abstract                 sql.NullString
+	Private                  sql.NullBool
+	DeletedAt                sql.NullTime
+	Idusers                  int32
+	Email                    sql.NullString
+	Username                 sql.NullString
+	DeletedAt_2              sql.NullTime
+	Idpreferences            int32
+	LanguageIdlanguage_2     int32
+	UsersIdusers_2           int32
+	Emailforumupdates        sql.NullBool
+	PageSize                 int32
+	AutoSubscribeReplies     bool
 }
 
 func (q *Queries) ListUsersSubscribedToWriting(ctx context.Context, arg ListUsersSubscribedToWritingParams) ([]*ListUsersSubscribedToWritingRow, error) {
@@ -405,7 +405,7 @@ func (q *Queries) ListUsersSubscribedToWriting(ctx context.Context, arg ListUser
 			&i.UsersIdusers,
 			&i.ForumthreadIdforumthread,
 			&i.LanguageIdlanguage,
-			&i.WritingcategoryIdwritingcategory,
+			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
 			&i.Writing,

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -20,7 +20,7 @@ SELECT w.*, u.Username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_idforumthread=w.forumthread_idforumthread AND w.forumthread_idforumthread != 0) as Comments
 FROM writing w
 LEFT JOIN users u ON w.Users_Idusers=u.idusers
-WHERE w.private = 0 AND w.writingCategory_idwritingCategory=?
+WHERE w.private = 0 AND w.writing_category_id=?
 ORDER BY w.published DESC
 LIMIT ? OFFSET ?
 ;
@@ -31,7 +31,7 @@ SET title = ?, abstract = ?, writing = ?, private = ?, language_idlanguage = ?
 WHERE idwriting = ?;
 
 -- name: InsertWriting :execlastid
-INSERT INTO writing (writingCategory_idwritingCategory, title, abstract, writing, private, language_idlanguage, published, users_idusers)
+INSERT INTO writing (writing_category_id, title, abstract, writing, private, language_idlanguage, published, users_idusers)
 VALUES (?, ?, ?, ?, ?, ?, NOW(), ?);
 
 -- name: GetWritingByIdForUserDescendingByPublishedDate :one
@@ -53,18 +53,18 @@ ORDER BY w.published DESC
 ;
 
 -- name: InsertWritingCategory :exec
-INSERT INTO writing_category (writingCategory_idwritingCategory, title, description)
+INSERT INTO writing_category (writing_category_id, title, description)
 VALUES (?, ?, ?);
 
 -- name: UpdateWritingCategory :exec
 UPDATE writing_category
-SET title = ?, description = ?, writingCategory_idwritingCategory = ?
+SET title = ?, description = ?, writing_category_id = ?
 WHERE idwritingCategory = ?;
 
 -- name: GetAllWritingCategories :many
 SELECT *
 FROM writing_category
-WHERE writingCategory_idwritingCategory = ?;
+WHERE writing_category_id = ?;
 
 -- name: FetchAllCategories :many
 SELECT wc.*

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -63,7 +63,7 @@ func (q *Queries) DeleteWritingApproval(ctx context.Context, arg DeleteWritingAp
 }
 
 const fetchAllCategories = `-- name: FetchAllCategories :many
-SELECT wc.idwritingcategory, wc.writingcategory_idwritingcategory, wc.title, wc.description
+SELECT wc.idwritingcategory, wc.writing_category_id, wc.title, wc.description
 FROM writing_category wc
 `
 
@@ -78,7 +78,7 @@ func (q *Queries) FetchAllCategories(ctx context.Context) ([]*WritingCategory, e
 		var i WritingCategory
 		if err := rows.Scan(
 			&i.Idwritingcategory,
-			&i.WritingcategoryIdwritingcategory,
+			&i.WritingCategoryID,
 			&i.Title,
 			&i.Description,
 		); err != nil {
@@ -141,13 +141,13 @@ func (q *Queries) GetAllWritingApprovals(ctx context.Context) ([]*GetAllWritingA
 }
 
 const getAllWritingCategories = `-- name: GetAllWritingCategories :many
-SELECT idwritingcategory, writingcategory_idwritingcategory, title, description
+SELECT idwritingcategory, writing_category_id, title, description
 FROM writing_category
-WHERE writingCategory_idwritingCategory = ?
+WHERE writing_category_id = ?
 `
 
-func (q *Queries) GetAllWritingCategories(ctx context.Context, writingcategoryIdwritingcategory int32) ([]*WritingCategory, error) {
-	rows, err := q.db.QueryContext(ctx, getAllWritingCategories, writingcategoryIdwritingcategory)
+func (q *Queries) GetAllWritingCategories(ctx context.Context, writingCategoryID int32) ([]*WritingCategory, error) {
+	rows, err := q.db.QueryContext(ctx, getAllWritingCategories, writingCategoryID)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (q *Queries) GetAllWritingCategories(ctx context.Context, writingcategoryId
 		var i WritingCategory
 		if err := rows.Scan(
 			&i.Idwritingcategory,
-			&i.WritingcategoryIdwritingcategory,
+			&i.WritingCategoryID,
 			&i.Title,
 			&i.Description,
 		); err != nil {
@@ -175,7 +175,7 @@ func (q *Queries) GetAllWritingCategories(ctx context.Context, writingcategoryId
 }
 
 const getAllWritingsByUser = `-- name: GetAllWritingsByUser :many
-SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writingcategory_idwritingcategory, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, u.username,
+SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, u.username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_idforumthread=w.forumthread_idforumthread AND w.forumthread_idforumthread != 0) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
@@ -184,19 +184,19 @@ ORDER BY w.published DESC
 `
 
 type GetAllWritingsByUserRow struct {
-	Idwriting                        int32
-	UsersIdusers                     int32
-	ForumthreadIdforumthread         int32
-	LanguageIdlanguage               int32
-	WritingcategoryIdwritingcategory int32
-	Title                            sql.NullString
-	Published                        sql.NullTime
-	Writing                          sql.NullString
-	Abstract                         sql.NullString
-	Private                          sql.NullBool
-	DeletedAt                        sql.NullTime
-	Username                         sql.NullString
-	Comments                         int64
+	Idwriting                int32
+	UsersIdusers             int32
+	ForumthreadIdforumthread int32
+	LanguageIdlanguage       int32
+	WritingCategoryID        int32
+	Title                    sql.NullString
+	Published                sql.NullTime
+	Writing                  sql.NullString
+	Abstract                 sql.NullString
+	Private                  sql.NullBool
+	DeletedAt                sql.NullTime
+	Username                 sql.NullString
+	Comments                 int64
 }
 
 func (q *Queries) GetAllWritingsByUser(ctx context.Context, usersIdusers int32) ([]*GetAllWritingsByUserRow, error) {
@@ -213,7 +213,7 @@ func (q *Queries) GetAllWritingsByUser(ctx context.Context, usersIdusers int32) 
 			&i.UsersIdusers,
 			&i.ForumthreadIdforumthread,
 			&i.LanguageIdlanguage,
-			&i.WritingcategoryIdwritingcategory,
+			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
 			&i.Writing,
@@ -237,7 +237,7 @@ func (q *Queries) GetAllWritingsByUser(ctx context.Context, usersIdusers int32) 
 }
 
 const getPublicWritings = `-- name: GetPublicWritings :many
-SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writingcategory_idwritingcategory, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at
+SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at
 FROM writing w
 WHERE w.private = 0
 ORDER BY w.published DESC
@@ -263,7 +263,7 @@ func (q *Queries) GetPublicWritings(ctx context.Context, arg GetPublicWritingsPa
 			&i.UsersIdusers,
 			&i.ForumthreadIdforumthread,
 			&i.LanguageIdlanguage,
-			&i.WritingcategoryIdwritingcategory,
+			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
 			&i.Writing,
@@ -285,7 +285,7 @@ func (q *Queries) GetPublicWritings(ctx context.Context, arg GetPublicWritingsPa
 }
 
 const getPublicWritingsByUser = `-- name: GetPublicWritingsByUser :many
-SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writingcategory_idwritingcategory, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, u.username,
+SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, u.username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_idforumthread=w.forumthread_idforumthread AND w.forumthread_idforumthread != 0) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
@@ -301,19 +301,19 @@ type GetPublicWritingsByUserParams struct {
 }
 
 type GetPublicWritingsByUserRow struct {
-	Idwriting                        int32
-	UsersIdusers                     int32
-	ForumthreadIdforumthread         int32
-	LanguageIdlanguage               int32
-	WritingcategoryIdwritingcategory int32
-	Title                            sql.NullString
-	Published                        sql.NullTime
-	Writing                          sql.NullString
-	Abstract                         sql.NullString
-	Private                          sql.NullBool
-	DeletedAt                        sql.NullTime
-	Username                         sql.NullString
-	Comments                         int64
+	Idwriting                int32
+	UsersIdusers             int32
+	ForumthreadIdforumthread int32
+	LanguageIdlanguage       int32
+	WritingCategoryID        int32
+	Title                    sql.NullString
+	Published                sql.NullTime
+	Writing                  sql.NullString
+	Abstract                 sql.NullString
+	Private                  sql.NullBool
+	DeletedAt                sql.NullTime
+	Username                 sql.NullString
+	Comments                 int64
 }
 
 func (q *Queries) GetPublicWritingsByUser(ctx context.Context, arg GetPublicWritingsByUserParams) ([]*GetPublicWritingsByUserRow, error) {
@@ -330,7 +330,7 @@ func (q *Queries) GetPublicWritingsByUser(ctx context.Context, arg GetPublicWrit
 			&i.UsersIdusers,
 			&i.ForumthreadIdforumthread,
 			&i.LanguageIdlanguage,
-			&i.WritingcategoryIdwritingcategory,
+			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
 			&i.Writing,
@@ -354,39 +354,39 @@ func (q *Queries) GetPublicWritingsByUser(ctx context.Context, arg GetPublicWrit
 }
 
 const getPublicWritingsInCategory = `-- name: GetPublicWritingsInCategory :many
-SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writingcategory_idwritingcategory, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, u.Username,
+SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, u.Username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_idforumthread=w.forumthread_idforumthread AND w.forumthread_idforumthread != 0) as Comments
 FROM writing w
 LEFT JOIN users u ON w.Users_Idusers=u.idusers
-WHERE w.private = 0 AND w.writingCategory_idwritingCategory=?
+WHERE w.private = 0 AND w.writing_category_id=?
 ORDER BY w.published DESC
 LIMIT ? OFFSET ?
 `
 
 type GetPublicWritingsInCategoryParams struct {
-	WritingcategoryIdwritingcategory int32
-	Limit                            int32
-	Offset                           int32
+	WritingCategoryID int32
+	Limit             int32
+	Offset            int32
 }
 
 type GetPublicWritingsInCategoryRow struct {
-	Idwriting                        int32
-	UsersIdusers                     int32
-	ForumthreadIdforumthread         int32
-	LanguageIdlanguage               int32
-	WritingcategoryIdwritingcategory int32
-	Title                            sql.NullString
-	Published                        sql.NullTime
-	Writing                          sql.NullString
-	Abstract                         sql.NullString
-	Private                          sql.NullBool
-	DeletedAt                        sql.NullTime
-	Username                         sql.NullString
-	Comments                         int64
+	Idwriting                int32
+	UsersIdusers             int32
+	ForumthreadIdforumthread int32
+	LanguageIdlanguage       int32
+	WritingCategoryID        int32
+	Title                    sql.NullString
+	Published                sql.NullTime
+	Writing                  sql.NullString
+	Abstract                 sql.NullString
+	Private                  sql.NullBool
+	DeletedAt                sql.NullTime
+	Username                 sql.NullString
+	Comments                 int64
 }
 
 func (q *Queries) GetPublicWritingsInCategory(ctx context.Context, arg GetPublicWritingsInCategoryParams) ([]*GetPublicWritingsInCategoryRow, error) {
-	rows, err := q.db.QueryContext(ctx, getPublicWritingsInCategory, arg.WritingcategoryIdwritingcategory, arg.Limit, arg.Offset)
+	rows, err := q.db.QueryContext(ctx, getPublicWritingsInCategory, arg.WritingCategoryID, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +399,7 @@ func (q *Queries) GetPublicWritingsInCategory(ctx context.Context, arg GetPublic
 			&i.UsersIdusers,
 			&i.ForumthreadIdforumthread,
 			&i.LanguageIdlanguage,
-			&i.WritingcategoryIdwritingcategory,
+			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
 			&i.Writing,
@@ -423,7 +423,7 @@ func (q *Queries) GetPublicWritingsInCategory(ctx context.Context, arg GetPublic
 }
 
 const getWritingByIdForUserDescendingByPublishedDate = `-- name: GetWritingByIdForUserDescendingByPublishedDate :one
-SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writingcategory_idwritingcategory, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, u.idusers AS WriterId, u.Username AS WriterUsername
+SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, u.idusers AS WriterId, u.Username AS WriterUsername
 FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 LEFT JOIN writingApprovedUsers wau ON w.idwriting = wau.writing_id AND wau.users_idusers = ?
@@ -437,19 +437,19 @@ type GetWritingByIdForUserDescendingByPublishedDateParams struct {
 }
 
 type GetWritingByIdForUserDescendingByPublishedDateRow struct {
-	Idwriting                        int32
-	UsersIdusers                     int32
-	ForumthreadIdforumthread         int32
-	LanguageIdlanguage               int32
-	WritingcategoryIdwritingcategory int32
-	Title                            sql.NullString
-	Published                        sql.NullTime
-	Writing                          sql.NullString
-	Abstract                         sql.NullString
-	Private                          sql.NullBool
-	DeletedAt                        sql.NullTime
-	Writerid                         int32
-	Writerusername                   sql.NullString
+	Idwriting                int32
+	UsersIdusers             int32
+	ForumthreadIdforumthread int32
+	LanguageIdlanguage       int32
+	WritingCategoryID        int32
+	Title                    sql.NullString
+	Published                sql.NullTime
+	Writing                  sql.NullString
+	Abstract                 sql.NullString
+	Private                  sql.NullBool
+	DeletedAt                sql.NullTime
+	Writerid                 int32
+	Writerusername           sql.NullString
 }
 
 func (q *Queries) GetWritingByIdForUserDescendingByPublishedDate(ctx context.Context, arg GetWritingByIdForUserDescendingByPublishedDateParams) (*GetWritingByIdForUserDescendingByPublishedDateRow, error) {
@@ -460,7 +460,7 @@ func (q *Queries) GetWritingByIdForUserDescendingByPublishedDate(ctx context.Con
 		&i.UsersIdusers,
 		&i.ForumthreadIdforumthread,
 		&i.LanguageIdlanguage,
-		&i.WritingcategoryIdwritingcategory,
+		&i.WritingCategoryID,
 		&i.Title,
 		&i.Published,
 		&i.Writing,
@@ -474,7 +474,7 @@ func (q *Queries) GetWritingByIdForUserDescendingByPublishedDate(ctx context.Con
 }
 
 const getWritingsByIdsForUserDescendingByPublishedDate = `-- name: GetWritingsByIdsForUserDescendingByPublishedDate :many
-SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writingcategory_idwritingcategory, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, u.idusers AS WriterId, u.username AS WriterUsername
+SELECT w.idwriting, w.users_idusers, w.forumthread_idforumthread, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, u.idusers AS WriterId, u.username AS WriterUsername
 FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 LEFT JOIN writingApprovedUsers wau ON w.idwriting = wau.writing_id AND wau.users_idusers = ?
@@ -488,19 +488,19 @@ type GetWritingsByIdsForUserDescendingByPublishedDateParams struct {
 }
 
 type GetWritingsByIdsForUserDescendingByPublishedDateRow struct {
-	Idwriting                        int32
-	UsersIdusers                     int32
-	ForumthreadIdforumthread         int32
-	LanguageIdlanguage               int32
-	WritingcategoryIdwritingcategory int32
-	Title                            sql.NullString
-	Published                        sql.NullTime
-	Writing                          sql.NullString
-	Abstract                         sql.NullString
-	Private                          sql.NullBool
-	DeletedAt                        sql.NullTime
-	Writerid                         int32
-	Writerusername                   sql.NullString
+	Idwriting                int32
+	UsersIdusers             int32
+	ForumthreadIdforumthread int32
+	LanguageIdlanguage       int32
+	WritingCategoryID        int32
+	Title                    sql.NullString
+	Published                sql.NullTime
+	Writing                  sql.NullString
+	Abstract                 sql.NullString
+	Private                  sql.NullBool
+	DeletedAt                sql.NullTime
+	Writerid                 int32
+	Writerusername           sql.NullString
 }
 
 func (q *Queries) GetWritingsByIdsForUserDescendingByPublishedDate(ctx context.Context, arg GetWritingsByIdsForUserDescendingByPublishedDateParams) ([]*GetWritingsByIdsForUserDescendingByPublishedDateRow, error) {
@@ -529,7 +529,7 @@ func (q *Queries) GetWritingsByIdsForUserDescendingByPublishedDate(ctx context.C
 			&i.UsersIdusers,
 			&i.ForumthreadIdforumthread,
 			&i.LanguageIdlanguage,
-			&i.WritingcategoryIdwritingcategory,
+			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
 			&i.Writing,
@@ -553,23 +553,23 @@ func (q *Queries) GetWritingsByIdsForUserDescendingByPublishedDate(ctx context.C
 }
 
 const insertWriting = `-- name: InsertWriting :execlastid
-INSERT INTO writing (writingCategory_idwritingCategory, title, abstract, writing, private, language_idlanguage, published, users_idusers)
+INSERT INTO writing (writing_category_id, title, abstract, writing, private, language_idlanguage, published, users_idusers)
 VALUES (?, ?, ?, ?, ?, ?, NOW(), ?)
 `
 
 type InsertWritingParams struct {
-	WritingcategoryIdwritingcategory int32
-	Title                            sql.NullString
-	Abstract                         sql.NullString
-	Writing                          sql.NullString
-	Private                          sql.NullBool
-	LanguageIdlanguage               int32
-	UsersIdusers                     int32
+	WritingCategoryID  int32
+	Title              sql.NullString
+	Abstract           sql.NullString
+	Writing            sql.NullString
+	Private            sql.NullBool
+	LanguageIdlanguage int32
+	UsersIdusers       int32
 }
 
 func (q *Queries) InsertWriting(ctx context.Context, arg InsertWritingParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, insertWriting,
-		arg.WritingcategoryIdwritingcategory,
+		arg.WritingCategoryID,
 		arg.Title,
 		arg.Abstract,
 		arg.Writing,
@@ -584,18 +584,18 @@ func (q *Queries) InsertWriting(ctx context.Context, arg InsertWritingParams) (i
 }
 
 const insertWritingCategory = `-- name: InsertWritingCategory :exec
-INSERT INTO writing_category (writingCategory_idwritingCategory, title, description)
+INSERT INTO writing_category (writing_category_id, title, description)
 VALUES (?, ?, ?)
 `
 
 type InsertWritingCategoryParams struct {
-	WritingcategoryIdwritingcategory int32
-	Title                            sql.NullString
-	Description                      sql.NullString
+	WritingCategoryID int32
+	Title             sql.NullString
+	Description       sql.NullString
 }
 
 func (q *Queries) InsertWritingCategory(ctx context.Context, arg InsertWritingCategoryParams) error {
-	_, err := q.db.ExecContext(ctx, insertWritingCategory, arg.WritingcategoryIdwritingcategory, arg.Title, arg.Description)
+	_, err := q.db.ExecContext(ctx, insertWritingCategory, arg.WritingCategoryID, arg.Title, arg.Description)
 	return err
 }
 
@@ -651,22 +651,22 @@ func (q *Queries) UpdateWritingApproval(ctx context.Context, arg UpdateWritingAp
 
 const updateWritingCategory = `-- name: UpdateWritingCategory :exec
 UPDATE writing_category
-SET title = ?, description = ?, writingCategory_idwritingCategory = ?
+SET title = ?, description = ?, writing_category_id = ?
 WHERE idwritingCategory = ?
 `
 
 type UpdateWritingCategoryParams struct {
-	Title                            sql.NullString
-	Description                      sql.NullString
-	WritingcategoryIdwritingcategory int32
-	Idwritingcategory                int32
+	Title             sql.NullString
+	Description       sql.NullString
+	WritingCategoryID int32
+	Idwritingcategory int32
 }
 
 func (q *Queries) UpdateWritingCategory(ctx context.Context, arg UpdateWritingCategoryParams) error {
 	_, err := q.db.ExecContext(ctx, updateWritingCategory,
 		arg.Title,
 		arg.Description,
-		arg.WritingcategoryIdwritingcategory,
+		arg.WritingCategoryID,
 		arg.Idwritingcategory,
 	)
 	return err

--- a/internal/db/queries_ext.go
+++ b/internal/db/queries_ext.go
@@ -566,8 +566,8 @@ func (q *Queries) ImageboardPostCounts(ctx context.Context) ([]*BoardPostCountRo
 // WritingCategoryCounts returns the number of writings per writing category ordered by title.
 func (q *Queries) WritingCategoryCounts(ctx context.Context) ([]*CategoryCountRow, error) {
 	rows, err := q.db.QueryContext(ctx,
-		"SELECT wc.title, COUNT(w.idwriting) FROM writingCategory wc "+
-			"LEFT JOIN writing w ON w.writingCategory_idwritingCategory = wc.idwritingCategory "+
+		"SELECT wc.title, COUNT(w.idwriting) FROM writing_category wc "+
+			"LEFT JOIN writing w ON w.writing_category_id = wc.idwritingCategory "+
 			"GROUP BY wc.idwritingCategory ORDER BY wc.title")
 	if err != nil {
 		return nil, err

--- a/migrations/0023.sql
+++ b/migrations/0023.sql
@@ -1,0 +1,7 @@
+ALTER TABLE writing
+    CHANGE COLUMN writingCategory_idwritingCategory writing_category_id INT NOT NULL;
+ALTER TABLE writing_category
+    CHANGE COLUMN writingCategory_idwritingCategory writing_category_id INT NOT NULL;
+
+-- Record upgrade to schema version 23
+UPDATE schema_version SET version = 23 WHERE version = 22;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -310,7 +310,7 @@ CREATE TABLE `writing` (
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `language_idlanguage` int(10) NOT NULL DEFAULT 0,
-  `writingCategory_idwritingCategory` int(10) NOT NULL DEFAULT 0,
+  `writing_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,
   `writing` longtext DEFAULT NULL,
@@ -318,7 +318,7 @@ CREATE TABLE `writing` (
   `private` tinyint(1) DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
   PRIMARY KEY (`idwriting`),
-  KEY `writing_FKIndex1` (`writingCategory_idwritingCategory`),
+  KEY `writing_FKIndex1` (`writing_category_id`),
   KEY `writing_FKIndex2` (`language_idlanguage`),
   KEY `writing_FKIndex3` (`forumthread_idforumthread`),
   KEY `writing_FKIndex4` (`users_idusers`)
@@ -326,11 +326,11 @@ CREATE TABLE `writing` (
 
 CREATE TABLE `writing_category` (
   `idwritingCategory` int(10) NOT NULL AUTO_INCREMENT,
-  `writingCategory_idwritingCategory` int(10) NOT NULL DEFAULT 0,
+  `writing_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   PRIMARY KEY (`idwritingCategory`),
-  KEY `writingCategory_FKIndex1` (`writingCategory_idwritingCategory`)
+  KEY `writingCategory_FKIndex1` (`writing_category_id`)
 );
 
 CREATE TABLE `writingSearch` (
@@ -482,7 +482,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_writings` (
   `users_idusers` int NOT NULL,
   `forumthread_idforumthread` int NOT NULL,
   `language_idlanguage` int NOT NULL,
-  `writingCategory_idwritingCategory` int NOT NULL,
+  `writing_category_id` int NOT NULL,
   `title` tinytext,
   `published` datetime,
   `writing` longtext,


### PR DESCRIPTION
## Summary
- update schema and queries to use `writing_category_id`
- bump expected schema version
- regenerate SQL code
- adjust Go source and templates for new field names
- add migration to rename DB columns

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686dc877aac4832f8ddad12f57ed2540