### PR TITLE
Use TemplateHandler in forgot password page

### DIFF
--- a/handlers/auth/forgotPassword.go
+++ b/handlers/auth/forgotPassword.go
@@ -7,20 +7,13 @@ import (
 	"log"
 	"net/http"
 
-	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/core/templates"
-	common "github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/utils/emailutil"
 )
 
 func ForgotPasswordPage(w http.ResponseWriter, r *http.Request) {
-	data := struct{ *corecommon.CoreData }{CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)}
-	if err := templates.RenderTemplate(w, "forgotPasswordPage.gohtml", data, corecommon.NewFuncs(r)); err != nil {
-		log.Printf("Template Error: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
+	hcommon.TemplateHandler("forgotPasswordPage.gohtml").ServeHTTP(w, r)
 }
 
 func ForgotPasswordActionPage(w http.ResponseWriter, r *http.Request) {
@@ -34,7 +27,7 @@ func ForgotPasswordActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing fields", http.StatusBadRequest)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
 	row, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		http.Error(w, "User not found", http.StatusNotFound)
@@ -62,7 +55,7 @@ func ForgotPasswordActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	if row.Email != "" {
 		page := r.URL.Scheme + "://" + r.Host + "/login"
-		_ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, page, common.TaskUserResetPassword, code)
+		_ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, page, hcommon.TaskUserResetPassword, code)
 	}
 	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }


### PR DESCRIPTION
## Summary
- simplify password reset by using `hcommon.TemplateHandler`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: assignment mismatch in middleware, etc.)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68765cd23000832f9d329e4734687375