### PR TITLE
Refine image upload task

### DIFF
--- a/handlers/images/routes.go
+++ b/handlers/images/routes.go
@@ -2,15 +2,9 @@ package images
 
 import (
 	"bytes"
-	"crypto/sha1"
-	"database/sql"
-	"fmt"
-	"io"
-	"log"
 	"net/http"
 	"path"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -18,11 +12,9 @@ import (
 	"github.com/arran4/goa4web/config"
 	corecommon "github.com/arran4/goa4web/core/common"
 	handlers "github.com/arran4/goa4web/handlers"
-	db "github.com/arran4/goa4web/internal/db"
 	router "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/internal/upload"
 	imagesign "github.com/arran4/goa4web/pkg/images"
-	"github.com/disintegration/imaging"
 )
 
 // SetSigningKey stores the key used for signing URLs.
@@ -61,7 +53,10 @@ func verify(data, tsStr, sig string) bool { return imagesign.Verify(data, tsStr,
 
 // RegisterRoutes attaches the image endpoints to r.
 func RegisterRoutes(r *mux.Router) {
-	r.HandleFunc("/images/upload/image", uploadHandler).Methods(http.MethodPost)
+	r.HandleFunc("/images/upload/image", uploadImageTask.Action).
+		Methods(http.MethodPost).
+		MatcherFunc(handlers.RequiresAnAccount()).
+		MatcherFunc(uploadImageTask.Matcher())
 	r.HandleFunc("/images/pasteimg.js", handlers.PasteImageJS).Methods(http.MethodGet)
 	r.Handle("/images/image/{id}", verifyMiddleware("image:")(http.HandlerFunc(serveImage))).Methods(http.MethodGet)
 	r.Handle("/images/cache/{id}", verifyMiddleware("cache:")(http.HandlerFunc(serveCache))).Methods(http.MethodGet)
@@ -97,90 +92,6 @@ func serveCache(w http.ResponseWriter, r *http.Request) {
 	}
 	full := filepath.Join(config.AppRuntimeConfig.ImageCacheDir, sub1, sub2, id)
 	http.ServeFile(w, r, full)
-}
-
-func uploadHandler(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, int64(config.AppRuntimeConfig.ImageMaxBytes))
-	if err := r.ParseMultipartForm(int64(config.AppRuntimeConfig.ImageMaxBytes)); err != nil {
-		http.Error(w, "bad upload", http.StatusBadRequest)
-		return
-	}
-	file, header, err := r.FormFile("image")
-	if err != nil {
-		http.Error(w, "image required", http.StatusBadRequest)
-		return
-	}
-	defer file.Close()
-
-	data, err := io.ReadAll(file)
-	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-	size := int64(len(data))
-
-	img, err := imaging.Decode(bytes.NewReader(data))
-	if err != nil {
-		http.Error(w, "invalid image", http.StatusBadRequest)
-		return
-	}
-
-	id := r.FormValue("id")
-	if id == "" {
-		id = fmt.Sprintf("%x", sha1.Sum(data))
-	}
-	ext := strings.ToLower(filepath.Ext(header.Filename))
-	sub1, sub2 := id[:2], id[2:4]
-	fname := id + ext
-	if p := upload.ProviderFromConfig(config.AppRuntimeConfig); p != nil {
-		if err := p.Write(r.Context(), path.Join(sub1, sub2, fname), data); err != nil {
-			log.Printf("upload write: %v", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
-	}
-	width := img.Bounds().Dx()
-	height := img.Bounds().Dy()
-	thumb := imaging.Thumbnail(img, 200, 200, imaging.Lanczos)
-	thumbName := id + "_thumb" + ext
-	var tbuf bytes.Buffer
-	imgFmt, _ := imaging.FormatFromExtension(ext)
-	if err := imaging.Encode(&tbuf, thumb, imgFmt); err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-	if cp := upload.CacheProviderFromConfig(config.AppRuntimeConfig); cp != nil {
-		if err := cp.Write(r.Context(), path.Join(sub1, sub2, thumbName), tbuf.Bytes()); err != nil {
-			log.Printf("cache write: %v", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
-		if ccp, ok := cp.(upload.CacheProvider); ok {
-			_ = ccp.Cleanup(r.Context(), int64(config.AppRuntimeConfig.ImageCacheMaxBytes))
-		}
-	}
-
-	url := path.Join("/uploads", sub1, sub2, fname)
-
-	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
-	uid := int32(0)
-	if cd, ok := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData); ok && cd != nil {
-		uid = cd.UserID
-	}
-	_, err = queries.CreateUploadedImage(r.Context(), db.CreateUploadedImageParams{
-		UsersIdusers: uid,
-		Path:         sql.NullString{String: url, Valid: true},
-		Width:        sql.NullInt32{Int32: int32(width), Valid: true},
-		Height:       sql.NullInt32{Int32: int32(height), Valid: true},
-		FileSize:     int32(size),
-	})
-	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "text/plain")
-	_, _ = w.Write([]byte(imagesign.SignedRef("image:" + fname)))
 }
 
 // Register registers the images router module.

--- a/handlers/images/tasks.go
+++ b/handlers/images/tasks.go
@@ -1,0 +1,6 @@
+package images
+
+import "github.com/arran4/goa4web/internal/tasks"
+
+// TaskUploadImage identifies a user image upload request.
+const TaskUploadImage tasks.TaskString = "Upload image"

--- a/handlers/images/upload_task.go
+++ b/handlers/images/upload_task.go
@@ -1,0 +1,113 @@
+package images
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"database/sql"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/arran4/goa4web/config"
+	corecommon "github.com/arran4/goa4web/core/common"
+	handlers "github.com/arran4/goa4web/handlers"
+	db "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/arran4/goa4web/internal/upload"
+	imagesign "github.com/arran4/goa4web/pkg/images"
+	"github.com/disintegration/imaging"
+)
+
+// UploadImageTask processes authenticated image uploads.
+type UploadImageTask struct{ tasks.TaskString }
+
+var uploadImageTask = &UploadImageTask{TaskString: TaskUploadImage}
+
+func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, int64(config.AppRuntimeConfig.ImageMaxBytes))
+	if err := r.ParseMultipartForm(int64(config.AppRuntimeConfig.ImageMaxBytes)); err != nil {
+		http.Error(w, "bad upload", http.StatusBadRequest)
+		return
+	}
+	file, header, err := r.FormFile("image")
+	if err != nil {
+		http.Error(w, "image required", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	size := int64(len(data))
+
+	img, err := imaging.Decode(bytes.NewReader(data))
+	if err != nil {
+		http.Error(w, "invalid image", http.StatusBadRequest)
+		return
+	}
+
+	id := r.FormValue("id")
+	if id == "" {
+		id = fmt.Sprintf("%x", sha1.Sum(data))
+	}
+	ext := strings.ToLower(filepath.Ext(header.Filename))
+	sub1, sub2 := id[:2], id[2:4]
+	fname := id + ext
+	if p := upload.ProviderFromConfig(config.AppRuntimeConfig); p != nil {
+		if err := p.Write(r.Context(), path.Join(sub1, sub2, fname), data); err != nil {
+			log.Printf("upload write: %v", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+	}
+	width := img.Bounds().Dx()
+	height := img.Bounds().Dy()
+	thumb := imaging.Thumbnail(img, 200, 200, imaging.Lanczos)
+	thumbName := id + "_thumb" + ext
+	var tbuf bytes.Buffer
+	imgFmt, _ := imaging.FormatFromExtension(ext)
+	if err := imaging.Encode(&tbuf, thumb, imgFmt); err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	if cp := upload.CacheProviderFromConfig(config.AppRuntimeConfig); cp != nil {
+		if err := cp.Write(r.Context(), path.Join(sub1, sub2, thumbName), tbuf.Bytes()); err != nil {
+			log.Printf("cache write: %v", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		if ccp, ok := cp.(upload.CacheProvider); ok {
+			_ = ccp.Cleanup(r.Context(), int64(config.AppRuntimeConfig.ImageCacheMaxBytes))
+		}
+	}
+
+	url := path.Join("/uploads", sub1, sub2, fname)
+
+	queries := r.Context().Value(handlers.KeyQueries).(*db.Queries)
+	uid := int32(0)
+	if cd, ok := r.Context().Value(handlers.KeyCoreData).(*corecommon.CoreData); ok && cd != nil {
+		uid = cd.UserID
+	}
+	_, err = queries.CreateUploadedImage(r.Context(), db.CreateUploadedImageParams{
+		UsersIdusers: uid,
+		Path:         sql.NullString{String: url, Valid: true},
+		Width:        sql.NullInt32{Int32: int32(width), Valid: true},
+		Height:       sql.NullInt32{Int32: int32(height), Valid: true},
+		FileSize:     int32(size),
+	})
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain")
+	_, _ = w.Write([]byte(imagesign.SignedRef("image:" + fname)))
+}


### PR DESCRIPTION
## Summary
- inline upload handler logic into `UploadImageTask` to avoid proxying
- register upload route using `UploadImageTask` and require authentication

## Testing
- `go mod tidy`
- `go fmt ./...` *(fails: expected ';', found 'if' in internal/notifications/bus_worker.go)*
- `go vet ./...` *(fails: invalid embed pattern)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: invalid embed pattern)*

------
https://chatgpt.com/codex/tasks/task_e_68788bc309d0832fb5b08118ad6b4304