### PR TITLE
Standardize index middleware

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -39,13 +39,14 @@ type CoreData struct {
 	ctx     context.Context
 	queries *db.Queries
 
-	user         lazyValue[*db.User]
-	perms        lazyValue[[]*db.GetPermissionsByUserIDRow]
-	pref         lazyValue[*db.Preference]
-	langs        lazyValue[[]*db.UserLanguage]
-	roles        lazyValue[[]string]
-	allRoles     lazyValue[[]*db.Role]
-	announcement lazyValue[*db.GetActiveAnnouncementWithNewsRow]
+	user            lazyValue[*db.User]
+	perms           lazyValue[[]*db.GetPermissionsByUserIDRow]
+	pref            lazyValue[*db.Preference]
+	langs           lazyValue[[]*db.UserLanguage]
+	roles           lazyValue[[]string]
+	allRoles        lazyValue[[]*db.Role]
+	announcement    lazyValue[*db.GetActiveAnnouncementWithNewsRow]
+	forumCategories lazyValue[[]*db.Forumcategory]
 
 	event *eventbus.Event
 }
@@ -243,6 +244,16 @@ func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsRow {
 		return row, nil
 	})
 	return ann
+}
+
+// ForumCategories loads all forum categories once.
+func (cd *CoreData) ForumCategories() ([]*db.Forumcategory, error) {
+	return cd.forumCategories.load(func() ([]*db.Forumcategory, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetAllForumCategories(cd.ctx)
+	})
 }
 
 // CanEditAny reports whether cd is in admin mode with administrator role.

--- a/handlers/blogs/bloggerListPage.go
+++ b/handlers/blogs/bloggerListPage.go
@@ -95,8 +95,6 @@ func BloggerListPage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	CustomBlogIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "bloggerListPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/blogs/bloggerPostsPage.go
+++ b/handlers/blogs/bloggerPostsPage.go
@@ -89,7 +89,6 @@ func BloggerPostsPage(w http.ResponseWriter, r *http.Request) {
 			EditUrl: editUrl,
 		})
 	}
