### PR TITLE
Fix news page permission checks

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -103,6 +103,9 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 
 			cd := r.Context().Value(ContextValues("coreData")).(*CoreData)
 			for _, post := range posts {
+				if !cd.HasGrant("news", "post", "see", post.Idsitenews) {
+					continue
+				}
 				ann, err := queries.GetLatestAnnouncementByNewsID(r.Context(), post.Idsitenews)
 				if err != nil && !errors.Is(err, sql.ErrNoRows) {
 					return nil, fmt.Errorf("getLatestAnnouncementByNewsID: %w", err)

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -1,8 +1,15 @@
 package common
 
 import (
+	"context"
+	"database/sql"
 	"net/http/httptest"
+	"reflect"
 	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	dbpkg "github.com/arran4/goa4web/internal/db"
 )
 
 func TestTemplateFuncsFirstline(t *testing.T) {
@@ -23,5 +30,52 @@ func TestTemplateFuncsLeft(t *testing.T) {
 	}
 	if got := left(10, "hi"); got != "hi" {
 		t.Errorf("left long=%q", got)
+	}
+}
+
+func TestLatestNewsRespectsPermissions(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := dbpkg.New(db)
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"writerName", "writerId", "idsitenews", "forumthread_id", "language_idlanguage",
+		"users_idusers", "news", "occurred", "comments",
+	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, 0).AddRow("w", 1, 2, 0, 1, 1, "b", now, 0)
+
+	mock.ExpectQuery("SELECT u.username").WithArgs(int32(15), int32(0)).WillReturnRows(rows)
+
+	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "news", sql.NullString{String: "post", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnError(sql.ErrNoRows)
+
+	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "news", sql.NullString{String: "post", Valid: true}, "see", sql.NullInt32{Int32: 2, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnError(sql.ErrNoRows)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)
+	cd := NewCoreData(ctx, queries)
+	cd.UserID = 1
+	cd.SetRoles([]string{"user"})
+	ctx = context.WithValue(ctx, ContextValues("coreData"), cd)
+	req = req.WithContext(ctx)
+
+	funcs := cd.Funcs(req)
+	latestFn := funcs["LatestNews"].(func() (any, error))
+	res, err := latestFn()
+	if err != nil {
+		t.Fatalf("LatestNews: %v", err)
+	}
+	if l := reflect.ValueOf(res).Len(); l != 1 {
+		t.Fatalf("expected 1 news post, got %d", l)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- enforce news view permissions when building the LatestNews list
- test that LatestNews filters out restricted posts

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687482c207c4832fbe19675e3b2e1cd4