### PR TITLE
Move handlers common utilities

### DIFF
--- a/handlers/common/redirect_test.go
+++ b/handlers/common/redirect_test.go
@@ -1,4 +1,4 @@
-package handlers
+package common
 
 import (
 	"net/http"

--- a/handlers/common/static.go
+++ b/handlers/common/static.go
@@ -1,4 +1,4 @@
-package handlers
+package common
 
 import (
 	"bytes"

--- a/handlers/images/routes.go
+++ b/handlers/images/routes.go
@@ -20,7 +20,6 @@ import (
 	db "github.com/arran4/goa4web/internal/db"
 	router "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/internal/upload"
-	handlerspkg "github.com/arran4/goa4web/pkg/handlers"
 	imagesign "github.com/arran4/goa4web/pkg/images"
 	"github.com/arran4/goa4web/runtimeconfig"
 	"github.com/disintegration/imaging"
@@ -63,7 +62,7 @@ func verify(data, tsStr, sig string) bool { return imagesign.Verify(data, tsStr,
 // RegisterRoutes attaches the image endpoints to r.
 func RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/images/upload/image", uploadHandler).Methods(http.MethodPost)
-	r.HandleFunc("/images/pasteimg.js", handlerspkg.PasteImageJS).Methods(http.MethodGet)
+	r.HandleFunc("/images/pasteimg.js", hcommon.PasteImageJS).Methods(http.MethodGet)
 	r.Handle("/images/image/{id}", verifyMiddleware("image:")(http.HandlerFunc(serveImage))).Methods(http.MethodGet)
 	r.Handle("/images/cache/{id}", verifyMiddleware("cache:")(http.HandlerFunc(serveCache))).Methods(http.MethodGet)
 }

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -9,7 +9,6 @@ import (
 
 	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
-	pkghandlers "github.com/arran4/goa4web/pkg/handlers"
 )
 
 var legacyRedirectsEnabled = true
@@ -37,8 +36,8 @@ func RegisterRoutes(r *mux.Router) {
 
 	if legacyRedirectsEnabled {
 		// legacy redirects
-		r.Path("/links").HandlerFunc(pkghandlers.RedirectPermanentPrefix("/links", "/linker"))
-		r.PathPrefix("/links/").HandlerFunc(pkghandlers.RedirectPermanentPrefix("/links", "/linker"))
+		r.Path("/links").HandlerFunc(hcommon.RedirectPermanentPrefix("/links", "/linker"))
+		r.PathPrefix("/links/").HandlerFunc(hcommon.RedirectPermanentPrefix("/links", "/linker"))
 	}
 }
 

--- a/handlers/user/routes.go
+++ b/handlers/user/routes.go
@@ -7,7 +7,6 @@ import (
 	auth "github.com/arran4/goa4web/handlers/auth"
 	"github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
-	"github.com/arran4/goa4web/pkg/handlers"
 )
 
 // RegisterRoutes attaches user account endpoints to the router.
@@ -43,8 +42,8 @@ func RegisterRoutes(r *mux.Router) {
 	ur.HandleFunc("/subscriptions/delete", userSubscriptionsDeleteAction).Methods(http.MethodPost).MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(common.TaskMatcher(common.TaskDelete))
 
 	// legacy redirects
-	r.HandleFunc("/user/lang", handlers.RedirectPermanent("/usr/lang"))
-	r.HandleFunc("/user/email", handlers.RedirectPermanent("/usr/email"))
+	r.HandleFunc("/user/lang", common.RedirectPermanent("/usr/lang"))
+	r.HandleFunc("/user/email", common.RedirectPermanent("/usr/email"))
 }
 
 // Register registers the user router module.

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -11,7 +11,6 @@ import (
 	router "github.com/arran4/goa4web/internal/router"
 
 	nav "github.com/arran4/goa4web/internal/navigation"
-	pkghandlers "github.com/arran4/goa4web/pkg/handlers"
 )
 
 var legacyRedirectsEnabled = true
@@ -44,8 +43,8 @@ func RegisterRoutes(r *mux.Router) {
 
 	if legacyRedirectsEnabled {
 		// legacy redirects
-		r.Path("/writing").HandlerFunc(pkghandlers.RedirectPermanentPrefix("/writing", "/writings"))
-		r.PathPrefix("/writing/").HandlerFunc(pkghandlers.RedirectPermanentPrefix("/writing", "/writings"))
+		r.Path("/writing").HandlerFunc(hcommon.RedirectPermanentPrefix("/writing", "/writings"))
+		r.PathPrefix("/writing/").HandlerFunc(hcommon.RedirectPermanentPrefix("/writing", "/writings"))
 	}
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -9,13 +9,12 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	handlers "github.com/arran4/goa4web/pkg/handlers"
 )
 
 // RegisterRoutes sets up all application routes on r.
 func RegisterRoutes(r *mux.Router) {
-	r.HandleFunc("/main.css", handlers.MainCSS).Methods("GET")
-	r.HandleFunc("/favicon.svg", handlers.Favicon).Methods("GET")
+	r.HandleFunc("/main.css", hcommon.MainCSS).Methods("GET")
+	r.HandleFunc("/favicon.svg", hcommon.Favicon).Methods("GET")
 
 	InitModules(r)
 


### PR DESCRIPTION
## Summary
- migrate static handler utilities from `pkg/handlers` into `handlers/common`
- remove old `pkg/handlers` module
- update imports to the new location

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686fb93ad4dc832f903d9d5e0a85d3c5