### PR TITLE
refactor utils paths

### DIFF
--- a/cmd/goa4web/config_test_cmd.go
+++ b/cmd/goa4web/config_test_cmd.go
@@ -11,10 +11,10 @@ import (
 
 	coretemplates "github.com/arran4/goa4web/core/templates"
 
+	"github.com/arran4/goa4web/config"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/dlq"
 	"github.com/arran4/goa4web/internal/email"
-	"github.com/arran4/goa4web/internal/utils/emailutil"
 )
 
 //go:embed templates/config_test_usage.txt
@@ -101,7 +101,7 @@ func (c *configTestEmailCmd) Run() error {
 		q = dbpkg.New(db)
 	}
 	ctx := context.Background()
-	emails := emailutil.GetAdminEmails(ctx, q)
+	emails := config.GetAdminEmails(ctx, q)
 	if len(emails) == 0 {
 		return fmt.Errorf("no administrator emails configured")
 	}

--- a/cmd/goa4web/user_approve.go
+++ b/cmd/goa4web/user_approve.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	dbpkg "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/utils/emailutil"
+	notif "github.com/arran4/goa4web/internal/notifications"
 )
 
 // userApproveCmd approves a pending user account.
@@ -54,7 +54,7 @@ func (c *userApproveCmd) Run() error {
 		return fmt.Errorf("add role: %w", err)
 	}
 	if u, err := queries.GetUserById(ctx, int32(c.ID)); err == nil && u.Email.Valid {
-		_ = emailutil.CreateEmailTemplateAndQueue(ctx, queries, int32(c.ID), u.Email.String, "", "user approved", nil)
+		_ = notif.CreateEmailTemplateAndQueue(ctx, queries, int32(c.ID), u.Email.String, "", "user approved", nil)
 	}
 	if c.rootCmd.Verbosity > 0 {
 		fmt.Printf("approved user %d\n", c.ID)

--- a/cmd/goa4web/user_reject.go
+++ b/cmd/goa4web/user_reject.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	dbpkg "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/utils/emailutil"
+	notif "github.com/arran4/goa4web/internal/notifications"
 )
 
 // userRejectCmd rejects a pending user account.
@@ -60,7 +60,7 @@ func (c *userRejectCmd) Run() error {
 	}
 	if u, err := queries.GetUserById(ctx, int32(c.ID)); err == nil && u.Email.Valid {
 		item := struct{ Reason string }{Reason: c.Reason}
-		_ = emailutil.CreateEmailTemplateAndQueue(ctx, queries, int32(c.ID), u.Email.String, "", "user rejected", item)
+		_ = notif.CreateEmailTemplateAndQueue(ctx, queries, int32(c.ID), u.Email.String, "", "user rejected", item)
 	}
 	if c.rootCmd.Verbosity > 0 {
 		fmt.Printf("rejected user %d\n", c.ID)

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/email"
-	"github.com/arran4/goa4web/internal/utils/emailutil"
+	emailutil "github.com/arran4/goa4web/internal/notifications"
 )
 
 type saveTemplateTask struct{ tasks.BasicTaskEvent }

--- a/handlers/admin/adminIPBanPage.go
+++ b/handlers/admin/adminIPBanPage.go
@@ -11,7 +11,6 @@ import (
 
 	common "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/utils/netutil"
 )
 
 type addIPBanTask struct{ tasks.BasicTaskEvent }
