### PR TITLE
Add user email verification task

### DIFF
--- a/handlers/auth/forgotPassword.go
+++ b/handlers/auth/forgotPassword.go
@@ -62,7 +62,7 @@ func ForgotPasswordActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	if row.Email != "" {
 		page := r.URL.Scheme + "://" + r.Host + "/login"
-		_ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, page, "Password Reset", code)
+		_ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, page, common.TaskUserResetPassword, code)
 	}
 	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }

--- a/handlers/common/tasks.go
+++ b/handlers/common/tasks.go
@@ -238,7 +238,10 @@ const (
 	TaskUserDoNothing = "User do nothing"
 
 	// TaskUserResetPassword resets a user's password.
-	TaskUserResetPassword = "Reset Password"
+	TaskUserResetPassword = "Password Reset"
+
+	// TaskUserEmailVerification verifies a user's email address.
+	TaskUserEmailVerification = "Email Verification"
 
 	// TaskAllow approves a news user level.
 	TaskAllow = "allow"

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -195,7 +195,7 @@ func userEmailAddActionPage(w http.ResponseWriter, r *http.Request) {
 	if runtimeconfig.AppRuntimeConfig.HTTPHostname != "" {
 		page = strings.TrimRight(runtimeconfig.AppRuntimeConfig.HTTPHostname, "/") + "/usr/email/verify?code=" + code
 	}
-	_ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, uid, emailAddr, page, "Email Verification", nil)
+	_ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, uid, emailAddr, page, common.TaskUserEmailVerification, nil)
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }
 
@@ -225,7 +225,7 @@ func userEmailResendActionPage(w http.ResponseWriter, r *http.Request) {
 	if runtimeconfig.AppRuntimeConfig.HTTPHostname != "" {
 		page = strings.TrimRight(runtimeconfig.AppRuntimeConfig.HTTPHostname, "/") + "/usr/email/verify?code=" + code
 	}
-	_ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, uid, ue.Email, page, "Email Verification", nil)
+	_ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, uid, ue.Email, page, common.TaskUserEmailVerification, nil)
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }
 

--- a/internal/emailutil/email.go
+++ b/internal/emailutil/email.go
@@ -24,14 +24,14 @@ type emailTemplate struct {
 }
 
 var defaultEmailTemplates = map[string]emailTemplate{
-	"update":                                   {text: defaultUpdateEmailText, html: defaultUpdateEmailHTML},
-	strings.ToLower(hcommon.TaskReply):         {text: defaultReplyEmailText, html: defaultReplyEmailHTML},
-	strings.ToLower(hcommon.TaskCreateThread):  {text: defaultThreadEmailText, html: defaultThreadEmailHTML},
-	strings.ToLower(hcommon.TaskNewPost):       {text: defaultBlogEmailText, html: defaultBlogEmailHTML},
-	strings.ToLower(hcommon.TaskSubmitWriting): {text: defaultWritingEmailText, html: defaultWritingEmailHTML},
-	strings.ToLower(hcommon.TaskRegister):      {text: defaultSignupEmailText, html: defaultSignupEmailHTML},
-	strings.ToLower("Email Verification"):      {text: defaultVerificationEmailText, html: defaultVerificationEmailHTML},
-	strings.ToLower("Password Reset"):          {text: defaultPasswordResetEmailText, html: defaultPasswordResetEmailHTML},
+	"update":                                           {text: defaultUpdateEmailText, html: defaultUpdateEmailHTML},
+	strings.ToLower(hcommon.TaskReply):                 {text: defaultReplyEmailText, html: defaultReplyEmailHTML},
+	strings.ToLower(hcommon.TaskCreateThread):          {text: defaultThreadEmailText, html: defaultThreadEmailHTML},
+	strings.ToLower(hcommon.TaskNewPost):               {text: defaultBlogEmailText, html: defaultBlogEmailHTML},
+	strings.ToLower(hcommon.TaskSubmitWriting):         {text: defaultWritingEmailText, html: defaultWritingEmailHTML},
+	strings.ToLower(hcommon.TaskRegister):              {text: defaultSignupEmailText, html: defaultSignupEmailHTML},
+	strings.ToLower(hcommon.TaskUserEmailVerification): {text: defaultVerificationEmailText, html: defaultVerificationEmailHTML},
+	strings.ToLower(hcommon.TaskUserResetPassword):     {text: defaultPasswordResetEmailText, html: defaultPasswordResetEmailHTML},
 }
 
 func getEmailTemplates(ctx context.Context, action string) (string, string) {


### PR DESCRIPTION
## Summary
- add new constant `TaskUserEmailVerification`
- change `TaskUserResetPassword` constant string value to `Password Reset`
- use these constants in email utilities and handlers

## Testing
- `go vet ./...` *(fails: cannot convert untyped int constants in blogs package)*
- `golangci-lint run ./...` *(fails: typecheck errors in blogs package)*
- `go test ./...` *(fails: build errors in blogs package)*

------
https://chatgpt.com/codex/tasks/task_e_686f41dde7c4832f93a7f5c3eeca0614