### PR TITLE
enforce board permissions for imagebbs

### DIFF
--- a/handlers/imagebbs/imagebbsFeed_test.go
+++ b/handlers/imagebbs/imagebbsFeed_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestImagebbsFeed(t *testing.T) {
-	rows := []*db.GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCountRow{
+	rows := []*db.GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCountForUserRow{
 		{
 			Idimagepost:   1,
 			ForumthreadID: 2,

--- a/handlers/imagebbs/imagebbsPage.go
+++ b/handlers/imagebbs/imagebbsPage.go
@@ -28,7 +28,11 @@ func Page(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
-	subBoardRows, err := queries.GetAllBoardsByParentBoardId(r.Context(), 0)
+	subBoardRows, err := queries.GetAllBoardsByParentBoardIdForUser(r.Context(), db.GetAllBoardsByParentBoardIdForUserParams{
+		ViewerID:     data.CoreData.UserID,
+		ParentID:     0,
+		ViewerUserID: sql.NullInt32{Int32: data.CoreData.UserID, Valid: data.CoreData.UserID != 0},
+	})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/imagebbs/imagebbsPosterPage.go
+++ b/handlers/imagebbs/imagebbsPosterPage.go
@@ -17,7 +17,7 @@ import (
 func PosterPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		Posts    []*db.GetImagePostsByUserDescendingRow
+		Posts    []*db.GetImagePostsByUserDescendingForUserRow
 		Username string
 		IsOffset bool
 	}
@@ -39,8 +39,11 @@ func PosterPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows, err := queries.GetImagePostsByUserDescending(r.Context(), db.GetImagePostsByUserDescendingParams{
-		UsersIdusers: u.Idusers,
+	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	rows, err := queries.GetImagePostsByUserDescendingForUser(r.Context(), db.GetImagePostsByUserDescendingForUserParams{
+		ViewerID:     cd.UserID,
+		UserID:       u.Idusers,
+		ViewerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 		Limit:        15,
 		Offset:       int32(offset),
 	})
@@ -50,9 +53,11 @@ func PosterPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	filtered := rows
+
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
-		Posts:    rows,
+		CoreData: cd,
+		Posts:    filtered,
 		Username: username,
 		IsOffset: offset != 0,
 	}

--- a/internal/db/queries-imagebbs.sql
+++ b/internal/db/queries-imagebbs.sql
@@ -62,3 +62,129 @@ UPDATE imageboard SET deleted_at = NOW() WHERE idimageboard = ?;
 -- name: ApproveImagePost :exec
 UPDATE imagepost SET approved = 1 WHERE idimagepost = ?;
 
+
+-- name: GetAllBoardsByParentBoardIdForUser :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT b.*
+FROM imageboard b
+WHERE b.imageboard_idimageboard = sqlc.arg(parent_id)
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='imagebbs'
+      AND g.item='board'
+      AND g.action='see'
+      AND g.active=1
+      AND g.item_id = b.idimageboard
+      AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  );
+
+-- name: GetAllImageBoardsForUser :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT b.*
+FROM imageboard b
+WHERE EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='imagebbs'
+      AND g.item='board'
+      AND g.action='see'
+      AND g.active=1
+      AND g.item_id = b.idimageboard
+      AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  );
+
+-- name: GetImagePostsByUserDescendingForUser :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT i.*, u.username, th.comments
+FROM imagepost i
+LEFT JOIN users u ON i.users_idusers = u.idusers
+LEFT JOIN forumthread th ON i.forumthread_id = th.idforumthread
+WHERE i.users_idusers = sqlc.arg(user_id)
+  AND i.approved = 1
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='imagebbs'
+      AND g.item='board'
+      AND g.action='see'
+      AND g.active=1
+      AND g.item_id = i.imageboard_idimageboard
+      AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
+ORDER BY i.posted DESC
+LIMIT ? OFFSET ?;
+
+-- name: GetAllImagePostsByBoardIdWithAuthorUsernameAndThreadCommentCountForUser :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT i.*, u.username, th.comments
+FROM imagepost i
+LEFT JOIN users u ON i.users_idusers = u.idusers
+LEFT JOIN forumthread th ON i.forumthread_id = th.idforumthread
+WHERE i.imageboard_idimageboard = sqlc.arg(board_id)
+  AND i.approved = 1
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='imagebbs'
+      AND g.item='board'
+      AND g.action='view'
+      AND g.active=1
+      AND g.item_id = i.imageboard_idimageboard
+      AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  );
+
+-- name: GetAllImagePostsByIdWithAuthorUsernameAndThreadCommentCountForUser :one
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT i.*, u.username, th.comments
+FROM imagepost i
+LEFT JOIN users u ON i.users_idusers = u.idusers
+LEFT JOIN forumthread th ON i.forumthread_id = th.idforumthread
+WHERE i.idimagepost = sqlc.arg(id)
+  AND i.approved = 1
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='imagebbs'
+      AND g.item='board'
+      AND g.action='view'
+      AND g.active=1
+      AND g.item_id = i.imageboard_idimageboard
+      AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
+LIMIT 1;

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -33,7 +33,7 @@ columns are:
 | `created_at`, `updated_at` | Timestamps                                     |
 | `user_id`  | Optional user the rule targets                                 |
 | `role_id`  | Optional role the rule targets                                 |
-| `section`  | Permission area such as `forum`, `news`, `writing` or `role`   |
+| `section`  | Permission area such as `forum`, `news`, `writing`, `imagebbs` or `role`   |
 | `item`     | Optional item type (e.g. `topic`, `article`)                    |
 | `rule_type`| Type of rule, typically `allow` or `deny`                      |
 | `item_id`  | Optional item identifier                                       |
@@ -92,6 +92,7 @@ Some features store per-object defaults using role identifiers:
 - `topic_permissions` – default required roles for forum topics
 - `user_topic_permissions` – user specific topic rules
 - `writing_user_permissions` – per writing user access
+- `imagebbs` boards are secured via grants in the `imagebbs` section using the `board` item type
 
 These tables reference roles via `role_id` columns instead of legacy `level`
 fields.


### PR DESCRIPTION
## Summary
- secure board access checks in SQL rather than Go loops
- filter board lists and posts directly in queries
- update handlers to use new filtered queries
- fix variable usage for viewer ID

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687483cf41d0832fafe5d3120bedbcc9