### PR TITLE
Fix blogger listing permissions

### DIFF
--- a/handlers/blogs/bloggerListPage.go
+++ b/handlers/blogs/bloggerListPage.go
@@ -41,14 +41,16 @@ func BloggerListPage(w http.ResponseWriter, r *http.Request) {
 	var err error
 	if data.Search != "" {
 		rows, err = queries.SearchBloggers(r.Context(), db.SearchBloggersParams{
-			Query:  data.Search,
-			Limit:  int32(pageSize + 1),
-			Offset: int32(offset),
+			ViewerID: data.UserID,
+			Query:    data.Search,
+			Limit:    int32(pageSize + 1),
+			Offset:   int32(offset),
 		})
 	} else {
 		rows, err = queries.ListBloggers(r.Context(), db.ListBloggersParams{
-			Limit:  int32(pageSize + 1),
-			Offset: int32(offset),
+			ViewerID: data.UserID,
+			Limit:    int32(pageSize + 1),
+			Offset:   int32(offset),
 		})
 	}
 	if err != nil {

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -86,3 +86,68 @@ LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE b.users_idusers = ?
 ORDER BY b.written DESC;
+
+-- name: ListBloggersForViewer :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT u.username, COUNT(b.idblogs) AS count
+FROM blogs b
+JOIN users u ON b.users_idusers = u.idusers
+WHERE (
+    NOT EXISTS (SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id))
+    OR b.language_idlanguage IN (
+        SELECT ul.language_idlanguage FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+    )
+)
+AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section = 'blogs'
+      AND g.item = 'entry'
+      AND g.action = 'see'
+      AND g.active = 1
+      AND g.item_id = b.idblogs
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+)
+GROUP BY u.idusers
+ORDER BY u.username
+LIMIT ? OFFSET ?;
+
+-- name: SearchBloggersForViewer :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT u.username, COUNT(b.idblogs) AS count
+FROM blogs b
+JOIN users u ON b.users_idusers = u.idusers
+WHERE (LOWER(u.username) LIKE LOWER(sqlc.arg(query)) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(sqlc.arg(query)))
+  AND (
+    NOT EXISTS (SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id))
+    OR b.language_idlanguage IN (
+        SELECT ul.language_idlanguage FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+    )
+  )
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section = 'blogs'
+      AND g.item = 'entry'
+      AND g.action = 'see'
+      AND g.active = 1
+      AND g.item_id = b.idblogs
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
+GROUP BY u.idusers
+ORDER BY u.username
+LIMIT ? OFFSET ?;


### PR DESCRIPTION
## Summary
- query accessible blogs for each viewer
- expose new ListBloggersForViewer and SearchBloggersForViewer SQL queries
- convert ListBloggers/SearchBloggers helpers to use the new queries
- pass viewer ID in blogger list handler so counts respect permissions

## Testing
- `go vet ./...`
- `go test ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_687497499b98832fb54b10345095ae87