### PR TITLE
Add user image gallery

### DIFF
--- a/core/templates/templates/user/gallery.gohtml
+++ b/core/templates/templates/user/gallery.gohtml
@@ -1,0 +1,19 @@
+{{ template "head" $ }}
+<h2>Your Uploaded Images</h2>
+{{- if .Images }}
+<div class="gallery">
+    {{- range .Images }}
+    <div class="notification" style="display:inline-block;margin:0.5em;">
+        <a href="{{ .Full }}" target="_blank"><img src="{{ .Thumb }}" alt="image"></a><br>
+        <code>{{ .A4Code }}</code>
+    </div>
+    {{- end }}
+</div>
+<div>
+    {{- if $.PrevLink }}<a href="{{ $.PrevLink }}">Previous {{ $.PageSize }}</a>{{ end }}
+    {{- if $.NextLink }} <a href="{{ $.NextLink }}">Next {{ $.PageSize }}</a>{{ end }}
+</div>
+{{- else }}
+<p>No images uploaded.</p>
+{{- end }}
+{{ template "tail" $ }}

--- a/core/templates/templates/user/notifications.gohtml
+++ b/core/templates/templates/user/notifications.gohtml
@@ -11,7 +11,6 @@
 {{ else }}
     No notifications
 {{ end }}
-<hr>
 <form method="post" action="/usr/notifications">
     {{ csrfField }}
     <select name="email_id">

--- a/core/templates/templates/user/page.gohtml
+++ b/core/templates/templates/user/page.gohtml
@@ -3,6 +3,7 @@
         User preferences:<br><br>
         Modify <a href="/usr/lang">Language settings</a><br>
         Modify <a href="/usr/email">Email and notification settings</a><br>
+        View <a href="/usr/notifications/gallery">Your uploaded images</a><br>
         Modify <a href="/usr/paging">Pagination settings</a><br>
         Modify <a href="/usr/page-size">Page size config</a><br>
         Manage <a href="/usr/subscriptions">Subscriptions</a><br>

--- a/handlers/user/routes.go
+++ b/handlers/user/routes.go
@@ -34,6 +34,7 @@ func RegisterRoutes(r *mux.Router) {
 	ur.HandleFunc("/notifications", userNotificationEmailActionPage).Methods(http.MethodPost).MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(common.TaskMatcher(TaskSaveAll))
 	ur.HandleFunc("/notifications/dismiss", userNotificationsDismissActionPage).Methods(http.MethodPost).MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(common.TaskMatcher(TaskDismiss))
 	ur.HandleFunc("/notifications/rss", notificationsRssPage).Methods(http.MethodGet).MatcherFunc(auth.RequiresAnAccount())
+	ur.HandleFunc("/notifications/gallery", userGalleryPage).Methods(http.MethodGet).MatcherFunc(auth.RequiresAnAccount())
 	ur.HandleFunc("/subscriptions", userSubscriptionsPage).Methods(http.MethodGet).MatcherFunc(auth.RequiresAnAccount())
 	ur.HandleFunc("/subscriptions/add/blogs", userSubscriptionsAddBlogsAction).Methods(http.MethodPost).MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(common.TaskMatcher(common.TaskSubscribeBlogs))
 	ur.HandleFunc("/subscriptions/add/writings", userSubscriptionsAddWritingsAction).Methods(http.MethodPost).MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(common.TaskMatcher(common.TaskSubscribeWritings))

--- a/handlers/user/userGalleryPage.go
+++ b/handlers/user/userGalleryPage.go
@@ -1,0 +1,108 @@
+package user
+
+import (
+	"log"
+	"net/http"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+	corecommon "github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/templates"
+	common "github.com/arran4/goa4web/handlers/common"
+	imageshandler "github.com/arran4/goa4web/handlers/images"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+type galleryImage struct {
+	Thumb  string
+	Full   string
+	A4Code string
+}
+
+func userGalleryPage(w http.ResponseWriter, r *http.Request) {
+	session, ok := core.GetSessionOrFail(w, r)
+	if !ok {
+		return
+	}
+	uid, _ := session.Values["UID"].(int32)
+	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+
+	pageStr := r.URL.Query().Get("p")
+	page, _ := strconv.Atoi(pageStr)
+	if page < 1 {
+		page = 1
+	}
+
+	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	size := config.AppRuntimeConfig.PageSizeDefault
+	if pref, _ := cd.Preference(); pref != nil {
+		size = int(pref.PageSize)
+	}
+
+	offset := (page - 1) * size
+
+	rows, err := queries.ListUploadedImagesByUser(r.Context(), db.ListUploadedImagesByUserParams{
+		UsersIdusers: uid,
+		Limit:        int32(size + 1),
+		Offset:       int32(offset),
+	})
+	if err != nil {
+		log.Printf("list images: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	hasMore := len(rows) > size
+	if hasMore {
+		rows = rows[:size]
+	}
+
+	var imgs []galleryImage
+	for _, img := range rows {
+		if !img.Path.Valid {
+			continue
+		}
+		fname := path.Base(img.Path.String)
+		ext := filepath.Ext(fname)
+		id := strings.TrimSuffix(fname, ext)
+		thumb := id + "_thumb" + ext
+		imgs = append(imgs, galleryImage{
+			Thumb:  imageshandler.SignedCacheURL(thumb),
+			Full:   imageshandler.SignedURL("image:" + fname),
+			A4Code: "[img=image:" + fname + "]",
+		})
+	}
+
+	base := "/usr/notifications/gallery"
+	var nextLink, prevLink string
+	if hasMore {
+		nextLink = base + "?p=" + strconv.Itoa(page+1)
+	}
+	if page > 1 {
+		prevLink = base + "?p=" + strconv.Itoa(page-1)
+	}
+
+	data := struct {
+		*common.CoreData
+		Images   []galleryImage
+		NextLink string
+		PrevLink string
+		PageSize int
+	}{
+		CoreData: cd,
+		Images:   imgs,
+		NextLink: nextLink,
+		PrevLink: prevLink,
+		PageSize: size,
+	}
+
+	if err := templates.RenderTemplate(w, "gallery.gohtml", data, corecommon.NewFuncs(r)); err != nil {
+		log.Printf("template error: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/internal/db/queries-uploadimages.sql
+++ b/internal/db/queries-uploadimages.sql
@@ -5,3 +5,10 @@ INSERT INTO uploaded_images (
 
 -- name: GetUploadedImage :one
 SELECT * FROM uploaded_images WHERE iduploadedimage = ?;
+
+-- name: ListUploadedImagesByUser :many
+SELECT iduploadedimage, users_idusers, path, width, height, file_size, uploaded
+FROM uploaded_images
+WHERE users_idusers = ?
+ORDER BY uploaded DESC
+LIMIT ? OFFSET ?;


### PR DESCRIPTION
## Summary
- create paginated personal gallery under user notifications
- add link on user index page to the gallery
- support listing uploaded images in db queries

## Testing
- `go test ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_6874756b59d4832f82bf564275fb480a