### PR TITLE
Implement comment edit endpoints for writings

### DIFF
--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	auth "github.com/arran4/goa4web/handlers/auth"
+	comments "github.com/arran4/goa4web/handlers/comments"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 
@@ -31,6 +32,8 @@ func RegisterRoutes(r *mux.Router) {
 	wr.HandleFunc("/users/permissions", UsersPermissionsDisallowPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskUserDisallow))
 	wr.HandleFunc("/article/{article}", ArticlePage).Methods("GET")
 	wr.HandleFunc("/article/{article}", ArticleReplyActionPage).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskReply))
+	wr.HandleFunc("/article/{article}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(ArticleCommentEditActionPage)).ServeHTTP).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskEditReply))
+	wr.HandleFunc("/article/{article}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(ArticleCommentEditActionCancelPage)).ServeHTTP).Methods("POST").MatcherFunc(hcommon.TaskMatcher(hcommon.TaskCancel))
 	wr.Handle("/article/{article}/edit", RequireWritingAuthor(http.HandlerFunc(ArticleEditPage))).Methods("GET").MatcherFunc(auth.RequiredAccess("writer", "administrator"))
 	wr.Handle("/article/{article}/edit", RequireWritingAuthor(http.HandlerFunc(ArticleEditActionPage))).Methods("POST").MatcherFunc(auth.RequiredAccess("writer", "administrator")).MatcherFunc(hcommon.TaskMatcher(hcommon.TaskUpdateWriting))
 	wr.HandleFunc("/categories", CategoriesPage).Methods("GET")

--- a/handlers/writings/writingsArticleCommentEditPage.go
+++ b/handlers/writings/writingsArticleCommentEditPage.go
@@ -1,0 +1,73 @@
+package writings
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/core"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+// ArticleCommentEditActionPage updates a comment on a writing and refreshes thread metadata.
+func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
+	languageId, err := strconv.Atoi(r.PostFormValue("language"))
+	if err != nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	text := r.PostFormValue("replytext")
+
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	vars := mux.Vars(r)
+	articleId, _ := strconv.Atoi(vars["article"])
+	commentId, _ := strconv.Atoi(vars["comment"])
+
+	session, ok := core.GetSessionOrFail(w, r)
+	if !ok {
+		return
+	}
+	uid, _ := session.Values["UID"].(int32)
+
+	comment := r.Context().Value(hcommon.KeyComment).(*db.GetCommentByIdForUserRow)
+
+	thread, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
+		UsersIdusers:  uid,
+		Idforumthread: comment.ForumthreadID,
+	})
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		log.Printf("Error: getThreadLastPosterAndPerms: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	if err = queries.UpdateComment(r.Context(), db.UpdateCommentParams{
+		Idcomments:         int32(commentId),
+		LanguageIdlanguage: int32(languageId),
+		Text:               sql.NullString{String: text, Valid: true},
+	}); err != nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	if err := hcommon.PostUpdate(r.Context(), queries, thread.Idforumthread, thread.ForumtopicIdforumtopic); err != nil {
+		log.Printf("Error: postUpdate: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	http.Redirect(w, r, fmt.Sprintf("/writings/article/%d", articleId), http.StatusTemporaryRedirect)
+}
+
+// ArticleCommentEditActionCancelPage aborts editing a comment.
+func ArticleCommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	articleId, _ := strconv.Atoi(vars["article"])
+	http.Redirect(w, r, fmt.Sprintf("/writings/article/%d", articleId), http.StatusTemporaryRedirect)
+}

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -207,9 +207,8 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		editUrl := ""
 		editSaveUrl := ""
 		if uid == row.UsersIdusers {
-      // TODO make a writer/writing/comment/reply not a forum/topic/thread/comment
-			editUrl = fmt.Sprintf("/forum/topic/%d/thread/%d?comment=%d#edit", threadRow.ForumtopicIdforumtopic, writing.ForumthreadID, row.Idcomments)
-			editSaveUrl = fmt.Sprintf("/forum/topic/%d/thread/%d/comment/%d", threadRow.ForumtopicIdforumtopic, writing.ForumthreadID, row.Idcomments)
+			editUrl = fmt.Sprintf("/writings/article/%d?comment=%d#edit", writing.Idwriting, row.Idcomments)
+			editSaveUrl = fmt.Sprintf("/writings/article/%d/comment/%d", writing.Idwriting, row.Idcomments)
 			if editCommentId != 0 && int32(editCommentId) == row.Idcomments {
 				data.IsReplyable = false
 			}


### PR DESCRIPTION
## Summary
- add routes to edit article comments instead of relying on the forum module
- implement `ArticleCommentEditActionPage` and cancel handler
- update comment edit URLs on article pages
- adjust comment edit routing to use `HandleFunc`

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f47dd30b0832fabd17731c4b1e3fe