### PR TITLE
Fix news comment edit link

### DIFF
--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -125,7 +125,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 	editCommentIdString := r.URL.Query().Get("editComment")
 	editCommentId, _ := strconv.Atoi(editCommentIdString)
 	for i, row := range commentRows {
-		editUrl := fmt.Sprintf("?edit=%d", row.Idcomments)
+		editUrl := fmt.Sprintf("?editComment=%d", row.Idcomments)
 		editSaveUrl := "?"
 		if uid == row.UsersIdusers {
 			// TODO


### PR DESCRIPTION
## Summary
- fix path for comment edit link on news posts

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e6ce7df24832fa9b13513e3c26349