### PR TITLE
Remove unused helper

### DIFF
--- a/handlers/common/auto_refresh.go
+++ b/handlers/common/auto_refresh.go
@@ -23,11 +23,3 @@ func TaskDoneAutoRefreshPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 }
-
-// taskRedirectWithoutQueryArgs redirects the request to the same URL path
-// stripped of any query parameters using an HTTP 307 Temporary Redirect.
-func taskRedirectWithoutQueryArgs(w http.ResponseWriter, r *http.Request) {
-	u := r.URL
-	u.RawQuery = ""
-	http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)
-}


### PR DESCRIPTION
## Summary
- delete `taskRedirectWithoutQueryArgs` from `auto_refresh.go`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: undefined symbols in internal/dbstart)*
- `golangci-lint run ./...` *(fails: typecheck errors in internal/dbstart)*
- `go test ./...` *(fails: build errors in internal/dbstart)*

------
https://chatgpt.com/codex/tasks/task_e_686f6a5e2e08832fbc0d19a1945bd6ab