@@ -37,7 +36,7 @@ func AdminIPBanPage(w http.ResponseWriter, r *http.Request) {
 func (addIPBanTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 	ipNet := strings.TrimSpace(r.PostFormValue("ip"))
-	ipNet = netutil.NormalizeIPNet(ipNet)
+	ipNet = NormalizeIPNet(ipNet)
 	reason := strings.TrimSpace(r.PostFormValue("reason"))
 	expiresStr := strings.TrimSpace(r.PostFormValue("expires"))
 	var expires sql.NullTime
@@ -62,7 +61,7 @@ func (deleteIPBanTask) Action(w http.ResponseWriter, r *http.Request) {
 		log.Printf("ParseForm: %v", err)
 	}
 	for _, ip := range r.Form["ip"] {
-		ipNet := netutil.NormalizeIPNet(ip)
+		ipNet := NormalizeIPNet(ip)
 		if err := queries.CancelBannedIp(r.Context(), ipNet); err != nil {
 			log.Printf("cancel banned ip %s: %v", ipNet, err)
 		}

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -8,8 +8,8 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/utils/emailutil"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	emailutil "github.com/arran4/goa4web/internal/notifications"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -171,12 +171,12 @@ func BlogReplyPostPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO move to searchworker that is automatically activated by a event.
-	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchworker.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchworker.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -13,7 +13,7 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
@@ -120,12 +120,12 @@ func ThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO move to searchworker that is automatically activated by a event.
-	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchworker.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchworker.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -10,13 +10,11 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/email"
 
-	"github.com/arran4/goa4web/internal/utils/emailutil"
-
 	"github.com/arran4/goa4web/core"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 )
 
 func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +52,7 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Error: listUsersSubscribedToThread: %s", err)
 	} else if provider != nil {
 		for _, row := range rows {
-			if err := emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, endUrl, "update", nil); err != nil {
+			if err := notif.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, endUrl, "update", nil); err != nil {
 				log.Printf("Error: notifyChange: %s", err)
 			}
 		}
@@ -67,7 +65,7 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Error: listUsersSubscribedToThread: %s", err)
 	} else if provider != nil {
 		for _, row := range rows {
-			if err := emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, endUrl, "update", nil); err != nil {
+			if err := notif.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, endUrl, "update", nil); err != nil {
 				log.Printf("Error: notifyChange: %s", err)
 
 			}
@@ -96,12 +94,12 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO move to searchworker that is automatically activated by a event.
-	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchworker.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchworker.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -16,7 +16,7 @@ import (
 	"github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
@@ -168,12 +168,12 @@ func BoardPostImageActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchworker.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if searchutil.InsertWordsToImageSearch(w, r, wordIds, queries, pid) {
+	if searchworker.InsertWordsToImageSearch(w, r, wordIds, queries, pid) {
 		return
 	}
 

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -11,7 +11,7 @@ import (
 	"github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
@@ -288,12 +288,12 @@ func BoardThreadReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO move to searchworker that is automatically activated by a event.
-	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchworker.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchworker.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/linker/linkerAdminQueuePage.go
+++ b/handlers/linker/linkerAdminQueuePage.go
@@ -13,7 +13,7 @@ import (
 	corecommon "github.com/arran4/goa4web/core/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 )
 
 func AdminQueuePage(w http.ResponseWriter, r *http.Request) {
@@ -165,11 +165,11 @@ func AdminQueueApproveActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, text := range []string{link.Title.String, link.Description.String} {
-		wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
+		wordIds, done := searchworker.SearchWordIdsFromText(w, r, text, queries)
 		if done {
 			return
 		}
-		if searchutil.InsertWordsToLinkerSearch(w, r, wordIds, queries, lid) {
+		if searchworker.InsertWordsToLinkerSearch(w, r, wordIds, queries, lid) {
 			return
 		}
 	}
@@ -208,11 +208,11 @@ func AdminQueueBulkApproveActionPage(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		for _, text := range []string{link.Title.String, link.Description.String} {
-			wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
+			wordIds, done := searchworker.SearchWordIdsFromText(w, r, text, queries)
 			if done {
 				return
 			}
-			if searchutil.InsertWordsToLinkerSearch(w, r, wordIds, queries, lid) {
+			if searchworker.InsertWordsToLinkerSearch(w, r, wordIds, queries, lid) {
 				return
 			}
 		}

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -12,11 +12,11 @@ import (
 	corelanguage "github.com/arran4/goa4web/core/language"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/email"
-	"github.com/arran4/goa4web/internal/utils/emailutil"
+	emailutil "github.com/arran4/goa4web/internal/notifications"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
@@ -282,12 +282,12 @@ func CommentsReplyPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO move to searchworker that is automatically activated by a event.
-	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchworker.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchworker.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -12,11 +12,11 @@ import (
 	corelanguage "github.com/arran4/goa4web/core/language"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/email"
-	"github.com/arran4/goa4web/internal/utils/emailutil"
+	emailutil "github.com/arran4/goa4web/internal/notifications"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
@@ -194,12 +194,12 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO move to searchworker that is automatically activated by a event.
-	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchworker.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchworker.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 

--- a/handlers/news/searchResultNewsActionPage.go
+++ b/handlers/news/searchResultNewsActionPage.go
@@ -9,8 +9,8 @@ import (
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
-	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+       db "github.com/arran4/goa4web/internal/db"
+       searchworker "github.com/arran4/goa4web/internal/searchworker"
 )
 
 func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
@@ -61,7 +61,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func NewsSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow, bool, bool, error) {
-	searchWords := searchutil.BreakupTextToWords(r.PostFormValue("searchwords"))
+       searchWords := searchworker.BreakupTextToWords(r.PostFormValue("searchwords"))
 	var newsIds []int32
 
 	if len(searchWords) == 0 {
@@ -127,7 +127,7 @@ func NewsSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid
 }
 
 func forumCommentSearchInRestrictedTopic(w http.ResponseWriter, r *http.Request, queries *db.Queries, forumTopicId []int32, uid int32) ([]*db.GetCommentsByIdsForUserWithThreadInfoRow, bool, bool, error) {
-	searchWords := searchutil.BreakupTextToWords(r.PostFormValue("searchwords"))
+       searchWords := searchworker.BreakupTextToWords(r.PostFormValue("searchwords"))
 	var commentIds []int32
 
 	if len(searchWords) == 0 {

--- a/handlers/search/searchResultBlogsActionPage.go
+++ b/handlers/search/searchResultBlogsActionPage.go
@@ -9,7 +9,7 @@ import (
 	common "github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 
 	"github.com/arran4/goa4web/core"
 )
@@ -62,7 +62,7 @@ func SearchResultBlogsActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func BlogSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.Blog, bool, bool, error) {
-	searchWords := searchutil.BreakupTextToWords(r.PostFormValue("searchwords"))
+	searchWords := searchworker.BreakupTextToWords(r.PostFormValue("searchwords"))
 	var blogIds []int32
 
 	if len(searchWords) == 0 {

--- a/handlers/search/searchResultForumActionPage.go
+++ b/handlers/search/searchResultForumActionPage.go
@@ -9,7 +9,7 @@ import (
 	common "github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 
 	"github.com/arran4/goa4web/core"
 )
@@ -44,7 +44,7 @@ func SearchResultForumActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func ForumCommentSearchNotInRestrictedTopic(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetCommentsByIdsForUserWithThreadInfoRow, bool, bool, error) {
-	searchWords := searchutil.BreakupTextToWords(r.PostFormValue("searchwords"))
+	searchWords := searchworker.BreakupTextToWords(r.PostFormValue("searchwords"))
 	var commentIds []int32
 
 	if len(searchWords) == 0 {
@@ -110,7 +110,7 @@ func ForumCommentSearchNotInRestrictedTopic(w http.ResponseWriter, r *http.Reque
 }
 
 func ForumCommentSearchInRestrictedTopic(w http.ResponseWriter, r *http.Request, queries *db.Queries, forumTopicId []int32, uid int32) ([]*db.GetCommentsByIdsForUserWithThreadInfoRow, bool, bool, error) {
-	searchWords := searchutil.BreakupTextToWords(r.PostFormValue("searchwords"))
+	searchWords := searchworker.BreakupTextToWords(r.PostFormValue("searchwords"))
 	var commentIds []int32
 
 	if len(searchWords) == 0 {

--- a/handlers/search/searchResultLinkerActionPage.go
+++ b/handlers/search/searchResultLinkerActionPage.go
@@ -10,7 +10,7 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	hlinker "github.com/arran4/goa4web/handlers/linker"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 
 	"github.com/arran4/goa4web/core"
 )
@@ -64,7 +64,7 @@ func SearchResultLinkerActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func LinkerSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow, bool, bool, error) {
-	searchWords := searchutil.BreakupTextToWords(r.PostFormValue("searchwords"))
+	searchWords := searchworker.BreakupTextToWords(r.PostFormValue("searchwords"))
 	var LinkerIds []int32
 
 	if len(searchWords) == 0 {

--- a/handlers/search/searchResultWritingsActionPage.go
+++ b/handlers/search/searchResultWritingsActionPage.go
@@ -10,7 +10,7 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	hwritings "github.com/arran4/goa4web/handlers/writings"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 
 	"github.com/arran4/goa4web/core"
 )
@@ -63,7 +63,7 @@ func SearchResultWritingsActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func WritingSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetWritingsByIdsForUserDescendingByPublishedDateRow, bool, bool, error) {
-	searchWords := searchutil.BreakupTextToWords(r.PostFormValue("searchwords"))
+	searchWords := searchworker.BreakupTextToWords(r.PostFormValue("searchwords"))
 	var writingsIds []int32
 
 	if len(searchWords) == 0 {

--- a/handlers/search/search_test.go
+++ b/handlers/search/search_test.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	dbpkg "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -24,7 +24,7 @@ func TestIsAlphanumericOrPunctuation(t *testing.T) {
 		{'!', false},
 	}
 	for _, c := range cases {
-		if got := searchutil.IsAlphanumericOrPunctuation(c.r); got != c.want {
+		if got := searchworker.IsAlphanumericOrPunctuation(c.r); got != c.want {
 			t.Errorf("%q got %v want %v", string(c.r), got, c.want)
 		}
 	}
@@ -43,7 +43,7 @@ func TestIsAlphanumericOrPunctuationExtra(t *testing.T) {
 		{'世', true},
 	}
 	for _, tt := range tests {
-		if got := searchutil.IsAlphanumericOrPunctuation(tt.r); got != tt.want {
+		if got := searchworker.IsAlphanumericOrPunctuation(tt.r); got != tt.want {
 			t.Errorf("%q got %v want %v", string(tt.r), got, tt.want)
 		}
 	}
@@ -51,7 +51,7 @@ func TestIsAlphanumericOrPunctuationExtra(t *testing.T) {
 
 func TestBreakupTextToWords(t *testing.T) {
 	in := "Hello, world! It's-me"
-	words := searchutil.BreakupTextToWords(in)
+	words := searchworker.BreakupTextToWords(in)
 	want := []string{"Hello", "world", "It's-me"}
 	if len(words) != len(want) {
 		t.Fatalf("len=%d want %d", len(words), len(want))
@@ -77,7 +77,7 @@ func TestBreakupTextToWordsEdge(t *testing.T) {
 		{"こんにちは 世界", []string{"こんにちは", "世界"}},
 	}
 	for _, c := range cases {
-		got := searchutil.BreakupTextToWords(c.in)
+		got := searchworker.BreakupTextToWords(c.in)
 		if len(got) != len(c.want) {
 			t.Errorf("%q len=%d want %d", c.in, len(got), len(c.want))
 			continue
@@ -120,7 +120,7 @@ func TestSearchWordIdsFromText(t *testing.T) {
 	q := dbpkg.New(db)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
-	ids, redirect := searchutil.SearchWordIdsFromText(rr, req, "Hello world Hello", q)
+	ids, redirect := searchworker.SearchWordIdsFromText(rr, req, "Hello world Hello", q)
 	if redirect {
 		t.Fatalf("unexpected redirect")
 	}
@@ -137,7 +137,7 @@ func TestSearchWordIdsFromTextError(t *testing.T) {
 	q := dbpkg.New(db)
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
-	ids, redirect := searchutil.SearchWordIdsFromText(rr, req, "bad", q)
+	ids, redirect := searchworker.SearchWordIdsFromText(rr, req, "bad", q)
 	if ids != nil {
 		t.Fatal("expected nil ids")
 	}

--- a/handlers/user/admin_pending.go
+++ b/handlers/user/admin_pending.go
@@ -7,7 +7,7 @@ import (
 
 	common "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/utils/emailutil"
+	emailutil "github.com/arran4/goa4web/internal/notifications"
 )
 
 func adminPendingUsersPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -19,7 +19,7 @@ import (
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/internal/email"
-	"github.com/arran4/goa4web/internal/utils/emailutil"
+	emailutil "github.com/arran4/goa4web/internal/notifications"
 
 	"github.com/arran4/goa4web/config"
 )

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -11,7 +11,7 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
@@ -86,12 +86,12 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 		title,
 		body,
 	} {
-		wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
+		wordIds, done := searchworker.SearchWordIdsFromText(w, r, text, queries)
 		if done {
 			return
 		}
 
-		if searchutil.InsertWordsToWritingSearch(w, r, wordIds, queries, articleId) {
+		if searchworker.InsertWordsToWritingSearch(w, r, wordIds, queries, articleId) {
 			return
 		}
 	}

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -11,7 +11,7 @@ import (
 	common "github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
@@ -92,12 +92,12 @@ func ArticleEditActionPage(w http.ResponseWriter, r *http.Request) {
 		title,
 		body,
 	} {
-		wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
+		wordIds, done := searchworker.SearchWordIdsFromText(w, r, text, queries)
 		if done {
 			return
 		}
 
-		if searchutil.InsertWordsToWritingSearch(w, r, wordIds, queries, int64(writing.Idwriting)) {
+		if searchworker.InsertWordsToWritingSearch(w, r, wordIds, queries, int64(writing.Idwriting)) {
 			return
 		}
 	}

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -15,7 +15,7 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/notifications"
-	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
+	searchworker "github.com/arran4/goa4web/internal/searchworker"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
@@ -381,12 +381,12 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 
 	// TODO move to searchworker that is automatically activated by a event.
 	cid := int64(0)
-	wordIds, done := searchutil.SearchWordIdsFromText(w, r, text, queries)
+	wordIds, done := searchworker.SearchWordIdsFromText(w, r, text, queries)
 	if done {
 		return
 	}
 
-	if searchutil.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
+	if searchworker.InsertWordsToForumSearch(w, r, wordIds, queries, cid) {
 		return
 	}
 	//??? if _, done := SearchWordIdsFromText(w, r, text, queries); done {

--- a/internal/dlq/email/email.go
+++ b/internal/dlq/email/email.go
@@ -10,7 +10,7 @@ import (
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/dlq"
 	"github.com/arran4/goa4web/internal/email"
-	"github.com/arran4/goa4web/internal/utils/emailutil"
+	emailutil "github.com/arran4/goa4web/internal/notifications"
 )
 
 // DLQ sends DLQ messages to administrator emails using the configured provider.

--- a/internal/email/emaildefaults/email_test.go
+++ b/internal/email/emaildefaults/email_test.go
@@ -19,7 +19,8 @@ import (
 	mockemail "github.com/arran4/goa4web/internal/email/mock"
 	sesProv "github.com/arran4/goa4web/internal/email/ses"
 	smtpProv "github.com/arran4/goa4web/internal/email/smtp"
-	"github.com/arran4/goa4web/internal/utils/emailutil"
+	emailqueue "github.com/arran4/goa4web/internal/emailqueue"
+	emailutil "github.com/arran4/goa4web/internal/notifications"
 	"strings"
 )
 
@@ -133,7 +134,7 @@ func TestEmailQueueWorker(t *testing.T) {
 	mock.ExpectExec("UPDATE pending_emails SET sent_at").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	rec := &mockemail.Provider{}
-	emailutil.ProcessPendingEmail(context.Background(), q, rec, nil)
+	emailqueue.ProcessPendingEmail(context.Background(), q, rec, nil)
 
 	if len(rec.Messages) != 1 || rec.Messages[0].To.String() != "\"bob\" <e@>" {
 		t.Fatalf("got %#v", rec.Messages)
@@ -167,7 +168,7 @@ func TestProcessPendingEmailDLQ(t *testing.T) {
 
 	p := errProvider{}
 	dlqRec := &mockdlq.Provider{}
-	emailutil.ProcessPendingEmail(context.Background(), q, p, dlqRec)
+	emailqueue.ProcessPendingEmail(context.Background(), q, p, dlqRec)
 
 	if len(dlqRec.Records) != 1 {
 		t.Fatalf("dlq records=%d", len(dlqRec.Records))

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	dbpkg "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/utils/emailutil"
 )
 
 func TestNotificationsQueries(t *testing.T) {
@@ -88,7 +87,7 @@ func TestNotifyThreadSubscribers(t *testing.T) {
 		WillReturnRows(rows)
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(int32(2), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 	rec := &dummyProvider{}
-	emailutil.NotifyThreadSubscribers(context.Background(), rec, q, 2, 1, "/p")
+	NotifyThreadSubscribers(context.Background(), rec, q, 2, 1, "/p")
 	if rec.to != "" {
 		t.Fatalf("expected no direct mail got %s", rec.to)
 	}


### PR DESCRIPTION
## Summary
- update imports to use new notification and search packages
- drop deprecated internal/utils references
- adjust IP ban page to use admin net utilities

## Testing
- `go vet ./...` *(fails: expected 'package', found 'const')*
- `golangci-lint run ./...`
- `go test ./...` *(fails: expected 'package', found 'const')*

------
https://chatgpt.com/codex/tasks/task_e_68782a0d5640832f97c8d36455d31a23