### PR TITLE
Implement news subscriber notifications

### DIFF
--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -299,20 +299,7 @@ func NewsPostReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// TODO
-	//if rows, err := queries.SomethingNotifyNews(r.Context(), somethingNotifyNewssParams{
-	//	Idusers: uid,
-	//	Idnewss: int32(bid),
-	//}); err != nil {
-	//	log.Printf("Error: listUsersSubscribedToThread: %s", err)
-	//} else {
-	//	for _, row := range rows {
-	//		if err := notifyChange(r.Context(), email.ProviderFromConfig(runtimeconfig.AppRuntimeConfig), row.String, endUrl); err != nil {
-	//			log.Printf("Error: notifyChange: %s", err)
-	//
-	//		}
-	//	}
-	//}
+	emailutil.NotifyNewsSubscribers(r.Context(), queries, int32(pid), uid, endUrl)
 
 	cid, err := queries.CreateComment(r.Context(), db.CreateCommentParams{
 		LanguageIdlanguage: int32(languageId),

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -58,6 +58,16 @@ FROM blogs t, users u, preferences p
 WHERE t.idblogs=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=t.users_idusers AND u.idusers!=?
 GROUP BY u.idusers;
 
+-- name: ListUsersSubscribedToNews :many
+SELECT idsitenews, forumthread_id, t.language_idlanguage, t.users_idusers,
+    news, occurred, u.idusers, u.username, u.deleted_at,
+    p.idpreferences, p.language_idlanguage, p.users_idusers, p.emailforumupdates,
+    p.page_size, p.auto_subscribe_replies,
+    (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers ORDER BY ue.id LIMIT 1) AS email
+FROM site_news t, users u, preferences p
+WHERE t.idsiteNews=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=t.users_idusers AND u.idusers!=?
+GROUP BY u.idusers;
+
 -- name: ListUsersSubscribedToLinker :many
 SELECT *, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers ORDER BY ue.id LIMIT 1) AS email
 FROM linker t, users u, preferences p

--- a/internal/emailutil/email_test.go
+++ b/internal/emailutil/email_test.go
@@ -183,6 +183,27 @@ func TestProcessPendingEmailDLQ(t *testing.T) {
 	}
 }
 
+func TestNotifyNewsSubscribers(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := dbpkg.New(db)
+	rows := sqlmock.NewRows([]string{
+		"idsitenews", "forumthread_id", "language_idlanguage", "users_idusers",
+		"news", "occurred", "idusers", "username", "deleted_at",
+		"idpreferences", "language_idlanguage_2", "users_idusers_2",
+		"emailforumupdates", "page_size", "auto_subscribe_replies", "email",
+	}).AddRow(1, 2, 1, 3, "n", nil, 3, "bob", nil, 1, 1, 3, 1, 10, true, "e@test")
+	mock.ExpectQuery("SELECT idsitenews").WithArgs(int32(1), int32(2)).WillReturnRows(rows)
+	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(int32(3), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	emailutil.NotifyNewsSubscribers(context.Background(), q, 1, 2, "/p")
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestGetEmailProviderSMTP(t *testing.T) {
 	p := email.ProviderFromConfig(runtimeconfig.RuntimeConfig{
 		EmailProvider:     "smtp",


### PR DESCRIPTION
## Summary
- add SQL query to list subscribed news users
- queue update emails for news subscribers
- implement `NotifyNewsSubscribers`
- cover new behaviour with unit tests

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f02f3ddc4832f9a1711ca7e68be61