### PR TITLE
Move legacy redirects into sections

### DIFF
--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -6,7 +6,10 @@ import (
 
 	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
+	pkghandlers "github.com/arran4/goa4web/pkg/handlers"
 )
+
+var legacyRedirectsEnabled = true
 
 // RegisterRoutes attaches the public linker endpoints to r.
 func RegisterRoutes(r *mux.Router) {
@@ -26,6 +29,12 @@ func RegisterRoutes(r *mux.Router) {
 	lr.HandleFunc("/show/{link}", ShowReplyPage).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskReply))
 	lr.HandleFunc("/suggest", SuggestPage).Methods("GET")
 	lr.HandleFunc("/suggest", SuggestActionPage).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskSuggest))
+
+	if legacyRedirectsEnabled {
+		// legacy redirects
+		r.Path("/links").HandlerFunc(pkghandlers.RedirectPermanentPrefix("/links", "/linker"))
+		r.PathPrefix("/links/").HandlerFunc(pkghandlers.RedirectPermanentPrefix("/links", "/linker"))
+	}
 }
 
 // Register registers the linker router module.

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -10,7 +10,10 @@ import (
 	router "github.com/arran4/goa4web/internal/router"
 
 	nav "github.com/arran4/goa4web/internal/navigation"
+	pkghandlers "github.com/arran4/goa4web/pkg/handlers"
 )
+
+var legacyRedirectsEnabled = true
 
 // RegisterRoutes attaches the public writings endpoints to r.
 func RegisterRoutes(r *mux.Router) {
@@ -35,6 +38,12 @@ func RegisterRoutes(r *mux.Router) {
 	wr.HandleFunc("/category/{category}", CategoryPage).Methods("GET")
 	wr.HandleFunc("/category/{category}/add", ArticleAddPage).Methods("GET").MatcherFunc(Or(auth.RequiredAccess("writer"), auth.RequiredAccess("administrator")))
 	wr.HandleFunc("/category/{category}/add", ArticleAddActionPage).Methods("POST").MatcherFunc(Or(auth.RequiredAccess("writer"), auth.RequiredAccess("administrator"))).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskSubmitWriting))
+
+	if legacyRedirectsEnabled {
+		// legacy redirects
+		r.Path("/writing").HandlerFunc(pkghandlers.RedirectPermanentPrefix("/writing", "/writings"))
+		r.PathPrefix("/writing/").HandlerFunc(pkghandlers.RedirectPermanentPrefix("/writing", "/writings"))
+	}
 }
 
 // Register registers the writings router module.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -20,11 +20,6 @@ func RegisterRoutes(r *mux.Router) {
 
 	InitModules(r)
 
-	// legacy redirects
-	r.Path("/writing").HandlerFunc(handlers.RedirectPermanentPrefix("/writing", "/writings"))
-	r.PathPrefix("/writing/").HandlerFunc(handlers.RedirectPermanentPrefix("/writing", "/writings"))
-	r.Path("/links").HandlerFunc(handlers.RedirectPermanentPrefix("/links", "/linker"))
-	r.PathPrefix("/links/").HandlerFunc(handlers.RedirectPermanentPrefix("/links", "/linker"))
 }
 
 // RoleCheckerMiddleware ensures the user has one of the supplied roles.


### PR DESCRIPTION
## Summary
- remove `LEGACY_REDIRECTS` environment variable and related runtime option
- keep legacy redirect routes controlled by per-section variables
- delete unused helper and update examples

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e6ffc2f30832f86acd11ee2f7780a