### PR TITLE
Add topicrestrictions primary key migration

### DIFF
--- a/handlers/common/constants.go
+++ b/handlers/common/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 29
+	ExpectedSchemaVersion = 30
 )

--- a/migrations/0030.sql
+++ b/migrations/0030.sql
@@ -1,0 +1,5 @@
+ALTER TABLE topicrestrictions
+    ADD PRIMARY KEY (forumtopic_idforumtopic);
+
+-- Record upgrade to schema version 30
+UPDATE schema_version SET version = 30 WHERE version = 29;


### PR DESCRIPTION
## Summary
- add migration 0030 that sets PRIMARY KEY(forumtopic_idforumtopic)
- bump expected schema version to 30

## Testing
- `sqlc generate`
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f02bf9434832fba9f4dbcff4170ff