### PR TITLE
Use CoreData for admin user export

### DIFF
--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 
+	corecommon "github.com/arran4/goa4web/core/common"
 	common "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
 )
@@ -23,20 +25,43 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 
 	uid, err := strconv.Atoi(r.URL.Query().Get("uid"))
 	if err != nil {
+		log.Printf("parse uid: %v", err)
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
 
-	urow, err := queries.GetUserById(r.Context(), int32(uid))
+	cd := corecommon.NewCoreData(r.Context(), queries)
+	cd.UserID = int32(uid)
+
+	user, err := cd.CurrentUser()
 	if err != nil {
+		log.Printf("current user: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	user := &db.User{Idusers: urow.Idusers, Username: urow.Username}
+	if user == nil {
+		http.NotFound(w, r)
+		return
+	}
 
-	pref, _ := queries.GetPreferenceByUserID(r.Context(), int32(uid))
-	langs, _ := queries.GetUserLanguages(r.Context(), int32(uid))
-	perms, _ := queries.GetPermissionsByUserID(r.Context(), int32(uid))
+	pref, err := cd.Preference()
+	if err != nil {
+		log.Printf("load preference: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	langs, err := cd.Languages()
+	if err != nil {
+		log.Printf("load languages: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	perms, err := cd.Permissions()
+	if err != nil {
+		log.Printf("load permissions: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
 
 	data := struct {
 		Note        string                          `json:"note"`
@@ -52,17 +77,27 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 		Permissions: perms,
 	}
 
-	cats, _ := queries.FetchAllCategories(r.Context())
+	cats, err := queries.FetchAllCategories(r.Context())
+	if err != nil {
+		log.Printf("fetch categories: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
 	catMap := make(map[int32]string)
 	for _, c := range cats {
 		catMap[c.Idwritingcategory] = c.Title.String
 	}
 
-	writings, _ := queries.GetAllWritingsByUser(r.Context(), db.GetAllWritingsByUserParams{
+	writings, err := queries.GetAllWritingsByUser(r.Context(), db.GetAllWritingsByUserParams{
 		ViewerID:      int32(uid),
 		AuthorID:      int32(uid),
 		ViewerMatchID: sql.NullInt32{Int32: int32(uid), Valid: true},
 	})
+	if err != nil {
+		log.Printf("fetch writings: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
 	type writingExport struct {
 		*db.GetAllWritingsByUserRow
 		Category string `json:"category"`
@@ -72,9 +107,24 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 		ws = append(ws, writingExport{wrow, catMap[wrow.WritingCategoryID]})
 	}
 
-	blogs, _ := queries.GetAllBlogEntriesByUser(r.Context(), int32(uid))
-	threads, _ := queries.GetThreadsStartedByUser(r.Context(), int32(uid))
-	comments, _ := queries.GetAllCommentsByUser(r.Context(), int32(uid))
+	blogs, err := queries.GetAllBlogEntriesByUser(r.Context(), int32(uid))
+	if err != nil {
+		log.Printf("fetch blogs: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	threads, err := queries.GetThreadsStartedByUser(r.Context(), int32(uid))
+	if err != nil {
+		log.Printf("fetch threads: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	comments, err := queries.GetAllCommentsByUser(r.Context(), int32(uid))
+	if err != nil {
+		log.Printf("fetch comments: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
 
 	w.Header().Set("Content-Type", "application/zip")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=user_%d.zip", uid))
@@ -82,32 +132,60 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 	defer zw.Close()
 
 	if f, err := zw.Create("user.json"); err == nil {
-		_ = json.NewEncoder(f).Encode(data)
+		if err := json.NewEncoder(f).Encode(data); err != nil {
+			log.Printf("write user.json: %v", err)
+		}
+	} else {
+		log.Printf("create user.json: %v", err)
 	}
 	if f, err := zw.Create("writings.json"); err == nil {
-		_ = json.NewEncoder(f).Encode(ws)
+		if err := json.NewEncoder(f).Encode(ws); err != nil {
+			log.Printf("write writings.json: %v", err)
+		}
+	} else {
+		log.Printf("create writings.json: %v", err)
 	}
 	for _, wrow := range writings {
 		if wrow.Writing.Valid {
 			if f, err := zw.Create(fmt.Sprintf("writings/%d.html", wrow.Idwriting)); err == nil {
-				_, _ = f.Write([]byte(wrow.Writing.String))
+				if _, err := f.Write([]byte(wrow.Writing.String)); err != nil {
+					log.Printf("write writing %d: %v", wrow.Idwriting, err)
+				}
+			} else {
+				log.Printf("create writing %d: %v", wrow.Idwriting, err)
 			}
 		}
 	}
 	if f, err := zw.Create("blogs.json"); err == nil {
-		_ = json.NewEncoder(f).Encode(blogs)
+		if err := json.NewEncoder(f).Encode(blogs); err != nil {
+			log.Printf("write blogs.json: %v", err)
+		}
+	} else {
+		log.Printf("create blogs.json: %v", err)
 	}
 	for _, b := range blogs {
 		if b.Blog.Valid {
 			if f, err := zw.Create(fmt.Sprintf("blogs/%d.html", b.Idblogs)); err == nil {
-				_, _ = f.Write([]byte(b.Blog.String))
+				if _, err := f.Write([]byte(b.Blog.String)); err != nil {
+					log.Printf("write blog %d: %v", b.Idblogs, err)
+				}
+			} else {
+				log.Printf("create blog %d: %v", b.Idblogs, err)
 			}
 		}
 	}
 	if f, err := zw.Create("threads.json"); err == nil {
-		_ = json.NewEncoder(f).Encode(threads)
+		if err := json.NewEncoder(f).Encode(threads); err != nil {
+			log.Printf("write threads.json: %v", err)
+		}
+	} else {
+		log.Printf("create threads.json: %v", err)
 	}
 	if f, err := zw.Create("comments.json"); err == nil {
-		_ = json.NewEncoder(f).Encode(comments)
+		if err := json.NewEncoder(f).Encode(comments); err != nil {
+			log.Printf("write comments.json: %v", err)
+		}
+	} else {
+		log.Printf("create comments.json: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- load export info using `CoreData` helpers in `admin_export.go`
- add detailed error logging for user info lookup and file generation

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6876397d4e68832f9ad7724eacf050e4