### PR TITLE
Refactor user tasks

### DIFF
--- a/handlers/user/tasks.go
+++ b/handlers/user/tasks.go
@@ -1,33 +1,40 @@
 package user
 
-// Task constants mirror values used by the main package.
+import "github.com/arran4/goa4web/internal/tasks"
+
+// The following constants define the allowed values of the "task" form field.
+// Each HTML form includes a hidden or submit input named "task" whose value
+// identifies the intended action. When routes are registered the constants are
+// passed to gorillamuxlogic's HasTask so that only requests specifying the
+// expected task reach a handler. Centralising these string values avoids typos
+// between templates and route declarations.
 const (
 	// TaskSaveLanguages saves multiple languages at once.
-	TaskSaveLanguages = "Save languages"
+	TaskSaveLanguages tasks.TaskString = "Save languages"
 	// TaskSaveLanguage saves updates to a single language.
-	TaskSaveLanguage = "Save language"
+	TaskSaveLanguage tasks.TaskString = "Save language"
 	// TaskSaveAll saves all changes in bulk.
-	TaskSaveAll = "Save all"
+	TaskSaveAll tasks.TaskString = "Save all"
 	// TaskTestMail sends a test email to the current user.
-	TaskTestMail = "Test mail"
+	TaskTestMail tasks.TaskString = "Test mail"
 	// TaskDismiss marks a notification as read.
-	TaskDismiss = "Dismiss"
+	TaskDismiss tasks.TaskString = "Dismiss"
 
 	// TaskAdd represents the "Add" action.
-	TaskAdd = "Add"
+	TaskAdd tasks.TaskString = "Add"
 
 	// TaskDelete removes an existing item.
-	TaskDelete = "Delete"
+	TaskDelete tasks.TaskString = "Delete"
 
 	// TaskUpdate updates an existing item.
-	TaskUpdate = "Update"
+	TaskUpdate tasks.TaskString = "Update"
 
 	// TaskUserAllow grants a user a permission or level.
-	TaskUserAllow = "User Allow"
+	TaskUserAllow tasks.TaskString = "User Allow"
 
 	// TaskUserDisallow removes a user's permission or level.
-	TaskUserDisallow = "User Disallow"
+	TaskUserDisallow tasks.TaskString = "User Disallow"
 
 	// TaskUserEmailVerification verifies a user's email address.
-	TaskUserEmailVerification = "Email Verification"
+	TaskUserEmailVerification tasks.TaskString = "Email Verification"
 )


### PR DESCRIPTION
## Summary
- convert user task constants to typed `tasks.TaskString`
- document allowed task values

## Testing
- `go mod tidy`
- `go fmt ./...` *(fails: internal/notifications/bus_worker.go: syntax errors)*
- `go vet ./...` *(fails: invalid pattern in templates.go)*
- `golangci-lint run ./...` *(fails: numerous typecheck errors)*
- `go test ./...` *(fails: invalid pattern in templates.go)*

------
https://chatgpt.com/codex/tasks/task_e_6878c7d1f19c832f80f9b0ab83a769a8