### PR TITLE
Update admin permission docs

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -39,6 +39,7 @@ func RoleCheckerMiddleware(roles ...string) func(http.Handler) http.Handler {
 }
 
 // AdminCheckerMiddleware ensures the requester has administrator rights.
+// Roles are loaded via the GetPermissionsByUserID query before this check.
 func AdminCheckerMiddleware(next http.Handler) http.Handler {
 	return RoleCheckerMiddleware("administrator")(next)
 }

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -177,18 +177,24 @@ Many queries now filter results directly in SQL using `viewer_id` together with 
 | `forum` | `topic` | `post` | `viewer_id` | viewer role ID | grant requiring both user and role |
 | `forum` | `topic` | `post` | `NULL` | viewer role ID | role-based grant |
 | `forum` | `topic` | `post` | `NULL` | `NULL` | public grant for everyone |
-| `admin` | `page` | `view` | `viewer_id` | `NULL` | TODO – admin filtering in SQL |
-| `admin` | `page` | `view` | `viewer_id` | viewer role ID | TODO – admin filtering in SQL |
-| `admin` | `page` | `view` | `NULL` | viewer role ID | TODO – admin filtering in SQL |
-| `admin` | `page` | `view` | `NULL` | `NULL` | TODO – admin filtering in SQL |
-| `admin` | `page` | `edit` | `viewer_id` | `NULL` | TODO – admin filtering in SQL |
-| `admin` | `page` | `edit` | `viewer_id` | viewer role ID | TODO – admin filtering in SQL |
-| `admin` | `page` | `edit` | `NULL` | viewer role ID | TODO – admin filtering in SQL |
-| `admin` | `page` | `edit` | `NULL` | `NULL` | TODO – admin filtering in SQL |
-| `admin` | `page` | `admin` | `viewer_id` | `NULL` | TODO – admin filtering in SQL |
-| `admin` | `page` | `admin` | `viewer_id` | viewer role ID | TODO – admin filtering in SQL |
-| `admin` | `page` | `admin` | `NULL` | viewer role ID | TODO – admin filtering in SQL |
-| `admin` | `page` | `admin` | `NULL` | `NULL` | TODO – admin filtering in SQL |
+| `admin` | `page` | `view` | `viewer_id` | `NULL` | access requires `administrator` role via `AdminCheckerMiddleware` |
+| `admin` | `page` | `view` | `viewer_id` | viewer role ID | access requires `administrator` role via `AdminCheckerMiddleware` |
+| `admin` | `page` | `view` | `NULL` | viewer role ID | access requires `administrator` role via `AdminCheckerMiddleware` |
+| `admin` | `page` | `view` | `NULL` | `NULL` | access requires `administrator` role via `AdminCheckerMiddleware` |
+| `admin` | `page` | `edit` | `viewer_id` | `NULL` | access requires `administrator` role via `AdminCheckerMiddleware` |
+| `admin` | `page` | `edit` | `viewer_id` | viewer role ID | access requires `administrator` role via `AdminCheckerMiddleware` |
+| `admin` | `page` | `edit` | `NULL` | viewer role ID | access requires `administrator` role via `AdminCheckerMiddleware` |
+| `admin` | `page` | `edit` | `NULL` | `NULL` | access requires `administrator` role via `AdminCheckerMiddleware` |
+| `admin` | `page` | `admin` | `viewer_id` | `NULL` | access requires `administrator` role via `AdminCheckerMiddleware` |
+| `admin` | `page` | `admin` | `viewer_id` | viewer role ID | access requires `administrator` role via `AdminCheckerMiddleware` |
+| `admin` | `page` | `admin` | `NULL` | viewer role ID | access requires `administrator` role via `AdminCheckerMiddleware` |
+| `admin` | `page` | `admin` | `NULL` | `NULL` | access requires `administrator` role via `AdminCheckerMiddleware` |
+
+Administrator endpoints are guarded by the `AdminCheckerMiddleware` implemented
+in `internal/router/router.go`. The middleware calls `corecommon.Allowed`, which
+loads roles for the current user using the `GetPermissionsByUserID` query from
+`internal/db/queries-permissions.sql`. Only users with the `administrator` role
+can reach these routes.
 
 Listing pages and RSS feeds still invoke `HasGrant` on each row for extra safety.
 


### PR DESCRIPTION
## Summary
- document how administrator role checks happen in AdminCheckerMiddleware
- note that admin routes require administrator role in permissions spec

## Testing
- `go mod tidy` *(fails: no matching versions for github.com/arran4/goa4web/internal/utils/emailutil)*
- `go vet ./...` *(fails to compile due to missing packages)*
- `go test ./...` *(fails to compile due to missing packages)*
- `golangci-lint run ./...` *(fails: undefined symbols and pattern errors)*

------
https://chatgpt.com/codex/tasks/task_e_68782c9b2328832f92ca2bce828f35fd