### PR TITLE
Fix forgot password form routing

### DIFF
--- a/core/templates/templates/forgotPasswordPage.gohtml
+++ b/core/templates/templates/forgotPasswordPage.gohtml
@@ -3,6 +3,6 @@
     {{ csrfField }}
     Username: <input name="username"><br>
     New Password: <input name="password" type="password"><br>
-    <input type="submit" name="task" value="Submit">
+    <input type="submit" name="task" value="Password Reset">
 </form>
 {{ template "tail" $ }}

--- a/core/templates/templates/passwordVerifyPage.gohtml
+++ b/core/templates/templates/passwordVerifyPage.gohtml
@@ -2,6 +2,6 @@
 <form method="post" action="/login/verify">
     {{ csrfField }}
     Code: <input name="code">
-    <input type="submit" name="task" value="Submit">
+    <input type="submit" name="task" value="Password Verify">
 </form>
 {{ template "tail" $ }}

--- a/handlers/auth/routes.go
+++ b/handlers/auth/routes.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/arran4/gorillamuxlogic"
 	"github.com/gorilla/mux"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 )
 
@@ -17,11 +16,11 @@ func RegisterRoutes(r *mux.Router) {
 	lr := r.PathPrefix("/login").Subrouter()
 	lr.HandleFunc("", LoginTask.Page).Methods("GET").MatcherFunc(Not(RequiresAnAccount()))
 	lr.HandleFunc("", LoginTask.Action).Methods("POST").MatcherFunc(Not(RequiresAnAccount())).MatcherFunc(LoginTask.Match)
-	lr.HandleFunc("/verify", LoginVerifyPage).Methods("POST").MatcherFunc(Not(RequiresAnAccount())).MatcherFunc(hcommon.SaveAllTask.Match)
+	lr.HandleFunc("/verify", LoginVerifyPage).Methods("POST").MatcherFunc(Not(RequiresAnAccount())).MatcherFunc(VerifyPasswordTask.Match)
 
 	fr := r.PathPrefix("/forgot").Subrouter()
 	fr.HandleFunc("", ForgotPasswordPage).Methods("GET").MatcherFunc(Not(RequiresAnAccount()))
-	fr.HandleFunc("", ForgotPasswordActionPage).Methods("POST").MatcherFunc(Not(RequiresAnAccount())).MatcherFunc(hcommon.AddTask.Match)
+	fr.HandleFunc("", ForgotPasswordActionPage).Methods("POST").MatcherFunc(Not(RequiresAnAccount())).MatcherFunc(ResetPasswordTask.Match)
 }
 
 // Register registers the auth router module.

--- a/handlers/auth/task_events.go
+++ b/handlers/auth/task_events.go
@@ -9,3 +9,9 @@ var RegisterTask = hcommon.NewTaskEventWithHandlers(hcommon.TaskRegister, Regist
 
 // LoginTask represents user login.
 var LoginTask = hcommon.NewTaskEventWithHandlers(hcommon.TaskLogin, LoginUserPassPage, LoginActionPage)
+
+// ResetPasswordTask handles password reset requests.
+var ResetPasswordTask = hcommon.NewTaskEventWithHandlers(hcommon.TaskUserResetPassword, ForgotPasswordPage, ForgotPasswordActionPage)
+
+// VerifyPasswordTask handles password reset verification.
+var VerifyPasswordTask = hcommon.NewTaskEvent(hcommon.TaskPasswordVerify)

--- a/handlers/common/task_events.go
+++ b/handlers/common/task_events.go
@@ -31,4 +31,10 @@ var (
 	DeleteTask    = NewTaskEvent(TaskDelete)
 	CancelTask    = NewTaskEvent(TaskCancel)
 	EditReplyTask = NewTaskEvent(TaskEditReply)
+
+	// ResetPasswordTask handles password reset requests.
+	ResetPasswordTask = NewTaskEvent(TaskUserResetPassword)
+
+	// PasswordVerifyTask handles password reset verification.
+	PasswordVerifyTask = NewTaskEvent(TaskPasswordVerify)
 )

--- a/handlers/common/tasks.go
+++ b/handlers/common/tasks.go
@@ -237,6 +237,9 @@ const (
 	// TaskUserResetPassword resets a user's password.
 	TaskUserResetPassword = "Password Reset"
 
+	// TaskPasswordVerify verifies a password reset code.
+	TaskPasswordVerify = "Password Verify"
+
 	// TaskUserEmailVerification verifies a user's email address.
 	TaskUserEmailVerification = "Email Verification"
 


### PR DESCRIPTION
## Summary
- add `Password Reset` and `Password Verify` tasks
- wire password reset routes to the new task matchers
- update forgot password form to use `Password Reset`
- update verification form to use `Password Verify`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687489e3cc4c832fb3ac2f78b64fbb1a