### PR TITLE
Add websocket notifications

### DIFF
--- a/cmd/goa4web/modules_websocket.go
+++ b/cmd/goa4web/modules_websocket.go
@@ -1,0 +1,11 @@
+//go:build websocket
+
+package main
+
+import (
+	websocket "github.com/arran4/goa4web/internal/websocket"
+)
+
+func init() {
+	websocket.Register()
+}

--- a/core/templates/assets/notifications.js
+++ b/core/templates/assets/notifications.js
@@ -1,0 +1,67 @@
+(function(){
+    const proto = location.protocol === 'https:' ? 'wss://' : 'ws://';
+    const url = proto + location.host + '/ws/notifications';
+    const seen = new Set();
+    let conn;
+
+    function connect(){
+        conn = new WebSocket(url);
+        conn.onmessage = evt => {
+            try{
+                const msg = JSON.parse(evt.data);
+                if(!msg || !msg.Data || !msg.Data.notification){
+                    return;
+                }
+                const n = msg.Data.notification;
+                if(seen.has(n.id)) return;
+                seen.add(n.id);
+                updateCount(1);
+                addNotification(n);
+            }catch(e){
+                console.log('ws message error', e);
+            }
+        };
+        conn.onclose = () => setTimeout(connect, 1000);
+    }
+
+    function updateCount(delta){
+        const link = document.getElementById('notif-index');
+        if(!link) return;
+        let m = link.textContent.match(/\((\d+)\)/);
+        let count = m ? parseInt(m[1],10) : 0;
+        count += delta;
+        if(m){
+            link.textContent = link.textContent.replace(/\(\d+\)/, '('+count+')');
+        } else {
+            link.textContent += ' ('+count+')';
+        }
+    }
+
+    function addNotification(n){
+        const list = document.getElementById('notifications-list');
+        if(!list) return;
+        if(document.getElementById('notif-'+n.id)) return;
+        const empty = document.getElementById('notifications-empty');
+        if(empty) empty.remove();
+        const div = document.createElement('div');
+        div.className = 'notification';
+        div.id = 'notif-'+n.id;
+        let html = '';
+        if(n.link){
+            html += '<a href="'+n.link+'">'+n.message+'</a>';
+        } else {
+            html += n.message;
+        }
+        html += ' <form method="post" action="/usr/notifications/dismiss" style="display:inline">';
+        html += '<input type="hidden" name="id" value="'+n.id+'">';
+        html += '<input type="submit" name="task" value="Dismiss">';
+        html += '</form>';
+        div.innerHTML = html;
+        list.prepend(div);
+    }
+
+    window.addEventListener('load', function(){
+        document.querySelectorAll('[data-notification-id]').forEach(el => seen.add(parseInt(el.dataset.notificationId,10)));
+        connect();
+    });
+})();

