### PR TITLE
Use TemplateHandler for forum admin pages

### DIFF
--- a/handlers/forum/adminForumFlaggedPostsPage.go
+++ b/handlers/forum/adminForumFlaggedPostsPage.go
@@ -1,23 +1,11 @@
 package forum
 
 import (
-	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
-	"log"
+	hcommon "github.com/arran4/goa4web/handlers/common"
 	"net/http"
-
-	"github.com/arran4/goa4web/core/templates"
 )
 
 // adminForumFlaggedPostsPage displays posts flagged for moderator review.
 func AdminForumFlaggedPostsPage(w http.ResponseWriter, r *http.Request) {
-	type Data struct {
-		*CoreData
-	}
-	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
-	if err := templates.RenderTemplate(w, "forumFlaggedPostsPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
-		log.Printf("Template Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
+	hcommon.TemplateHandler("forumFlaggedPostsPage.gohtml").ServeHTTP(w, r)
 }

--- a/handlers/forum/adminForumModeratorLogsPage.go
+++ b/handlers/forum/adminForumModeratorLogsPage.go
@@ -1,23 +1,11 @@
 package forum
 
 import (
-	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
-	"log"
+	hcommon "github.com/arran4/goa4web/handlers/common"
 	"net/http"
-
-	"github.com/arran4/goa4web/core/templates"
 )
 
 // adminForumModeratorLogsPage displays recent moderator actions.
 func AdminForumModeratorLogsPage(w http.ResponseWriter, r *http.Request) {
-	type Data struct {
-		*CoreData
-	}
-	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
-	if err := templates.RenderTemplate(w, "forumModeratorLogsPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
-		log.Printf("Template Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
+	hcommon.TemplateHandler("forumModeratorLogsPage.gohtml").ServeHTTP(w, r)
 }


### PR DESCRIPTION
## Summary
- use `hcommon.TemplateHandler` in flagged posts page
- use `hcommon.TemplateHandler` in moderator logs page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: declared and not used errors)*
- `golangci-lint run ./...` *(fails: typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_68765c93632c832f9c54d1c4076f1d08