### PR TITLE
Fix docker-compose example

### DIFF
--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -14,14 +14,18 @@ services:
     ports:
       - "8080:8080"
     environment:
+      GOA4WEB_DOCKER: "1"
       DB_DRIVER: mysql
       DB_CONN: root:changeme@tcp(db:3306)/a4web?parseTime=true
       AUTO_MIGRATE: "true"
+      IMAGE_UPLOAD_DIR: /data/imagebbs
     volumes:
-      - app-data:/data
+      - app-images:/data/imagebbs
+      - app-data:/var/lib/goa4web
     depends_on:
       - db
 
 volumes:
   db-data:
   app-data:
+  app-images:

--- a/handlers/auth/routes.go
+++ b/handlers/auth/routes.go
@@ -14,10 +14,10 @@ func RegisterRoutes(r *mux.Router) {
 	rr.HandleFunc("", RegisterPage).Methods("GET").MatcherFunc(Not(RequiresAnAccount()))
 	rr.HandleFunc("", RegisterActionPage).Methods("POST").MatcherFunc(Not(RequiresAnAccount())).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskRegister))
 
-        lr := r.PathPrefix("/login").Subrouter()
-        lr.HandleFunc("", LoginUserPassPage).Methods("GET").MatcherFunc(Not(RequiresAnAccount()))
-        lr.HandleFunc("", LoginActionPage).Methods("POST").MatcherFunc(Not(RequiresAnAccount())).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskLogin))
-        lr.HandleFunc("/verify", LoginVerifyPage).Methods("POST").MatcherFunc(Not(RequiresAnAccount())).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskSaveAll))
+	lr := r.PathPrefix("/login").Subrouter()
+	lr.HandleFunc("", LoginUserPassPage).Methods("GET").MatcherFunc(Not(RequiresAnAccount()))
+	lr.HandleFunc("", LoginActionPage).Methods("POST").MatcherFunc(Not(RequiresAnAccount())).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskLogin))
+	lr.HandleFunc("/verify", LoginVerifyPage).Methods("POST").MatcherFunc(Not(RequiresAnAccount())).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskSaveAll))
 
 	fr := r.PathPrefix("/forgot").Subrouter()
 	fr.HandleFunc("", ForgotPasswordPage).Methods("GET").MatcherFunc(Not(RequiresAnAccount()))

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -128,7 +128,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		editUrl := ""
 		editSaveUrl := ""
 		if uid == row.UsersIdusers {
-  		editUrl = fmt.Sprintf("?editComment=%d", row.Idcomments)
+			editUrl = fmt.Sprintf("?editComment=%d", row.Idcomments)
 			editSaveUrl = "?"
 			// TODO
 			//editUrl = fmt.Sprintf("/forum/topic/%d/thread/%d?comment=%d#edit", topicRow.Idforumtopic, threadId, row.Idcomments)


### PR DESCRIPTION
## Summary
- ensure example docker-compose sets docker mode and persist volumes
- `go fmt` cleaned up some whitespace in auth routes and news post

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go mod tidy`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686effa9412c832fb2893a61ee0014f4