--- a/core/templates/embedded.go
+++ b/core/templates/embedded.go
@@ -17,6 +17,8 @@ var (
 	faviconData []byte
 	//go:embed "assets/pasteimg.js"
 	pasteImageJSData []byte
+	//go:embed "assets/notifications.js"
+	notificationsJSData []byte
 )
 
 func GetCompiledTemplates(funcs template.FuncMap) *template.Template {
@@ -37,3 +39,7 @@ func GetFaviconData() []byte {
 func GetPasteImageJSData() []byte {
 	return pasteImageJSData
 }
+
+// GetNotificationsJSData returns the JavaScript used for real-time
+// notification updates.
+func GetNotificationsJSData() []byte { return notificationsJSData }

--- a/core/templates/live.go
+++ b/core/templates/live.go
@@ -37,3 +37,11 @@ func GetPasteImageJSData() []byte {
 	}
 	return b
 }
+
+func GetNotificationsJSData() []byte {
+	b, err := os.ReadFile("core/templates/assets/notifications.js")
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/core/templates/templates/head.gohtml
+++ b/core/templates/templates/head.gohtml
@@ -4,10 +4,11 @@
         <head>
                 <title>{{$.Title}}</title>
                 {{template "headdata"}}
-                <link rel="stylesheet" href="/main.css">
-                <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-                <script src="/images/pasteimg.js"></script>
-        {{ if $.AutoRefresh }}
+               <link rel="stylesheet" href="/main.css">
+               <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+               <script src="/images/pasteimg.js"></script>
+               <script src="/notifications.js"></script>
+       {{ if $.AutoRefresh }}
             <meta http-equiv="refresh" content="1">
         {{ end }}
 	</head>

--- a/core/templates/templates/indexItems.gohtml
+++ b/core/templates/templates/indexItems.gohtml
@@ -1,5 +1,5 @@
 {{- define "indexItems"}}
     {{ range $i := $.IndexItems }}
-        <a href="{{ addmode $i.Link }}">{{ $i.Name }}</a><br>
+        <a href="{{ addmode $i.Link }}" {{ if eq $i.Link "/usr/notifications" }}id="notif-index"{{ end }}>{{ $i.Name }}</a><br>
     {{ end }}
 {{- end}}

--- a/core/templates/templates/user/notifications.gohtml
+++ b/core/templates/templates/user/notifications.gohtml
@@ -1,6 +1,7 @@
 {{ template "head" $ }}
+<div id="notifications-list">
 {{ range .Notifications }}
-    <div class="notification">
+    <div class="notification" id="notif-{{ .ID }}" data-notification-id="{{ .ID }}">
         {{ if .Link.Valid }}<a href="{{ .Link.String }}">{{ end }}{{ .Message.String }}{{ if .Link.Valid }}</a>{{ end }}
         <form method="post" action="/usr/notifications/dismiss" style="display:inline">
             {{ csrfField }}
@@ -9,8 +10,9 @@
         </form>
     </div>
 {{ else }}
-    No notifications
+    <div id="notifications-empty">No notifications</div>
 {{ end }}
+</div>
 <form method="post" action="/usr/notifications">
     {{ csrfField }}
     <select name="email_id">

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	golang.org/x/term v0.32.0
 )
 
+require github.com/gorilla/websocket v1.5.3
+
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kX
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/sessions v1.4.0 h1:kpIYOp/oi6MG/p5PgxApU8srsSw9tuFbt46Lt7auzqQ=
 github.com/gorilla/sessions v1.4.0/go.mod h1:FLWm50oby91+hl7p/wRxDth9bWSuk0qVL2emc7lT5ik=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/internal/websocket/notifications.go
+++ b/internal/websocket/notifications.go
@@ -1,0 +1,153 @@
+//go:build websocket
+
+package websocket
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+
+	"github.com/arran4/goa4web/core"
+	corecommon "github.com/arran4/goa4web/core/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+	routerpkg "github.com/arran4/goa4web/internal/router"
+)
+
+// NotificationsHandler provides a websocket endpoint streaming bus events.
+type NotificationsHandler struct {
+	Bus      *eventbus.Bus      // event source
+	Upgrader websocket.Upgrader // websocket upgrader
+}
+
+func buildPatterns(task, path string) []string {
+	name := strings.ToLower(task)
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return []string{fmt.Sprintf("%s:/*", name)}
+	}
+	parts := strings.Split(path, "/")
+	patterns := []string{fmt.Sprintf("%s:/%s", name, path)}
+	for i := len(parts) - 1; i >= 1; i-- {
+		prefix := strings.Join(parts[:i], "/")
+		patterns = append(patterns, fmt.Sprintf("%s:/%s/*", name, prefix))
+	}
+	patterns = append(patterns, fmt.Sprintf("%s:/*", name))
+	return patterns
+}
+
+// NewNotificationsHandler returns a handler using bus for events.
+func NewNotificationsHandler(bus *eventbus.Bus) *NotificationsHandler {
+	return &NotificationsHandler{
+		Bus:      bus,
+		Upgrader: websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }},
+	}
+}
+
+// ServeHTTP upgrades the connection and streams events as JSON.
+
+func (h *NotificationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	sess, err := core.GetSession(r)
+	if err != nil {
+		core.SessionError(w, r, err)
+		http.Error(w, "invalid session", http.StatusUnauthorized)
+		return
+	}
+	uid, _ := sess.Values["UID"].(int32)
+	if uid == 0 {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	queries, ok := r.Context().Value(corecommon.KeyQueries).(*dbpkg.Queries)
+	if !ok || queries == nil {
+		http.Error(w, "db unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	ctx := r.Context()
+
+	loadSubs := func() ([]*dbpkg.ListSubscriptionsByUserRow, map[string]bool, error) {
+		rows, err := queries.ListSubscriptionsByUser(ctx, uid)
+		if err != nil {
+			return nil, nil, err
+		}
+		p := make(map[string]bool)
+		for _, row := range rows {
+			if row.Method == "internal" {
+				p[row.Pattern] = true
+			}
+		}
+		return rows, p, nil
+	}
+
+	subsRows, patterns, err := loadSubs()
+	if err != nil {
+		log.Printf("list subscriptions: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	log.Printf("subscriptions loaded: %d entries", len(subsRows))
+
+	conn, err := h.Upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("websocket upgrade: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	ch := h.Bus.Subscribe()
+	for {
+		select {
+		case evt := <-ch:
+			if evt.UserID == uid && strings.HasPrefix(evt.Path, "/usr/subscriptions") &&
+				(evt.Task == hcommon.TaskUpdate || evt.Task == hcommon.TaskDelete) {
+				var err error
+				subsRows, patterns, err = loadSubs()
+				if err != nil {
+					log.Printf("refresh subscriptions: %v", err)
+				} else {
+					log.Printf("subscriptions updated: %d entries", len(subsRows))
+				}
+				continue
+			}
+			if evt.UserID == uid {
+				continue
+			}
+			allowed := false
+			for _, p := range buildPatterns(evt.Task, evt.Path) {
+				if patterns[p] {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				continue
+			}
+			data, _ := json.Marshal(evt)
+			if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// RegisterRoutes attaches the websocket handler to r.
+func RegisterRoutes(r *mux.Router) {
+	h := NewNotificationsHandler(eventbus.DefaultBus)
+	r.Handle("/ws/notifications", h).Methods(http.MethodGet)
+	r.HandleFunc("/notifications.js", NotificationsJS).Methods(http.MethodGet)
+}
+
+// Register registers the websocket router module.
+func Register() {
+	routerpkg.RegisterModule("websocket", nil, RegisterRoutes)
+}

--- a/internal/websocket/static.go
+++ b/internal/websocket/static.go
@@ -1,0 +1,17 @@
+//go:build websocket
+
+package websocket
+
+import (
+	"bytes"
+	"net/http"
+	"time"
+
+	"github.com/arran4/goa4web/core/templates"
+)
+
+// NotificationsJS serves the JavaScript used for WebSocket notification updates.
+func NotificationsJS(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/javascript")
+	http.ServeContent(w, r, "notifications.js", time.Time{}, bytes.NewReader(templates.GetNotificationsJSData()))
+}

--- a/readme.md
+++ b/readme.md
@@ -435,3 +435,20 @@ and automatically applies migrations on startup.
 ```bash
 docker compose -f examples/docker-compose.yaml up
 ```
+
+## Flutter Client Notifications
+
+When built with the `websocket` build tag the server exposes a WebSocket
+endpoint at `/ws/notifications`. Clients must include the normal session
+cookie when connecting. Events published on the server's event bus are sent
+in JSON format only when the connected user is subscribed to the matching
+event pattern.
+
+Example Dart usage:
+```dart
+final channel = WebSocketChannel.connect(
+  Uri.parse('ws://<host>/ws/notifications'),
+);
+```
+
+


### PR DESCRIPTION
## Summary
- add websocket notifications package with gorilla websocket
- register optional websocket module behind `websocket` build tag
- document Flutter client connection
- filter WebSocket events using user subscriptions
- refresh active subscription patterns when user updates preferences
- add JavaScript to update notifications via WebSocket
- serve notifications.js under websocket module

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875e6d798d8832f99cc2f46210e14d5