### PR TITLE
Use CoreData loader for preferences

### DIFF
--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -20,6 +20,7 @@ const gdprExportNote = "# Personal data export - handle according to GDPR"
 // admins. The user ID is provided via the "uid" query parameter.
 func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
 
 	uid, err := strconv.Atoi(r.URL.Query().Get("uid"))
 	if err != nil {
@@ -34,7 +35,7 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 	}
 	user := &db.User{Idusers: urow.Idusers, Username: urow.Username}
 
-	pref, _ := queries.GetPreferenceByUserID(r.Context(), int32(uid))
+	pref, _ := cd.Preference()
 	langs, _ := queries.GetUserLanguages(r.Context(), int32(uid))
 	perms, _ := queries.GetPermissionsByUserID(r.Context(), int32(uid))
 

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -93,12 +93,14 @@ func userEmailSaveActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+
 	updates := r.PostFormValue("emailupdates") != ""
 	auto := r.PostFormValue("autosubscribe") != ""
 
-	_, err := queries.GetPreferenceByUserID(r.Context(), uid)
+	_, err := cd.Preference()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		log.Printf("GetPreferenceByUserID Error: %s", err)
+		log.Printf("preference load: %v", err)
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -156,6 +156,7 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 
 	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
 	cd := corecommon.NewCoreData(ctx, queries, corecommon.WithSession(sess))
+	cd.UserID = 1
 	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rows := sqlmock.NewRows([]string{"idlanguage", "nameof"}).AddRow(1, "en").AddRow(2, "fr")
@@ -204,6 +205,7 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 
 	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
 	cd := corecommon.NewCoreData(ctx, queries, corecommon.WithSession(sess))
+	cd.UserID = 1
 	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -253,6 +255,7 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 
 	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
 	cd := corecommon.NewCoreData(ctx, queries, corecommon.WithSession(sess))
+	cd.UserID = 1
 	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 


### PR DESCRIPTION
## Summary
- swap direct `GetPreferenceByUserID` calls for `cd.Preference()` in user handlers
- simplify logic for creating or updating preferences
- fix tests to set the current user's ID

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68763a85cd20832fbaed1a0b92ba983c