-	CustomBlogIndex(data.CoreData, r)
 
 	if err := templates.RenderTemplate(w, "bloggerPostsPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -43,8 +43,6 @@ func BlogAddPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	CustomBlogIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "blogAddPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -46,8 +46,6 @@ func BlogEditPage(w http.ResponseWriter, r *http.Request) {
 	row := r.Context().Value(common.KeyBlogEntry).(*db.GetBlogEntryForUserByIdRow)
 	data.Blog = row
 
-	CustomBlogIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "blogEditPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/blogs/blogsBlogPage.go
+++ b/handlers/blogs/blogsBlogPage.go
@@ -123,8 +123,6 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	CustomBlogIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "blogPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/blogs/blogsBloggersBloggerPage.go
+++ b/handlers/blogs/blogsBloggersBloggerPage.go
@@ -31,8 +31,6 @@ func BloggersBloggerPage(w http.ResponseWriter, r *http.Request) {
 	//}
 	//data.Rows = rows
 
-	CustomBlogIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "bloggersBloggerPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -182,8 +182,6 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	CustomBlogIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "commentPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -79,8 +79,6 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	CustomBlogIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "blogsPage", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/blogs/blogsUserPermissionsPage.go
+++ b/handlers/blogs/blogsUserPermissionsPage.go
@@ -61,7 +61,6 @@ func GetPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Re
 
 	data.Rows = rows
 
-	CustomBlogIndex(data.CoreData, r)
 	err = templates.RenderTemplate(w, "userPermissionsPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
@@ -92,8 +91,6 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
 	}
 
-	CustomBlogIndex(data.CoreData, r)
-
 	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
@@ -119,7 +116,6 @@ func UsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 	} else if err := queries.DeleteUserRole(r.Context(), int32(permidi)); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
 	}
-	CustomBlogIndex(data.CoreData, r)
 	err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r))
 	if err != nil {
 		log.Printf("Template Error: %s", err)
@@ -159,7 +155,6 @@ func UsersPermissionsBulkAllowPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	CustomBlogIndex(data.CoreData, r)
 	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -194,7 +189,6 @@ func UsersPermissionsBulkDisallowPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	CustomBlogIndex(data.CoreData, r)
 	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, common.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/blogs/routes.go
+++ b/handlers/blogs/routes.go
@@ -12,11 +12,15 @@ import (
 	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
+// AddBlogIndex injects blog index links into CoreData.
+func AddBlogIndex(h http.Handler) http.Handler { return hcommon.IndexMiddleware(CustomBlogIndex)(h) }
+
 // RegisterRoutes attaches the public blog endpoints to r.
 func RegisterRoutes(r *mux.Router) {
 	nav.RegisterIndexLink("Blogs", "/blogs", SectionWeight)
 	nav.RegisterAdminControlCenter("Blogs", "/admin/blogs/user/permissions", SectionWeight)
 	br := r.PathPrefix("/blogs").Subrouter()
+	br.Use(AddBlogIndex)
 	br.HandleFunc("/rss", RssPage).Methods("GET")
 	br.HandleFunc("/atom", AtomPage).Methods("GET")
 	br.HandleFunc("", Page).Methods("GET")

--- a/handlers/bookmarks/edit.go
+++ b/handlers/bookmarks/edit.go
@@ -44,7 +44,6 @@ func EditPage(w http.ResponseWriter, r *http.Request) {
 		data.BookmarkContent = bookmarks.List.String
 		data.Bid = bookmarks.Idbookmarks
 	}
-	bookmarksCustomIndex(data.CoreData)
 
 	if err := templates.RenderTemplate(w, "editPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)

--- a/handlers/bookmarks/mine.go
+++ b/handlers/bookmarks/mine.go
@@ -99,7 +99,6 @@ func MinePage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
 		Columns:  preprocessBookmarks(bookmarks.List.String),
 	}
-	bookmarksCustomIndex(data.CoreData)
 
 	if err := templates.RenderTemplate(w, "minePage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)

--- a/handlers/bookmarks/page.go
+++ b/handlers/bookmarks/page.go
@@ -34,8 +34,6 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bookmarksCustomIndex(data.CoreData)
-
 	if err := templates.RenderTemplate(w, "bookmarksPage", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/bookmarks/routes.go
+++ b/handlers/bookmarks/routes.go
@@ -1,6 +1,8 @@
 package bookmarks
 
 import (
+	"net/http"
+
 	"github.com/gorilla/mux"
 
 	auth "github.com/arran4/goa4web/handlers/auth"
@@ -10,10 +12,18 @@ import (
 	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
+// AddBookmarksIndex injects bookmark index links into CoreData.
+func AddBookmarksIndex(h http.Handler) http.Handler {
+	return hcommon.IndexMiddleware(func(cd *hcommon.CoreData, r *http.Request) {
+		bookmarksCustomIndex(cd)
+	})(h)
+}
+
 // RegisterRoutes attaches the bookmarks endpoints to r.
 func RegisterRoutes(r *mux.Router) {
 	nav.RegisterIndexLink("Bookmarks", "/bookmarks", SectionWeight)
 	br := r.PathPrefix("/bookmarks").Subrouter()
+	br.Use(AddBookmarksIndex)
 	br.HandleFunc("", Page).Methods("GET")
 	br.HandleFunc("/mine", MinePage).Methods("GET").MatcherFunc(auth.RequiresAnAccount())
 	br.HandleFunc("/edit", SaveTask.Page).Methods("GET").MatcherFunc(auth.RequiresAnAccount())

--- a/handlers/common/template.go
+++ b/handlers/common/template.go
@@ -1,0 +1,33 @@
+package common
+
+import (
+	"log"
+	"net/http"
+
+	corecommon "github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/templates"
+)
+
+// TemplateHandler renders tmpl using only CoreData from the request context.
+func TemplateHandler(tmpl string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data := struct{ *CoreData }{r.Context().Value(KeyCoreData).(*CoreData)}
+		if err := templates.RenderTemplate(w, tmpl, data, corecommon.NewFuncs(r)); err != nil {
+			log.Printf("Template Error: %s", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+	})
+}
+
+// IndexMiddleware injects custom index items via fn before executing the next handler.
+func IndexMiddleware(fn func(*CoreData, *http.Request)) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if cd, ok := r.Context().Value(KeyCoreData).(*CoreData); ok && cd != nil {
+				fn(cd, r)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/handlers/faq/admin_answer.go
+++ b/handlers/faq/admin_answer.go
@@ -48,8 +48,6 @@ func AdminAnswerPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	CustomFAQIndex(data.CoreData)
-
 	if err := templates.RenderTemplate(w, "adminAnswerPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/faq/admin_categories.go
+++ b/handlers/faq/admin_categories.go
@@ -36,8 +36,6 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	CustomFAQIndex(data.CoreData)
-
 	if err := templates.RenderTemplate(w, "adminCategoriesPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/faq/admin_question.go
+++ b/handlers/faq/admin_question.go
@@ -49,8 +49,6 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	CustomFAQIndex(data.CoreData)
-
 	if err := templates.RenderTemplate(w, "adminQuestionPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -35,8 +35,6 @@ func AskPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	CustomFAQIndex(data.CoreData)
-
 	if err := templates.RenderTemplate(w, "askPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/faq/page.go
+++ b/handlers/faq/page.go
@@ -62,7 +62,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		data.FAQ = append(data.FAQ, &currentCategoryFAQs)
 	}
 
-	CustomFAQIndex(data.CoreData)
+	// index links provided via middleware
 
 	if err := templates.RenderTemplate(w, "faqPage", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)

--- a/handlers/faq/routes.go
+++ b/handlers/faq/routes.go
@@ -4,9 +4,17 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
+	hcommon "github.com/arran4/goa4web/handlers/common"
 	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
 )
+
+// AddFAQIndex injects FAQ index links into CoreData.
+func AddFAQIndex(h http.Handler) http.Handler {
+	return hcommon.IndexMiddleware(func(cd *hcommon.CoreData, r *http.Request) {
+		CustomFAQIndex(cd)
+	})(h)
+}
 
 // Task constants mirror the values used by the main package.
 const (
@@ -45,6 +53,7 @@ func RegisterRoutes(r *mux.Router) {
 	nav.RegisterIndexLink("FAQ", "/faq", SectionWeight)
 	nav.RegisterAdminControlCenter("FAQ", "/admin/faq/categories", SectionWeight)
 	faqr := r.PathPrefix("/faq").Subrouter()
+	faqr.Use(AddFAQIndex)
 	faqr.HandleFunc("", Page).Methods("GET", "POST")
 	faqr.HandleFunc("/ask", AskPage).Methods("GET")
 	faqr.HandleFunc("/ask", AskActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskAsk))
@@ -53,6 +62,7 @@ func RegisterRoutes(r *mux.Router) {
 // RegisterAdminRoutes attaches the admin FAQ endpoints to the router.
 func RegisterAdminRoutes(ar *mux.Router) {
 	farq := ar.PathPrefix("/faq").Subrouter()
+	farq.Use(AddFAQIndex)
 	farq.HandleFunc("/answer", AdminAnswerPage).Methods("GET", "POST").MatcherFunc(noTask())
 	farq.HandleFunc("/answer", AnswerAnswerActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskAnswer))
 	farq.HandleFunc("/answer", AnswerRemoveActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskRemoveRemove))

--- a/handlers/forum/forumAdminCategoriesPage.go
+++ b/handlers/forum/forumAdminCategoriesPage.go
@@ -38,8 +38,6 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Categories = categoryRows
 
-	CustomForumIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "adminCategoriesPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/forum/forumAdminPage.go
+++ b/handlers/forum/forumAdminPage.go
@@ -39,8 +39,6 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 	count("SELECT COUNT(*) FROM forumtopic", &data.Stats.Topics)
 	count("SELECT COUNT(*) FROM forumthread", &data.Stats.Threads)
 
-	CustomForumIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "forumAdminPage", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/forum/forumAdminThreadsPage.go
+++ b/handlers/forum/forumAdminThreadsPage.go
@@ -47,8 +47,6 @@ func AdminThreadsPage(w http.ResponseWriter, r *http.Request) {
 		g.Threads = append(g.Threads, row)
 	}
 
-	CustomForumIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "adminThreadsPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -52,15 +52,11 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 	data.CopyDataToSubCategories = copyDataToSubCategories
 
-	categoryRows, err := queries.GetAllForumCategories(r.Context())
+	categoryRows, err := data.CoreData.ForumCategories()
 	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-		default:
-			log.Printf("getAllForumCategories Error: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-			return
-		}
+		log.Printf("getAllForumCategories Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
 	}
 	var topicRows []*ForumtopicPlus
 	if categoryId == 0 {
@@ -128,8 +124,6 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		data.CategoryBreadcrumbs = categoryTree.CategoryRoots(int32(categoryId))
 		data.Back = true
 	}
-
-	CustomForumIndex(data.CoreData, r)
 
 	if err := templates.RenderTemplate(w, "forumPage", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -140,15 +140,11 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 		Edit:                         false,
 	}
 
-	categoryRows, err := queries.GetAllForumCategories(r.Context())
+	categoryRows, err := data.CoreData.ForumCategories()
 	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-		default:
-			log.Printf("getAllForumCategories Error: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-			return
-		}
+		log.Printf("getAllForumCategories Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
 	}
 
 	categoryTree := NewCategoryTree(categoryRows, []*ForumtopicPlus{data.Topic})

--- a/handlers/forum/forumTopicPage.go
+++ b/handlers/forum/forumTopicPage.go
@@ -52,15 +52,11 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.CopyDataToSubCategories = copyDataToSubCategories
 
-	categoryRows, err := queries.GetAllForumCategories(r.Context())
+	categoryRows, err := data.CoreData.ForumCategories()
 	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-		default:
-			log.Printf("getAllForumCategories Error: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-			return
-		}
+		log.Printf("getAllForumCategories Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
 	}
 	topicRow, err := queries.GetForumTopicByIdForUser(r.Context(), db.GetForumTopicByIdForUserParams{
 		ViewerID:      uid,
@@ -111,8 +107,6 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	data.Threads = threadRows
-
-	CustomForumIndex(data.CoreData, r)
 
 	if err := templates.RenderTemplate(w, "topicsPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -11,11 +11,15 @@ import (
 	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
+// AddForumIndex injects forum index links into CoreData.
+func AddForumIndex(h http.Handler) http.Handler { return hcommon.IndexMiddleware(CustomForumIndex)(h) }
+
 // RegisterRoutes attaches the public forum endpoints to r.
 func RegisterRoutes(r *mux.Router) {
 	nav.RegisterIndexLink("Forum", "/forum", SectionWeight)
 	nav.RegisterAdminControlCenter("Forum", "/admin/forum", SectionWeight)
 	fr := r.PathPrefix("/forum").Subrouter()
+	fr.Use(AddForumIndex)
 	fr.HandleFunc("/topic/{topic}.rss", TopicRssPage).Methods("GET")
 	fr.HandleFunc("/topic/{topic}.atom", TopicAtomPage).Methods("GET")
 	fr.HandleFunc("", Page).Methods("GET")

--- a/handlers/imagebbs/imagebbsAdminBoardsPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardsPage.go
@@ -56,8 +56,6 @@ func AdminBoardsPage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	CustomImageBBSIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "adminBoardsPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/imagebbs/imagebbsAdminNewBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminNewBoardPage.go
@@ -37,8 +37,6 @@ func AdminNewBoardPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Boards = boardRows
 
-	CustomImageBBSIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "adminNewBoardPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/imagebbs/imagebbsAdminPage.go
+++ b/handlers/imagebbs/imagebbsAdminPage.go
@@ -1,28 +1,11 @@
 package imagebbs
 
 import (
-	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
-	"log"
 	"net/http"
 
-	"github.com/arran4/goa4web/core/templates"
+	hcommon "github.com/arran4/goa4web/handlers/common"
 )
 
 func AdminPage(w http.ResponseWriter, r *http.Request) {
-	type Data struct {
-		*common.CoreData
-	}
-
-	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
-	}
-
-	CustomImageBBSIndex(data.CoreData, r)
-
-	if err := templates.RenderTemplate(w, "imagebbsAdminPage", data, corecommon.NewFuncs(r)); err != nil {
-		log.Printf("Template Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
+	hcommon.TemplateHandler("imagebbsAdminPage").ServeHTTP(w, r)
 }

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -86,8 +86,6 @@ func BoardPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Posts = posts
 
-	CustomImageBBSIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "boardPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -150,8 +150,6 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Languages = languageRows
 
-	CustomImageBBSIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "boardThreadPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/imagebbs/imagebbsPage.go
+++ b/handlers/imagebbs/imagebbsPage.go
@@ -45,8 +45,6 @@ func Page(w http.ResponseWriter, r *http.Request) {
 
 	data.Boards = subBoardRows
 
-	CustomImageBBSIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "imagebbsPage", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/imagebbs/imagebbsPosterPage.go
+++ b/handlers/imagebbs/imagebbsPosterPage.go
@@ -62,8 +62,6 @@ func PosterPage(w http.ResponseWriter, r *http.Request) {
 		IsOffset: offset != 0,
 	}
 
-	CustomImageBBSIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "posterPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/imagebbs/routes.go
+++ b/handlers/imagebbs/routes.go
@@ -7,10 +7,16 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	auth "github.com/arran4/goa4web/handlers/auth"
+	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 
 	nav "github.com/arran4/goa4web/internal/navigation"
 )
+
+// AddImageBBSIndex injects image board index links into CoreData.
+func AddImageBBSIndex(h http.Handler) http.Handler {
+	return hcommon.IndexMiddleware(CustomImageBBSIndex)(h)
+}
 
 // RegisterRoutes attaches the public image board endpoints to r.
 func RegisterRoutes(r *mux.Router) {
@@ -18,6 +24,7 @@ func RegisterRoutes(r *mux.Router) {
 	nav.RegisterAdminControlCenter("ImageBBS", "/admin/imagebbs", SectionWeight)
 	r.HandleFunc("/imagebbs.rss", RssPage).Methods("GET")
 	ibr := r.PathPrefix("/imagebbs").Subrouter()
+	ibr.Use(AddImageBBSIndex)
 	ibr.PathPrefix("/images/").Handler(http.StripPrefix("/imagebbs/images/", http.FileServer(http.Dir(config.AppRuntimeConfig.ImageUploadDir))))
 	ibr.HandleFunc("/board/{boardno:[0-9]+}.rss", BoardRssPage).Methods("GET")
 	r.HandleFunc("/imagebbs.atom", AtomPage).Methods("GET")

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -50,8 +50,6 @@ func AdminAddPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	CustomLinkerIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "adminAddPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/linker/linkerAdminCategoriesPage.go
+++ b/handlers/linker/linkerAdminCategoriesPage.go
@@ -38,8 +38,6 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Categories = categoryRows
 
-	CustomLinkerIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/linker/linkerAdminQueuePage.go
+++ b/handlers/linker/linkerAdminQueuePage.go
@@ -113,8 +113,6 @@ func AdminQueuePage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	CustomLinkerIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "adminQueuePage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -70,7 +70,6 @@ func AdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.UserLevels = perms
 
-	CustomLinkerIndex(data.CoreData, r)
 	if err := templates.RenderTemplate(w, "adminUserLevelsPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/linker/linkerCategoriesPage.go
+++ b/handlers/linker/linkerCategoriesPage.go
@@ -37,7 +37,6 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Categories = categories
 
-	CustomLinkerIndex(data.CoreData, r)
 	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/linker/linkerCategoryPage.go
+++ b/handlers/linker/linkerCategoryPage.go
@@ -51,8 +51,6 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Links = linkerPosts
 
-	CustomLinkerIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "linkerCategoryPage", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -145,7 +145,6 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Thread = threadRow
 
-	CustomLinkerIndex(data.CoreData, r)
 	if err := templates.RenderTemplate(w, "commentsPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/linker/linkerLinkerPage.go
+++ b/handlers/linker/linkerLinkerPage.go
@@ -57,8 +57,6 @@ func LinkerPage(w http.ResponseWriter, r *http.Request) {
 		HasOffset: offset != 0,
 	}
 
-	CustomLinkerIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "linkerPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/linker/linkerPage.go
+++ b/handlers/linker/linkerPage.go
@@ -66,8 +66,6 @@ func Page(w http.ResponseWriter, r *http.Request) {
 
 	data.Categories = categories
 
-	CustomLinkerIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "linkerPage", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -57,7 +57,6 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Link = link
 
-	CustomLinkerIndex(data.CoreData, r)
 	if err := templates.RenderTemplate(w, "showPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -50,7 +50,6 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	CustomLinkerIndex(data.CoreData, r)
 	if err := templates.RenderTemplate(w, "suggestPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -11,6 +11,11 @@ import (
 	router "github.com/arran4/goa4web/internal/router"
 )
 
+// AddLinkerIndex injects linker index links into CoreData.
+func AddLinkerIndex(h http.Handler) http.Handler {
+	return hcommon.IndexMiddleware(CustomLinkerIndex)(h)
+}
+
 var legacyRedirectsEnabled = true
 
 // RegisterRoutes attaches the public linker endpoints to r.
@@ -18,6 +23,7 @@ func RegisterRoutes(r *mux.Router) {
 	nav.RegisterIndexLink("Linker", "/linker", SectionWeight)
 	nav.RegisterAdminControlCenter("Linker", "/admin/linker/categories", SectionWeight)
 	lr := r.PathPrefix("/linker").Subrouter()
+	lr.Use(AddLinkerIndex)
 	lr.HandleFunc("/rss", RssPage).Methods("GET")
 	lr.HandleFunc("/atom", AtomPage).Methods("GET")
 	lr.HandleFunc("", Page).Methods("GET")

--- a/handlers/news/newsAdminUserLevelsPage.go
+++ b/handlers/news/newsAdminUserLevelsPage.go
@@ -40,8 +40,6 @@ func NewsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.UserLevels = rows
 
-	CustomNewsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "adminUserLevelsPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -195,8 +195,6 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		IsAdmin:      data.CoreData.HasRole("administrator") && data.CoreData.AdminMode,
 	}
 
-	CustomNewsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "postPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/news/newsUserPermissionsPage.go
+++ b/handlers/news/newsUserPermissionsPage.go
@@ -46,7 +46,6 @@ func NewsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	CustomNewsIndex(data.CoreData, r)
 	if err := templates.RenderTemplate(w, "userPermissionsPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -76,8 +75,6 @@ func NewsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.
 		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
 	}
 
-	CustomNewsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -102,7 +99,6 @@ func NewsUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 	} else if err := queries.DeleteUserRole(r.Context(), int32(permidi)); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
 	}
-	CustomNewsIndex(data.CoreData, r)
 	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -26,8 +26,6 @@ func runTemplate(tmpl string) func(http.ResponseWriter, *http.Request) {
 			CoreData: r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData),
 		}
 
-		CustomNewsIndex(data.CoreData, r)
-
 		if err := templates.RenderTemplate(w, tmpl, data, corecommon.NewFuncs(r)); err != nil {
 			log.Printf("Template Error: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -36,13 +34,7 @@ func runTemplate(tmpl string) func(http.ResponseWriter, *http.Request) {
 	})
 }
 
-func AddNewsIndex(handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cd := r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)
-		CustomNewsIndex(cd, r)
-		handler.ServeHTTP(w, r)
-	})
-}
+func AddNewsIndex(h http.Handler) http.Handler { return hcommon.IndexMiddleware(CustomNewsIndex)(h) }
 
 // RegisterRoutes attaches the public news endpoints to r.
 func RegisterRoutes(r *mux.Router) {

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -13,6 +13,11 @@ import (
 	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
+// AddWritingsIndex injects writings index links into CoreData.
+func AddWritingsIndex(h http.Handler) http.Handler {
+	return hcommon.IndexMiddleware(CustomWritingsIndex)(h)
+}
+
 var legacyRedirectsEnabled = true
 
 // RegisterRoutes attaches the public writings endpoints to r.
@@ -20,6 +25,7 @@ func RegisterRoutes(r *mux.Router) {
 	nav.RegisterIndexLink("Writings", "/writings", SectionWeight)
 	nav.RegisterAdminControlCenter("Writings", "/admin/writings/categories", SectionWeight)
 	wr := r.PathPrefix("/writings").Subrouter()
+	wr.Use(AddWritingsIndex)
 	wr.HandleFunc("/rss", RssPage).Methods("GET")
 	wr.HandleFunc("/atom", AtomPage).Methods("GET")
 	wr.HandleFunc("", Page).Methods("GET")

--- a/handlers/writings/writingsAdminCategoriesPage.go
+++ b/handlers/writings/writingsAdminCategoriesPage.go
@@ -37,8 +37,6 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Categories = categoryRows
 
-	CustomWritingsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/writings/writingsAdminUserLevelsPage.go
+++ b/handlers/writings/writingsAdminUserLevelsPage.go
@@ -40,8 +40,6 @@ func AdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.UserLevels = rows
 
-	CustomWritingsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "adminUserLevelsPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -35,8 +35,6 @@ func ArticleAddPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	CustomWritingsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "articleAddPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -51,8 +51,6 @@ func ArticleEditPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	CustomWritingsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "articleEditPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -252,8 +252,6 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 
 	data.Thread = threadRow
 
-	CustomWritingsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "articlePage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/writings/writingsCategoriesPage.go
+++ b/handlers/writings/writingsCategoriesPage.go
@@ -86,8 +86,6 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 		data.Abstracts = append(data.Abstracts, wrow)
 	}
 
-	CustomWritingsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "categoriesPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/writings/writingsCategoryPage.go
+++ b/handlers/writings/writingsCategoryPage.go
@@ -103,8 +103,6 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 		data.Abstracts = append(data.Abstracts, wrow)
 	}
 
-	CustomWritingsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "writingsCategoryPage", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/writings/writingsPage.go
+++ b/handlers/writings/writingsPage.go
@@ -59,16 +59,14 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		data.Categories = append(data.Categories, cat)
 	}
 
-	CustomWritingsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "writingsPage", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 }
-
 func CustomWritingsIndex(data *corecommon.CoreData, r *http.Request) {
+
 	data.CustomIndexItems = append(data.CustomIndexItems,
 		corecommon.IndexItem{Name: "Atom Feed", Link: "/writings/atom"},
 		corecommon.IndexItem{Name: "RSS Feed", Link: "/writings/rss"},

--- a/handlers/writings/writingsUserPermissionsPage.go
+++ b/handlers/writings/writingsUserPermissionsPage.go
@@ -41,7 +41,6 @@ func UserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	CustomWritingsIndex(data.CoreData, r)
 	if err := templates.RenderTemplate(w, "usersPermissionsPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -71,8 +70,6 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
 	}
 
-	CustomWritingsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -97,7 +94,6 @@ func UsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 	} else if err := queries.DeleteUserRole(r.Context(), int32(permidi)); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
 	}
-	CustomWritingsIndex(data.CoreData, r)
 	if err := templates.RenderTemplate(w, "runTaskPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/writings/writingsWriterListPage.go
+++ b/handlers/writings/writingsWriterListPage.go
@@ -100,8 +100,6 @@ func WriterListPage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	CustomWritingsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "writerListPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/writings/writingsWriterPage.go
+++ b/handlers/writings/writingsWriterPage.go
@@ -65,8 +65,6 @@ func WriterPage(w http.ResponseWriter, r *http.Request) {
 		data.Abstracts = append(data.Abstracts, row)
 	}
 
-	CustomWritingsIndex(data.CoreData, r)
-
 	if err := templates.RenderTemplate(w, "writerPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
 		log.Printf("Template Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)


### PR DESCRIPTION
## Summary
- add TemplateHandler and IndexMiddleware helpers
- hook up middleware for blogs, bookmarks, forum, faq, linker, image boards, writings and news
- remove direct Custom*Index calls in handlers
- add lazy ForumCategories loader

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875faaa2db0832fa643c90080d250da