### PR TITLE
Allow blogs to have optional thread link

### DIFF
--- a/cmd/goa4web/blog_comments_list.go
+++ b/cmd/goa4web/blog_comments_list.go
@@ -49,7 +49,11 @@ func (c *blogCommentsListCmd) Run() error {
 	if err != nil {
 		return fmt.Errorf("get blog: %w", err)
 	}
-	rows, err := queries.GetCommentsByThreadIdForUser(ctx, dbpkg.GetCommentsByThreadIdForUserParams{UsersIdusers: 0, ForumthreadID: b.ForumthreadID})
+	var threadID int32
+	if b.ForumthreadID.Valid {
+		threadID = b.ForumthreadID.Int32
+	}
+	rows, err := queries.GetCommentsByThreadIdForUser(ctx, dbpkg.GetCommentsByThreadIdForUserParams{UsersIdusers: 0, ForumthreadID: threadID})
 	if err != nil {
 		return fmt.Errorf("list comments: %w", err)
 	}

--- a/cmd/goa4web/blog_comments_read.go
+++ b/cmd/goa4web/blog_comments_read.go
@@ -62,7 +62,11 @@ func (c *blogCommentsReadCmd) Run() error {
 		return fmt.Errorf("get blog: %w", err)
 	}
 	if c.All {
-		rows, err := queries.GetCommentsByThreadIdForUser(ctx, dbpkg.GetCommentsByThreadIdForUserParams{UsersIdusers: 0, ForumthreadID: b.ForumthreadID})
+		var threadID int32
+		if b.ForumthreadID.Valid {
+			threadID = b.ForumthreadID.Int32
+		}
+		rows, err := queries.GetCommentsByThreadIdForUser(ctx, dbpkg.GetCommentsByThreadIdForUserParams{UsersIdusers: 0, ForumthreadID: threadID})
 		if err != nil {
 			return fmt.Errorf("get comments: %w", err)
 		}

--- a/cmd/goa4web/blog_deactivate.go
+++ b/cmd/goa4web/blog_deactivate.go
@@ -43,9 +43,13 @@ func (c *blogDeactivateCmd) Run() error {
 	if err != nil {
 		return fmt.Errorf("fetch blog: %w", err)
 	}
+	var threadID int32
+	if b.ForumthreadID.Valid {
+		threadID = b.ForumthreadID.Int32
+	}
 	if err := queries.ArchiveBlog(ctx, dbpkg.ArchiveBlogParams{
 		Idblogs:            b.Idblogs,
-		ForumthreadID:      b.ForumthreadID,
+		ForumthreadID:      threadID,
 		UsersIdusers:       b.UsersIdusers,
 		LanguageIdlanguage: b.LanguageIdlanguage,
 		Blog:               b.Blog,

--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -126,9 +126,13 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("list blogs: %w", err)
 	}
 	for _, b := range blogs {
+		var threadID int32
+		if b.ForumthreadID.Valid {
+			threadID = b.ForumthreadID.Int32
+		}
 		if err := qtx.ArchiveBlog(ctx, dbpkg.ArchiveBlogParams{
 			Idblogs:            b.Idblogs,
-			ForumthreadID:      b.ForumthreadID,
+			ForumthreadID:      threadID,
 			UsersIdusers:       b.UsersIdusers,
 			LanguageIdlanguage: b.LanguageIdlanguage,
 			Blog:               b.Blog,

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -46,7 +46,10 @@ func BlogReplyPostPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var pthid int32 = blog.ForumthreadID
+	var pthid int32
+	if blog.ForumthreadID.Valid {
+		pthid = blog.ForumthreadID.Int32
+	}
 	pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{
 		String: BloggerTopicName,
 		Valid:  true,
@@ -86,7 +89,7 @@ func BlogReplyPostPage(w http.ResponseWriter, r *http.Request) {
 		}
 		pthid = int32(pthidi)
 		if err := queries.AssignThreadIdToBlogEntry(r.Context(), db.AssignThreadIdToBlogEntryParams{
-			ForumthreadID: pthid,
+			ForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
 			Idblogs:       int32(bid),
 		}); err != nil {
 			log.Printf("Error: assignThreadIdToBlogEntry: %s", err)

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -92,7 +92,8 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 	replyType := r.URL.Query().Get("type")
 	commentIdString := r.URL.Query().Get("comment")
 	commentId, _ := strconv.Atoi(commentIdString)
-	if blog.ForumthreadID > 0 { // TODO make nullable.
+	if blog.ForumthreadID.Valid {
+		pthid := blog.ForumthreadID.Int32
 
 		if commentIdString != "" {
 			comment, err := queries.GetCommentByIdForUser(r.Context(), db.GetCommentByIdForUserParams{
@@ -114,7 +115,7 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 
 		rows, err := queries.GetCommentsByThreadIdForUser(r.Context(), db.GetCommentsByThreadIdForUserParams{
 			UsersIdusers:  uid,
-			ForumthreadID: blog.ForumthreadID,
+			ForumthreadID: pthid,
 		})
 		if err != nil {
 			switch {

--- a/handlers/common/constants.go
+++ b/handlers/common/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 29
+	ExpectedSchemaVersion = 30
 )

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -27,7 +27,7 @@ type BannedIp struct {
 
 type Blog struct {
 	Idblogs            int32
-	ForumthreadID      int32
+	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
 	LanguageIdlanguage int32
 	Blog               sql.NullString

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -19,7 +19,7 @@ WHERE idblogs = ?
 `
 
 type AssignThreadIdToBlogEntryParams struct {
-	ForumthreadID int32
+	ForumthreadID sql.NullInt32
 	Idblogs       int32
 }
 
@@ -135,7 +135,7 @@ ORDER BY b.written DESC
 
 type GetAllBlogEntriesByUserRow struct {
 	Idblogs            int32
-	ForumthreadID      int32
+	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
 	LanguageIdlanguage int32
 	Blog               sql.NullString
@@ -187,7 +187,7 @@ ORDER BY b.written DESC
 
 type GetBlogEntriesByIdsDescendingRow struct {
 	Idblogs            int32
-	ForumthreadID      int32
+	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
 	LanguageIdlanguage int32
 	Blog               sql.NullString
@@ -254,7 +254,7 @@ type GetBlogEntriesForUserDescendingParams struct {
 
 type GetBlogEntriesForUserDescendingRow struct {
 	Idblogs            int32
-	ForumthreadID      int32
+	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
 	LanguageIdlanguage int32
 	Blog               sql.NullString
@@ -327,7 +327,7 @@ type GetBlogEntriesForUserDescendingLanguagesParams struct {
 
 type GetBlogEntriesForUserDescendingLanguagesRow struct {
 	Idblogs            int32
-	ForumthreadID      int32
+	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
 	LanguageIdlanguage int32
 	Blog               sql.NullString
@@ -386,7 +386,7 @@ LIMIT 1
 
 type GetBlogEntryForUserByIdRow struct {
 	Idblogs            int32
-	ForumthreadID      int32
+	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
 	LanguageIdlanguage int32
 	Blog               sql.NullString

--- a/internal/db/queries-users.sql.go
+++ b/internal/db/queries-users.sql.go
@@ -150,7 +150,7 @@ type ListUsersSubscribedToBlogsParams struct {
 
 type ListUsersSubscribedToBlogsRow struct {
 	Idblogs              int32
-	ForumthreadID        int32
+	ForumthreadID        sql.NullInt32
 	UsersIdusers         int32
 	LanguageIdlanguage   int32
 	Blog                 sql.NullString

--- a/migrations/0030.sql
+++ b/migrations/0030.sql
@@ -1,0 +1,5 @@
+ALTER TABLE blogs
+    MODIFY COLUMN forumthread_id int(10) DEFAULT NULL;
+
+-- Record upgrade to schema version 30
+UPDATE schema_version SET version = 30 WHERE version = 29;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
-  `forumthread_id` int(10) NOT NULL DEFAULT 0,
+  `forumthread_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `language_idlanguage` int(10) NOT NULL DEFAULT 0,
   `blog` longtext DEFAULT NULL,


### PR DESCRIPTION
## Summary
- allow `blogs.forumthread_id` to be NULL via new migration
- update expected schema version
- regenerate sqlc models so blog structs use `sql.NullInt32`
- handle `NULL` forumthread IDs across handlers and CLI commands

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f024ac2e4832fa1659edd4faf1ff4