### PR TITLE
Ensure base user role

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -133,21 +133,19 @@ func ContainsItem(items []IndexItem, name string) bool {
 // Role returns the user role loaded lazily.
 func (cd *CoreData) Roles() []string {
 	roles, _ := cd.roles.load(func() ([]string, error) {
+		rs := []string{"anonymous"}
 		if cd.UserID == 0 || cd.queries == nil {
-			return []string{"anonymous"}, nil
+			return rs, nil
 		}
+		rs = append(rs, "user")
 		perms, err := cd.queries.GetPermissionsByUserID(cd.ctx, cd.UserID)
 		if err != nil {
-			return []string{"anonymous"}, nil
+			return rs, nil
 		}
-		var rs []string
 		for _, p := range perms {
 			if p.Role != "" {
 				rs = append(rs, p.Role)
 			}
-		}
-		if len(rs) == 0 {
-			rs = []string{"anonymous"}
 		}
 		return rs, nil
 	})

--- a/core/common/role.go
+++ b/core/common/role.go
@@ -38,10 +38,11 @@ func Allowed(r *http.Request, roles ...string) bool {
 		return false
 	}
 	perms, err := queries.GetPermissionsByUserID(r.Context(), uid)
-	if err != nil || len(perms) == 0 {
+	if err != nil {
 		return false
 	}
 	var rolesList []string
+	rolesList = append(rolesList, "anonymous", "user")
 	for _, p := range perms {
 		if p.Role != "" {
 			rolesList = append(rolesList, p.Role)

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -72,16 +72,13 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 
 		roles := []string{"anonymous"}
 		if uid != 0 {
+			roles = append(roles, "user")
 			perms, err := queries.GetPermissionsByUserID(r.Context(), uid)
 			if err == nil {
-				roles = roles[:0]
 				for _, p := range perms {
 					if p.Role != "" {
 						roles = append(roles, p.Role)
 					}
-				}
-				if len(roles) == 0 {
-					roles = []string{"anonymous"}
 				}
 			}
 		}

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -17,6 +17,10 @@ modelled via entries in the `grants` table with `section = 'role'`. For example,
 `administrator` inherits `moderator` and `content writer` which in turn inherit
 `user`.
 
+The `user` role does not need to be explicitly assigned. Any authenticated
+account automatically gains the `user` role while the `anonymous` role applies
+to every connection regardless of login state.
+
 ## Grants Table
 
 All permission rules live in the `grants` table. A grant may apply to a specific


### PR DESCRIPTION
## Summary
- automatically apply the `user` role to logged in users
- add the `anonymous` role for all connections
- update permissions documentation

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6874731809b4832fb21ef9705a499916