### PR TITLE
Add cached forum thread loader

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -61,6 +61,7 @@ type CoreData struct {
 	forumCategories lazyValue[[]*db.Forumcategory]
 	latestNews      lazyValue[[]*NewsPost]
 	writeCats       lazyValue[[]*db.WritingCategory]
+	forumThreads    map[int32]*lazyValue[[]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow]
 
 	event *eventbus.Event
 }
@@ -267,6 +268,28 @@ func (cd *CoreData) ForumCategories() ([]*db.Forumcategory, error) {
 			return nil, nil
 		}
 		return cd.queries.GetAllForumCategories(cd.ctx)
+	})
+}
+
+// ForumThreads loads the threads for a forum topic once per topic.
+func (cd *CoreData) ForumThreads(topicID int32) ([]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow, error) {
+	if cd.forumThreads == nil {
+		cd.forumThreads = make(map[int32]*lazyValue[[]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow])
+	}
+	lv, ok := cd.forumThreads[topicID]
+	if !ok {
+		lv = &lazyValue[[]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow]{}
+		cd.forumThreads[topicID] = lv
+	}
+	return lv.load(func() ([]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostText(cd.ctx, db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextParams{
+			ViewerID:      cd.UserID,
+			TopicID:       topicID,
+			ViewerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		})
 	})
 }
 

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -81,3 +81,37 @@ func TestWritingCategoriesLazy(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestForumThreadsLazy(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := dbpkg.New(db)
+	rows := sqlmock.NewRows([]string{
+		"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic",
+		"comments", "lastaddition", "locked", "lastposterusername", "lastposterid",
+		"firstpostusername", "firstpostwritten", "firstposttext",
+	}).AddRow(1, 1, 1, 1, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	mock.ExpectQuery("SELECT th.idforumthread").
+		WithArgs(int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
+		WillReturnRows(rows)
+
+	ctx := context.WithValue(context.Background(), ContextValues("queries"), queries)
+	cd := NewCoreData(ctx, queries)
+	cd.UserID = 1
+
+	if _, err := cd.ForumThreads(1); err != nil {
+		t.Fatalf("ForumThreads: %v", err)
+	}
+	if _, err := cd.ForumThreads(1); err != nil {
+		t.Fatalf("ForumThreads second call: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/handlers/forum/forumFeed.go
+++ b/handlers/forum/forumFeed.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/arran4/goa4web/a4code2html"
 	"github.com/arran4/goa4web/core"
+	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers/common"
 	imageshandler "github.com/arran4/goa4web/handlers/images"
 	db "github.com/arran4/goa4web/internal/db"
@@ -66,6 +67,7 @@ func TopicRssPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	topicID, _ := strconv.Atoi(vars["topic"])
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)
 
 	topic, err := queries.GetForumTopicByIdForUser(r.Context(), db.GetForumTopicByIdForUserParams{
 		ViewerID:      uid,
@@ -80,11 +82,7 @@ func TopicRssPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows, err := queries.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostText(r.Context(), db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextParams{
-		ViewerID:      uid,
-		TopicID:       int32(topicID),
-		ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0},
-	})
+	rows, err := cd.ForumThreads(int32(topicID))
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -108,6 +106,7 @@ func TopicAtomPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	topicID, _ := strconv.Atoi(vars["topic"])
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)
 
 	topic, err := queries.GetForumTopicByIdForUser(r.Context(), db.GetForumTopicByIdForUserParams{
 		ViewerID:      uid,
@@ -122,11 +121,7 @@ func TopicAtomPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows, err := queries.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostText(r.Context(), db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextParams{
-		ViewerID:      uid,
-		TopicID:       int32(topicID),
-		ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0},
-	})
+	rows, err := cd.ForumThreads(int32(topicID))
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/forum/forumTopicPage.go
+++ b/handlers/forum/forumTopicPage.go
@@ -92,19 +92,11 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	threadRows, err := queries.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostText(r.Context(), db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextParams{
-		ViewerID:      uid,
-		TopicID:       int32(topicId),
-		ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0},
-	})
-	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-		default:
-			log.Printf("Error: getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-			return
-		}
+	threadRows, err := cd.ForumThreads(int32(topicId))
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		log.Printf("Error: ForumThreads: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
 	}
 	data.Threads = threadRows
 


### PR DESCRIPTION
## Summary
- add cached forum threads loader on `CoreData`
- switch topic and feed handlers to use `ForumThreads`
- test caching logic
- run `go vet`, `golangci-lint`, and `go test`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68763a8a3e30832f86d6f1890703a96e