### PR TITLE
Merge common handlers into root package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ go test ./...
 SQL query files are compiled using `sqlc`. Do not manually edit the generated `*.sql.go` files; instead edit the `.sql` files under `internal/db/` and run `sqlc generate`.
 Avoid using the `overrides` section in `sqlc.yaml`; prefer Go type aliases if a different struct name is required.
 
-All database schema changes must include a new migration script in the `migrations/` directory (for example `0002.sql`, `0003.sql`). Never modify existing migration files as that would break deployments running older versions. Every migration must also update the `schema_version` table so deployments can track the current schema state. Bump the `ExpectedSchemaVersion` constant in `handlers/common/constants.go` whenever a new migration is added so tests stay in sync.
+All database schema changes must include a new migration script in the `migrations/` directory (for example `0002.sql`, `0003.sql`). Never modify existing migration files as that would break deployments running older versions. Every migration must also update the `schema_version` table so deployments can track the current schema state. Bump the `ExpectedSchemaVersion` constant in `handlers/constants.go` whenever a new migration is added so tests stay in sync.
 
 Errors in critical functions like `main()` or `run()` must be logged or wrapped using `fmt.Errorf` with context. Prefer doing both when errors propagate.
 

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gorilla/sessions"
 
 	"github.com/arran4/goa4web/core"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
 
@@ -32,7 +32,7 @@ func TestSessionMiddlewareBadSession(t *testing.T) {
 	})
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(&http.Cookie{Name: sessionName, Value: "bad"})
-	ctx := context.WithValue(req.Context(), common.KeyQueries, dbpkg.New(nil))
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, dbpkg.New(nil))
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)

--- a/handlers/admin/adminAnnouncementsPage.go
+++ b/handlers/admin/adminAnnouncementsPage.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -21,8 +21,8 @@ func AdminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
 		Announcements []*db.ListAnnouncementsWithNewsRow
 		NewsID        string
 	}
-	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	data := Data{CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData)}
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	rows, err := queries.ListAnnouncementsWithNews(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list announcements: %v", err)
@@ -31,25 +31,25 @@ func AdminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Announcements = rows
 	data.NewsID = r.FormValue("news_id")
-	common.TemplateHandler(w, r, "announcementsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "announcementsPage.gohtml", data)
 }
 
 func (addAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	nid, err := strconv.Atoi(r.PostFormValue("news_id"))
 	if err != nil {
 		log.Printf("news id: %v", err)
-		common.TaskDoneAutoRefreshPage(w, r)
+		handlers.TaskDoneAutoRefreshPage(w, r)
 		return
 	}
 	if err := queries.CreateAnnouncement(r.Context(), int32(nid)); err != nil {
 		log.Printf("create announcement: %v", err)
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func (deleteAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm: %v", err)
 	}
@@ -59,5 +59,5 @@ func (deleteAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) {
 			log.Printf("delete announcement: %v", err)
 		}
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/admin/adminAuditLogPage.go
+++ b/handlers/admin/adminAuditLogPage.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -33,14 +33,14 @@ func AdminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		User:     r.URL.Query().Get("user"),
 		Action:   r.URL.Query().Get("action"),
-		PageSize: common.GetPageSize(r),
+		PageSize: handlers.GetPageSize(r),
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	usernameFilter := "%"
 	if strings.TrimSpace(data.User) != "" {
@@ -95,5 +95,5 @@ func AdminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	common.TemplateHandler(w, r, "auditLogPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "auditLogPage.gohtml", data)
 }

--- a/handlers/admin/adminCategoriesPage.go
+++ b/handlers/admin/adminCategoriesPage.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -20,10 +20,10 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Section:  r.URL.Query().Get("section"),
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if data.Section == "" || data.Section == "forum" {
 		rows, err := queries.GetAllForumCategoriesWithSubcategoryCount(r.Context())
@@ -53,5 +53,5 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 		data.LinkerCategories = rows
 	}
 
-	common.TemplateHandler(w, r, "categoriesPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "categoriesPage.gohtml", data)
 }

--- a/handlers/admin/adminDLQPage.go
+++ b/handlers/admin/adminDLQPage.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	db "github.com/arran4/goa4web/internal/db"
 )
@@ -19,20 +19,20 @@ func AdminDLQPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Errors []*db.DeadLetter
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	rows, err := queries.ListDeadLetters(r.Context(), 100)
 	if err != nil {
 		log.Printf("list dead letters: %v", err)
 	} else {
 		data.Errors = rows
 	}
-	common.TemplateHandler(w, r, "admin/dlqPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "admin/dlqPage.gohtml", data)
 }
 
 func (deleteDLQTask) Action(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm: %v", err)
 	}
@@ -59,5 +59,5 @@ func (deleteDLQTask) Action(w http.ResponseWriter, r *http.Request) {
 			log.Printf("purge errors: %v", err)
 		}
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/config"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
 )
@@ -28,9 +28,9 @@ func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 		Emails []EmailItem
 	}
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	rows, err := queries.ListUnsentPendingEmails(r.Context())
 	if err != nil {
 		log.Printf("list pending emails: %v", err)
@@ -58,11 +58,11 @@ func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 		}
 		data.Emails = append(data.Emails, EmailItem{e, emailStr, subj})
 	}
