### PR TITLE
Fix redirect loop bug in prefix handler

### DIFF
--- a/pkg/handlers/common.go
+++ b/pkg/handlers/common.go
@@ -38,7 +38,9 @@ func RedirectPermanentPrefix(from, to string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		rest := strings.TrimPrefix(r.URL.Path, from)
 		if !strings.HasPrefix(rest, "/") && rest != "" {
-			rest = "/" + rest
+			// not an exact match or subpath - avoid redirect loop
+			http.NotFound(w, r)
+			return
 		}
 		target := to + rest
 		if r.URL.RawQuery != "" {

--- a/pkg/handlers/common_test.go
+++ b/pkg/handlers/common_test.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRedirectPermanentPrefix(t *testing.T) {
+	h := RedirectPermanentPrefix("/writing", "/writings")
+	r := httptest.NewRequest("GET", "http://example.com/writing/foo?bar=baz", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusPermanentRedirect {
+		t.Fatalf("want %d got %d", http.StatusPermanentRedirect, w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/writings/foo?bar=baz" {
+		t.Errorf("unexpected location %s", loc)
+	}
+}
+
+func TestRedirectPermanentPrefixNoMatch(t *testing.T) {
+	h := RedirectPermanentPrefix("/writing", "/writings")
+	r := httptest.NewRequest("GET", "http://example.com/writings", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- prevent malformed redirects in `RedirectPermanentPrefix`
- add tests for `RedirectPermanentPrefix`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e6ec38e8c832fa1e436d574543788