### PR TITLE
Add writers listing page

### DIFF
--- a/core/templates/templates/writings/writerListPage.gohtml
+++ b/core/templates/templates/writings/writerListPage.gohtml
@@ -1,0 +1,16 @@
+{{ template "head" $ }}
+    <form method="get">
+        <input name="search" value="{{$.Search}}">
+        <input type="submit" value="Search">
+    </form>
+    {{if .Rows}}
+        <font size="5">All writers.</font><br>
+        {{range .Rows}}
+            Writer: <a href="/writings/writer/{{.Username.String}}">{{.Username.String}}</a> has {{.Count}} writings.<br>
+        {{end}}
+    {{else}}
+        No writers here.
+    {{end}}
+    {{if $.PrevLink}}<a href="{{$.PrevLink}}">Previous {{$.PageSize}}</a>{{end}}
+    {{if $.NextLink}}<a href="{{$.NextLink}}">Next {{$.PageSize}}</a>{{end}}
+{{ template "tail" $ }}

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -26,6 +26,7 @@ func RegisterRoutes(r *mux.Router) {
 	wr.HandleFunc("/", Page).Methods("GET")
 	wr.HandleFunc("/writer/{username}", WriterPage).Methods("GET")
 	wr.HandleFunc("/writer/{username}/", WriterPage).Methods("GET")
+	wr.HandleFunc("/writers", WriterListPage).Methods("GET")
 	wr.HandleFunc("/user/permissions", UserPermissionsPage).Methods("GET").MatcherFunc(auth.RequiredAccess("administrator"))
 	wr.HandleFunc("/users/permissions", UsersPermissionsPermissionUserAllowPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(UserAllowTask.Match)
 	wr.HandleFunc("/users/permissions", UsersPermissionsDisallowPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(UserDisallowTask.Match)

--- a/handlers/writings/writingsPage.go
+++ b/handlers/writings/writingsPage.go
@@ -96,6 +96,10 @@ func CustomWritingsIndex(data *corecommon.CoreData, r *http.Request) {
 		Link: fmt.Sprintf("/writings?offset=%d", 0),
 	})
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	data.CustomIndexItems = append(data.CustomIndexItems, corecommon.IndexItem{
+		Name: "List writers",
+		Link: "/writings/writers",
+	})
 	if offset != 0 {
 		data.CustomIndexItems = append(data.CustomIndexItems, corecommon.IndexItem{
 			Name: "The start",

--- a/handlers/writings/writingsWriterListPage.go
+++ b/handlers/writings/writingsWriterListPage.go
@@ -1,0 +1,105 @@
+package writings
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	corecommon "github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/templates"
+	common "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// WriterListPage shows all writers with their article counts.
+func WriterListPage(w http.ResponseWriter, r *http.Request) {
+	type Data struct {
+		*corecommon.CoreData
+		Rows     []*db.WriterCountRow
+		Search   string
+		NextLink string
+		PrevLink string
+		PageSize int
+	}
+
+	data := Data{
+		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		Search:   r.URL.Query().Get("search"),
+		PageSize: common.GetPageSize(r),
+	}
+
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+
+	pageSize := common.GetPageSize(r)
+	var rows []*db.WriterCountRow
+	var err error
+	if data.Search != "" {
+		rows, err = queries.SearchWriters(r.Context(), db.SearchWritersParams{
+			ViewerID: data.UserID,
+			Query:    data.Search,
+			Limit:    int32(pageSize + 1),
+			Offset:   int32(offset),
+		})
+	} else {
+		rows, err = queries.ListWriters(r.Context(), db.ListWritersParams{
+			ViewerID: data.UserID,
+			Limit:    int32(pageSize + 1),
+			Offset:   int32(offset),
+		})
+	}
+	if err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+		default:
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	hasMore := len(rows) > pageSize
+	if hasMore {
+		rows = rows[:pageSize]
+	}
+	data.Rows = rows
+
+	base := "/writings/writers"
+	if data.Search != "" {
+		base += "?search=" + url.QueryEscape(data.Search)
+	}
+	if hasMore {
+		if strings.Contains(base, "?") {
+			data.NextLink = fmt.Sprintf("%s&offset=%d", base, offset+pageSize)
+		} else {
+			data.NextLink = fmt.Sprintf("%s?offset=%d", base, offset+pageSize)
+		}
+		data.CustomIndexItems = append(data.CustomIndexItems, corecommon.IndexItem{
+			Name: fmt.Sprintf("Next %d", pageSize),
+			Link: data.NextLink,
+		})
+	}
+	if offset > 0 {
+		if strings.Contains(base, "?") {
+			data.PrevLink = fmt.Sprintf("%s&offset=%d", base, offset-pageSize)
+		} else {
+			data.PrevLink = fmt.Sprintf("%s?offset=%d", base, offset-pageSize)
+		}
+		data.CustomIndexItems = append(data.CustomIndexItems, corecommon.IndexItem{
+			Name: fmt.Sprintf("Previous %d", pageSize),
+			Link: data.PrevLink,
+		})
+	}
+
+	CustomWritingsIndex(data.CoreData, r)
+
+	if err := templates.RenderTemplate(w, "writerListPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
+		log.Printf("Template Error: %s", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/handlers/writings/writingsWriterListPage_test.go
+++ b/handlers/writings/writingsWriterListPage_test.go
@@ -1,0 +1,42 @@
+package writings
+
+import (
+	"context"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	corecommon "github.com/arran4/goa4web/core/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+func TestWriterListPage(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+
+	queries := db.New(sqldb)
+	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.username, COUNT(w.idwriting) AS count")).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(rows)
+
+	req := httptest.NewRequest("GET", "/writings/writers", nil)
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
+	ctx = context.WithValue(ctx, hcommon.KeyCoreData, &corecommon.CoreData{})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	WriterListPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Result().StatusCode != 200 {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+}

--- a/internal/db/queries_dynamic_writer_test.go
+++ b/internal/db/queries_dynamic_writer_test.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"regexp"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestListWriters(t *testing.T) {
+	dbconn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer dbconn.Close()
+
+	q := New(dbconn)
+	rows := sqlmock.NewRows([]string{"username", "count"}).
+		AddRow(sql.NullString{String: "alice", Valid: true}, int64(3))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.username, COUNT(w.idwriting) AS count")).
+		WithArgs(int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(5), int32(0)).
+		WillReturnRows(rows)
+
+	res, err := q.ListWriters(context.Background(), ListWritersParams{ViewerID: 1, Limit: 5, Offset: 0})
+	if err != nil {
+		t.Fatalf("ListWriters: %v", err)
+	}
+	if len(res) != 1 || res[0].Count != 3 || !res[0].Username.Valid || res[0].Username.String != "alice" {
+		t.Fatalf("unexpected result %+v", res)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSearchWriters(t *testing.T) {
+	dbconn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer dbconn.Close()
+
+	q := New(dbconn)
+	rows := sqlmock.NewRows([]string{"username", "count"}).
+		AddRow(sql.NullString{String: "bob", Valid: true}, int64(2))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.username, COUNT(w.idwriting) AS count")).
+		WithArgs(int32(1), "%query%", "%query%", int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(5), int32(0)).
+		WillReturnRows(rows)
+
+	res, err := q.SearchWriters(context.Background(), SearchWritersParams{ViewerID: 1, Query: "query", Limit: 5, Offset: 0})
+	if err != nil {
+		t.Fatalf("SearchWriters: %v", err)
+	}
+	if len(res) != 1 || res[0].Count != 2 || !res[0].Username.Valid || res[0].Username.String != "bob" {
+		t.Fatalf("unexpected result %+v", res)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- introduce WriterListPage handler and routing
- show link for writers list in writings index
- provide sqlc-backed helper functions to fetch writers
- add template for listing writers
- include unit tests for handler and db helpers

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test -tags nosqlite ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875e84b4dc4832fa1b94bfdb4154764