### PR TITLE
Add event bus admin notification for FAQ

### DIFF
--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -2,6 +2,7 @@ package faq
 
 import (
 	"context"
+	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,9 +12,11 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/sessions"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
 )
 
 func TestAskActionPage_InvalidForms(t *testing.T) {
@@ -52,5 +55,66 @@ func TestAskActionPage_InvalidForms(t *testing.T) {
 		if rr.Code != http.StatusBadRequest {
 			t.Errorf("form=%v status=%d", form, rr.Code)
 		}
+	}
+}
+
+func TestAskActionPage_AdminEvent(t *testing.T) {
+	dbconn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer dbconn.Close()
+
+	queries := db.New(dbconn)
+
+	origCfg := config.AppRuntimeConfig
+	config.AppRuntimeConfig.EmailEnabled = true
+	config.AppRuntimeConfig.AdminNotify = true
+	config.AppRuntimeConfig.AdminEmails = "a@test"
+	config.AppRuntimeConfig.EmailFrom = "from@example.com"
+	config.AppRuntimeConfig.NotificationsEnabled = true
+	t.Cleanup(func() { config.AppRuntimeConfig = origCfg })
+
+	mock.ExpectExec("INSERT INTO faq").
+		WithArgs(sql.NullString{String: "hi", Valid: true}, int32(1), int32(1)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test-session"
+
+	form := url.Values{"language": {"1"}, "text": {"hi"}}
+	req := httptest.NewRequest("POST", "/faq/ask", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	sess, _ := store.Get(req, core.SessionName)
+	sess.Values["UID"] = int32(1)
+	w := httptest.NewRecorder()
+	sess.Save(req, w)
+	for _, c := range w.Result().Cookies() {
+		req.AddCookie(c)
+	}
+	evt := &eventbus.Event{Path: "/faq/ask", Task: hcommon.TaskAsk, UserID: 1}
+	cd := &hcommon.CoreData{}
+	cd.SetEvent(evt)
+
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
+	ctx = context.WithValue(ctx, hcommon.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	AskActionPage(rr, req)
+
+	if rr.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	if loc := rr.Header().Get("Location"); loc != "/faq" {
+		t.Fatalf("location=%q", loc)
+	}
+	if !evt.Admin || evt.Path != "/admin/faq" {
+		t.Fatalf("event %+v", evt)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
 	}
 }

--- a/internal/notifications/templates.go
+++ b/internal/notifications/templates.go
@@ -18,6 +18,8 @@ var (
 	writingTemplate string
 	//go:embed templates/signup.txt
 	signupTemplate string
+	//go:embed templates/ask.txt
+	askTemplate string
 	//go:embed templates/set_user_level.txt
 	setUserLevelTemplate string
 	//go:embed templates/update_user_level.txt
@@ -40,6 +42,7 @@ var defaultTemplates = map[string]string{
 	strings.ToLower(hcommon.TaskNewPost):                blogTemplate,
 	strings.ToLower(hcommon.TaskSubmitWriting):          writingTemplate,
 	strings.ToLower(hcommon.TaskRegister):               signupTemplate,
+	strings.ToLower(hcommon.TaskAsk):                    askTemplate,
 	strings.ToLower(hcommon.TaskSetUserLevel):           setUserLevelTemplate,
 	strings.ToLower(hcommon.TaskUpdateUserLevel):        updateUserLevelTemplate,
 	strings.ToLower(hcommon.TaskDeleteUserLevel):        deleteUserLevelTemplate,

--- a/internal/notifications/templates/ask.txt
+++ b/internal/notifications/templates/ask.txt
@@ -1,0 +1,1 @@
+New FAQ question submitted


### PR DESCRIPTION
## Summary
- use direct call to `NotifyAdmins` after FAQ question submission
- check for missing event and log in dev
- update FAQ handler test accordingly

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875e6b27d64832f947a384f9d01b968