### PR TITLE
Add writer listing page

### DIFF
--- a/core/templates/templates/writings/writerListPage.gohtml
+++ b/core/templates/templates/writings/writerListPage.gohtml
@@ -1,0 +1,16 @@
+{{ template "head" $ }}
+    <form method="get">
+        <input name="search" value="{{$.Search}}">
+        <input type="submit" value="Search">
+    </form>
+    {{if .Rows}}
+        <font size="5">All writers.</font><br>
+        {{range .Rows}}
+            Writer: <a href="/writings/writer/{{.Username.String}}">{{.Username.String}}</a> has {{.Count}} articles.<br>
+        {{end}}
+    {{else}}
+        No writers here.
+    {{end}}
+    {{if $.PrevLink}}<a href="{{$.PrevLink}}">Previous {{$.PageSize}}</a>{{end}}
+    {{if $.NextLink}}<a href="{{$.NextLink}}">Next {{$.PageSize}}</a>{{end}}
+{{ template "tail" $ }}

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -26,6 +26,7 @@ func RegisterRoutes(r *mux.Router) {
 	wr.HandleFunc("/", Page).Methods("GET")
 	wr.HandleFunc("/writer/{username}", WriterPage).Methods("GET")
 	wr.HandleFunc("/writer/{username}/", WriterPage).Methods("GET")
+	wr.HandleFunc("/writers", WriterListPage).Methods("GET")
 	wr.HandleFunc("/user/permissions", UserPermissionsPage).Methods("GET").MatcherFunc(auth.RequiredAccess("administrator"))
 	wr.HandleFunc("/users/permissions", UsersPermissionsPermissionUserAllowPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(UserAllowTask.Match)
 	wr.HandleFunc("/users/permissions", UsersPermissionsDisallowPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(UserDisallowTask.Match)

--- a/handlers/writings/writingsPage.go
+++ b/handlers/writings/writingsPage.go
@@ -92,6 +92,11 @@ func CustomWritingsIndex(data *corecommon.CoreData, r *http.Request) {
 	}
 
 	data.CustomIndexItems = append(data.CustomIndexItems, corecommon.IndexItem{
+		Name: "Writers",
+		Link: "/writings/writers",
+	})
+
+	data.CustomIndexItems = append(data.CustomIndexItems, corecommon.IndexItem{
 		Name: "Return to list",
 		Link: fmt.Sprintf("/writings?offset=%d", 0),
 	})

--- a/handlers/writings/writingsWriterListPage.go
+++ b/handlers/writings/writingsWriterListPage.go
@@ -1,0 +1,110 @@
+package writings
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	corecommon "github.com/arran4/goa4web/core/common"
+	common "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/arran4/goa4web/core/templates"
+)
+
+// WriterListPage shows all writers with their article counts.
+func WriterListPage(w http.ResponseWriter, r *http.Request) {
+	type Data struct {
+		*corecommon.CoreData
+		Rows                []*db.WriterCountRow
+		Search              string
+		NextLink            string
+		PrevLink            string
+		PageSize            int
+		IsAdmin             bool
+		CategoryBreadcrumbs []*db.WritingCategory
+		CategoryId          int32
+	}
+
+	data := Data{
+		CoreData:   r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		Search:     r.URL.Query().Get("search"),
+		PageSize:   common.GetPageSize(r),
+		IsAdmin:    false,
+		CategoryId: 0,
+	}
+
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+
+	pageSize := common.GetPageSize(r)
+	var rows []*db.WriterCountRow
+	var err error
+	if data.Search != "" {
+		rows, err = queries.SearchWriters(r.Context(), db.SearchWritersParams{
+			ViewerID: data.UserID,
+			Query:    data.Search,
+			Limit:    int32(pageSize + 1),
+			Offset:   int32(offset),
+		})
+	} else {
+		rows, err = queries.ListWriters(r.Context(), db.ListWritersParams{
+			ViewerID: data.UserID,
+			Limit:    int32(pageSize + 1),
+			Offset:   int32(offset),
+		})
+	}
+	if err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+		default:
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	hasMore := len(rows) > pageSize
+	if hasMore {
+		rows = rows[:pageSize]
+	}
+	data.Rows = rows
+
+	base := "/writings/writers"
+	if data.Search != "" {
+		base += "?search=" + url.QueryEscape(data.Search)
+	}
+	if hasMore {
+		if strings.Contains(base, "?") {
+			data.NextLink = fmt.Sprintf("%s&offset=%d", base, offset+pageSize)
+		} else {
+			data.NextLink = fmt.Sprintf("%s?offset=%d", base, offset+pageSize)
+		}
+		data.CustomIndexItems = append(data.CustomIndexItems, corecommon.IndexItem{
+			Name: fmt.Sprintf("Next %d", pageSize),
+			Link: data.NextLink,
+		})
+	}
+	if offset > 0 {
+		if strings.Contains(base, "?") {
+			data.PrevLink = fmt.Sprintf("%s&offset=%d", base, offset-pageSize)
+		} else {
+			data.PrevLink = fmt.Sprintf("%s?offset=%d", base, offset-pageSize)
+		}
+		data.CustomIndexItems = append(data.CustomIndexItems, corecommon.IndexItem{
+			Name: fmt.Sprintf("Previous %d", pageSize),
+			Link: data.PrevLink,
+		})
+	}
+
+	CustomWritingsIndex(data.CoreData, r)
+
+	if err := templates.RenderTemplate(w, "writerListPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
+		log.Printf("Template Error: %s", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/handlers/writings/writingsWriterListPage_test.go
+++ b/handlers/writings/writingsWriterListPage_test.go
@@ -1,0 +1,68 @@
+package writings
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	corecommon "github.com/arran4/goa4web/core/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+func TestWriterListPage_List(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+	q := db.New(sqldb)
+
+	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
+	mock.ExpectQuery(".*").WillReturnRows(rows)
+
+	req := httptest.NewRequest("GET", "/writings/writers", nil)
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	cd := &corecommon.CoreData{UserID: 1}
+	ctx = context.WithValue(ctx, hcommon.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	WriterListPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Result().StatusCode != 200 {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+}
+
+func TestWriterListPage_Search(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+	q := db.New(sqldb)
+
+	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
+	mock.ExpectQuery(".*").WillReturnRows(rows)
+
+	req := httptest.NewRequest("GET", "/writings/writers?search=bob", nil)
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	cd := &corecommon.CoreData{UserID: 1}
+	ctx = context.WithValue(ctx, hcommon.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	WriterListPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Result().StatusCode != 200 {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+}

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -212,3 +212,67 @@ WHERE w.users_idusers = sqlc.arg(author_id)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
 ORDER BY w.published DESC;
+-- name: ListWritersForViewer :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT u.username, COUNT(w.idwriting) AS count
+FROM writing w
+JOIN users u ON w.users_idusers = u.idusers
+WHERE (
+    NOT EXISTS (SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id))
+    OR w.language_idlanguage IN (
+        SELECT ul.language_idlanguage FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+    )
+)
+AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section = 'writing'
+      AND g.item = 'article'
+      AND g.action = 'see'
+      AND g.active = 1
+      AND g.item_id = w.idwriting
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+)
+GROUP BY u.idusers
+ORDER BY u.username
+LIMIT ? OFFSET ?;
+
+-- name: SearchWritersForViewer :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT u.username, COUNT(w.idwriting) AS count
+FROM writing w
+JOIN users u ON w.users_idusers = u.idusers
+WHERE (LOWER(u.username) LIKE LOWER(sqlc.arg(query)) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(sqlc.arg(query)))
+  AND (
+    NOT EXISTS (SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id))
+    OR w.language_idlanguage IN (
+        SELECT ul.language_idlanguage FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+    )
+  )
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section = 'writing'
+      AND g.item = 'article'
+      AND g.action = 'see'
+      AND g.active = 1
+      AND g.item_id = w.idwriting
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
+GROUP BY u.idusers
+ORDER BY u.username
+LIMIT ? OFFSET ?;

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -823,6 +823,160 @@ func (q *Queries) InsertWritingCategory(ctx context.Context, arg InsertWritingCa
 	return err
 }
 
+const listWritersForViewer = `-- name: ListWritersForViewer :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT u.username, COUNT(w.idwriting) AS count
+FROM writing w
+JOIN users u ON w.users_idusers = u.idusers
+WHERE (
+    NOT EXISTS (SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?)
+    OR w.language_idlanguage IN (
+        SELECT ul.language_idlanguage FROM user_language ul WHERE ul.users_idusers = ?
+    )
+)
+AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section = 'writing'
+      AND g.item = 'article'
+      AND g.action = 'see'
+      AND g.active = 1
+      AND g.item_id = w.idwriting
+      AND (g.user_id = ? OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+)
+GROUP BY u.idusers
+ORDER BY u.username
+LIMIT ? OFFSET ?
+`
+
+type ListWritersForViewerParams struct {
+	ViewerID int32
+	UserID   sql.NullInt32
+	Limit    int32
+	Offset   int32
+}
+
+type ListWritersForViewerRow struct {
+	Username sql.NullString
+	Count    int64
+}
+
+func (q *Queries) ListWritersForViewer(ctx context.Context, arg ListWritersForViewerParams) ([]*ListWritersForViewerRow, error) {
+	rows, err := q.db.QueryContext(ctx, listWritersForViewer,
+		arg.ViewerID,
+		arg.ViewerID,
+		arg.ViewerID,
+		arg.UserID,
+		arg.Limit,
+		arg.Offset,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListWritersForViewerRow
+	for rows.Next() {
+		var i ListWritersForViewerRow
+		if err := rows.Scan(&i.Username, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const searchWritersForViewer = `-- name: SearchWritersForViewer :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT u.username, COUNT(w.idwriting) AS count
+FROM writing w
+JOIN users u ON w.users_idusers = u.idusers
+WHERE (LOWER(u.username) LIKE LOWER(?) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(?))
+  AND (
+    NOT EXISTS (SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?)
+    OR w.language_idlanguage IN (
+        SELECT ul.language_idlanguage FROM user_language ul WHERE ul.users_idusers = ?
+    )
+  )
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section = 'writing'
+      AND g.item = 'article'
+      AND g.action = 'see'
+      AND g.active = 1
+      AND g.item_id = w.idwriting
+      AND (g.user_id = ? OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
+GROUP BY u.idusers
+ORDER BY u.username
+LIMIT ? OFFSET ?
+`
+
+type SearchWritersForViewerParams struct {
+	ViewerID int32
+	Query    string
+	UserID   sql.NullInt32
+	Limit    int32
+	Offset   int32
+}
+
+type SearchWritersForViewerRow struct {
+	Username sql.NullString
+	Count    int64
+}
+
+func (q *Queries) SearchWritersForViewer(ctx context.Context, arg SearchWritersForViewerParams) ([]*SearchWritersForViewerRow, error) {
+	rows, err := q.db.QueryContext(ctx, searchWritersForViewer,
+		arg.ViewerID,
+		arg.Query,
+		arg.Query,
+		arg.ViewerID,
+		arg.ViewerID,
+		arg.UserID,
+		arg.Limit,
+		arg.Offset,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*SearchWritersForViewerRow
+	for rows.Next() {
+		var i SearchWritersForViewerRow
+		if err := rows.Scan(&i.Username, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateWriting = `-- name: UpdateWriting :exec
 UPDATE writing
 SET title = ?, abstract = ?, writing = ?, private = ?, language_idlanguage = ?

--- a/internal/db/queries_dynamic.go
+++ b/internal/db/queries_dynamic.go
@@ -65,6 +65,63 @@ func (q *Queries) SearchBloggers(ctx context.Context, arg SearchBloggersParams) 
 	return items, nil
 }
 
+// WriterCountRow includes a username with the number of writings.
+type WriterCountRow struct {
+	Username sql.NullString
+	Count    int64
+}
+
+// ListWriters returns writers with the number of writings, ordered by username.
+type ListWritersParams struct {
+	ViewerID int32
+	Limit    int32
+	Offset   int32
+}
+
+func (q *Queries) ListWriters(ctx context.Context, arg ListWritersParams) ([]*WriterCountRow, error) {
+	rows, err := q.ListWritersForViewer(ctx, ListWritersForViewerParams{
+		ViewerID: arg.ViewerID,
+		UserID:   sql.NullInt32{Int32: arg.ViewerID, Valid: arg.ViewerID != 0},
+		Limit:    arg.Limit,
+		Offset:   arg.Offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+	items := make([]*WriterCountRow, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, &WriterCountRow{Username: r.Username, Count: r.Count})
+	}
+	return items, nil
+}
+
+// SearchWriters finds writers by username or email with pagination.
+type SearchWritersParams struct {
+	ViewerID int32
+	Query    string
+	Limit    int32
+	Offset   int32
+}
+
+func (q *Queries) SearchWriters(ctx context.Context, arg SearchWritersParams) ([]*WriterCountRow, error) {
+	like := "%" + arg.Query + "%"
+	rows, err := q.SearchWritersForViewer(ctx, SearchWritersForViewerParams{
+		ViewerID: arg.ViewerID,
+		Query:    like,
+		UserID:   sql.NullInt32{Int32: arg.ViewerID, Valid: arg.ViewerID != 0},
+		Limit:    arg.Limit,
+		Offset:   arg.Offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+	items := make([]*WriterCountRow, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, &WriterCountRow{Username: r.Username, Count: r.Count})
+	}
+	return items, nil
+}
+
 // ListUsersFiltered returns users filtered by role and status with pagination.
 type ListUsersFilteredParams struct {
 	Role   string

--- a/internal/db/queries_writers_test.go
+++ b/internal/db/queries_writers_test.go
@@ -1,0 +1,61 @@
+package db
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestQueries_ListWriters(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := New(db)
+
+	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
+	mock.ExpectQuery(regexp.QuoteMeta(listWritersForViewer)).
+		WithArgs(int32(1), int32(1), int32(1), sqlmock.AnyArg(), int32(5), int32(0)).
+		WillReturnRows(rows)
+
+	res, err := q.ListWriters(context.Background(), ListWritersParams{ViewerID: 1, Limit: 5, Offset: 0})
+	if err != nil {
+		t.Fatalf("ListWriters: %v", err)
+	}
+	if len(res) != 1 || res[0].Username.String != "bob" || res[0].Count != 2 {
+		t.Fatalf("unexpected result %+v", res)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestQueries_SearchWriters(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := New(db)
+
+	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
+	mock.ExpectQuery(regexp.QuoteMeta(searchWritersForViewer)).
+		WithArgs(int32(1), "%bob%", "%bob%", int32(1), int32(1), sqlmock.AnyArg(), int32(5), int32(0)).
+		WillReturnRows(rows)
+
+	res, err := q.SearchWriters(context.Background(), SearchWritersParams{ViewerID: 1, Query: "bob", Limit: 5, Offset: 0})
+	if err != nil {
+		t.Fatalf("SearchWriters: %v", err)
+	}
+	if len(res) != 1 || res[0].Username.String != "bob" || res[0].Count != 2 {
+		t.Fatalf("unexpected result %+v", res)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add listing queries for writers
- show list of writers with article counts
- link to writers list in the writings index
- expose /writings/writers route
- support writer pagination/search template
- test writer list queries and handler

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test -tags nosqlite ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875e840b874832fb94efc0fd53b41c3