### PR TITLE
Fix news functions references

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -101,7 +101,7 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 				switch {
 				case errors.Is(err, sql.ErrNoRows):
 				default:
-					return nil, fmt.Errorf("getNewsPostsWithWriterUsernameAndThreadCommentCountDescending: %w", err)
+					return nil, fmt.Errorf("getNewsPostsWithWriterUsernameAndThreadCommentCountForUserDescending: %w", err)
 				}
 			}
 

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -91,7 +91,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 			_ = templates.GetCompiledTemplates(corecommon.NewFuncs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
 			return
 		default:
-			log.Printf("getNewsPostByIdWithWriterIdAndThreadCommentCount Error: %s", err)
+			log.Printf("GetNewsPostByIdWithWriterIdAndThreadCommentCountForUser Error: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
@@ -236,7 +236,7 @@ func NewsPostReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})
 	if err != nil {
-		log.Printf("getNewsPostByIdWithWriterIdAndThreadCommentCount Error: %s", err)
+		log.Printf("GetNewsPostByIdWithWriterIdAndThreadCommentCountForUser Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary
- fix typo in error message in `core/common`
- update log messages in `newsPostPage` to reference the correct function

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687509a450a0832f9ae54701c0d5627a