### PR TITLE
Add caching for news announcements

### DIFF
--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -75,6 +76,61 @@ func TestWritingCategoriesLazy(t *testing.T) {
 	}
 	if _, err := cd.WritingCategories(); err != nil {
 		t.Fatalf("WritingCategories second call: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestAnnouncementForNewsCaching(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := dbpkg.New(db)
+	now := time.Now()
+	annRows := sqlmock.NewRows([]string{"id", "site_news_id", "active", "created_at"}).
+		AddRow(1, 1, true, now)
+
+	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnRows(annRows)
+
+	ctx := context.WithValue(context.Background(), ContextValues("queries"), queries)
+	cd := NewCoreData(ctx, queries)
+
+	if _, err := cd.AnnouncementForNews(1); err != nil {
+		t.Fatalf("AnnouncementForNews: %v", err)
+	}
+	if _, err := cd.AnnouncementForNews(1); err != nil {
+		t.Fatalf("AnnouncementForNews second: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestAnnouncementForNewsError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	queries := dbpkg.New(db)
+
+	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnError(sql.ErrConnDone)
+
+	ctx := context.WithValue(context.Background(), ContextValues("queries"), queries)
+	cd := NewCoreData(ctx, queries)
+
+	if _, err := cd.AnnouncementForNews(1); !errors.Is(err, sql.ErrConnDone) {
+		t.Fatalf("AnnouncementForNews error=%v", err)
+	}
+	if _, err := cd.AnnouncementForNews(1); !errors.Is(err, sql.ErrConnDone) {
+		t.Fatalf("AnnouncementForNews second=%v", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/handlers/news/newsAnnouncementHandlers.go
+++ b/handlers/news/newsAnnouncementHandlers.go
@@ -15,14 +15,13 @@ import (
 
 func NewsAnnouncementActivateActionPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
 
-	ann, err := queries.GetLatestAnnouncementByNewsID(r.Context(), int32(pid))
-	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			log.Printf("getLatestAnnouncementByNewsID: %v", err)
-		}
+	ann, err := cd.AnnouncementForNews(int32(pid))
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		log.Printf("announcementForNews: %v", err)
 	}
 	if ann == nil {
 		if err := queries.CreateAnnouncement(r.Context(), int32(pid)); err != nil {
@@ -38,13 +37,14 @@ func NewsAnnouncementActivateActionPage(w http.ResponseWriter, r *http.Request) 
 
 func NewsAnnouncementDeactivateActionPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
 
-	ann, err := queries.GetLatestAnnouncementByNewsID(r.Context(), int32(pid))
+	ann, err := cd.AnnouncementForNews(int32(pid))
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
-			log.Printf("getLatestAnnouncementByNewsID: %v", err)
+			log.Printf("announcementForNews: %v", err)
 		}
 		hcommon.TaskDoneAutoRefreshPage(w, r)
 		return

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -182,9 +182,9 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data.Thread = threadRow
-	ann, err := queries.GetLatestAnnouncementByNewsID(r.Context(), post.Idsitenews)
+	ann, err := data.CoreData.AnnouncementForNews(post.Idsitenews)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		log.Printf("getLatestAnnouncementByNewsID: %v", err)
+		log.Printf("announcementForNews: %v", err)
 	}
 	data.Post = &Post{
 		GetNewsPostByIdWithWriterIdAndThreadCommentCountRow: post,


### PR DESCRIPTION
## Summary
- cache latest announcement lookups by news ID in `CoreData`
- use the cached helper in news handlers and latest news fetch
- cover the caching and error paths with tests

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68763994a68c832fb758bfcb317ea1c9