### PR TITLE
Validate form keys in handlers

### DIFF
--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -53,6 +53,10 @@ func BlogAddPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func BlogAddActionPage(w http.ResponseWriter, r *http.Request) {
+	if err := common.ValidateForm(r, []string{"language", "text"}, []string{"language", "text"}); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	languageId, err := strconv.Atoi(r.PostFormValue("language"))
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/handlers/blogs/blogsBlogAddPage_test.go
+++ b/handlers/blogs/blogsBlogAddPage_test.go
@@ -1,0 +1,56 @@
+package blogs
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/core"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+func TestBlogAddActionPage_InvalidForms(t *testing.T) {
+	dbconn, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer dbconn.Close()
+
+	queries := db.New(dbconn)
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test-session"
+
+	cases := []url.Values{
+		{"text": {"hi"}},
+		{"language": {"1"}},
+		{"language": {"1"}, "text": {"hi"}, "foo": {"bar"}},
+	}
+	for _, form := range cases {
+		req := httptest.NewRequest("POST", "/blogs/add", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		sess, _ := store.Get(req, core.SessionName)
+		sess.Values["UID"] = int32(1)
+		w := httptest.NewRecorder()
+		sess.Save(req, w)
+		for _, c := range w.Result().Cookies() {
+			req.AddCookie(c)
+		}
+		ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
+		ctx = context.WithValue(ctx, hcommon.KeyCoreData, &hcommon.CoreData{})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+		BlogAddActionPage(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("form=%v status=%d", form, rr.Code)
+		}
+	}
+}

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -24,6 +24,11 @@ func BlogReplyPostPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := hcommon.ValidateForm(r, []string{"language", "replytext"}, []string{"language", "replytext"}); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	vars := mux.Vars(r)
 	bid, err := strconv.Atoi(vars["blog"])
 

--- a/handlers/common/form.go
+++ b/handlers/common/form.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"net/http"
+
+	corecommon "github.com/arran4/goa4web/core/common"
+)
+
+// ValidateForm ensures that only the allowed form keys are present and that all required keys exist with a non-empty value.
+// It parses the request form if needed. Allowed keys should include required keys.
+func ValidateForm(r *http.Request, allowed, required []string) error {
+	if err := r.ParseForm(); err != nil {
+		return err
+	}
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, k := range allowed {
+		allowedSet[k] = struct{}{}
+	}
+	for k := range r.PostForm {
+		if _, ok := allowedSet[k]; !ok {
+			return corecommon.UserError{ErrorMessage: "invalid form"}
+		}
+	}
+	for _, k := range required {
+		if v := r.PostFormValue(k); v == "" {
+			return corecommon.UserError{ErrorMessage: "missing " + k}
+		}
+	}
+	return nil
+}

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -45,6 +45,10 @@ func AskPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func AskActionPage(w http.ResponseWriter, r *http.Request) {
+	if err := common.ValidateForm(r, []string{"language", "text"}, []string{"language", "text"}); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	languageId, err := strconv.Atoi(r.PostFormValue("language"))
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -1,0 +1,56 @@
+package faq
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/core"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+func TestAskActionPage_InvalidForms(t *testing.T) {
+	dbconn, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer dbconn.Close()
+
+	queries := db.New(dbconn)
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test-session"
+
+	cases := []url.Values{
+		{"text": {"hi"}},
+		{"language": {"1"}},
+		{"language": {"1"}, "text": {"hi"}, "foo": {"bar"}},
+	}
+	for _, form := range cases {
+		req := httptest.NewRequest("POST", "/faq/ask", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		sess, _ := store.Get(req, core.SessionName)
+		sess.Values["UID"] = int32(1)
+		w := httptest.NewRecorder()
+		sess.Save(req, w)
+		for _, c := range w.Result().Cookies() {
+			req.AddCookie(c)
+		}
+		ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
+		ctx = context.WithValue(ctx, hcommon.KeyCoreData, &hcommon.CoreData{})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+		AskActionPage(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("form=%v status=%d", form, rr.Code)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `ValidateForm` helper
- require specific form fields in FAQ & Blog handlers
- test invalid forms for FAQ Ask and blog add actions

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f02f6db38832f96af4c0d7f0c841f