### PR TITLE
Fix linker handler names

### DIFF
--- a/handlers/linker/linkerCommentsEditPage.go
+++ b/handlers/linker/linkerCommentsEditPage.go
@@ -17,11 +17,15 @@ import (
 )
 
 // CommentEditActionPage updates a comment then refreshes thread metadata.
-type editReplyTask struct{ tasks.TaskString }
+type EditReplyTask struct{ tasks.TaskString }
 
-var EditReplyTask = &editReplyTask{TaskString: TaskEditReply}
+var commentEditAction = &EditReplyTask{TaskString: TaskEditReply}
 
-func (editReplyTask) Action(w http.ResponseWriter, r *http.Request) {
+func (t EditReplyTask) Page(w http.ResponseWriter, r *http.Request) {
+	t.Action(w, r)
+}
+
+func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) {
 	languageId, err := strconv.Atoi(r.PostFormValue("language"))
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
@@ -86,4 +90,12 @@ func CommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	linkId, _ := strconv.Atoi(vars["link"])
 	http.Redirect(w, r, fmt.Sprintf("/linker/comments/%d", linkId), http.StatusTemporaryRedirect)
+}
+
+type cancelEditReplyTask struct{ tasks.TaskString }
+
+var commentEditActionCancel = &cancelEditReplyTask{TaskString: TaskCancel}
+
+func (cancelEditReplyTask) Page(w http.ResponseWriter, r *http.Request) {
+	CommentEditActionCancelPage(w, r)
 }

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -150,7 +150,9 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 
 type replyTask struct{ tasks.TaskString }
 
-var ReplyTaskEvent = &replyTask{TaskString: TaskReply}
+var replyTaskEvent = &replyTask{TaskString: TaskReply}
+
+func (replyTask) Page(w http.ResponseWriter, r *http.Request) { CommentsPage(w, r) }
 
 func (replyTask) IndexType() string { return searchworker.TypeComment }
 

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -55,11 +55,13 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 	handlers.TemplateHandler(w, r, "suggestPage.gohtml", data)
 }
 
-type suggestTask struct{ tasks.TaskString }
+type SuggestTask struct{ tasks.TaskString }
 
-var SuggestTask = &suggestTask{TaskString: TaskSuggest}
+var suggestTask = &SuggestTask{TaskString: TaskSuggest}
 
-func (suggestTask) Action(w http.ResponseWriter, r *http.Request) {
+func (SuggestTask) Page(w http.ResponseWriter, r *http.Request) { SuggestPage(w, r) }
+
+func (SuggestTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(common.KeyQueries).(*db.Queries)
 
 	session, ok := core.GetSessionOrFail(w, r)

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -2,7 +2,6 @@ package linker
 
 import (
 	"github.com/arran4/goa4web/handlers/forum/comments"
-	"github.com/arran4/goa4web/internal/tasks"
 	"net/http"
 
 	handlers "github.com/arran4/goa4web/handlers"

--- a/handlers/linker/tasks.go
+++ b/handlers/linker/tasks.go
@@ -15,6 +15,10 @@ const (
 	// TaskEditReply edits a comment or reply.
 	TaskEditReply tasks.TaskString = "Edit Reply"
 
+	// TaskCancel cancels the current operation and returns to the previous
+	// page.
+	TaskCancel tasks.TaskString = "Cancel"
+
 	// TaskSuggest creates a suggestion in the linker.
 	TaskSuggest tasks.TaskString = "Suggest"
 


### PR DESCRIPTION
## Summary
- align linker handler variable names with router
- implement Page methods for reply and suggest tasks
- add cancel task constant and definitions

## Testing
- `go vet ./handlers/linker/...`
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879f3910614832fb308c48cd65a83f7