### PR TITLE
Add subscription target interface for bus events

### DIFF
--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -9,6 +9,7 @@ import (
 	corelanguage "github.com/arran4/goa4web/core/language"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/notifications"
 	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
 	"log"
 	"net/http"
@@ -348,23 +349,17 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if cd, ok := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData); ok {
+		if evt := cd.Event(); evt != nil {
+			if evt.Data == nil {
+				evt.Data = map[string]any{}
+			}
+			evt.Data["target"] = notifications.Target{Type: "writing", ID: int32(aid)}
+		}
+	}
+
 	text := r.PostFormValue("replytext")
 	languageId, _ := strconv.Atoi(r.PostFormValue("language"))
-
-	// TODO
-	//if rows, err := queries.SomethingNotifyArticle(r.Context(), SomethingNotifyArticlesParams{
-	//	Idusers: uid,
-	//	Idarticles: int32(bid),
-	//}); err != nil {
-	//	log.Printf("Error: listUsersSubscribedToThread: %s", err)
-	//} else {
-	//	for _, row := range rows {
-	//		if err := notifyChange(r.Context(), getEmailProvider(), row.String, endUrl); err != nil {
-	//			log.Printf("Error: notifyChange: %s", err)
-	//
-	//		}
-	//	}
-	//}
 
 	if _, err := queries.CreateComment(r.Context(), db.CreateCommentParams{
 		LanguageIdlanguage: int32(languageId),

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -100,3 +100,8 @@ func (n Notifier) NotifyThreadSubscribers(ctx context.Context, threadID, exclude
 		}
 	}
 }
+
+// NotifyWritingSubscribers informs subscribed users about a writing update.
+func (n Notifier) NotifyWritingSubscribers(ctx context.Context, writingID, excludeUser int32, page string) {
+	emailutil.NotifyWritingSubscribers(ctx, n.Queries, writingID, excludeUser, page)
+}

--- a/internal/notifications/types.go
+++ b/internal/notifications/types.go
@@ -31,3 +31,19 @@ type WritingInfo struct {
 type SignupInfo struct {
 	Username string
 }
+
+// SubscriptionTarget exposes a subscribeable object.
+type SubscriptionTarget interface {
+	// SubscriptionTarget returns the item type and id used when building
+	// subscriptions and notifications.
+	SubscriptionTarget() (string, int32)
+}
+
+// Target references a specific item for subscription notifications.
+type Target struct {
+	Type string
+	ID   int32
+}
+
+// SubscriptionTarget implements SubscriptionTarget.
+func (t Target) SubscriptionTarget() (string, int32) { return t.Type, t.ID }

--- a/internal/utils/emailutil/email_test.go
+++ b/internal/utils/emailutil/email_test.go
@@ -202,6 +202,31 @@ func TestNotifyNewsSubscribers(t *testing.T) {
 	}
 }
 
+func TestNotifyWritingSubscribers(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := dbpkg.New(db)
+	rows := sqlmock.NewRows([]string{
+		"idwriting", "users_idusers", "forumthread_id", "language_idlanguage",
+		"writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at",
+		"idusers", "username", "deleted_at_2", "idpreferences", "language_idlanguage_2",
+		"users_idusers_2", "emailforumupdates", "page_size", "auto_subscribe_replies", "email",
+	}).AddRow(1, 2, 3, 1, 4, "t", nil, "w", "a", 0, nil, 2, "bob", nil, 1, 1, 2, 1, 10, true, "e@test")
+	mock.ExpectQuery("SELECT idwriting").WithArgs(int32(1), int32(2)).WillReturnRows(rows)
+	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(int32(2), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO notifications").WithArgs(int32(2), sqlmock.AnyArg(), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	origCfg := config.AppRuntimeConfig
+	config.AppRuntimeConfig.NotificationsEnabled = true
+	t.Cleanup(func() { config.AppRuntimeConfig = origCfg })
+	emailutil.NotifyWritingSubscribers(context.Background(), q, 1, 2, "/p")
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
 func TestGetEmailProviderSMTP(t *testing.T) {
 	p := email.ProviderFromConfig(config.RuntimeConfig{
 		EmailProvider:     "smtp",


### PR DESCRIPTION
## Summary
- support explicit subscription targets on eventbus events
- notify writing subscribers by reading `evt.Data["target"]`
- attach target info when submitting writing replies
- update tests for new interface
- parseEvent now requires a target in event data

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875e6c081a0832f99dfb98996321aa3