### PR TITLE
Refactor role loading via CoreData

### DIFF
--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -64,24 +64,21 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 		queries := r.Context().Value(hcommon.KeyQueries).(*dbpkg.Queries)
 		if session.ID != "" {
 			if uid != 0 {
-				_ = queries.InsertSession(r.Context(), dbpkg.InsertSessionParams{SessionID: session.ID, UsersIdusers: uid})
+				if err := queries.InsertSession(r.Context(), dbpkg.InsertSessionParams{SessionID: session.ID, UsersIdusers: uid}); err != nil {
+					log.Printf("insert session: %v", err)
+				}
 			} else {
-				_ = queries.DeleteSessionByID(r.Context(), session.ID)
-			}
-		}
-
-		roles := []string{"anonymous"}
-		if uid != 0 {
-			roles = append(roles, "user")
-			perms, err := queries.GetPermissionsByUserID(r.Context(), uid)
-			if err == nil {
-				for _, p := range perms {
-					if p.Name != "" {
-						roles = append(roles, p.Name)
-					}
+				if err := queries.DeleteSessionByID(r.Context(), session.ID); err != nil {
+					log.Printf("delete session: %v", err)
 				}
 			}
 		}
+
+		cd := common.NewCoreData(r.Context(), queries,
+			common.WithImageURLMapper(imagesign.MapURL),
+			common.WithSession(session))
+		cd.UserID = uid
+		_ = cd.Roles()
 
 		idx := nav.IndexItems()
 		if uid != 0 {
@@ -90,17 +87,14 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 		var count int32
 		if uid != 0 && hcommon.NotificationsEnabled() {
 			c, err := queries.CountUnreadNotifications(r.Context(), uid)
-			if err == nil {
+			if err != nil {
+				log.Printf("count unread notifications: %v", err)
+			} else {
 				count = int32(c)
 				idx = append(idx, common.IndexItem{Name: fmt.Sprintf("Notifications (%d)", c), Link: "/usr/notifications"})
 			}
 		}
-		cd := common.NewCoreData(r.Context(), queries,
-			common.WithImageURLMapper(imagesign.MapURL),
-			common.WithSession(session))
-		cd.SetRoles(roles)
 		cd.IndexItems = idx
-		cd.UserID = uid
 		cd.Title = "Arran's Site"
 		cd.FeedsEnabled = config.AppRuntimeConfig.FeedsEnabled
 		cd.AdminMode = r.URL.Query().Get("mode") == "admin"

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -1,0 +1,92 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	corecommon "github.com/arran4/goa4web/core/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/google/go-cmp/cmp"
+	"github.com/gorilla/sessions"
+)
+
+func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	mock.MatchExpectationsInOrder(false)
+
+	q := dbpkg.New(db)
+
+	mock.ExpectExec("INSERT INTO sessions").WithArgs("sessid", int32(1)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	rows := sqlmock.NewRows([]string{"iduser_roles", "users_idusers", "name"}).
+		AddRow(1, 1, "moderator")
+	mock.ExpectQuery(regexp.QuoteMeta("FROM user_roles")).WithArgs(int32(1)).
+		WillReturnRows(rows)
+
+	session := &sessions.Session{ID: "sessid", Values: map[interface{}]interface{}{"UID": int32(1)}}
+	req := httptest.NewRequest("GET", "/", nil)
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	ctx = context.WithValue(ctx, corecommon.ContextValues("session"), session)
+	req = req.WithContext(ctx)
+
+	var cd *corecommon.CoreData
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cd, _ = r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)
+	})
+
+	CoreAdderMiddleware(handler).ServeHTTP(httptest.NewRecorder(), req)
+
+	want := []string{"anonymous", "user", "moderator"}
+	if diff := cmp.Diff(want, cd.Roles()); diff != "" {
+		t.Fatalf("roles mismatch (-want +got):\n%s", diff)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	mock.MatchExpectationsInOrder(false)
+
+	q := dbpkg.New(db)
+
+	mock.ExpectExec("DELETE FROM sessions").WithArgs("sessid").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	session := &sessions.Session{ID: "sessid"}
+	req := httptest.NewRequest("GET", "/", nil)
+	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	ctx = context.WithValue(ctx, corecommon.ContextValues("session"), session)
+	req = req.WithContext(ctx)
+
+	var cd *corecommon.CoreData
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cd, _ = r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)
+	})
+
+	CoreAdderMiddleware(handler).ServeHTTP(httptest.NewRecorder(), req)
+
+	want := []string{"anonymous"}
+	if diff := cmp.Diff(want, cd.Roles()); diff != "" {
+		t.Fatalf("roles mismatch (-want +got):\n%s", diff)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- simplify CoreAdderMiddleware role logic
- preload roles using `CoreData.Roles()`
- add regression tests for middleware role handling
- log failures for session save queries and notification counts

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68763977bea8832f910db906e0dfda89