### PR TITLE
Add lazy loaders for news and categories

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"net/http"
+	"strconv"
 
 	"github.com/gorilla/sessions"
 
@@ -18,6 +20,16 @@ type ContextValues string
 type IndexItem struct {
 	Name string
 	Link string
+}
+
+// NewsPost describes a news entry with access metadata.
+type NewsPost struct {
+	*db.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow
+	ShowReply    bool
+	ShowEdit     bool
+	Editing      bool
+	Announcement *db.SiteAnnouncement
+	IsAdmin      bool
 }
 
 type CoreData struct {
@@ -46,6 +58,8 @@ type CoreData struct {
 	roles        lazyValue[[]string]
 	allRoles     lazyValue[[]*db.Role]
 	announcement lazyValue[*db.GetActiveAnnouncementWithNewsRow]
+	latestNews   lazyValue[[]*NewsPost]
+	writeCats    lazyValue[[]*db.WritingCategory]
 
 	event *eventbus.Event
 }
@@ -243,6 +257,71 @@ func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsRow {
 		return row, nil
 	})
 	return ann
+}
+
+// LatestNews returns recent news posts with permission data.
+func (cd *CoreData) LatestNews(r *http.Request) ([]*NewsPost, error) {
+	return cd.latestNews.load(func() ([]*NewsPost, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		rows, err := cd.queries.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(cd.ctx, db.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams{
+			ViewerID: cd.UserID,
+			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+			Limit:    15,
+			Offset:   int32(offset),
+		})
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+		editID, _ := strconv.Atoi(r.URL.Query().Get("reply"))
+		var posts []*NewsPost
+		for _, row := range rows {
+			if !cd.HasGrant("news", "post", "see", row.Idsitenews) {
+				continue
+			}
+			ann, err := cd.queries.GetLatestAnnouncementByNewsID(cd.ctx, row.Idsitenews)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return nil, err
+			}
+			posts = append(posts, &NewsPost{
+				GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow: row,
+				ShowReply:    cd.UserID != 0,
+				ShowEdit:     cd.HasGrant("news", "post", "edit", row.Idsitenews) && (cd.AdminMode || cd.UserID != 0),
+				Editing:      editID == int(row.Idsitenews),
+				Announcement: ann,
+				IsAdmin:      cd.HasRole("administrator") && cd.AdminMode,
+			})
+		}
+		return posts, nil
+	})
+}
+
+// WritingCategories returns the visible writing categories for the user.
+func (cd *CoreData) WritingCategories() ([]*db.WritingCategory, error) {
+	return cd.writeCats.load(func() ([]*db.WritingCategory, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		rows, err := cd.queries.FetchCategoriesForUser(cd.ctx, db.FetchCategoriesForUserParams{
+			ViewerID: cd.UserID,
+			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		var cats []*db.WritingCategory
+		for _, row := range rows {
+			if cd.HasGrant("writing", "category", "see", row.Idwritingcategory) {
+				cats = append(cats, row)
+			}
+		}
+		return cats, nil
+	})
 }
 
 // CanEditAny reports whether cd is in admin mode with administrator role.

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -1,0 +1,83 @@
+package common
+
+import (
+	"context"
+	"database/sql"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+func TestCoreDataLatestNewsLazy(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := dbpkg.New(db)
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"writerName", "writerId", "idsitenews", "forumthread_id", "language_idlanguage",
+		"users_idusers", "news", "occurred", "comments",
+	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, 0)
+
+	mock.ExpectQuery("SELECT u.username").WithArgs(int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
+	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "news", sql.NullString{String: "post", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnError(sql.ErrNoRows)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)
+	cd := NewCoreData(ctx, queries)
+	cd.UserID = 1
+	cd.SetRoles([]string{"user"})
+	ctx = context.WithValue(ctx, ContextValues("coreData"), cd)
+	req = req.WithContext(ctx)
+
+	if _, err := cd.LatestNews(req); err != nil {
+		t.Fatalf("LatestNews: %v", err)
+	}
+	if _, err := cd.LatestNews(req); err != nil {
+		t.Fatalf("LatestNews second call: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestWritingCategoriesLazy(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := dbpkg.New(db)
+	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
+		AddRow(1, 0, "a", "b")
+
+	mock.ExpectQuery("SELECT wc.idwritingcategory").WillReturnRows(rows)
+	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "category", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	ctx := context.WithValue(context.Background(), ContextValues("queries"), queries)
+	cd := NewCoreData(ctx, queries)
+	cd.UserID = 1
+	cd.SetRoles([]string{"user"})
+
+	if _, err := cd.WritingCategories(); err != nil {
+		t.Fatalf("WritingCategories: %v", err)
+	}
+	if _, err := cd.WritingCategories(); err != nil {
+		t.Fatalf("WritingCategories second call: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/handlers/news/newsRssPage.go
+++ b/handlers/news/newsRssPage.go
@@ -1,8 +1,6 @@
 package news
 
 import (
-	"database/sql"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -14,21 +12,13 @@ import (
 	"github.com/arran4/goa4web/a4code2html"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	imageshandler "github.com/arran4/goa4web/handlers/images"
-	db "github.com/arran4/goa4web/internal/db"
 )
 
 func NewsRssPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
-	uid := cd.UserID
-	posts, err := queries.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(r.Context(), db.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams{
-		ViewerID: uid,
-		UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
-		Limit:    15,
-		Offset:   0,
-	})
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		log.Printf("GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending: %s", err)
+	posts, err := cd.LatestNews(r)
+	if err != nil {
+		log.Printf("latestNews: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}

--- a/handlers/writings/writingsCategoriesPage.go
+++ b/handlers/writings/writingsCategoriesPage.go
@@ -35,22 +35,14 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 	data.EditingCategoryId = int32(editID)
 	data.WritingCategoryID = 0
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-
-	categoryRows, err := queries.FetchCategoriesForUser(r.Context(), db.FetchCategoriesForUserParams{
-		ViewerID: data.CoreData.UserID,
-		UserID:   sql.NullInt32{Int32: data.CoreData.UserID, Valid: data.CoreData.UserID != 0},
-	})
+	categoryRows, err := data.CoreData.WritingCategories()
 	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-		default:
-			log.Printf("getAllWritingCategories Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
+		log.Printf("writingCategories: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
 	}
 
+	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	writingsRows, err := queries.GetPublicWritingsInCategoryForUser(r.Context(), db.GetPublicWritingsInCategoryForUserParams{
 		ViewerID:          data.CoreData.UserID,
 		WritingCategoryID: 0,

--- a/handlers/writings/writingsCategoryPage.go
+++ b/handlers/writings/writingsCategoryPage.go
@@ -44,18 +44,11 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
-	categoryRows, err := queries.FetchCategoriesForUser(r.Context(), db.FetchCategoriesForUserParams{
-		ViewerID: data.CoreData.UserID,
-		UserID:   sql.NullInt32{Int32: data.CoreData.UserID, Valid: data.CoreData.UserID != 0},
-	})
+	categoryRows, err := data.CoreData.WritingCategories()
 	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-		default:
-			log.Printf("getAllWritingCategories Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
+		log.Printf("writingCategories: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
 	}
 
 	writingsRows, err := queries.GetPublicWritingsInCategoryForUser(r.Context(), db.GetPublicWritingsInCategoryForUserParams{

--- a/handlers/writings/writingsPage.go
+++ b/handlers/writings/writingsPage.go
@@ -1,8 +1,6 @@
 package writings
 
 import (
-	"database/sql"
-	"errors"
 	"fmt"
 	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
@@ -36,28 +34,13 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	data.CategoryId = 0
 	data.WritingCategoryID = data.CategoryId
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-
-	categoryRows, err := queries.FetchCategoriesForUser(r.Context(), db.FetchCategoriesForUserParams{
-		ViewerID: data.CoreData.UserID,
-		UserID:   sql.NullInt32{Int32: data.CoreData.UserID, Valid: data.CoreData.UserID != 0},
-	})
+	categoryRows, err := data.CoreData.WritingCategories()
 	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-		default:
-			log.Printf("getAllWritingCategories Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
+		log.Printf("writingCategories: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
 	}
-
-	for _, cat := range categoryRows {
-		if !data.CoreData.HasGrant("writing", "category", "see", cat.Idwritingcategory) {
-			continue
-		}
-		data.Categories = append(data.Categories, cat)
-	}
+	data.Categories = append(data.Categories, categoryRows...)
 
 	CustomWritingsIndex(data.CoreData, r)
 


### PR DESCRIPTION
## Summary
- implement lazy loading of news posts and writing categories
- simplify template helper `LatestNews`
- update handlers to use new lazy accessors
- add unit tests for new loaders

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run ./...`
- `go fmt ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6875fa95a4bc832f8c236e09036f8dad