### PR TITLE
Improve news post form validation

### DIFF
--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -357,7 +358,11 @@ func NewsPostReplyActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func NewsPostEditActionPage(w http.ResponseWriter, r *http.Request) {
-	// TODO verify field names
+	if err := hcommon.ValidateForm(r, []string{"language", "text"}, []string{"language", "text"}); err != nil {
+		r.URL.RawQuery = "error=" + url.QueryEscape(err.Error())
+		hcommon.TaskErrorAcknowledgementPage(w, r)
+		return
+	}
 	languageId, err := strconv.Atoi(r.PostFormValue("language"))
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
@@ -370,7 +375,8 @@ func NewsPostEditActionPage(w http.ResponseWriter, r *http.Request) {
 
 	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
 	if !cd.HasGrant("news", "post", "edit", int32(postId)) {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		r.URL.RawQuery = "error=" + url.QueryEscape("Forbidden")
+		hcommon.TaskErrorAcknowledgementPage(w, r)
 		return
 	}
 	err = queries.UpdateNewsPost(r.Context(), db.UpdateNewsPostParams{
@@ -390,7 +396,11 @@ func NewsPostEditActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func NewsPostNewActionPage(w http.ResponseWriter, r *http.Request) {
-	// TODO verify field names
+	if err := hcommon.ValidateForm(r, []string{"language", "text"}, []string{"language", "text"}); err != nil {
+		r.URL.RawQuery = "error=" + url.QueryEscape(err.Error())
+		hcommon.TaskErrorAcknowledgementPage(w, r)
+		return
+	}
 	languageId, err := strconv.Atoi(r.PostFormValue("language"))
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
@@ -405,7 +415,8 @@ func NewsPostNewActionPage(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 
 	if cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData); !cd.HasGrant("news", "post", "post", 0) {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		r.URL.RawQuery = "error=" + url.QueryEscape("Forbidden")
+		hcommon.TaskErrorAcknowledgementPage(w, r)
 		return
 	}
 	id, err := queries.CreateNewsPost(r.Context(), db.CreateNewsPostParams{

--- a/handlers/news/newsPostPage_test.go
+++ b/handlers/news/newsPostPage_test.go
@@ -1,0 +1,109 @@
+package news
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/core"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+func TestNewsPostNewActionPage_InvalidForms(t *testing.T) {
+	dbconn, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer dbconn.Close()
+
+	queries := db.New(dbconn)
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test-session"
+
+	cases := []url.Values{
+		{"text": {"hi"}},
+		{"language": {"1"}},
+		{"language": {"1"}, "text": {"hi"}, "foo": {"bar"}},
+	}
+	for _, form := range cases {
+		req := httptest.NewRequest("POST", "/news", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		sess, _ := store.Get(req, core.SessionName)
+		sess.Values["UID"] = int32(1)
+		w := httptest.NewRecorder()
+		sess.Save(req, w)
+		for _, c := range w.Result().Cookies() {
+			req.AddCookie(c)
+		}
+		ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
+		ctx = context.WithValue(ctx, hcommon.KeyCoreData, &hcommon.CoreData{})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+		NewsPostNewActionPage(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("form=%v status=%d", form, rr.Code)
+		}
+		if req.URL.RawQuery == "" {
+			t.Errorf("query not set")
+		}
+		if !strings.Contains(rr.Body.String(), "<a href=") {
+			t.Errorf("body=%q", rr.Body.String())
+		}
+	}
+}
+
+func TestNewsPostEditActionPage_InvalidForms(t *testing.T) {
+	dbconn, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer dbconn.Close()
+
+	queries := db.New(dbconn)
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test-session"
+
+	cases := []url.Values{
+		{"text": {"hi"}},
+		{"language": {"1"}},
+		{"language": {"1"}, "text": {"hi"}, "foo": {"bar"}},
+	}
+	for _, form := range cases {
+		req := httptest.NewRequest("POST", "/news/1", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req = mux.SetURLVars(req, map[string]string{"post": "1"})
+		sess, _ := store.Get(req, core.SessionName)
+		sess.Values["UID"] = int32(1)
+		w := httptest.NewRecorder()
+		sess.Save(req, w)
+		for _, c := range w.Result().Cookies() {
+			req.AddCookie(c)
+		}
+		ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
+		ctx = context.WithValue(ctx, hcommon.KeyCoreData, &hcommon.CoreData{})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+		NewsPostEditActionPage(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("form=%v status=%d", form, rr.Code)
+		}
+		if req.URL.RawQuery == "" {
+			t.Errorf("query not set")
+		}
+		if !strings.Contains(rr.Body.String(), "<a href=") {
+			t.Errorf("body=%q", rr.Body.String())
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- verify allowed keys before processing news post actions
- replace http.Error with templated acknowledgements
- add tests for missing fields in news post handlers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875e6c9c3f4832f9de3ad8b8fd4adc3