### PR TITLE
Remove unused email sending helper

### DIFF
--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -207,7 +207,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		editUrl := ""
 		editSaveUrl := ""
 		if uid == row.UsersIdusers {
-      // TODO make a writer/writing/comment/reply not a forum/topic/thread/comment
+			// TODO make a writer/writing/comment/reply not a forum/topic/thread/comment
 			editUrl = fmt.Sprintf("/forum/topic/%d/thread/%d?comment=%d#edit", threadRow.ForumtopicIdforumtopic, writing.ForumthreadID, row.Idcomments)
 			editSaveUrl = fmt.Sprintf("/forum/topic/%d/thread/%d/comment/%d", threadRow.ForumtopicIdforumtopic, writing.ForumthreadID, row.Idcomments)
 			if editCommentId != 0 && int32(editCommentId) == row.Idcomments {

--- a/internal/emailutil/email.go
+++ b/internal/emailutil/email.go
@@ -129,20 +129,6 @@ func CreateEmailTemplate(ctx context.Context, emailAddr, page, action string, it
 	return msg, toAddr, nil
 }
 
-func CreateEmailTemplateAndSend(ctx context.Context, provider email.Provider, emailAddr, page, action string, item interface{}) error {
-	if !EmailSendingEnabled() {
-		return nil
-	}
-	msg, toAddr, err := CreateEmailTemplate(ctx, emailAddr, page, action, item)
-	if err != nil {
-		return err
-	}
-	if provider == nil {
-		return fmt.Errorf("no provider")
-	}
-	return provider.Send(ctx, toAddr, msg)
-}
-
 func CreateEmailTemplateAndQueue(ctx context.Context, q *db.Queries, userID int32, emailAddr, page, action string, item interface{}) error {
 	if q == nil {
 		return fmt.Errorf("no query")

--- a/internal/emailutil/email_test.go
+++ b/internal/emailutil/email_test.go
@@ -96,8 +96,7 @@ func TestCreateEmailTemplateAndQueue(t *testing.T) {
 }
 
 func TestCreateEmailTemplateErrors(t *testing.T) {
-	rec := &mockemail.Provider{}
-	if err := emailutil.CreateEmailTemplateAndSend(context.Background(), rec, "", "p", "update", nil); err == nil {
+	if _, _, err := emailutil.CreateEmailTemplate(context.Background(), "", "p", "update", nil); err == nil {
 		t.Fatal("expected error for empty email")
 	}
 }


### PR DESCRIPTION
## Summary
- remove `CreateEmailTemplateAndSend`
- inline sending logic in notifier
- update tests
- gofmt cleanup

## Testing
- `go vet ./...` *(fails: cannot convert 0 to sql.NullInt32 in blogs package)*
- `go test ./...` *(fails: build errors in blogs package)*
- `golangci-lint run ./...` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f4438a894832fbdee157c471bb8f1