### PR TITLE
Rename roles field in CoreData

### DIFF
--- a/cmd/goa4web/writing_list.go
+++ b/cmd/goa4web/writing_list.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 
+	corecommon "github.com/arran4/goa4web/core/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
 

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -63,7 +63,7 @@ type CoreData struct {
 	perms             lazyValue[[]*db.GetPermissionsByUserIDRow]
 	pref              lazyValue[*db.Preference]
 	langs             lazyValue[[]*db.Language]
-	roles             lazyValue[[]string]
+	userRoles         lazyValue[[]string]
 	allRoles          lazyValue[[]*db.Role]
 	announcement      lazyValue[*db.GetActiveAnnouncementWithNewsRow]
 	forumCategories   lazyValue[[]*db.Forumcategory]
@@ -88,8 +88,8 @@ type CoreData struct {
 	event *eventbus.Event
 }
 
-// SetRole preloads the current role value.
-func (cd *CoreData) SetRoles(r []string) { cd.roles.set(r) }
+// SetRoles preloads the current user roles value.
+func (cd *CoreData) SetRoles(r []string) { cd.userRoles.set(r) }
 
 // CoreOption configures a new CoreData instance.
 type CoreOption func(*CoreData)
@@ -182,9 +182,9 @@ func pageSize(r *http.Request) int {
 	return size
 }
 
-// Role returns the user role loaded lazily.
+// Roles returns the user roles loaded lazily.
 func (cd *CoreData) Roles() []string {
-	roles, _ := cd.roles.load(func() ([]string, error) {
+	roles, _ := cd.userRoles.load(func() ([]string, error) {
 		rs := []string{"anonymous"}
 		if cd.UserID == 0 || cd.queries == nil {
 			return rs, nil

--- a/handlers/auth/forgotPassword.go
+++ b/handlers/auth/forgotPassword.go
@@ -8,14 +8,14 @@ import (
 	"net/http"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
 
 func ForgotPasswordPage(w http.ResponseWriter, r *http.Request) {
-	data := struct{ *corecommon.CoreData }{CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)}
-	common.TemplateHandler(w, r, "forgotPasswordPage.gohtml", data)
+	data := struct{ *corecommon.CoreData }{CoreData: r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)}
+	hcommon.TemplateHandler(w, r, "forgotPasswordPage.gohtml", data)
 }
 
 func ForgotPasswordActionPage(w http.ResponseWriter, r *http.Request) {
@@ -56,7 +56,7 @@ func ForgotPasswordActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if row.Email != "" {
-		if cd, ok := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData); ok {
+		if cd, ok := r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData); ok {
 			if evt := cd.Event(); evt != nil {
 				if evt.Data == nil {
 					evt.Data = map[string]any{}

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	hcommon "github.com/arran4/goa4web/handlers/common"
 )
 
 // RegisterPage renders the user registration form.
@@ -22,10 +22,10 @@ func RegisterPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData),
 	}
 
-	common.TemplateHandler(w, r, "registerPage.gohtml", data)
+	hcommon.TemplateHandler(w, r, "registerPage.gohtml", data)
 }
 
 // RegisterActionPage handles user creation from the registration form.

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/a4code"
 	corelanguage "github.com/arran4/goa4web/core/language"
+	blogs "github.com/arran4/goa4web/handlers/blogs"
 	common "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
 

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -4,7 +4,6 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
-	blogs "github.com/arran4/goa4web/handlers/blogs"
 	comments "github.com/arran4/goa4web/handlers/comments"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -1,20 +1,40 @@
 package news
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/gorilla/mux"
 
 	auth "github.com/arran4/goa4web/handlers/auth"
 	comments "github.com/arran4/goa4web/handlers/comments"
-	"github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 
+	corecommon "github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/templates"
 	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 func AddNewsIndex(h http.Handler) http.Handler { return hcommon.IndexMiddleware(CustomNewsIndex)(h) }
+
+func runTemplate(tmpl string) func(http.ResponseWriter, *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		type Data struct {
+			*corecommon.CoreData
+		}
+
+		data := Data{
+			CoreData: r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData),
+		}
+
+		if err := templates.RenderTemplate(w, tmpl, data, corecommon.NewFuncs(r)); err != nil {
+			log.Printf("Template Error: %s", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+	})
+}
 
 // RegisterRoutes attaches the public news endpoints to r.
 func RegisterRoutes(r *mux.Router) {
@@ -26,7 +46,7 @@ func RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/news.rss", NewsRssPage).Methods("GET")
 	nr := r.PathPrefix("/news").Subrouter()
 	nr.Use(hcommon.IndexMiddleware(CustomNewsIndex))
-	nr.Handle("", hcommon.TemplateHandler("newsPage")).Methods("GET")
+	nr.HandleFunc("", runTemplate("newsPage")).Methods("GET")
 	nr.HandleFunc("", hcommon.TaskDoneAutoRefreshPage).Methods("POST")
 	nr.HandleFunc("/news/{post}", NewsPostPage).Methods("GET")
 	nr.HandleFunc("/news/{post}", ReplyTask.Action).Methods("POST").MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(ReplyTask.Match)

--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -30,7 +30,7 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cd = corecommon.NewCoreData(r.Context(), queries)
+	cd := corecommon.NewCoreData(r.Context(), queries)
 	cd.UserID = int32(uid)
 
 	user, err := cd.CurrentUser()
@@ -50,11 +50,15 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	langs, err := queries.GetUserLanguages(r.Context(), int32(uid))
+	userLangs, err := queries.GetUserLanguages(r.Context(), int32(uid))
 	if err != nil {
 		log.Printf("load languages: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
+	}
+	var langs []*db.Language
+	for _, ul := range userLangs {
+		langs = append(langs, &db.Language{Idlanguage: ul.LanguageIdlanguage})
 	}
 	perms, err := cd.Permissions()
 	if err != nil {


### PR DESCRIPTION
## Summary
- rename `roles` field in `CoreData` to `userRoles`
- adjust `SetRoles` and `Roles` for new field
- fix compile issues in auth handlers and news routes
- add missing imports and update admin export logic

## Testing
- `go mod tidy`
- `go fmt ./...`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6876fa6c23a4832f9c640f3f3e4f3ba7