### PR TITLE
Implement permission check for editing news

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -110,7 +110,7 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 				result = append(result, &Post{
 					GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow: post,
 					ShowReply:    cd.UserID != 0,
-					ShowEdit:     cd.HasRole("writer"),
+					ShowEdit:     (cd.HasRole("administrator") && cd.AdminMode) || (cd.HasRole("writer") && cd.UserID == post.UsersIdusers),
 					Editing:      editingId == int(post.Idsitenews),
 					Announcement: ann,
 					IsAdmin:      cd.HasRole("administrator") && cd.AdminMode,

--- a/handlers/news/helpers.go
+++ b/handlers/news/helpers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -66,4 +67,15 @@ func PostUpdateLocal(ctx context.Context, q *db.Queries, threadID, topicID int32
 		return fmt.Errorf("rebuild topic metadata: %w", err)
 	}
 	return nil
+}
+
+// canEditNewsPost returns true if cd has permission to edit a news post by authorID.
+func canEditNewsPost(cd *hcommon.CoreData, authorID int32) bool {
+	if cd == nil {
+		return false
+	}
+	if cd.HasRole("administrator") && cd.AdminMode {
+		return true
+	}
+	return cd.HasRole("writer") && cd.UserID == authorID
 }

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -167,7 +167,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 	data.Post = &Post{
 		GetNewsPostByIdWithWriterIdAndThreadCommentCountRow: post,
 		ShowReply:    data.CoreData.UserID != 0,
-		ShowEdit:     data.CoreData.HasRole("writer"),
+		ShowEdit:     canEditNewsPost(data.CoreData, post.UsersIdusers),
 		Editing:      editingId == int(post.Idsitenews),
 		Announcement: ann,
 		IsAdmin:      data.CoreData.HasRole("administrator") && data.CoreData.AdminMode,


### PR DESCRIPTION
## Summary
- add `canEditNewsPost` helper
- show edit action only if the user may modify the post
- gate edit link visibility in news templates

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f02e8e4a4832f8c05ab48d595165b