### PR TITLE
Handle unauthorized news post

### DIFF
--- a/core/templates/templates/admin/noAccessPage.gohtml
+++ b/core/templates/templates/admin/noAccessPage.gohtml
@@ -1,4 +1,4 @@
 {{ template "head" $ }}
     [<a href="/admin">Admin</a>]<br />
-You do not have permission to access this page.
+The requested content may not exist or you may not have permission to access it.
 {{ template "tail" $ }}

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -7,6 +7,7 @@ import (
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/a4code"
+	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	common "github.com/arran4/goa4web/handlers/common"
 	"log"
@@ -78,9 +79,15 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 		ID:            int32(blogId),
 	})
 	if err != nil {
-		log.Printf("getBlogEntryForUserById_comments Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			_ = templates.GetCompiledTemplates(corecommon.NewFuncs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
+			return
+		default:
+			log.Printf("getBlogEntryForUserById_comments Error: %s", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	editUrl := ""

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -134,9 +134,15 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 		ViewerUserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})
 	if err != nil {
-		log.Printf("getAllBoardsByParentBoardId Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			_ = templates.GetCompiledTemplates(corecommon.NewFuncs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
+			return
+		default:
+			log.Printf("getAllBoardsByParentBoardId Error: %s", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	data.ImagePost = post
@@ -183,9 +189,15 @@ func BoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		ViewerUserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})
 	if err != nil {
-		log.Printf("getAllBoardsByParentBoardId Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			_ = templates.GetCompiledTemplates(corecommon.NewFuncs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData))
+			return
+		default:
+			log.Printf("getAllBoardsByParentBoardId Error: %s", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	var pthid int32 = post.ForumthreadID

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -79,9 +79,15 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		UserID:    sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})
 	if err != nil {
-		log.Printf("getWritingByIdForUserDescendingByPublishedDate Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			_ = templates.GetCompiledTemplates(corecommon.NewFuncs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
+			return
+		default:
+			log.Printf("getWritingByIdForUserDescendingByPublishedDate Error: %s", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	if !cd.HasGrant("writing", "article", "view", writing.Idwriting) {
@@ -282,9 +288,15 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		UserID:    sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})
 	if err != nil {
-		log.Printf("getArticlePost Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			_ = templates.GetCompiledTemplates(corecommon.NewFuncs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData))
+			return
+		default:
+			log.Printf("getArticlePost Error: %s", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	var pthid int32 = post.ForumthreadID


### PR DESCRIPTION
## Summary
- return `noAccessPage` when DB lookups fail on various pages
- use a switch statement for consistent error handling

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68749805ca90832fb183790d413015ca