### PR TITLE
Update admin event checks in tests

### DIFF
--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -114,7 +114,8 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 		t.Fatalf("location=%q", loc)
 	}
 	evt := cd.Event()
-	if !evt.Admin || evt.Path != "/admin/faq" {
+	named, ok := evt.Task.(tasks.Name)
+	if !ok || named.Name() != TaskAsk || evt.Path != "/admin/faq" {
 		t.Fatalf("event %+v", evt)
 	}
 


### PR DESCRIPTION
## Summary
- use `tasks.Name` and path prefix checks in `TaskEventMiddleware` tests
- update FAQ ask page test to check task name instead of deleted admin flag

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: undefined types in dbstart and other packages)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879c4c5e034832f920243d771487e37