### PR TITLE
Add user-filtered news query

### DIFF
--- a/handlers/news/searchResultNewsActionPage.go
+++ b/handlers/news/searchResultNewsActionPage.go
@@ -18,7 +18,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*hcommon.CoreData
 		Comments           []*db.GetCommentsByIdsForUserWithThreadInfoRow
-		News               []*db.GetNewsPostsByIdsWithWriterIdAndThreadCommentCountRow
+		News               []*db.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow
 		CommentsNoResults  bool
 		CommentsEmptyWords bool
 		NoResults          bool
@@ -65,7 +65,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func NewsSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetNewsPostsByIdsWithWriterIdAndThreadCommentCountRow, bool, bool, error) {
+func NewsSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow, bool, bool, error) {
 	searchWords := searchutil.BreakupTextToWords(r.PostFormValue("searchwords"))
 	var newsIds []int32
 
@@ -113,7 +113,7 @@ func NewsSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid
 		}
 	}
 
-	news, err := queries.GetNewsPostsByIdsWithWriterIdAndThreadCommentCount(r.Context(), db.GetNewsPostsByIdsWithWriterIdAndThreadCommentCountParams{
+	news, err := queries.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount(r.Context(), db.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountParams{
 		ViewerID: uid,
 		Newsids:  newsIds,
 		UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},

--- a/handlers/news/search_test.go
+++ b/handlers/news/search_test.go
@@ -1,0 +1,63 @@
+package news
+
+import (
+	"context"
+	"database/sql"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+func TestNewsSearchFiltersUnauthorized(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+
+	queries := dbpkg.New(sqldb)
+
+	firstRows := sqlmock.NewRows([]string{"site_news_id"}).AddRow(1).AddRow(2)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT DISTINCT cs.site_news_id")).
+		WithArgs(sql.NullString{String: "foo", Valid: true}).
+		WillReturnRows(firstRows)
+
+	newsRows := sqlmock.NewRows([]string{
+		"writerName", "writerId", "idsitenews", "forumthread_id",
+		"language_idlanguage", "users_idusers", "news", "occurred", "Comments",
+	}).AddRow("bob", 1, 1, 0, 1, 1, "text", time.Unix(0, 0), 0)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.username AS writerName")).
+		WithArgs(int32(1), int32(1), int32(2), sql.NullInt32{Int32: 1, Valid: true}).
+		WillReturnRows(newsRows)
+
+	form := url.Values{"searchwords": {"foo"}}
+	req := httptest.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	news, emptyWords, noResults, err := NewsSearch(rr, req, queries, 1)
+	if err != nil {
+		t.Fatalf("NewsSearch: %v", err)
+	}
+	if emptyWords || noResults {
+		t.Fatalf("unexpected flags")
+	}
+	if len(news) != 1 {
+		t.Fatalf("expected 1 result got %d", len(news))
+	}
+	if news[0].Idsitenews != 1 {
+		t.Errorf("unexpected id %d", news[0].Idsitenews)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -68,6 +68,31 @@ WHERE s.Idsitenews IN (sqlc.slice(newsIds)) AND EXISTS (
 )
 ORDER BY s.occurred DESC;
 
+-- name: GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT u.username AS writerName, u.idusers as writerId, s.*, th.comments as Comments
+FROM site_news s
+LEFT JOIN users u ON s.users_idusers = u.idusers
+LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+WHERE s.Idsitenews IN (sqlc.slice(newsIds)) AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='news'
+      AND g.item='post'
+      AND g.action='view'
+      AND g.active=1
+      AND g.item_id = s.idsiteNews
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+)
+ORDER BY s.occurred DESC;
+
 -- name: GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)


### PR DESCRIPTION
## Summary
- add query `GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount`
- use new query in news search handler
- add regression test ensuring unauthorised posts are filtered

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68750964eab0832f9e1fa4729c91b129