### PR TITLE
Add CLI user rejection and profile features

### DIFF
--- a/cmd/goa4web/templates/user_comments_usage.txt
+++ b/cmd/goa4web/templates/user_comments_usage.txt
@@ -1,0 +1,13 @@
+Usage:
+  {{.Prog}} user comments <command> [<args>]
+
+Commands:
+  list        list admin comments for a user
+  add         add an admin comment to a user
+
+Examples:
+  {{.Prog}} user comments list -id 3
+  {{.Prog}} user comments add -id 3 -comment "needs review"
+
+Flags:
+{{template "flags" .Flags}}

--- a/cmd/goa4web/templates/user_usage.txt
+++ b/cmd/goa4web/templates/user_usage.txt
@@ -8,11 +8,18 @@ Commands:
   list        list users
   deactivate  deactivate a user
   activate    restore a deactivated user
+  approve     approve a pending user
+  reject      reject a pending user
+  comments    manage admin comments for a user
+  profile     show user profile information
 
 Examples:
   {{.Prog}} user add -username bob -password secret
   {{.Prog}} user deactivate -username bob
   {{.Prog}} user list
+  {{.Prog}} user approve -id 3
+  {{.Prog}} user reject -id 3 -reason spam
+  {{.Prog}} user comments list -id 3
 
 Flags:
 {{template "flags" .Flags}}

--- a/cmd/goa4web/user.go
+++ b/cmd/goa4web/user.go
@@ -75,6 +75,30 @@ func (c *userCmd) Run() error {
 			return fmt.Errorf("activate: %w", err)
 		}
 		return cmd.Run()
+	case "approve":
+		cmd, err := parseUserApproveCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("approve: %w", err)
+		}
+		return cmd.Run()
+	case "reject":
+		cmd, err := parseUserRejectCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("reject: %w", err)
+		}
+		return cmd.Run()
+	case "comments":
+		cmd, err := parseUserCommentsCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("comments: %w", err)
+		}
+		return cmd.Run()
+	case "profile":
+		cmd, err := parseUserProfileCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("profile: %w", err)
+		}
+		return cmd.Run()
 	default:
 		c.fs.Usage()
 		return fmt.Errorf("unknown user command %q", c.args[0])

