### PR TITLE
Fix empty writings categories list

### DIFF
--- a/core/templates/templates/listWritingCategories.gohtml
+++ b/core/templates/templates/listWritingCategories.gohtml
@@ -1,6 +1,9 @@
 {{ define "listWritingCategories" }}
     <font size="4">{{ if $.WritingCategoryID }}Sub-{{ end }}Categories:</font><br>
     <table>
+        {{ if eq (len .Categories) 0 }}
+            <tr><td>There are no categories.</td></tr>
+        {{ end }}
         {{ range .Categories }}
             {{ $title := .Title.String }}
             {{ $description := .Description.String }}


### PR DESCRIPTION
## Summary
- show a message on the writings index when no categories exist

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68749701c14c832fac454c42b1ca5e63