### PR TITLE
Add cached news announcement loader

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"sync"
 
 	"github.com/gorilla/sessions"
 
@@ -51,16 +52,18 @@ type CoreData struct {
 	ctx     context.Context
 	queries *db.Queries
 
-	user            lazyValue[*db.User]
-	perms           lazyValue[[]*db.GetPermissionsByUserIDRow]
-	pref            lazyValue[*db.Preference]
-	langs           lazyValue[[]*db.UserLanguage]
-	roles           lazyValue[[]string]
-	allRoles        lazyValue[[]*db.Role]
-	announcement    lazyValue[*db.GetActiveAnnouncementWithNewsRow]
-	forumCategories lazyValue[[]*db.Forumcategory]
-	latestNews      lazyValue[[]*NewsPost]
-	writeCats       lazyValue[[]*db.WritingCategory]
+	user              lazyValue[*db.User]
+	perms             lazyValue[[]*db.GetPermissionsByUserIDRow]
+	pref              lazyValue[*db.Preference]
+	langs             lazyValue[[]*db.UserLanguage]
+	roles             lazyValue[[]string]
+	allRoles          lazyValue[[]*db.Role]
+	announcement      lazyValue[*db.GetActiveAnnouncementWithNewsRow]
+	forumCategories   lazyValue[[]*db.Forumcategory]
+	latestNews        lazyValue[[]*NewsPost]
+	writeCats         lazyValue[[]*db.WritingCategory]
+	newsAnnouncements map[int32]*lazyValue[*db.SiteAnnouncement]
+	annMu             sync.Mutex
 
 	event *eventbus.Event
 }
@@ -86,7 +89,7 @@ func WithEvent(evt *eventbus.Event) CoreOption { return func(cd *CoreData) { cd.
 
 // NewCoreData creates a CoreData with context and queries applied.
 func NewCoreData(ctx context.Context, q *db.Queries, opts ...CoreOption) *CoreData {
-	cd := &CoreData{ctx: ctx, queries: q}
+	cd := &CoreData{ctx: ctx, queries: q, newsAnnouncements: map[int32]*lazyValue[*db.SiteAnnouncement]{}}
 	for _, o := range opts {
 		o(cd)
 	}
@@ -260,6 +263,33 @@ func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsRow {
 	return ann
 }
 
+// NewsAnnouncement returns the latest announcement for the given news post. The
+// result is cached so repeated lookups for the same id hit the database only
+// once.
+func (cd *CoreData) NewsAnnouncement(id int32) (*db.SiteAnnouncement, error) {
+	cd.annMu.Lock()
+	lv, ok := cd.newsAnnouncements[id]
+	if !ok {
+		lv = &lazyValue[*db.SiteAnnouncement]{}
+		cd.newsAnnouncements[id] = lv
+	}
+	cd.annMu.Unlock()
+
+	return lv.load(func() (*db.SiteAnnouncement, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		ann, err := cd.queries.GetLatestAnnouncementByNewsID(cd.ctx, id)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		return ann, nil
+	})
+}
+
 // ForumCategories loads all forum categories once.
 func (cd *CoreData) ForumCategories() ([]*db.Forumcategory, error) {
 	return cd.forumCategories.load(func() ([]*db.Forumcategory, error) {
@@ -292,7 +322,7 @@ func (cd *CoreData) LatestNews(r *http.Request) ([]*NewsPost, error) {
 			if !cd.HasGrant("news", "post", "see", row.Idsitenews) {
 				continue
 			}
-			ann, err := cd.queries.GetLatestAnnouncementByNewsID(cd.ctx, row.Idsitenews)
+			ann, err := cd.NewsAnnouncement(row.Idsitenews)
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				return nil, err
 			}

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -81,3 +81,34 @@ func TestWritingCategoriesLazy(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestNewsAnnouncementLazy(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := dbpkg.New(db)
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{"id", "site_news_id", "active", "created_at"}).
+		AddRow(1, 1, false, now)
+
+	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").
+		WithArgs(int32(1)).
+		WillReturnRows(rows)
+
+	ctx := context.WithValue(context.Background(), ContextValues("queries"), queries)
+	cd := NewCoreData(ctx, queries)
+
+	if _, err := cd.NewsAnnouncement(1); err != nil {
+		t.Fatalf("NewsAnnouncement: %v", err)
+	}
+	if _, err := cd.NewsAnnouncement(1); err != nil {
+		t.Fatalf("NewsAnnouncement second call: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/handlers/news/newsAnnouncementHandlers.go
+++ b/handlers/news/newsAnnouncementHandlers.go
@@ -15,10 +15,11 @@ import (
 
 func NewsAnnouncementActivateActionPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
 
-	ann, err := queries.GetLatestAnnouncementByNewsID(r.Context(), int32(pid))
+	ann, err := cd.NewsAnnouncement(int32(pid))
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("getLatestAnnouncementByNewsID: %v", err)
@@ -38,10 +39,11 @@ func NewsAnnouncementActivateActionPage(w http.ResponseWriter, r *http.Request) 
 
 func NewsAnnouncementDeactivateActionPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
 
-	ann, err := queries.GetLatestAnnouncementByNewsID(r.Context(), int32(pid))
+	ann, err := cd.NewsAnnouncement(int32(pid))
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("getLatestAnnouncementByNewsID: %v", err)

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -182,7 +182,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data.Thread = threadRow
-	ann, err := queries.GetLatestAnnouncementByNewsID(r.Context(), post.Idsitenews)
+	ann, err := data.CoreData.NewsAnnouncement(post.Idsitenews)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("getLatestAnnouncementByNewsID: %v", err)
 	}


### PR DESCRIPTION
## Summary
- cache news announcements per post
- load announcements lazily in news pages and handlers
- test NewsAnnouncement lazy loading

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68763a9538a8832fa4f1eb349a42df7b