### PR TITLE
Replace FetchLanguages with CoreData

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -55,6 +55,7 @@ type CoreData struct {
 	perms           lazyValue[[]*db.GetPermissionsByUserIDRow]
 	pref            lazyValue[*db.Preference]
 	langs           lazyValue[[]*db.UserLanguage]
+	languageList    lazyValue[[]*db.Language]
 	roles           lazyValue[[]string]
 	allRoles        lazyValue[[]*db.Role]
 	announcement    lazyValue[*db.GetActiveAnnouncementWithNewsRow]
@@ -225,13 +226,23 @@ func (cd *CoreData) Preference() (*db.Preference, error) {
 	})
 }
 
-// Languages returns the user's language selections loaded on demand.
-func (cd *CoreData) Languages() ([]*db.UserLanguage, error) {
+// UserLanguages returns the user's language selections loaded on demand.
+func (cd *CoreData) UserLanguages() ([]*db.UserLanguage, error) {
 	return cd.langs.load(func() ([]*db.UserLanguage, error) {
 		if cd.UserID == 0 || cd.queries == nil {
 			return nil, nil
 		}
 		return cd.queries.GetUserLanguages(cd.ctx, cd.UserID)
+	})
+}
+
+// Languages returns the available languages loaded once.
+func (cd *CoreData) Languages() ([]*db.Language, error) {
+	return cd.languageList.load(func() ([]*db.Language, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.FetchLanguages(cd.ctx)
 	})
 }
 

--- a/handlers/admin/adminSiteSettingsPage.go
+++ b/handlers/admin/adminSiteSettingsPage.go
@@ -15,6 +15,7 @@ import (
 
 func AdminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
 
 	if r.Method == http.MethodPost {
 		if err := r.ParseForm(); err != nil {
@@ -23,7 +24,7 @@ func AdminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 		}
 		config.AppRuntimeConfig.FeedsEnabled = r.PostFormValue("feeds_enabled") != ""
 		langID, _ := strconv.Atoi(r.PostFormValue("default_language"))
-		langs, _ := queries.FetchLanguages(r.Context())
+		langs, _ := cd.Languages()
 		name := ""
 		for _, l := range langs {
 			if int(l.Idlanguage) == langID {
@@ -50,7 +51,7 @@ func AdminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId: corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage),
 	}
 	data.CoreData.FeedsEnabled = config.AppRuntimeConfig.FeedsEnabled
-	if langs, err := queries.FetchLanguages(r.Context()); err == nil {
+	if langs, err := cd.Languages(); err == nil {
 		data.Languages = langs
 	}
 

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -36,7 +36,7 @@ func BlogAddPage(w http.ResponseWriter, r *http.Request) {
 		Mode:               "Add",
 	}
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := cd.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -36,7 +36,7 @@ func BlogEditPage(w http.ResponseWriter, r *http.Request) {
 		Mode:               "Edit",
 	}
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := cd.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/blogs/blogsBlogPage.go
+++ b/handlers/blogs/blogsBlogPage.go
@@ -58,7 +58,7 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 		EditUrl:            fmt.Sprintf("/blogs/blog/%d/edit", blogId),
 	}
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := data.CoreData.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -61,7 +61,7 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 		EditUrl:            fmt.Sprintf("/blogs/blog/%d/edit", blogId),
 	}
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := data.CoreData.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -28,7 +28,7 @@ func AskPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId: corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage),
 	}
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := data.CoreData.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -34,7 +34,7 @@ func ThreadNewPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
 	}
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := data.CoreData.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -53,8 +53,9 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 		IsReplyable:        true,
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
 	}
+	cd := data.CoreData
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := cd.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -59,6 +59,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 		BoardId:       bid,
 		ForumThreadId: thid,
 	}
+	cd := data.CoreData
 
 	if !data.CoreData.HasGrant("imagebbs", "board", "view", int32(bid)) {
 		_ = templates.GetCompiledTemplates(corecommon.NewFuncs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
@@ -97,7 +98,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := cd.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/languages/admin.go
+++ b/handlers/languages/admin.go
@@ -28,9 +28,7 @@ func adminLanguagesPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
-
-	rows, err := queries.FetchLanguages(r.Context())
+	rows, err := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData).Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -29,6 +29,7 @@ func AdminAddPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:           r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
 	}
+	cd := data.CoreData
 
 	categoryRows, err := queries.GetAllLinkerCategories(r.Context())
 	if err != nil {
@@ -43,7 +44,7 @@ func AdminAddPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Categories = categoryRows
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := cd.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -69,7 +69,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 
 	queries = r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := cd.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -41,7 +41,7 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	linkId, _ := strconv.Atoi(vars["link"])
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := cd.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -29,6 +29,7 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:           r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
 	}
+	cd := data.CoreData
 
 	categoryRows, err := queries.GetAllLinkerCategories(r.Context())
 	if err != nil {
@@ -43,7 +44,7 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Categories = categoryRows
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := cd.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -135,7 +135,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := data.CoreData.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -31,12 +31,11 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
 	pref, _ := cd.Preference()
-	userLangs, _ := cd.Languages()
+	userLangs, _ := cd.UserLanguages()
 
-	langs, err := queries.FetchLanguages(r.Context())
+	langs, err := cd.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -76,7 +75,7 @@ func saveUserLanguages(r *http.Request, queries *db.Queries, uid int32) error {
 		return err
 	}
 
-	langs, err := queries.FetchLanguages(r.Context())
+	langs, err := r.Context().Value(common.KeyCoreData).(*common.CoreData).Languages()
 	if err != nil {
 		return err
 	}

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -26,9 +26,7 @@ func ArticleAddPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData),
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
-
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := data.CoreData.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -44,7 +44,7 @@ func ArticleEditPage(w http.ResponseWriter, r *http.Request) {
 	writing := r.Context().Value(hcommon.KeyWriting).(*db.GetWritingByIdForUserDescendingByPublishedDateRow)
 	data.Writing = writing
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := data.CoreData.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -145,7 +145,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 	data.CanEdit = (cd.HasRole("administrator") && cd.AdminMode) || (cd.HasRole("content writer") && data.IsAuthor)
 	data.CategoryId = writing.WritingCategoryID
 
-	languageRows, err := queries.FetchLanguages(r.Context())
+	languageRows, err := cd.Languages()
 	if err != nil {
 		log.Printf("FetchLanguages Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)


### PR DESCRIPTION
## Summary
- centralize language listing in CoreData
- adjust handlers to use `cd.Languages()`
- rename old `Languages()` to `UserLanguages`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68763a85ea74832f959bbdf22f61b127