### PR TITLE
Clarify edit permissions for news posts

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -109,8 +109,10 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 				}
 				result = append(result, &Post{
 					GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow: post,
-					ShowReply:    cd.UserID != 0,
-					ShowEdit:     cd.HasRole("writer"),
+					ShowReply: cd.UserID != 0,
+					ShowEdit: cd.HasRole("writer") ||
+						cd.HasRole("moderator") ||
+						cd.HasRole("administrator"),
 					Editing:      editingId == int(post.Idsitenews),
 					Announcement: ann,
 					IsAdmin:      cd.HasRole("administrator") && cd.AdminMode,

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -27,8 +27,9 @@ import (
 
 type NewsPost struct {
 	ShowReply bool
-	ShowEdit  bool
-	// TODO or (eq .Level "authWriter") (and (ge .Level "authModerator") (le .Level "authAdministrator"))
+	// ShowEdit is true when the current user can modify the post. Users with
+	// the writer, moderator or administrator role are permitted to edit.
+	ShowEdit bool
 }
 
 func NewsPostPage(w http.ResponseWriter, r *http.Request) {
@@ -166,8 +167,10 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Post = &Post{
 		GetNewsPostByIdWithWriterIdAndThreadCommentCountRow: post,
-		ShowReply:    data.CoreData.UserID != 0,
-		ShowEdit:     data.CoreData.HasRole("writer"),
+		ShowReply: data.CoreData.UserID != 0,
+		ShowEdit: data.CoreData.HasRole("writer") ||
+			data.CoreData.HasRole("moderator") ||
+			data.CoreData.HasRole("administrator"),
 		Editing:      editingId == int(post.Idsitenews),
 		Announcement: ann,
 		IsAdmin:      data.CoreData.HasRole("administrator") && data.CoreData.AdminMode,

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,8 @@ The code in this repository exposes all pages using the [Gorilla Mux](https://gi
 
 ## Features
 
-- **News** – publish posts and allow discussion in comment threads.
+- **News** – publish posts and allow discussion in comment threads. Writers,
+  moderators and administrators may edit posts.
 - **FAQ** – manage question and answer entries with administrative tools.
 - **Blogs** – users can write blogs, comment on posts and subscribe to bloggers.
 - **Forum** – a traditional threaded forum with categories, topics and moderation tools.


### PR DESCRIPTION
## Summary
- document which roles may edit news
- show edit link when user is a writer, moderator, or administrator

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f029f2bac832fb5c80b1f1d0c2492