### PR TITLE
Display message when no news posts

### DIFF
--- a/core/templates/templates/news/page.gohtml
+++ b/core/templates/templates/news/page.gohtml
@@ -2,6 +2,8 @@
     {{ template "head" $ }}
         {{ range LatestNews }}
             {{ template "newsPost" . }}
+        {{ else }}
+            <p>There is no news.</p>
         {{ end }}
     {{ template "tail" $ }}
 {{ end }}


### PR DESCRIPTION
## Summary
- show a message on the news index when there are no news posts

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687497afeb68832f8ff5591633a1229b