### PR TITLE
Add new thread permission checks

### DIFF
--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -61,7 +61,16 @@ func ThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	// TODO check if the user has the right right to topic
+	allowed, err := UserCanCreateThread(r.Context(), queries, int32(topicId), uid)
+	if err != nil {
+		log.Printf("UserCanCreateThread error: %v", err)
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	if !allowed {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
 
 	threadId, err := queries.MakeThread(r.Context(), int32(topicId))
 	if err != nil {

--- a/handlers/forum/permissions.go
+++ b/handlers/forum/permissions.go
@@ -1,0 +1,34 @@
+package forum
+
+import (
+	"context"
+	"database/sql"
+
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+// UserCanCreateThread reports whether uid may create a thread in the topic.
+func UserCanCreateThread(ctx context.Context, q *db.Queries, topicID, uid int32) (bool, error) {
+	rows, err := q.GetForumTopicRestrictionsByForumTopicId(ctx, topicID)
+	if err != nil {
+		return false, err
+	}
+	var required int32
+	if len(rows) > 0 && rows[0].Newthreadlevel.Valid {
+		required = rows[0].Newthreadlevel.Int32
+	}
+
+	level, err := q.GetUsersTopicLevelByUserIdAndThreadId(ctx, db.GetUsersTopicLevelByUserIdAndThreadIdParams{
+		UsersIdusers:           uid,
+		ForumtopicIdforumtopic: topicID,
+	})
+	if err != nil && err != sql.ErrNoRows {
+		return false, err
+	}
+	var have int32
+	if err == nil && level.Level.Valid {
+		have = level.Level.Int32
+	}
+
+	return have >= required, nil
+}

--- a/handlers/forum/permissions_test.go
+++ b/handlers/forum/permissions_test.go
@@ -1,0 +1,64 @@
+package forum
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+func TestUserCanCreateThread_Allowed(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+
+	q := db.New(sqldb)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT t.idforumtopic, r.forumtopic_idforumtopic, r.viewlevel, r.replylevel, r.newthreadlevel, r.seelevel, r.invitelevel, r.readlevel, r.modlevel, r.adminlevel FROM forumtopic t LEFT JOIN topicrestrictions r ON t.idforumtopic = r.forumtopic_idforumtopic WHERE idforumtopic = ?")).
+		WithArgs(int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "forumtopic_idforumtopic", "viewlevel", "replylevel", "newthreadlevel", "seelevel", "invitelevel", "readlevel", "modlevel", "adminlevel"}).AddRow(1, 1, nil, nil, 2, nil, nil, nil, nil, nil))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT utl.users_idusers, utl.forumtopic_idforumtopic, utl.level, utl.invitemax, utl.expires_at FROM userstopiclevel utl WHERE utl.users_idusers = ? AND utl.forumtopic_idforumtopic = ?")).
+		WithArgs(int32(2), int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"users_idusers", "forumtopic_idforumtopic", "level", "invitemax", "expires_at"}).AddRow(2, 1, 3, nil, nil))
+
+	ok, err := UserCanCreateThread(context.Background(), q, 1, 2)
+	if err != nil {
+		t.Fatalf("UserCanCreateThread: %v", err)
+	}
+	if !ok {
+		t.Errorf("expected allowed")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestUserCanCreateThread_Denied(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+
+	q := db.New(sqldb)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT t.idforumtopic, r.forumtopic_idforumtopic, r.viewlevel, r.replylevel, r.newthreadlevel, r.seelevel, r.invitelevel, r.readlevel, r.modlevel, r.adminlevel FROM forumtopic t LEFT JOIN topicrestrictions r ON t.idforumtopic = r.forumtopic_idforumtopic WHERE idforumtopic = ?")).
+		WithArgs(int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "forumtopic_idforumtopic", "viewlevel", "replylevel", "newthreadlevel", "seelevel", "invitelevel", "readlevel", "modlevel", "adminlevel"}).AddRow(1, 1, nil, nil, 3, nil, nil, nil, nil, nil))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT utl.users_idusers, utl.forumtopic_idforumtopic, utl.level, utl.invitemax, utl.expires_at FROM userstopiclevel utl WHERE utl.users_idusers = ? AND utl.forumtopic_idforumtopic = ?")).
+		WithArgs(int32(2), int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"users_idusers", "forumtopic_idforumtopic", "level", "invitemax", "expires_at"}).AddRow(2, 1, 1, nil, nil))
+
+	ok, err := UserCanCreateThread(context.Background(), q, 1, 2)
+	if err != nil {
+		t.Fatalf("UserCanCreateThread: %v", err)
+	}
+	if ok {
+		t.Errorf("expected denied")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce topic permission before creating a thread
- expose `UserCanCreateThread` helper
- test allowed and denied thread creation rules

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f0301b648832fbf47dcbd1eea34cd