### PR TITLE
Fix forum restrictions upsert

### DIFF
--- a/handlers/common/constants.go
+++ b/handlers/common/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 29
+	ExpectedSchemaVersion = 30
 )

--- a/internal/db/topicrestrictions_test.go
+++ b/internal/db/topicrestrictions_test.go
@@ -1,0 +1,70 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestUpsertForumTopicRestrictionsUpdates(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+
+	q := New(sqldb)
+
+	arg := UpsertForumTopicRestrictionsParams{
+		ForumtopicIdforumtopic: 1,
+		Viewlevel:              sql.NullInt32{Int32: 1, Valid: true},
+		Replylevel:             sql.NullInt32{Int32: 1, Valid: true},
+		Newthreadlevel:         sql.NullInt32{Int32: 1, Valid: true},
+		Seelevel:               sql.NullInt32{Int32: 1, Valid: true},
+		Invitelevel:            sql.NullInt32{Int32: 1, Valid: true},
+		Readlevel:              sql.NullInt32{Int32: 1, Valid: true},
+		Modlevel:               sql.NullInt32{Int32: 1, Valid: true},
+		Adminlevel:             sql.NullInt32{Int32: 1, Valid: true},
+	}
+
+	mock.ExpectExec("INSERT INTO topicrestrictions").
+		WithArgs(
+			arg.ForumtopicIdforumtopic,
+			arg.Viewlevel,
+			arg.Replylevel,
+			arg.Newthreadlevel,
+			arg.Seelevel,
+			arg.Invitelevel,
+			arg.Readlevel,
+			arg.Modlevel,
+			arg.Adminlevel,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	if err := q.UpsertForumTopicRestrictions(context.Background(), arg); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	arg.Viewlevel.Int32 = 2
+	mock.ExpectExec("INSERT INTO topicrestrictions").
+		WithArgs(
+			arg.ForumtopicIdforumtopic,
+			arg.Viewlevel,
+			arg.Replylevel,
+			arg.Newthreadlevel,
+			arg.Seelevel,
+			arg.Invitelevel,
+			arg.Readlevel,
+			arg.Modlevel,
+			arg.Adminlevel,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 2))
+	if err := q.UpsertForumTopicRestrictions(context.Background(), arg); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/migrations/0030.sql
+++ b/migrations/0030.sql
@@ -1,0 +1,6 @@
+-- Ensure each forum topic only has one restrictions row
+ALTER TABLE topicrestrictions
+    ADD UNIQUE INDEX topicrestrictions_forumtopic_idx (forumtopic_idforumtopic);
+
+-- Record upgrade to schema version 30
+UPDATE schema_version SET version = 30 WHERE version = 29;


### PR DESCRIPTION
## Summary
- enforce uniqueness on `topicrestrictions` with a new migration
- bump expected schema version
- add regression test for `UpsertForumTopicRestrictions`

## Testing
- `go vet ./...`
- `go mod tidy`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f029a5a9c832f9ff0b9c83decb831