### PR TITLE
Centralize database migration helpers

### DIFF
--- a/cmd/goa4web/db_migrate.go
+++ b/cmd/goa4web/db_migrate.go
@@ -10,7 +10,7 @@ import (
 
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	dbdrivers "github.com/arran4/goa4web/internal/dbdrivers"
-	"github.com/arran4/goa4web/internal/migrate"
+	"github.com/arran4/goa4web/internal/dbstart"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -67,7 +67,7 @@ func (c *dbMigrateCmd) Run() error {
 	if c.rootCmd.Verbosity >= 0 {
 		fmt.Printf("applying migrations from %s\n", c.Dir)
 	}
-	if err := migrate.Apply(ctx, db, fsys, c.rootCmd.Verbosity >= 0); err != nil {
+	if err := dbstart.Apply(ctx, db, fsys, c.rootCmd.Verbosity >= 0); err != nil {
 		return err
 	}
 	return nil

--- a/internal/dbstart/automigrate.go
+++ b/internal/dbstart/automigrate.go
@@ -11,7 +11,6 @@ import (
 	"github.com/arran4/goa4web/config"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	dbdrivers "github.com/arran4/goa4web/internal/dbdrivers"
-	"github.com/arran4/goa4web/internal/migrate"
 	"github.com/arran4/goa4web/runtimeconfig"
 )
 
@@ -43,7 +42,7 @@ func applyMigrations(ctx context.Context, cfg runtimeconfig.RuntimeConfig) error
 		return err
 	}
 	fsys := os.DirFS("migrations")
-	return migrate.Apply(ctx, db, fsys, false)
+	return Apply(ctx, db, fsys, false)
 }
 
 // MaybeAutoMigrate runs migrations when enabled via AUTO_MIGRATE.

--- a/internal/dbstart/migrate_test.go
+++ b/internal/dbstart/migrate_test.go
@@ -1,4 +1,4 @@
-package migrate
+package dbstart
 
 import (
 	"context"

--- a/internal/dbstart/version_test.go
+++ b/internal/dbstart/version_test.go
@@ -1,4 +1,4 @@
-package migrate
+package dbstart
 
 import (
 	"io/fs"

--- a/startup_test.go
+++ b/startup_test.go
@@ -19,8 +19,6 @@ func TestEnsureSchemaVersionMatch(t *testing.T) {
 
 	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)")).
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM schema_version")).
-		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
 		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(hcommon.ExpectedSchemaVersion))
 
@@ -41,8 +39,6 @@ func TestEnsureSchemaVersionMismatch(t *testing.T) {
 
 	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)")).
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM schema_version")).
-		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
 		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(hcommon.ExpectedSchemaVersion - 1))
 


### PR DESCRIPTION
## Summary
- move migration helpers into `internal/dbstart`
- ensure migrations and schema checks share the same table helper
- update CLI and automated migration code
- refresh tests to use new package

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686fabb73724832f8a5c2765c2e6332a