### PR TITLE
Validate S3 upload path

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -274,6 +274,8 @@ environment variables listed below.
 | `AUTO_MIGRATE` | n/a | No | `false` | Run database migrations on startup. |
 | `CREATE_DIRS` | `--create-dirs` | No | `false` | Create missing directories on startup. |
 
+Paths using the `s3://` scheme must include a bucket name and may specify an optional prefix, e.g. `s3://mybucket/uploads`.
+
 ### Dead Letter Queue Providers
 
 The `DLQ_PROVIDER` setting selects how failed messages are recorded:


### PR DESCRIPTION
## Summary
- validate `cfg.ImageUploadDir` when using S3 paths
- document the required `s3://bucket/prefix` syntax

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6875e6ba6d58832fbfa9a7d9167a223a