### PR TITLE
Enforce forum posting permissions

### DIFF
--- a/core/templates/templates/forum/topicsPage.gohtml
+++ b/core/templates/templates/forum/topicsPage.gohtml
@@ -3,7 +3,9 @@
 
     {{ template "getAllForumCategories" $ }}
 
+    {{ if .CanCreateThread }}
     <a href="/forum/topic/{{.Topic.Idforumtopic}}/thread">New Thread</a><br />
+    {{ end }}
 
     {{ template "topicThreads" $ }}
 {{ template "tail" $ }}

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -185,20 +185,24 @@ func CustomForumIndex(data *CoreData, r *http.Request) {
 			},
 		)
 	}
-	if threadId != "" && topicId != "" { // TODO Permissions system
-		data.CustomIndexItems = append(data.CustomIndexItems,
-			IndexItem{
-				Name: "Write Reply",
-				Link: fmt.Sprintf("/forum/topic/%s/thread/%s/reply", topicId, threadId),
-			},
-		)
+	if threadId != "" && topicId != "" {
+		if tid, err := strconv.Atoi(topicId); err == nil && CanReply(r, int32(tid)) {
+			data.CustomIndexItems = append(data.CustomIndexItems,
+				IndexItem{
+					Name: "Write Reply",
+					Link: fmt.Sprintf("/forum/topic/%s/thread/%s/reply", topicId, threadId),
+				},
+			)
+		}
 	}
-	if categoryId != "" && topicId != "" { // TODO Permissions system
-		data.CustomIndexItems = append(data.CustomIndexItems,
-			IndexItem{
-				Name: "Create Thread",
-				Link: fmt.Sprintf("/forum/topic/%s/new", topicId),
-			},
-		)
+	if categoryId != "" && topicId != "" {
+		if tid, err := strconv.Atoi(topicId); err == nil && CanCreateThread(r, int32(tid)) {
+			data.CustomIndexItems = append(data.CustomIndexItems,
+				IndexItem{
+					Name: "Create Thread",
+					Link: fmt.Sprintf("/forum/topic/%s/new", topicId),
+				},
+			)
+		}
 	}
 }

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -29,6 +29,13 @@ func ThreadNewPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int
 	}
 
+	vars := mux.Vars(r)
+	tid, _ := strconv.Atoi(vars["topic"])
+	if !CanCreateThread(r, int32(tid)) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
 	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	data := Data{
 		CoreData:           r.Context().Value(hcommon.KeyCoreData).(*CoreData),
@@ -61,7 +68,10 @@ func ThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	// TODO check if the user has the right right to topic
+	if !CanCreateThread(r, int32(topicId)) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 
 	threadId, err := queries.MakeThread(r.Context(), int32(topicId))
 	if err != nil {

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -49,7 +49,6 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData:           r.Context().Value(common.KeyCoreData).(*CoreData),
 		Offset:             offset,
-		IsReplyable:        true,
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, runtimeconfig.AppRuntimeConfig.DefaultLanguage)),
 	}
 
@@ -62,6 +61,8 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 
 	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
 	topicRow := r.Context().Value(common.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+
+	data.IsReplyable = CanReply(r, topicRow.Idforumtopic)
 
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
@@ -116,7 +117,7 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 
 		data.Comments = append(data.Comments, &CommentPlus{
 			GetCommentsByThreadIdForUserRow: row,
-			ShowReply:                       true,
+			ShowReply:                       data.IsReplyable,
 			EditUrl:                         editUrl,
 			EditSaveUrl:                     editSaveUrl,
 			Editing:                         commentId != 0 && int32(commentId) == row.Idcomments,

--- a/handlers/forum/forumTopicPage.go
+++ b/handlers/forum/forumTopicPage.go
@@ -26,6 +26,7 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 		Categories              []*ForumcategoryPlus
 		Category                *ForumcategoryPlus
 		CopyDataToSubCategories func(rootCategory *ForumcategoryPlus) *Data
+		CanCreateThread         bool
 	}
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
@@ -38,8 +39,9 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 	topicId, _ := strconv.Atoi(vars["topic"])
 
 	data := &Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
-		Admin:    true,
+		CoreData:        r.Context().Value(common.KeyCoreData).(*CoreData),
+		Admin:           true,
+		CanCreateThread: CanCreateThread(r, int32(topicId)),
 	}
 
 	copyDataToSubCategories := func(rootCategory *ForumcategoryPlus) *Data {

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -29,6 +29,11 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 	threadRow := r.Context().Value(hcommon.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
 	topicRow := r.Context().Value(hcommon.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
+	if !CanReply(r, topicRow.Idforumtopic) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
 	if evt, ok := r.Context().Value(hcommon.KeyBusEvent).(*eventbus.Event); ok && evt != nil {
 		evt.Item = notif.ForumReplyInfo{TopicTitle: topicRow.Title.String, ThreadID: threadRow.Idforumthread, Thread: threadRow}
 	}

--- a/handlers/forum/permcheck.go
+++ b/handlers/forum/permcheck.go
@@ -1,0 +1,63 @@
+package forum
+
+import (
+	"net/http"
+
+	"github.com/arran4/goa4web/core"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+// userTopicLevel returns the user's level for the given topic.
+func userTopicLevel(r *http.Request, q *db.Queries, tid int32) int32 {
+	session, _ := core.GetSession(r)
+	uid, _ := session.Values["UID"].(int32)
+	if uid == 0 {
+		return 0
+	}
+	row, err := q.GetUsersTopicLevelByUserIdAndThreadId(r.Context(), db.GetUsersTopicLevelByUserIdAndThreadIdParams{
+		UsersIdusers:           uid,
+		ForumtopicIdforumtopic: tid,
+	})
+	if err != nil || !row.Level.Valid {
+		return 0
+	}
+	return row.Level.Int32
+}
+
+// topicRestriction fetches restriction details for the topic.
+func topicRestriction(r *http.Request, q *db.Queries, tid int32) *db.GetForumTopicRestrictionsByForumTopicIdRow {
+	rows, err := q.GetForumTopicRestrictionsByForumTopicId(r.Context(), tid)
+	if err != nil || len(rows) == 0 {
+		return nil
+	}
+	return rows[0]
+}
+
+// CanReply reports whether the current user may reply in the given topic.
+func CanReply(r *http.Request, tid int32) bool {
+	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+	if !cd.HasRole("writer") {
+		return false
+	}
+	q := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	res := topicRestriction(r, q, tid)
+	if res == nil || !res.Replylevel.Valid {
+		return true
+	}
+	return userTopicLevel(r, q, tid) >= res.Replylevel.Int32
+}
+
+// CanCreateThread reports whether the current user may create a new thread in the topic.
+func CanCreateThread(r *http.Request, tid int32) bool {
+	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+	if !cd.HasRole("writer") {
+		return false
+	}
+	q := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	res := topicRestriction(r, q, tid)
+	if res == nil || !res.Newthreadlevel.Valid {
+		return true
+	}
+	return userTopicLevel(r, q, tid) >= res.Newthreadlevel.Int32
+}


### PR DESCRIPTION
## Summary
- add `CanReply` and `CanCreateThread` helpers
- gate forum actions on `CanReply`/`CanCreateThread`
- conditionally render write/create links using new helpers

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f0292817c832fb4ceb96d1e8f439a