### PR TITLE
Restore edit comments in linker

### DIFF
--- a/handlers/linker/linkerCommentsEditPage.go
+++ b/handlers/linker/linkerCommentsEditPage.go
@@ -1,0 +1,78 @@
+package linker
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"github.com/arran4/goa4web/core"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+	"github.com/gorilla/mux"
+	"log"
+	"net/http"
+	"strconv"
+)
+
+// CommentEditActionPage updates a comment then refreshes thread metadata.
+func CommentEditActionPage(w http.ResponseWriter, r *http.Request) {
+	languageId, err := strconv.Atoi(r.PostFormValue("language"))
+	if err != nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	text := r.PostFormValue("replytext")
+
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	vars := mux.Vars(r)
+	linkId, _ := strconv.Atoi(vars["link"])
+	commentId, _ := strconv.Atoi(vars["comment"])
+
+	session, ok := core.GetSessionOrFail(w, r)
+	if !ok {
+		return
+	}
+	uid, _ := session.Values["UID"].(int32)
+
+	comment := r.Context().Value(hcommon.KeyComment).(*db.GetCommentByIdForUserRow)
+
+	thread, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
+		UsersIdusers:  uid,
+		Idforumthread: comment.ForumthreadID,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+		default:
+			log.Printf("Error: getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions: %s", err)
+			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			return
+		}
+	}
+
+	if err = queries.UpdateComment(r.Context(), db.UpdateCommentParams{
+		Idcomments:         int32(commentId),
+		LanguageIdlanguage: int32(languageId),
+		Text: sql.NullString{
+			String: text,
+			Valid:  true,
+		},
+	}); err != nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	if err := PostUpdate(r.Context(), queries, thread.Idforumthread, thread.ForumtopicIdforumtopic); err != nil {
+		log.Printf("Error: postUpdate: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	http.Redirect(w, r, fmt.Sprintf("/linker/comments/%d", linkId), http.StatusTemporaryRedirect)
+}
+
+// CommentEditActionCancelPage aborts editing a comment.
+func CommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	linkId, _ := strconv.Atoi(vars["link"])
+	http.Redirect(w, r, fmt.Sprintf("/linker/comments/%d", linkId), http.StatusTemporaryRedirect)
+}

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -122,9 +122,8 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		editUrl := ""
 		editSaveUrl := ""
 		if uid == row.UsersIdusers {
-			// TODO
-			//editUrl = fmt.Sprintf("/forum/topic/%d/thread/%d?comment=%d#edit", topicRow.Idforumtopic, threadId, row.Idcomments)
-			//editSaveUrl = fmt.Sprintf("/forum/topic/%d/thread/%d/comment/%d", topicRow.Idforumtopic, threadId, row.Idcomments)
+			editUrl = fmt.Sprintf("/linker/comments/%d?comment=%d#edit", link.Idlinker, row.Idcomments)
+			editSaveUrl = fmt.Sprintf("/linker/comments/%d/comment/%d", link.Idlinker, row.Idcomments)
 			if commentId != 0 && int32(commentId) == row.Idcomments {
 				data.IsReplyable = false
 			}

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -1,6 +1,9 @@
 package linker
 
 import (
+	"net/http"
+
+	comments "github.com/arran4/goa4web/handlers/comments"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	"github.com/gorilla/mux"
 
@@ -25,6 +28,8 @@ func RegisterRoutes(r *mux.Router) {
 	lr.HandleFunc("/category/{category}", CategoryPage).Methods("GET")
 	lr.HandleFunc("/comments/{link}", CommentsPage).Methods("GET")
 	lr.HandleFunc("/comments/{link}", CommentsReplyPage).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskReply))
+	lr.Handle("/comments/{link}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(CommentEditActionPage))).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskEditReply))
+	lr.Handle("/comments/{link}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(CommentEditActionCancelPage))).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskCancel))
 	lr.HandleFunc("/show/{link}", ShowPage).Methods("GET")
 	lr.HandleFunc("/show/{link}", ShowReplyPage).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskReply))
 	lr.HandleFunc("/suggest", SuggestPage).Methods("GET")


### PR DESCRIPTION
## Summary
- add missing edit link for linker comments when viewing your own comment
- implement comment edit save handler for linker section
- register comment edit routes

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f027df2d4832f979d4a5e93e44957