### PR TITLE
Add unread notification count loader

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -61,6 +61,7 @@ type CoreData struct {
 	forumCategories lazyValue[[]*db.Forumcategory]
 	latestNews      lazyValue[[]*NewsPost]
 	writeCats       lazyValue[[]*db.WritingCategory]
+	notifCount      lazyValue[int32]
 
 	event *eventbus.Event
 }
@@ -333,6 +334,22 @@ func (cd *CoreData) WritingCategories() ([]*db.WritingCategory, error) {
 		}
 		return cats, nil
 	})
+}
+
+// UnreadNotificationCount loads the number of unread notifications once.
+func (cd *CoreData) UnreadNotificationCount() (int32, error) {
+	count, err := cd.notifCount.load(func() (int32, error) {
+		if cd.UserID == 0 || cd.queries == nil {
+			return 0, nil
+		}
+		c, err := cd.queries.CountUnreadNotifications(cd.ctx, cd.UserID)
+		if err != nil {
+			return 0, err
+		}
+		return int32(c), nil
+	})
+	cd.NotificationCount = count
+	return count, err
 }
 
 // CanEditAny reports whether cd is in admin mode with administrator role.

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -81,3 +81,33 @@ func TestWritingCategoriesLazy(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestUnreadNotificationCount(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := dbpkg.New(db)
+	rows := sqlmock.NewRows([]string{"cnt"}).AddRow(2)
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\)").WithArgs(int32(1)).WillReturnRows(rows)
+
+	ctx := context.WithValue(context.Background(), ContextValues("queries"), queries)
+	cd := NewCoreData(ctx, queries)
+	cd.UserID = 1
+
+	if c, err := cd.UnreadNotificationCount(); err != nil || c != 2 {
+		t.Fatalf("count=%d err=%v", c, err)
+	}
+	if cd.NotificationCount != 2 {
+		t.Fatalf("NotificationCount=%d", cd.NotificationCount)
+	}
+	if c, err := cd.UnreadNotificationCount(); err != nil || c != 2 {
+		t.Fatalf("second count=%d err=%v", c, err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -87,24 +87,20 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 		if uid != 0 {
 			idx = append(idx, common.IndexItem{Name: "Preferences", Link: "/usr"})
 		}
-		var count int32
-		if uid != 0 && hcommon.NotificationsEnabled() {
-			c, err := queries.CountUnreadNotifications(r.Context(), uid)
-			if err == nil {
-				count = int32(c)
-				idx = append(idx, common.IndexItem{Name: fmt.Sprintf("Notifications (%d)", c), Link: "/usr/notifications"})
-			}
-		}
 		cd := common.NewCoreData(r.Context(), queries,
 			common.WithImageURLMapper(imagesign.MapURL),
 			common.WithSession(session))
 		cd.SetRoles(roles)
-		cd.IndexItems = idx
 		cd.UserID = uid
 		cd.Title = "Arran's Site"
 		cd.FeedsEnabled = config.AppRuntimeConfig.FeedsEnabled
 		cd.AdminMode = r.URL.Query().Get("mode") == "admin"
-		cd.NotificationCount = count
+		if uid != 0 && hcommon.NotificationsEnabled() {
+			if c, err := cd.UnreadNotificationCount(); err == nil {
+				idx = append(idx, common.IndexItem{Name: fmt.Sprintf("Notifications (%d)", c), Link: "/usr/notifications"})
+			}
+		}
+		cd.IndexItems = idx
 		ctx := context.WithValue(r.Context(), hcommon.KeyCoreData, cd)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})


### PR DESCRIPTION
## Summary
- add `UnreadNotificationCount` loader to `CoreData`
- update middleware to use the new loader
- cover unread notification count loader with tests

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68763a98bebc832fa7df0bfa3bd078c5