### PR TITLE
Fix nullable email in GetUserById

### DIFF
--- a/cmd/goa4web/email_queue_list.go
+++ b/cmd/goa4web/email_queue_list.go
@@ -52,8 +52,8 @@ func (c *emailQueueListCmd) Run() error {
 	}
 	for _, e := range rows {
 		emailStr := ""
-		if u, ok := users[e.ToUserID]; ok && u.Email != "" {
-			emailStr = u.Email
+		if u, ok := users[e.ToUserID]; ok && u.Email.Valid && u.Email.String != "" {
+			emailStr = u.Email.String
 		}
 		subj := ""
 		if m, err := mail.ReadMessage(strings.NewReader(e.Body)); err == nil {

--- a/cmd/goa4web/email_queue_resend.go
+++ b/cmd/goa4web/email_queue_resend.go
@@ -51,11 +51,11 @@ func (c *emailQueueResendCmd) Run() error {
 		if err != nil {
 			return fmt.Errorf("get user: %w", err)
 		}
-		if user.Email == "" {
+		if !user.Email.Valid || user.Email.String == "" {
 			log.Printf("invalid user email for %d", e.ToUserID)
 			return nil
 		}
-		addr := mail.Address{Name: user.Username.String, Address: user.Email}
+		addr := mail.Address{Name: user.Username.String, Address: user.Email.String}
 		if err := provider.Send(ctx, addr, []byte(e.Body)); err != nil {
 			return fmt.Errorf("send email: %w", err)
 		}

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -47,8 +47,8 @@ func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, e := range rows {
 		emailStr := ""
-		if u, ok := users[e.ToUserID]; ok && u.Email != "" {
-			emailStr = u.Email
+		if u, ok := users[e.ToUserID]; ok && u.Email.Valid && u.Email.String != "" {
+			emailStr = u.Email.String
 		}
 		subj := ""
 		if m, err := mail.ReadMessage(strings.NewReader(e.Body)); err == nil {
@@ -89,11 +89,11 @@ func AdminEmailQueueResendActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, e := range emails {
 		user, ok := users[e.ToUserID]
-		if !ok || user.Email == "" {
+		if !ok || !user.Email.Valid || user.Email.String == "" {
 			log.Printf("missing or invalid user email for %d", e.ToUserID)
 			continue
 		}
-		addr := mail.Address{Name: user.Username.String, Address: user.Email}
+		addr := mail.Address{Name: user.Username.String, Address: user.Email.String}
 		if provider != nil {
 			if err := provider.Send(r.Context(), addr, []byte(e.Body)); err != nil {
 				log.Printf("send email: %v", err)

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -85,7 +85,7 @@ func AdminEmailTemplateTestActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	if urow.Email == "" {
+	if !urow.Email.Valid || urow.Email.String == "" {
 		http.Error(w, "email unknown", http.StatusBadRequest)
 		return
 	}
@@ -108,7 +108,7 @@ func AdminEmailTemplateTestActionPage(w http.ResponseWriter, r *http.Request) {
 		unsub = strings.TrimRight(runtimeconfig.AppRuntimeConfig.HTTPHostname, "/") + unsub
 	}
 	content := struct{ To, From, Subject, URL, Action, Path, Time, UnsubURL string }{
-		To:       (&mail.Address{Name: urow.Username.String, Address: urow.Email}).String(),
+		To:       (&mail.Address{Name: urow.Username.String, Address: urow.Email.String}).String(),
 		From:     runtimeconfig.AppRuntimeConfig.EmailFrom,
 		Subject:  "Website Update Notification",
 		URL:      pageURL,
@@ -122,7 +122,7 @@ func AdminEmailTemplateTestActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	toAddr := mail.Address{Name: urow.Username.String, Address: urow.Email}
+	toAddr := mail.Address{Name: urow.Username.String, Address: urow.Email.String}
 	var fromAddr mail.Address
 
 	if f, err := mail.ParseAddress(runtimeconfig.AppRuntimeConfig.EmailFrom); err == nil {

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -56,7 +56,7 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 	q := db.New(sqldb)
 	rows := sqlmock.NewRows([]string{"idusers", "email", "username"}).
 		AddRow(1, "u@example.com", "u")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idusers, (SELECT email FROM user_emails ue WHERE ue.user_id = users.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email, username\nFROM users\nWHERE idusers = ?")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
 		WithArgs(int32(1)).WillReturnRows(rows)
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -51,7 +51,7 @@ func AdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 			log.Printf("GetUserById Error: %s", err)
 			continue
 		}
-		perms = append(perms, &PermissionUser{Permission: p, Username: row.Username, Email: sql.NullString{String: row.Email, Valid: row.Email != ""}})
+		perms = append(perms, &PermissionUser{Permission: p, Username: row.Username, Email: row.Email})
 	}
 
 	if data.Search != "" {

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -90,10 +90,10 @@ func TestUserAdderMiddleware_AttachesPrefs(t *testing.T) {
 	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
 	req = req.WithContext(ctx)
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idusers, (SELECT email FROM user_emails ue WHERE ue.user_id = users.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email, username\nFROM users\nWHERE idusers = ?")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
 		WithArgs(int32(1)).
 		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).
-			AddRow(1, "e", "u"))
+			AddRow(1, sql.NullString{String: "e", Valid: true}, "u"))
 	mock.ExpectQuery("SELECT idpermissions, users_idusers, section, level FROM permissions WHERE users_idusers = ?").
 		WithArgs(int32(1)).
 		WillReturnRows(sqlmock.NewRows([]string{"idpermissions", "users_idusers", "section", "level"}).AddRow(1, 1, "all", "admin"))

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -25,11 +25,14 @@ ORDER BY p.created_at DESC
 LIMIT 1;
 
 -- name: GetUserById :one
-SELECT idusers,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = users.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
-       username
-FROM users
-WHERE idusers = ?;
+SELECT u.idusers, ue.email, u.username
+FROM users u
+LEFT JOIN user_emails ue ON ue.id = (
+        SELECT id FROM user_emails ue2
+        WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL
+        ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1
+)
+WHERE u.idusers = ?;
 
 -- name: UserByUsername :one
 SELECT idusers,

--- a/internal/db/queries-users.sql.go
+++ b/internal/db/queries-users.sql.go
@@ -53,16 +53,19 @@ func (q *Queries) AllUsers(ctx context.Context) ([]*AllUsersRow, error) {
 }
 
 const getUserById = `-- name: GetUserById :one
-SELECT idusers,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = users.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
-       username
-FROM users
-WHERE idusers = ?
+SELECT u.idusers, ue.email, u.username
+FROM users u
+LEFT JOIN user_emails ue ON ue.id = (
+        SELECT id FROM user_emails ue2
+        WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL
+        ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1
+)
+WHERE u.idusers = ?
 `
 
 type GetUserByIdRow struct {
 	Idusers  int32
-	Email    string
+	Email    sql.NullString
 	Username sql.NullString
 }
 

--- a/internal/emailutil/email_queue.go
+++ b/internal/emailutil/email_queue.go
@@ -56,11 +56,11 @@ func ProcessPendingEmail(ctx context.Context, q *db.Queries, provider email.Prov
 		log.Printf("get user: %v", err)
 		return
 	}
-	if user.Email == "" {
+	if !user.Email.Valid || user.Email.String == "" {
 		log.Printf("invalid email for user %d", e.ToUserID)
 		return
 	}
-	addr := mail.Address{Name: user.Username.String, Address: user.Email}
+	addr := mail.Address{Name: user.Username.String, Address: user.Email.String}
 	if err := provider.Send(ctx, addr, []byte(e.Body)); err != nil {
 		log.Printf("send queued mail: %v", err)
 		count, incErr := q.IncrementEmailError(ctx, e.ID)
@@ -70,7 +70,7 @@ func ProcessPendingEmail(ctx context.Context, q *db.Queries, provider email.Prov
 		}
 		if count > 4 {
 			if dlqProvider != nil {
-				msg := fmt.Sprintf("email %d to %s failed: %v\n%s", e.ID, user.Email, err, e.Body)
+				msg := fmt.Sprintf("email %d to %s failed: %v\n%s", e.ID, user.Email.String, err, e.Body)
 				_ = dlqProvider.Record(ctx, msg)
 			}
 			if delErr := q.DeletePendingEmail(ctx, e.ID); delErr != nil {

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -169,8 +169,8 @@ func processEvent(ctx context.Context, evt eventbus.Event, n Notifier, q dlq.DLQ
 
 	if evt.Task == hcommon.TaskTestMail {
 		user, err := n.Queries.GetUserById(ctx, evt.UserID)
-		if err == nil && user.Email != "" {
-			if err := emailutil.CreateEmailTemplateAndQueue(ctx, n.Queries, evt.UserID, user.Email, evt.Path, evt.Task, evt.Item); err != nil {
+		if err == nil && user.Email.Valid && user.Email.String != "" {
+			if err := emailutil.CreateEmailTemplateAndQueue(ctx, n.Queries, evt.UserID, user.Email.String, evt.Path, evt.Task, evt.Item); err != nil {
 				recordAndNotify(ctx, q, n, fmt.Sprintf("notify change: %v", err))
 			}
 			_ = n.Queries.InsertNotification(ctx, dbpkg.InsertNotificationParams{
@@ -208,11 +208,11 @@ func processEvent(ctx context.Context, evt eventbus.Event, n Notifier, q dlq.DLQ
 					uid := id
 					subs[id][method] = func(c context.Context) error {
 						user, err := n.Queries.GetUserById(c, uid)
-						if err != nil || user.Email == "" {
+						if err != nil || !user.Email.Valid || user.Email.String == "" {
 							notifyMissingEmail(c, n.Queries, uid)
 							return err
 						}
-						return emailutil.CreateEmailTemplateAndQueue(c, n.Queries, uid, user.Email, evt.Path, evt.Task, evt.Item)
+						return emailutil.CreateEmailTemplateAndQueue(c, n.Queries, uid, user.Email.String, evt.Path, evt.Task, evt.Item)
 					}
 				} else if method == "internal" && msg != "" {
 					uid := id


### PR DESCRIPTION
## Summary
- rewrite `GetUserById` query to return `sql.NullString` email
- handle nullable email in email queue processing and notification code
- update admin pages and CLI to work with `sql.NullString`
- adjust tests to match new query

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e5569bc8c832f9d564da171de3d20