### PR TITLE
Restrict writing access via grants

### DIFF
--- a/handlers/writings/matchers.go
+++ b/handlers/writings/matchers.go
@@ -2,6 +2,7 @@ package writings
 
 import (
 	"context"
+	"database/sql"
 	"log"
 	"net/http"
 	"strconv"
@@ -38,6 +39,7 @@ func RequireWritingAuthor(next http.Handler) http.Handler {
 		row, err := queries.GetWritingByIdForUserDescendingByPublishedDate(r.Context(), db.GetWritingByIdForUserDescendingByPublishedDateParams{
 			Userid:    uid,
 			Idwriting: int32(writingID),
+			UserID:    sql.NullInt32{Int32: uid, Valid: uid != 0},
 		})
 		if err != nil {
 			log.Printf("Error: %s", err)

--- a/handlers/writings/matchers_test.go
+++ b/handlers/writings/matchers_test.go
@@ -45,7 +45,7 @@ func TestRequireWritingAuthorArticleVar(t *testing.T) {
 		"idwriting", "users_idusers", "forumthread_idforumthread", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "WriterId", "WriterUsername",
 	}).AddRow(2, 1, 0, 1, 1, sql.NullString{}, sql.NullTime{}, sql.NullString{}, sql.NullString{}, sql.NullBool{}, sql.NullTime{}, 1, sql.NullString{})
 	mock.ExpectQuery("SELECT w.idwriting").
-		WithArgs(int32(1), int32(2), int32(1)).
+		WithArgs(int32(1), int32(1), int32(2), int32(1), sqlmock.AnyArg()).
 		WillReturnRows(rows)
 
 	called := false

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -76,10 +76,16 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 	writing, err := queries.GetWritingByIdForUserDescendingByPublishedDate(r.Context(), db.GetWritingByIdForUserDescendingByPublishedDateParams{
 		Userid:    uid,
 		Idwriting: int32(articleId),
+		UserID:    sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})
 	if err != nil {
 		log.Printf("getWritingByIdForUserDescendingByPublishedDate Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	if !cd.HasGrant("writing", "article", "view", writing.Idwriting) {
+		_ = templates.GetCompiledTemplates(corecommon.NewFuncs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
 		return
 	}
 
@@ -273,6 +279,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	post, err := queries.GetWritingByIdForUserDescendingByPublishedDate(r.Context(), db.GetWritingByIdForUserDescendingByPublishedDateParams{
 		Userid:    uid,
 		Idwriting: int32(aid),
+		UserID:    sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})
 	if err != nil {
 		log.Printf("getArticlePost Error: %s", err)

--- a/handlers/writings/writingsArticlePage_test.go
+++ b/handlers/writings/writingsArticlePage_test.go
@@ -50,7 +50,7 @@ func TestArticleReplyActionPage_UsesArticleParam(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT w.idwriting")).
-		WithArgs(int32(1), int32(1), int32(1)).
+		WithArgs(int32(1), int32(1), int32(1), int32(1), sqlmock.AnyArg()).
 		WillReturnError(sqlmock.ErrCancelled)
 
 	rr := httptest.NewRecorder()

--- a/handlers/writings/writingsCategoriesPage.go
+++ b/handlers/writings/writingsCategoriesPage.go
@@ -21,7 +21,7 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 		EditingCategoryId   int32
 		IsAdmin             bool
 		IsWriter            bool
-		Abstracts           []*db.GetPublicWritingsInCategoryRow
+		Abstracts           []*db.GetPublicWritingsInCategoryForUserRow
 		WritingCategoryID   int32
 	}
 
@@ -37,7 +37,10 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
-	categoryRows, err := queries.FetchAllCategories(r.Context())
+	categoryRows, err := queries.FetchCategoriesForUser(r.Context(), db.FetchCategoriesForUserParams{
+		ViewerID: data.CoreData.UserID,
+		UserID:   sql.NullInt32{Int32: data.CoreData.UserID, Valid: data.CoreData.UserID != 0},
+	})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -48,8 +51,10 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	writingsRows, err := queries.GetPublicWritingsInCategory(r.Context(), db.GetPublicWritingsInCategoryParams{
+	writingsRows, err := queries.GetPublicWritingsInCategoryForUser(r.Context(), db.GetPublicWritingsInCategoryForUserParams{
+		ViewerID:          data.CoreData.UserID,
 		WritingCategoryID: 0,
+		UserID:            sql.NullInt32{Int32: data.CoreData.UserID, Valid: data.CoreData.UserID != 0},
 		Limit:             15,
 		Offset:            0,
 	})
@@ -65,13 +70,21 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	categoryMap := map[int32]*db.WritingCategory{}
 	for _, cat := range categoryRows {
+		if !data.CoreData.HasGrant("writing", "category", "see", cat.Idwritingcategory) {
+			continue
+		}
 		categoryMap[cat.Idwritingcategory] = cat
 		if cat.WritingCategoryID == 0 {
 			data.Categories = append(data.Categories, cat)
 		}
 	}
 
-	data.Abstracts = writingsRows
+	for _, wrow := range writingsRows {
+		if !data.CoreData.HasGrant("writing", "article", "see", wrow.Idwriting) {
+			continue
+		}
+		data.Abstracts = append(data.Abstracts, wrow)
+	}
 
 	CustomWritingsIndex(data.CoreData, r)
 

--- a/handlers/writings/writingsFeed.go
+++ b/handlers/writings/writingsFeed.go
@@ -30,7 +30,11 @@ func feedGen(r *http.Request, queries *db.Queries) (*feeds.Feed, error) {
 		}
 	}
 
+	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
 	for _, row := range rows {
+		if !cd.HasGrant("writing", "article", "see", row.Idwriting) {
+			continue
+		}
 		desc := row.Abstract.String
 		if desc == "" {
 			desc = row.Writing.String

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -15,12 +15,67 @@ WHERE w.private = 0 AND w.users_idusers = ?
 ORDER BY w.published DESC
 LIMIT ? OFFSET ?;
 
+-- name: GetPublicWritingsByUserForViewer :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT w.*, u.username,
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
+FROM writing w
+LEFT JOIN users u ON w.users_idusers = u.idusers
+WHERE w.private = 0 AND w.users_idusers = sqlc.arg(author_id)
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='writing'
+      AND g.item='article'
+      AND g.action='see'
+      AND g.active=1
+      AND g.item_id = w.idwriting
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
+ORDER BY w.published DESC
+LIMIT ? OFFSET ?;
+
 -- name: GetPublicWritingsInCategory :many
 SELECT w.*, u.Username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) as Comments
 FROM writing w
 LEFT JOIN users u ON w.Users_Idusers=u.idusers
 WHERE w.private = 0 AND w.writing_category_id=?
+ORDER BY w.published DESC
+LIMIT ? OFFSET ?
+;
+
+-- name: GetPublicWritingsInCategoryForUser :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT w.*, u.Username,
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) as Comments
+FROM writing w
+LEFT JOIN users u ON w.Users_Idusers=u.idusers
+WHERE w.private = 0 AND w.writing_category_id = sqlc.arg(writing_category_id)
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='writing'
+      AND g.item='article'
+      AND g.action='see'
+      AND g.active=1
+      AND g.item_id = w.idwriting
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
 ORDER BY w.published DESC
 LIMIT ? OFFSET ?
 ;
@@ -35,11 +90,29 @@ INSERT INTO writing (writing_category_id, title, abstract, writing, private, lan
 VALUES (?, ?, ?, ?, ?, ?, NOW(), ?);
 
 -- name: GetWritingByIdForUserDescendingByPublishedDate :one
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(Userid)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
 SELECT w.*, u.idusers AS WriterId, u.Username AS WriterUsername
 FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
-LEFT JOIN writing_user_permissions wau ON w.idwriting = wau.writing_id AND wau.users_idusers = sqlc.arg(UserId)
-WHERE w.idwriting = ? AND (w.private = 0 OR wau.readdoc = 1 OR w.users_idusers = sqlc.arg(UserId))
+LEFT JOIN writing_user_permissions wau ON w.idwriting = wau.writing_id AND wau.users_idusers = sqlc.arg(Userid)
+WHERE w.idwriting = sqlc.arg(Idwriting) AND (w.private = 0 OR wau.can_read = 1 OR w.users_idusers = sqlc.arg(Userid))
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='writing'
+      AND g.item='article'
+      AND g.action='view'
+      AND g.active=1
+      AND g.item_id = w.idwriting
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
 ORDER BY w.published DESC
 ;
 
@@ -70,6 +143,28 @@ WHERE writing_category_id = ?;
 SELECT wc.*
 FROM writing_category wc
 ;
+
+-- name: FetchCategoriesForUser :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT wc.*
+FROM writing_category wc
+WHERE EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='writing'
+      AND g.item='category'
+      AND g.action='see'
+      AND g.active=1
+      AND g.item_id = wc.idwritingcategory
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+);
 
 -- name: DeleteWritingApproval :exec
 DELETE FROM writing_user_permissions


### PR DESCRIPTION
## Summary
- filter writing categories and articles by grants
- implement SQL queries with grant checks
- verify permissions in writing handlers
- adapt mocks and tests

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68748469cbf0832fa1a0815eff818466