### PR TITLE
Refactor parser to remove implicit root

### DIFF
--- a/a4code/a4code.go
+++ b/a4code/a4code.go
@@ -1,0 +1,10 @@
+package a4code
+
+import "bytes"
+
+// ToA4Code serializes the node tree back into A4code markup.
+func ToA4Code(n Node) string {
+	var buf bytes.Buffer
+	n.a4code(&buf)
+	return buf.String()
+}

--- a/a4code/ast.go
+++ b/a4code/ast.go
@@ -1,0 +1,415 @@
+package a4code
+
+import (
+	"bytes"
+	"io"
+)
+
+func writeByte(w io.Writer, b byte) {
+	w.Write([]byte{b})
+}
+
+// Node represents a parsed element of markup.
+type Node interface {
+	html(io.Writer)
+	a4code(io.Writer)
+	isNode()
+}
+
+type parent interface {
+	childrenPtr() *[]Node
+}
+
+// Root is the top level node of a document.
+type Root struct {
+	Children []Node
+}
+
+func (*Root) isNode() {}
+
+func (r *Root) html(w io.Writer) {
+	for _, c := range r.Children {
+		c.html(w)
+	}
+}
+
+func (r *Root) a4code(w io.Writer) {
+	for _, c := range r.Children {
+		c.a4code(w)
+	}
+}
+
+func (r *Root) childrenPtr() *[]Node { return &r.Children }
+
+// Text contains plain text content.
+type Text struct {
+	Value string
+}
+
+func (*Text) isNode() {}
+
+func (t *Text) html(w io.Writer) {
+	for i := 0; i < len(t.Value); i++ {
+		switch t.Value[i] {
+		case '&':
+			io.WriteString(w, "&amp;")
+		case '<':
+			io.WriteString(w, "&lt;")
+		case '>':
+			io.WriteString(w, "&gt;")
+		case '\n':
+			io.WriteString(w, "<br />\n")
+		default:
+			writeByte(w, t.Value[i])
+		}
+	}
+}
+
+func (t *Text) a4code(w io.Writer) {
+	for i := 0; i < len(t.Value); i++ {
+		switch t.Value[i] {
+		case '[', ']', '=', '\\', '*', '/', '_':
+			writeByte(w, '\\')
+			writeByte(w, t.Value[i])
+		default:
+			writeByte(w, t.Value[i])
+		}
+	}
+}
+
+// Bold text.
+type Bold struct{ Children []Node }
+
+func (*Bold) isNode()                {}
+func (b *Bold) childrenPtr() *[]Node { return &b.Children }
+
+func (b *Bold) html(w io.Writer) {
+	io.WriteString(w, "<strong>")
+	for _, c := range b.Children {
+		c.html(w)
+	}
+	io.WriteString(w, "</strong>")
+}
+
+func (b *Bold) a4code(w io.Writer) {
+	io.WriteString(w, "[b")
+	for _, c := range b.Children {
+		c.a4code(w)
+	}
+	writeByte(w, ']')
+}
+
+// Italic text.
+type Italic struct{ Children []Node }
+
+func (*Italic) isNode()                {}
+func (i *Italic) childrenPtr() *[]Node { return &i.Children }
+
+func (i *Italic) html(w io.Writer) {
+	io.WriteString(w, "<i>")
+	for _, c := range i.Children {
+		c.html(w)
+	}
+	io.WriteString(w, "</i>")
+}
+
+func (i *Italic) a4code(w io.Writer) {
+	io.WriteString(w, "[i")
+	for _, c := range i.Children {
+		c.a4code(w)
+	}
+	writeByte(w, ']')
+}
+
+// Underline text.
+type Underline struct{ Children []Node }
+
+func (*Underline) isNode()                {}
+func (u *Underline) childrenPtr() *[]Node { return &u.Children }
+
+func (u *Underline) html(w io.Writer) {
+	io.WriteString(w, "<u>")
+	for _, c := range u.Children {
+		c.html(w)
+	}
+	io.WriteString(w, "</u>")
+}
+
+func (u *Underline) a4code(w io.Writer) {
+	io.WriteString(w, "[u")
+	for _, c := range u.Children {
+		c.a4code(w)
+	}
+	writeByte(w, ']')
+}
+
+// Superscript text.
+type Sup struct{ Children []Node }
+
+func (*Sup) isNode()                {}
+func (s *Sup) childrenPtr() *[]Node { return &s.Children }
+
+func (s *Sup) html(w io.Writer) {
+	io.WriteString(w, "<sup>")
+	for _, c := range s.Children {
+		c.html(w)
+	}
+	io.WriteString(w, "</sup>")
+}
+
+func (s *Sup) a4code(w io.Writer) {
+	io.WriteString(w, "[sup")
+	for _, c := range s.Children {
+		c.a4code(w)
+	}
+	writeByte(w, ']')
+}
+
+// Subscript text.
+type Sub struct{ Children []Node }
+
+func (*Sub) isNode()                {}
+func (s *Sub) childrenPtr() *[]Node { return &s.Children }
+
+func (s *Sub) html(w io.Writer) {
+	io.WriteString(w, "<sub>")
+	for _, c := range s.Children {
+		c.html(w)
+	}
+	io.WriteString(w, "</sub>")
+}
+
+func (s *Sub) a4code(w io.Writer) {
+	io.WriteString(w, "[sub")
+	for _, c := range s.Children {
+		c.a4code(w)
+	}
+	writeByte(w, ']')
+}
+
+// Link to a URL.
+type Link struct {
+	Href     string
+	Children []Node
+}
+
+func (*Link) isNode()                {}
+func (l *Link) childrenPtr() *[]Node { return &l.Children }
+
+func (l *Link) html(w io.Writer) {
+	if safe, ok := SanitizeURL(l.Href); ok {
+		io.WriteString(w, "<a href=\"")
+		io.WriteString(w, safe)
+		io.WriteString(w, "\" target=\"_BLANK\">")
+		for _, c := range l.Children {
+			c.html(w)
+		}
+		io.WriteString(w, "</a>")
+	} else {
+		io.WriteString(w, safe)
+		for _, c := range l.Children {
+			c.html(w)
+		}
+	}
+}
+
+func (l *Link) a4code(w io.Writer) {
+	io.WriteString(w, "[a=")
+	escapeArg(w, l.Href)
+	for _, c := range l.Children {
+		c.a4code(w)
+	}
+	writeByte(w, ']')
+}
+
+// Image embeds an image.
+type Image struct{ Src string }
+
+func (*Image) isNode() {}
+
+func (i *Image) html(w io.Writer) {
+	io.WriteString(w, "<img src=\"")
+	io.WriteString(w, htmlEscape(i.Src))
+	io.WriteString(w, "\" />")
+}
+
+func (i *Image) a4code(w io.Writer) {
+	io.WriteString(w, "[img=")
+	escapeArg(w, i.Src)
+	writeByte(w, ']')
+}
+
+// Code block.
+type Code struct{ Value string }
+
+func (*Code) isNode() {}
+
+func (c *Code) html(w io.Writer) {
+	io.WriteString(w, "<table width=90% align=center bgcolor=lightblue><tr><th>Code: <tr><td><pre>")
+	io.WriteString(w, htmlEscape(c.Value))
+	io.WriteString(w, "</pre></table>")
+}
+
+func (c *Code) a4code(w io.Writer) {
+	io.WriteString(w, "[code]")
+	io.WriteString(w, c.Value)
+	io.WriteString(w, "[/code]")
+}
+
+// Quote node.
+type Quote struct{ Children []Node }
+
+func (*Quote) isNode()                {}
+func (q *Quote) childrenPtr() *[]Node { return &q.Children }
+
+func (q *Quote) html(w io.Writer) {
+	io.WriteString(w, "<table width=90% align=center bgcolor=lightgreen><tr><th>Quote: <tr><td>")
+	for _, c := range q.Children {
+		c.html(w)
+	}
+	io.WriteString(w, "</table>")
+}
+
+func (q *Quote) a4code(w io.Writer) {
+	io.WriteString(w, "[quote")
+	for _, c := range q.Children {
+		c.a4code(w)
+	}
+	writeByte(w, ']')
+}
+
+// QuoteOf node.
+type QuoteOf struct {
+	Name     string
+	Children []Node
+}
+
+func (*QuoteOf) isNode()                {}
+func (q *QuoteOf) childrenPtr() *[]Node { return &q.Children }
+
+func (q *QuoteOf) html(w io.Writer) {
+	io.WriteString(w, "<table width=90% align=center bgcolor=lightgreen><tr><th>Quote of ")
+	io.WriteString(w, htmlEscape(q.Name))
+	io.WriteString(w, ": <tr><td>")
+	for _, c := range q.Children {
+		c.html(w)
+	}
+	io.WriteString(w, "</table>")
+}
+
+func (q *QuoteOf) a4code(w io.Writer) {
+	io.WriteString(w, "[quoteof ")
+	escapeArg(w, q.Name)
+	for _, c := range q.Children {
+		c.a4code(w)
+	}
+	writeByte(w, ']')
+}
+
+// Spoiler node.
+type Spoiler struct{ Children []Node }
+
+func (*Spoiler) isNode()                {}
+func (s *Spoiler) childrenPtr() *[]Node { return &s.Children }
+
+func (s *Spoiler) html(w io.Writer) {
+	io.WriteString(w, "<span class=\"spoiler\">")
+	for _, c := range s.Children {
+		c.html(w)
+	}
+	io.WriteString(w, "</span>")
+}
+
+func (s *Spoiler) a4code(w io.Writer) {
+	io.WriteString(w, "[spoiler")
+	for _, c := range s.Children {
+		c.a4code(w)
+	}
+	writeByte(w, ']')
+}
+
+// Indent node.
+type Indent struct{ Children []Node }
+
+func (*Indent) isNode()                {}
+func (i *Indent) childrenPtr() *[]Node { return &i.Children }
+
+func (i *Indent) html(w io.Writer) {
+	io.WriteString(w, "<table width=90% align=center><tr><td>")
+	for _, c := range i.Children {
+		c.html(w)
+	}
+	io.WriteString(w, "</table>")
+}
+
+func (i *Indent) a4code(w io.Writer) {
+	io.WriteString(w, "[indent")
+	for _, c := range i.Children {
+		c.a4code(w)
+	}
+	writeByte(w, ']')
+}
+
+// HR node.
+type HR struct{}
+
+func (*HR) isNode() {}
+
+func (*HR) html(w io.Writer) { io.WriteString(w, "<hr/>") }
+
+func (*HR) a4code(w io.Writer) { io.WriteString(w, "[hr]") }
+
+// Custom element for unrecognised tags.
+type Custom struct {
+	Tag      string
+	Children []Node
+}
+
+func (*Custom) isNode()                {}
+func (c *Custom) childrenPtr() *[]Node { return &c.Children }
+
+func (c *Custom) html(w io.Writer) {
+	for _, ch := range c.Children {
+		ch.html(w)
+	}
+}
+
+func (c *Custom) a4code(w io.Writer) {
+	writeByte(w, '[')
+	io.WriteString(w, c.Tag)
+	for _, ch := range c.Children {
+		ch.a4code(w)
+	}
+	writeByte(w, ']')
+}
+
+// helper to escape plain strings for HTML output.
+func htmlEscape(s string) string {
+	var b bytes.Buffer
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '&':
+			b.WriteString("&amp;")
+		case '<':
+			b.WriteString("&lt;")
+		case '>':
+			b.WriteString("&gt;")
+		default:
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
+}
+
+// escapeArg escapes characters in a tag argument.
+func escapeArg(w io.Writer, s string) {
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '[', ']', '=', '\\':
+			writeByte(w, '\\')
+			writeByte(w, s[i])
+		default:
+			writeByte(w, s[i])
+		}
+	}
+}

