### PR TITLE
Improve subscription UI

### DIFF
--- a/core/templates/templates/user/subscriptions.gohtml
+++ b/core/templates/templates/user/subscriptions.gohtml
@@ -27,11 +27,9 @@
     <form method="post" action="/usr/subscriptions/add/{{ .Path }}" style="display:inline">
         {{ csrfField }}
         <input type="hidden" name="task" value="{{ .Task }}">
-        Method:
-        <select name="method">
-            <option value="internal">Internal</option>
-            <option value="email">Email</option>
-        </select>
+        Notify via:
+        <label><input type="checkbox" name="method" value="internal" checked>Internal</label>
+        <label><input type="checkbox" name="method" value="email">Email</label>
         <input type="submit" value="Subscribe">
         {{ .Name }}
     </form>

--- a/handlers/user/userSubscriptionsPage.go
+++ b/handlers/user/userSubscriptionsPage.go
@@ -20,10 +20,10 @@ type subscriptionOption struct {
 }
 
 var userSubscriptionOptions = []subscriptionOption{
-	{Name: "Blog posts", Pattern: "post:/blog/*", Path: "blogs", Task: common.TaskSubscribeBlogs},
-	{Name: "Writings", Pattern: "post:/writing/*", Path: "writings", Task: common.TaskSubscribeWritings},
-	{Name: "News posts", Pattern: "post:/news/*", Path: "news", Task: common.TaskSubscribeNews},
-	{Name: "Image board posts", Pattern: "post:/image/*", Path: "images", Task: common.TaskSubscribeImages},
+	{Name: "New blog posts", Pattern: "post:/blog/*", Path: "blogs", Task: common.TaskSubscribeBlogs},
+	{Name: "New articles", Pattern: "post:/writing/*", Path: "writings", Task: common.TaskSubscribeWritings},
+	{Name: "New news posts", Pattern: "post:/news/*", Path: "news", Task: common.TaskSubscribeNews},
+	{Name: "New image board posts", Pattern: "post:/image/*", Path: "images", Task: common.TaskSubscribeImages},
 }
 
 func userSubscriptionsPage(w http.ResponseWriter, r *http.Request) {
@@ -67,12 +67,14 @@ func addSubscription(w http.ResponseWriter, r *http.Request, pattern string) {
 		http.Redirect(w, r, "/usr/subscriptions?error="+err.Error(), http.StatusSeeOther)
 		return
 	}
-	method := r.PostFormValue("method")
+	methods := r.PostForm["method"]
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-	if err := queries.InsertSubscription(r.Context(), db.InsertSubscriptionParams{UsersIdusers: uid, Pattern: pattern, Method: method}); err != nil {
-		log.Printf("insert sub: %v", err)
-		http.Redirect(w, r, "/usr/subscriptions?error="+err.Error(), http.StatusSeeOther)
-		return
+	for _, method := range methods {
+		if err := queries.InsertSubscription(r.Context(), db.InsertSubscriptionParams{UsersIdusers: uid, Pattern: pattern, Method: method}); err != nil {
+			log.Printf("insert sub: %v", err)
+			http.Redirect(w, r, "/usr/subscriptions?error="+err.Error(), http.StatusSeeOther)
+			return
+		}
 	}
 	http.Redirect(w, r, "/usr/subscriptions", http.StatusSeeOther)
 }


### PR DESCRIPTION
## Summary
- clarify UI copy for subscription options
- allow multiple notification methods by selecting checkboxes
- permit submitting without choosing a method for no subscription

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68748536bc14832f9c06f701045354a1