### PR TITLE
Add AllRoles lazy loading test

### DIFF
--- a/core/common/coredata_allroles_test.go
+++ b/core/common/coredata_allroles_test.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+func TestAllRolesLazy(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"id", "name"}).
+		AddRow(int32(1), "user").
+		AddRow(int32(2), "administrator")
+
+	mock.ExpectQuery("SELECT id, name FROM roles ORDER BY id").WillReturnRows(rows)
+
+	cd := NewCoreData(context.Background(), dbpkg.New(db))
+
+	if _, err := cd.AllRoles(); err != nil {
+		t.Fatalf("AllRoles: %v", err)
+	}
+	if _, err := cd.AllRoles(); err != nil {
+		t.Fatalf("AllRoles second call: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `coredata_allroles_test.go` to check AllRoles lazy queries
- ensure repeated AllRoles calls execute a single `ListRoles` query

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68763ac6e218832f91e8b440b9d4e993