### PR TITLE
Add constant comments for clarity

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -25,9 +25,12 @@ type IndexItem struct {
 }
 
 const (
+	// defaultPageSize is used when a user-supplied value is missing.
 	defaultPageSize = 15
-	pageSizeMin     = 5
-	pageSizeMax     = 50
+	// pageSizeMin is the lowest allowed page size.
+	pageSizeMin = 5
+	// pageSizeMax is the largest allowed page size.
+	pageSizeMax = 50
 )
 
 // NewsPost describes a news entry with access metadata.


### PR DESCRIPTION
## Summary
- document page size constants in `coredata.go`

## Testing
- `go mod tidy` *(fails: no matching versions for internal packages)*
- `go fmt ./...` *(fails: expected 'package', found 'const')*
- `go vet ./...` *(fails: expected 'package', found 'const')*
- `golangci-lint run ./...` *(fails: typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_68782cae6a68832f96322a4010401551