### PR TITLE
Optimize news permission checks

### DIFF
--- a/cmd/goa4web/news_comments_list.go
+++ b/cmd/goa4web/news_comments_list.go
@@ -49,7 +49,11 @@ func (c *newsCommentsListCmd) Run() error {
 	ctx := context.Background()
 	queries := dbpkg.New(db)
 	uid := int32(c.UserID)
-	n, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx, int32(c.ID))
+	n, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCountForUser(ctx, dbpkg.GetNewsPostByIdWithWriterIdAndThreadCommentCountForUserParams{
+		ViewerID: uid,
+		UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
+		ID:       int32(c.ID),
+	})
 	if err != nil {
 		return fmt.Errorf("get news: %w", err)
 	}

--- a/cmd/goa4web/news_comments_read.go
+++ b/cmd/goa4web/news_comments_read.go
@@ -61,7 +61,11 @@ func (c *newsCommentsReadCmd) Run() error {
 	ctx := context.Background()
 	queries := dbpkg.New(db)
 	uid := int32(c.UserID)
-	n, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx, int32(c.NewsID))
+	n, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCountForUser(ctx, dbpkg.GetNewsPostByIdWithWriterIdAndThreadCommentCountForUserParams{
+		ViewerID: uid,
+		UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
+		ID:       int32(c.NewsID),
+	})
 	if err != nil {
 		return fmt.Errorf("get news: %w", err)
 	}

--- a/cmd/goa4web/news_read.go
+++ b/cmd/goa4web/news_read.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"flag"
 	"fmt"
 	"strconv"
@@ -46,7 +47,11 @@ func (c *newsReadCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	row, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx, int32(c.ID))
+	row, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCountForUser(ctx, dbpkg.GetNewsPostByIdWithWriterIdAndThreadCommentCountForUserParams{
+		ViewerID: 0,
+		UserID:   sql.NullInt32{Int32: 0, Valid: false},
+		ID:       int32(c.ID),
+	})
 	if err != nil {
 		return fmt.Errorf("get news: %w", err)
 	}

