### PR TITLE
Refactor news routes

### DIFF
--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -1,7 +1,6 @@
 package news
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -11,28 +10,8 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 
-	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/core/templates"
 	nav "github.com/arran4/goa4web/internal/navigation"
 )
-
-func runTemplate(tmpl string) func(http.ResponseWriter, *http.Request) {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		type Data struct {
-			*corecommon.CoreData
-		}
-
-		data := Data{
-			CoreData: r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData),
-		}
-
-		if err := templates.RenderTemplate(w, tmpl, data, corecommon.NewFuncs(r)); err != nil {
-			log.Printf("Template Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
-	})
-}
 
 func AddNewsIndex(h http.Handler) http.Handler { return hcommon.IndexMiddleware(CustomNewsIndex)(h) }
 
@@ -40,12 +19,12 @@ func AddNewsIndex(h http.Handler) http.Handler { return hcommon.IndexMiddleware(
 func RegisterRoutes(r *mux.Router) {
 	nav.RegisterIndexLink("News", "/", SectionWeight)
 	nav.RegisterAdminControlCenter("News", "/admin/news/users/levels", SectionWeight)
-	r.Handle("/", AddNewsIndex(http.HandlerFunc(runTemplate("newsPage")))).Methods("GET")
+	r.Handle("/", AddNewsIndex(hcommon.TemplateHandler("newsPage"))).Methods("GET")
 	r.HandleFunc("/", hcommon.TaskDoneAutoRefreshPage).Methods("POST")
 	r.HandleFunc("/news.rss", NewsRssPage).Methods("GET")
 	nr := r.PathPrefix("/news").Subrouter()
 	nr.Use(AddNewsIndex)
-	nr.HandleFunc("", runTemplate("newsPage")).Methods("GET")
+	nr.Handle("", hcommon.TemplateHandler("newsPage")).Methods("GET")
 	nr.HandleFunc("", hcommon.TaskDoneAutoRefreshPage).Methods("POST")
 	nr.HandleFunc("/news/{post}", NewsPostPage).Methods("GET")
 	nr.HandleFunc("/news/{post}", ReplyTask.Action).Methods("POST").MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(ReplyTask.Match)


### PR DESCRIPTION
## Summary
- remove `runTemplate` helper
- use `hcommon.TemplateHandler` directly for news page routing

## Testing
- `go vet ./...` *(fails: declared and not used, assignment mismatch, undefined identifiers)*
- `golangci-lint run ./...` *(fails: typecheck errors across modules)*
- `go test ./...` *(fails to build packages)*

------
https://chatgpt.com/codex/tasks/task_e_68765ce63718832fb1b781d60013ac06