--- a/cmd/goa4web/user_approve.go
+++ b/cmd/goa4web/user_approve.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/utils/emailutil"
+)
+
+// userApproveCmd approves a pending user account.
+type userApproveCmd struct {
+	*userCmd
+	fs       *flag.FlagSet
+	ID       int
+	Username string
+	args     []string
+}
+
+func parseUserApproveCmd(parent *userCmd, args []string) (*userApproveCmd, error) {
+	c := &userApproveCmd{userCmd: parent}
+	fs, rest, err := parseFlags("approve", args, func(fs *flag.FlagSet) {
+		fs.IntVar(&c.ID, "id", 0, "user id")
+		fs.StringVar(&c.Username, "username", "", "username")
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = rest
+	return c, nil
+}
+
+func (c *userApproveCmd) Run() error {
+	if c.ID == 0 && c.Username == "" {
+		return fmt.Errorf("id or username required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	if c.ID == 0 {
+		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+		if err != nil {
+			return fmt.Errorf("get user: %w", err)
+		}
+		c.ID = int(u.Idusers)
+	}
+	if err := queries.CreateUserRole(ctx, dbpkg.CreateUserRoleParams{UsersIdusers: int32(c.ID), Name: "user"}); err != nil {
+		return fmt.Errorf("add role: %w", err)
+	}
+	if u, err := queries.GetUserById(ctx, int32(c.ID)); err == nil && u.Email.Valid {
+		_ = emailutil.CreateEmailTemplateAndQueue(ctx, queries, int32(c.ID), u.Email.String, "", "user approved", nil)
+	}
+	if c.rootCmd.Verbosity > 0 {
+		fmt.Printf("approved user %d\n", c.ID)
+	}
+	return nil
+}

--- a/cmd/goa4web/user_comments.go
+++ b/cmd/goa4web/user_comments.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	_ "embed"
+	"flag"
+	"fmt"
+)
+
+//go:embed templates/user_comments_usage.txt
+var userCommentsUsageTemplate string
+
+// userCommentsCmd handles "user comments".
+type userCommentsCmd struct {
+	*userCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseUserCommentsCmd(parent *userCmd, args []string) (*userCommentsCmd, error) {
+	c := &userCommentsCmd{userCmd: parent}
+	fs := flag.NewFlagSet("comments", flag.ContinueOnError)
+	c.fs = fs
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *userCommentsCmd) Run() error {
+	if len(c.args) == 0 {
+		c.fs.Usage()
+		return fmt.Errorf("missing comments command")
+	}
+	switch c.args[0] {
+	case "list":
+		cmd, err := parseUserCommentsListCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("list: %w", err)
+		}
+		return cmd.Run()
+	case "add":
+		cmd, err := parseUserCommentsAddCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("add: %w", err)
+		}
+		return cmd.Run()
+	default:
+		c.fs.Usage()
+		return fmt.Errorf("unknown comments command %q", c.args[0])
+	}
+}
+
+func (c *userCommentsCmd) Usage() {
+	executeUsage(c.fs.Output(), userCommentsUsageTemplate, c.fs, c.rootCmd.fs.Name())
+}

--- a/cmd/goa4web/user_comments_add.go
+++ b/cmd/goa4web/user_comments_add.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"strings"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// userCommentsAddCmd implements "user comments add".
+type userCommentsAddCmd struct {
+	*userCommentsCmd
+	fs       *flag.FlagSet
+	ID       int
+	Username string
+	Comment  string
+	args     []string
+}
+
+func parseUserCommentsAddCmd(parent *userCommentsCmd, args []string) (*userCommentsAddCmd, error) {
+	c := &userCommentsAddCmd{userCommentsCmd: parent}
+	fs, rest, err := parseFlags("add", args, func(fs *flag.FlagSet) {
+		fs.IntVar(&c.ID, "id", 0, "user id")
+		fs.StringVar(&c.Username, "username", "", "username")
+		fs.StringVar(&c.Comment, "comment", "", "comment text")
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = rest
+	return c, nil
+}
+
+func (c *userCommentsAddCmd) Run() error {
+	if c.ID == 0 && c.Username == "" {
+		return fmt.Errorf("id or username required")
+	}
+	if strings.TrimSpace(c.Comment) == "" {
+		return fmt.Errorf("empty comment")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	if c.ID == 0 {
+		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+		if err != nil {
+			return fmt.Errorf("get user: %w", err)
+		}
+		c.ID = int(u.Idusers)
+	}
+	if err := queries.InsertAdminUserComment(ctx, dbpkg.InsertAdminUserCommentParams{UsersIdusers: int32(c.ID), Comment: c.Comment}); err != nil {
+		return fmt.Errorf("insert comment: %w", err)
+	}
+	if c.rootCmd.Verbosity > 0 {
+		fmt.Printf("added comment for user %d\n", c.ID)
+	}
+	return nil
+}

--- a/cmd/goa4web/user_comments_list.go
+++ b/cmd/goa4web/user_comments_list.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// userCommentsListCmd implements "user comments list".
+type userCommentsListCmd struct {
+	*userCommentsCmd
+	fs       *flag.FlagSet
+	ID       int
+	Username string
+	args     []string
+}
+
+func parseUserCommentsListCmd(parent *userCommentsCmd, args []string) (*userCommentsListCmd, error) {
+	c := &userCommentsListCmd{userCommentsCmd: parent}
+	fs, rest, err := parseFlags("list", args, func(fs *flag.FlagSet) {
+		fs.IntVar(&c.ID, "id", 0, "user id")
+		fs.StringVar(&c.Username, "username", "", "username")
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = rest
+	return c, nil
+}
+
+func (c *userCommentsListCmd) Run() error {
+	if c.ID == 0 && c.Username == "" {
+		return fmt.Errorf("id or username required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	if c.ID == 0 {
+		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+		if err != nil {
+			return fmt.Errorf("get user: %w", err)
+		}
+		c.ID = int(u.Idusers)
+	}
+	rows, err := queries.ListAdminUserComments(ctx, int32(c.ID))
+	if err != nil {
+		return fmt.Errorf("list comments: %w", err)
+	}
+	for _, cm := range rows {
+		fmt.Printf("%s\t%s\n", cm.CreatedAt.Format("2006-01-02 15:04"), cm.Comment)
+	}
+	return nil
+}

--- a/cmd/goa4web/user_profile.go
+++ b/cmd/goa4web/user_profile.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// userProfileCmd implements "user profile" to show user details.
+type userProfileCmd struct {
+	*userCmd
+	fs       *flag.FlagSet
+	ID       int
+	Username string
+	args     []string
+}
+
+func parseUserProfileCmd(parent *userCmd, args []string) (*userProfileCmd, error) {
+	c := &userProfileCmd{userCmd: parent}
+	fs, rest, err := parseFlags("profile", args, func(fs *flag.FlagSet) {
+		fs.IntVar(&c.ID, "id", 0, "user id")
+		fs.StringVar(&c.Username, "username", "", "username")
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = rest
+	return c, nil
+}
+
+func (c *userProfileCmd) Run() error {
+	if c.ID == 0 && c.Username == "" {
+		return fmt.Errorf("id or username required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	if c.ID == 0 {
+		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+		if err != nil {
+			return fmt.Errorf("get user: %w", err)
+		}
+		c.ID = int(u.Idusers)
+	}
+	u, err := queries.GetUserById(ctx, int32(c.ID))
+	if err != nil {
+		return fmt.Errorf("get user: %w", err)
+	}
+	fmt.Printf("ID: %d\nUsername: %s\n", c.ID, u.Username.String)
+	emails, _ := queries.GetUserEmailsByUserID(ctx, int32(c.ID))
+	for _, e := range emails {
+		fmt.Printf("Email: %s verified:%t priority:%d\n", e.Email, e.VerifiedAt.Valid, e.NotificationPriority)
+	}
+	comments, _ := queries.ListAdminUserComments(ctx, int32(c.ID))
+	if len(comments) > 0 {
+		fmt.Println("Admin comments:")
+		for _, cm := range comments {
+			fmt.Printf("%s %s\n", cm.CreatedAt.Format("2006-01-02 15:04"), cm.Comment)
+		}
+	}
+	return nil
+}

--- a/cmd/goa4web/user_reject.go
+++ b/cmd/goa4web/user_reject.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/utils/emailutil"
+)
+
+// userRejectCmd rejects a pending user account.
+type userRejectCmd struct {
+	*userCmd
+	fs       *flag.FlagSet
+	ID       int
+	Username string
+	Reason   string
+	args     []string
+}
+
+func parseUserRejectCmd(parent *userCmd, args []string) (*userRejectCmd, error) {
+	c := &userRejectCmd{userCmd: parent}
+	fs, rest, err := parseFlags("reject", args, func(fs *flag.FlagSet) {
+		fs.IntVar(&c.ID, "id", 0, "user id")
+		fs.StringVar(&c.Username, "username", "", "username")
+		fs.StringVar(&c.Reason, "reason", "", "rejection reason")
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	c.args = rest
+	return c, nil
+}
+
+func (c *userRejectCmd) Run() error {
+	if c.ID == 0 && c.Username == "" {
+		return fmt.Errorf("id or username required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	if c.ID == 0 {
+		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+		if err != nil {
+			return fmt.Errorf("get user: %w", err)
+		}
+		c.ID = int(u.Idusers)
+	}
+	if err := queries.CreateUserRole(ctx, dbpkg.CreateUserRoleParams{UsersIdusers: int32(c.ID), Name: "rejected"}); err != nil {
+		return fmt.Errorf("add role: %w", err)
+	}
+	if c.Reason != "" {
+		_ = queries.InsertAdminUserComment(ctx, dbpkg.InsertAdminUserCommentParams{UsersIdusers: int32(c.ID), Comment: c.Reason})
+	}
+	if u, err := queries.GetUserById(ctx, int32(c.ID)); err == nil && u.Email.Valid {
+		item := struct{ Reason string }{Reason: c.Reason}
+		_ = emailutil.CreateEmailTemplateAndQueue(ctx, queries, int32(c.ID), u.Email.String, "", "user rejected", item)
+	}
+	if c.rootCmd.Verbosity > 0 {
+		fmt.Printf("rejected user %d\n", c.ID)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add CLI subcommands to reject pending users and manage admin comments
- support viewing user profiles from the command line
- document new `user comments`, `user reject` and `user profile` commands

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68750aa7b858832f936cf47345e9ea56