### PR TITLE
Use TemplateHandler for register page

### DIFF
--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -3,33 +3,19 @@ package auth
 import (
 	"database/sql"
 	"errors"
-	db "github.com/arran4/goa4web/internal/db"
-	notif "github.com/arran4/goa4web/internal/notifications"
 	"log"
 	"net/http"
 	"strings"
 
 	"github.com/arran4/goa4web/config"
-	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/core/templates"
-	common "github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
+	db "github.com/arran4/goa4web/internal/db"
+	notif "github.com/arran4/goa4web/internal/notifications"
 )
 
 // RegisterPage renders the user registration form.
 func RegisterPage(w http.ResponseWriter, r *http.Request) {
-	type Data struct {
-		*corecommon.CoreData
-	}
-
-	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
-	}
-
-	if err := templates.RenderTemplate(w, "registerPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
-		log.Printf("Template Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
+	hcommon.TemplateHandler("registerPage.gohtml").ServeHTTP(w, r)
 }
 
 // RegisterActionPage handles user creation from the registration form.
@@ -58,7 +44,7 @@ func RegisterActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid email", http.StatusBadRequest)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 
 	if _, err := queries.UserByUsername(r.Context(), sql.NullString{
 		String: username,
@@ -123,7 +109,7 @@ func RegisterActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if cd, ok := r.Context().Value(common.KeyCoreData).(*common.CoreData); ok {
+	if cd, ok := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData); ok {
 		if evt := cd.Event(); evt != nil {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}


### PR DESCRIPTION
## Summary
- simplify register page rendering by using `TemplateHandler`
- drop unused helper struct and imports

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: assignment mismatch and unused variables)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails to build)*

------
https://chatgpt.com/codex/tasks/task_e_68765c9c5fc4832f8b80afe3d2aee56d