-	common.TemplateHandler(w, r, "emailQueuePage.gohtml", data)
+	handlers.TemplateHandler(w, r, "emailQueuePage.gohtml", data)
 }
 
 func (resendQueueTask) Action(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	provider := email.ProviderFromConfig(config.AppRuntimeConfig)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm: %v", err)
@@ -102,11 +102,11 @@ func (resendQueueTask) Action(w http.ResponseWriter, r *http.Request) {
 			log.Printf("mark sent: %v", err)
 		}
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func (deleteQueueTask) Action(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm: %v", err)
 	}
@@ -116,5 +116,5 @@ func (deleteQueueTask) Action(w http.ResponseWriter, r *http.Request) {
 			log.Printf("delete email: %v", err)
 		}
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 	"time"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
 	db "github.com/arran4/goa4web/internal/db"
 
@@ -46,13 +46,13 @@ func AdminEmailTemplatePage(w http.ResponseWriter, r *http.Request) {
 		Preview string
 		Error   string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Body:     b,
 		Preview:  preview,
 		Error:    r.URL.Query().Get("error"),
 	}
 
-	common.TemplateHandler(w, r, "emailTemplatePage.gohtml", data)
+	handlers.TemplateHandler(w, r, "emailTemplatePage.gohtml", data)
 }
 
 func (saveTemplateTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -61,7 +61,7 @@ func (saveTemplateTask) Action(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	body := r.PostFormValue("body")
-	q := r.Context().Value(common.KeyQueries).(*db.Queries)
+	q := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if err := q.SetTemplateOverride(r.Context(), db.SetTemplateOverrideParams{Name: "updateEmail", Body: body}); err != nil {
 		log.Printf("db save template: %v", err)
 	}
@@ -72,12 +72,12 @@ func (testTemplateTask) Action(w http.ResponseWriter, r *http.Request) {
 	if email.ProviderFromConfig(config.AppRuntimeConfig) == nil {
 		q := url.QueryEscape(userhandlers.ErrMailNotConfigured.Error())
 		r.URL.RawQuery = "error=" + q
-		common.TaskErrorAcknowledgementPage(w, r)
+		handlers.TaskErrorAcknowledgementPage(w, r)
 		return
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*CoreData)
 	urow, err := queries.GetUserById(r.Context(), cd.UserID)
 	if err != nil {
 		log.Printf("get user: %v", err)

--- a/handlers/admin/adminHandler.go
+++ b/handlers/admin/adminHandler.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	nav "github.com/arran4/goa4web/internal/navigation"
 )
@@ -30,10 +30,10 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData:   r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData:   r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		AdminLinks: nav.AdminLinks(),
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	ctx := r.Context()
 	count := func(query string, dest *int64) {
 		if err := queries.DB().QueryRowContext(ctx, query).Scan(dest); err != nil && err != sql.ErrNoRows {
@@ -48,5 +48,5 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 	count("SELECT COUNT(*) FROM forumthread", &data.Stats.ForumThreads)
 	count("SELECT COUNT(*) FROM writing", &data.Stats.Writings)
 
-	common.TemplateHandler(w, r, "adminPage", data)
+	handlers.TemplateHandler(w, r, "adminPage", data)
 }

--- a/handlers/admin/adminIPBanPage.go
+++ b/handlers/admin/adminIPBanPage.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -21,8 +21,8 @@ func AdminIPBanPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Bans []*db.BannedIp
 	}
-	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	data := Data{CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData)}
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	rows, err := queries.ListBannedIps(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list banned ips: %v", err)
@@ -30,11 +30,11 @@ func AdminIPBanPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data.Bans = rows
-	common.TemplateHandler(w, r, "iPBanPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "iPBanPage.gohtml", data)
 }
 
 func (addIPBanTask) Action(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	ipNet := strings.TrimSpace(r.PostFormValue("ip"))
 	ipNet = NormalizeIPNet(ipNet)
 	reason := strings.TrimSpace(r.PostFormValue("reason"))
@@ -52,11 +52,11 @@ func (addIPBanTask) Action(w http.ResponseWriter, r *http.Request) {
 			ExpiresAt: expires,
 		})
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func (deleteIPBanTask) Action(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm: %v", err)
 	}
@@ -66,5 +66,5 @@ func (deleteIPBanTask) Action(w http.ResponseWriter, r *http.Request) {
 			log.Printf("cancel banned ip %s: %v", ipNet, err)
 		}
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/admin/adminNotificationsPage.go
+++ b/handlers/admin/adminNotificationsPage.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -25,9 +25,9 @@ func AdminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		Roles         []*db.Role
 	}
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	roles, err := data.AllRoles()
 	if err != nil {
 		log.Printf("load roles: %v", err)
@@ -48,11 +48,11 @@ func AdminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 	data.Notifications = items
 	data.Total = len(items)
 	data.Unread = unread
-	common.TemplateHandler(w, r, "notificationsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "notificationsPage.gohtml", data)
 }
 
 func (markReadTask) Action(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm: %v", err)
 	}
@@ -62,19 +62,19 @@ func (markReadTask) Action(w http.ResponseWriter, r *http.Request) {
 			log.Printf("mark read: %v", err)
 		}
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func (purgeNotificationsTask) Action(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if err := queries.PurgeReadNotifications(r.Context()); err != nil {
 		log.Printf("purge notifications: %v", err)
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func (sendNotificationTask) Action(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	message := r.PostFormValue("message")
 	link := r.PostFormValue("link")
 	role := r.PostFormValue("role")
@@ -119,5 +119,5 @@ func (sendNotificationTask) Action(w http.ResponseWriter, r *http.Request) {
 			log.Printf("insert notification: %v", err)
 		}
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/admin/adminReloadConfigPage.go
+++ b/handlers/admin/adminReloadConfigPage.go
@@ -9,7 +9,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	corelanguage "github.com/arran4/goa4web/core/language"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -20,7 +20,7 @@ func AdminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Back:     "/admin",
 	}
 
@@ -35,5 +35,5 @@ func AdminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Messages = append(data.Messages, "Configuration reloaded")
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/handlers/admin/adminServerStatsPage.go
+++ b/handlers/admin/adminServerStatsPage.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"runtime"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 func AdminServerStatsPage(w http.ResponseWriter, r *http.Request) {
@@ -27,7 +27,7 @@ func AdminServerStatsPage(w http.ResponseWriter, r *http.Request) {
 	runtime.ReadMemStats(&mem)
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Stats: Stats{
 			Goroutines: runtime.NumGoroutine(),
 			Alloc:      mem.Alloc,
@@ -39,5 +39,5 @@ func AdminServerStatsPage(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	common.TemplateHandler(w, r, "serverStatsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "serverStatsPage.gohtml", data)
 }

--- a/handlers/admin/adminShutdownPage.go
+++ b/handlers/admin/adminShutdownPage.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 func AdminShutdownPage(w http.ResponseWriter, r *http.Request) {
@@ -16,7 +16,7 @@ func AdminShutdownPage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Back:     "/admin",
 	}
 
@@ -28,5 +28,5 @@ func AdminShutdownPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/handlers/admin/adminSiteSettingsPage.go
+++ b/handlers/admin/adminSiteSettingsPage.go
@@ -6,15 +6,15 @@ import (
 	"strconv"
 
 	corelanguage "github.com/arran4/goa4web/core/language"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/config"
 )
 
 func AdminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*CoreData)
 
 	if r.Method == http.MethodPost {
 		if err := r.ParseForm(); err != nil {
@@ -54,5 +54,5 @@ func AdminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 		data.Languages = langs
 	}
 
-	common.TemplateHandler(w, r, "siteSettingsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "siteSettingsPage.gohtml", data)
 }

--- a/handlers/admin/adminUsageStatsPage.go
+++ b/handlers/admin/adminUsageStatsPage.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/config"
@@ -23,8 +23,8 @@ func AdminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 		UserMonthly       []*db.UserMonthlyUsageRow
 		StartYear         int
 	}
-	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	data := Data{CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData)}
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	var err error
 	if data.ForumTopics, err = queries.ForumTopicThreadCounts(r.Context()); err != nil {
@@ -53,5 +53,5 @@ func AdminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.StartYear = config.AppRuntimeConfig.StatsStartYear
 
-	common.TemplateHandler(w, r, "usageStatsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "usageStatsPage.gohtml", data)
 }

--- a/handlers/admin/adminUserListPage.go
+++ b/handlers/admin/adminUserListPage.go
@@ -4,12 +4,12 @@ import (
 	"net/http"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
 func adminUserListPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	users, err := queries.AllUsers(r.Context())
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -19,8 +19,8 @@ func adminUserListPage(w http.ResponseWriter, r *http.Request) {
 		*corecommon.CoreData
 		Users []*db.AllUsersRow
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 		Users:    users,
 	}
-	common.TemplateHandler(w, r, "admin/userList.gohtml", data)
+	handlers.TemplateHandler(w, r, "admin/userList.gohtml", data)
 }

--- a/handlers/admin/adminUserProfilePage.go
+++ b/handlers/admin/adminUserProfilePage.go
@@ -8,14 +8,14 @@ import (
 	"github.com/gorilla/mux"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
 func adminUserProfilePage(w http.ResponseWriter, r *http.Request) {
 	idStr := mux.Vars(r)["id"]
 	id, _ := strconv.Atoi(idStr)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	user, err := queries.GetUserById(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "user not found", http.StatusNotFound)
@@ -29,12 +29,12 @@ func adminUserProfilePage(w http.ResponseWriter, r *http.Request) {
 		Emails   []*db.UserEmail
 		Comments []*db.AdminUserComment
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 		User:     &db.User{Idusers: user.Idusers, Username: user.Username},
 		Emails:   emails,
 		Comments: comments,
 	}
-	common.TemplateHandler(w, r, "admin/userProfile.gohtml", data)
+	handlers.TemplateHandler(w, r, "admin/userProfile.gohtml", data)
 }
 
 func adminUserAddCommentPage(w http.ResponseWriter, r *http.Request) {
@@ -45,7 +45,7 @@ func adminUserAddCommentPage(w http.ResponseWriter, r *http.Request) {
 		Errors []string
 		Back   string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 		Back:     "/admin/user/" + idStr,
 	}
 	comment := r.PostFormValue("comment")
@@ -54,10 +54,10 @@ func adminUserAddCommentPage(w http.ResponseWriter, r *http.Request) {
 	} else if strings.TrimSpace(comment) == "" {
 		data.Errors = append(data.Errors, "empty comment")
 	} else {
-		queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+		queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 		if err := queries.InsertAdminUserComment(r.Context(), db.InsertAdminUserCommentParams{UsersIdusers: int32(id), Comment: comment}); err != nil {
 			data.Errors = append(data.Errors, err.Error())
 		}
 	}
-	common.TemplateHandler(w, r, "admin/runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "admin/runTaskPage.gohtml", data)
 }

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
 	db "github.com/arran4/goa4web/internal/db"
 	logProv "github.com/arran4/goa4web/internal/email/log"
@@ -27,7 +27,7 @@ func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 	config.AppRuntimeConfig.EmailProvider = ""
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
-	ctx := context.WithValue(req.Context(), common.KeyCoreData, &CoreData{UserID: 1})
+	ctx := context.WithValue(req.Context(), handlers.KeyCoreData, &CoreData{UserID: 1})
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()
@@ -60,8 +60,8 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 		WithArgs(int32(1)).WillReturnRows(rows)
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
-	ctx := context.WithValue(req.Context(), common.KeyCoreData, &CoreData{UserID: 1})
-	ctx = context.WithValue(ctx, common.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyCoreData, &CoreData{UserID: 1})
+	ctx = context.WithValue(ctx, handlers.KeyQueries, q)
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()

--- a/handlers/admin/constants.go
+++ b/handlers/admin/constants.go
@@ -1,10 +1,10 @@
 package admin
 
 import corecommon "github.com/arran4/goa4web/core/common"
-import hcommon "github.com/arran4/goa4web/handlers/common"
+import handlers "github.com/arran4/goa4web/handlers"
 
 // IndexItem exposes the navigation item type.
 type IndexItem = corecommon.IndexItem
 
-// CoreData exposes the common.CoreData type for handlers.
-type CoreData = hcommon.CoreData
+// CoreData exposes the handlers.CoreData type for handlers.
+type CoreData = handlers.CoreData

--- a/handlers/auth/forgotPassword.go
+++ b/handlers/auth/forgotPassword.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net/http"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -53,7 +53,7 @@ func (f ForgotPasswordTask) SelfInternalNotificationTemplate() *string {
 }
 
 func (ForgotPasswordTask) Page(w http.ResponseWriter, r *http.Request) {
-	hcommon.TemplateHandler(w, r, "forgotPasswordPage.gohtml", r.Context().Value(hcommon.KeyCoreData))
+	handlers.TemplateHandler(w, r, "forgotPasswordPage.gohtml", r.Context().Value(handlers.KeyCoreData))
 }
 
 func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -67,7 +67,7 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing fields", http.StatusBadRequest)
 		return
 	}
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	row, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		http.Error(w, "User not found", http.StatusNotFound)
@@ -94,7 +94,7 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if row.Email != "" {
-		if cd, ok := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData); ok {
+		if cd, ok := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData); ok {
 			if evt := cd.Event(); evt != nil {
 				if evt.Data == nil {
 					evt.Data = map[string]any{}
@@ -102,7 +102,7 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) {
 				evt.Data["reset"] = notif.PasswordResetInfo{Username: row.Username.String, Code: code}
 			}
 		}
-		// OLD _ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, page, hcommon.TaskUserResetPassword, code)
+		// OLD _ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, page, handlers.TaskUserResetPassword, code)
 	}
 	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }

--- a/handlers/auth/loginPage_test.go
+++ b/handlers/auth/loginPage_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
 
@@ -31,9 +31,9 @@ func TestLoginAction_NoSuchUser(t *testing.T) {
 	req := httptest.NewRequest("POST", "/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = "1.2.3.4:1111"
-	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
 	cd := corecommon.NewCoreData(ctx, queries)
-	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()
@@ -69,9 +69,9 @@ func TestLoginAction_InvalidPassword(t *testing.T) {
 	req := httptest.NewRequest("POST", "/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = "1.2.3.4:1111"
-	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
 	cd := corecommon.NewCoreData(ctx, queries)
-	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()

--- a/handlers/auth/matchers_test.go
+++ b/handlers/auth/matchers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gorilla/mux"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 )
 
 func TestRequiredAccessAllowed(t *testing.T) {
@@ -16,7 +16,7 @@ func TestRequiredAccessAllowed(t *testing.T) {
 	cd := corecommon.NewCoreData(req.Context(), nil)
 	cd.UserID = 1
 	cd.SetRoles([]string{"content writer"})
-	ctx := context.WithValue(req.Context(), common.KeyCoreData, cd)
+	ctx := context.WithValue(req.Context(), handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	if !RequiredAccess("content writer")(req, &mux.RouteMatch{}) {
@@ -29,7 +29,7 @@ func TestRequiredAccessDenied(t *testing.T) {
 	cd := corecommon.NewCoreData(req.Context(), nil)
 	cd.UserID = 1
 	cd.SetRoles([]string{"anonymous"})
-	ctx := context.WithValue(req.Context(), common.KeyCoreData, cd)
+	ctx := context.WithValue(req.Context(), handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	if RequiredAccess("content writer")(req, &mux.RouteMatch{}) {

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -11,13 +11,13 @@ import (
 	notif "github.com/arran4/goa4web/internal/notifications"
 
 	"github.com/arran4/goa4web/config"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 // RegisterPage renders the user registration form.
 func RegisterPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(hcommon.KeyCoreData)
-	hcommon.TemplateHandler(w, r, "registerPage.gohtml", cd)
+	cd := r.Context().Value(handlers.KeyCoreData)
+	handlers.TemplateHandler(w, r, "registerPage.gohtml", cd)
 }
 
 // RegisterActionPage handles user creation from the registration form.
@@ -46,7 +46,7 @@ func RegisterActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid email", http.StatusBadRequest)
 		return
 	}
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if _, err := queries.UserByUsername(r.Context(), sql.NullString{
 		String: username,
@@ -111,7 +111,7 @@ func RegisterActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if cd, ok := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData); ok {
+	if cd, ok := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData); ok {
 		if evt := cd.Event(); evt != nil {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}

--- a/handlers/auto_refresh.go
+++ b/handlers/auto_refresh.go
@@ -1,4 +1,4 @@
-package common
+package handlers
 
 import "net/http"
 

--- a/handlers/blogs/bloggerListPage.go
+++ b/handlers/blogs/bloggerListPage.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 // BloggerListPage shows all bloggers with their post counts.
@@ -27,14 +27,14 @@ func BloggerListPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Search:   r.URL.Query().Get("search"),
-		PageSize: common.GetPageSize(r),
+		PageSize: handlers.GetPageSize(r),
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
-	pageSize := common.GetPageSize(r)
+	pageSize := handlers.GetPageSize(r)
 	rows, err := data.CoreData.Bloggers(r)
 	if err != nil {
 		switch {
@@ -78,5 +78,5 @@ func BloggerListPage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	common.TemplateHandler(w, r, "bloggerListPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "bloggerListPage.gohtml", data)
 }

--- a/handlers/blogs/bloggerPostsPage.go
+++ b/handlers/blogs/bloggerPostsPage.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"strconv"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
@@ -39,7 +39,7 @@ func BloggerPostsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	bu, err := queries.GetUserByUsername(r.Context(), sql.NullString{
 		String: username,
@@ -75,7 +75,7 @@ func BloggerPostsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		IsOffset: offset != 0,
 		UID:      strconv.Itoa(int(buid)),
 	}
@@ -91,5 +91,5 @@ func BloggerPostsPage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	common.TemplateHandler(w, r, "bloggerPostsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "bloggerPostsPage.gohtml", data)
 }

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -10,14 +10,14 @@ import (
 	"strconv"
 
 	corelanguage "github.com/arran4/goa4web/core/language"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 )
 
 func BlogAddPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*CoreData)
 	if !(cd.HasRole("content writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
@@ -29,7 +29,7 @@ func BlogAddPage(w http.ResponseWriter, r *http.Request) {
 		Mode               string
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := Data{
 		CoreData:           cd,
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
@@ -43,11 +43,11 @@ func BlogAddPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	common.TemplateHandler(w, r, "blogAddPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "blogAddPage.gohtml", data)
 }
 
 func BlogAddActionPage(w http.ResponseWriter, r *http.Request) {
-	if err := common.ValidateForm(r, []string{"language", "text"}, []string{"language", "text"}); err != nil {
+	if err := handlers.ValidateForm(r, []string{"language", "text"}, []string{"language", "text"}); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -57,7 +57,7 @@ func BlogAddActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/handlers/blogs/blogsBlogAddPage_test.go
+++ b/handlers/blogs/blogsBlogAddPage_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gorilla/sessions"
 
 	"github.com/arran4/goa4web/core"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -43,8 +43,8 @@ func TestBlogAddActionPage_InvalidForms(t *testing.T) {
 		for _, c := range w.Result().Cookies() {
 			req.AddCookie(c)
 		}
-		ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
-		ctx = context.WithValue(ctx, hcommon.KeyCoreData, &hcommon.CoreData{})
+		ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
+		ctx = context.WithValue(ctx, handlers.KeyCoreData, &handlers.CoreData{})
 		req = req.WithContext(ctx)
 
 		rr := httptest.NewRecorder()

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -10,13 +10,13 @@ import (
 	"strconv"
 
 	corelanguage "github.com/arran4/goa4web/core/language"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/config"
 )
 
 func BlogEditPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*CoreData)
 	if !(cd.HasRole("content writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
@@ -29,7 +29,7 @@ func BlogEditPage(w http.ResponseWriter, r *http.Request) {
 		Mode               string
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := Data{
 		CoreData:           cd,
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
@@ -43,10 +43,10 @@ func BlogEditPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	row := r.Context().Value(common.KeyBlogEntry).(*db.GetBlogEntryForUserByIdRow)
+	row := r.Context().Value(handlers.KeyBlogEntry).(*db.GetBlogEntryForUserByIdRow)
 	data.Blog = row
 
-	common.TemplateHandler(w, r, "blogEditPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "blogEditPage.gohtml", data)
 }
 
 func BlogEditActionPage(w http.ResponseWriter, r *http.Request) {
@@ -56,8 +56,8 @@ func BlogEditActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-	row := r.Context().Value(common.KeyBlogEntry).(*db.GetBlogEntryForUserByIdRow)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
+	row := r.Context().Value(handlers.KeyBlogEntry).(*db.GetBlogEntryForUserByIdRow)
 
 	err = queries.UpdateBlogEntry(r.Context(), db.UpdateBlogEntryParams{
 		Idblogs:            row.Idblogs,

--- a/handlers/blogs/blogsBlogPage.go
+++ b/handlers/blogs/blogsBlogPage.go
@@ -13,7 +13,7 @@ import (
 
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
@@ -51,9 +51,9 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	blogId, _ := strconv.Atoi(vars["blog"])
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := Data{
-		CoreData:           r.Context().Value(hcommon.KeyCoreData).(*CoreData),
+		CoreData:           r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Offset:             offset,
 		IsReplyable:        true,
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
@@ -80,7 +80,7 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			_ = templates.GetCompiledSiteTemplates(r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
+			_ = templates.GetCompiledSiteTemplates(r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
 			return
 		default:
 			log.Printf("getBlogEntryForUserById_comments Error: %s", err)
@@ -89,7 +89,7 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if !data.CoreData.HasGrant("blogs", "entry", "view", blog.Idblogs) {
-		_ = templates.GetCompiledSiteTemplates(r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
+		_ = templates.GetCompiledSiteTemplates(r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
 		return
 	}
 
@@ -125,5 +125,5 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	hcommon.TemplateHandler(w, r, "blogPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "blogPage.gohtml", data)
 }

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	emailutil "github.com/arran4/goa4web/internal/notifications"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
@@ -26,7 +26,7 @@ func BlogReplyPostPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	if err := hcommon.ValidateForm(r, []string{"language", "replytext"}, []string{"language", "replytext"}); err != nil {
+	if err := handlers.ValidateForm(r, []string{"language", "replytext"}, []string{"language", "replytext"}); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -44,7 +44,7 @@ func BlogReplyPostPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	blog, err := queries.GetBlogEntryForUserById(r.Context(), db.GetBlogEntryForUserByIdParams{
 		ViewerIdusers: uid,
@@ -53,7 +53,7 @@ func BlogReplyPostPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+			cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 			_ = templates.GetCompiledSiteTemplates(cd.Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", cd)
 			return
 		default:

--- a/handlers/blogs/blogsBloggersBloggerPage.go
+++ b/handlers/blogs/blogsBloggersBloggerPage.go
@@ -3,7 +3,7 @@ package blogs
 import (
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 func BloggersBloggerPage(w http.ResponseWriter, r *http.Request) {
@@ -13,10 +13,10 @@ func BloggersBloggerPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 	}
 
-	//queries := r.Context().Name(common.KeyQueries).(*db.Queries)
+	//queries := r.Context().Name(handlers.KeyQueries).(*db.Queries)
 	//
 	//rows, err := queries.GetCountOfBlogPostsByUser(r.Context())
 	//if err != nil {
@@ -29,5 +29,5 @@ func BloggersBloggerPage(w http.ResponseWriter, r *http.Request) {
 	//}
 	//data.Rows = rows
 
-	common.TemplateHandler(w, r, "bloggersBloggerPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "bloggersBloggerPage.gohtml", data)
 }

--- a/handlers/blogs/blogsCommentEditPage.go
+++ b/handlers/blogs/blogsCommentEditPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/arran4/goa4web/core"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/mux"
 	"log"
@@ -22,7 +22,7 @@ func CommentEditPostPage(w http.ResponseWriter, r *http.Request) {
 	}
 	text := r.PostFormValue("replytext")
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	vars := mux.Vars(r)
 	blogId, _ := strconv.Atoi(vars["blog"])
 	commentId, _ := strconv.Atoi(vars["comment"])
@@ -32,7 +32,7 @@ func CommentEditPostPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	comment := r.Context().Value(common.KeyComment).(*db.GetCommentByIdForUserRow)
+	comment := r.Context().Value(handlers.KeyComment).(*db.GetCommentByIdForUserRow)
 
 	thread, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		ViewerID:      uid,

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -14,7 +14,7 @@ import (
 	"github.com/arran4/goa4web/a4code"
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
@@ -54,9 +54,9 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	blogId, _ := strconv.Atoi(vars["blog"])
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := Data{
-		CoreData:           r.Context().Value(hcommon.KeyCoreData).(*CoreData),
+		CoreData:           r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Offset:             offset,
 		IsReplyable:        true,
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
@@ -83,7 +83,7 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			_ = templates.GetCompiledSiteTemplates(r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
+			_ = templates.GetCompiledSiteTemplates(r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
 			return
 		default:
 			log.Printf("getBlogEntryForUserById_comments Error: %s", err)
@@ -184,5 +184,5 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	hcommon.TemplateHandler(w, r, "commentPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "commentPage.gohtml", data)
 }

--- a/handlers/blogs/blogsCommentPage_replyable_test.go
+++ b/handlers/blogs/blogsCommentPage_replyable_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	common "github.com/arran4/goa4web/core/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -29,9 +29,9 @@ func setupCommentRequest(t *testing.T, queries *db.Queries, store *sessions.Cook
 	for _, c := range w.Result().Cookies() {
 		req.AddCookie(c)
 	}
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess))
-	ctx = context.WithValue(ctx, hcommon.KeyCoreData, cd)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
+	cd := handlers.NewCoreData(ctx, queries, handlers.WithSession(sess))
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	return req, sess
 }

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"time"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/a4code/a4code2html"
 	"github.com/arran4/goa4web/core"
@@ -43,7 +43,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	rows, err := queries.GetBlogEntriesForUserDescendingLanguages(r.Context(), db.GetBlogEntriesForUserDescendingLanguagesParams{
 		UsersIdusers:  int32(userId),
 		ViewerIdusers: uid,
@@ -61,7 +61,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		IsOffset: offset != 0,
 		UID:      buid,
 	}
@@ -80,7 +80,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	common.TemplateHandler(w, r, "blogsPage", data)
+	handlers.TemplateHandler(w, r, "blogsPage", data)
 }
 
 func CustomBlogIndex(data *CoreData, r *http.Request) {
@@ -160,7 +160,7 @@ func CustomBlogIndex(data *CoreData, r *http.Request) {
 
 func RssPage(w http.ResponseWriter, r *http.Request) {
 	username := r.URL.Query().Get("rss")
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{
 		String: username,
 		Valid:  true,
@@ -185,7 +185,7 @@ func RssPage(w http.ResponseWriter, r *http.Request) {
 
 func AtomPage(w http.ResponseWriter, r *http.Request) {
 	username := r.URL.Query().Get("rss")
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{
 		String: username,
 		Valid:  true,

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -51,9 +51,9 @@ func TestBlogsBloggerPostsPage(t *testing.T) {
 		req.AddCookie(c)
 	}
 
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, q)
 	cd := corecommon.NewCoreData(ctx, q, corecommon.WithSession(sess))
-	ctx = context.WithValue(ctx, hcommon.KeyCoreData, cd)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	userRows := sqlmock.NewRows([]string{"idusers", "email", "username"}).
@@ -101,7 +101,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 			AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), "bob", 0, true))
 
 	req := httptest.NewRequest("GET", "http://example.com/blogs/rss?rss=bob", nil)
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 
@@ -127,7 +127,7 @@ func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
 	cd := corecommon.NewCoreData(req.Context(), nil)
 	cd.SetRoles([]string{"anonymous"})
-	ctx := context.WithValue(req.Context(), hcommon.KeyCoreData, cd)
+	ctx := context.WithValue(req.Context(), handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	BlogAddPage(rr, req)
@@ -140,7 +140,7 @@ func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/1/edit", nil)
 	cd := corecommon.NewCoreData(req.Context(), nil)
 	cd.SetRoles([]string{"anonymous"})
-	ctx := context.WithValue(req.Context(), hcommon.KeyCoreData, cd)
+	ctx := context.WithValue(req.Context(), handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	BlogEditPage(rr, req)
@@ -153,7 +153,7 @@ func TestGetPermissionsByUserIdAndSectionBlogsPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin/blogs/user/permissions", nil)
 	cd := corecommon.NewCoreData(req.Context(), nil)
 	cd.SetRoles([]string{"anonymous"})
-	ctx := context.WithValue(req.Context(), hcommon.KeyCoreData, cd)
+	ctx := context.WithValue(req.Context(), handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	GetPermissionsByUserIdAndSectionBlogsPage(rr, req)

--- a/handlers/blogs/blogsUserPermissionsPage.go
+++ b/handlers/blogs/blogsUserPermissionsPage.go
@@ -11,11 +11,11 @@ import (
 	"strconv"
 	"strings"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 func GetPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*CoreData)
 	if !(cd.HasRole("content writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
@@ -33,7 +33,7 @@ func GetPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Re
 		Filter:   r.URL.Query().Get("level"),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if roles, err := cd.AllRoles(); err == nil {
 		data.Roles = roles
 	}
@@ -60,11 +60,11 @@ func GetPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Re
 
 	data.Rows = rows
 
-	common.TemplateHandler(w, r, "userPermissionsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "userPermissionsPage.gohtml", data)
 }
 
 func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	username := r.PostFormValue("username")
 	level := r.PostFormValue("role")
 	data := struct {
@@ -73,7 +73,7 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Back:     "/blogs/bloggers",
 	}
 	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
@@ -85,11 +85,11 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
 	}
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 
 func UsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	permid := r.PostFormValue("permid")
 	data := struct {
 		*CoreData
@@ -97,7 +97,7 @@ func UsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Back:     "/blogs/bloggers",
 	}
 	if permidi, err := strconv.Atoi(permid); err != nil {
@@ -105,11 +105,11 @@ func UsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 	} else if err := queries.DeleteUserRole(r.Context(), int32(permidi)); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
 	}
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 
 func UsersPermissionsBulkAllowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	names := strings.FieldsFunc(r.PostFormValue("usernames"), func(r rune) bool { return r == ',' || r == '\n' || r == ' ' || r == '\t' })
 	level := r.PostFormValue("role")
 	data := struct {
@@ -118,7 +118,7 @@ func UsersPermissionsBulkAllowPage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Back:     "/blogs/bloggers",
 	}
 
@@ -139,11 +139,11 @@ func UsersPermissionsBulkAllowPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 
 func UsersPermissionsBulkDisallowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	permids := r.PostForm["permid"]
 	data := struct {
 		*CoreData
@@ -151,7 +151,7 @@ func UsersPermissionsBulkDisallowPage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Back:     "/blogs/bloggers",
 	}
 
@@ -169,5 +169,5 @@ func UsersPermissionsBulkDisallowPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/handlers/blogs/matchers.go
+++ b/handlers/blogs/matchers.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/core"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -24,7 +24,7 @@ func RequireBlogAuthor(next http.Handler) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+		queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 		session, err := core.GetSession(r)
 		if err != nil {
 			http.NotFound(w, r)
@@ -46,9 +46,9 @@ func RequireBlogAuthor(next http.Handler) http.Handler {
 			}
 			return
 		}
-		cd, _ := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+		cd, _ := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 		if cd != nil && cd.HasRole("administrator") {
-			ctx := context.WithValue(r.Context(), hcommon.KeyBlogEntry, row)
+			ctx := context.WithValue(r.Context(), handlers.KeyBlogEntry, row)
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
@@ -56,7 +56,7 @@ func RequireBlogAuthor(next http.Handler) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		ctx := context.WithValue(r.Context(), hcommon.KeyBlogEntry, row)
+		ctx := context.WithValue(r.Context(), handlers.KeyBlogEntry, row)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/handlers/blogs/routes.go
+++ b/handlers/blogs/routes.go
@@ -6,22 +6,22 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
+	handlers "github.com/arran4/goa4web/handlers"
 	auth "github.com/arran4/goa4web/handlers/auth"
-	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 
 	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 // AddBlogIndex injects blog index links into CoreData.
-func AddBlogIndex(h http.Handler) http.Handler { return hcommon.IndexMiddleware(CustomBlogIndex)(h) }
+func AddBlogIndex(h http.Handler) http.Handler { return handlers.IndexMiddleware(CustomBlogIndex)(h) }
 
 // RegisterRoutes attaches the public blog endpoints to r.
 func RegisterRoutes(r *mux.Router) {
 	nav.RegisterIndexLink("Blogs", "/blogs", SectionWeight)
 	nav.RegisterAdminControlCenter("Blogs", "/admin/blogs/user/permissions", SectionWeight)
 	br := r.PathPrefix("/blogs").Subrouter()
-	br.Use(hcommon.IndexMiddleware(CustomBlogIndex))
+	br.Use(handlers.IndexMiddleware(CustomBlogIndex))
 	br.HandleFunc("/rss", RssPage).Methods("GET")
 	br.HandleFunc("/atom", AtomPage).Methods("GET")
 	br.HandleFunc("", Page).Methods("GET")
@@ -32,14 +32,14 @@ func RegisterRoutes(r *mux.Router) {
 	br.HandleFunc("/blogger/{username}", BloggerPostsPage).Methods("GET")
 	br.HandleFunc("/blogger/{username}/", BloggerPostsPage).Methods("GET")
 	br.HandleFunc("/blog/{blog}", BlogPage).Methods("GET")
-	br.HandleFunc("/blog/{blog}", hcommon.TaskDoneAutoRefreshPage).Methods("POST")
+	br.HandleFunc("/blog/{blog}", handlers.TaskDoneAutoRefreshPage).Methods("POST")
 	br.HandleFunc("/blog/{blog}/comments", CommentPage).Methods("GET", "POST")
 	br.HandleFunc("/blog/{blog}/reply", ReplyBlogTask.Action).Methods("POST").MatcherFunc(ReplyBlogTask.Match)
 	br.Handle("/blog/{blog}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(CommentEditPostPage))).Methods("POST").MatcherFunc(tasks.EditReplyTask.Match)
 	br.Handle("/blog/{blog}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(CommentEditPostCancelPage))).Methods("POST").MatcherFunc(tasks.CancelTask.Match)
 	br.Handle("/blog/{blog}/edit", RequireBlogAuthor(http.HandlerFunc(EditBlogTask.Page))).Methods("GET").MatcherFunc(auth.RequiredAccess("content writer", "administrator"))
 	br.Handle("/blog/{blog}/edit", RequireBlogAuthor(http.HandlerFunc(EditBlogTask.Action))).Methods("POST").MatcherFunc(auth.RequiredAccess("content writer", "administrator")).MatcherFunc(EditBlogTask.Match)
-	br.HandleFunc("/blog/{blog}/edit", hcommon.TaskDoneAutoRefreshPage).Methods("POST").MatcherFunc(tasks.CancelTask.Match)
+	br.HandleFunc("/blog/{blog}/edit", handlers.TaskDoneAutoRefreshPage).Methods("POST").MatcherFunc(tasks.CancelTask.Match)
 
 	// Admin endpoints for blogs
 	br.HandleFunc("/user/permissions", GetPermissionsByUserIdAndSectionBlogsPage).Methods("GET").MatcherFunc(auth.RequiredAccess("administrator"))

--- a/handlers/blogs/types.go
+++ b/handlers/blogs/types.go
@@ -2,11 +2,11 @@ package blogs
 
 import (
 	corecommon "github.com/arran4/goa4web/core/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 // IndexItem exposes the navigation item type.
 type IndexItem = corecommon.IndexItem
 
-// CoreData exposes the common.CoreData type for handlers.
-type CoreData = hcommon.CoreData
+// CoreData exposes the handlers.CoreData type for handlers.
+type CoreData = handlers.CoreData

--- a/handlers/bookmarks/edit.go
+++ b/handlers/bookmarks/edit.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -20,7 +20,7 @@ func EditPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData:        r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData:        r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 		BookmarkContent: "Category: Example 1\nhttp://www.google.com.au Google\nColumn\nCategory: Example 2\nhttp://www.google.com.au Google\nhttp://www.google.com.au Google\n",
 	}
 	session, ok := core.GetSessionOrFail(w, r)
@@ -28,7 +28,7 @@ func EditPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = session
-	cd := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
 	bookmarks, err := cd.Bookmarks()
 	if err != nil {
 		switch {
@@ -43,12 +43,12 @@ func EditPage(w http.ResponseWriter, r *http.Request) {
 		data.Bid = bookmarks.Idbookmarks
 	}
 
-	common.TemplateHandler(w, r, "editPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "editPage.gohtml", data)
 }
 
 func EditSaveActionPage(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -72,7 +72,7 @@ func EditSaveActionPage(w http.ResponseWriter, r *http.Request) {
 
 func EditCreateActionPage(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/handlers/bookmarks/mine.go
+++ b/handlers/bookmarks/mine.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 type BookmarkEntry struct {
@@ -80,7 +80,7 @@ func MinePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = session
-	cd := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
 	bookmarks, err := cd.Bookmarks()
 	if err != nil {
 		switch {
@@ -97,5 +97,5 @@ func MinePage(w http.ResponseWriter, r *http.Request) {
 		Columns:  preprocessBookmarks(bookmarks.List.String),
 	}
 
-	common.TemplateHandler(w, r, "minePage.gohtml", data)
+	handlers.TemplateHandler(w, r, "minePage.gohtml", data)
 }

--- a/handlers/bookmarks/page.go
+++ b/handlers/bookmarks/page.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 func Page(w http.ResponseWriter, r *http.Request) {
@@ -20,15 +20,15 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
 	if uid == 0 {
-		common.TemplateHandler(w, r, "infoPage.gohtml", data)
+		handlers.TemplateHandler(w, r, "infoPage.gohtml", data)
 		return
 	}
 
-	common.TemplateHandler(w, r, "bookmarksPage", data)
+	handlers.TemplateHandler(w, r, "bookmarksPage", data)
 }
 
 func bookmarksCustomIndex(data *corecommon.CoreData) {

--- a/handlers/bookmarks/routes.go
+++ b/handlers/bookmarks/routes.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/gorilla/mux"
 
+	handlers "github.com/arran4/goa4web/handlers"
 	auth "github.com/arran4/goa4web/handlers/auth"
-	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 
 	nav "github.com/arran4/goa4web/internal/navigation"
@@ -14,7 +14,7 @@ import (
 
 // AddBookmarksIndex injects bookmark index links into CoreData.
 func AddBookmarksIndex(h http.Handler) http.Handler {
-	return hcommon.IndexMiddleware(func(cd *hcommon.CoreData, r *http.Request) {
+	return handlers.IndexMiddleware(func(cd *handlers.CoreData, r *http.Request) {
 		bookmarksCustomIndex(cd)
 	})(h)
 }
@@ -29,7 +29,7 @@ func RegisterRoutes(r *mux.Router) {
 	br.HandleFunc("/edit", SaveTask.Page).Methods("GET").MatcherFunc(auth.RequiresAnAccount())
 	br.HandleFunc("/edit", SaveTask.Action).Methods("POST").MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(SaveTask.Match)
 	br.HandleFunc("/edit", CreateTask.Action).Methods("POST").MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(CreateTask.Match)
-	br.HandleFunc("/edit", hcommon.TaskDoneAutoRefreshPage).Methods("POST").MatcherFunc(auth.RequiresAnAccount())
+	br.HandleFunc("/edit", handlers.TaskDoneAutoRefreshPage).Methods("POST").MatcherFunc(auth.RequiresAnAccount())
 }
 
 // Register registers the bookmarks router module.

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -1,4 +1,4 @@
-package common
+package handlers
 
 const (
 	// Alphabet lists letters for search navigation.

--- a/handlers/contextkeys.go
+++ b/handlers/contextkeys.go
@@ -1,4 +1,4 @@
-package common
+package handlers
 
 import common "github.com/arran4/goa4web/core/common"
 

--- a/handlers/error_acknowledgement.go
+++ b/handlers/error_acknowledgement.go
@@ -1,4 +1,4 @@
-package common
+package handlers
 
 import "net/http"
 

--- a/handlers/faq/admin_answer.go
+++ b/handlers/faq/admin_answer.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -20,10 +20,10 @@ func AdminAnswerPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	catrows, err := queries.GetAllFAQCategories(r.Context())
 	if err != nil {
@@ -47,7 +47,7 @@ func AdminAnswerPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	common.TemplateHandler(w, r, "adminAnswerPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminAnswerPage.gohtml", data)
 }
 
 func AnswerAnswerActionPage(w http.ResponseWriter, r *http.Request) {
@@ -65,7 +65,7 @@ func AnswerAnswerActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if err := queries.UpdateFAQQuestionAnswer(r.Context(), db.UpdateFAQQuestionAnswerParams{
 		Answer:                       sql.NullString{Valid: true, String: answer},
@@ -78,7 +78,7 @@ func AnswerAnswerActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func AnswerRemoveActionPage(w http.ResponseWriter, r *http.Request) {
@@ -88,7 +88,7 @@ func AnswerRemoveActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if err := queries.DeleteFAQ(r.Context(), int32(faq)); err != nil {
 		log.Printf("Error: %s", err)
@@ -96,5 +96,5 @@ func AnswerRemoveActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/faq/admin_categories.go
+++ b/handlers/faq/admin_categories.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -19,10 +19,10 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	rows, err := queries.GetFAQCategoriesWithQuestionCount(r.Context())
 	if err != nil {
@@ -35,7 +35,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	common.TemplateHandler(w, r, "adminCategoriesPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminCategoriesPage.gohtml", data)
 }
 
 func CategoriesRenameActionPage(w http.ResponseWriter, r *http.Request) {
@@ -46,7 +46,7 @@ func CategoriesRenameActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if err := queries.RenameFAQCategory(r.Context(), db.RenameFAQCategoryParams{
 		Name: sql.NullString{
@@ -60,7 +60,7 @@ func CategoriesRenameActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func CategoriesDeleteActionPage(w http.ResponseWriter, r *http.Request) {
@@ -70,7 +70,7 @@ func CategoriesDeleteActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if err := queries.DeleteFAQCategory(r.Context(), int32(cid)); err != nil {
 		log.Printf("Error: %s", err)
@@ -78,12 +78,12 @@ func CategoriesDeleteActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func CategoriesCreateActionPage(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("cname")
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if err := queries.CreateFAQCategory(r.Context(), sql.NullString{
 		String: text,
@@ -94,5 +94,5 @@ func CategoriesCreateActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/faq/admin_question.go
+++ b/handlers/faq/admin_question.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/core"
@@ -22,10 +22,10 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	catrows, err := queries.GetAllFAQCategories(r.Context())
 	if err != nil {
@@ -49,7 +49,7 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	common.TemplateHandler(w, r, "adminQuestionPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminQuestionPage.gohtml", data)
 }
 
 func QuestionsDeleteActionPage(w http.ResponseWriter, r *http.Request) {
@@ -59,7 +59,7 @@ func QuestionsDeleteActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if err := queries.DeleteFAQ(r.Context(), int32(faq)); err != nil {
 		log.Printf("Error: %s", err)
@@ -67,7 +67,7 @@ func QuestionsDeleteActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func QuestionsEditActionPage(w http.ResponseWriter, r *http.Request) {
@@ -85,7 +85,7 @@ func QuestionsEditActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if err := queries.UpdateFAQQuestionAnswer(r.Context(), db.UpdateFAQQuestionAnswerParams{
 		Answer:                       sql.NullString{Valid: true, String: answer},
@@ -98,7 +98,7 @@ func QuestionsEditActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func QuestionsCreateActionPage(w http.ResponseWriter, r *http.Request) {
@@ -110,7 +110,7 @@ func QuestionsCreateActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -128,5 +128,5 @@ func QuestionsCreateActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -8,7 +8,7 @@ import (
 
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/config"
@@ -22,8 +22,8 @@ func AskPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int32
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-	cd := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
 	data := Data{
 		CoreData:           cd,
 		SelectedLanguageId: corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage),
@@ -36,11 +36,11 @@ func AskPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	common.TemplateHandler(w, r, "askPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "askPage.gohtml", data)
 }
 
 func AskActionPage(w http.ResponseWriter, r *http.Request) {
-	if err := common.ValidateForm(r, []string{"language", "text"}, []string{"language", "text"}); err != nil {
+	if err := handlers.ValidateForm(r, []string{"language", "text"}, []string{"language", "text"}); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -50,7 +50,7 @@ func AskActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -69,7 +69,7 @@ func AskActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if cd, ok := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData); ok {
+	if cd, ok := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData); ok {
 		if evt := cd.Event(); evt != nil {
 			evt.Admin = true
 			evt.Path = "/admin/faq"

--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 )
@@ -47,8 +47,8 @@ func TestAskActionPage_InvalidForms(t *testing.T) {
 		for _, c := range w.Result().Cookies() {
 			req.AddCookie(c)
 		}
-		ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
-		ctx = context.WithValue(ctx, hcommon.KeyCoreData, &hcommon.CoreData{})
+		ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
+		ctx = context.WithValue(ctx, handlers.KeyCoreData, &handlers.CoreData{})
 		req = req.WithContext(ctx)
 
 		rr := httptest.NewRecorder()
@@ -95,11 +95,11 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 		req.AddCookie(c)
 	}
 	evt := &eventbus.Event{Path: "/faq/ask", Task: tasks.TaskAsk, UserID: 1}
-	cd := &hcommon.CoreData{}
+	cd := &handlers.CoreData{}
 	cd.SetEvent(evt)
 
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
-	ctx = context.WithValue(ctx, hcommon.KeyCoreData, cd)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()

--- a/handlers/faq/page.go
+++ b/handlers/faq/page.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -29,10 +29,10 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	var currentCategoryFAQs CategoryFAQs
 
@@ -63,7 +63,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 
 	// index links provided via middleware
 
-	common.TemplateHandler(w, r, "faqPage", data)
+	handlers.TemplateHandler(w, r, "faqPage", data)
 }
 
 func CustomFAQIndex(data *corecommon.CoreData, r *http.Request) {

--- a/handlers/faq/routes.go
+++ b/handlers/faq/routes.go
@@ -4,14 +4,14 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
 )
 
 // AddFAQIndex injects FAQ index links into CoreData.
 func AddFAQIndex(h http.Handler) http.Handler {
-	return hcommon.IndexMiddleware(func(cd *hcommon.CoreData, r *http.Request) {
+	return handlers.IndexMiddleware(func(cd *handlers.CoreData, r *http.Request) {
 		CustomFAQIndex(cd, r)
 	})(h)
 }
@@ -53,7 +53,7 @@ func RegisterRoutes(r *mux.Router) {
 	nav.RegisterIndexLink("FAQ", "/faq", SectionWeight)
 	nav.RegisterAdminControlCenter("FAQ", "/admin/faq/categories", SectionWeight)
 	faqr := r.PathPrefix("/faq").Subrouter()
-	faqr.Use(hcommon.IndexMiddleware(CustomFAQIndex))
+	faqr.Use(handlers.IndexMiddleware(CustomFAQIndex))
 	faqr.HandleFunc("", Page).Methods("GET", "POST")
 	faqr.HandleFunc("/ask", AskPage).Methods("GET")
 	faqr.HandleFunc("/ask", AskActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskAsk))
@@ -62,7 +62,7 @@ func RegisterRoutes(r *mux.Router) {
 // RegisterAdminRoutes attaches the admin FAQ endpoints to the router.
 func RegisterAdminRoutes(ar *mux.Router) {
 	farq := ar.PathPrefix("/faq").Subrouter()
-	farq.Use(hcommon.IndexMiddleware(CustomFAQIndex))
+	farq.Use(handlers.IndexMiddleware(CustomFAQIndex))
 	farq.HandleFunc("/answer", AdminAnswerPage).Methods("GET", "POST").MatcherFunc(noTask())
 	farq.HandleFunc("/answer", AnswerAnswerActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskAnswer))
 	farq.HandleFunc("/answer", AnswerRemoveActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskRemoveRemove))

--- a/handlers/form.go
+++ b/handlers/form.go
@@ -1,4 +1,4 @@
-package common
+package handlers
 
 import (
 	"net/http"

--- a/handlers/forum/adminForumFlaggedPostsPage.go
+++ b/handlers/forum/adminForumFlaggedPostsPage.go
@@ -3,7 +3,7 @@ package forum
 import (
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 // adminForumFlaggedPostsPage displays posts flagged for moderator review.
@@ -11,6 +11,6 @@ func AdminForumFlaggedPostsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*CoreData
 	}
-	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
-	common.TemplateHandler(w, r, "forumFlaggedPostsPage.gohtml", data)
+	data := Data{CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData)}
+	handlers.TemplateHandler(w, r, "forumFlaggedPostsPage.gohtml", data)
 }

--- a/handlers/forum/adminForumHandler.go
+++ b/handlers/forum/adminForumHandler.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -16,20 +16,20 @@ func AdminForumPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 	}
-	common.TemplateHandler(w, r, "forumPage", data)
+	handlers.TemplateHandler(w, r, "forumPage", data)
 }
 
 func AdminForumRemakeForumThreadPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := struct {
 		*CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Back:     "/admin/forum",
 	}
 
@@ -43,18 +43,18 @@ func AdminForumRemakeForumThreadPage(w http.ResponseWriter, r *http.Request) {
 	} else {
 		data.Messages = append(data.Messages, "Thread metadata rebuild complete.")
 	}
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 
 func AdminForumRemakeForumTopicPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := struct {
 		*CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Back:     "/admin/forum",
 	}
 
@@ -67,7 +67,7 @@ func AdminForumRemakeForumTopicPage(w http.ResponseWriter, r *http.Request) {
 	} else {
 		data.Messages = append(data.Messages, "Topic metadata rebuild complete.")
 	}
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 
 func countForumThreads(ctx context.Context, q *db.Queries) (int64, error) {

--- a/handlers/forum/adminForumModeratorLogsPage.go
+++ b/handlers/forum/adminForumModeratorLogsPage.go
@@ -3,7 +3,7 @@ package forum
 import (
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 // adminForumModeratorLogsPage displays recent moderator actions.
@@ -11,6 +11,6 @@ func AdminForumModeratorLogsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*CoreData
 	}
-	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*CoreData)}
-	common.TemplateHandler(w, r, "forumModeratorLogsPage.gohtml", data)
+	data := Data{CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData)}
+	handlers.TemplateHandler(w, r, "forumModeratorLogsPage.gohtml", data)
 }

--- a/handlers/forum/adminForumWordListHandler.go
+++ b/handlers/forum/adminForumWordListHandler.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -17,10 +17,10 @@ func AdminForumWordListPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	rows, err := queries.CompleteWordList(r.Context())
 	if err != nil {
@@ -33,5 +33,5 @@ func AdminForumWordListPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	common.TemplateHandler(w, r, "forumWordListPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "forumWordListPage.gohtml", data)
 }

--- a/handlers/forum/comments/matchers.go
+++ b/handlers/forum/comments/matchers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/core"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -22,7 +22,7 @@ func RequireCommentAuthor(next http.Handler) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+		queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 		session, err := core.GetSession(r)
 		if err != nil {
 			http.NotFound(w, r)
@@ -41,12 +41,12 @@ func RequireCommentAuthor(next http.Handler) http.Handler {
 			return
 		}
 
-		cd, _ := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+		cd, _ := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 		if row.UsersIdusers != uid && (cd == nil || !cd.HasRole("administrator")) {
 			http.NotFound(w, r)
 			return
 		}
-		ctx := context.WithValue(r.Context(), hcommon.KeyComment, row)
+		ctx := context.WithValue(r.Context(), handlers.KeyComment, row)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/handlers/forum/constants.go
+++ b/handlers/forum/constants.go
@@ -1,13 +1,13 @@
 package forum
 
 import corecommon "github.com/arran4/goa4web/core/common"
-import hcommon "github.com/arran4/goa4web/handlers/common"
+import handlers "github.com/arran4/goa4web/handlers"
 
 // IndexItem exposes the navigation item type.
 type IndexItem = corecommon.IndexItem
 
-// CoreData exposes the common.CoreData type for handlers.
-type CoreData = hcommon.CoreData
+// CoreData exposes the handlers.CoreData type for handlers.
+type CoreData = handlers.CoreData
 
 // ForumTopicName is the default name for the hidden forum topic.
 const ForumTopicName = "A FORUM TOPIC"

--- a/handlers/forum/forumAdminCategoriesPage.go
+++ b/handlers/forum/forumAdminCategoriesPage.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/gorilla/mux"
@@ -18,10 +18,10 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 		*CoreData
 		Categories []*db.GetAllForumCategoriesWithSubcategoryCountRow
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 	}
 
 	categoryRows, err := queries.GetAllForumCategoriesWithSubcategoryCount(r.Context())
@@ -37,7 +37,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Categories = categoryRows
 
-	common.TemplateHandler(w, r, "adminCategoriesPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminCategoriesPage.gohtml", data)
 }
 
 func AdminCategoryEditPage(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +48,7 @@ func AdminCategoryEditPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	vars := mux.Vars(r)
 	categoryId, _ := strconv.Atoi(vars["category"])
 
@@ -80,7 +80,7 @@ func AdminCategoryCreatePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if err := queries.CreateForumCategory(r.Context(), db.CreateForumCategoryParams{
 		ForumcategoryIdforumcategory: int32(pcid),
 		Title: sql.NullString{
@@ -100,7 +100,7 @@ func AdminCategoryCreatePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func AdminCategoryDeletePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	cid, err := strconv.Atoi(r.PostFormValue("cid"))
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/handlers/forum/forumAdminPage.go
+++ b/handlers/forum/forumAdminPage.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -22,10 +22,10 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	ctx := r.Context()
 	count := func(q string, dest *int64) {
 		if err := queries.DB().QueryRowContext(ctx, q).Scan(dest); err != nil && err != sql.ErrNoRows {
@@ -37,5 +37,5 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 	count("SELECT COUNT(*) FROM forumtopic", &data.Stats.Topics)
 	count("SELECT COUNT(*) FROM forumthread", &data.Stats.Threads)
 
-	common.TemplateHandler(w, r, "forumAdminPage", data)
+	handlers.TemplateHandler(w, r, "forumAdminPage", data)
 }

--- a/handlers/forum/forumAdminThreadsPage.go
+++ b/handlers/forum/forumAdminThreadsPage.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/gorilla/mux"
@@ -22,7 +22,7 @@ func AdminThreadsPage(w http.ResponseWriter, r *http.Request) {
 		Order  []int32
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	rows, err := queries.GetAllForumThreadsWithTopic(r.Context())
 	if err != nil {
@@ -32,7 +32,7 @@ func AdminThreadsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*CoreData),
 		Groups:   make(map[int32]*Group),
 	}
 
@@ -46,7 +46,7 @@ func AdminThreadsPage(w http.ResponseWriter, r *http.Request) {
 		g.Threads = append(g.Threads, row)
 	}
 
-	common.TemplateHandler(w, r, "adminThreadsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminThreadsPage.gohtml", data)
 }
 
 func AdminThreadDeletePage(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +60,7 @@ func AdminThreadDeletePage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if err := ThreadDelete(r.Context(), queries, int32(threadID), int32(topicID)); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return

--- a/handlers/forum/forumFeed.go
+++ b/handlers/forum/forumFeed.go
@@ -7,7 +7,7 @@ import (
 	"github.com/arran4/goa4web/a4code/a4code2html"
 	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	imageshandler "github.com/arran4/goa4web/handlers/images"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/feeds"
@@ -64,7 +64,7 @@ func TopicRssPage(w http.ResponseWriter, r *http.Request) {
 	}
 	vars := mux.Vars(r)
 	topicID, _ := strconv.Atoi(vars["topic"])
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	topic, err := cd.ForumTopicByID(int32(topicID))
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
@@ -95,7 +95,7 @@ func TopicAtomPage(w http.ResponseWriter, r *http.Request) {
 	}
 	vars := mux.Vars(r)
 	topicID, _ := strconv.Atoi(vars["topic"])
-	cd := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
 
 	topic, err := cd.ForumTopicByID(int32(topicID))
 	if err != nil {

--- a/handlers/forum/forumIndexPermissions_test.go
+++ b/handlers/forum/forumIndexPermissions_test.go
@@ -8,7 +8,7 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	corecommon "github.com/arran4/goa4web/core/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/mux"
 )
@@ -23,7 +23,7 @@ func TestCustomForumIndexWriteReply(t *testing.T) {
 	}
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, q)
 	cd := corecommon.NewCoreData(ctx, q)
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
@@ -49,7 +49,7 @@ func TestCustomForumIndexWriteReplyDenied(t *testing.T) {
 	}
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, q)
 	cd := corecommon.NewCoreData(ctx, q)
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
@@ -75,7 +75,7 @@ func TestCustomForumIndexCreateThread(t *testing.T) {
 	}
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, q)
 	cd := corecommon.NewCoreData(ctx, q)
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
@@ -101,7 +101,7 @@ func TestCustomForumIndexCreateThreadDenied(t *testing.T) {
 	}
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, q)
 	cd := corecommon.NewCoreData(ctx, q)
 
 	mock.ExpectQuery("SELECT 1 FROM grants").

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/core"
@@ -27,7 +27,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		Back                    bool
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -36,7 +36,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	categoryId, _ := strconv.Atoi(vars["category"])
 
-	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*CoreData)
 	data := &Data{
 		CoreData: cd,
 		Admin:    cd.CanEditAny(),
@@ -124,7 +124,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		data.Back = true
 	}
 
-	common.TemplateHandler(w, r, "forumPage", data)
+	handlers.TemplateHandler(w, r, "forumPage", data)
 }
 
 func CustomForumIndex(data *CoreData, r *http.Request) {

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -8,9 +8,8 @@ import (
 	"strconv"
 
 	corelanguage "github.com/arran4/goa4web/core/language"
+	handlers "github.com/arran4/goa4web/handlers"
 	blogs "github.com/arran4/goa4web/handlers/blogs"
-	common "github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
@@ -28,8 +27,8 @@ func ThreadNewPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
-	cd := r.Context().Value(hcommon.KeyCoreData).(*CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*CoreData)
 	data := Data{
 		CoreData:           cd,
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
@@ -44,11 +43,11 @@ func ThreadNewPage(w http.ResponseWriter, r *http.Request) {
 
 	blogs.CustomBlogIndex(data.CoreData, r)
 
-	common.TemplateHandler(w, r, "threadNewPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "threadNewPage.gohtml", data)
 }
 
 func ThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	vars := mux.Vars(r)
 	topicId, err := strconv.Atoi(vars["topic"])
 	session, ok := core.GetSessionOrFail(w, r)
@@ -82,7 +81,7 @@ func ThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
 	if u, err := queries.GetUserById(r.Context(), uid); err == nil {
 		author = u.Username.String
 	}
-	if cd, ok := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData); ok {
+	if cd, ok := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData); ok {
 		if evt := cd.Event(); evt != nil {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/arran4/goa4web/a4code"
 	corelanguage "github.com/arran4/goa4web/core/language"
+	handlers "github.com/arran4/goa4web/handlers"
 	blogs "github.com/arran4/goa4web/handlers/blogs"
-	common "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/config"
@@ -45,8 +45,8 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*CoreData)
 	data := Data{
 		CoreData:           cd,
 		Offset:             offset,
@@ -61,8 +61,8 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
-	topicRow := r.Context().Value(common.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+	threadRow := r.Context().Value(handlers.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
+	topicRow := r.Context().Value(handlers.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
@@ -172,5 +172,5 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 
 	blogs.CustomBlogIndex(data.CoreData, r)
 
-	common.TemplateHandler(w, r, "threadPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "threadPage.gohtml", data)
 }

--- a/handlers/forum/forumTopicPage.go
+++ b/handlers/forum/forumTopicPage.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/core"
@@ -33,7 +33,7 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	topicId, _ := strconv.Atoi(vars["topic"])
 
-	cd := r.Context().Value(common.KeyCoreData).(*CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*CoreData)
 	data := &Data{
 		CoreData: cd,
 		Admin:    cd.CanEditAny(),
@@ -92,5 +92,5 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Threads = threadRows
 
-	common.TemplateHandler(w, r, "topicsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "topicsPage.gohtml", data)
 }

--- a/handlers/forum/forumTopicThreadCommentEditPage.go
+++ b/handlers/forum/forumTopicThreadCommentEditPage.go
@@ -3,7 +3,7 @@ package forum
 import (
 	"database/sql"
 	"fmt"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/mux"
 	"log"
@@ -19,9 +19,9 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	text := r.PostFormValue("replytext")
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
-	topicRow := r.Context().Value(common.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
+	threadRow := r.Context().Value(handlers.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
+	topicRow := r.Context().Value(handlers.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 	commentId, _ := strconv.Atoi(mux.Vars(r)["comment"])
 
 	err = queries.UpdateComment(r.Context(), db.UpdateCommentParams{
@@ -47,8 +47,8 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func TopicThreadCommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
-	threadRow := r.Context().Value(common.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
-	topicRow := r.Context().Value(common.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+	threadRow := r.Context().Value(handlers.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
+	topicRow := r.Context().Value(handlers.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
 

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -13,7 +13,7 @@ import (
 	emailutil "github.com/arran4/goa4web/internal/notifications"
 
 	"github.com/arran4/goa4web/core"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
@@ -25,10 +25,10 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	threadRow := r.Context().Value(hcommon.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
-	topicRow := r.Context().Value(hcommon.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+	threadRow := r.Context().Value(handlers.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
+	topicRow := r.Context().Value(handlers.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
-	if cd, ok := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData); ok {
+	if cd, ok := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData); ok {
 		if evt := cd.Event(); evt != nil {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
@@ -37,7 +37,7 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	text := r.PostFormValue("replytext")
 	languageId, _ := strconv.Atoi(r.PostFormValue("language"))
@@ -112,8 +112,8 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func TopicThreadReplyCancelPage(w http.ResponseWriter, r *http.Request) {
-	threadRow := r.Context().Value(hcommon.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
-	topicRow := r.Context().Value(hcommon.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+	threadRow := r.Context().Value(handlers.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
+	topicRow := r.Context().Value(handlers.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
 

--- a/handlers/forum/matchers.go
+++ b/handlers/forum/matchers.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -32,7 +32,7 @@ func RequireThreadAndTopic(next http.Handler) http.Handler {
 			return
 		}
 
-		queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+		queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 		session, _ := core.GetSession(r)
 		var uid int32
@@ -74,8 +74,8 @@ func RequireThreadAndTopic(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx := context.WithValue(r.Context(), hcommon.KeyThread, threadRow)
-		ctx = context.WithValue(ctx, hcommon.KeyTopic, topicRow)
+		ctx := context.WithValue(r.Context(), handlers.KeyThread, threadRow)
+		ctx = context.WithValue(ctx, handlers.KeyTopic, topicRow)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/handlers/forum/matchers_test.go
+++ b/handlers/forum/matchers_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/mux"
 )
@@ -36,14 +36,14 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
-	ctx := context.WithValue(req.Context(), common.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, q)
 	req = req.WithContext(ctx)
 
 	called := false
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		if r.Context().Value(common.KeyThread) == nil || r.Context().Value(common.KeyTopic) == nil {
+		if r.Context().Value(handlers.KeyThread) == nil || r.Context().Value(handlers.KeyTopic) == nil {
 			t.Errorf("context values missing")
 		}
 		w.WriteHeader(http.StatusOK)
@@ -84,7 +84,7 @@ func TestRequireThreadAndTopicFalse(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
-	ctx := context.WithValue(req.Context(), common.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, q)
 	req = req.WithContext(ctx)
 
 	called := false
@@ -121,7 +121,7 @@ func TestRequireThreadAndTopicError(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
-	ctx := context.WithValue(req.Context(), common.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, q)
 	req = req.WithContext(ctx)
 
 	called := false

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -6,21 +6,21 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	router "github.com/arran4/goa4web/internal/router"
 
 	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 // AddForumIndex injects forum index links into CoreData.
-func AddForumIndex(h http.Handler) http.Handler { return hcommon.IndexMiddleware(CustomForumIndex)(h) }
+func AddForumIndex(h http.Handler) http.Handler { return handlers.IndexMiddleware(CustomForumIndex)(h) }
 
 // RegisterRoutes attaches the public forum endpoints to r.
 func RegisterRoutes(r *mux.Router) {
 	nav.RegisterIndexLink("Forum", "/forum", SectionWeight)
 	nav.RegisterAdminControlCenter("Forum", "/admin/forum", SectionWeight)
 	fr := r.PathPrefix("/forum").Subrouter()
-	fr.Use(hcommon.IndexMiddleware(CustomForumIndex))
+	fr.Use(handlers.IndexMiddleware(CustomForumIndex))
 	fr.HandleFunc("/topic/{topic}.rss", TopicRssPage).Methods("GET")
 	fr.HandleFunc("/topic/{topic}.atom", TopicAtomPage).Methods("GET")
 	fr.HandleFunc("", Page).Methods("GET")
@@ -30,7 +30,7 @@ func RegisterRoutes(r *mux.Router) {
 	fr.HandleFunc("/topic/{topic}/thread", CreateThreadTask.Action).Methods("POST").MatcherFunc(CreateThreadTask.Match)
 	fr.HandleFunc("/topic/{topic}/thread", ThreadNewCancelPage).Methods("POST").MatcherFunc(tasks.CancelTask.Match)
 	fr.Handle("/topic/{topic}/thread/{thread}", RequireThreadAndTopic(http.HandlerFunc(ThreadPage))).Methods("GET")
-	fr.Handle("/topic/{topic}/thread/{thread}", RequireThreadAndTopic(http.HandlerFunc(hcommon.TaskDoneAutoRefreshPage))).Methods("POST")
+	fr.Handle("/topic/{topic}/thread/{thread}", RequireThreadAndTopic(http.HandlerFunc(handlers.TaskDoneAutoRefreshPage))).Methods("POST")
 	fr.Handle("/topic/{topic}/thread/{thread}/reply", RequireThreadAndTopic(http.HandlerFunc(ReplyTask.Action))).Methods("POST").MatcherFunc(ReplyTask.Match)
 	fr.Handle("/topic/{topic}/thread/{thread}/reply", RequireThreadAndTopic(http.HandlerFunc(TopicThreadReplyCancelPage))).Methods("POST").MatcherFunc(tasks.CancelTask.Match)
 	fr.Handle("/topic/{topic}/thread/{thread}/comment/{comment}", RequireThreadAndTopic(comments.RequireCommentAuthor(http.HandlerFunc(TopicThreadCommentEditActionPage)))).Methods("POST").MatcherFunc(tasks.EditReplyTask.Match)

--- a/handlers/forum/routes_admin.go
+++ b/handlers/forum/routes_admin.go
@@ -3,7 +3,7 @@ package forum
 import (
 	"github.com/gorilla/mux"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 // RegisterAdminRoutes attaches forum admin endpoints to ar.
@@ -16,11 +16,11 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	far.HandleFunc("/logs", AdminForumModeratorLogsPage).Methods("GET")
 	far.HandleFunc("/list", AdminForumWordListPage).Methods("GET")
 	far.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")
-	far.HandleFunc("/categories", hcommon.TaskDoneAutoRefreshPage).Methods("POST")
+	far.HandleFunc("/categories", handlers.TaskDoneAutoRefreshPage).Methods("POST")
 	far.HandleFunc("/category/{category}", AdminCategoryEditPage).Methods("POST").MatcherFunc(CategoryChangeTask.Match)
 	far.HandleFunc("/category", AdminCategoryCreatePage).Methods("POST").MatcherFunc(CategoryCreateTask.Match)
 	far.HandleFunc("/category/delete", AdminCategoryDeletePage).Methods("POST").MatcherFunc(DeleteCategoryTask.Match)
-	far.HandleFunc("/topics", hcommon.TaskDoneAutoRefreshPage).Methods("POST")
+	far.HandleFunc("/topics", handlers.TaskDoneAutoRefreshPage).Methods("POST")
 	far.HandleFunc("/conversations", AdminThreadsPage).Methods("GET")
 	far.HandleFunc("/thread/{thread}/delete", AdminThreadDeletePage).Methods("POST").MatcherFunc(ThreadDeleteTask.Match)
 }

--- a/handlers/imagebbs/imagebbsAdminApprove.go
+++ b/handlers/imagebbs/imagebbsAdminApprove.go
@@ -1,7 +1,7 @@
 package imagebbs
 
 import (
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/mux"
 	"log"
@@ -12,11 +12,11 @@ import (
 func AdminApprovePostPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if err := queries.ApproveImagePost(r.Context(), int32(pid)); err != nil {
 		log.Printf("ApproveImagePost error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/imagebbs/imagebbsAdminBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardPage.go
@@ -2,7 +2,7 @@ package imagebbs
 
 import (
 	"database/sql"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/mux"
 	"log"
@@ -17,7 +17,7 @@ func AdminBoardModifyBoardActionPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bid, _ := strconv.Atoi(vars["board"])
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	err := queries.UpdateImageBoard(r.Context(), db.UpdateImageBoardParams{
 		ImageboardIdimageboard: int32(parentBoardId),

--- a/handlers/imagebbs/imagebbsAdminBoardsPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardsPage.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -19,14 +19,14 @@ func AdminBoardsPage(w http.ResponseWriter, r *http.Request) {
 		Nsfw     bool
 	}
 	type Data struct {
-		*common.CoreData
+		*handlers.CoreData
 		Boards []*BoardRow
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	boardRows, err := data.CoreData.ImageBoards()
 	if err != nil {
 		switch {
@@ -53,5 +53,5 @@ func AdminBoardsPage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	common.TemplateHandler(w, r, "adminBoardsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminBoardsPage.gohtml", data)
 }

--- a/handlers/imagebbs/imagebbsAdminFilesPage.go
+++ b/handlers/imagebbs/imagebbsAdminFilesPage.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/config"
 )
@@ -21,7 +21,7 @@ func AdminFilesPage(w http.ResponseWriter, r *http.Request) {
 		IsDir bool
 	}
 	type Data struct {
-		*common.CoreData
+		*handlers.CoreData
 		Path    string
 		Parent  string
 		Entries []Entry
@@ -50,7 +50,7 @@ func AdminFilesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Path:     cleaned,
 	}
 	if cleaned != "/" {
@@ -68,5 +68,5 @@ func AdminFilesPage(w http.ResponseWriter, r *http.Request) {
 	}
 	sort.Slice(data.Entries, func(i, j int) bool { return data.Entries[i].Name < data.Entries[j].Name })
 
-	common.TemplateHandler(w, r, "adminFilesPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminFilesPage.gohtml", data)
 }

--- a/handlers/imagebbs/imagebbsAdminNewBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminNewBoardPage.go
@@ -7,18 +7,18 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
 func AdminNewBoardPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*common.CoreData
+		*handlers.CoreData
 		Boards []*db.Imageboard
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
 	boardRows, err := data.CoreData.ImageBoards()
 	if err != nil {
@@ -33,7 +33,7 @@ func AdminNewBoardPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Boards = boardRows
 
-	common.TemplateHandler(w, r, "adminNewBoardPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminNewBoardPage.gohtml", data)
 }
 
 func AdminNewBoardMakePage(w http.ResponseWriter, r *http.Request) {
@@ -41,7 +41,7 @@ func AdminNewBoardMakePage(w http.ResponseWriter, r *http.Request) {
 	desc := r.PostFormValue("desc")
 	parentBoardId, _ := strconv.Atoi(r.PostFormValue("pbid"))
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	err := queries.CreateImageBoard(r.Context(), db.CreateImageBoardParams{
 		ImageboardIdimageboard: int32(parentBoardId),

--- a/handlers/imagebbs/imagebbsAdminPage.go
+++ b/handlers/imagebbs/imagebbsAdminPage.go
@@ -3,10 +3,10 @@ package imagebbs
 import (
 	"net/http"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 func AdminPage(w http.ResponseWriter, r *http.Request) {
-	data := struct{ *hcommon.CoreData }{r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)}
-	hcommon.TemplateHandler(w, r, "imagebbsAdminPage", data)
+	data := struct{ *handlers.CoreData }{r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)}
+	handlers.TemplateHandler(w, r, "imagebbsAdminPage", data)
 }

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
 
@@ -29,7 +29,7 @@ import (
 
 func BoardPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Boards      []*db.Imageboard
 		IsSubBoard  bool
 		BoardNumber int
@@ -40,13 +40,13 @@ func BoardPage(w http.ResponseWriter, r *http.Request) {
 	bid, _ := strconv.Atoi(vars["boardno"])
 
 	data := Data{
-		CoreData:    r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData:    r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		IsSubBoard:  bid != 0,
 		BoardNumber: bid,
 	}
 
 	if !data.CoreData.HasGrant("imagebbs", "board", "view", int32(bid)) {
-		_ = templates.GetCompiledSiteTemplates(r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
+		_ = templates.GetCompiledSiteTemplates(r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
 		return
 	}
 
@@ -68,7 +68,7 @@ func BoardPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Posts = posts
 
-	common.TemplateHandler(w, r, "boardPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "boardPage.gohtml", data)
 }
 
 func BoardPostImageActionPage(w http.ResponseWriter, r *http.Request) {
@@ -83,7 +83,7 @@ func BoardPostImageActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	board, err := queries.GetImageBoardById(r.Context(), int32(bid))
 	if err != nil {
@@ -177,5 +177,5 @@ func BoardPostImageActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hcommon.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
 
@@ -30,7 +30,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 		EditSaveUrl        string
 	}
 	type Data struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Replyable          bool
 		Languages          []*db.Language
 		SelectedLanguageId int
@@ -53,16 +53,16 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 	var uid int32
 	uid, _ = session.Values["UID"].(int32)
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := Data{
-		CoreData:      r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData:      r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Replyable:     true,
 		BoardId:       bid,
 		ForumThreadId: thid,
 	}
 
 	if !data.CoreData.HasGrant("imagebbs", "board", "view", int32(bid)) {
-		_ = templates.GetCompiledSiteTemplates(r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
+		_ = templates.GetCompiledSiteTemplates(r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
 		return
 	}
 
@@ -138,7 +138,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			_ = templates.GetCompiledSiteTemplates(r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
+			_ = templates.GetCompiledSiteTemplates(r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
 			return
 		default:
 			log.Printf("getAllBoardsByParentBoardId Error: %s", err)
@@ -151,7 +151,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Languages = languageRows
 
-	common.TemplateHandler(w, r, "boardThreadPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "boardThreadPage.gohtml", data)
 }
 
 func BoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
@@ -177,7 +177,7 @@ func BoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	post, err := queries.GetAllImagePostsByIdWithAuthorUsernameAndThreadCommentCountForUser(r.Context(), db.GetAllImagePostsByIdWithAuthorUsernameAndThreadCommentCountForUserParams{
 		ViewerID:     uid,
@@ -187,7 +187,7 @@ func BoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+			cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 			_ = templates.GetCompiledSiteTemplates(cd.Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", cd)
 			return
 		default:
@@ -281,7 +281,7 @@ func BoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := hcommon.PostUpdate(r.Context(), queries, pthid, ptid); err != nil {
+	if err := handlers.PostUpdate(r.Context(), queries, pthid, ptid); err != nil {
 		log.Printf("Error: postUpdate: %s", err)
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return

--- a/handlers/imagebbs/imagebbsFeed.go
+++ b/handlers/imagebbs/imagebbsFeed.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/arran4/goa4web/a4code/a4code2html"
 	"github.com/arran4/goa4web/core/templates"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	imageshandler "github.com/arran4/goa4web/handlers/images"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/feeds"
@@ -65,8 +65,8 @@ func imagebbsFeed(r *http.Request, title string, boardID int, rows []*db.GetAllI
 }
 
 func RssPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	boards, err := queries.GetAllImageBoardsForUser(r.Context(), db.GetAllImageBoardsForUserParams{
 		ViewerID:     cd.UserID,
 		ViewerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
@@ -99,8 +99,8 @@ func RssPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func AtomPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	boards, err := queries.GetAllImageBoardsForUser(r.Context(), db.GetAllImageBoardsForUserParams{
 		ViewerID:     cd.UserID,
 		ViewerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
@@ -135,8 +135,8 @@ func AtomPage(w http.ResponseWriter, r *http.Request) {
 func BoardRssPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bid, _ := strconv.Atoi(vars["boardno"])
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if !cd.HasGrant("imagebbs", "board", "see", int32(bid)) {
 		_ = templates.GetCompiledSiteTemplates(cd.Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", cd)
 		return
@@ -177,8 +177,8 @@ func BoardRssPage(w http.ResponseWriter, r *http.Request) {
 func BoardAtomPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bid, _ := strconv.Atoi(vars["boardno"])
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if !cd.HasGrant("imagebbs", "board", "see", int32(bid)) {
 		_ = templates.GetCompiledSiteTemplates(cd.Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", cd)
 		return

--- a/handlers/imagebbs/imagebbsPage.go
+++ b/handlers/imagebbs/imagebbsPage.go
@@ -5,20 +5,20 @@ import (
 	"net/http"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
 func Page(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*common.CoreData
+		*handlers.CoreData
 		Boards      []*db.Imageboard
 		IsSubBoard  bool
 		BoardNumber int
 	}
 
 	data := Data{
-		CoreData:    r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData:    r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		IsSubBoard:  false,
 		BoardNumber: 0,
 	}
@@ -32,10 +32,10 @@ func Page(w http.ResponseWriter, r *http.Request) {
 
 	data.Boards = boards
 
-	common.TemplateHandler(w, r, "imagebbsPage", data)
+	handlers.TemplateHandler(w, r, "imagebbsPage", data)
 }
 
-func CustomImageBBSIndex(data *common.CoreData, r *http.Request) {
+func CustomImageBBSIndex(data *handlers.CoreData, r *http.Request) {
 
 	if data.FeedsEnabled {
 		data.RSSFeedUrl = "/imagebbs/rss"

--- a/handlers/imagebbs/imagebbsPosterPage.go
+++ b/handlers/imagebbs/imagebbsPosterPage.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/gorilla/mux"
@@ -15,7 +15,7 @@ import (
 
 func PosterPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*common.CoreData
+		*handlers.CoreData
 		Posts    []*db.GetImagePostsByUserDescendingForUserRow
 		Username string
 		IsOffset bool
@@ -25,7 +25,7 @@ func PosterPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	username := vars["username"]
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		switch {
@@ -38,7 +38,7 @@ func PosterPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	rows, err := queries.GetImagePostsByUserDescendingForUser(r.Context(), db.GetImagePostsByUserDescendingForUserParams{
 		ViewerID:     cd.UserID,
 		UserID:       u.Idusers,
@@ -61,5 +61,5 @@ func PosterPage(w http.ResponseWriter, r *http.Request) {
 		IsOffset: offset != 0,
 	}
 
-	common.TemplateHandler(w, r, "posterPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "posterPage.gohtml", data)
 }

--- a/handlers/imagebbs/routes.go
+++ b/handlers/imagebbs/routes.go
@@ -6,8 +6,8 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
+	handlers "github.com/arran4/goa4web/handlers"
 	auth "github.com/arran4/goa4web/handlers/auth"
-	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 
 	nav "github.com/arran4/goa4web/internal/navigation"
@@ -15,7 +15,7 @@ import (
 
 // AddImageBBSIndex injects image board index links into CoreData.
 func AddImageBBSIndex(h http.Handler) http.Handler {
-	return hcommon.IndexMiddleware(CustomImageBBSIndex)(h)
+	return handlers.IndexMiddleware(CustomImageBBSIndex)(h)
 }
 
 // RegisterRoutes attaches the public image board endpoints to r.
@@ -24,7 +24,7 @@ func RegisterRoutes(r *mux.Router) {
 	nav.RegisterAdminControlCenter("ImageBBS", "/admin/imagebbs", SectionWeight)
 	r.HandleFunc("/imagebbs.rss", RssPage).Methods("GET")
 	ibr := r.PathPrefix("/imagebbs").Subrouter()
-	ibr.Use(hcommon.IndexMiddleware(CustomImageBBSIndex))
+	ibr.Use(handlers.IndexMiddleware(CustomImageBBSIndex))
 	ibr.PathPrefix("/images/").Handler(http.StripPrefix("/imagebbs/images/", http.FileServer(http.Dir(config.AppRuntimeConfig.ImageUploadDir))))
 	ibr.HandleFunc("/board/{boardno:[0-9]+}.rss", BoardRssPage).Methods("GET")
 	r.HandleFunc("/imagebbs.atom", AtomPage).Methods("GET")

--- a/handlers/imagebbs/routes_admin.go
+++ b/handlers/imagebbs/routes_admin.go
@@ -3,18 +3,18 @@ package imagebbs
 import (
 	"github.com/gorilla/mux"
 
+	handlers "github.com/arran4/goa4web/handlers"
 	auth "github.com/arran4/goa4web/handlers/auth"
-	hcommon "github.com/arran4/goa4web/handlers/common"
 )
 
 // RegisterAdminRoutes attaches image board admin endpoints to ar.
 func RegisterAdminRoutes(ar *mux.Router) {
 	ar.HandleFunc("", AdminPage).Methods("GET").MatcherFunc(auth.RequiredAccess("administrator"))
 	ar.HandleFunc("/boards", AdminBoardsPage).Methods("GET").MatcherFunc(auth.RequiredAccess("administrator"))
-	ar.HandleFunc("/boards", hcommon.TaskDoneAutoRefreshPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator"))
+	ar.HandleFunc("/boards", handlers.TaskDoneAutoRefreshPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator"))
 	ar.HandleFunc("/board", AdminNewBoardPage).Methods("GET").MatcherFunc(auth.RequiredAccess("administrator"))
 	ar.HandleFunc("/board", NewBoardTask.Action).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(NewBoardTask.Match)
-	ar.HandleFunc("/board", hcommon.TaskDoneAutoRefreshPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator"))
+	ar.HandleFunc("/board", handlers.TaskDoneAutoRefreshPage).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator"))
 	ar.HandleFunc("/board/{board}", ModifyBoardTask.Action).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(ModifyBoardTask.Match)
 	ar.HandleFunc("/approve/{post}", ApprovePostTask.Action).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(ApprovePostTask.Match)
 	ar.HandleFunc("/files", AdminFilesPage).Methods("GET").MatcherFunc(auth.RequiredAccess("administrator"))

--- a/handlers/images/routes.go
+++ b/handlers/images/routes.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	corecommon "github.com/arran4/goa4web/core/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	router "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/internal/upload"
@@ -62,7 +62,7 @@ func verify(data, tsStr, sig string) bool { return imagesign.Verify(data, tsStr,
 // RegisterRoutes attaches the image endpoints to r.
 func RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/images/upload/image", uploadHandler).Methods(http.MethodPost)
-	r.HandleFunc("/images/pasteimg.js", hcommon.PasteImageJS).Methods(http.MethodGet)
+	r.HandleFunc("/images/pasteimg.js", handlers.PasteImageJS).Methods(http.MethodGet)
 	r.Handle("/images/image/{id}", verifyMiddleware("image:")(http.HandlerFunc(serveImage))).Methods(http.MethodGet)
 	r.Handle("/images/cache/{id}", verifyMiddleware("cache:")(http.HandlerFunc(serveCache))).Methods(http.MethodGet)
 }
@@ -162,9 +162,9 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	url := path.Join("/uploads", sub1, sub2, fname)
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	uid := int32(0)
-	if cd, ok := r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData); ok && cd != nil {
+	if cd, ok := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData); ok && cd != nil {
 		uid = cd.UserID
 	}
 	_, err = queries.CreateUploadedImage(r.Context(), db.CreateUploadedImageParams{

--- a/handlers/information/information.go
+++ b/handlers/information/information.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/host"
@@ -27,7 +27,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 	ld, err := load.Avg()
 	if err != nil {
@@ -60,5 +60,5 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 	data.System.Processors = cpuInfo
 
-	common.TemplateHandler(w, r, "informationPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "informationPage.gohtml", data)
 }

--- a/handlers/languages/admin.go
+++ b/handlers/languages/admin.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -17,15 +17,15 @@ func adminLanguageRedirect(w http.ResponseWriter, r *http.Request) {
 
 func adminLanguagesPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Rows []*db.Language
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
 
-	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 
 	rows, err := cd.Languages()
 	if err != nil {
@@ -34,20 +34,20 @@ func adminLanguagesPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	hcommon.TemplateHandler(w, r, "languagesPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "languagesPage.gohtml", data)
 }
 
 func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	cid := r.PostFormValue("cid")
 	cname := r.PostFormValue("cname")
 	data := struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/languages",
 	}
 	if cidi, err := strconv.Atoi(cid); err != nil {
@@ -58,18 +58,18 @@ func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {
 	}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("RenameLanguage: %w", err).Error())
 	}
-	hcommon.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	cid := r.PostFormValue("cid")
 	data := struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/languages",
 	}
 	if cidi, err := strconv.Atoi(cid); err != nil {
@@ -77,18 +77,18 @@ func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
 	} else if err := queries.DeleteLanguage(r.Context(), int32(cidi)); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("DeleteLanguage: %w", err).Error())
 	}
-	hcommon.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 func adminLanguagesCreatePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	cname := r.PostFormValue("cname")
 	data := struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/languages",
 	}
 	if err := queries.CreateLanguage(r.Context(), sql.NullString{
@@ -97,5 +97,5 @@ func adminLanguagesCreatePage(w http.ResponseWriter, r *http.Request) {
 	}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
 	}
-	hcommon.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/handlers/linker/constants.go
+++ b/handlers/linker/constants.go
@@ -1,13 +1,13 @@
 package linker
 
 import corecommon "github.com/arran4/goa4web/core/common"
-import hcommon "github.com/arran4/goa4web/handlers/common"
+import handlers "github.com/arran4/goa4web/handlers"
 
 // IndexItem exposes the navigation item type.
 type IndexItem = corecommon.IndexItem
 
-// CoreData exposes the common.CoreData type for handlers.
-type CoreData = hcommon.CoreData
+// CoreData exposes the handlers.CoreData type for handlers.
+type CoreData = handlers.CoreData
 
 // LinkerTopicName is the default name for the hidden linker forum.
 const LinkerTopicName = "A LINKER TOPIC"

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -9,7 +9,7 @@ import (
 
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/config"
@@ -24,9 +24,9 @@ func AdminAddPage(w http.ResponseWriter, r *http.Request) {
 		Categories         []*db.LinkerCategory
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := Data{
-		CoreData:           r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData:           r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
 	}
 
@@ -50,10 +50,10 @@ func AdminAddPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	common.TemplateHandler(w, r, "adminAddPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminAddPage.gohtml", data)
 }
 func AdminAddActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
@@ -79,6 +79,6 @@ func AdminAddActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 
 }

--- a/handlers/linker/linkerAdminCategoriesPage.go
+++ b/handlers/linker/linkerAdminCategoriesPage.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -19,7 +19,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
 	categoryRows, err := data.LinkerCategoryCounts()
@@ -35,11 +35,11 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Categories = categoryRows
 
-	common.TemplateHandler(w, r, "categoriesPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "categoriesPage.gohtml", data)
 }
 
 func AdminCategoriesUpdatePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
 	title := r.PostFormValue("title")
 	pos, _ := strconv.Atoi(r.PostFormValue("position"))
@@ -61,11 +61,11 @@ func AdminCategoriesUpdatePage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func AdminCategoriesRenamePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
 	title := r.PostFormValue("title")
 	pos, _ := strconv.Atoi(r.PostFormValue("position"))
@@ -78,13 +78,13 @@ func AdminCategoriesRenamePage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func AdminCategoriesDeletePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
-	cd := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
 	rows, _ := cd.LinkerCategoryCounts()
 	for _, c := range rows {
 		if int(c.Idlinkercategory) == cid && c.Linkcount > 0 {
@@ -107,13 +107,13 @@ func AdminCategoriesDeletePage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func AdminCategoriesCreatePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	title := r.PostFormValue("title")
-	cd := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
 	rows, _ := cd.LinkerCategoryCounts()
 	pos := len(rows) + 1
 	if err := queries.CreateLinkerCategory(r.Context(), db.CreateLinkerCategoryParams{
@@ -124,5 +124,5 @@ func AdminCategoriesCreatePage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/linker/linkerAdminQueuePage.go
+++ b/handlers/linker/linkerAdminQueuePage.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
 )
@@ -32,14 +32,14 @@ func AdminQueuePage(w http.ResponseWriter, r *http.Request) {
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	data := Data{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 		Search:   r.URL.Query().Get("search"),
 		User:     r.URL.Query().Get("user"),
 		Category: r.URL.Query().Get("category"),
 		Offset:   offset,
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	queue, err := queries.GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails(r.Context())
 	if err != nil {
@@ -71,7 +71,7 @@ func AdminQueuePage(w http.ResponseWriter, r *http.Request) {
 		filtered = append(filtered, &QueueRow{q, FetchPageTitle(r.Context(), q.Url.String)})
 	}
 
-	pageSize := hcommon.GetPageSize(r)
+	pageSize := handlers.GetPageSize(r)
 	if data.Offset < 0 {
 		data.Offset = 0
 	}
@@ -112,22 +112,22 @@ func AdminQueuePage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	hcommon.TemplateHandler(w, r, "adminQueuePage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminQueuePage.gohtml", data)
 }
 
 func AdminQueueDeleteActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	qid, _ := strconv.Atoi(r.URL.Query().Get("qid"))
 	if err := queries.DeleteLinkerQueuedItem(r.Context(), int32(qid)); err != nil {
 		log.Printf("updateLinkerQueuedItem Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	hcommon.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func AdminQueueUpdateActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	qid, _ := strconv.Atoi(r.URL.Query().Get("qid"))
 	title := r.URL.Query().Get("title")
 	URL := r.URL.Query().Get("URL")
@@ -144,11 +144,11 @@ func AdminQueueUpdateActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	hcommon.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func AdminQueueApproveActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	qid, _ := strconv.Atoi(r.URL.Query().Get("qid"))
 	lid, err := queries.SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId(r.Context(), int32(qid))
 	if err != nil {
@@ -173,11 +173,11 @@ func AdminQueueApproveActionPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	hcommon.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func AdminQueueBulkDeleteActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm Error: %s", err)
 	}
@@ -187,11 +187,11 @@ func AdminQueueBulkDeleteActionPage(w http.ResponseWriter, r *http.Request) {
 			log.Printf("deleteLinkerQueuedItem Error: %s", err)
 		}
 	}
-	hcommon.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func AdminQueueBulkApproveActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm Error: %s", err)
 	}
@@ -217,5 +217,5 @@ func AdminQueueBulkApproveActionPage(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	hcommon.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -28,11 +28,11 @@ func AdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 		Search:   r.URL.Query().Get("search"),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if roles, err := data.AllRoles(); err == nil {
 		data.Roles = roles
 	}
@@ -69,11 +69,11 @@ func AdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.UserLevels = perms
 
-	common.TemplateHandler(w, r, "adminUserLevelsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminUserLevelsPage.gohtml", data)
 }
 
 func AdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	usernames := r.PostFormValue("usernames")
 	level := r.PostFormValue("role")
 	fields := strings.FieldsFunc(usernames, func(r rune) bool {
@@ -95,11 +95,11 @@ func AdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) {
 			log.Printf("permissionUserAllow Error: %s", err)
 		}
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func AdminUserLevelsRemoveActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	r.ParseForm()
 	ids := r.Form["permids"]
 	if len(ids) == 0 {
@@ -113,5 +113,5 @@ func AdminUserLevelsRemoveActionPage(w http.ResponseWriter, r *http.Request) {
 			log.Printf("permissionUserDisallow Error: %s", err)
 		}
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/linker/linkerCategoriesPage.go
+++ b/handlers/linker/linkerCategoriesPage.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -18,10 +18,10 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	categories, err := queries.GetAllLinkerCategories(r.Context())
 	if err != nil {
@@ -36,5 +36,5 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Categories = categories
 
-	common.TemplateHandler(w, r, "categoriesPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "categoriesPage.gohtml", data)
 }

--- a/handlers/linker/linkerCategoryPage.go
+++ b/handlers/linker/linkerCategoryPage.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/gorilla/mux"
@@ -26,7 +26,7 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
 	data.Offset, _ = strconv.Atoi(r.URL.Query().Get("offset"))
@@ -36,7 +36,7 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 	data.CommentOnId, _ = strconv.Atoi(r.URL.Query().Get("comment"))
 	data.ReplyToId, _ = strconv.Atoi(r.URL.Query().Get("reply"))
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	linkerPosts, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(data.CatId)})
 	if err != nil {
@@ -51,5 +51,5 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Links = linkerPosts
 
-	common.TemplateHandler(w, r, "linkerCategoryPage", data)
+	handlers.TemplateHandler(w, r, "linkerCategoryPage", data)
 }

--- a/handlers/linker/linkerCommentsEditPage.go
+++ b/handlers/linker/linkerCommentsEditPage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/arran4/goa4web/core"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/mux"
 	"log"
@@ -22,7 +22,7 @@ func CommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	text := r.PostFormValue("replytext")
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	vars := mux.Vars(r)
 	linkId, _ := strconv.Atoi(vars["link"])
 	commentId, _ := strconv.Atoi(vars["comment"])
@@ -33,7 +33,7 @@ func CommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	comment := r.Context().Value(hcommon.KeyComment).(*db.GetCommentByIdForUserRow)
+	comment := r.Context().Value(handlers.KeyComment).(*db.GetCommentByIdForUserRow)
 
 	thread, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		ViewerID:      uid,

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -10,7 +10,7 @@ import (
 
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
 
@@ -49,8 +49,8 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-	cd := r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := Data{
 		CoreData:           cd,
 		CanReply:           cd.UserID != 0,
@@ -67,7 +67,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 	data.UserId = uid
 
-	queries = r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries = r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	languageRows, err := cd.Languages()
 	if err != nil {
@@ -145,7 +145,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Thread = threadRow
 
-	hcommon.TemplateHandler(w, r, "commentsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "commentsPage.gohtml", data)
 }
 
 func CommentsReplyPage(w http.ResponseWriter, r *http.Request) {
@@ -167,7 +167,7 @@ func CommentsReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	link, err := queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(r.Context(), int32(linkId))
 	if err != nil {

--- a/handlers/linker/linkerFeed.go
+++ b/handlers/linker/linkerFeed.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/arran4/goa4web/a4code/a4code2html"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	imageshandler "github.com/arran4/goa4web/handlers/images"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/feeds"
@@ -58,7 +58,7 @@ func linkerFeed(r *http.Request, rows []*db.GetAllLinkerItemsByCategoryIdWitherP
 }
 
 func RssPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
 	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(catID)})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -73,7 +73,7 @@ func RssPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func AtomPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
 	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(catID)})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/handlers/linker/linkerLinkerPage.go
+++ b/handlers/linker/linkerLinkerPage.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/gorilla/mux"
@@ -26,7 +26,7 @@ func LinkerPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	username := vars["username"]
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		switch {
@@ -51,11 +51,11 @@ func LinkerPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData:  r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData:  r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 		Links:     rows,
 		Username:  username,
 		HasOffset: offset != 0,
 	}
 
-	common.TemplateHandler(w, r, "linkerPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "linkerPage.gohtml", data)
 }

--- a/handlers/linker/linkerPage.go
+++ b/handlers/linker/linkerPage.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/gorilla/mux"
@@ -29,7 +29,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
 	data.Offset, _ = strconv.Atoi(r.URL.Query().Get("offset"))
@@ -38,7 +38,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	data.CommentOnId, _ = strconv.Atoi(r.URL.Query().Get("comment"))
 	data.ReplyToId, _ = strconv.Atoi(r.URL.Query().Get("reply"))
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	linkerPosts, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(data.CatId)})
 	if err != nil {
@@ -66,7 +66,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 
 	data.Categories = categories
 
-	common.TemplateHandler(w, r, "linkerPage", data)
+	handlers.TemplateHandler(w, r, "linkerPage", data)
 }
 
 func CustomLinkerIndex(data *corecommon.CoreData, r *http.Request) {

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -60,8 +60,8 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 	mock.ExpectExec("INSERT IGNORE INTO linker_search").WithArgs(int32(1), int32(2)).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	req := httptest.NewRequest("POST", "/admin/queue?qid=1", nil)
-	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
-	ctx = context.WithValue(ctx, common.KeyCoreData, &corecommon.CoreData{})
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, &corecommon.CoreData{})
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	AdminQueueApproveActionPage(rr, req)

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -10,7 +10,7 @@ import (
 
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
 
@@ -31,8 +31,8 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int
 	}
 
-	cd := r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := Data{
 		CoreData:           cd,
 		CanReply:           cd.UserID != 0,
@@ -57,7 +57,7 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Link = link
 
-	hcommon.TemplateHandler(w, r, "showPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "showPage.gohtml", data)
 }
 
 func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
@@ -79,7 +79,7 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	link, err := queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(r.Context(), int32(linkId))
 	if err != nil {

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -9,7 +9,7 @@ import (
 
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/config"
@@ -24,9 +24,9 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := Data{
-		CoreData:           r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData:           r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
 	}
 
@@ -50,11 +50,11 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	common.TemplateHandler(w, r, "suggestPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "suggestPage.gohtml", data)
 }
 
 func SuggestActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
@@ -80,5 +80,5 @@ func SuggestActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -5,7 +5,7 @@ import (
 	"github.com/arran4/goa4web/internal/tasks"
 	"net/http"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	"github.com/gorilla/mux"
 
 	nav "github.com/arran4/goa4web/internal/navigation"
@@ -14,7 +14,7 @@ import (
 
 // AddLinkerIndex injects linker index links into CoreData.
 func AddLinkerIndex(h http.Handler) http.Handler {
-	return hcommon.IndexMiddleware(CustomLinkerIndex)(h)
+	return handlers.IndexMiddleware(CustomLinkerIndex)(h)
 }
 
 var legacyRedirectsEnabled = true
@@ -24,7 +24,7 @@ func RegisterRoutes(r *mux.Router) {
 	nav.RegisterIndexLink("Linker", "/linker", SectionWeight)
 	nav.RegisterAdminControlCenter("Linker", "/admin/linker/categories", SectionWeight)
 	lr := r.PathPrefix("/linker").Subrouter()
-	lr.Use(hcommon.IndexMiddleware(CustomLinkerIndex))
+	lr.Use(handlers.IndexMiddleware(CustomLinkerIndex))
 	lr.HandleFunc("/rss", RssPage).Methods("GET")
 	lr.HandleFunc("/atom", AtomPage).Methods("GET")
 	lr.HandleFunc("", Page).Methods("GET")
@@ -43,8 +43,8 @@ func RegisterRoutes(r *mux.Router) {
 
 	if legacyRedirectsEnabled {
 		// legacy redirects
-		r.Path("/links").HandlerFunc(hcommon.RedirectPermanentPrefix("/links", "/linker"))
-		r.PathPrefix("/links/").HandlerFunc(hcommon.RedirectPermanentPrefix("/links", "/linker"))
+		r.Path("/links").HandlerFunc(handlers.RedirectPermanentPrefix("/links", "/linker"))
+		r.PathPrefix("/links/").HandlerFunc(handlers.RedirectPermanentPrefix("/links", "/linker"))
 	}
 }
 

--- a/handlers/news/helpers.go
+++ b/handlers/news/helpers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -19,7 +19,7 @@ func PostUpdateLocal(ctx context.Context, q *db.Queries, threadID, topicID int32
 }
 
 // canEditNewsPost reports whether cd can modify the specified news post.
-func canEditNewsPost(cd *hcommon.CoreData, postID int32) bool {
+func canEditNewsPost(cd *handlers.CoreData, postID int32) bool {
 	if cd == nil {
 		return false
 	}

--- a/handlers/news/matchers.go
+++ b/handlers/news/matchers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/core"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -21,7 +21,7 @@ func RequireNewsPostAuthor(next http.Handler) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+		queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 		session, err := core.GetSession(r)
 		if err != nil {
 			http.NotFound(w, r)
@@ -41,7 +41,7 @@ func RequireNewsPostAuthor(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx := context.WithValue(r.Context(), hcommon.KeyNewsPost, row)
+		ctx := context.WithValue(r.Context(), handlers.KeyNewsPost, row)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/handlers/news/newsAdminUserLevelsPage.go
+++ b/handlers/news/newsAdminUserLevelsPage.go
@@ -7,23 +7,23 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
 func NewsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		UserLevels []*db.GetUserRolesRow
 		Roles      []*db.Role
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if roles, err := data.AllRoles(); err == nil {
 		data.Roles = roles
 	}
@@ -39,11 +39,11 @@ func NewsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.UserLevels = rows
 
-	common.TemplateHandler(w, r, "adminUserLevelsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminUserLevelsPage.gohtml", data)
 }
 
 func NewsAdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	username := r.PostFormValue("username")
 	level := r.PostFormValue("role")
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
@@ -61,12 +61,12 @@ func NewsAdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	hcommon.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 
 }
 
 func NewsAdminUserLevelsRemoveActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	permid, err := strconv.Atoi(r.PostFormValue("permid"))
 	if err != nil {
 		log.Printf("strconv.Atoi(permid) Error: %s", err)
@@ -78,5 +78,5 @@ func NewsAdminUserLevelsRemoveActionPage(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	hcommon.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/news/newsAnnouncementHandlers.go
+++ b/handlers/news/newsAnnouncementHandlers.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/gorilla/mux"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
 func NewsAnnouncementActivateActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
-	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
 
@@ -34,12 +34,12 @@ func NewsAnnouncementActivateActionPage(w http.ResponseWriter, r *http.Request) 
 			log.Printf("activate announcement: %v", err)
 		}
 	}
-	hcommon.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func NewsAnnouncementDeactivateActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
-	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
 
@@ -48,7 +48,7 @@ func NewsAnnouncementDeactivateActionPage(w http.ResponseWriter, r *http.Request
 		if !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("announcementForNews: %v", err)
 		}
-		hcommon.TaskDoneAutoRefreshPage(w, r)
+		handlers.TaskDoneAutoRefreshPage(w, r)
 		return
 	}
 	if ann != nil && ann.Active {
@@ -56,5 +56,5 @@ func NewsAnnouncementDeactivateActionPage(w http.ResponseWriter, r *http.Request
 			log.Printf("deactivate announcement: %v", err)
 		}
 	}
-	hcommon.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/news/newsPage.go
+++ b/handlers/news/newsPage.go
@@ -8,10 +8,10 @@ import (
 	"github.com/gorilla/mux"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
-func CustomNewsIndex(data *hcommon.CoreData, r *http.Request) {
+func CustomNewsIndex(data *handlers.CoreData, r *http.Request) {
 	data.RSSFeedUrl = "/news.rss"
 	data.CustomIndexItems = append(data.CustomIndexItems, corecommon.IndexItem{
 		Name: "RSS Feed",

--- a/handlers/news/newsPostCommentEditPage.go
+++ b/handlers/news/newsPostCommentEditPage.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/core"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -21,7 +21,7 @@ func NewsPostCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	text := r.PostFormValue("replytext")
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	vars := mux.Vars(r)
 	postId, _ := strconv.Atoi(vars["post"])
 	commentId, _ := strconv.Atoi(vars["comment"])
@@ -32,7 +32,7 @@ func NewsPostCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	comment := r.Context().Value(hcommon.KeyComment).(*db.GetCommentByIdForUserRow)
+	comment := r.Context().Value(handlers.KeyComment).(*db.GetCommentByIdForUserRow)
 
 	thread, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		ViewerID:      uid,

--- a/handlers/news/newsPostPage_test.go
+++ b/handlers/news/newsPostPage_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gorilla/sessions"
 
 	"github.com/arran4/goa4web/core"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -44,8 +44,8 @@ func TestNewsPostNewActionPage_InvalidForms(t *testing.T) {
 		for _, c := range w.Result().Cookies() {
 			req.AddCookie(c)
 		}
-		ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
-		ctx = context.WithValue(ctx, hcommon.KeyCoreData, &hcommon.CoreData{})
+		ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
+		ctx = context.WithValue(ctx, handlers.KeyCoreData, &handlers.CoreData{})
 		req = req.WithContext(ctx)
 
 		rr := httptest.NewRecorder()
@@ -90,8 +90,8 @@ func TestNewsPostEditActionPage_InvalidForms(t *testing.T) {
 		for _, c := range w.Result().Cookies() {
 			req.AddCookie(c)
 		}
-		ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
-		ctx = context.WithValue(ctx, hcommon.KeyCoreData, &hcommon.CoreData{})
+		ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
+		ctx = context.WithValue(ctx, handlers.KeyCoreData, &handlers.CoreData{})
 		req = req.WithContext(ctx)
 
 		rr := httptest.NewRecorder()

--- a/handlers/news/newsRssPage.go
+++ b/handlers/news/newsRssPage.go
@@ -10,12 +10,12 @@ import (
 	"github.com/gorilla/feeds"
 
 	"github.com/arran4/goa4web/a4code/a4code2html"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	imageshandler "github.com/arran4/goa4web/handlers/images"
 )
 
 func NewsRssPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	posts, err := cd.LatestNews(r)
 	if err != nil {
 		log.Printf("latestNews: %v", err)

--- a/handlers/news/newsUserPermissionsPage.go
+++ b/handlers/news/newsUserPermissionsPage.go
@@ -7,19 +7,19 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
 func NewsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	if !(cd.HasRole("content writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
 	type Data struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Rows  []*db.GetUserRolesRow
 		Roles []*db.Role
 	}
@@ -28,7 +28,7 @@ func NewsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: cd,
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if roles, err := cd.AllRoles(); err == nil {
 		data.Roles = roles
 	}
@@ -44,20 +44,20 @@ func NewsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	common.TemplateHandler(w, r, "userPermissionsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "userPermissionsPage.gohtml", data)
 }
 
 func NewsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	username := r.PostFormValue("username")
 	level := r.PostFormValue("role")
 	data := struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/news",
 	}
 	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
@@ -69,19 +69,19 @@ func NewsUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.
 		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
 	}
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 
 func NewsUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	permid := r.PostFormValue("permid")
 	data := struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/news",
 	}
 	if permidi, err := strconv.Atoi(permid); err != nil {
@@ -89,5 +89,5 @@ func NewsUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 	} else if err := queries.DeleteUserRole(r.Context(), int32(permidi)); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
 	}
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -7,18 +7,18 @@ import (
 
 	"github.com/gorilla/mux"
 
+	handlers "github.com/arran4/goa4web/handlers"
 	auth "github.com/arran4/goa4web/handlers/auth"
-	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 
 	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
-func AddNewsIndex(h http.Handler) http.Handler { return hcommon.IndexMiddleware(CustomNewsIndex)(h) }
+func AddNewsIndex(h http.Handler) http.Handler { return handlers.IndexMiddleware(CustomNewsIndex)(h) }
 
 func runTemplate(name string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		hcommon.TemplateHandler(w, r, name, r.Context().Value(hcommon.KeyCoreData))
+		handlers.TemplateHandler(w, r, name, r.Context().Value(handlers.KeyCoreData))
 	}
 }
 
@@ -26,14 +26,14 @@ func runTemplate(name string) http.HandlerFunc {
 func RegisterRoutes(r *mux.Router) {
 	nav.RegisterIndexLink("News", "/", SectionWeight)
 	nav.RegisterAdminControlCenter("News", "/admin/news/users/levels", SectionWeight)
-	r.Use(hcommon.IndexMiddleware(CustomNewsIndex))
+	r.Use(handlers.IndexMiddleware(CustomNewsIndex))
 	r.HandleFunc("/", runTemplate("newsPage.gohtml")).Methods("GET")
-	r.HandleFunc("/", hcommon.TaskDoneAutoRefreshPage).Methods("POST")
+	r.HandleFunc("/", handlers.TaskDoneAutoRefreshPage).Methods("POST")
 	r.HandleFunc("/news.rss", NewsRssPage).Methods("GET")
 	nr := r.PathPrefix("/news").Subrouter()
-	nr.Use(hcommon.IndexMiddleware(CustomNewsIndex))
+	nr.Use(handlers.IndexMiddleware(CustomNewsIndex))
 	nr.HandleFunc("", runTemplate("newsPage.gohtml")).Methods("GET")
-	nr.HandleFunc("", hcommon.TaskDoneAutoRefreshPage).Methods("POST")
+	nr.HandleFunc("", handlers.TaskDoneAutoRefreshPage).Methods("POST")
 	nr.HandleFunc("/news/{post}", NewsPostPage).Methods("GET")
 	nr.HandleFunc("/news/{post}", ReplyTask.Action).Methods("POST").MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(ReplyTask.Match)
 	nr.Handle("/news/{post}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(NewsPostCommentEditActionPage))).Methods("POST").MatcherFunc(tasks.EditReplyTask.Match)
@@ -42,8 +42,8 @@ func RegisterRoutes(r *mux.Router) {
 	nr.HandleFunc("/news/{post}", NewPostTask.Action).Methods("POST").MatcherFunc(auth.RequiredAccess("content writer", "administrator")).MatcherFunc(NewPostTask.Match)
 	nr.HandleFunc("/news/{post}/announcement", AnnouncementAddTask.Action).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(AnnouncementAddTask.Match)
 	nr.HandleFunc("/news/{post}/announcement", AnnouncementDeleteTask.Action).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(AnnouncementDeleteTask.Match)
-	nr.HandleFunc("/news/{post}", hcommon.TaskDoneAutoRefreshPage).Methods("POST").MatcherFunc(tasks.CancelTask.Match)
-	nr.HandleFunc("/news/{post}", hcommon.TaskDoneAutoRefreshPage).Methods("POST")
+	nr.HandleFunc("/news/{post}", handlers.TaskDoneAutoRefreshPage).Methods("POST").MatcherFunc(tasks.CancelTask.Match)
+	nr.HandleFunc("/news/{post}", handlers.TaskDoneAutoRefreshPage).Methods("POST")
 	nr.HandleFunc("/user/permissions", NewsUserPermissionsPage).Methods("GET").MatcherFunc(auth.RequiredAccess("administrator"))
 	nr.HandleFunc("/users/permissions", UserAllowTask.Action).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(UserAllowTask.Match)
 	nr.HandleFunc("/users/permissions", UserDisallowTask.Action).Methods("POST").MatcherFunc(auth.RequiredAccess("administrator")).MatcherFunc(UserDisallowTask.Match)

--- a/handlers/news/searchResultNewsActionPage.go
+++ b/handlers/news/searchResultNewsActionPage.go
@@ -7,15 +7,15 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core"
-	"github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
 )
 
 func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Comments           []*db.GetCommentsByIdsForUserWithThreadInfoRow
 		News               []*db.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow
 		CommentsNoResults  bool
@@ -25,9 +25,9 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -57,7 +57,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 		data.EmptyWords = noResults
 	}
 
-	common.TemplateHandler(w, r, "resultNewsActionPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "resultNewsActionPage.gohtml", data)
 }
 
 func NewsSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow, bool, bool, error) {

--- a/handlers/news/search_test.go
+++ b/handlers/news/search_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
 
@@ -40,7 +40,7 @@ func TestNewsSearchFiltersUnauthorized(t *testing.T) {
 	form := url.Values{"searchwords": {"foo"}}
 	req := httptest.NewRequest("POST", "/", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 

--- a/handlers/notifications.go
+++ b/handlers/notifications.go
@@ -1,4 +1,4 @@
-package common
+package handlers
 
 import "github.com/arran4/goa4web/config"
 

--- a/handlers/pagesize.go
+++ b/handlers/pagesize.go
@@ -1,4 +1,4 @@
-package common
+package handlers
 
 import (
 	"net/http"

--- a/handlers/pagesize_test.go
+++ b/handlers/pagesize_test.go
@@ -1,4 +1,4 @@
-package common
+package handlers
 
 import (
 	"context"

--- a/handlers/postupdate.go
+++ b/handlers/postupdate.go
@@ -1,4 +1,4 @@
-package common
+package handlers
 
 import (
 	"context"

--- a/handlers/redirect_test.go
+++ b/handlers/redirect_test.go
@@ -1,4 +1,4 @@
-package common
+package handlers
 
 import (
 	"net/http"

--- a/handlers/search/admin.go
+++ b/handlers/search/admin.go
@@ -6,8 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -25,15 +24,15 @@ func adminSearchPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type Data struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Stats Stats
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	ctx := r.Context()
 	count := func(query string, dest *int64) {
 		if err := queries.DB().QueryRowContext(ctx, query).Scan(dest); err != nil && err != sql.ErrNoRows {
@@ -50,18 +49,18 @@ func adminSearchPage(w http.ResponseWriter, r *http.Request) {
 	count("SELECT COUNT(*) FROM writing_search", &data.Stats.Writings)
 	count("SELECT COUNT(*) FROM imagepost_search", &data.Stats.Images)
 
-	common.TemplateHandler(w, r, "adminSearchPage", data)
+	handlers.TemplateHandler(w, r, "adminSearchPage", data)
 }
 
 func adminSearchRemakeCommentsSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteCommentsSearch(r.Context()); err != nil {
@@ -71,17 +70,17 @@ func adminSearchRemakeCommentsSearchPage(w http.ResponseWriter, r *http.Request)
 		data.Errors = append(data.Errors, fmt.Errorf("RemakeCommentsSearchInsert: %w", err).Error())
 	}
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 func adminSearchRemakeNewsSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteSiteNewsSearch(r.Context()); err != nil {
@@ -91,17 +90,17 @@ func adminSearchRemakeNewsSearchPage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("RemakeNewsSearchInsert: %w", err).Error())
 	}
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 func adminSearchRemakeBlogSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteBlogsSearch(r.Context()); err != nil {
@@ -111,17 +110,17 @@ func adminSearchRemakeBlogSearchPage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("RemakeBlogsSearchInsert: %w", err).Error())
 	}
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 func adminSearchRemakeLinkerSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteLinkerSearch(r.Context()); err != nil {
@@ -131,17 +130,17 @@ func adminSearchRemakeLinkerSearchPage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("RemakeLinkerSearchInsert: %w", err).Error())
 	}
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 func adminSearchRemakeWritingSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteWritingSearch(r.Context()); err != nil {
@@ -151,18 +150,18 @@ func adminSearchRemakeWritingSearchPage(w http.ResponseWriter, r *http.Request) 
 		data.Errors = append(data.Errors, fmt.Errorf("RemakeWritingSearchInsert: %w", err).Error())
 	}
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 
 func adminSearchRemakeImageSearchPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/search",
 	}
 	if err := queries.DeleteImagePostSearch(r.Context()); err != nil {
@@ -172,5 +171,5 @@ func adminSearchRemakeImageSearchPage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("RemakeImagePostSearchInsert: %w", err).Error())
 	}
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/handlers/search/admin_wordlist.go
+++ b/handlers/search/admin_wordlist.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -25,7 +25,7 @@ type WordCount struct {
 
 func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*common.CoreData
+		*handlers.CoreData
 		Rows       []WordCount
 		NextLink   string
 		PrevLink   string
@@ -35,11 +35,11 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
 
-	letters := make([]string, len(common.Alphabet))
-	for i, c := range common.Alphabet {
+	letters := make([]string, len(handlers.Alphabet))
+	for i, c := range handlers.Alphabet {
 		letters[i] = strings.ToUpper(string(c))
 	}
 	data.Letters = letters
@@ -58,7 +58,7 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 
 	offset := (page - 1) * pageSize
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if r.URL.Query().Get("download") != "" {
 		rows, err := queries.CompleteWordList(r.Context())
@@ -140,12 +140,12 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 		data.PrevLink = base + "?" + vals.Encode()
 	}
 
-	common.TemplateHandler(w, r, "searchWordListPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "searchWordListPage.gohtml", data)
 }
 
 // adminSearchWordListDownloadPage sends the full word list as a text file.
 func adminSearchWordListDownloadPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	rows, err := queries.CompleteWordList(r.Context())
 	if err != nil {

--- a/handlers/search/searchPage.go
+++ b/handlers/search/searchPage.go
@@ -3,19 +3,18 @@ package search
 import (
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 func Page(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		SearchWords string
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
 
-	common.TemplateHandler(w, r, "searchPage", data)
+	handlers.TemplateHandler(w, r, "searchPage", data)
 }

--- a/handlers/search/searchResultBlogsActionPage.go
+++ b/handlers/search/searchResultBlogsActionPage.go
@@ -5,9 +5,8 @@ import (
 	"log"
 	"net/http"
 
+	handlers "github.com/arran4/goa4web/handlers"
 	hblogs "github.com/arran4/goa4web/handlers/blogs"
-	common "github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
 
@@ -16,7 +15,7 @@ import (
 
 func SearchResultBlogsActionPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Comments           []*db.GetCommentsByIdsForUserWithThreadInfoRow
 		Blogs              []*db.Blog
 		CommentsNoResults  bool
@@ -26,9 +25,9 @@ func SearchResultBlogsActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -58,7 +57,7 @@ func SearchResultBlogsActionPage(w http.ResponseWriter, r *http.Request) {
 		data.EmptyWords = noResults
 	}
 
-	common.TemplateHandler(w, r, "resultBlogsActionPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "resultBlogsActionPage.gohtml", data)
 }
 
 func BlogSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.Blog, bool, bool, error) {

--- a/handlers/search/searchResultForumActionPage.go
+++ b/handlers/search/searchResultForumActionPage.go
@@ -6,8 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
 
@@ -16,16 +15,16 @@ import (
 
 func SearchResultForumActionPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Comments           []*db.GetCommentsByIdsForUserWithThreadInfoRow
 		CommentsNoResults  bool
 		CommentsEmptyWords bool
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -40,7 +39,7 @@ func SearchResultForumActionPage(w http.ResponseWriter, r *http.Request) {
 		data.CommentsEmptyWords = noResults
 	}
 
-	common.TemplateHandler(w, r, "resultForumActionPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "resultForumActionPage.gohtml", data)
 }
 
 func ForumCommentSearchNotInRestrictedTopic(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetCommentsByIdsForUserWithThreadInfoRow, bool, bool, error) {

--- a/handlers/search/searchResultLinkerActionPage.go
+++ b/handlers/search/searchResultLinkerActionPage.go
@@ -6,8 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	hlinker "github.com/arran4/goa4web/handlers/linker"
 	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
@@ -17,7 +16,7 @@ import (
 
 func SearchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Comments           []*db.GetCommentsByIdsForUserWithThreadInfoRow
 		Links              []*db.GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow
 		CommentsNoResults  bool
@@ -28,9 +27,9 @@ func SearchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -60,7 +59,7 @@ func SearchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
 		data.EmptyWords = noResults
 	}
 
-	common.TemplateHandler(w, r, "resultLinkerActionPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "resultLinkerActionPage.gohtml", data)
 }
 
 func LinkerSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow, bool, bool, error) {

--- a/handlers/search/searchResultWritingsActionPage.go
+++ b/handlers/search/searchResultWritingsActionPage.go
@@ -6,8 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	hwritings "github.com/arran4/goa4web/handlers/writings"
 	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
@@ -17,7 +16,7 @@ import (
 
 func SearchResultWritingsActionPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*hcommon.CoreData
+		*handlers.CoreData
 		Comments           []*db.GetCommentsByIdsForUserWithThreadInfoRow
 		Writings           []*db.GetWritingsByIdsForUserDescendingByPublishedDateRow
 		CommentsNoResults  bool
@@ -27,9 +26,9 @@ func SearchResultWritingsActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -59,7 +58,7 @@ func SearchResultWritingsActionPage(w http.ResponseWriter, r *http.Request) {
 		data.EmptyWords = noResults
 	}
 
-	common.TemplateHandler(w, r, "resultWritingsActionPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "resultWritingsActionPage.gohtml", data)
 }
 
 func WritingSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetWritingsByIdsForUserDescendingByPublishedDateRow, bool, bool, error) {

--- a/handlers/static.go
+++ b/handlers/static.go
@@ -1,4 +1,4 @@
-package common
+package handlers
 
 import (
 	"bytes"

--- a/handlers/template.go
+++ b/handlers/template.go
@@ -1,4 +1,4 @@
-package common
+package handlers
 
 import (
 	"log"

--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -21,7 +21,7 @@ const gdprExportNote = "# Personal data export - handle according to GDPR"
 // adminUsersExportPage streams all data for a single user in a zip archive for
 // admins. The user ID is provided via the "uid" query parameter.
 func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	uid, err := strconv.Atoi(r.URL.Query().Get("uid"))
 	if err != nil {

--- a/handlers/user/admin_loginattempts.go
+++ b/handlers/user/admin_loginattempts.go
@@ -4,17 +4,17 @@ import (
 	"log"
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
 func adminLoginAttemptsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*common.CoreData
+		*handlers.CoreData
 		Attempts []*db.LoginAttempt
 	}
-	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData)}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	data := Data{CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)}
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	items, err := queries.ListLoginAttempts(r.Context())
 	if err != nil {
 		log.Printf("list login attempts: %v", err)
@@ -22,5 +22,5 @@ func adminLoginAttemptsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data.Attempts = items
-	common.TemplateHandler(w, r, "loginAttemptsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "loginAttemptsPage.gohtml", data)
 }

--- a/handlers/user/admin_pending.go
+++ b/handlers/user/admin_pending.go
@@ -5,39 +5,39 @@ import (
 	"fmt"
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	emailutil "github.com/arran4/goa4web/internal/notifications"
 )
 
 func adminPendingUsersPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	rows, err := queries.ListPendingUsers(r.Context())
 	if err != nil && err != sql.ErrNoRows {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 	data := struct {
-		*common.CoreData
+		*handlers.CoreData
 		Rows []*db.ListPendingUsersRow
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Rows:     rows,
 	}
-	common.TemplateHandler(w, r, "admin/pendingUsersPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "admin/pendingUsersPage.gohtml", data)
 }
 
 func adminPendingUsersApprove(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	uid := r.PostFormValue("uid")
 	var id int32
 	fmt.Sscanf(uid, "%d", &id)
 	data := struct {
-		*common.CoreData
+		*handlers.CoreData
 		Errors []string
 		Back   string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/users/pending",
 	}
 	if id == 0 {
@@ -50,21 +50,21 @@ func adminPendingUsersApprove(w http.ResponseWriter, r *http.Request) {
 			_ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, id, u.Email.String, "", "user approved", nil)
 		}
 	}
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 
 func adminPendingUsersReject(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	uid := r.PostFormValue("uid")
 	reason := r.PostFormValue("reason")
 	var id int32
 	fmt.Sscanf(uid, "%d", &id)
 	data := struct {
-		*common.CoreData
+		*handlers.CoreData
 		Errors []string
 		Back   string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/users/pending",
 	}
 	if id == 0 {
@@ -81,5 +81,5 @@ func adminPendingUsersReject(w http.ResponseWriter, r *http.Request) {
 			_ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, id, u.Email.String, "", "user rejected", item)
 		}
 	}
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/handlers/user/admin_permissions.go
+++ b/handlers/user/admin_permissions.go
@@ -8,22 +8,22 @@ import (
 	"sort"
 	"strconv"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
 func adminUsersPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*common.CoreData
+		*handlers.CoreData
 		Rows  []*db.GetPermissionsWithUsersRow
 		Roles []*db.Role
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if roles, err := data.AllRoles(); err == nil {
 		data.Roles = roles
 	}
@@ -42,20 +42,20 @@ func adminUsersPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	})
 	data.Rows = rows
 
-	common.TemplateHandler(w, r, "usersPermissionsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "usersPermissionsPage.gohtml", data)
 }
 
 func adminUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	username := r.PostFormValue("username")
 	level := r.PostFormValue("role")
 	data := struct {
-		*common.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/users/permissions",
 	}
 	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
@@ -66,19 +66,19 @@ func adminUsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http
 	}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
 	}
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 
 func adminUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	permid := r.PostFormValue("permid")
 	data := struct {
-		*common.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/users/permissions",
 	}
 	if permidi, err := strconv.Atoi(permid); err != nil {
@@ -86,21 +86,21 @@ func adminUsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 	} else if err := queries.DeleteUserRole(r.Context(), int32(permidi)); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
 	}
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 
 func adminUsersPermissionsUpdatePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	permid := r.PostFormValue("permid")
 	level := r.PostFormValue("role")
 
 	data := struct {
-		*common.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/users/permissions",
 	}
 
@@ -113,5 +113,5 @@ func adminUsersPermissionsUpdatePage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("UpdatePermission: %w", err).Error())
 	}
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/handlers/user/admin_sessions.go
+++ b/handlers/user/admin_sessions.go
@@ -4,17 +4,17 @@ import (
 	"log"
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
 func adminSessionsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*common.CoreData
+		*handlers.CoreData
 		Sessions []*db.ListSessionsRow
 	}
-	data := Data{CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData)}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	data := Data{CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)}
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	items, err := queries.ListSessions(r.Context())
 	if err != nil {
 		log.Printf("list sessions: %v", err)
@@ -22,26 +22,26 @@ func adminSessionsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data.Sessions = items
-	common.TemplateHandler(w, r, "sessionsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "sessionsPage.gohtml", data)
 }
 
 func adminSessionsDeletePage(w http.ResponseWriter, r *http.Request) {
 	sid := r.PostFormValue("sid")
 	data := struct {
-		*common.CoreData
+		*handlers.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Back:     "/admin/sessions",
 	}
 	if sid == "" {
 		data.Errors = append(data.Errors, "missing sid")
 	} else {
-		if err := r.Context().Value(common.KeyQueries).(*db.Queries).DeleteSessionByID(r.Context(), sid); err != nil {
+		if err := r.Context().Value(handlers.KeyQueries).(*db.Queries).DeleteSessionByID(r.Context(), sid); err != nil {
 			data.Errors = append(data.Errors, err.Error())
 		}
 	}
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/handlers/user/routes.go
+++ b/handlers/user/routes.go
@@ -4,8 +4,8 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
+	"github.com/arran4/goa4web/handlers"
 	auth "github.com/arran4/goa4web/handlers/auth"
-	"github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 )
 
@@ -40,8 +40,8 @@ func RegisterRoutes(r *mux.Router) {
 	ur.HandleFunc("/subscriptions/delete", userSubscriptionsDeleteAction).Methods(http.MethodPost).MatcherFunc(auth.RequiresAnAccount()).MatcherFunc(DeleteTask.Match)
 
 	// legacy redirects
-	r.HandleFunc("/user/lang", common.RedirectPermanent("/usr/lang"))
-	r.HandleFunc("/user/email", common.RedirectPermanent("/usr/email"))
+	r.HandleFunc("/user/lang", handlers.RedirectPermanent("/usr/lang"))
+	r.HandleFunc("/user/email", handlers.RedirectPermanent("/usr/email"))
 }
 
 // Register registers the user router module.

--- a/handlers/user/userGalleryPage.go
+++ b/handlers/user/userGalleryPage.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	imageshandler "github.com/arran4/goa4web/handlers/images"
 	db "github.com/arran4/goa4web/internal/db"
 )
@@ -27,7 +27,7 @@ func userGalleryPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	pageStr := r.URL.Query().Get("p")
 	page, _ := strconv.Atoi(pageStr)
@@ -35,7 +35,7 @@ func userGalleryPage(w http.ResponseWriter, r *http.Request) {
 		page = 1
 	}
 
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	size := config.AppRuntimeConfig.PageSizeDefault
 	if pref, _ := cd.Preference(); pref != nil {
 		size = int(pref.PageSize)
@@ -85,7 +85,7 @@ func userGalleryPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := struct {
-		*common.CoreData
+		*handlers.CoreData
 		Images   []galleryImage
 		NextLink string
 		PrevLink string
@@ -98,5 +98,5 @@ func userGalleryPage(w http.ResponseWriter, r *http.Request) {
 		PageSize: size,
 	}
 
-	common.TemplateHandler(w, r, "gallery.gohtml", data)
+	handlers.TemplateHandler(w, r, "gallery.gohtml", data)
 }

--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/core"
 	db "github.com/arran4/goa4web/internal/db"
@@ -25,12 +25,12 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type Data struct {
-		*common.CoreData
+		*handlers.CoreData
 		LanguageOptions []LanguageOption
 	}
 
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	pref, _ := cd.Preference()
 	userLangs, _ := queries.GetUserLanguages(r.Context(), cd.UserID)
@@ -63,9 +63,9 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 		LanguageOptions: opts,
 	}
 
-	common.TemplateHandler(w, r, "langPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "langPage.gohtml", data)
 }
-func saveUserLanguages(r *http.Request, cd *common.CoreData, queries *db.Queries, uid int32) error {
+func saveUserLanguages(r *http.Request, cd *handlers.CoreData, queries *db.Queries, uid int32) error {
 	// Clear existing language selections for the user.
 	if _, err := queries.DB().ExecContext(r.Context(), "DELETE FROM user_language WHERE users_idusers = ?", uid); err != nil {
 		return err
@@ -92,7 +92,7 @@ func saveUserLanguagePreference(r *http.Request, queries *db.Queries, uid int32)
 		return err
 	}
 
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	pref, err := cd.Preference()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
@@ -117,7 +117,7 @@ func saveUserLanguagePreference(r *http.Request, queries *db.Queries, uid int32)
 func saveDefaultLanguage(r *http.Request, queries *db.Queries, uid int32) error {
 	langID, _ := strconv.Atoi(r.PostFormValue("defaultLanguage"))
 
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	pref, err := cd.Preference()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
@@ -143,9 +143,9 @@ func userLangSaveLanguagesActionPage(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if err := saveUserLanguages(r, cd, queries, uid); err != nil {
 		log.Printf("Save languages Error: %s", err)
@@ -153,7 +153,7 @@ func userLangSaveLanguagesActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func userLangSaveLanguagePreferenceActionPage(w http.ResponseWriter, r *http.Request) {
@@ -168,7 +168,7 @@ func userLangSaveLanguagePreferenceActionPage(w http.ResponseWriter, r *http.Req
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if err := saveUserLanguagePreference(r, queries, uid); err != nil {
 		log.Printf("Save language Error: %s", err)
@@ -176,7 +176,7 @@ func userLangSaveLanguagePreferenceActionPage(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func userLangSaveAllActionPage(w http.ResponseWriter, r *http.Request) {
@@ -190,9 +190,9 @@ func userLangSaveAllActionPage(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if err := saveUserLanguages(r, cd, queries, uid); err != nil {
 		log.Printf("Save languages Error: %s", err)
@@ -206,5 +206,5 @@ func userLangSaveAllActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/user/userLogoutPage.go
+++ b/handlers/user/userLogoutPage.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/core"
 	db "github.com/arran4/goa4web/internal/db"
@@ -18,18 +18,18 @@ func userLogoutPage(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 	log.Printf("logout request session=%s uid=%d", session.ID, uid)
 	type Data struct {
-		*common.CoreData
+		*handlers.CoreData
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
 
 	// session retrieved earlier
 	delete(session.Values, "UID")
 	delete(session.Values, "LoginTime")
 	delete(session.Values, "ExpiryTime")
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if session.ID != "" {
 		_ = queries.DeleteSessionByID(r.Context(), session.ID)
 	}
@@ -44,5 +44,5 @@ func userLogoutPage(w http.ResponseWriter, r *http.Request) {
 
 	data.CoreData.UserID = 0
 
-	common.TemplateHandler(w, r, "logoutPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "logoutPage.gohtml", data)
 }

--- a/handlers/user/userNotificationsPage.go
+++ b/handlers/user/userNotificationsPage.go
@@ -5,14 +5,14 @@ import (
 	"net/http"
 	"strconv"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/core"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
 func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
-	if !common.NotificationsEnabled() {
+	if !handlers.NotificationsEnabled() {
 		http.NotFound(w, r)
 		return
 	}
@@ -21,7 +21,7 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	notifs, err := queries.GetUnreadNotifications(r.Context(), uid)
 	if err != nil {
 		log.Printf("get notifications: %v", err)
@@ -36,21 +36,21 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	data := struct {
-		*common.CoreData
+		*handlers.CoreData
 		Notifications []*db.Notification
 		Emails        []*db.UserEmail
 		MaxPriority   int32
 	}{
-		CoreData:      r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData:      r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Notifications: notifs,
 		Emails:        emails,
 		MaxPriority:   maxPr,
 	}
-	common.TemplateHandler(w, r, "notifications.gohtml", data)
+	handlers.TemplateHandler(w, r, "notifications.gohtml", data)
 }
 
 func userNotificationsDismissActionPage(w http.ResponseWriter, r *http.Request) {
-	if !common.NotificationsEnabled() {
+	if !handlers.NotificationsEnabled() {
 		http.NotFound(w, r)
 		return
 	}
@@ -64,7 +64,7 @@ func userNotificationsDismissActionPage(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	id, _ := strconv.Atoi(r.FormValue("id"))
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	n, err := queries.GetUnreadNotifications(r.Context(), uid)
 	if err == nil {
 		for _, no := range n {
@@ -78,7 +78,7 @@ func userNotificationsDismissActionPage(w http.ResponseWriter, r *http.Request) 
 }
 
 func notificationsRssPage(w http.ResponseWriter, r *http.Request) {
-	if !common.NotificationsEnabled() {
+	if !handlers.NotificationsEnabled() {
 		http.NotFound(w, r)
 		return
 	}
@@ -87,7 +87,7 @@ func notificationsRssPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	notifs, err := queries.GetUnreadNotifications(r.Context(), uid)
 	if err != nil {
 		log.Printf("notify feed: %v", err)
@@ -114,7 +114,7 @@ func userNotificationEmailActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	idStr := r.FormValue("email_id")
 	id, _ := strconv.Atoi(idStr)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	val, _ := queries.GetMaxNotificationPriority(r.Context(), uid)
 	var maxPr int32
 	switch v := val.(type) {

--- a/handlers/user/userPage.go
+++ b/handlers/user/userPage.go
@@ -3,7 +3,7 @@ package user
 import (
 	"net/http"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/middleware"
 
 	"github.com/arran4/goa4web/core"
@@ -11,11 +11,11 @@ import (
 
 func userPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		*common.CoreData
+		*handlers.CoreData
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 	}
 
 	if data.CoreData.UserID == 0 {
@@ -28,5 +28,5 @@ func userPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TemplateHandler(w, r, "userPage", data)
+	handlers.TemplateHandler(w, r, "userPage", data)
 }

--- a/handlers/user/userPageSizePage.go
+++ b/handlers/user/userPageSizePage.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/config"
 )
@@ -21,17 +21,17 @@ func userPageSizePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data := struct {
-		*common.CoreData
+		*handlers.CoreData
 		Min     int
 		Max     int
 		Default int
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Min:      config.AppRuntimeConfig.PageSizeMin,
 		Max:      config.AppRuntimeConfig.PageSizeMax,
 		Default:  config.AppRuntimeConfig.PageSizeDefault,
 	}
-	common.TemplateHandler(w, r, "pageSizePage.gohtml", data)
+	handlers.TemplateHandler(w, r, "pageSizePage.gohtml", data)
 }
 
 func userPageSizeSaveActionPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/user/userPagingPage.go
+++ b/handlers/user/userPagingPage.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/core"
 	db "github.com/arran4/goa4web/internal/db"
@@ -16,14 +16,14 @@ import (
 )
 
 func userPagingPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	pref, _ := cd.Preference()
 	size := config.AppRuntimeConfig.PageSizeDefault
 	if pref != nil {
 		size = int(pref.PageSize)
 	}
 	data := struct {
-		*common.CoreData
+		*handlers.CoreData
 		Size int
 		Min  int
 		Max  int
@@ -33,7 +33,7 @@ func userPagingPage(w http.ResponseWriter, r *http.Request) {
 		Min:      config.AppRuntimeConfig.PageSizeMin,
 		Max:      config.AppRuntimeConfig.PageSizeMax,
 	}
-	common.TemplateHandler(w, r, "pagingPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "pagingPage.gohtml", data)
 }
 
 func userPagingSaveActionPage(w http.ResponseWriter, r *http.Request) {
@@ -53,8 +53,8 @@ func userPagingSaveActionPage(w http.ResponseWriter, r *http.Request) {
 	if size > config.AppRuntimeConfig.PageSizeMax {
 		size = config.AppRuntimeConfig.PageSizeMax
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 
 	pref, err := cd.Preference()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/handlers/user/userSubscriptionsPage.go
+++ b/handlers/user/userSubscriptionsPage.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/core"
 	db "github.com/arran4/goa4web/internal/db"
@@ -30,7 +30,7 @@ func userSubscriptionsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	rows, err := queries.ListSubscriptionsByUser(r.Context(), uid)
 	if err != nil {
 		log.Printf("list subs: %v", err)
@@ -43,19 +43,19 @@ func userSubscriptionsPage(w http.ResponseWriter, r *http.Request) {
 		subMap[key] = true
 	}
 	data := struct {
-		*common.CoreData
+		*handlers.CoreData
 		Subs    []*db.ListSubscriptionsByUserRow
 		Options []subscriptionOption
 		SubMap  map[string]bool
 		Error   string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*common.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData),
 		Subs:     rows,
 		Options:  userSubscriptionOptions,
 		SubMap:   subMap,
 		Error:    r.URL.Query().Get("error"),
 	}
-	common.TemplateHandler(w, r, "subscriptions.gohtml", data)
+	handlers.TemplateHandler(w, r, "subscriptions.gohtml", data)
 }
 
 func userSubscriptionsUpdateAction(w http.ResponseWriter, r *http.Request) {
@@ -68,7 +68,7 @@ func userSubscriptionsUpdateAction(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/usr/subscriptions?error="+err.Error(), http.StatusSeeOther)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	existing, err := queries.ListSubscriptionsByUser(r.Context(), uid)
 	if err != nil {
 		log.Printf("list subs: %v", err)
@@ -114,7 +114,7 @@ func userSubscriptionsDeleteAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	idStr := r.PostFormValue("id")
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if idStr == "" {
 		http.Redirect(w, r, "/usr/subscriptions?error=missing id", http.StatusSeeOther)
 		return

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	logProv "github.com/arran4/goa4web/internal/email/log"
 )
@@ -51,10 +51,10 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "e", "u"))
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("POST", "/email", nil)
-	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
 	cd := corecommon.NewCoreData(ctx, queries)
 	cd.UserID = 1
-	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()
@@ -82,10 +82,10 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "e", "u"))
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("POST", "/email", nil)
-	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
 	cd := corecommon.NewCoreData(ctx, queries)
 	cd.UserID = 1
-	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()
@@ -106,10 +106,10 @@ func TestUserEmailPage_ShowError(t *testing.T) {
 	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "e", "u"))
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("GET", "/usr/email?error=missing", nil)
-	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
 	cd := corecommon.NewCoreData(ctx, queries)
 	cd.UserID = 1
-	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()
@@ -154,10 +154,10 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 	}
 	rr := httptest.NewRecorder()
 
-	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
 	cd := corecommon.NewCoreData(ctx, queries, corecommon.WithSession(sess))
 	cd.UserID = 1
-	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rows := sqlmock.NewRows([]string{"idlanguage", "nameof"}).AddRow(1, "en").AddRow(2, "fr")
 	mock.ExpectExec("DELETE FROM user_language").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
@@ -203,10 +203,10 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 	}
 	rr := httptest.NewRecorder()
 
-	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
 	cd := corecommon.NewCoreData(ctx, queries, corecommon.WithSession(sess))
 	cd.UserID = 1
-	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	rows := sqlmock.NewRows([]string{"idlanguage", "nameof"}).AddRow(1, "en")
@@ -253,10 +253,10 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	}
 	rr := httptest.NewRecorder()
 
-	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
 	cd := corecommon.NewCoreData(ctx, queries, corecommon.WithSession(sess))
 	cd.UserID = 1
-	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies"}).

--- a/handlers/writings/matchers.go
+++ b/handlers/writings/matchers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/core"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -28,7 +28,7 @@ func RequireWritingAuthor(next http.Handler) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+		queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 		session, err := core.GetSession(r)
 		if err != nil {
 			http.NotFound(w, r)
@@ -47,9 +47,9 @@ func RequireWritingAuthor(next http.Handler) http.Handler {
 			return
 		}
 
-		cd, _ := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+		cd, _ := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 		if cd != nil && cd.HasRole("administrator") {
-			ctx := context.WithValue(r.Context(), hcommon.KeyWriting, row)
+			ctx := context.WithValue(r.Context(), handlers.KeyWriting, row)
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
@@ -57,7 +57,7 @@ func RequireWritingAuthor(next http.Handler) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		ctx := context.WithValue(r.Context(), hcommon.KeyWriting, row)
+		ctx := context.WithValue(r.Context(), handlers.KeyWriting, row)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/handlers/writings/matchers_test.go
+++ b/handlers/writings/matchers_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -37,8 +37,8 @@ func TestRequireWritingAuthorArticleVar(t *testing.T) {
 
 	cd := corecommon.NewCoreData(req.Context(), q, corecommon.WithSession(sess))
 	cd.SetRoles([]string{"content writer"})
-	ctx := context.WithValue(req.Context(), hcommon.KeyCoreData, cd)
-	ctx = context.WithValue(ctx, hcommon.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyCoreData, cd)
+	ctx = context.WithValue(ctx, handlers.KeyQueries, q)
 	req = req.WithContext(ctx)
 
 	rows := sqlmock.NewRows([]string{

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -6,8 +6,8 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
+	handlers "github.com/arran4/goa4web/handlers"
 	auth "github.com/arran4/goa4web/handlers/auth"
-	hcommon "github.com/arran4/goa4web/handlers/common"
 	router "github.com/arran4/goa4web/internal/router"
 
 	nav "github.com/arran4/goa4web/internal/navigation"
@@ -15,7 +15,7 @@ import (
 
 // AddWritingsIndex injects writings index links into CoreData.
 func AddWritingsIndex(h http.Handler) http.Handler {
-	return hcommon.IndexMiddleware(CustomWritingsIndex)(h)
+	return handlers.IndexMiddleware(CustomWritingsIndex)(h)
 }
 
 var legacyRedirectsEnabled = true
@@ -25,7 +25,7 @@ func RegisterRoutes(r *mux.Router) {
 	nav.RegisterIndexLink("Writings", "/writings", SectionWeight)
 	nav.RegisterAdminControlCenter("Writings", "/admin/writings/categories", SectionWeight)
 	wr := r.PathPrefix("/writings").Subrouter()
-	wr.Use(hcommon.IndexMiddleware(CustomWritingsIndex))
+	wr.Use(handlers.IndexMiddleware(CustomWritingsIndex))
 	wr.HandleFunc("/rss", RssPage).Methods("GET")
 	wr.HandleFunc("/atom", AtomPage).Methods("GET")
 	wr.HandleFunc("", Page).Methods("GET")
@@ -50,8 +50,8 @@ func RegisterRoutes(r *mux.Router) {
 
 	if legacyRedirectsEnabled {
 		// legacy redirects
-		r.Path("/writing").HandlerFunc(hcommon.RedirectPermanentPrefix("/writing", "/writings"))
-		r.PathPrefix("/writing/").HandlerFunc(hcommon.RedirectPermanentPrefix("/writing", "/writings"))
+		r.Path("/writing").HandlerFunc(handlers.RedirectPermanentPrefix("/writing", "/writings"))
+		r.PathPrefix("/writing/").HandlerFunc(handlers.RedirectPermanentPrefix("/writing", "/writings"))
 	}
 }
 

--- a/handlers/writings/writingsAdminCategoriesPage.go
+++ b/handlers/writings/writingsAdminCategoriesPage.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -23,7 +23,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 		WritingCategoryID   int32
 	}
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 	data.IsAdmin = data.CoreData.HasRole("administrator") && data.CoreData.AdminMode
 	data.IsWriter = data.CoreData.HasRole("content writer") || data.IsAdmin
@@ -41,7 +41,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	data.Categories = categoryRows
 
-	common.TemplateHandler(w, r, "categoriesPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "categoriesPage.gohtml", data)
 }
 
 func AdminCategoriesModifyPage(w http.ResponseWriter, r *http.Request) {
@@ -52,7 +52,7 @@ func AdminCategoriesModifyPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	categoryId, err := strconv.Atoi(r.PostFormValue("cid"))
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
@@ -75,7 +75,7 @@ func AdminCategoriesModifyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func AdminCategoriesCreatePage(w http.ResponseWriter, r *http.Request) {
@@ -87,7 +87,7 @@ func AdminCategoriesCreatePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if err := queries.InsertWritingCategory(r.Context(), db.InsertWritingCategoryParams{
 		WritingCategoryID: int32(pcid),
 		Title: sql.NullString{
@@ -102,5 +102,5 @@ func AdminCategoriesCreatePage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/writings/writingsAdminCategoriesPage_test.go
+++ b/handlers/writings/writingsAdminCategoriesPage_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -27,9 +27,9 @@ func TestWritingsAdminCategoriesPage(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT wc.idwritingcategory, wc.writing_category_id, wc.title, wc.description\nFROM writing_category wc")).WillReturnRows(rows)
 
 	req := httptest.NewRequest("GET", "/admin/writings/categories", nil)
-	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
 	cd := corecommon.NewCoreData(ctx, queries)
-	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 

--- a/handlers/writings/writingsAdminUserLevelsPage.go
+++ b/handlers/writings/writingsAdminUserLevelsPage.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -20,10 +20,10 @@ func AdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if roles, err := data.AllRoles(); err == nil {
 		data.Roles = roles
 	}
@@ -39,11 +39,11 @@ func AdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.UserLevels = rows
 
-	common.TemplateHandler(w, r, "adminUserLevelsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminUserLevelsPage.gohtml", data)
 }
 
 func AdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	username := r.PostFormValue("username")
 	level := r.PostFormValue("role")
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
@@ -61,11 +61,11 @@ func AdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
 func AdminUserLevelsRemoveActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	permid := r.PostFormValue("permid")
 	permidi, err := strconv.Atoi(permid)
 	if err != nil {
@@ -78,5 +78,5 @@ func AdminUserLevelsRemoveActionPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	common.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -7,8 +7,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
@@ -24,7 +23,7 @@ func ArticleAddPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
 	languageRows, err := data.CoreData.Languages()
@@ -34,7 +33,7 @@ func ArticleAddPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	common.TemplateHandler(w, r, "articleAddPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "articleAddPage.gohtml", data)
 }
 func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
@@ -51,7 +50,7 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 	body := r.PostFormValue("body")
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	articleId, err := queries.InsertWriting(r.Context(), db.InsertWritingParams{
 		WritingCategoryID:  int32(categoryId),
@@ -72,7 +71,7 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 	if u, err := queries.GetUserById(r.Context(), uid); err == nil {
 		author = u.Username.String
 	}
-	if cd, ok := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData); ok {
+	if cd, ok := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData); ok {
 		if evt := cd.Event(); evt != nil {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}

--- a/handlers/writings/writingsArticleCommentEditPage.go
+++ b/handlers/writings/writingsArticleCommentEditPage.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/core"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -24,7 +24,7 @@ func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	text := r.PostFormValue("replytext")
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	vars := mux.Vars(r)
 	articleId, _ := strconv.Atoi(vars["article"])
 	commentId, _ := strconv.Atoi(vars["comment"])
@@ -35,7 +35,7 @@ func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	comment := r.Context().Value(hcommon.KeyComment).(*db.GetCommentByIdForUserRow)
+	comment := r.Context().Value(handlers.KeyComment).(*db.GetCommentByIdForUserRow)
 
 	thread, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		ViewerID:      uid,
@@ -57,7 +57,7 @@ func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := hcommon.PostUpdate(r.Context(), queries, thread.Idforumthread, thread.ForumtopicIdforumtopic); err != nil {
+	if err := handlers.PostUpdate(r.Context(), queries, thread.Idforumthread, thread.ForumtopicIdforumtopic); err != nil {
 		log.Printf("Error: postUpdate: %s", err)
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -8,8 +8,7 @@ import (
 
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
-	common "github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
 
@@ -26,8 +25,8 @@ func ArticleEditPage(w http.ResponseWriter, r *http.Request) {
 		UserId             int32
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
-	cd := r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
 	data := Data{
 		CoreData:           cd,
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
@@ -43,7 +42,7 @@ func ArticleEditPage(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 	data.UserId = uid
 
-	writing := r.Context().Value(hcommon.KeyWriting).(*db.GetWritingByIdForUserDescendingByPublishedDateRow)
+	writing := r.Context().Value(handlers.KeyWriting).(*db.GetWritingByIdForUserDescendingByPublishedDateRow)
 	data.Writing = writing
 
 	languageRows, err := cd.Languages()
@@ -53,12 +52,12 @@ func ArticleEditPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	common.TemplateHandler(w, r, "articleEditPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "articleEditPage.gohtml", data)
 }
 
 func ArticleEditActionPage(w http.ResponseWriter, r *http.Request) {
 	// RequireWritingAuthor middleware loads the writing and validates access.
-	writing := r.Context().Value(hcommon.KeyWriting).(*db.GetWritingByIdForUserDescendingByPublishedDateRow)
+	writing := r.Context().Value(handlers.KeyWriting).(*db.GetWritingByIdForUserDescendingByPublishedDateRow)
 
 	languageId, _ := strconv.Atoi(r.PostFormValue("language"))
 	private, _ := strconv.ParseBool(r.PostFormValue("isitprivate"))
@@ -66,7 +65,7 @@ func ArticleEditActionPage(w http.ResponseWriter, r *http.Request) {
 	abstract := r.PostFormValue("abstract")
 	body := r.PostFormValue("body")
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	if err := queries.UpdateWriting(r.Context(), db.UpdateWritingParams{
 		Title:              sql.NullString{Valid: true, String: title},

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -11,8 +11,7 @@ import (
 	"github.com/arran4/goa4web/a4code"
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
-	common "github.com/arran4/goa4web/handlers/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/notifications"
 	searchutil "github.com/arran4/goa4web/internal/searchworker"
@@ -55,8 +54,8 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		ReplyText           string
 	}
 
-	cd := r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	data := Data{
 		CoreData:           cd,
 		CanReply:           cd.UserID != 0,
@@ -74,7 +73,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 	data.UserId = uid
-	queries = r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries = r.Context().Value(handlers.KeyQueries).(*db.Queries)
 
 	writing, err := queries.GetWritingByIdForUserDescendingByPublishedDate(r.Context(), db.GetWritingByIdForUserDescendingByPublishedDateParams{
 		ViewerID:      uid,
@@ -84,7 +83,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			_ = templates.GetCompiledSiteTemplates(r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
+			_ = templates.GetCompiledSiteTemplates(r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
 			return
 		default:
 			log.Printf("getWritingByIdForUserDescendingByPublishedDate Error: %s", err)
@@ -94,7 +93,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !cd.HasGrant("writing", "article", "view", writing.Idwriting) {
-		_ = templates.GetCompiledSiteTemplates(r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
+		_ = templates.GetCompiledSiteTemplates(r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData)
 		return
 	}
 
@@ -255,7 +254,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 
 	data.Thread = threadRow
 
-	common.TemplateHandler(w, r, "articlePage.gohtml", data)
+	handlers.TemplateHandler(w, r, "articlePage.gohtml", data)
 }
 
 func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
@@ -277,7 +276,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(hcommon.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	uid, _ := session.Values["UID"].(int32)
 
 	post, err := queries.GetWritingByIdForUserDescendingByPublishedDate(r.Context(), db.GetWritingByIdForUserDescendingByPublishedDateParams{
@@ -288,7 +287,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			cd := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+			cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 			_ = templates.GetCompiledSiteTemplates(cd.Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", cd)
 			return
 		default:
@@ -347,7 +346,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if cd, ok := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData); ok {
+	if cd, ok := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData); ok {
 		if evt := cd.Event(); evt != nil {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
@@ -373,7 +372,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := hcommon.PostUpdate(r.Context(), queries, pthid, ptid); err != nil {
+	if err := handlers.PostUpdate(r.Context(), queries, pthid, ptid); err != nil {
 		log.Printf("Error: postUpdate: %s", err)
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
@@ -391,5 +390,5 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	//??? if _, done := SearchWordIdsFromText(w, r, text, queries); done {
 
-	hcommon.TaskDoneAutoRefreshPage(w, r)
+	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/writings/writingsArticlePage_test.go
+++ b/handlers/writings/writingsArticlePage_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gorilla/sessions"
 
 	"github.com/arran4/goa4web/core"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -46,8 +46,8 @@ func TestArticleReplyActionPage_UsesArticleParam(t *testing.T) {
 		req.AddCookie(c)
 	}
 
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, queries)
-	ctx = context.WithValue(ctx, hcommon.KeyCoreData, &hcommon.CoreData{})
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, queries)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, &handlers.CoreData{})
 	req = req.WithContext(ctx)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT w.idwriting")).

--- a/handlers/writings/writingsCategoriesPage.go
+++ b/handlers/writings/writingsCategoriesPage.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -25,7 +25,7 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
 	data.IsAdmin = data.CoreData.HasRole("administrator") && data.CoreData.AdminMode
@@ -70,5 +70,5 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 		data.Abstracts = append(data.Abstracts, wrow)
 	}
 
-	common.TemplateHandler(w, r, "categoriesPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "categoriesPage.gohtml", data)
 }

--- a/handlers/writings/writingsCategoryPage.go
+++ b/handlers/writings/writingsCategoryPage.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/gorilla/mux"
@@ -29,7 +29,7 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
 	data.IsAdmin = data.CoreData.HasRole("administrator") && data.CoreData.AdminMode
@@ -87,5 +87,5 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 		data.Abstracts = append(data.Abstracts, wrow)
 	}
 
-	common.TemplateHandler(w, r, "writingsCategoryPage", data)
+	handlers.TemplateHandler(w, r, "writingsCategoryPage", data)
 }

--- a/handlers/writings/writingsFeed.go
+++ b/handlers/writings/writingsFeed.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/arran4/goa4web/a4code/a4code2html"
 	corecommon "github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	imageshandler "github.com/arran4/goa4web/handlers/images"
 	"github.com/gorilla/feeds"
 	"io"
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-func feedGen(r *http.Request, cd *common.CoreData) (*feeds.Feed, error) {
+func feedGen(r *http.Request, cd *handlers.CoreData) (*feeds.Feed, error) {
 	feed := &feeds.Feed{
 		Title:       "Latest writings",
 		Link:        &feeds.Link{Href: r.URL.String()},
@@ -60,7 +60,7 @@ func feedGen(r *http.Request, cd *common.CoreData) (*feeds.Feed, error) {
 }
 
 func RssPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	feed, err := feedGen(r, cd)
 	if err != nil {
 		log.Printf("FeedGen Error: %s", err)
@@ -75,7 +75,7 @@ func RssPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func AtomPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
+	cd := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 	feed, err := feedGen(r, cd)
 	if err != nil {
 		log.Printf("FeedGen Error: %s", err)

--- a/handlers/writings/writingsPage.go
+++ b/handlers/writings/writingsPage.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -24,7 +24,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
 	data.IsAdmin = data.CoreData.HasRole("administrator") && data.CoreData.AdminMode
@@ -41,7 +41,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Categories = append(data.Categories, categoryRows...)
 
-	common.TemplateHandler(w, r, "writingsPage", data)
+	handlers.TemplateHandler(w, r, "writingsPage", data)
 }
 func CustomWritingsIndex(data *corecommon.CoreData, r *http.Request) {
 

--- a/handlers/writings/writingsUserPermissionsPage.go
+++ b/handlers/writings/writingsUserPermissionsPage.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -20,10 +20,10 @@ func UserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 	}
 
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	if roles, err := data.AllRoles(); err == nil {
 		data.Roles = roles
 	}
@@ -39,11 +39,11 @@ func UserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
-	common.TemplateHandler(w, r, "usersPermissionsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "usersPermissionsPage.gohtml", data)
 }
 
 func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	username := r.PostFormValue("username")
 	level := r.PostFormValue("role")
 	data := struct {
@@ -52,7 +52,7 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 		Back:     "/writings",
 	}
 	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
@@ -64,11 +64,11 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
 	}
 
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 
 func UsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	permid := r.PostFormValue("permid")
 	data := struct {
 		*corecommon.CoreData
@@ -76,7 +76,7 @@ func UsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData: r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 		Back:     "/writings",
 	}
 	if permidi, err := strconv.Atoi(permid); err != nil {
@@ -84,5 +84,5 @@ func UsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 	} else if err := queries.DeleteUserRole(r.Context(), int32(permidi)); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
 	}
-	common.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/handlers/writings/writingsWriterListPage.go
+++ b/handlers/writings/writingsWriterListPage.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -29,16 +29,16 @@ func WriterListPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData:   r.Context().Value(common.KeyCoreData).(*corecommon.CoreData),
+		CoreData:   r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData),
 		Search:     r.URL.Query().Get("search"),
-		PageSize:   common.GetPageSize(r),
+		PageSize:   handlers.GetPageSize(r),
 		IsAdmin:    false,
 		CategoryId: 0,
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
-	pageSize := common.GetPageSize(r)
+	pageSize := handlers.GetPageSize(r)
 	rows, err := data.CoreData.Writers(r)
 	if err != nil {
 		switch {
@@ -82,5 +82,5 @@ func WriterListPage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	common.TemplateHandler(w, r, "writerListPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "writerListPage.gohtml", data)
 }

--- a/handlers/writings/writingsWriterListPage_test.go
+++ b/handlers/writings/writingsWriterListPage_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	corecommon "github.com/arran4/goa4web/core/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -23,10 +23,10 @@ func TestWriterListPage_List(t *testing.T) {
 	mock.ExpectQuery(".*").WillReturnRows(rows)
 
 	req := httptest.NewRequest("GET", "/writings/writers", nil)
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, q)
 	cd := corecommon.NewCoreData(ctx, q)
 	cd.UserID = 1
-	ctx = context.WithValue(ctx, hcommon.KeyCoreData, cd)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 
@@ -52,10 +52,10 @@ func TestWriterListPage_Search(t *testing.T) {
 	mock.ExpectQuery(".*").WillReturnRows(rows)
 
 	req := httptest.NewRequest("GET", "/writings/writers?search=bob", nil)
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, q)
 	cd := corecommon.NewCoreData(ctx, q)
 	cd.UserID = 1
-	ctx = context.WithValue(ctx, hcommon.KeyCoreData, cd)
+	ctx = context.WithValue(ctx, handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 

--- a/handlers/writings/writingsWriterPage.go
+++ b/handlers/writings/writingsWriterPage.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	common "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/gorilla/mux"
@@ -26,8 +26,8 @@ func WriterPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	username := vars["username"]
 
-	cd := r.Context().Value(common.KeyCoreData).(*corecommon.CoreData)
-	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		switch {
@@ -59,5 +59,5 @@ func WriterPage(w http.ResponseWriter, r *http.Request) {
 		data.Abstracts = append(data.Abstracts, row)
 	}
 
-	common.TemplateHandler(w, r, "writerPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "writerPage.gohtml", data)
 }

--- a/internal/app/dbstart/version_test.go
+++ b/internal/app/dbstart/version_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/migrations"
 )
 
@@ -32,7 +32,7 @@ func TestExpectedSchemaVersionMatchesMigrations(t *testing.T) {
 			max = n
 		}
 	}
-	if max != hcommon.ExpectedSchemaVersion {
-		t.Fatalf("schema version constant %d does not match latest migration %d", hcommon.ExpectedSchemaVersion, max)
+	if max != handlers.ExpectedSchemaVersion {
+		t.Fatalf("schema version constant %d does not match latest migration %d", handlers.ExpectedSchemaVersion, max)
 	}
 }

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -59,7 +59,7 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	}
-	common.Version = version
+	handlers.Version = version
 
 	if err := PerformChecks(cfg); err != nil {
 		return fmt.Errorf("startup checks: %w", err)

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	corecommon "github.com/arran4/goa4web/core/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/sessions"
@@ -34,13 +34,13 @@ func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
 
 	session := &sessions.Session{ID: "sessid", Values: map[interface{}]interface{}{"UID": int32(1)}}
 	req := httptest.NewRequest("GET", "/", nil)
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, q)
 	ctx = context.WithValue(ctx, corecommon.ContextValues("session"), session)
 	req = req.WithContext(ctx)
 
 	var cd *corecommon.CoreData
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cd, _ = r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)
+		cd, _ = r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
 	})
 
 	CoreAdderMiddleware(handler).ServeHTTP(httptest.NewRecorder(), req)
@@ -70,13 +70,13 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 
 	session := &sessions.Session{ID: "sessid"}
 	req := httptest.NewRequest("GET", "/", nil)
-	ctx := context.WithValue(req.Context(), hcommon.KeyQueries, q)
+	ctx := context.WithValue(req.Context(), handlers.KeyQueries, q)
 	ctx = context.WithValue(ctx, corecommon.ContextValues("session"), session)
 	req = req.WithContext(ctx)
 
 	var cd *corecommon.CoreData
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cd, _ = r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)
+		cd, _ = r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
 	})
 
 	CoreAdderMiddleware(handler).ServeHTTP(httptest.NewRecorder(), req)

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -8,7 +8,7 @@ import (
 	"net/netip"
 	"strings"
 
-	"github.com/arran4/goa4web/handlers/common"
+	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -45,7 +45,7 @@ func requestIP(r *http.Request) string {
 func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ip := requestIP(r)
-		if queries, ok := r.Context().Value(common.KeyQueries).(*db.Queries); ok {
+		if queries, ok := r.Context().Value(handlers.KeyQueries).(*db.Queries); ok {
 			bans, err := queries.ListActiveBans(r.Context())
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/eventbus"
 )
 
@@ -85,7 +85,7 @@ func TaskEventMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		task := r.PostFormValue("task")
 		uid := int32(0)
-		cd, _ := r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)
+		cd, _ := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
 		if cd != nil {
 			uid = cd.UserID
 		}

--- a/internal/middleware/taskbus_test.go
+++ b/internal/middleware/taskbus_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/eventbus"
 )
 
@@ -64,7 +64,7 @@ func TestTaskEventMiddleware(t *testing.T) {
 
 	// ensure handlers can attach event data
 	itemHandler := TaskEventMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if cd, ok := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData); ok {
+		if cd, ok := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData); ok {
 			if evt := cd.Event(); evt != nil {
 				if evt.Data == nil {
 					evt.Data = map[string]any{}
@@ -78,7 +78,7 @@ func TestTaskEventMiddleware(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec = httptest.NewRecorder()
 	ch = bus.Subscribe()
-	ctx := context.WithValue(req.Context(), hcommon.KeyCoreData, &hcommon.CoreData{})
+	ctx := context.WithValue(req.Context(), handlers.KeyCoreData, &handlers.CoreData{})
 	itemHandler.ServeHTTP(rec, req.WithContext(ctx))
 	select {
 	case evt := <-ch:
@@ -128,7 +128,7 @@ func TestTaskEventQueue(t *testing.T) {
 
 func TestTaskEventMiddleware_EventProvided(t *testing.T) {
 	handler := TaskEventMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cd, _ := r.Context().Value(hcommon.KeyCoreData).(*hcommon.CoreData)
+		cd, _ := r.Context().Value(handlers.KeyCoreData).(*handlers.CoreData)
 		if cd == nil || cd.Event() == nil {
 			t.Fatalf("missing event")
 		}
@@ -136,7 +136,7 @@ func TestTaskEventMiddleware_EventProvided(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest("GET", "/test", nil)
-	ctx := context.WithValue(req.Context(), hcommon.KeyCoreData, &hcommon.CoreData{})
+	ctx := context.WithValue(req.Context(), handlers.KeyCoreData, &handlers.CoreData{})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req.WithContext(ctx))
 

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"text/template"
 
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/dlq"
 	dbdlq "github.com/arran4/goa4web/internal/dlq/db"
@@ -130,7 +130,7 @@ func BusWorker(ctx context.Context, bus *eventbus.Bus, n Notifier, q dlq.DLQ) {
 }
 
 func processEvent(ctx context.Context, evt eventbus.Event, n Notifier, q dlq.DLQ) {
-	if !hcommon.NotificationsEnabled() {
+	if !handlers.NotificationsEnabled() {
 		return
 	}
 
@@ -289,7 +289,7 @@ func processEvent(ctx context.Context, evt eventbus.Event, n Notifier, q dlq.DLQ
 
 		// thread 2nd
 
-		if n.Queries == nil || !common.NotificationsEnabled() {
+		if n.Queries == nil || !handlers.NotificationsEnabled() {
 			return
 		}
 		rows, err := n.Queries.ListUsersSubscribedToThread(ctx, db.ListUsersSubscribedToThreadParams{
@@ -345,7 +345,7 @@ func processEvent(ctx context.Context, evt eventbus.Event, n Notifier, q dlq.DLQ
 			if err := CreateEmailTemplateAndQueue(ctx, q, row.Idusers, row.Email, page, "update", nil); err != nil {
 				log.Printf("Error: notifyChange: %v", err)
 			}
-			if hcommon.NotificationsEnabled() {
+			if handlers.NotificationsEnabled() {
 				err := q.InsertNotification(ctx, db.InsertNotificationParams{
 					UsersIdusers: row.Idusers,
 					Link:         sql.NullString{String: page, Valid: page != ""},

--- a/internal/notifications/email.go
+++ b/internal/notifications/email.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/arran4/goa4web/config"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
 )
@@ -25,7 +25,7 @@ func getEmailTemplates(ctx context.Context, action string) (string, string) {
 	name := "email_" + strings.ToLower(action)
 	nameHTML := name + "_html"
 	var text, html string
-	if q, ok := ctx.Value(hcommon.KeyQueries).(*db.Queries); ok && q != nil {
+	if q, ok := ctx.Value(handlers.KeyQueries).(*db.Queries); ok && q != nil {
 		if body, err := q.GetTemplateOverride(ctx, name); err == nil && body != "" {
 			text = body
 		}

--- a/internal/router/roles_test.go
+++ b/internal/router/roles_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	corecommon "github.com/arran4/goa4web/core/common"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/middleware"
 )
 
@@ -15,7 +15,7 @@ func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
 	cd := corecommon.NewCoreData(req.Context(), nil)
 	cd.SetRoles([]string{"administrator"})
-	ctx := context.WithValue(req.Context(), hcommon.KeyCoreData, cd)
+	ctx := context.WithValue(req.Context(), handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	called := false
@@ -40,7 +40,7 @@ func TestRoleCheckerMiddlewareDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
 	cd := corecommon.NewCoreData(req.Context(), nil)
 	cd.SetRoles([]string{"anonymous"})
-	ctx := context.WithValue(req.Context(), hcommon.KeyCoreData, cd)
+	ctx := context.WithValue(req.Context(), handlers.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	called := false

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -8,13 +8,13 @@ import (
 
 	corecommon "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 // RegisterRoutes sets up all application routes on r.
 func RegisterRoutes(r *mux.Router) {
-	r.HandleFunc("/main.css", hcommon.MainCSS).Methods("GET")
-	r.HandleFunc("/favicon.svg", hcommon.Favicon).Methods("GET")
+	r.HandleFunc("/main.css", handlers.MainCSS).Methods("GET")
+	r.HandleFunc("/favicon.svg", handlers.Favicon).Methods("GET")
 
 	InitModules(r)
 
@@ -25,7 +25,7 @@ func RoleCheckerMiddleware(roles ...string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !corecommon.Allowed(r, roles...) {
-				cd := r.Context().Value(hcommon.KeyCoreData).(*corecommon.CoreData)
+				cd := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData)
 				err := templates.GetCompiledSiteTemplates(cd.Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", cd)
 				if err != nil {
 					log.Printf("Template Error: %s", err)

--- a/startup_test.go
+++ b/startup_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	hcommon "github.com/arran4/goa4web/handlers/common"
+	handlers "github.com/arran4/goa4web/handlers"
 )
 
 func TestEnsureSchemaVersionMatch(t *testing.T) {
@@ -20,7 +20,7 @@ func TestEnsureSchemaVersionMatch(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)")).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
-		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(hcommon.ExpectedSchemaVersion))
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(handlers.ExpectedSchemaVersion))
 
 	if err := dbstart2.EnsureSchema(context.Background(), db); err != nil {
 		t.Fatalf("ensureSchema: %v", err)
@@ -40,13 +40,13 @@ func TestEnsureSchemaVersionMismatch(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)")).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
-		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(hcommon.ExpectedSchemaVersion - 1))
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(handlers.ExpectedSchemaVersion - 1))
 
 	err = dbstart2.EnsureSchema(context.Background(), db)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
-	expected := dbstart2.RenderSchemaMismatch(hcommon.ExpectedSchemaVersion-1, hcommon.ExpectedSchemaVersion)
+	expected := dbstart2.RenderSchemaMismatch(handlers.ExpectedSchemaVersion-1, handlers.ExpectedSchemaVersion)
 	if err.Error() != expected {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- update all imports to use the `handlers` package directly
- replace the old `common` alias with `handlers`
- adjust code references to the new alias

## Testing
- `go mod tidy`
- `go fmt ./...` *(fails: expected ';' in internal/notifications/bus_worker.go)*
- `go vet ./...` *(fails: invalid pattern syntax in templates.go)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: invalid pattern syntax in templates.go)*

------
https://chatgpt.com/codex/tasks/task_e_687859f98bb8832f8890e7a3ef81e8db