### PR TITLE
Check thread lock for blog replies

### DIFF
--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -89,6 +89,23 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 		EditUrl:                    editUrl,
 	}
 
+	if blog.ForumthreadID == 0 {
+		data.IsReplyable = false
+	} else {
+		threadRow, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
+			UsersIdusers:  uid,
+			Idforumthread: blog.ForumthreadID,
+		})
+		if err != nil {
+			if err != sql.ErrNoRows {
+				log.Printf("GetThreadLastPosterAndPerms: %v", err)
+			}
+			data.IsReplyable = false
+		} else if threadRow.Locked.Valid && threadRow.Locked.Bool {
+			data.IsReplyable = false
+		}
+	}
+
 	replyType := r.URL.Query().Get("type")
 	commentIdString := r.URL.Query().Get("comment")
 	commentId, _ := strconv.Atoi(commentIdString)

--- a/handlers/blogs/blogsCommentPage_replyable_test.go
+++ b/handlers/blogs/blogsCommentPage_replyable_test.go
@@ -1,0 +1,115 @@
+package blogs
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/core"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+func setupCommentRequest(t *testing.T, queries *db.Queries, store *sessions.CookieStore, blogID int) (*http.Request, *sessions.Session) {
+	req := httptest.NewRequest("GET", "/blogs/blog/1/comments", nil)
+	req = mux.SetURLVars(req, map[string]string{"blog": "1"})
+	w := httptest.NewRecorder()
+	sess, _ := store.Get(req, core.SessionName)
+	sess.Values["UID"] = int32(2)
+	sess.Save(req, w)
+	for _, c := range w.Result().Cookies() {
+		req.AddCookie(c)
+	}
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
+	ctx = context.WithValue(ctx, hcommon.KeyCoreData, &CoreData{})
+	ctx = context.WithValue(ctx, hcommon.KeySession, sess)
+	req = req.WithContext(ctx)
+	return req, sess
+}
+
+func TestCommentPageLockedThreadDisablesReply(t *testing.T) {
+	dbconn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer dbconn.Close()
+
+	queries := db.New(dbconn)
+	store := sessions.NewCookieStore([]byte("t"))
+	core.Store = store
+	core.SessionName = "test-session"
+
+	req, _ := setupCommentRequest(t, queries, store, 1)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof FROM language")).
+		WillReturnRows(sqlmock.NewRows([]string{"idlanguage", "nameof"}).AddRow(1, "en"))
+
+	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)"}).
+		AddRow(1, 1, 2, 1, "hi", time.Unix(0, 0), "bob", 0)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).WithArgs(int32(1)).WillReturnRows(blogRows)
+
+	threadRows := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername", "seelevel", "level"}).
+		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), true, "bob", 0, 0)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(int32(2), int32(1)).WillReturnRows(threadRows)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
+		WithArgs(int32(2), int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "deleted_at", "posterusername"}))
+
+	rr := httptest.NewRecorder()
+	CommentPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if regexp.MustCompile(`Reply:`).FindString(rr.Body.String()) != "" {
+		t.Fatalf("reply form should be hidden")
+	}
+}
+
+func TestCommentPageUnlockedThreadShowsReply(t *testing.T) {
+	dbconn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer dbconn.Close()
+
+	queries := db.New(dbconn)
+	store := sessions.NewCookieStore([]byte("t"))
+	core.Store = store
+	core.SessionName = "test-session"
+
+	req, _ := setupCommentRequest(t, queries, store, 1)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof FROM language")).
+		WillReturnRows(sqlmock.NewRows([]string{"idlanguage", "nameof"}).AddRow(1, "en"))
+
+	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)"}).
+		AddRow(1, 1, 2, 1, "hi", time.Unix(0, 0), "bob", 0)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).WithArgs(int32(1)).WillReturnRows(blogRows)
+
+	threadRows := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername", "seelevel", "level"}).
+		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), false, "bob", 0, 0)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(int32(2), int32(1)).WillReturnRows(threadRows)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
+		WithArgs(int32(2), int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "deleted_at", "posterusername"}))
+
+	rr := httptest.NewRecorder()
+	CommentPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if !regexp.MustCompile(`Reply:`).MatchString(rr.Body.String()) {
+		t.Fatalf("reply form should be shown")
+	}
+}


### PR DESCRIPTION
## Summary
- ensure blog reply forms are hidden when the thread is locked
- mark blog comments page as not replyable when thread is locked
- test blog comments page replyability

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f025268e8832f96d38db89abc5e8f