### PR TITLE
Fix event path assignment

### DIFF
--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -211,12 +211,13 @@ func (AddEmailTask) Action(w http.ResponseWriter, r *http.Request) {
 		page = strings.TrimRight(config.AppRuntimeConfig.HTTPHostname, "/") + "/usr/email/verify?code=" + code
 	}
 	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
-	evt := cd.Event()
-	evt.Path = // TODO
-	if evt.Data == nil {
-		evt.Data = map[string]any{}
+	if evt := cd.Event(); evt != nil {
+		evt.Path = r.URL.Path
+		if evt.Data == nil {
+			evt.Data = map[string]any{}
+		}
+		evt.Data["page"] = page
 	}
-	evt.Data["page"] = page
 	// _ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, uid, emailAddr, page, TaskUserEmailVerification, nil) TODO Make addEmailTask sendSelf
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }
@@ -248,12 +249,13 @@ func (AddEmailTask) Resend(w http.ResponseWriter, r *http.Request) {
 		page = strings.TrimRight(config.AppRuntimeConfig.HTTPHostname, "/") + "/usr/email/verify?code=" + code
 	}
 	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
-	evt := cd.Event()
-	evt.Path = // TODO
-	if evt.Data == nil {
-		evt.Data = map[string]any{}
+	if evt := cd.Event(); evt != nil {
+		evt.Path = r.URL.Path
+		if evt.Data == nil {
+			evt.Data = map[string]any{}
+		}
+		evt.Data["page"] = page
 	}
-	evt.Data["page"] = page
 
 	// _ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, uid, ue.Email, page, TaskUserEmailVerification, nil) TODO make AddEmailTask sendSelf
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)


### PR DESCRIPTION
## Summary
- ensure AddEmailTask records event path
- ensure AddEmailTask.Resend records event path

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: handlers/blogs/routes.go:5:2: "github.com/arran4/goa4web/internal/tasks" imported and not used)*
- `golangci-lint run ./...` *(fails: cmd/goa4web/config_test_cmd.go:104:22: undefined: emailutil.GetAdminEmails)*
- `go test ./...` *(fails to build handlers/blogs and others)*

------
https://chatgpt.com/codex/tasks/task_e_687a02066140832f8fbe4f2b69612222