### PR TITLE
Queue user emails via db

### DIFF
--- a/handlers/auth/forgotPassword.go
+++ b/handlers/auth/forgotPassword.go
@@ -11,9 +11,7 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	common "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/internal/emailutil"
-	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func ForgotPasswordPage(w http.ResponseWriter, r *http.Request) {
@@ -62,10 +60,9 @@ func ForgotPasswordActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	provider := email.ProviderFromConfig(runtimeconfig.AppRuntimeConfig)
-	if provider != nil && row.Email != "" {
+	if row.Email != "" {
 		page := r.URL.Scheme + "://" + r.Host + "/login"
-		_ = emailutil.CreateEmailTemplateAndSend(r.Context(), provider, row.Email, page, "Password Reset", code)
+		_ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, page, "Password Reset", code)
 	}
 	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }

--- a/internal/emailutil/email.go
+++ b/internal/emailutil/email.go
@@ -206,22 +206,9 @@ func EmailSendingEnabled() bool {
 	return runtimeconfig.AppRuntimeConfig.EmailEnabled
 }
 
-// NotifyAdmins sends a change notification email to all administrator addresses
-// returned by GetAdminEmails.
-func NotifyAdmins(ctx context.Context, provider email.Provider, q *db.Queries, page string) {
-	if provider == nil || !AdminNotificationsEnabled() {
-		return
-	}
-	for _, email := range GetAdminEmails(ctx, q) {
-		if err := CreateEmailTemplateAndSend(ctx, provider, email, page, "update", nil); err != nil {
-			log.Printf("Error: send: %s", err)
-		}
-	}
-}
-
 // notifyThreadSubscribers emails users subscribed to the forum thread.
 func NotifyThreadSubscribers(ctx context.Context, provider email.Provider, q *db.Queries, threadID, excludeUser int32, page string) {
-	if provider == nil {
+	if q == nil {
 		return
 	}
 	rows, err := q.ListUsersSubscribedToThread(ctx, db.ListUsersSubscribedToThreadParams{
@@ -233,8 +220,8 @@ func NotifyThreadSubscribers(ctx context.Context, provider email.Provider, q *db
 		return
 	}
 	for _, row := range rows {
-		if err := CreateEmailTemplateAndSend(ctx, provider, row.Email, page, "update", nil); err != nil {
-			log.Printf("Error: send: %s", err)
+		if err := CreateEmailTemplateAndQueue(ctx, q, row.Idusers, row.Email, page, "update", nil); err != nil {
+			log.Printf("Error: queue: %s", err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- queue auto emails instead of sending directly
- adjust user email flows to use the queue
- update notifier tests for queued emails
- refactor admin notifications logic so admins receive queued emails when possible

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f00ae7ff0832fab1d594eef14d8de