### PR TITLE
Refactor subscription management

### DIFF
--- a/core/templates/templates/user/subscriptions.gohtml
+++ b/core/templates/templates/user/subscriptions.gohtml
@@ -21,18 +21,16 @@
 <p>No subscriptions</p>
 {{ end }}
 
-<h3>Add Subscription</h3>
-{{ range .Options }}
-<div>
-    <form method="post" action="/usr/subscriptions/add/{{ .Path }}" style="display:inline">
-        {{ csrfField }}
-        <input type="hidden" name="task" value="{{ .Task }}">
-        Notify via:
-        <label><input type="checkbox" name="method" value="internal" checked>Internal</label>
-        <label><input type="checkbox" name="method" value="email">Email</label>
-        <input type="submit" value="Subscribe">
+<h3>Update Subscriptions</h3>
+<form method="post" action="/usr/subscriptions/update">
+    {{ csrfField }}
+    {{ range .Options }}
+    <div>
         {{ .Name }}
-    </form>
-</div>
-{{ end }}
+        <label><input type="checkbox" name="{{ .Path }}_internal" {{ if index $.SubMap (printf "%s|internal" .Pattern) }}checked{{ end }}>Internal</label>
+        <label><input type="checkbox" name="{{ .Path }}_email" {{ if index $.SubMap (printf "%s|email" .Pattern) }}checked{{ end }}>Email</label>
+    </div>
+    {{ end }}
+    <input type="submit" value="Update">
+</form>
 {{ template "tail" $ }}

--- a/handlers/user/routes.go
+++ b/handlers/user/routes.go
@@ -36,10 +36,7 @@ func RegisterRoutes(r *mux.Router) {
 	ur.HandleFunc("/notifications/rss", notificationsRssPage).Methods(http.MethodGet).MatcherFunc(auth.RequiresAnAccount())
 	ur.HandleFunc("/notifications/gallery", userGalleryPage).Methods(http.MethodGet).MatcherFunc(auth.RequiresAnAccount())
 	ur.HandleFunc("/subscriptions", userSubscriptionsPage).Methods(http.MethodGet).MatcherFunc(auth.RequiresAnAccount())
-	ur.HandleFunc("/subscriptions/add/blogs", userSubscriptionsAddBlogsAction).Methods(http.MethodPost).MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(SubscribeBlogsTask.Match)
-	ur.HandleFunc("/subscriptions/add/writings", userSubscriptionsAddWritingsAction).Methods(http.MethodPost).MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(SubscribeWritingsTask.Match)
-	ur.HandleFunc("/subscriptions/add/news", userSubscriptionsAddNewsAction).Methods(http.MethodPost).MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(SubscribeNewsTask.Match)
-	ur.HandleFunc("/subscriptions/add/images", userSubscriptionsAddImagesAction).Methods(http.MethodPost).MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(SubscribeImagesTask.Match)
+	ur.HandleFunc("/subscriptions/update", userSubscriptionsUpdateAction).Methods(http.MethodPost).MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(UpdateSubscriptionsTask.Match)
 	ur.HandleFunc("/subscriptions/delete", userSubscriptionsDeleteAction).Methods(http.MethodPost).MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(DeleteTask.Match)
 
 	// legacy redirects

--- a/handlers/user/task_events.go
+++ b/handlers/user/task_events.go
@@ -9,10 +9,7 @@ var AddEmailTask = hcommon.NewTaskEvent(hcommon.TaskAdd)
 var DeleteEmailTask = hcommon.NewTaskEvent(hcommon.TaskDelete)
 var TestMailTask = hcommon.NewTaskEvent(TaskTestMail)
 var DismissTask = hcommon.NewTaskEvent(TaskDismiss)
-var SubscribeBlogsTask = hcommon.NewTaskEvent(hcommon.TaskSubscribeBlogs)
-var SubscribeWritingsTask = hcommon.NewTaskEvent(hcommon.TaskSubscribeWritings)
-var SubscribeNewsTask = hcommon.NewTaskEvent(hcommon.TaskSubscribeNews)
-var SubscribeImagesTask = hcommon.NewTaskEvent(hcommon.TaskSubscribeImages)
+var UpdateSubscriptionsTask = hcommon.NewTaskEvent(hcommon.TaskUpdate)
 
 // Permission management tasks used in the admin interface.
 var PermissionUserAllowTask = hcommon.NewTaskEvent(hcommon.TaskUserAllow)


### PR DESCRIPTION
## Summary
- replace per-option subscribe forms with a single update form
- create new handler `userSubscriptionsUpdateAction`
- remove legacy add subscription routes
- pass existing subscriptions to template for checkbox defaults

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68748e1e4fc8832fa73574e4f88effd9