### PR TITLE
Move admin notifications to bus

### DIFF
--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -18,6 +18,7 @@ import (
 	userhandlers "github.com/arran4/goa4web/handlers/user"
 	db "github.com/arran4/goa4web/internal/db"
 	logProv "github.com/arran4/goa4web/internal/email/log"
+	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -132,7 +133,7 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	runtimeconfig.AppRuntimeConfig.AdminEmails = "a@test.com,b@test.com"
 	defer func() { runtimeconfig.AppRuntimeConfig.AdminEmails = origEmails }()
 	rec := &recordAdminMail{}
-	notifyAdmins(context.Background(), rec, nil, "page")
+	notif.Notifier{EmailProvider: rec}.NotifyAdmins(context.Background(), "page")
 	if len(rec.to) != 2 {
 		t.Fatalf("expected 2 mails, got %d", len(rec.to))
 	}
@@ -155,7 +156,7 @@ func TestNotifyAdminsDisabled(t *testing.T) {
 	runtimeconfig.AppRuntimeConfig.AdminEmails = "a@test.com"
 	defer func() { runtimeconfig.AppRuntimeConfig.AdminEmails = origEmails }()
 	rec := &recordAdminMail{}
-	notifyAdmins(context.Background(), rec, nil, "page")
+	notif.Notifier{EmailProvider: rec}.NotifyAdmins(context.Background(), "page")
 	if len(rec.to) != 0 {
 		t.Fatalf("expected 0 mails, got %d", len(rec.to))
 	}

--- a/handlers/forum/forumAdminRestrictionsPage.go
+++ b/handlers/forum/forumAdminRestrictionsPage.go
@@ -6,14 +6,12 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/email"
 	"log"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/arran4/goa4web/core/templates"
-	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func AdminUsersRestrictionsPage(w http.ResponseWriter, r *http.Request) {
@@ -127,8 +125,6 @@ func AdminUsersRestrictionsUpdatePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	notifyAdmins(r.Context(), email.ProviderFromConfig(runtimeconfig.AppRuntimeConfig), queries, r.URL.Path)
-
 	common.TaskDoneAutoRefreshPage(w, r)
 
 }
@@ -153,8 +149,6 @@ func AdminUsersRestrictionsDeletePage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-
-	notifyAdmins(r.Context(), email.ProviderFromConfig(runtimeconfig.AppRuntimeConfig), queries, r.URL.Path)
 
 	common.TaskDoneAutoRefreshPage(w, r)
 

--- a/handlers/forum/forumAdminTopicRestrictions.go
+++ b/handlers/forum/forumAdminTopicRestrictions.go
@@ -6,13 +6,11 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/email"
 	"log"
 	"net/http"
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
-	"github.com/arran4/goa4web/runtimeconfig"
 	"github.com/gorilla/mux"
 )
 
@@ -114,8 +112,6 @@ func AdminTopicRestrictionLevelChangePage(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	notifyAdmins(r.Context(), email.ProviderFromConfig(runtimeconfig.AppRuntimeConfig), queries, r.URL.Path)
-
 	common.TaskDoneAutoRefreshPage(w, r)
 }
 
@@ -129,8 +125,6 @@ func AdminTopicRestrictionLevelDeletePage(w http.ResponseWriter, r *http.Request
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-
-	notifyAdmins(r.Context(), email.ProviderFromConfig(runtimeconfig.AppRuntimeConfig), queries, r.URL.Path)
 
 	common.TaskDoneAutoRefreshPage(w, r)
 }
@@ -177,8 +171,6 @@ func AdminTopicRestrictionLevelCopyPage(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 	}
-
-	notifyAdmins(r.Context(), email.ProviderFromConfig(runtimeconfig.AppRuntimeConfig), queries, r.URL.Path)
 
 	common.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/forum/forumAdminTopicsRestrictions.go
+++ b/handlers/forum/forumAdminTopicsRestrictions.go
@@ -6,13 +6,11 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/email"
 	"log"
 	"net/http"
 	"strconv"
 
 	"github.com/arran4/goa4web/core/templates"
-	"github.com/arran4/goa4web/runtimeconfig"
 )
 
 func AdminTopicsRestrictionLevelPage(w http.ResponseWriter, r *http.Request) {
@@ -113,8 +111,6 @@ func AdminTopicsRestrictionLevelChangePage(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	notifyAdmins(r.Context(), email.ProviderFromConfig(runtimeconfig.AppRuntimeConfig), queries, r.URL.Path)
-
 	common.TaskDoneAutoRefreshPage(w, r)
 }
 
@@ -130,8 +126,6 @@ func AdminTopicsRestrictionLevelDeletePage(w http.ResponseWriter, r *http.Reques
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-
-	notifyAdmins(r.Context(), email.ProviderFromConfig(runtimeconfig.AppRuntimeConfig), queries, r.URL.Path)
 
 	common.TaskDoneAutoRefreshPage(w, r)
 }
@@ -178,8 +172,6 @@ func AdminTopicsRestrictionLevelCopyPage(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
-
-	notifyAdmins(r.Context(), email.ProviderFromConfig(runtimeconfig.AppRuntimeConfig), queries, r.URL.Path)
 
 	common.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/forum/forumAdminUserLevelPage.go
+++ b/handlers/forum/forumAdminUserLevelPage.go
@@ -6,14 +6,12 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/email"
 	"log"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/arran4/goa4web/core/templates"
-	"github.com/arran4/goa4web/runtimeconfig"
 	"github.com/gorilla/mux"
 )
 
@@ -101,8 +99,6 @@ func AdminUserLevelUpdatePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	notifyAdmins(r.Context(), email.ProviderFromConfig(runtimeconfig.AppRuntimeConfig), queries, r.URL.Path)
-
 	common.TaskDoneAutoRefreshPage(w, r)
 
 }
@@ -124,8 +120,6 @@ func AdminUserLevelDeletePage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-
-	notifyAdmins(r.Context(), email.ProviderFromConfig(runtimeconfig.AppRuntimeConfig), queries, r.URL.Path)
 
 	common.TaskDoneAutoRefreshPage(w, r)
 

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -149,6 +149,10 @@ func processEvent(ctx context.Context, evt eventbus.Event, n Notifier, q dlq.DLQ
 		return
 	}
 
+	if evt.Admin {
+		n.NotifyAdmins(ctx, evt.Path)
+	}
+
 	if evt.Task == hcommon.TaskReply && n.Queries != nil {
 		auto := true
 		email := false


### PR DESCRIPTION
## Summary
- trigger NotifyAdmins when bus events originate from admin actions
- remove direct NotifyAdmins calls from forum admin handlers
- adapt NotifyAdmins tests to use the notifier directly
- test admin notifications through the bus worker

## Testing
- `go vet ./...` *(fails: handlers/blogs build errors)*
- `golangci-lint run` *(fails: typecheck errors in handlers/blogs)*
- `go test ./...` *(fails: build errors in handlers/blogs and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_686f4192e00c832f90678892082d8878