### PR TITLE
Align linker task constants with common style

### DIFF
--- a/handlers/linker/tasks.go
+++ b/handlers/linker/tasks.go
@@ -1,49 +1,54 @@
 package linker
 
+import "github.com/arran4/goa4web/internal/tasks"
+
 // The following constants define the allowed values of the "task" form field.
 // Each HTML form includes a hidden or submit input named "task" whose value
-// identifies the intended action.
+// identifies the intended action. When routes are registered the constants are
+// passed to gorillamuxlogic's HasTask so that only requests specifying the
+// expected task reach a handler. Centralising these string values avoids typos
+// between templates and route declarations.
 const (
 	// TaskReply posts a reply to a thread or comment.
-	TaskReply = "Reply"
+	TaskReply tasks.TaskString = "Reply"
 
 	// TaskEditReply edits a comment or reply.
-	TaskEditReply = "Edit Reply"
+	TaskEditReply tasks.TaskString = "Edit Reply"
 
 	// TaskSuggest creates a suggestion in the linker.
-	TaskSuggest = "Suggest"
+	TaskSuggest tasks.TaskString = "Suggest"
 
 	// TaskUpdate updates an existing item.
-	TaskUpdate = "Update"
+	TaskUpdate tasks.TaskString = "Update"
 
 	// TaskRenameCategory renames a category.
-	TaskRenameCategory = "Rename Category"
+	TaskRenameCategory tasks.TaskString = "Rename Category"
 
 	// TaskDeleteCategory removes a category.
-	TaskDeleteCategory = "Delete Category"
+	TaskDeleteCategory tasks.TaskString = "Delete Category"
 
 	// TaskCreateCategory creates a new category entry.
-	TaskCreateCategory = "Create Category"
+	TaskCreateCategory tasks.TaskString = "Create Category"
 
 	// TaskAdd represents the "Add" action, commonly used when creating a new
 	// record.
-	TaskAdd = "Add"
+	TaskAdd tasks.TaskString = "Add"
 
 	// TaskDelete removes an existing item.
-	TaskDelete = "Delete"
+	TaskDelete tasks.TaskString = "Delete"
 
 	// TaskApprove approves an item in moderation queues.
-	TaskApprove = "Approve"
+	TaskApprove tasks.TaskString = "Approve"
 
 	// TaskBulkApprove approves multiple queued items at once.
-	TaskBulkApprove = "Bulk Approve"
+	TaskBulkApprove tasks.TaskString = "Bulk Approve"
 
 	// TaskBulkDelete removes multiple queued items at once.
-	TaskBulkDelete = "Bulk Delete"
+	TaskBulkDelete tasks.TaskString = "Bulk Delete"
 
 	// TaskUserAllow grants a user a permission or level.
-	TaskUserAllow = "User Allow"
+	TaskUserAllow tasks.TaskString = "User Allow"
 
 	// TaskUserDisallow removes a user's permission or level.
-	TaskUserDisallow = "User Disallow"
+	TaskUserDisallow tasks.TaskString = "User Disallow"
 )


### PR DESCRIPTION
## Summary
- update linker task constants to use `tasks.TaskString`
- add missing details in task comment block

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: declared and not used: name, undefined: named, etc.)*
- `golangci-lint run ./...` *(fails: typecheck errors in notifications and handlers)*
- `go test ./...` *(fails: typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879ef934a0c832fad88cd64e5f9ad64