--- a/a4code/html.go
+++ b/a4code/html.go
@@ -1,0 +1,10 @@
+package a4code
+
+import "bytes"
+
+// ToHTML converts a node tree to HTML.
+func ToHTML(n Node) string {
+	var buf bytes.Buffer
+	n.html(&buf)
+	return buf.String()
+}

--- a/a4code/parser.go
+++ b/a4code/parser.go
@@ -1,0 +1,306 @@
+package a4code
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"iter"
+	"slices"
+	"strings"
+)
+
+type streamOptions struct {
+	maxDepth int // nodes deeper than this level are skipped; -1 yields all
+}
+
+// StreamOption configures Stream behaviour.
+type StreamOption func(*streamOptions)
+
+// WithDepth limits yielded nodes to the specified depth, where 0 is top level
+// and -1 yields all nodes.
+func WithDepth(d int) StreamOption { return func(o *streamOptions) { o.maxDepth = d } }
+
+// WithAllNodes yields every node encountered while parsing.
+func WithAllNodes() StreamOption { return func(o *streamOptions) { o.maxDepth = -1 } }
+
+// Stream parses markup from r and yields nodes according to the provided options.
+func Stream(r io.Reader, opts ...StreamOption) iter.Seq[Node] {
+	o := streamOptions{maxDepth: -1}
+	for _, op := range opts {
+		op(&o)
+	}
+
+	return func(yield func(Node) bool) {
+		internalYield := func(n Node, level int) bool {
+			if o.maxDepth == -1 || level <= o.maxDepth {
+				yield(n)
+			}
+			return true
+		}
+		streamImpl(r, internalYield)
+	}
+}
+
+func streamImpl(r io.Reader, yield func(Node, int) bool) {
+	br := bufio.NewReader(r)
+	var stack []parent
+	var buf bytes.Buffer
+
+	flush := func() bool {
+		if buf.Len() == 0 {
+			return true
+		}
+		t := &Text{Value: buf.String()}
+		buf.Reset()
+		if len(stack) > 0 {
+			*stack[len(stack)-1].childrenPtr() = append(*stack[len(stack)-1].childrenPtr(), t)
+		}
+		return yield(t, len(stack)+1)
+	}
+
+	for {
+		ch, err := br.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				if !flush() {
+				}
+				for len(stack) > 0 {
+					n := stack[len(stack)-1]
+					stack = stack[:len(stack)-1]
+					if len(stack) > 0 {
+						*stack[len(stack)-1].childrenPtr() = append(*stack[len(stack)-1].childrenPtr(), n.(Node))
+					}
+					if !yield(n.(Node), len(stack)+1) {
+					}
+				}
+				return
+			}
+			return
+		}
+		switch ch {
+		case '[':
+			if !flush() {
+				return
+			}
+			var e error
+			stack, e = parseCommand(br, stack, len(stack)+1, yield)
+			if e != nil {
+				return
+			}
+		case ']':
+			if !flush() {
+				return
+			}
+			if len(stack) > 0 {
+				n := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				if len(stack) > 0 {
+					*stack[len(stack)-1].childrenPtr() = append(*stack[len(stack)-1].childrenPtr(), n.(Node))
+				}
+				if !yield(n.(Node), len(stack)+1) {
+					return
+				}
+			}
+		case '\\':
+			next, err := br.ReadByte()
+			if err != nil {
+				if err == io.EOF {
+					buf.WriteByte('\\')
+					continue
+				}
+				return
+			}
+			switch next {
+			case ' ', '[', ']', '=', '\\', '*', '/', '_':
+				buf.WriteByte(next)
+			default:
+				buf.WriteByte('\\')
+				buf.WriteByte(next)
+			}
+		default:
+			buf.WriteByte(ch)
+		}
+	}
+}
+
+// Parse reads markup from r and returns the root node.
+func Parse(r io.Reader) (*Root, error) {
+	nodes := slices.Collect(Stream(r, WithDepth(1)))
+	return &Root{Children: nodes}, nil
+}
+
+// ParseString parses markup from s and returns the root node.
+func ParseString(s string) (*Root, error) {
+	return Parse(strings.NewReader(s))
+}
+
+// ParseNodesReader parses r and returns only the top-level nodes.
+func ParseNodesReader(r io.Reader) ([]Node, error) {
+	return slices.Collect(Stream(r, WithDepth(1))), nil
+}
+
+// ParseNodes parses s and returns only the top-level nodes.
+func ParseNodes(s string) ([]Node, error) {
+	return ParseNodesReader(strings.NewReader(s))
+}
+
+func parseCommand(r *bufio.Reader, stack []parent, depth int, yield func(Node, int) bool) ([]parent, error) {
+	cmd, err := getNext(r, true)
+	if err != nil && err != io.EOF {
+		return stack, err
+	}
+	switch strings.ToLower(cmd) {
+	case "*", "b", "bold":
+		stack = append(stack, &Bold{})
+	case "/", "i", "italic":
+		stack = append(stack, &Italic{})
+	case "_", "u", "underline":
+		stack = append(stack, &Underline{})
+	case "^", "p", "power", "sup":
+		stack = append(stack, &Sup{})
+	case ".", "s", "sub":
+		stack = append(stack, &Sub{})
+	case "img", "image":
+		skipArgPrefix(r)
+		raw, err := getNext(r, false)
+		if err != nil && err != io.EOF {
+			return stack, err
+		}
+		n := &Image{Src: raw}
+		if len(stack) > 0 {
+			*stack[len(stack)-1].childrenPtr() = append(*stack[len(stack)-1].childrenPtr(), n)
+		}
+		yield(n, depth)
+	case "a", "link", "url":
+		skipArgPrefix(r)
+		raw, err := getNext(r, false)
+		if err != nil && err != io.EOF {
+			return stack, err
+		}
+		stack = append(stack, &Link{Href: raw})
+	case "code":
+		skipArgPrefix(r)
+		raw, err := directOutput(r, "[/code]", "code]")
+		if err != nil {
+			return stack, err
+		}
+		n := &Code{Value: raw}
+		if len(stack) > 0 {
+			*stack[len(stack)-1].childrenPtr() = append(*stack[len(stack)-1].childrenPtr(), n)
+		}
+		yield(n, depth)
+	case "quoteof":
+		skipArgPrefix(r)
+		name, err := getNext(r, false)
+		if err != nil && err != io.EOF {
+			return stack, err
+		}
+		stack = append(stack, &QuoteOf{Name: name})
+	case "quote", "q":
+		stack = append(stack, &Quote{})
+	case "spoiler", "sp":
+		stack = append(stack, &Spoiler{})
+	case "indent":
+		stack = append(stack, &Indent{})
+	case "hr":
+		n := &HR{}
+		if len(stack) > 0 {
+			*stack[len(stack)-1].childrenPtr() = append(*stack[len(stack)-1].childrenPtr(), n)
+		}
+		yield(n, depth)
+	default:
+		stack = append(stack, &Custom{Tag: cmd})
+	}
+	return stack, nil
+}
+
+func getNext(r *bufio.Reader, endAtEqual bool) (string, error) {
+	var result bytes.Buffer
+	for {
+		ch, err := r.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				return result.String(), io.EOF
+			}
+			return "", err
+		}
+		switch ch {
+		case '\n', ']', '[', ' ', '\r':
+			if err := r.UnreadByte(); err != nil {
+				return "", err
+			}
+			return result.String(), nil
+		case '=':
+			if endAtEqual {
+				if err := r.UnreadByte(); err != nil {
+					return "", err
+				}
+				return result.String(), nil
+			}
+			result.WriteByte(ch)
+		case '\\':
+			next, err := r.ReadByte()
+			if err != nil {
+				if err == io.EOF {
+					result.WriteByte('\\')
+					return result.String(), io.EOF
+				}
+				return "", err
+			}
+			switch next {
+			case ' ', '[', ']', '=', '\\', '*', '/', '_':
+				result.WriteByte(next)
+			default:
+				result.WriteByte('\\')
+				result.WriteByte(next)
+			}
+		default:
+			result.WriteByte(ch)
+		}
+	}
+}
+
+func skipArgPrefix(r *bufio.Reader) {
+	if ch, err := r.ReadByte(); err == nil {
+		if ch != '=' && ch != ' ' {
+			r.UnreadByte()
+		}
+	}
+}
+
+func directOutput(r *bufio.Reader, terminators ...string) (string, error) {
+	lens := make([]int, len(terminators))
+	for i, t := range terminators {
+		lens[i] = len(t)
+	}
+	var buf bytes.Buffer
+	for {
+		ch, err := r.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				return buf.String(), nil
+			}
+			return "", err
+		}
+		switch ch {
+		case '\\':
+			next, err := r.ReadByte()
+			if err != nil {
+				if err == io.EOF {
+					buf.WriteByte('\\')
+					return buf.String(), nil
+				}
+				return "", err
+			}
+			buf.WriteByte(next)
+		default:
+			buf.WriteByte(ch)
+			for idx, term := range terminators {
+				if buf.Len() >= lens[idx] && strings.EqualFold(term, buf.String()[buf.Len()-lens[idx]:]) {
+					out := buf.Bytes()[:buf.Len()-lens[idx]]
+					return string(out), nil
+				}
+			}
+		}
+	}
+}

