### PR TITLE
Improve eventbus shutdown handling

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -113,11 +113,21 @@ func RunWithConfig(ctx context.Context, cfg runtimeconfig.RuntimeConfig, session
 	}
 
 	dlqProvider := dlq.ProviderFromConfig(cfg, dbpkg.New(dbPool))
-	startWorkers(ctx, dbPool, emailProvider, dlqProvider, cfg)
+
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	defer workerCancel()
+	startWorkers(workerCtx, dbPool, emailProvider, dlqProvider, cfg)
 
 	if err := server.Run(ctx, srv, cfg.HTTPListen); err != nil {
 		return fmt.Errorf("run server: %w", err)
 	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := eventbus.DefaultBus.Shutdown(shutdownCtx); err != nil {
+		log.Printf("eventbus shutdown: %v", err)
+	}
+	workerCancel()
 
 	return nil
 }

--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -43,7 +44,10 @@ func TaskEventMiddleware(next http.Handler) http.Handler {
 		sr := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(sr, r.WithContext(ctx))
 		if task != "" && sr.status < http.StatusBadRequest {
-			eventbus.DefaultBus.Publish(*evt)
+			if err := eventbus.DefaultBus.Publish(*evt); err != nil {
+				log.Printf("publish task event: %v", err)
+				// TODO: queue task events for resumption when the bus is closed
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- add `Bus.Shutdown` to drain the event bus
- ensure new events are rejected during shutdown
- run workers with their own context and wait for event bus to flush on shutdown
- return an error when publishing to a closed bus
- **log publish errors** from TaskEventMiddleware

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f00d3a8d8832fa17a22a2dcb49913