### PR TITLE
Implement blog reply permission

### DIFF
--- a/handlers/blogs/blogsBlogPage.go
+++ b/handlers/blogs/blogsBlogPage.go
@@ -50,7 +50,6 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		Offset:             offset,
-		IsReplyable:        true,
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, runtimeconfig.AppRuntimeConfig.DefaultLanguage)),
 		EditUrl:            fmt.Sprintf("/blogs/blog/%d/edit", blogId),
 	}
@@ -80,10 +79,12 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 		editUrl = fmt.Sprintf("/blogs/blog/%d/edit", blog.Idblogs)
 	}
 
+	rep := currentUserMayReply(r, blog)
+	data.IsReplyable = rep
 	data.Blog = &BlogRow{
 		GetBlogEntryForUserByIdRow: blog,
 		EditUrl:                    editUrl,
-		IsReplyable:                true, // TODO
+		IsReplyable:                rep,
 	}
 
 	CustomBlogIndex(data.CoreData, r)

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -54,7 +54,6 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		Offset:             offset,
-		IsReplyable:        true,
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, runtimeconfig.AppRuntimeConfig.DefaultLanguage)),
 		EditUrl:            fmt.Sprintf("/blogs/blog/%d/edit", blogId),
 	}
@@ -84,6 +83,8 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 		editUrl = fmt.Sprintf("/blogs/blog/%d/edit", blog.Idblogs)
 	}
 
+	rep := currentUserMayReply(r, blog)
+	data.IsReplyable = rep
 	data.Blog = &BlogRow{
 		GetBlogEntryForUserByIdRow: blog,
 		EditUrl:                    editUrl,

--- a/handlers/blogs/helpers.go
+++ b/handlers/blogs/helpers.go
@@ -1,0 +1,37 @@
+package blogs
+
+import (
+	"context"
+	"net/http"
+
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+// userMayReply reports whether uid may reply to blog post b.
+func userMayReply(ctx context.Context, q *db.Queries, b *db.GetBlogEntryForUserByIdRow, uid int32) bool {
+	if uid == 0 {
+		return false
+	}
+	if b.ForumthreadID == 0 {
+		return true
+	}
+	th, err := q.GetThreadLastPosterAndPerms(ctx, db.GetThreadLastPosterAndPermsParams{
+		UsersIdusers:  uid,
+		Idforumthread: b.ForumthreadID,
+	})
+	if err != nil {
+		return false
+	}
+	return !(th.Locked.Valid && th.Locked.Bool)
+}
+
+// currentUserMayReply returns whether the current request user may reply to b.
+func currentUserMayReply(r *http.Request, b *db.GetBlogEntryForUserByIdRow) bool {
+	cd, _ := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+	q, _ := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	if q == nil || cd == nil {
+		return false
+	}
+	return userMayReply(r.Context(), q, b, cd.UserID)
+}

--- a/handlers/blogs/helpers_test.go
+++ b/handlers/blogs/helpers_test.go
@@ -1,0 +1,89 @@
+package blogs
+
+import (
+	"context"
+	"database/sql"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+func TestCurrentUserMayReply(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+
+	q := db.New(sqldb)
+	req := httptest.NewRequest("GET", "/", nil)
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	ctx = context.WithValue(ctx, hcommon.KeyCoreData, &hcommon.CoreData{UserID: 1})
+	req = req.WithContext(ctx)
+
+	blog := &db.GetBlogEntryForUserByIdRow{ForumthreadID: 2}
+	mock.ExpectQuery("SELECT th.idforumthread").
+		WithArgs(int32(1), int32(2)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic",
+			"comments", "lastaddition", "locked", "LastPosterUsername", "seelevel", "level",
+		}).AddRow(2, 0, 0, 1, sql.NullInt32{}, sql.NullTime{}, sql.NullBool{Bool: false, Valid: true}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}))
+
+	if !currentUserMayReply(req, blog) {
+		t.Errorf("expected true")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestCurrentUserMayReplyLocked(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+
+	q := db.New(sqldb)
+	req := httptest.NewRequest("GET", "/", nil)
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	ctx = context.WithValue(ctx, hcommon.KeyCoreData, &hcommon.CoreData{UserID: 1})
+	req = req.WithContext(ctx)
+
+	blog := &db.GetBlogEntryForUserByIdRow{ForumthreadID: 2}
+	mock.ExpectQuery("SELECT th.idforumthread").
+		WithArgs(int32(1), int32(2)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic",
+			"comments", "lastaddition", "locked", "LastPosterUsername", "seelevel", "level",
+		}).AddRow(2, 0, 0, 1, sql.NullInt32{}, sql.NullTime{}, sql.NullBool{Bool: true, Valid: true}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}))
+
+	if currentUserMayReply(req, blog) {
+		t.Errorf("expected false")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestCurrentUserMayReplyNoUser(t *testing.T) {
+	sqldb, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+
+	q := db.New(sqldb)
+	req := httptest.NewRequest("GET", "/", nil)
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	// no CoreData user
+	req = req.WithContext(ctx)
+
+	blog := &db.GetBlogEntryForUserByIdRow{ForumthreadID: 0}
+	if currentUserMayReply(req, blog) {
+		t.Errorf("expected false")
+	}
+}


### PR DESCRIPTION
## Summary
- add helper to check whether the current user may reply to a blog post
- set `IsReplyable` using this helper in blog views
- test reply permission logic

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f02d41678832f9238dddf6ab4f320