### PR TITLE
Add email subject templates

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -23,6 +23,8 @@ const (
 	// EnvEmailFrom sets the default From address for outgoing mail.
 	// The value must be a valid RFC 5322 address.
 	EnvEmailFrom = "EMAIL_FROM"
+	// EnvEmailSubjectPrefix sets the prefix used for email subjects.
+	EnvEmailSubjectPrefix = "EMAIL_SUBJECT_PREFIX"
 	// EnvAWSRegion is the AWS region for the SES provider.
 	EnvAWSRegion = "AWS_REGION"
 	// EnvJMAPEndpoint is the JMAP API endpoint.

--- a/config/options_runtime.go
+++ b/config/options_runtime.go
@@ -44,6 +44,7 @@ var StringOptions = []StringOption{
 	{"smtp-pass", EnvSMTPPass, "SMTP pass", "", nil, "", func(c *RuntimeConfig) *string { return &c.EmailSMTPPass }},
 	{"smtp-auth", EnvSMTPAuth, "SMTP auth method", "", nil, "", func(c *RuntimeConfig) *string { return &c.EmailSMTPAuth }},
 	{"email-from", EnvEmailFrom, "default From address", "", nil, "", func(c *RuntimeConfig) *string { return &c.EmailFrom }},
+	{"email-subject-prefix", EnvEmailSubjectPrefix, "email subject prefix", "goa4web", nil, "", func(c *RuntimeConfig) *string { return &c.EmailSubjectPrefix }},
 	{"aws-region", EnvAWSRegion, "AWS region", "", []string{"us-east-1"}, "", func(c *RuntimeConfig) *string { return &c.EmailAWSRegion }},
 	{"jmap-endpoint", EnvJMAPEndpoint, "JMAP endpoint", "", nil, "", func(c *RuntimeConfig) *string { return &c.EmailJMAPEndpoint }},
 	{"jmap-account", EnvJMAPAccount, "JMAP account", "", nil, "", func(c *RuntimeConfig) *string { return &c.EmailJMAPAccount }},

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -20,21 +20,22 @@ type RuntimeConfig struct {
 	HTTPListen   string
 	HTTPHostname string
 
-	EmailProvider     string
-	EmailSMTPHost     string
-	EmailSMTPPort     string
-	EmailSMTPUser     string
-	EmailSMTPPass     string
-	EmailSMTPAuth     string
-	EmailSMTPStartTLS bool
-	EmailFrom         string
-	EmailAWSRegion    string
-	EmailJMAPEndpoint string
-	EmailJMAPAccount  string
-	EmailJMAPIdentity string
-	EmailJMAPUser     string
-	EmailJMAPPass     string
-	EmailSendGridKey  string
+	EmailProvider      string
+	EmailSMTPHost      string
+	EmailSMTPPort      string
+	EmailSMTPUser      string
+	EmailSMTPPass      string
+	EmailSMTPAuth      string
+	EmailSMTPStartTLS  bool
+	EmailFrom          string
+	EmailAWSRegion     string
+	EmailJMAPEndpoint  string
+	EmailJMAPAccount   string
+	EmailJMAPIdentity  string
+	EmailJMAPUser      string
+	EmailJMAPPass      string
+	EmailSendGridKey   string
+	EmailSubjectPrefix string
 
 	// EmailEnabled toggles sending queued emails.
 	EmailEnabled bool

--- a/core/templates/email/adminNotificationUserRequestPasswordResetEmailSubject.gotxt
+++ b/core/templates/email/adminNotificationUserRequestPasswordResetEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] User Password Reset Requested

--- a/core/templates/email/blogEmail.gotxt
+++ b/core/templates/email/blogEmail.gotxt
@@ -1,6 +1,6 @@
 To: {{.To}}
 From: {{.From}}
-Subject: [A4] {{.Subject}}
+Subject: [{{.SubjectPrefix}}] {{.Subject}}
 
 Hello,
 

--- a/core/templates/email/passwordResetEmail.gotxt
+++ b/core/templates/email/passwordResetEmail.gotxt
@@ -1,6 +1,6 @@
 To: {{.To}}
 From: {{.From}}
-Subject: [A4] Password reset request
+Subject: [{{.SubjectPrefix}}] Password reset request
 
 Hi {{.Item.Username}},
 Use code {{.Item.Code}} when logging in with your new password.

--- a/core/templates/email/passwordResetEmailSubject.gotxt
+++ b/core/templates/email/passwordResetEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Password reset request

--- a/core/templates/email/replyEmail.gotxt
+++ b/core/templates/email/replyEmail.gotxt
@@ -1,6 +1,6 @@
 To: {{.To}}
 From: {{.From}}
-Subject: [A4] {{.Subject}}
+Subject: [{{.SubjectPrefix}}] {{.Subject}}
 
 Hi {{.Item.Thread.Lastposterusername.String}},
 

--- a/core/templates/email/signupEmail.gotxt
+++ b/core/templates/email/signupEmail.gotxt
@@ -1,6 +1,6 @@
 To: {{.To}}
 From: {{.From}}
-Subject: [A4] {{.Subject}}
+Subject: [{{.SubjectPrefix}}] {{.Subject}}
 
 Hello,
 

--- a/core/templates/email/threadEmail.gotxt
+++ b/core/templates/email/threadEmail.gotxt
@@ -1,6 +1,6 @@
 To: {{.To}}
 From: {{.From}}
-Subject: [A4] {{.Subject}}
+Subject: [{{.SubjectPrefix}}] {{.Subject}}
 
 Hello,
 

--- a/core/templates/email/updateEmail.gotxt
+++ b/core/templates/email/updateEmail.gotxt
@@ -1,6 +1,6 @@
 To: {{.To}}
 From: {{.From}}
-Subject: [A4] {{.Subject}}
+Subject: [{{.SubjectPrefix}}] {{.Subject}}
 
 Hello,
 

--- a/core/templates/email/userApprovedEmail.gotxt
+++ b/core/templates/email/userApprovedEmail.gotxt
@@ -1,6 +1,6 @@
 To: {{.To}}
 From: {{.From}}
-Subject: [A4] {{.Subject}}
+Subject: [{{.SubjectPrefix}}] {{.Subject}}
 
 Hello,
 

--- a/core/templates/email/userRejectedEmail.gotxt
+++ b/core/templates/email/userRejectedEmail.gotxt
@@ -1,6 +1,6 @@
 To: {{.To}}
 From: {{.From}}
-Subject: [A4] {{.Subject}}
+Subject: [{{.SubjectPrefix}}] {{.Subject}}
 
 Hello,
 

--- a/core/templates/email/verifyEmail.gotxt
+++ b/core/templates/email/verifyEmail.gotxt
@@ -1,6 +1,6 @@
 To: {{.To}}
 From: {{.From}}
-Subject: [A4] Verify your email
+Subject: [{{.SubjectPrefix}}] Verify your email
 
 Hi {{.Item.Username}},
 Please verify your email address by visiting:

--- a/core/templates/email/writingEmail.gotxt
+++ b/core/templates/email/writingEmail.gotxt
@@ -1,6 +1,6 @@
 To: {{.To}}
 From: {{.From}}
-Subject: [A4] {{.Subject}}
+Subject: [{{.SubjectPrefix}}] {{.Subject}}
 
 Hello,
 

--- a/handlers/auth/forgotPassword.go
+++ b/handlers/auth/forgotPassword.go
@@ -29,10 +29,7 @@ var forgotPasswordTask = &ForgotPasswordTask{
 }
 
 func (f ForgotPasswordTask) AdminEmailTemplate() *notif.EmailTemplates {
-	return &notif.EmailTemplates{
-		Text: "adminNotificationUserRequestPasswordResetEmail.gotxt",
-		HTML: "adminNotificationUserRequestPasswordResetEmail.gohtml",
-	}
+	return notif.NewEmailTemplates("adminNotificationUserRequestPasswordResetEmail")
 }
 
 func (f ForgotPasswordTask) AdminInternalNotificationTemplate() *string {
@@ -41,10 +38,7 @@ func (f ForgotPasswordTask) AdminInternalNotificationTemplate() *string {
 }
 
 func (f ForgotPasswordTask) SelfEmailTemplate() *notif.EmailTemplates {
-	return &notif.EmailTemplates{
-		Text: "userRequestPasswordResetEmail.gotxt",
-		HTML: "userRequestPasswordResetEmail.gohtml",
-	}
+	return notif.NewEmailTemplates("passwordResetEmail")
 }
 
 func (f ForgotPasswordTask) SelfInternalNotificationTemplate() *string {

--- a/handlers/auth/forgotPassword_test.go
+++ b/handlers/auth/forgotPassword_test.go
@@ -1,0 +1,27 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/core/templates"
+)
+
+func requireEmailTemplates(t *testing.T, prefix string) {
+	t.Helper()
+	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
+	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
+	if htmlTmpls.Lookup(prefix+".gohtml") == nil {
+		t.Errorf("missing html template %s.gohtml", prefix)
+	}
+	if textTmpls.Lookup(prefix+".gotxt") == nil {
+		t.Errorf("missing text template %s.gotxt", prefix)
+	}
+	if textTmpls.Lookup(prefix+"Subject.gotxt") == nil {
+		t.Errorf("missing subject template %sSubject.gotxt", prefix)
+	}
+}
+
+func TestForgotPasswordTemplatesExist(t *testing.T) {
+	requireEmailTemplates(t, "passwordResetEmail")
+	requireEmailTemplates(t, "adminNotificationUserRequestPasswordResetEmail")
+}

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"html/template"
 	"log"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/arran4/goa4web/config"
@@ -22,7 +22,7 @@ import (
 
 type namedTask struct{ name string }
 
-func (n namedTask) TaskName() string { return n.name }
+func (n namedTask) Name() string { return n.name }
 
 func dlqRecordAndNotify(ctx context.Context, q dlq.DLQ, n Notifier, msg string) error {
 	if q == nil {
@@ -84,13 +84,20 @@ func collectSubscribers(ctx context.Context, q *dbpkg.Queries, patterns []string
 }
 
 // sendSubscriberEmail queues an email notification for a subscriber.
-func sendSubscriberEmail(ctx context.Context, n Notifier, userID int32, evt eventbus.Event) error {
+func sendSubscriberEmail(ctx context.Context, n Notifier, userID int32, evt eventbus.Event, et *EmailTemplates) error {
 	user, err := n.Queries.GetUserById(ctx, userID)
 	if err != nil || !user.Email.Valid || user.Email.String == "" {
 		notifyMissingEmail(ctx, n.Queries, userID)
 		return err
 	}
-	return CreateEmailTemplateAndQueue(ctx, n.Queries, userID, user.Email.String, evt.Path, evt.Task, evt.Data)
+	if et != nil {
+		return QueueEmailFromTemplates(ctx, n.Queries, userID, user.Email.String, et, evt.Data)
+	}
+	name := ""
+	if tn, ok := evt.Task.(tasks.Name); ok {
+		name = tn.Name()
+	}
+	return CreateEmailTemplateAndQueue(ctx, n.Queries, userID, user.Email.String, evt.Path, name, evt.Data)
 }
 
 // sendInternalNotification stores an internal notification for the user.
@@ -157,7 +164,7 @@ func processEvent(ctx context.Context, evt eventbus.Event, n Notifier, q dlq.DLQ
 	}
 
 	if tp, ok := evt.Task.(SelfNotificationTemplateProvider); ok {
-		if err := notifySelf(ctx, evt, n, tp, tp); err != nil {
+		if err := notifySelf(ctx, evt, n, tp); err != nil {
 			if dlqErr := dlqRecordAndNotify(ctx, q, n, fmt.Sprintf("deliver self to %d: %v", evt.UserID, err)); dlqErr != nil {
 				return dlqErr
 			}
@@ -189,8 +196,18 @@ func notifySelf(ctx context.Context, evt eventbus.Event, n Notifier, tp SelfNoti
 	if err != nil || !user.Email.Valid || user.Email.String == "" {
 		notifyMissingEmail(ctx, n.Queries, evt.UserID)
 	} else {
-		if err := CreateEmailTemplateAndQueue(ctx, n.Queries, evt.UserID, user.Email.String, evt.Path, evt.Task, evt.Data); err != nil {
-			return err
+		if et := tp.SelfEmailTemplate(); et != nil {
+			if err := QueueEmailFromTemplates(ctx, n.Queries, evt.UserID, user.Email.String, et, evt.Data); err != nil {
+				return err
+			}
+		} else {
+			name := ""
+			if tn, ok := evt.Task.(tasks.Name); ok {
+				name = tn.Name()
+			}
+			if err := CreateEmailTemplateAndQueue(ctx, n.Queries, evt.UserID, user.Email.String, evt.Path, name, evt.Data); err != nil {
+				return err
+			}
 		}
 	}
 	msg := renderMessage(ctx, n.Queries, evt.Task, evt.Path, evt.Data)
@@ -206,8 +223,12 @@ func notifySelf(ctx context.Context, evt eventbus.Event, n Notifier, tp SelfNoti
 	return nil
 }
 
-func notifySubscribers(ctx context.Context, evt eventbus.Event, n Notifier) error {
-	patterns := buildPatterns(namedTask{evt.Task}, evt.Path)
+func notifySubscribers(ctx context.Context, evt eventbus.Event, n Notifier, tp SubscribersNotificationTemplateProvider) error {
+	name := ""
+	if tn, ok := evt.Task.(tasks.Name); ok {
+		name = tn.Name()
+	}
+	patterns := buildPatterns(namedTask{name}, evt.Path)
 
 	emailSubs, err := collectSubscribers(ctx, n.Queries, patterns, "email")
 	if err != nil {
@@ -221,10 +242,20 @@ func notifySubscribers(ctx context.Context, evt eventbus.Event, n Notifier) erro
 	delete(emailSubs, evt.UserID)
 	delete(internalSubs, evt.UserID)
 
-	msg := renderMessage(ctx, n.Queries, evt.Task, evt.Path, evt.Data)
+	var msg string
+	if nt := tp.SubscribedInternalNotificationTemplate(); nt != nil {
+		var buf bytes.Buffer
+		noteTmpls := templates.GetCompiledNotificationTemplates(map[string]any{})
+		if err := noteTmpls.ExecuteTemplate(&buf, *nt, evt.Data); err == nil {
+			msg = buf.String()
+		}
+	} else {
+		msg = renderMessage(ctx, n.Queries, evt.Task, evt.Path, evt.Data)
+	}
 
+	et := tp.SubscribedEmailTemplate()
 	for id := range emailSubs {
-		if err := sendSubscriberEmail(ctx, n, id, evt); err != nil {
+		if err := sendSubscriberEmail(ctx, n, id, evt, et); err != nil {
 			return fmt.Errorf("deliver email to %d: %w", id, err)
 		}
 	}
@@ -251,8 +282,8 @@ func handleAutoSubscribe(ctx context.Context, evt eventbus.Event, n Notifier, tp
 	}
 	if auto {
 		task, path := tp.AutoSubscribePath()
-		pattern := buildPatterns(task, path)[0]
-		if internalNotification {
+		pattern := buildPatterns(namedTask{task}, path)[0]
+		if config.AppRuntimeConfig.NotificationsEnabled {
 			ensureSubscription(ctx, n.Queries, evt.UserID, pattern, "internal")
 		}
 		if email {
@@ -275,7 +306,7 @@ func notifyAdmins(ctx context.Context, evt eventbus.Event, n Notifier, tp AdminE
 			}
 		}
 		if et := tp.AdminEmailTemplate(); et != nil {
-			if err := CreateEmailTemplateAndQueue(ctx, n.Queries, uid, addr, evt.Path, evt.Task, evt.Data); err != nil {
+			if err := QueueEmailFromTemplates(ctx, n.Queries, uid, addr, et, evt.Data); err != nil {
 				return err
 			}
 		}
@@ -311,6 +342,20 @@ func ensureSubscription(ctx context.Context, q *dbpkg.Queries, userID int32, pat
 	if err := q.InsertSubscription(ctx, dbpkg.InsertSubscriptionParams{UsersIdusers: userID, Pattern: pattern, Method: method}); err != nil {
 		log.Printf("insert subscription: %v", err)
 	}
+}
+
+func renderMessage(ctx context.Context, q *dbpkg.Queries, task tasks.Task, path string, data any) string {
+	tmpl := templates.GetCompiledNotificationTemplates(map[string]any{})
+	name := ""
+	if tn, ok := task.(tasks.Name); ok {
+		name = strings.ToLower(tn.Name()) + ".gotxt"
+	}
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, name, data); err != nil {
+		log.Printf("render message %s: %v", name, err)
+		return ""
+	}
+	return buf.String()
 }
 
 func notifyMissingEmail(ctx context.Context, q *dbpkg.Queries, userID int32) {

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -2,7 +2,6 @@ package notifications
 
 import (
 	"context"
-	"database/sql"
 	"log"
 
 	"github.com/arran4/goa4web/config"
@@ -25,7 +24,7 @@ func NotifyAdmins(ctx context.Context, n Notifier, page string) {
 	for _, addr := range config.GetAdminEmails(ctx, n.Queries) {
 		var uid int32
 		if n.Queries != nil {
-			if u, err := n.Queries.UserByEmail(ctx, sql.NullString{String: addr, Valid: true}); err == nil {
+			if u, err := n.Queries.UserByEmail(ctx, addr); err == nil {
 				uid = u.Idusers
 			} else {
 				log.Printf("user by email %s: %v", addr, err)

--- a/internal/notifications/subscriptionsinterfaces.go
+++ b/internal/notifications/subscriptionsinterfaces.go
@@ -1,8 +1,25 @@
 package notifications
 
 type EmailTemplates struct {
-	Text string
-	HTML string
+	Text    string
+	HTML    string
+	Subject string
+}
+
+// CreateEmail renders the templates using emailAddr and data.
+// This is a convenience wrapper around RenderEmailFromTemplates.
+func (et *EmailTemplates) CreateEmail(emailAddr string, data interface{}) ([]byte, error) {
+	return RenderEmailFromTemplates(emailAddr, et, data)
+}
+
+// NewEmailTemplates returns EmailTemplates populated with file names derived
+// from prefix.
+func NewEmailTemplates(prefix string) *EmailTemplates {
+	return &EmailTemplates{
+		Text:    prefix + ".gotxt",
+		HTML:    prefix + ".gohtml",
+		Subject: prefix + "Subject.gotxt",
+	}
 }
 
 // AdminEmailTemplateProvider indicates the notification should be sent via

--- a/internal/tasks/task_event.go
+++ b/internal/tasks/task_event.go
@@ -27,6 +27,9 @@ func (t TaskString) Name() string {
 	return string(t)
 }
 
+// Action implements the Task interface. TODO: evaluate if this is required.
+func (t TaskString) Action(http.ResponseWriter, *http.Request) {}
+
 func (t TaskString) Matcher() mux.MatcherFunc {
 	return HasTask(string(t))
 }


### PR DESCRIPTION
## Summary
- add subject templates for password reset emails
- support subject rendering via `EmailTemplates`
- expose `EMAIL_SUBJECT_PREFIX` flag and config
- allow subscriber emails to use provided templates
- minor refactors and TODO markers for future cleanup
- fix subscriber pattern generation

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: build errors)*
- `golangci-lint run` *(fails: typecheck errors)*
- `go test ./...` *(build failures)*


------
https://chatgpt.com/codex/tasks/task_e_687984eca318832f81454b4c183bd27e