### PR TITLE
Move log and audit workers out of eventbus

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -18,10 +18,12 @@ import (
 	corelanguage "github.com/arran4/goa4web/core/language"
 	adminhandlers "github.com/arran4/goa4web/handlers/admin"
 	imageshandler "github.com/arran4/goa4web/handlers/images"
+	"github.com/arran4/goa4web/internal/auditworker"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/dlq"
 	email "github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/internal/logworker"
 	middleware "github.com/arran4/goa4web/internal/middleware"
 	csrfmw "github.com/arran4/goa4web/internal/middleware/csrf"
 	notifications "github.com/arran4/goa4web/internal/notifications"
@@ -154,9 +156,9 @@ func startWorkers(ctx context.Context, db *sql.DB, provider email.Provider, dlqP
 	log.Printf("Starting notification purger worker")
 	safeGo(func() { notifications.NotificationPurgeWorker(ctx, dbpkg.New(db), time.Hour) })
 	log.Printf("Starting event bus logger worker")
-	safeGo(func() { eventbus.LogWorker(ctx, eventbus.DefaultBus) })
+	safeGo(func() { logworker.Worker(ctx, eventbus.DefaultBus) })
 	log.Printf("Starting audit worker")
-	safeGo(func() { eventbus.AuditWorker(ctx, eventbus.DefaultBus, dbpkg.New(db)) })
+	safeGo(func() { auditworker.Worker(ctx, eventbus.DefaultBus, dbpkg.New(db)) })
 	log.Printf("Starting notification bus worker")
 	safeGo(func() {
 		notifications.BusWorker(ctx, eventbus.DefaultBus, provider, dbpkg.New(db), dlqProvider)

--- a/internal/auditworker/worker.go
+++ b/internal/auditworker/worker.go
@@ -1,28 +1,16 @@
-package eventbus
+package auditworker
 
 import (
 	"context"
 	"log"
 
 	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
-// LogWorker listens on the bus and logs all received events.
-func LogWorker(ctx context.Context, bus *Bus) {
-	ch := bus.Subscribe()
-	for {
-		select {
-		case evt := <-ch:
-			log.Printf("event path=%s task=%s uid=%d data=%v", evt.Path, evt.Task, evt.UserID, evt.Data)
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-// AuditWorker records bus events into the audit_log table.
-func AuditWorker(ctx context.Context, bus *Bus, q *dbpkg.Queries) {
+// Worker records bus events into the audit_log table.
+func Worker(ctx context.Context, bus *eventbus.Bus, q *dbpkg.Queries) {
 	if q == nil || bus == nil {
 		return
 	}

--- a/internal/logworker/worker.go
+++ b/internal/logworker/worker.go
@@ -1,0 +1,24 @@
+package logworker
+
+import (
+	"context"
+	"log"
+
+	"github.com/arran4/goa4web/internal/eventbus"
+)
+
+// Worker listens on the bus and logs all received events.
+func Worker(ctx context.Context, bus *eventbus.Bus) {
+	if bus == nil {
+		return
+	}
+	ch := bus.Subscribe()
+	for {
+		select {
+		case evt := <-ch:
+			log.Printf("event path=%s task=%s uid=%d data=%v", evt.Path, evt.Task, evt.UserID, evt.Data)
+		case <-ctx.Done():
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- refactor: move log/audit workers into their own packages
- update app startup to use new worker locations

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot use tasks.TaskString in middleware etc.)*
- `golangci-lint run` *(fails: typecheck errors in notifications and other packages)*
- `go test ./...` *(fails to build multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_6879853ce770832fb17268f30d36ba39