### PR TITLE
Fix schema version mismatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ go test ./...
 SQL query files are compiled using `sqlc`. Do not manually edit the generated `*.sql.go` files; instead edit the `.sql` files under `internal/db/` and run `sqlc generate`.
 Avoid using the `overrides` section in `sqlc.yaml`; prefer Go type aliases if a different struct name is required.
 
-All database schema changes must include a new migration script in the `migrations/` directory (for example `0002.sql`, `0003.sql`). Never modify existing migration files as that would break deployments running older versions. Every migration must also update the `schema_version` table so deployments can track the current schema state.
+All database schema changes must include a new migration script in the `migrations/` directory (for example `0002.sql`, `0003.sql`). Never modify existing migration files as that would break deployments running older versions. Every migration must also update the `schema_version` table so deployments can track the current schema state. Bump the `ExpectedSchemaVersion` constant in `handlers/common/constants.go` whenever a new migration is added so tests stay in sync.
 
 Errors in critical functions like `main()` or `run()` must be logged or wrapped using `fmt.Errorf` with context. Prefer doing both when errors propagate.
 

--- a/core/templates/templates/boardPosts.gohtml
+++ b/core/templates/templates/boardPosts.gohtml
@@ -5,8 +5,7 @@
             <table>
                 <tr>
                     <th><a href="{{ .Fullimage.String }}" target="_BLANK"><img src="{{ .Thumbnail.String }}"></a>
-                    <td>{{ .Description.String }}<hr>{{ .Username.String }} - Posted: {{ .Posted.Time }} - [<a href="/imagebbs/board/{{ $.BoardNumber }}/thread/{{ .ForumthreadIdforumthread }}">{{ .Comments.Int32 }} COMMENTS</a>]
+                    <td>{{ .Description.String }}<hr>{{ .Username.String }} - Posted: {{ .Posted.Time }} - [<a href="/imagebbs/board/{{ $.BoardNumber }}/thread/{{ .ForumthreadID }}">{{ .Comments.Int32 }} COMMENTS</a>]
             </table><br>
         {{ end }}
-    {{ end }}
-{{ end }}
+    {{ end }}{{ end }}

--- a/core/templates/templates/showLinkComments.gohtml
+++ b/core/templates/templates/showLinkComments.gohtml
@@ -13,7 +13,7 @@
             </tr>
         </table><br>
 
-        {{ with .ForumthreadIdforumthread }}
+        {{ with .ForumthreadID }}
             {{ template "threadComments" $ }}
         {{ end }}
 
@@ -21,7 +21,7 @@
             <font size="4">Reply:</font><br>
             <form method="post">
         {{ csrfField }}
-                <input type="hidden" name="replyTo" value="{{ .ForumthreadIdforumthread }}">
+                <input type="hidden" name="replyTo" value="{{ .ForumthreadID }}">
                 <input type="hidden" name="lpid" value="{{ .Idlinker }}">
                 <textarea name="replytext" cols="40" rows="20"></textarea><br>
                 {{ template "languageCombobox" $ }}

--- a/handlers/common/constants.go
+++ b/handlers/common/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 24
+	ExpectedSchemaVersion = 25
 )

--- a/internal/emailutil/email.go
+++ b/internal/emailutil/email.go
@@ -209,8 +209,8 @@ func NotifyThreadSubscribers(ctx context.Context, provider email.Provider, q *db
 		return
 	}
 	rows, err := q.ListUsersSubscribedToThread(ctx, db.ListUsersSubscribedToThreadParams{
-		ForumthreadIdforumthread: threadID,
-		Idusers:                  excludeUser,
+		ForumthreadID: threadID,
+		Idusers:       excludeUser,
 	})
 	if err != nil {
 		log.Printf("Error: listUsersSubscribedToThread: %s", err)

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -77,12 +77,12 @@ func TestNotifyThreadSubscribers(t *testing.T) {
 	runtimeconfig.AppRuntimeConfig.NotificationsEnabled = true
 	t.Cleanup(func() { runtimeconfig.AppRuntimeConfig = origCfg })
 	rows := sqlmock.NewRows([]string{
-		"idcomments", "forumthread_idforumthread", "users_idusers", "language_idlanguage",
+		"idcomments", "forumthread_id", "users_idusers", "language_idlanguage",
 		"written", "text", "idusers", "email", "username",
 		"idpreferences", "language_idlanguage_2", "users_idusers_2", "emailforumupdates",
 		"page_size", "auto_subscribe_replies",
 	}).AddRow(1, 2, 2, 1, nil, "t", 2, "e", "bob", 1, 1, 2, 1, 10, true)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments, c.forumthread_idforumthread, c.users_idusers, c.language_idlanguage, c.written, c.text, u.idusers, u.email, u.username, p.idpreferences, p.language_idlanguage, p.users_idusers, p.emailforumupdates, p.page_size, p.auto_subscribe_replies\nFROM comments c, users u, preferences p\nWHERE c.forumthread_idforumthread=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=c.users_idusers AND u.idusers!=?\nGROUP BY u.idusers")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments, c.forumthread_id, c.users_idusers, c.language_idlanguage, c.written, c.text, u.idusers, u.email, u.username, p.idpreferences, p.language_idlanguage, p.users_idusers, p.emailforumupdates, p.page_size, p.auto_subscribe_replies\nFROM comments c, users u, preferences p\nWHERE c.forumthread_id=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=c.users_idusers AND u.idusers!=?\nGROUP BY u.idusers")).
 		WithArgs(int32(2), int32(1)).
 		WillReturnRows(rows)
 	rec := &dummyProvider{}

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -64,8 +64,8 @@ func (n Notifier) NotifyThreadSubscribers(ctx context.Context, threadID, exclude
 		return
 	}
 	rows, err := n.Queries.ListUsersSubscribedToThread(ctx, db.ListUsersSubscribedToThreadParams{
-		ForumthreadIdforumthread: threadID,
-		Idusers:                  excludeUser,
+		ForumthreadID: threadID,
+		Idusers:       excludeUser,
 	})
 	if err != nil {
 		log.Printf("list subscribers: %v", err)


### PR DESCRIPTION
## Summary
- bump `ExpectedSchemaVersion` constant to match latest migration
- update AGENTS guidelines to remind devs to change this constant when adding migrations
- update code and templates for new `ForumthreadID` field
- adjust notifications tests for new column name

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686dd95fd9b4832faec3b76c7b61e583