### PR TITLE
Clarify admin permissions

### DIFF
--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -177,18 +177,18 @@ Many queries now filter results directly in SQL using `viewer_id` together with 
 | `forum` | `topic` | `post` | `viewer_id` | viewer role ID | grant requiring both user and role |
 | `forum` | `topic` | `post` | `NULL` | viewer role ID | role-based grant |
 | `forum` | `topic` | `post` | `NULL` | `NULL` | public grant for everyone |
-| `admin` | `page` | `view` | `viewer_id` | `NULL` | TODO – admin filtering in SQL |
-| `admin` | `page` | `view` | `viewer_id` | viewer role ID | TODO – admin filtering in SQL |
-| `admin` | `page` | `view` | `NULL` | viewer role ID | TODO – admin filtering in SQL |
-| `admin` | `page` | `view` | `NULL` | `NULL` | TODO – admin filtering in SQL |
-| `admin` | `page` | `edit` | `viewer_id` | `NULL` | TODO – admin filtering in SQL |
-| `admin` | `page` | `edit` | `viewer_id` | viewer role ID | TODO – admin filtering in SQL |
-| `admin` | `page` | `edit` | `NULL` | viewer role ID | TODO – admin filtering in SQL |
-| `admin` | `page` | `edit` | `NULL` | `NULL` | TODO – admin filtering in SQL |
-| `admin` | `page` | `admin` | `viewer_id` | `NULL` | TODO – admin filtering in SQL |
-| `admin` | `page` | `admin` | `viewer_id` | viewer role ID | TODO – admin filtering in SQL |
-| `admin` | `page` | `admin` | `NULL` | viewer role ID | TODO – admin filtering in SQL |
-| `admin` | `page` | `admin` | `NULL` | `NULL` | TODO – admin filtering in SQL |
+| `admin` | `page` | `view` | `viewer_id` | `NULL` | requires `administrator` role |
+| `admin` | `page` | `view` | `viewer_id` | viewer role ID | requires `administrator` role |
+| `admin` | `page` | `view` | `NULL` | viewer role ID | requires `administrator` role |
+| `admin` | `page` | `view` | `NULL` | `NULL` | requires `administrator` role |
+| `admin` | `page` | `edit` | `viewer_id` | `NULL` | requires `administrator` role |
+| `admin` | `page` | `edit` | `viewer_id` | viewer role ID | requires `administrator` role |
+| `admin` | `page` | `edit` | `NULL` | viewer role ID | requires `administrator` role |
+| `admin` | `page` | `edit` | `NULL` | `NULL` | requires `administrator` role |
+| `admin` | `page` | `admin` | `viewer_id` | `NULL` | requires `administrator` role |
+| `admin` | `page` | `admin` | `viewer_id` | viewer role ID | requires `administrator` role |
+| `admin` | `page` | `admin` | `NULL` | viewer role ID | requires `administrator` role |
+| `admin` | `page` | `admin` | `NULL` | `NULL` | requires `administrator` role |
 
 Listing pages and RSS feeds still invoke `HasGrant` on each row for extra safety.
 


### PR DESCRIPTION
## Summary
- document that admin pages require the `administrator` role

## Testing
- `go mod tidy` *(fails: no matching versions for internal utils)*
- `go fmt ./...` *(fails: expected `package`, found `const` in tasks.go)*
- `go vet ./...` *(fails with pattern errors and missing modules)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: missing modules and invalid packages)*

------
https://chatgpt.com/codex/tasks/task_e_68783bed93bc832fa3c64aa1eab76706