### PR TITLE
Add search bus worker

### DIFF
--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -12,8 +12,8 @@ import (
 	common "github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
@@ -119,15 +119,12 @@ func ThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO move to searchworker that is automatically activated by a event.
-	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
-	if done {
-		return
-	}
-
-	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
-		return
-	}
+	// publish search indexing event
+	_ = eventbus.DefaultBus.Publish(eventbus.Event{Path: r.URL.Path, Data: map[string]any{
+		"search_text":  text,
+		"search_table": "forum",
+		"search_id":    cid,
+	}})
 
 	// TODO remove and replace with proper eventbus notification
 	notif.Notifier{EmailProvider: provider, Queries: queries}.NotifyThreadSubscribers(r.Context(), int32(threadId), uid, endUrl)

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -16,7 +16,7 @@ import (
 	"github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	"github.com/arran4/goa4web/internal/eventbus"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
@@ -168,14 +168,12 @@ func BoardPostImageActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
-	if done {
-		return
-	}
-
-	if searchutil.InsertWordsToImageSearch(w, r, wordIds, queries, pid) {
-		return
-	}
+	// publish search indexing event
+	_ = eventbus.DefaultBus.Publish(eventbus.Event{Path: r.URL.Path, Data: map[string]any{
+		"search_text":  text,
+		"search_table": "image",
+		"search_id":    pid,
+	}})
 
 	hcommon.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -11,7 +11,7 @@ import (
 	"github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	"github.com/arran4/goa4web/internal/eventbus"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
@@ -287,15 +287,12 @@ func BoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO move to searchworker that is automatically activated by a event.
-	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
-	if done {
-		return
-	}
-
-	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
-		return
-	}
+	// publish search indexing event
+	_ = eventbus.DefaultBus.Publish(eventbus.Event{Path: r.URL.Path, Data: map[string]any{
+		"search_text":  text,
+		"search_table": "forum",
+		"search_id":    cid,
+	}})
 
 	http.Redirect(w, r, endUrl, http.StatusTemporaryRedirect)
 }

--- a/handlers/linker/linkerAdminQueuePage.go
+++ b/handlers/linker/linkerAdminQueuePage.go
@@ -13,7 +13,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	"github.com/arran4/goa4web/internal/eventbus"
 )
 
 func AdminQueuePage(w http.ResponseWriter, r *http.Request) {
@@ -165,13 +165,11 @@ func AdminQueueApproveActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, text := range []string{link.Title.String, link.Description.String} {
-		wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
-		if done {
-			return
-		}
-		if searchutil.InsertWordsToLinkerSearch(w, r, wordIds, queries, lid) {
-			return
-		}
+		_ = eventbus.DefaultBus.Publish(eventbus.Event{Path: r.URL.Path, Data: map[string]any{
+			"search_text":  text,
+			"search_table": "linker",
+			"search_id":    lid,
+		}})
 	}
 	hcommon.TaskDoneAutoRefreshPage(w, r)
 }
@@ -208,13 +206,11 @@ func AdminQueueBulkApproveActionPage(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		for _, text := range []string{link.Title.String, link.Description.String} {
-			wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
-			if done {
-				return
-			}
-			if searchutil.InsertWordsToLinkerSearch(w, r, wordIds, queries, lid) {
-				return
-			}
+			_ = eventbus.DefaultBus.Publish(eventbus.Event{Path: r.URL.Path, Data: map[string]any{
+				"search_text":  text,
+				"search_table": "linker",
+				"search_id":    lid,
+			}})
 		}
 	}
 	hcommon.TaskDoneAutoRefreshPage(w, r)

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -12,7 +12,7 @@ import (
 	corelanguage "github.com/arran4/goa4web/core/language"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	"github.com/arran4/goa4web/internal/eventbus"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/email"
@@ -193,15 +193,12 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO move to searchworker that is automatically activated by a event.
-	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
-	if done {
-		return
-	}
-
-	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
-		return
-	}
+	// publish search indexing event
+	_ = eventbus.DefaultBus.Publish(eventbus.Event{Path: r.URL.Path, Data: map[string]any{
+		"search_text":  text,
+		"search_table": "forum",
+		"search_id":    cid,
+	}})
 
 	http.Redirect(w, r, endUrl, http.StatusTemporaryRedirect)
 }

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -10,8 +10,8 @@ import (
 	common "github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
@@ -86,13 +86,10 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 		title,
 		body,
 	} {
-		wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
-		if done {
-			return
-		}
-
-		if searchutil.InsertWordsToWritingSearch(w, r, wordIds, queries, articleId) {
-			return
-		}
+		_ = eventbus.DefaultBus.Publish(eventbus.Event{Path: r.URL.Path, Data: map[string]any{
+			"search_text":  text,
+			"search_table": "writing",
+			"search_id":    articleId,
+		}})
 	}
 }

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -11,7 +11,7 @@ import (
 	common "github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	"github.com/arran4/goa4web/internal/eventbus"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
@@ -92,13 +92,10 @@ func ArticleEditActionPage(w http.ResponseWriter, r *http.Request) {
 		title,
 		body,
 	} {
-		wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
-		if done {
-			return
-		}
-
-		if searchutil.InsertWordsToWritingSearch(w, r, wordIds, queries, int64(writing.Idwriting)) {
-			return
-		}
+		_ = eventbus.DefaultBus.Publish(eventbus.Event{Path: r.URL.Path, Data: map[string]any{
+			"search_text":  text,
+			"search_table": "writing",
+			"search_id":    int64(writing.Idwriting),
+		}})
 	}
 }

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -26,6 +26,7 @@ import (
 	csrfmw "github.com/arran4/goa4web/internal/middleware/csrf"
 	notifications "github.com/arran4/goa4web/internal/notifications"
 	routerpkg "github.com/arran4/goa4web/internal/router"
+	"github.com/arran4/goa4web/internal/searchworker"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 )
@@ -160,4 +161,6 @@ func startWorkers(ctx context.Context, db *sql.DB, provider email.Provider, dlqP
 	safeGo(func() {
 		notifications.BusWorker(ctx, eventbus.DefaultBus, provider, dbpkg.New(db), dlqProvider)
 	})
+	log.Printf("Starting search index worker")
+	safeGo(func() { searchworker.BusWorker(ctx, eventbus.DefaultBus, dbpkg.New(db)) })
 }

