### PR TITLE
Remove copyright © symbol

### DIFF
--- a/core/templates/templates/footer.gohtml
+++ b/core/templates/templates/footer.gohtml
@@ -1,7 +1,7 @@
 {{define "footer"}}
 <div>
         Date and time is now: {{now}}<br>
-        <i>Arran4© 2004-2005, 2023-2025; All works on this page copyrighted to their respective authors.</i><br>
+        <i>Arran 2004-2005, 2023-2025; All works on this page copyrighted to their respective authors.</i><br>
         <a href="https://github.com/arran4/goa4web">GitHub</a> Version {{version}}
 </div>
 {{end}}


### PR DESCRIPTION
## Summary
- adjust footer copyright to use `Arran` instead of `Arran4©`

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e6cbd5910832f9901f0672a1954f0