--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -75,7 +75,7 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 				return LatestNews, nil
 			}
 			type Post struct {
-				*db.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow
+				*db.GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescendingRow
 				ShowReply    bool
 				ShowEdit     bool
 				Editing      bool
@@ -87,9 +87,11 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 
 			offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
-			posts, err := queries.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(r.Context(), db.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams{
-				Limit:  15,
-				Offset: int32(offset),
+			posts, err := queries.GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescending(r.Context(), db.GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescendingParams{
+				ViewerID: cd.UserID,
+				UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+				Limit:    15,
+				Offset:   int32(offset),
 			})
 			if err != nil {
 				switch {
@@ -111,7 +113,7 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 					return nil, fmt.Errorf("getLatestAnnouncementByNewsID: %w", err)
 				}
 				result = append(result, &Post{
-					GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow: post,
+					GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescendingRow: post,
 					ShowReply:    cd.UserID != 0,
 					ShowEdit:     (cd.HasRole("administrator") && cd.AdminMode) || (cd.HasRole("content writer") && cd.UserID == post.UsersIdusers),
 					Editing:      editingId == int(post.Idsitenews),

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -48,7 +48,7 @@ func TestLatestNewsRespectsPermissions(t *testing.T) {
 		"users_idusers", "news", "occurred", "comments",
 	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, 0).AddRow("w", 1, 2, 0, 1, 1, "b", now, 0)
 
-	mock.ExpectQuery("SELECT u.username").WithArgs(int32(15), int32(0)).WillReturnRows(rows)
+	mock.ExpectQuery("WITH RECURSIVE role_ids").WithArgs(int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
 
 	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "news", sql.NullString{String: "post", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))

--- a/handlers/news/newsRssPage.go
+++ b/handlers/news/newsRssPage.go
@@ -20,12 +20,14 @@ import (
 func NewsRssPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
-	posts, err := queries.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(r.Context(), db.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams{
-		Limit:  15,
-		Offset: 0,
+	posts, err := queries.GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescending(r.Context(), db.GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescendingParams{
+		ViewerID: cd.UserID,
+		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		Limit:    15,
+		Offset:   0,
 	})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		log.Printf("GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending: %s", err)
+		log.Printf("GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescending: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}

--- a/handlers/news/searchResultNewsActionPage.go
+++ b/handlers/news/searchResultNewsActionPage.go
@@ -18,7 +18,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*hcommon.CoreData
 		Comments           []*db.GetCommentsByIdsForUserWithThreadInfoRow
-		News               []*db.GetNewsPostsByIdsWithWriterIdAndThreadCommentCountRow
+		News               []*db.GetNewsPostsByIdsWithWriterIdAndThreadCommentCountForUserRow
 		CommentsNoResults  bool
 		CommentsEmptyWords bool
 		NoResults          bool
@@ -65,7 +65,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func NewsSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetNewsPostsByIdsWithWriterIdAndThreadCommentCountRow, bool, bool, error) {
+func NewsSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetNewsPostsByIdsWithWriterIdAndThreadCommentCountForUserRow, bool, bool, error) {
 	searchWords := searchutil.BreakupTextToWords(r.PostFormValue("searchwords"))
 	var newsIds []int32
 
@@ -113,7 +113,11 @@ func NewsSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid
 		}
 	}
 
-	news, err := queries.GetNewsPostsByIdsWithWriterIdAndThreadCommentCount(r.Context(), newsIds)
+	news, err := queries.GetNewsPostsByIdsWithWriterIdAndThreadCommentCountForUser(r.Context(), db.GetNewsPostsByIdsWithWriterIdAndThreadCommentCountForUserParams{
+		ViewerID: uid,
+		UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
+		Newsids:  newsIds,
+	})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -25,6 +25,31 @@ LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
 WHERE s.idsiteNews = ?
 ;
 
+-- name: GetNewsPostByIdWithWriterIdAndThreadCommentCountForUser :one
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT u.username AS writerName, u.idusers as writerId, s.*, th.comments as Comments
+FROM site_news s
+LEFT JOIN users u ON s.users_idusers = u.idusers
+LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+WHERE s.idsiteNews = sqlc.arg(id)
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='news'
+      AND g.item='post'
+      AND g.action='view'
+      AND g.active=1
+      AND g.item_id = s.idsiteNews
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  );
+
 -- name: GetNewsPostsByIdsWithWriterIdAndThreadCommentCount :many
 SELECT u.username AS writerName, u.idusers as writerId, s.*, th.comments as Comments
 FROM site_news s
@@ -32,6 +57,31 @@ LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
 WHERE s.Idsitenews IN (sqlc.slice(newsIds))
 ;
+
+-- name: GetNewsPostsByIdsWithWriterIdAndThreadCommentCountForUser :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT u.username AS writerName, u.idusers as writerId, s.*, th.comments as Comments
+FROM site_news s
+LEFT JOIN users u ON s.users_idusers = u.idusers
+LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+WHERE s.Idsitenews IN (sqlc.slice(newsIds))
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='news'
+      AND g.item='post'
+      AND g.action='see'
+      AND g.active=1
+      AND g.item_id = s.idsiteNews
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  );
 
 -- name: GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending :many
 SELECT u.username AS writerName, u.idusers as writerId, s.*, th.comments as Comments
@@ -42,3 +92,28 @@ ORDER BY s.occurred DESC
 LIMIT ? OFFSET ?
 ;
 
+-- name: GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescending :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT u.username AS writerName, u.idusers as writerId, s.*, th.comments as Comments
+FROM site_news s
+LEFT JOIN users u ON s.users_idusers = u.idusers
+LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+WHERE EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='news'
+      AND g.item='post'
+      AND g.action='see'
+      AND g.active=1
+      AND g.item_id = s.idsiteNews
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+)
+ORDER BY s.occurred DESC
+LIMIT ? OFFSET ?;

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -106,6 +106,67 @@ func (q *Queries) GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx context.C
 	return &i, err
 }
 
+const getNewsPostByIdWithWriterIdAndThreadCommentCountForUser = `-- name: GetNewsPostByIdWithWriterIdAndThreadCommentCountForUser :one
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT u.username AS writerName, u.idusers as writerId, s.idsitenews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
+FROM site_news s
+LEFT JOIN users u ON s.users_idusers = u.idusers
+LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+WHERE s.idsiteNews = ?
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='news'
+      AND g.item='post'
+      AND g.action='view'
+      AND g.active=1
+      AND g.item_id = s.idsiteNews
+      AND (g.user_id = ? OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
+`
+
+type GetNewsPostByIdWithWriterIdAndThreadCommentCountForUserParams struct {
+	ViewerID int32
+	ID       int32
+	UserID   sql.NullInt32
+}
+
+type GetNewsPostByIdWithWriterIdAndThreadCommentCountForUserRow struct {
+	Writername         sql.NullString
+	Writerid           sql.NullInt32
+	Idsitenews         int32
+	ForumthreadID      int32
+	LanguageIdlanguage int32
+	UsersIdusers       int32
+	News               sql.NullString
+	Occurred           sql.NullTime
+	Comments           sql.NullInt32
+}
+
+func (q *Queries) GetNewsPostByIdWithWriterIdAndThreadCommentCountForUser(ctx context.Context, arg GetNewsPostByIdWithWriterIdAndThreadCommentCountForUserParams) (*GetNewsPostByIdWithWriterIdAndThreadCommentCountForUserRow, error) {
+	row := q.db.QueryRowContext(ctx, getNewsPostByIdWithWriterIdAndThreadCommentCountForUser, arg.ViewerID, arg.ID, arg.UserID)
+	var i GetNewsPostByIdWithWriterIdAndThreadCommentCountForUserRow
+	err := row.Scan(
+		&i.Writername,
+		&i.Writerid,
+		&i.Idsitenews,
+		&i.ForumthreadID,
+		&i.LanguageIdlanguage,
+		&i.UsersIdusers,
+		&i.News,
+		&i.Occurred,
+		&i.Comments,
+	)
+	return &i, err
+}
+
 const getNewsPostsByIdsWithWriterIdAndThreadCommentCount = `-- name: GetNewsPostsByIdsWithWriterIdAndThreadCommentCount :many
 SELECT u.username AS writerName, u.idusers as writerId, s.idsitenews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
@@ -169,6 +230,95 @@ func (q *Queries) GetNewsPostsByIdsWithWriterIdAndThreadCommentCount(ctx context
 	return items, nil
 }
 
+const getNewsPostsByIdsWithWriterIdAndThreadCommentCountForUser = `-- name: GetNewsPostsByIdsWithWriterIdAndThreadCommentCountForUser :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT u.username AS writerName, u.idusers as writerId, s.idsitenews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
+FROM site_news s
+LEFT JOIN users u ON s.users_idusers = u.idusers
+LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+WHERE s.Idsitenews IN (/*SLICE:newsids*/?)
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='news'
+      AND g.item='post'
+      AND g.action='see'
+      AND g.active=1
+      AND g.item_id = s.idsiteNews
+      AND (g.user_id = ? OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
+`
+
+type GetNewsPostsByIdsWithWriterIdAndThreadCommentCountForUserParams struct {
+	ViewerID int32
+	Newsids  []int32
+	UserID   sql.NullInt32
+}
+
+type GetNewsPostsByIdsWithWriterIdAndThreadCommentCountForUserRow struct {
+	Writername         sql.NullString
+	Writerid           sql.NullInt32
+	Idsitenews         int32
+	ForumthreadID      int32
+	LanguageIdlanguage int32
+	UsersIdusers       int32
+	News               sql.NullString
+	Occurred           sql.NullTime
+	Comments           sql.NullInt32
+}
+
+func (q *Queries) GetNewsPostsByIdsWithWriterIdAndThreadCommentCountForUser(ctx context.Context, arg GetNewsPostsByIdsWithWriterIdAndThreadCommentCountForUserParams) ([]*GetNewsPostsByIdsWithWriterIdAndThreadCommentCountForUserRow, error) {
+	query := getNewsPostsByIdsWithWriterIdAndThreadCommentCountForUser
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.ViewerID)
+	if len(arg.Newsids) > 0 {
+		for _, v := range arg.Newsids {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:newsids*/?", strings.Repeat(",?", len(arg.Newsids))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:newsids*/?", "NULL", 1)
+	}
+	queryParams = append(queryParams, arg.UserID)
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetNewsPostsByIdsWithWriterIdAndThreadCommentCountForUserRow
+	for rows.Next() {
+		var i GetNewsPostsByIdsWithWriterIdAndThreadCommentCountForUserRow
+		if err := rows.Scan(
+			&i.Writername,
+			&i.Writerid,
+			&i.Idsitenews,
+			&i.ForumthreadID,
+			&i.LanguageIdlanguage,
+			&i.UsersIdusers,
+			&i.News,
+			&i.Occurred,
+			&i.Comments,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getNewsPostsWithWriterUsernameAndThreadCommentCountDescending = `-- name: GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending :many
 SELECT u.username AS writerName, u.idusers as writerId, s.idsitenews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
@@ -204,6 +354,90 @@ func (q *Queries) GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(
 	var items []*GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow
 	for rows.Next() {
 		var i GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow
+		if err := rows.Scan(
+			&i.Writername,
+			&i.Writerid,
+			&i.Idsitenews,
+			&i.ForumthreadID,
+			&i.LanguageIdlanguage,
+			&i.UsersIdusers,
+			&i.News,
+			&i.Occurred,
+			&i.Comments,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescending = `-- name: GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescending :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT u.username AS writerName, u.idusers as writerId, s.idsitenews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
+FROM site_news s
+LEFT JOIN users u ON s.users_idusers = u.idusers
+LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+WHERE EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='news'
+      AND g.item='post'
+      AND g.action='see'
+      AND g.active=1
+      AND g.item_id = s.idsiteNews
+      AND (g.user_id = ? OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+)
+ORDER BY s.occurred DESC
+LIMIT ? OFFSET ?
+`
+
+type GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescendingParams struct {
+	ViewerID int32
+	UserID   sql.NullInt32
+	Limit    int32
+	Offset   int32
+}
+
+type GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescendingRow struct {
+	Writername         sql.NullString
+	Writerid           sql.NullInt32
+	Idsitenews         int32
+	ForumthreadID      int32
+	LanguageIdlanguage int32
+	UsersIdusers       int32
+	News               sql.NullString
+	Occurred           sql.NullTime
+	Comments           sql.NullInt32
+}
+
+func (q *Queries) GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescending(ctx context.Context, arg GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescendingParams) ([]*GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescendingRow, error) {
+	rows, err := q.db.QueryContext(ctx, getNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescending,
+		arg.ViewerID,
+		arg.UserID,
+		arg.Limit,
+		arg.Offset,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescendingRow
+	for rows.Next() {
+		var i GetNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescendingRow
 		if err := rows.Scan(
 			&i.Writername,
 			&i.Writerid,


### PR DESCRIPTION
## Summary
- embed grant checks directly into news queries
- keep HasGrant validation in LatestNews and RSS
- adjust page handlers and CLI to use new queries

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6874887e1e1c832faf18e91044d6c6ce