### PR TITLE
Fix tests

### DIFF
--- a/handlers/blogs/blogsCommentPage_replyable_test.go
+++ b/handlers/blogs/blogsCommentPage_replyable_test.go
@@ -29,7 +29,6 @@ func setupCommentRequest(t *testing.T, queries *db.Queries, store *sessions.Cook
 	}
 	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
 	ctx = context.WithValue(ctx, hcommon.KeyCoreData, &CoreData{})
-	ctx = context.WithValue(ctx, hcommon.KeySession, sess)
 	req = req.WithContext(ctx)
 	return req, sess
 }

--- a/internal/dbstart/dbstart.go
+++ b/internal/dbstart/dbstart.go
@@ -6,6 +6,9 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
+	"strings"
 
 	common "github.com/arran4/goa4web/core/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
@@ -53,7 +56,7 @@ func InitDB(cfg runtimeconfig.RuntimeConfig) *common.UserError {
 
 // PerformStartupChecks checks the database and upload directory configuration.
 func PerformStartupChecks(cfg runtimeconfig.RuntimeConfig) error {
-	if err := maybeAutoMigrate(cfg); err != nil {
+	if err := MaybeAutoMigrate(cfg); err != nil {
 		return err
 	}
 	if ue := InitDB(cfg); ue != nil {

--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"context"
 	"log"
 	"net/http"
 	"strings"


### PR DESCRIPTION
## Summary
- remove unused context import in taskbus middleware
- import os/filepath/strings for dbstart
- use `MaybeAutoMigrate` in startup checks
- drop obsolete session context use in blogs comment tests

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f70a8242c832fb2235a101e21410c