### PR TITLE
Implement WriterWritings lazy loader

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -61,6 +61,7 @@ type CoreData struct {
 	forumCategories lazyValue[[]*db.Forumcategory]
 	latestNews      lazyValue[[]*NewsPost]
 	writeCats       lazyValue[[]*db.WritingCategory]
+	writerWritings  map[int32]*lazyValue[[]*db.GetPublicWritingsByUserForViewerRow]
 
 	event *eventbus.Event
 }
@@ -332,6 +333,42 @@ func (cd *CoreData) WritingCategories() ([]*db.WritingCategory, error) {
 			}
 		}
 		return cats, nil
+	})
+}
+
+// WriterWritings returns public writings for the specified author respecting cd's permissions.
+func (cd *CoreData) WriterWritings(userID int32, r *http.Request) ([]*db.GetPublicWritingsByUserForViewerRow, error) {
+	if cd.writerWritings == nil {
+		cd.writerWritings = map[int32]*lazyValue[[]*db.GetPublicWritingsByUserForViewerRow]{}
+	}
+	lv, ok := cd.writerWritings[userID]
+	if !ok {
+		lv = &lazyValue[[]*db.GetPublicWritingsByUserForViewerRow]{}
+		cd.writerWritings[userID] = lv
+	}
+	return lv.load(func() ([]*db.GetPublicWritingsByUserForViewerRow, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		rows, err := cd.queries.GetPublicWritingsByUserForViewer(cd.ctx, db.GetPublicWritingsByUserForViewerParams{
+			ViewerID: cd.UserID,
+			AuthorID: userID,
+			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+			Limit:    15,
+			Offset:   int32(offset),
+		})
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+		var list []*db.GetPublicWritingsByUserForViewerRow
+		for _, row := range rows {
+			if !cd.HasGrant("writing", "article", "see", row.Idwriting) {
+				continue
+			}
+			list = append(list, row)
+		}
+		return list, nil
 	})
 }
 

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -81,3 +81,38 @@ func TestWritingCategoriesLazy(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestWriterWritingsLazy(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := dbpkg.New(db)
+	rows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "username", "Comments"}).
+		AddRow(1, 2, 0, 1, 1, sql.NullString{}, sql.NullTime{}, sql.NullString{}, sql.NullString{}, sql.NullBool{}, sql.NullTime{}, sql.NullString{}, int64(0))
+
+	mock.ExpectQuery("SELECT w.idwriting").WithArgs(int32(1), int32(2), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
+	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "article", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)
+	cd := NewCoreData(ctx, queries)
+	cd.UserID = 1
+	cd.SetRoles([]string{"user"})
+	ctx = context.WithValue(ctx, ContextValues("coreData"), cd)
+	req = req.WithContext(ctx)
+
+	if _, err := cd.WriterWritings(2, req); err != nil {
+		t.Fatalf("WriterWritings: %v", err)
+	}
+	if _, err := cd.WriterWritings(2, req); err != nil {
+		t.Fatalf("WriterWritings second call: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/handlers/writings/writingsWriterPage.go
+++ b/handlers/writings/writingsWriterPage.go
@@ -40,15 +40,9 @@ func WriterPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows, err := queries.GetPublicWritingsByUserForViewer(r.Context(), db.GetPublicWritingsByUserForViewerParams{
-		ViewerID: cd.UserID,
-		AuthorID: u.Idusers,
-		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-		Limit:    15,
-		Offset:   int32(offset),
-	})
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		log.Printf("GetPublicWritingsByUser Error: %s", err)
+	rows, err := cd.WriterWritings(u.Idusers, r)
+	if err != nil {
+		log.Printf("WriterWritings: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary
- add `WriterWritings` cache to `CoreData`
- use the loader in `WriterPage`
- test that `WriterWritings` only queries once

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687639a478f0832f8b773c27971abaf5