### PR TITLE
Align linker handler with new router

### DIFF
--- a/handlers/linker/linkerCommentsEditPage.go
+++ b/handlers/linker/linkerCommentsEditPage.go
@@ -16,12 +16,12 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// CommentEditActionPage updates a comment then refreshes thread metadata.
-type editReplyTask struct{ tasks.TaskString }
+// commentEditAction updates a comment then refreshes thread metadata.
+type commentEditActionTask struct{ tasks.TaskString }
 
-var EditReplyTask = &editReplyTask{TaskString: TaskEditReply}
+var commentEditAction = &commentEditActionTask{TaskString: TaskEditReply}
 
-func (editReplyTask) Action(w http.ResponseWriter, r *http.Request) {
+func (commentEditActionTask) Page(w http.ResponseWriter, r *http.Request) {
 	languageId, err := strconv.Atoi(r.PostFormValue("language"))
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
@@ -82,7 +82,11 @@ func (editReplyTask) Action(w http.ResponseWriter, r *http.Request) {
 }
 
 // CommentEditActionCancelPage aborts editing a comment.
-func CommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
+type commentEditActionCancelTask struct{ tasks.TaskString }
+
+var commentEditActionCancel = &commentEditActionCancelTask{TaskString: TaskCancel}
+
+func (commentEditActionCancelTask) Page(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	linkId, _ := strconv.Atoi(vars["link"])
 	http.Redirect(w, r, fmt.Sprintf("/linker/comments/%d", linkId), http.StatusTemporaryRedirect)

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 
 	common "github.com/arran4/goa4web/core/common"
 	corelanguage "github.com/arran4/goa4web/core/language"
@@ -150,7 +151,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 
 type replyTask struct{ tasks.TaskString }
 
-var ReplyTaskEvent = &replyTask{TaskString: TaskReply}
+var replyTaskEvent = &replyTask{TaskString: TaskReply}
 
 func (replyTask) IndexType() string { return searchworker.TypeComment }
 
@@ -162,6 +163,14 @@ func (replyTask) IndexData(data map[string]any) []searchworker.IndexEventData {
 }
 
 var _ searchworker.IndexedTask = replyTask{}
+
+func (replyTask) Page(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/linker/comments/") {
+		CommentsPage(w, r)
+		return
+	}
+	ShowPage(w, r)
+}
 
 func (replyTask) Action(w http.ResponseWriter, r *http.Request) {
 	session, ok := core.GetSessionOrFail(w, r)

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -55,11 +55,13 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 	handlers.TemplateHandler(w, r, "suggestPage.gohtml", data)
 }
 
-type suggestTask struct{ tasks.TaskString }
+type suggestTaskStruct struct{ tasks.TaskString }
 
-var SuggestTask = &suggestTask{TaskString: TaskSuggest}
+var suggestTask = &suggestTaskStruct{TaskString: TaskSuggest}
 
-func (suggestTask) Action(w http.ResponseWriter, r *http.Request) {
+func (suggestTaskStruct) Page(w http.ResponseWriter, r *http.Request) { SuggestPage(w, r) }
+
+func (suggestTaskStruct) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
 	session, ok := core.GetSessionOrFail(w, r)

--- a/handlers/linker/tasks.go
+++ b/handlers/linker/tasks.go
@@ -18,6 +18,9 @@ const (
 	// TaskSuggest creates a suggestion in the linker.
 	TaskSuggest tasks.TaskString = "Suggest"
 
+	// TaskCancel aborts an edit action.
+	TaskCancel tasks.TaskString = "Cancel"
+
 	// TaskUpdate updates an existing item.
 	TaskUpdate tasks.TaskString = "Update"
 


### PR DESCRIPTION
## Summary
- rename linker task variables to match new router expectations
- expose new Page methods on suggest and comment edit tasks
- add TaskCancel constant for linker

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: undefined references in multiple packages)*
- `golangci-lint run ./...` *(fails: vet errors)*
- `go test ./...` *(fails: compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879f3910614832fb308c48cd65a83f7