--- a/a4code/parser_test.go
+++ b/a4code/parser_test.go
@@ -1,0 +1,63 @@
+package a4code
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseToHTML(t *testing.T) {
+	input := "[b Bold [i Italic]] plain"
+	ast, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	got := ToHTML(ast)
+	want := "<strong> Bold <i> Italic</i></strong> plain"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestParseImage(t *testing.T) {
+	ast, err := Parse(strings.NewReader("[img=image.jpg]"))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	got := ToHTML(ast)
+	want := "<img src=\"image.jpg\" />"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	input := "[b Hello [i world]]"
+	root, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	markup := ToA4Code(root)
+	root2, err := Parse(strings.NewReader(markup))
+	if err != nil {
+		t.Fatalf("reparse error: %v", err)
+	}
+	html1 := ToHTML(root)
+	html2 := ToHTML(root2)
+	if html1 != html2 {
+		t.Errorf("round trip mismatch: %q vs %q", html1, html2)
+	}
+}
+
+func TestParseNodes(t *testing.T) {
+	input := "[b foo][i bar]"
+	nodes, err := ParseNodes(input)
+	if err != nil {
+		t.Fatalf("parse nodes error: %v", err)
+	}
+	root := &Root{Children: nodes}
+	got := ToHTML(root)
+	want := "<strong> foo</strong><i> bar</i>"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}

--- a/a4code/sanitize.go
+++ b/a4code/sanitize.go
@@ -1,0 +1,20 @@
+package a4code
+
+import (
+	"html"
+	"net/url"
+)
+
+// SanitizeURL validates a hyperlink and returns a safe version.
+func SanitizeURL(raw string) (string, bool) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" {
+		return html.EscapeString(raw), false
+	}
+	switch u.Scheme {
+	case "http", "https":
+		return html.EscapeString(u.String()), true
+	default:
+		return html.EscapeString(raw), false
+	}
+}


### PR DESCRIPTION
## Summary
- eliminate the root placeholder from `streamImpl` so the parser only manages open tags
- adjust closing/flush logic to attach nodes when a parent exists and report the correct depth
- fix argument parsing for commands so optional `=` or spaces are skipped
- update tests to reflect new image parsing

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f003a2a3c832f9be15dca2dfe28c5