### PR TITLE
Enable comment editing

### DIFF
--- a/core/templates/comment_template_test.go
+++ b/core/templates/comment_template_test.go
@@ -1,0 +1,58 @@
+package templates
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	corecommon "github.com/arran4/goa4web/core/common"
+)
+
+type commentForTest struct {
+	Written            struct{ Time time.Time }
+	Text               struct{ String string }
+	Posterusername     struct{ String string }
+	Idcomments         int32
+	ShowReply          bool
+	EditUrl            string
+	EditSaveUrl        string
+	Editing            bool
+	Languages          []struct{}
+	SelectedLanguageId int32
+}
+
+// Test that the comment template shows the edit form when Editing is true.
+func TestCommentTemplateEditing(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	tmpl := GetCompiledTemplates(corecommon.NewFuncs(r))
+
+	c := commentForTest{}
+	c.Written.Time = time.Now()
+	c.Text.String = "hello"
+	c.Posterusername.String = "user"
+	c.Idcomments = 1
+	c.ShowReply = true
+	c.EditUrl = "/edit"
+	c.EditSaveUrl = "/save"
+	c.Editing = true
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "comment", c); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, "Edit Reply") {
+		t.Errorf("edit form not rendered when expected")
+	}
+
+	c.Editing = false
+	buf.Reset()
+	if err := tmpl.ExecuteTemplate(&buf, "comment", c); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if strings.Contains(buf.String(), "Edit Reply") {
+		t.Errorf("edit form rendered unexpectedly")
+	}
+}

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -95,9 +95,8 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 		editUrl := ""
 		editSaveUrl := ""
 		if uid == row.UsersIdusers {
-			// TODO
-			//editUrl = fmt.Sprintf("/forum/topic/%d/thread/%d?comment=%d#edit", topicRow.Idforumtopic, threadId, row.Idcomments)
-			//editSaveUrl = fmt.Sprintf("/forum/topic/%d/thread/%d/comment/%d", topicRow.Idforumtopic, threadId, row.Idcomments)
+			editUrl = fmt.Sprintf("/forum/topic/%d/thread/%d?comment=%d#edit", threadRow.ForumtopicIdforumtopic, thid, row.Idcomments)
+			editSaveUrl = fmt.Sprintf("/forum/topic/%d/thread/%d/comment/%d", threadRow.ForumtopicIdforumtopic, thid, row.Idcomments)
 			if commentId != 0 && int32(commentId) == row.Idcomments {
 				data.IsReplyable = false
 			}

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -122,9 +122,8 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		editUrl := ""
 		editSaveUrl := ""
 		if uid == row.UsersIdusers {
-			// TODO
-			//editUrl = fmt.Sprintf("/forum/topic/%d/thread/%d?comment=%d#edit", topicRow.Idforumtopic, threadId, row.Idcomments)
-			//editSaveUrl = fmt.Sprintf("/forum/topic/%d/thread/%d/comment/%d", topicRow.Idforumtopic, threadId, row.Idcomments)
+			editUrl = fmt.Sprintf("/forum/topic/%d/thread/%d?comment=%d#edit", threadRow.ForumtopicIdforumtopic, link.ForumthreadID, row.Idcomments)
+			editSaveUrl = fmt.Sprintf("/forum/topic/%d/thread/%d/comment/%d", threadRow.ForumtopicIdforumtopic, link.ForumthreadID, row.Idcomments)
 			if commentId != 0 && int32(commentId) == row.Idcomments {
 				data.IsReplyable = false
 			}

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -3,6 +3,7 @@ package writings
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	hcommon "github.com/arran4/goa4web/handlers/common"
@@ -206,9 +207,8 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		editUrl := ""
 		editSaveUrl := ""
 		if uid == row.UsersIdusers {
-			// TODO
-			//editUrl = fmt.Sprintf("/forum/topic/%d/thread/%d?comment=%d#edit", topicRow.Idforumtopic, threadId, row.Idcomments)
-			//editSaveUrl = fmt.Sprintf("/forum/topic/%d/thread/%d/comment/%d", topicRow.Idforumtopic, threadId, row.Idcomments)
+			editUrl = fmt.Sprintf("/forum/topic/%d/thread/%d?comment=%d#edit", threadRow.ForumtopicIdforumtopic, writing.ForumthreadID, row.Idcomments)
+			editSaveUrl = fmt.Sprintf("/forum/topic/%d/thread/%d/comment/%d", threadRow.ForumtopicIdforumtopic, writing.ForumthreadID, row.Idcomments)
 			if editCommentId != 0 && int32(editCommentId) == row.Idcomments {
 				data.IsReplyable = false
 			}


### PR DESCRIPTION
## Summary
- enable `editUrl`/`editSaveUrl` on comments across image boards, linkers and writings
- add a regression test to ensure comment edit mode highlights correctly

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686f0280837c832fbfafdab0af7926cb