### PR TITLE
Check forum grants before showing actions

### DIFF
--- a/handlers/forum/forumIndexPermissions_test.go
+++ b/handlers/forum/forumIndexPermissions_test.go
@@ -1,0 +1,118 @@
+package forum
+
+import (
+	"context"
+	"database/sql"
+	"net/http/httptest"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	corecommon "github.com/arran4/goa4web/core/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/gorilla/mux"
+)
+
+func TestCustomForumIndexWriteReply(t *testing.T) {
+	req := httptest.NewRequest("GET", "/forum/topic/2/thread/3", nil)
+	req = mux.SetURLVars(req, map[string]string{"topic": "2", "thread": "3"})
+
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+	q := dbpkg.New(sqldb)
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	cd := corecommon.NewCoreData(ctx, q)
+
+	mock.ExpectQuery("SELECT 1 FROM grants").
+		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "reply", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	CustomForumIndex(cd, req.WithContext(ctx))
+	if !corecommon.ContainsItem(cd.CustomIndexItems, "Write Reply") {
+		t.Errorf("expected write reply item")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestCustomForumIndexWriteReplyDenied(t *testing.T) {
+	req := httptest.NewRequest("GET", "/forum/topic/2/thread/3", nil)
+	req = mux.SetURLVars(req, map[string]string{"topic": "2", "thread": "3"})
+
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+	q := dbpkg.New(sqldb)
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	cd := corecommon.NewCoreData(ctx, q)
+
+	mock.ExpectQuery("SELECT 1 FROM grants").
+		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "reply", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnError(sql.ErrNoRows)
+
+	CustomForumIndex(cd, req.WithContext(ctx))
+	if corecommon.ContainsItem(cd.CustomIndexItems, "Write Reply") {
+		t.Errorf("unexpected write reply item")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestCustomForumIndexCreateThread(t *testing.T) {
+	req := httptest.NewRequest("GET", "/forum/topic/2", nil)
+	req = mux.SetURLVars(req, map[string]string{"topic": "2", "category": "1"})
+
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+	q := dbpkg.New(sqldb)
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	cd := corecommon.NewCoreData(ctx, q)
+
+	mock.ExpectQuery("SELECT 1 FROM grants").
+		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	CustomForumIndex(cd, req.WithContext(ctx))
+	if !corecommon.ContainsItem(cd.CustomIndexItems, "Create Thread") {
+		t.Errorf("expected create thread item")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestCustomForumIndexCreateThreadDenied(t *testing.T) {
+	req := httptest.NewRequest("GET", "/forum/topic/2", nil)
+	req = mux.SetURLVars(req, map[string]string{"topic": "2", "category": "1"})
+
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+	q := dbpkg.New(sqldb)
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	cd := corecommon.NewCoreData(ctx, q)
+
+	mock.ExpectQuery("SELECT 1 FROM grants").
+		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnError(sql.ErrNoRows)
+
+	CustomForumIndex(cd, req.WithContext(ctx))
+	if corecommon.ContainsItem(cd.CustomIndexItems, "Create Thread") {
+		t.Errorf("unexpected create thread item")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -186,20 +186,24 @@ func CustomForumIndex(data *CoreData, r *http.Request) {
 			},
 		)
 	}
-	if threadId != "" && topicId != "" { // TODO Permissions system
-		data.CustomIndexItems = append(data.CustomIndexItems,
-			IndexItem{
-				Name: "Write Reply",
-				Link: fmt.Sprintf("/forum/topic/%s/thread/%s/reply", topicId, threadId),
-			},
-		)
+	if threadId != "" && topicId != "" {
+		if tid, err := strconv.Atoi(topicId); err == nil && data.HasGrant("forum", "topic", "reply", int32(tid)) {
+			data.CustomIndexItems = append(data.CustomIndexItems,
+				IndexItem{
+					Name: "Write Reply",
+					Link: fmt.Sprintf("/forum/topic/%s/thread/%s/reply", topicId, threadId),
+				},
+			)
+		}
 	}
-	if categoryId != "" && topicId != "" { // TODO Permissions system
-		data.CustomIndexItems = append(data.CustomIndexItems,
-			IndexItem{
-				Name: "Create Thread",
-				Link: fmt.Sprintf("/forum/topic/%s/new", topicId),
-			},
-		)
+	if categoryId != "" && topicId != "" {
+		if tid, err := strconv.Atoi(topicId); err == nil && data.HasGrant("forum", "topic", "post", int32(tid)) {
+			data.CustomIndexItems = append(data.CustomIndexItems,
+				IndexItem{
+					Name: "Create Thread",
+					Link: fmt.Sprintf("/forum/topic/%s/new", topicId),
+				},
+			)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- gate "Write Reply" and "Create Thread" index links behind `CoreData.HasGrant`
- add tests verifying CustomForumIndex only adds those items when permissions allow

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875e69bccf4832f964ba96f97ab9593