### PR TITLE
Cache forum topic loader

### DIFF
--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -81,3 +81,34 @@ func TestWritingCategoriesLazy(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestForumTopicByIDLazy(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := dbpkg.New(db)
+	rows := sqlmock.NewRows([]string{
+		"idforumtopic", "lastposter", "forumcategory_idforumcategory", "title", "description",
+		"threads", "comments", "lastaddition", "LastPosterUsername",
+	}).AddRow(1, 1, 1, sql.NullString{String: "t", Valid: true}, sql.NullString{String: "d", Valid: true}, sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 0, Valid: true}, sql.NullTime{}, sql.NullString{String: "bob", Valid: true})
+
+	mock.ExpectQuery("SELECT t.idforumtopic").WithArgs(int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(rows)
+
+	ctx := context.WithValue(context.Background(), ContextValues("queries"), queries)
+	cd := NewCoreData(ctx, queries)
+	cd.UserID = 1
+
+	if _, err := cd.ForumTopicByID(1); err != nil {
+		t.Fatalf("ForumTopicByID: %v", err)
+	}
+	if _, err := cd.ForumTopicByID(1); err != nil {
+		t.Fatalf("ForumTopicByID second call: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/handlers/forum/forumFeed.go
+++ b/handlers/forum/forumFeed.go
@@ -66,12 +66,8 @@ func TopicRssPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	topicID, _ := strconv.Atoi(vars["topic"])
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-
-	topic, err := queries.GetForumTopicByIdForUser(r.Context(), db.GetForumTopicByIdForUserParams{
-		ViewerID:      uid,
-		Idforumtopic:  int32(topicID),
-		ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0},
-	})
+	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	topic, err := cd.ForumTopicByID(int32(topicID))
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("GetForumTopicByIdForUser error: %s", err)
@@ -108,12 +104,9 @@ func TopicAtomPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	topicID, _ := strconv.Atoi(vars["topic"])
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
 
-	topic, err := queries.GetForumTopicByIdForUser(r.Context(), db.GetForumTopicByIdForUserParams{
-		ViewerID:      uid,
-		Idforumtopic:  int32(topicID),
-		ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0},
-	})
+	topic, err := cd.ForumTopicByID(int32(topicID))
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("GetForumTopicByIdForUser error: %s", err)

--- a/handlers/forum/forumTopicPage.go
+++ b/handlers/forum/forumTopicPage.go
@@ -58,11 +58,7 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	topicRow, err := queries.GetForumTopicByIdForUser(r.Context(), db.GetForumTopicByIdForUserParams{
-		ViewerID:      uid,
-		Idforumtopic:  int32(topicId),
-		ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0},
-	})
+	topicRow, err := data.CoreData.ForumTopicByID(int32(topicId))
 	if err != nil {
 		log.Printf("showTableTopics Error: %s", err)
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)


### PR DESCRIPTION
## Summary
- add forum topic caching in CoreData
- use `ForumTopicByID` in handlers
- test loader caching

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68763aa4bc84832fbcc531ce4c1b8dc5