### PR TITLE
Remove unused forum email helpers

### DIFF
--- a/handlers/forum/email_helpers.go
+++ b/handlers/forum/email_helpers.go
@@ -5,23 +5,8 @@ import (
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/internal/email"
-	"github.com/arran4/goa4web/internal/emailutil"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
-
-// getAdminEmails returns a slice of administrator email addresses. Environment
-// variable ADMIN_EMAILS takes precedence over the database.
-func getAdminEmails(ctx context.Context, q *db.Queries) []string {
-	return emailutil.GetAdminEmails(ctx, q)
-}
-
-func adminNotificationsEnabled() bool {
-	return emailutil.AdminNotificationsEnabled()
-}
-
-func notifyAdmins(ctx context.Context, provider email.Provider, q *db.Queries, page string) {
-	notif.Notifier{EmailProvider: provider, Queries: q}.NotifyAdmins(ctx, page)
-}
 
 func notifyThreadSubscribers(ctx context.Context, provider email.Provider, q *db.Queries, threadID, excludeUser int32, page string) {
 	notif.Notifier{EmailProvider: provider, Queries: q}.NotifyThreadSubscribers(ctx, threadID, excludeUser, page)

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -127,7 +127,7 @@ func ThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	notifyThreadSubscribers(r.Context(), provider, queries, int32(threadId), uid, endUrl)
+	notif.Notifier{EmailProvider: provider, Queries: queries}.NotifyThreadSubscribers(r.Context(), int32(threadId), uid, endUrl)
 
 	http.Redirect(w, r, endUrl, http.StatusTemporaryRedirect)
 }

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -100,7 +100,7 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	notifyThreadSubscribers(r.Context(), provider, queries, threadRow.Idforumthread, uid, endUrl)
+	notif.Notifier{EmailProvider: provider, Queries: queries}.NotifyThreadSubscribers(r.Context(), threadRow.Idforumthread, uid, endUrl)
 
 	http.Redirect(w, r, endUrl, http.StatusTemporaryRedirect)
 }


### PR DESCRIPTION
## Summary
- drop unused helpers from `handlers/forum/email_helpers.go`
- call `notifications.Notifier` directly in forum handlers

## Testing
- `go vet ./...` *(fails: undefined symbols in internal/dbstart)*
- `golangci-lint run ./...` *(fails: could not import internal/dbstart)*
- `go test ./...` *(fails: undefined symbols in internal/dbstart)*

------
https://chatgpt.com/codex/tasks/task_e_686f6a4445b4832f9b2b902e118a5228