### PR TITLE
Add lazy loaders for bloggers and writers

### DIFF
--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -1,4 +1,4 @@
-package common
+package common_test
 
 import (
 	"context"
@@ -9,12 +9,13 @@ import (
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	common "github.com/arran4/goa4web/core/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
 
 func TestTemplateFuncsFirstline(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
-	funcs := NewFuncs(r)
+	funcs := common.NewFuncs(r)
 	first := funcs["firstline"].(func(string) string)
 	if got := first("a\nb\n"); got != "a" {
 		t.Errorf("firstline=%q", got)
@@ -23,7 +24,7 @@ func TestTemplateFuncsFirstline(t *testing.T) {
 
 func TestTemplateFuncsLeft(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
-	funcs := NewFuncs(r)
+	funcs := common.NewFuncs(r)
 	left := funcs["left"].(func(int, string) string)
 	if got := left(3, "hello"); got != "hel" {
 		t.Errorf("left short=%q", got)
@@ -58,11 +59,11 @@ func TestLatestNewsRespectsPermissions(t *testing.T) {
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "news", sql.NullString{String: "post", Valid: true}, "see", sql.NullInt32{Int32: 2, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnError(sql.ErrNoRows)
 
 	req := httptest.NewRequest("GET", "/", nil)
-	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)
-	cd := NewCoreData(ctx, queries)
+	ctx := context.WithValue(req.Context(), common.ContextValues("queries"), queries)
+	cd := common.NewCoreData(ctx, queries)
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
-	ctx = context.WithValue(ctx, ContextValues("coreData"), cd)
+	ctx = context.WithValue(ctx, common.ContextValues("coreData"), cd)
 	req = req.WithContext(ctx)
 
 	funcs := cd.Funcs(req)

--- a/handlers/blogs/bloggerListPage.go
+++ b/handlers/blogs/bloggerListPage.go
@@ -34,25 +34,9 @@ func BloggerListPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
 	pageSize := common.GetPageSize(r)
-	var rows []*db.BloggerCountRow
-	var err error
-	if data.Search != "" {
-		rows, err = queries.SearchBloggers(r.Context(), db.SearchBloggersParams{
-			ViewerID: data.UserID,
-			Query:    data.Search,
-			Limit:    int32(pageSize + 1),
-			Offset:   int32(offset),
-		})
-	} else {
-		rows, err = queries.ListBloggers(r.Context(), db.ListBloggersParams{
-			ViewerID: data.UserID,
-			Limit:    int32(pageSize + 1),
-			Offset:   int32(offset),
-		})
-	}
+	rows, err := data.CoreData.Bloggers(r)
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/writings/writingsWriterListPage.go
+++ b/handlers/writings/writingsWriterListPage.go
@@ -39,25 +39,9 @@ func WriterListPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
 	pageSize := common.GetPageSize(r)
-	var rows []*db.WriterCountRow
-	var err error
-	if data.Search != "" {
-		rows, err = queries.SearchWriters(r.Context(), db.SearchWritersParams{
-			ViewerID: data.UserID,
-			Query:    data.Search,
-			Limit:    int32(pageSize + 1),
-			Offset:   int32(offset),
-		})
-	} else {
-		rows, err = queries.ListWriters(r.Context(), db.ListWritersParams{
-			ViewerID: data.UserID,
-			Limit:    int32(pageSize + 1),
-			Offset:   int32(offset),
-		})
-	}
+	rows, err := data.CoreData.Writers(r)
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/writings/writingsWriterListPage_test.go
+++ b/handlers/writings/writingsWriterListPage_test.go
@@ -24,7 +24,8 @@ func TestWriterListPage_List(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/writings/writers", nil)
 	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
-	cd := &corecommon.CoreData{UserID: 1}
+	cd := corecommon.NewCoreData(ctx, q)
+	cd.UserID = 1
 	ctx = context.WithValue(ctx, hcommon.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -52,7 +53,8 @@ func TestWriterListPage_Search(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/writings/writers?search=bob", nil)
 	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
-	cd := &corecommon.CoreData{UserID: 1}
+	cd := corecommon.NewCoreData(ctx, q)
+	cd.UserID = 1
 	ctx = context.WithValue(ctx, hcommon.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- implement Bloggers and Writers lazy loaders in core/common
- refactor blog and writer list pages to use the lazy loaders
- ensure repeated calls only query once
- update writer list page tests accordingly

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`
- `go mod tidy`

------
https://chatgpt.com/codex/tasks/task_e_68763a9b4fe8832f819602106b20b74d