### PR TITLE
Add lazy bookmarks loader

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -61,6 +61,7 @@ type CoreData struct {
 	forumCategories lazyValue[[]*db.Forumcategory]
 	latestNews      lazyValue[[]*NewsPost]
 	writeCats       lazyValue[[]*db.WritingCategory]
+	bookmarks       lazyValue[*db.GetBookmarksForUserRow]
 
 	event *eventbus.Event
 }
@@ -332,6 +333,16 @@ func (cd *CoreData) WritingCategories() ([]*db.WritingCategory, error) {
 			}
 		}
 		return cats, nil
+	})
+}
+
+// Bookmarks returns the user's bookmark list loaded lazily.
+func (cd *CoreData) Bookmarks() (*db.GetBookmarksForUserRow, error) {
+	return cd.bookmarks.load(func() (*db.GetBookmarksForUserRow, error) {
+		if cd.UserID == 0 || cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetBookmarksForUser(cd.ctx, cd.UserID)
 	})
 }
 

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -81,3 +81,31 @@ func TestWritingCategoriesLazy(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestBookmarksLazy(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := dbpkg.New(db)
+	rows := sqlmock.NewRows([]string{"Idbookmarks", "list"}).AddRow(1, sql.NullString{String: "a", Valid: true})
+
+	mock.ExpectQuery("SELECT Idbookmarks").WithArgs(int32(1)).WillReturnRows(rows)
+
+	ctx := context.WithValue(context.Background(), ContextValues("queries"), queries)
+	cd := NewCoreData(ctx, queries)
+	cd.UserID = 1
+
+	if _, err := cd.Bookmarks(); err != nil {
+		t.Fatalf("Bookmarks: %v", err)
+	}
+	if _, err := cd.Bookmarks(); err != nil {
+		t.Fatalf("Bookmarks second call: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/handlers/bookmarks/edit.go
+++ b/handlers/bookmarks/edit.go
@@ -24,14 +24,13 @@ func EditPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:        r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
 		BookmarkContent: "Category: Example 1\nhttp://www.google.com.au Google\nColumn\nCategory: Example 2\nhttp://www.google.com.au Google\nhttp://www.google.com.au Google\n",
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
-	uid, _ := session.Values["UID"].(int32)
-
-	bookmarks, err := queries.GetBookmarksForUser(r.Context(), uid)
+	_ = session
+	cd := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)
+	bookmarks, err := cd.Bookmarks()
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/bookmarks/mine.go
+++ b/handlers/bookmarks/mine.go
@@ -11,7 +11,6 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
 	common "github.com/arran4/goa4web/handlers/common"
-	db "github.com/arran4/goa4web/internal/db"
 )
 
 type BookmarkEntry struct {
@@ -77,14 +76,13 @@ func MinePage(w http.ResponseWriter, r *http.Request) {
 		Columns []*BookmarkColumn
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
-	uid, _ := session.Values["UID"].(int32)
-
-	bookmarks, err := queries.GetBookmarksForUser(r.Context(), uid)
+	_ = session
+	cd := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)
+	bookmarks, err := cd.Bookmarks()
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -96,7 +94,7 @@ func MinePage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: cd,
 		Columns:  preprocessBookmarks(bookmarks.List.String),
 	}
 


### PR DESCRIPTION
## Summary
- add Bookmarks lazy loader to CoreData
- switch bookmark handlers to use the new loader
- verify loader caching in coredata tests

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68763a91f968832fa13e2722ddccb777