--- a/internal/searchworker/bus_worker.go
+++ b/internal/searchworker/bus_worker.go
@@ -1,0 +1,92 @@
+package searchworker
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+)
+
+// BusWorker listens for search events and updates the search indices.
+func BusWorker(ctx context.Context, bus *eventbus.Bus, q *db.Queries) {
+	if bus == nil || q == nil {
+		return
+	}
+	ch := bus.Subscribe()
+	for {
+		select {
+		case evt := <-ch:
+			processEvent(ctx, evt, q)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func processEvent(ctx context.Context, evt eventbus.Event, q *db.Queries) {
+	if evt.Data == nil {
+		return
+	}
+	text, ok := evt.Data["search_text"].(string)
+	if !ok || text == "" {
+		return
+	}
+	table, ok := evt.Data["search_table"].(string)
+	if !ok {
+		return
+	}
+	var id int64
+	switch v := evt.Data["search_id"].(type) {
+	case int64:
+		id = v
+	case int32:
+		id = int64(v)
+	case float64:
+		id = int64(v)
+	}
+
+	words := map[string]struct{}{}
+	for _, w := range BreakupTextToWords(text) {
+		words[strings.ToLower(w)] = struct{}{}
+	}
+
+	for word := range words {
+		wid, err := q.CreateSearchWord(ctx, strings.ToLower(word))
+		if err != nil {
+			log.Printf("create search word: %v", err)
+			continue
+		}
+		switch table {
+		case "forum":
+			if err := q.AddToForumCommentSearch(ctx, db.AddToForumCommentSearchParams{
+				CommentID:                      int32(id),
+				SearchwordlistIdsearchwordlist: int32(wid),
+			}); err != nil {
+				log.Printf("add to forum search: %v", err)
+			}
+		case "image":
+			if err := q.AddToImagePostSearch(ctx, db.AddToImagePostSearchParams{
+				ImagePostID:                    int32(id),
+				SearchwordlistIdsearchwordlist: int32(wid),
+			}); err != nil {
+				log.Printf("add to image search: %v", err)
+			}
+		case "writing":
+			if err := q.AddToForumWritingSearch(ctx, db.AddToForumWritingSearchParams{
+				WritingID:                      int32(id),
+				SearchwordlistIdsearchwordlist: int32(wid),
+			}); err != nil {
+				log.Printf("add to writing search: %v", err)
+			}
+		case "linker":
+			if err := q.AddToLinkerSearch(ctx, db.AddToLinkerSearchParams{
+				LinkerID:                       int32(id),
+				SearchwordlistIdsearchwordlist: int32(wid),
+			}); err != nil {
+				log.Printf("add to linker search: %v", err)
+			}
+		}
+	}
+}

--- a/internal/searchworker/bus_worker_test.go
+++ b/internal/searchworker/bus_worker_test.go
@@ -1,0 +1,53 @@
+package searchworker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+)
+
+func TestBusWorker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := eventbus.NewBus()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := dbpkg.New(db)
+
+	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").
+		WithArgs("hello").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").
+		WithArgs("world").
+		WillReturnResult(sqlmock.NewResult(2, 1))
+	mock.ExpectExec("INSERT IGNORE INTO comments_search").
+		WithArgs(int32(5), int32(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT IGNORE INTO comments_search").
+		WithArgs(int32(5), int32(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	go BusWorker(ctx, bus, q)
+
+	bus.Publish(eventbus.Event{Data: map[string]any{
+		"search_text":  "Hello world Hello",
+		"search_table": "forum",
+		"search_id":    int64(5),
+	}})
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	time.Sleep(10 * time.Millisecond)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `BusWorker` to update search indices on events
- publish search index events in various handlers
- start the search bus worker in app run
- test the new worker

## Testing
- `go mod tidy` *(fails: no matching versions for query)*
- `go fmt ./...` *(fails: expected 'package', found 'const')*
- `go vet ./...` *(fails: expected 'package', found 'const')*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: expected 'package', found 'const')*

------
https://chatgpt.com/codex/tasks/task_e_687829e7d478832fa71e78030913eaf8