### PR TITLE
Add permission check for new threads

### DIFF
--- a/handlers/forum/permissions.go
+++ b/handlers/forum/permissions.go
@@ -1,0 +1,39 @@
+package forum
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+// canCreateThread returns true if user uid is allowed to create
+// a new thread in the given topic according to topic restrictions.
+func canCreateThread(ctx context.Context, q *db.Queries, topicID, uid int32) (bool, error) {
+	restr, err := q.GetForumTopicRestrictionsByForumTopicId(ctx, topicID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, err
+	}
+	var required int32
+	if len(restr) > 0 && restr[0].Newthreadlevel.Valid {
+		required = restr[0].Newthreadlevel.Int32
+	}
+	// No restriction -> allowed.
+	if required == 0 {
+		return true, nil
+	}
+
+	userLevel, err := q.GetUsersTopicLevelByUserIdAndThreadId(ctx, db.GetUsersTopicLevelByUserIdAndThreadIdParams{
+		UsersIdusers:           uid,
+		ForumtopicIdforumtopic: topicID,
+	})
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, err
+	}
+	var level int32
+	if userLevel != nil && userLevel.Level.Valid {
+		level = userLevel.Level.Int32
+	}
+	return level >= required, nil
+}

--- a/handlers/forum/permissions_test.go
+++ b/handlers/forum/permissions_test.go
@@ -1,0 +1,74 @@
+package forum
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+func TestCanCreateThreadAllowed(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+
+	q := db.New(sqldb)
+
+	mock.ExpectQuery("SELECT t.idforumtopic").
+		WithArgs(int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"idforumtopic", "forumtopic_idforumtopic", "viewlevel", "replylevel", "newthreadlevel", "seelevel", "invitelevel", "readlevel", "modlevel", "adminlevel",
+		}).AddRow(1, 1, sql.NullInt32{}, sql.NullInt32{}, sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullInt32{}))
+
+	mock.ExpectQuery("SELECT utl.*").
+		WithArgs(int32(2), int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"users_idusers", "forumtopic_idforumtopic", "level", "invitemax", "expires_at"}).
+			AddRow(2, 1, sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{}, sql.NullTime{}))
+
+	ok, err := canCreateThread(context.Background(), q, 1, 2)
+	if err != nil {
+		t.Fatalf("canCreateThread: %v", err)
+	}
+	if !ok {
+		t.Errorf("expected allowed")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations: %v", err)
+	}
+}
+
+func TestCanCreateThreadDenied(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+
+	q := db.New(sqldb)
+
+	mock.ExpectQuery("SELECT t.idforumtopic").
+		WithArgs(int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"idforumtopic", "forumtopic_idforumtopic", "viewlevel", "replylevel", "newthreadlevel", "seelevel", "invitelevel", "readlevel", "modlevel", "adminlevel",
+		}).AddRow(1, 1, sql.NullInt32{}, sql.NullInt32{}, sql.NullInt32{Int32: 5, Valid: true}, sql.NullInt32{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullInt32{}))
+
+	mock.ExpectQuery("SELECT utl.*").
+		WithArgs(int32(2), int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"users_idusers", "forumtopic_idforumtopic", "level", "invitemax", "expires_at"}).
+			AddRow(2, 1, sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{}, sql.NullTime{}))
+
+	ok, err := canCreateThread(context.Background(), q, 1, 2)
+	if err != nil {
+		t.Fatalf("canCreateThread: %v", err)
+	}
+	if ok {
+		t.Errorf("expected denied")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce topic permission in `ThreadNewActionPage`
- add helper function to check topic restrictions
- test `canCreateThread`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f0286c24c832f90d21580d09f396c