### PR TITLE
Add cached PublicWritings loader

### DIFF
--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -81,3 +81,52 @@ func TestWritingCategoriesLazy(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestPublicWritingsLazy(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := dbpkg.New(db)
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "Username", "Comments"}).
+		AddRow(1, 1, 0, 1, 0, "t", now, "w", "a", false, now, "u", 0)
+
+	mock.ExpectQuery("SELECT w.idwriting").WithArgs(int32(1), int32(0), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
+	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "article", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	rows2 := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "Username", "Comments"}).
+		AddRow(2, 1, 0, 1, 1, "t2", now, "w2", "a2", false, now, "u", 0)
+
+	mock.ExpectQuery("SELECT w.idwriting").WithArgs(int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows2)
+	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "article", Valid: true}, "see", sql.NullInt32{Int32: 2, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	ctx := context.WithValue(req.Context(), ContextValues("queries"), queries)
+	cd := NewCoreData(ctx, queries)
+	cd.UserID = 1
+	cd.SetRoles([]string{"user"})
+	ctx = context.WithValue(ctx, ContextValues("coreData"), cd)
+	req = req.WithContext(ctx)
+
+	if _, err := cd.PublicWritings(0, req); err != nil {
+		t.Fatalf("PublicWritings: %v", err)
+	}
+	if _, err := cd.PublicWritings(0, req); err != nil {
+		t.Fatalf("PublicWritings second call: %v", err)
+	}
+	if _, err := cd.PublicWritings(1, req); err != nil {
+		t.Fatalf("PublicWritings other category: %v", err)
+	}
+	if _, err := cd.PublicWritings(1, req); err != nil {
+		t.Fatalf("PublicWritings other category second call: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/handlers/writings/writingsCategoriesPage.go
+++ b/handlers/writings/writingsCategoriesPage.go
@@ -42,14 +42,7 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-	writingsRows, err := queries.GetPublicWritingsInCategoryForUser(r.Context(), db.GetPublicWritingsInCategoryForUserParams{
-		ViewerID:          data.CoreData.UserID,
-		WritingCategoryID: 0,
-		UserID:            sql.NullInt32{Int32: data.CoreData.UserID, Valid: data.CoreData.UserID != 0},
-		Limit:             15,
-		Offset:            0,
-	})
+	writingsRows, err := data.CoreData.PublicWritings(0, r)
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/writings/writingsCategoryPage.go
+++ b/handlers/writings/writingsCategoryPage.go
@@ -42,22 +42,13 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 	data.CategoryId = int32(categoryId)
 	data.WritingCategoryID = data.CategoryId
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-
 	categoryRows, err := data.CoreData.WritingCategories()
 	if err != nil {
 		log.Printf("writingCategories: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-
-	writingsRows, err := queries.GetPublicWritingsInCategoryForUser(r.Context(), db.GetPublicWritingsInCategoryForUserParams{
-		ViewerID:          data.CoreData.UserID,
-		WritingCategoryID: data.CategoryId,
-		UserID:            sql.NullInt32{Int32: data.CoreData.UserID, Valid: data.CoreData.UserID != 0},
-		Limit:             15,
-		Offset:            0,
-	})
+	writingsRows, err := data.CoreData.PublicWritings(data.CategoryId, r)
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):


### PR DESCRIPTION
## Summary
- add publicWritings cache to CoreData
- implement `PublicWritings` with per-category+offset lazy loading
- use `PublicWritings` in writings pages
- test loader behaviour

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687639a2e5f0832fbdc42bbf5264ed20