### PR TITLE
Add create-dirs config option

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -110,4 +110,7 @@ const (
 
 	// EnvAutoMigrate toggles automatic database migrations on startup.
 	EnvAutoMigrate = "AUTO_MIGRATE"
+
+	// EnvCreateDirs creates missing directories when enabled.
+	EnvCreateDirs = "CREATE_DIRS"
 )

--- a/core/fs.go
+++ b/core/fs.go
@@ -11,6 +11,14 @@ type FileSystem interface {
 	WriteFile(name string, data []byte, perm fs.FileMode) error
 }
 
+// DirFS extends FileSystem with directory operations used by startup checks.
+type DirFS interface {
+	FileSystem
+	MkdirAll(path string, perm fs.FileMode) error
+	Stat(name string) (fs.FileInfo, error)
+	Remove(name string) error
+}
+
 // OSFS implements FileSystem using the os package.
 type OSFS struct{}
 
@@ -18,3 +26,10 @@ func (OSFS) ReadFile(name string) ([]byte, error) { return os.ReadFile(name) }
 func (OSFS) WriteFile(name string, data []byte, perm fs.FileMode) error {
 	return os.WriteFile(name, data, perm)
 }
+
+// OSDirFS implements DirFS using the os package.
+type OSDirFS struct{ OSFS }
+
+func (OSDirFS) MkdirAll(path string, perm fs.FileMode) error { return os.MkdirAll(path, perm) }
+func (OSDirFS) Stat(name string) (fs.FileInfo, error)        { return os.Stat(name) }
+func (OSDirFS) Remove(name string) error                     { return os.Remove(name) }

--- a/internal/dbstart/dbstart.go
+++ b/internal/dbstart/dbstart.go
@@ -78,6 +78,12 @@ func CheckUploadDir(cfg runtimeconfig.RuntimeConfig) *common.UserError {
 		return nil
 	}
 	info, err := os.Stat(cfg.ImageUploadDir)
+	if (err != nil || !info.IsDir()) && cfg.CreateDirs {
+		if err := os.MkdirAll(cfg.ImageUploadDir, 0o755); err != nil {
+			return &common.UserError{Err: err, ErrorMessage: "image upload directory invalid"}
+		}
+		info, err = os.Stat(cfg.ImageUploadDir)
+	}
 	if err != nil || !info.IsDir() {
 		return &common.UserError{Err: err, ErrorMessage: "image upload directory invalid"}
 	}
@@ -88,7 +94,14 @@ func CheckUploadDir(cfg runtimeconfig.RuntimeConfig) *common.UserError {
 	os.Remove(test)
 
 	if cfg.ImageCacheDir != "" {
-		if info, err := os.Stat(cfg.ImageCacheDir); err != nil || !info.IsDir() {
+		info, err := os.Stat(cfg.ImageCacheDir)
+		if (err != nil || !info.IsDir()) && cfg.CreateDirs {
+			if err := os.MkdirAll(cfg.ImageCacheDir, 0o755); err != nil {
+				return &common.UserError{Err: err, ErrorMessage: "image cache directory invalid"}
+			}
+			info, err = os.Stat(cfg.ImageCacheDir)
+		}
+		if err != nil || !info.IsDir() {
 			return &common.UserError{Err: err, ErrorMessage: "image cache directory invalid"}
 		}
 		test := filepath.Join(cfg.ImageCacheDir, ".check")

--- a/readme.md
+++ b/readme.md
@@ -260,6 +260,7 @@ environment variables listed below.
 | `DLQ_PROVIDER` | `--dlq-provider` | No | `log` | Dead letter queue provider. |
 | `DLQ_FILE` | `--dlq-file` | No | `dlq.log` | File path for the file or directory DLQ providers. |
 | `AUTO_MIGRATE` | n/a | No | `false` | Run database migrations on startup. |
+| `CREATE_DIRS` | `--create-dirs` | No | `false` | Create missing directories on startup. |
 
 ### Dead Letter Queue Providers
 

--- a/runtimeconfig/config.go
+++ b/runtimeconfig/config.go
@@ -76,6 +76,9 @@ type RuntimeConfig struct {
 	ImageSignSecret string
 	// ImageSignSecretFile specifies the path to the image signing key.
 	ImageSignSecretFile string
+
+	// CreateDirs creates missing directories when enabled.
+	CreateDirs bool
 }
 
 // AppRuntimeConfig stores the current application configuration.

--- a/runtimeconfig/options.go
+++ b/runtimeconfig/options.go
@@ -85,4 +85,5 @@ var BoolOptions = []BoolOption{
 	{"notifications-enabled", config.EnvNotificationsEnabled, "enable internal notifications", true, "", func(c *RuntimeConfig) *bool { return &c.NotificationsEnabled }},
 	{"csrf-enabled", config.EnvCSRFEnabled, "enable or disable CSRF protection", true, "", func(c *RuntimeConfig) *bool { return &c.CSRFEnabled }},
 	{"admin-notify", config.EnvAdminNotify, "enable admin notification emails", true, "", func(c *RuntimeConfig) *bool { return &c.AdminNotify }},
+	{"create-dirs", config.EnvCreateDirs, "create missing directories", false, "", func(c *RuntimeConfig) *bool { return &c.CreateDirs }},
 }


### PR DESCRIPTION
## Summary
- add `CREATE_DIRS` env var and `--create-dirs` flag
- support `CreateDirs` in runtime config
- create missing image directories on startup when enabled

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f005d22f4832f8359cbebc26f522f