### PR TITLE
Fix FAQ task matchers

### DIFF
--- a/handlers/faq/admin_answer.go
+++ b/handlers/faq/admin_answer.go
@@ -10,7 +10,23 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/gorilla/mux"
 )
+
+type AnswerTask struct{ tasks.TaskString }
+type RemoveQuestionTask struct{ tasks.TaskString }
+
+var answerTask = &AnswerTask{TaskString: TaskAnswer}
+var removeQuestionTask = &RemoveQuestionTask{TaskString: TaskRemoveRemove}
+
+func (AnswerTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskAnswer)(r, m)
+}
+
+func (RemoveQuestionTask) Match(req *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskRemoveRemove)(req, m)
+}
 
 func AdminAnswerPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
@@ -50,7 +66,7 @@ func AdminAnswerPage(w http.ResponseWriter, r *http.Request) {
 	handlers.TemplateHandler(w, r, "adminAnswerPage.gohtml", data)
 }
 
-func AnswerAnswerActionPage(w http.ResponseWriter, r *http.Request) {
+func (AnswerTask) Action(w http.ResponseWriter, r *http.Request) {
 	question := r.PostFormValue("question")
 	answer := r.PostFormValue("answer")
 	category, err := strconv.Atoi(r.PostFormValue("category"))
@@ -81,7 +97,7 @@ func AnswerAnswerActionPage(w http.ResponseWriter, r *http.Request) {
 	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
-func AnswerRemoveActionPage(w http.ResponseWriter, r *http.Request) {
+func (RemoveQuestionTask) Action(w http.ResponseWriter, r *http.Request) {
 	faq, err := strconv.Atoi(r.PostFormValue("faq"))
 	if err != nil {
 		log.Printf("Error: %s", err)

--- a/handlers/faq/admin_categories.go
+++ b/handlers/faq/admin_categories.go
@@ -10,7 +10,29 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/gorilla/mux"
 )
+
+type RenameCategoryTask struct{ tasks.TaskString }
+type DeleteCategoryTask struct{ tasks.TaskString }
+type CreateCategoryTask struct{ tasks.TaskString }
+
+var renameCategoryTask = &RenameCategoryTask{TaskString: TaskRenameCategory}
+var deleteCategoryTask = &DeleteCategoryTask{TaskString: TaskDeleteCategory}
+var createCategoryTask = &CreateCategoryTask{TaskString: TaskCreateCategory}
+
+func (RenameCategoryTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskRenameCategory)(r, m)
+}
+
+func (DeleteCategoryTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskDeleteCategory)(r, m)
+}
+
+func (CreateCategoryTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskCreateCategory)(r, m)
+}
 
 func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
@@ -38,7 +60,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	handlers.TemplateHandler(w, r, "adminCategoriesPage.gohtml", data)
 }
 
-func CategoriesRenameActionPage(w http.ResponseWriter, r *http.Request) {
+func (RenameCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("cname")
 	cid, err := strconv.Atoi(r.PostFormValue("cid"))
 	if err != nil {
@@ -63,7 +85,7 @@ func CategoriesRenameActionPage(w http.ResponseWriter, r *http.Request) {
 	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
-func CategoriesDeleteActionPage(w http.ResponseWriter, r *http.Request) {
+func (DeleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
 	cid, err := strconv.Atoi(r.PostFormValue("cid"))
 	if err != nil {
 		log.Printf("Error: %s", err)
@@ -81,7 +103,7 @@ func CategoriesDeleteActionPage(w http.ResponseWriter, r *http.Request) {
 	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
-func CategoriesCreateActionPage(w http.ResponseWriter, r *http.Request) {
+func (CreateCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("cname")
 	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
 

--- a/handlers/faq/admin_question.go
+++ b/handlers/faq/admin_question.go
@@ -7,12 +7,33 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
-
-	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/gorilla/mux"
 )
+
+type EditQuestionTask struct{ tasks.TaskString }
+type DeleteQuestionTask struct{ tasks.TaskString }
+type CreateQuestionTask struct{ tasks.TaskString }
+
+var editQuestionTask = &EditQuestionTask{TaskString: TaskEdit}
+var deleteQuestionTask = &DeleteQuestionTask{TaskString: TaskRemoveRemove}
+var createQuestionTask = &CreateQuestionTask{TaskString: TaskCreate}
+
+func (EditQuestionTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskEdit)(r, m)
+}
+
+func (DeleteQuestionTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskRemoveRemove)(r, m)
+}
+
+func (CreateQuestionTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskCreate)(r, m)
+}
 
 func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
@@ -52,7 +73,7 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 	handlers.TemplateHandler(w, r, "adminQuestionPage.gohtml", data)
 }
 
-func QuestionsDeleteActionPage(w http.ResponseWriter, r *http.Request) {
+func (DeleteQuestionTask) Action(w http.ResponseWriter, r *http.Request) {
 	faq, err := strconv.Atoi(r.PostFormValue("faq"))
 	if err != nil {
 		log.Printf("Error: %s", err)
@@ -70,7 +91,7 @@ func QuestionsDeleteActionPage(w http.ResponseWriter, r *http.Request) {
 	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
-func QuestionsEditActionPage(w http.ResponseWriter, r *http.Request) {
+func (EditQuestionTask) Action(w http.ResponseWriter, r *http.Request) {
 	question := r.PostFormValue("question")
 	answer := r.PostFormValue("answer")
 	category, err := strconv.Atoi(r.PostFormValue("category"))
@@ -101,7 +122,7 @@ func QuestionsEditActionPage(w http.ResponseWriter, r *http.Request) {
 	handlers.TaskDoneAutoRefreshPage(w, r)
 }
 
-func QuestionsCreateActionPage(w http.ResponseWriter, r *http.Request) {
+func (CreateQuestionTask) Action(w http.ResponseWriter, r *http.Request) {
 	question := r.PostFormValue("question")
 	answer := r.PostFormValue("answer")
 	category, err := strconv.Atoi(r.PostFormValue("category"))

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -2,20 +2,28 @@ package faq
 
 import (
 	"database/sql"
-	"log"
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
 	corecommon "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
-
-	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/gorilla/mux"
 )
 
-func AskPage(w http.ResponseWriter, r *http.Request) {
+type AskTask struct{ tasks.TaskString }
+
+var askTask = &AskTask{TaskString: TaskAsk}
+
+func (AskTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskAsk)(r, m)
+}
+
+func (AskTask) Page(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*corecommon.CoreData
 		Languages          []*db.Language
@@ -39,7 +47,7 @@ func AskPage(w http.ResponseWriter, r *http.Request) {
 	handlers.TemplateHandler(w, r, "askPage.gohtml", data)
 }
 
-func AskActionPage(w http.ResponseWriter, r *http.Request) {
+func (AskTask) Action(w http.ResponseWriter, r *http.Request) {
 	if err := handlers.ValidateForm(r, []string{"language", "text"}, []string{"language", "text"}); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -3,7 +3,6 @@ package faq
 import (
 	"context"
 	"database/sql"
-	"github.com/arran4/goa4web/internal/tasks"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -52,7 +51,7 @@ func TestAskActionPage_InvalidForms(t *testing.T) {
 		req = req.WithContext(ctx)
 
 		rr := httptest.NewRecorder()
-		AskActionPage(rr, req)
+		askTask.Action(rr, req)
 		if rr.Code != http.StatusBadRequest {
 			t.Errorf("form=%v status=%d", form, rr.Code)
 		}
@@ -103,7 +102,7 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()
-	AskActionPage(rr, req)
+	askTask.Action(rr, req)
 
 	if rr.Code != http.StatusTemporaryRedirect {
 		t.Fatalf("status=%d", rr.Code)

--- a/handlers/faq/routes.go
+++ b/handlers/faq/routes.go
@@ -16,32 +16,6 @@ func AddFAQIndex(h http.Handler) http.Handler {
 	})(h)
 }
 
-// Task constants mirror the values used by the main package.
-const (
-	// TaskAsk submits a new question to the FAQ system.
-	TaskAsk = "Ask"
-	// TaskAnswer submits an answer in the FAQ admin interface.
-	TaskAnswer = "Answer"
-	// TaskRemoveRemove removes an item, typically from a list.
-	TaskRemoveRemove = "Remove"
-	// TaskRenameCategory renames a category.
-	TaskRenameCategory = "Rename Category"
-	// TaskDeleteCategory removes a category.
-	TaskDeleteCategory = "Delete Category"
-	// TaskCreateCategory creates a new category entry.
-	TaskCreateCategory = "Create Category"
-	// TaskEdit modifies an existing item.
-	TaskEdit = "Edit"
-	// TaskCreate indicates creation of an object.
-	TaskCreate = "Create"
-)
-
-func taskMatcher(taskName string) mux.MatcherFunc {
-	return func(r *http.Request, match *mux.RouteMatch) bool {
-		return r.PostFormValue("task") == taskName
-	}
-}
-
 func noTask() mux.MatcherFunc {
 	return func(r *http.Request, match *mux.RouteMatch) bool {
 		return r.PostFormValue("task") == ""
@@ -55,8 +29,8 @@ func RegisterRoutes(r *mux.Router) {
 	faqr := r.PathPrefix("/faq").Subrouter()
 	faqr.Use(handlers.IndexMiddleware(CustomFAQIndex))
 	faqr.HandleFunc("", Page).Methods("GET", "POST")
-	faqr.HandleFunc("/ask", AskPage).Methods("GET")
-	faqr.HandleFunc("/ask", AskActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskAsk))
+	faqr.HandleFunc("/ask", askTask.Page).Methods("GET")
+	faqr.HandleFunc("/ask", askTask.Action).Methods("POST").MatcherFunc(askTask.Match)
 }
 
 // RegisterAdminRoutes attaches the admin FAQ endpoints to the router.
@@ -64,16 +38,16 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	farq := ar.PathPrefix("/faq").Subrouter()
 	farq.Use(handlers.IndexMiddleware(CustomFAQIndex))
 	farq.HandleFunc("/answer", AdminAnswerPage).Methods("GET", "POST").MatcherFunc(noTask())
-	farq.HandleFunc("/answer", AnswerAnswerActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskAnswer))
-	farq.HandleFunc("/answer", AnswerRemoveActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskRemoveRemove))
+	farq.HandleFunc("/answer", answerTask.Action).Methods("POST").MatcherFunc(answerTask.Match)
+	farq.HandleFunc("/answer", removeQuestionTask.Action).Methods("POST").MatcherFunc(removeQuestionTask.Match)
 	farq.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")
-	farq.HandleFunc("/categories", CategoriesRenameActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskRenameCategory))
-	farq.HandleFunc("/categories", CategoriesDeleteActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskDeleteCategory))
-	farq.HandleFunc("/categories", CategoriesCreateActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskCreateCategory))
+	farq.HandleFunc("/categories", renameCategoryTask.Action).Methods("POST").MatcherFunc(renameCategoryTask.Match)
+	farq.HandleFunc("/categories", deleteCategoryTask.Action).Methods("POST").MatcherFunc(deleteCategoryTask.Match)
+	farq.HandleFunc("/categories", createCategoryTask.Action).Methods("POST").MatcherFunc(createCategoryTask.Match)
 	farq.HandleFunc("/questions", AdminQuestionsPage).Methods("GET", "POST").MatcherFunc(noTask())
-	farq.HandleFunc("/questions", QuestionsEditActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskEdit))
-	farq.HandleFunc("/questions", QuestionsDeleteActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskRemoveRemove))
-	farq.HandleFunc("/questions", QuestionsCreateActionPage).Methods("POST").MatcherFunc(taskMatcher(TaskCreate))
+	farq.HandleFunc("/questions", editQuestionTask.Action).Methods("POST").MatcherFunc(editQuestionTask.Match)
+	farq.HandleFunc("/questions", deleteQuestionTask.Action).Methods("POST").MatcherFunc(deleteQuestionTask.Match)
+	farq.HandleFunc("/questions", createQuestionTask.Action).Methods("POST").MatcherFunc(createQuestionTask.Match)
 }
 
 // Register registers the faq router module.

--- a/handlers/faq/tasks.go
+++ b/handlers/faq/tasks.go
@@ -1,5 +1,8 @@
 package faq
 
+// TODO remove what is unused here
+// TODO this should be the basis for all the others.
+
 // The following constants define the allowed values of the "task" form field.
 // Each HTML form includes a hidden or submit input named "task" whose value
 // identifies the intended action. When routes are registered the constants are
@@ -7,130 +10,11 @@ package faq
 // expected task reach a handler. Centralising these string values avoids typos
 // between templates and route declarations.
 const (
-	// TaskAdd represents the "Add" action, commonly used when creating a new
-	// record.
-	TaskAdd = "Add"
-
-	// TaskAddApproval adds an approval for a user or item.
-	TaskAddApproval = "Add approval"
-
-	// TaskUploadImage uploads an image file to the image board.
-	TaskUploadImage = "Upload image"
-
-	// TaskAnswer submits an answer in the FAQ admin interface.
-	TaskAnswer = "Answer"
-
-	// TaskApprove approves an item in moderation queues.
-	TaskApprove = "Approve"
-
 	// TaskAsk submits a new question to the FAQ system.
 	TaskAsk = "Ask"
 
-	// TaskCancel cancels the current operation and returns to the previous
-	// page.
-	TaskCancel = "Cancel"
-
-	// TaskCreate indicates creation of an object, for instance a bookmark or
-	// other record.
-	TaskCreate = "Create"
-
-	// TaskCreateCategory creates a new category entry.
-	TaskCreateCategory = "Create Category"
-
-	// TaskCreateLanguage creates a new language entry.
-	TaskCreateLanguage = "Create Language"
-
-	// TaskCreateThread creates a new forum thread.
-	TaskCreateThread = "Create Thread"
-
-	// TaskDelete removes an existing item.
-	TaskDelete = "Delete"
-
-	// TaskDeleteCategory removes a category.
-	TaskDeleteCategory = "Delete Category"
-
-	// TaskDeleteLanguage removes a language entry.
-	TaskDeleteLanguage = "Delete Language"
-
-	// TaskDeleteTopicRestriction deletes a topic restriction record.
-	TaskDeleteTopicRestriction = "Delete topic restriction"
-
-	// TaskDeleteUserApproval deletes a user's approval entry.
-	TaskDeleteUserApproval = "Delete user approval"
-
-	// TaskDeleteUserLevel deletes a user's access level.
-	TaskDeleteUserLevel = "Delete user level"
-
-	// TaskEdit modifies an existing item.
-	TaskEdit = "Edit"
-
-	// TaskEditReply edits a comment or reply.
-	TaskEditReply = "Edit Reply"
-
-	// TaskForumCategoryChange updates the name of a forum category.
-	TaskForumCategoryChange = "Forum category change"
-
-	// TaskForumCategoryCreate creates a new forum category.
-	TaskForumCategoryCreate = "Forum category create"
-
-	// TaskForumTopicChange updates the name of a forum topic.
-	TaskForumTopicChange = "Forum topic change"
-
-	// TaskForumTopicCreate creates a new forum topic.
-	TaskForumTopicCreate = "Forum topic create"
-
-	// TaskForumTopicDelete removes a forum topic.
-	TaskForumTopicDelete = "Forum topic delete"
-
-	// TaskForumThreadDelete removes a forum thread.
-	TaskForumThreadDelete = "Forum thread delete"
-
-	// TaskLogin performs a user login.
-	TaskLogin = "Login"
-
-	// TaskModifyCategory modifies an existing writing category.
-	TaskModifyCategory = "Modify Category"
-
-	// TaskModifyBoard modifies the settings of an image board.
-	TaskModifyBoard = "Modify board"
-
-	// TaskNewCategory creates a new writing category.
-	TaskNewCategory = "New Category"
-
-	// TaskNewPost creates a new news post.
-	TaskNewPost = "New Post"
-
-	// TaskNewBoard creates a new image board.
-	TaskNewBoard = "New board"
-
-	// TaskRegister registers a new user account.
-	TaskRegister = "Register"
-
-	// TaskRemakeBlogSearch rebuilds the blog search index.
-	TaskRemakeBlogSearch = "Remake blog search"
-
-	// TaskRemakeCommentsSearch rebuilds the comments search index.
-	TaskRemakeCommentsSearch = "Remake comments search"
-
-	// TaskRemakeLinkerSearch rebuilds the linker search index.
-	TaskRemakeLinkerSearch = "Remake linker search"
-
-	// TaskRemakeNewsSearch rebuilds the news search index.
-	TaskRemakeNewsSearch = "Remake news search"
-
-	// TaskRemakeStatisticInformationOnForumthread updates forum thread
-	// statistics.
-	TaskRemakeStatisticInformationOnForumthread = "Remake statistic information on forumthread"
-
-	// TaskRemakeStatisticInformationOnForumtopic updates forum topic
-	// statistics.
-	TaskRemakeStatisticInformationOnForumtopic = "Remake statistic information on forumtopic"
-
-	// TaskRemakeWritingSearch rebuilds the writing search index.
-	TaskRemakeWritingSearch = "Remake writing search"
-
-	// TaskRemakeImageSearch rebuilds the image search index.
-	TaskRemakeImageSearch = "Remake image search"
+	// TaskAnswer submits an answer in the FAQ admin interface.
+	TaskAnswer = "Answer"
 
 	// TaskRemoveRemove removes an item, typically from a list.
 	TaskRemoveRemove = "Remove"
@@ -138,138 +22,15 @@ const (
 	// TaskRenameCategory renames a category.
 	TaskRenameCategory = "Rename Category"
 
-	// TaskRenameLanguage renames a language entry.
-	TaskRenameLanguage = "Rename Language"
+	// TaskDeleteCategory removes a category.
+	TaskDeleteCategory = "Delete Category"
 
-	// TaskReply posts a reply to a thread or comment.
-	TaskReply = "Reply"
+	// TaskCreateCategory creates a new category entry.
+	TaskCreateCategory = "Create Category"
 
-	// TaskSave persists changes for an item.
-	TaskSave = "Save"
+	// TaskEdit modifies an existing item.
+	TaskEdit = "Edit"
 
-	// TaskSaveAll saves all changes in bulk.
-	TaskSaveAll = "Save all"
-
-	// TaskSaveLanguage saves updates to a single language.
-	TaskSaveLanguage = "Save language"
-
-	// TaskSaveLanguages saves multiple languages at once.
-	TaskSaveLanguages = "Save languages"
-
-	// TaskSearchBlogs triggers a blog search.
-	TaskSearchBlogs = "Search blogs"
-
-	// TaskSearchForum triggers a forum search.
-	TaskSearchForum = "Search forum"
-
-	// TaskSearchLinker triggers a linker search.
-	TaskSearchLinker = "Search linker"
-
-	// TaskSearchNews triggers a news search.
-	TaskSearchNews = "Search news"
-
-	// TaskSearchWritings triggers a writing search.
-	TaskSearchWritings = "Search writings"
-
-	// TaskSetTopicRestriction sets a new topic restriction.
-	TaskSetTopicRestriction = "Set topic restriction"
-
-	// TaskCopyTopicRestriction copies restriction levels from one topic to another.
-	TaskCopyTopicRestriction = "Copy topic restriction"
-
-	// TaskSetUserLevel sets a user's access level.
-	TaskSetUserLevel = "Set user level"
-
-	// TaskSubmitWriting submits a new writing.
-	TaskSubmitWriting = "Submit writing"
-
-	// TaskSuggest creates a suggestion in the linker.
-	TaskSuggest = "Suggest"
-
-	// TaskTestMail sends a test email to the current user.
-	TaskTestMail = "Test mail"
-
-	// TaskResend attempts to send queued emails immediately.
-	TaskResend = "Resend"
-
-	// TaskDismiss marks a notification as read.
-	TaskDismiss = "Dismiss"
-
-	// TaskUpdate updates an existing item.
-	TaskUpdate = "Update"
-
-	// TaskUpdateTopicRestriction updates an existing topic restriction.
-	TaskUpdateTopicRestriction = "Update topic restriction"
-
-	// TaskUpdateUserApproval updates a writing user's approval state.
-	TaskUpdateUserApproval = "Update user approval"
-
-	// TaskUpdateUserLevel updates a user's access level.
-	TaskUpdateUserLevel = "Update user level"
-
-	// TaskBulkApprove approves multiple queued items at once.
-	TaskBulkApprove = "Bulk Approve"
-
-	// TaskBulkDelete removes multiple queued items at once.
-	TaskBulkDelete = "Bulk Delete"
-
-	// TaskUpdateWriting updates an existing writing.
-	TaskUpdateWriting = "Update writing"
-
-	// TaskUserAllow grants a user a permission or level.
-	TaskUserAllow = "User Allow"
-
-	// TaskUpdatePermission modifies an existing user permission.
-	TaskUpdatePermission = "Update permission"
-
-	// TaskUserDisallow removes a user's permission or level.
-	TaskUserDisallow = "User Disallow"
-
-	// TaskUsersAllow grants multiple users a permission or level.
-	TaskUsersAllow = "Users Allow"
-
-	// TaskUsersDisallow removes multiple user permissions or levels.
-	TaskUsersDisallow = "Users Disallow"
-
-	// TaskUserDoNothing is used when no action should be taken on a user.
-	TaskUserDoNothing = "User do nothing"
-
-	// TaskUserResetPassword resets a user's password.
-	TaskUserResetPassword = "Password Reset"
-
-	// TaskPasswordVerify verifies a password reset code.
-	TaskPasswordVerify = "Password Verify"
-
-	// TaskUserEmailVerification verifies a user's email address.
-	TaskUserEmailVerification = "Email Verification"
-
-	// TaskAllow approves a news user level.
-	TaskAllow = "allow"
-
-	// TaskRemoveLower removes a news user level.
-	TaskRemoveLower = "remove"
-
-	// TaskWritingCategoryChange changes a writing category name.
-	TaskWritingCategoryChange = "writing category change"
-
-	// TaskWritingCategoryCreate creates a new writing category.
-	TaskWritingCategoryCreate = "writing category create"
-
-	// TaskNotify sends a custom notification to users.
-	TaskNotify = "Notify"
-
-	// TaskPurge removes old records.
-	TaskPurge = "Purge"
-
-	// TaskSubscribeBlogs subscribes a user to all blog posts.
-	TaskSubscribeBlogs = "Subscribe blogs"
-
-	// TaskSubscribeWritings subscribes a user to all writing posts.
-	TaskSubscribeWritings = "Subscribe writings"
-
-	// TaskSubscribeNews subscribes a user to all news posts.
-	TaskSubscribeNews = "Subscribe news"
-
-	// TaskSubscribeImages subscribes a user to all image board posts.
-	TaskSubscribeImages = "Subscribe images"
+	// TaskCreate indicates creation of an object.
+	TaskCreate = "Create"
 )


### PR DESCRIPTION
## Summary
- adjust FAQ task Match methods to avoid using struct components

## Testing
- `go mod tidy`
- `go fmt ./...` *(fails: expected ';', etc.)*
- `go vet ./...` *(fails: invalid pattern syntax)*
- `golangci-lint run ./...` *(fails: multiple typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_68788ba9bb30832fbb5a239679f1dca6