### PR TITLE
Fix BusWorker argument mismatch

### DIFF
--- a/workers/workers.go
+++ b/workers/workers.go
@@ -48,7 +48,8 @@ func Start(ctx context.Context, db *sql.DB, provider email.Provider, dlqProvider
 	safeGo(func() { auditworker.Worker(ctx, eventbus.DefaultBus, dbpkg.New(db)) })
 	log.Printf("Starting notification bus worker")
 	safeGo(func() {
-		notifications.BusWorker(ctx, eventbus.DefaultBus, provider, dbpkg.New(db), dlqProvider)
+		n := notifications.Notifier{EmailProvider: provider, Queries: dbpkg.New(db)}
+		notifications.BusWorker(ctx, eventbus.DefaultBus, n, dlqProvider)
 	})
 	log.Printf("Starting search index worker")
 	safeGo(func() { searchworker.Worker(ctx, eventbus.DefaultBus, dbpkg.New(db)) })


### PR DESCRIPTION
## Summary
- build Notifier struct for BusWorker

## Testing
- `go mod tidy`
- `gofmt -w workers/workers.go`
- `go fmt ./...` *(fails: expected operand in userEmailPage.go)*
- `go vet ./...` *(fails: several undefined identifiers)*
- `golangci-lint run ./...` *(fails: various typecheck issues)*
- `go test ./...` *(fails: build errors and test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687a02250d3c832f937bac9c09edc780