### PR TITLE
Refactor notifications to struct methods

### DIFF
--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -132,7 +132,8 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	config.AppRuntimeConfig.AdminEmails = "a@test.com,b@test.com"
 	defer func() { config.AppRuntimeConfig.AdminEmails = origEmails }()
 	rec := &recordAdminMail{}
-	notif.NotifyAdmins(context.Background(), notif.Notifier{EmailProvider: rec}, &notif.EmailTemplates{}, notif.EmailData{})
+	n := notif.New(nil, rec)
+	n.NotifyAdmins(context.Background(), &notif.EmailTemplates{}, notif.EmailData{})
 	if len(rec.to) != 2 {
 		t.Fatalf("expected 2 mails, got %d", len(rec.to))
 	}
@@ -155,7 +156,8 @@ func TestNotifyAdminsDisabled(t *testing.T) {
 	config.AppRuntimeConfig.AdminEmails = "a@test.com"
 	defer func() { config.AppRuntimeConfig.AdminEmails = origEmails }()
 	rec := &recordAdminMail{}
-	notif.NotifyAdmins(context.Background(), notif.Notifier{EmailProvider: rec}, &notif.EmailTemplates{}, notif.EmailData{})
+	n := notif.New(nil, rec)
+	n.NotifyAdmins(context.Background(), &notif.EmailTemplates{}, notif.EmailData{})
 	if len(rec.to) != 0 {
 		t.Fatalf("expected 0 mails, got %d", len(rec.to))
 	}

--- a/handlers/blogs/task_structs.go
+++ b/handlers/blogs/task_structs.go
@@ -1,0 +1,25 @@
+package blogs
+
+import (
+	"net/http"
+
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// EditReplyTask updates an existing comment.
+type EditReplyTask struct{ tasks.TaskString }
+
+var editReplyTask = &EditReplyTask{TaskString: TaskEditReply}
+
+func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) {
+	CommentEditPostPage(w, r)
+}
+
+// CancelTask cancels comment editing.
+type CancelTask struct{ tasks.TaskString }
+
+var cancelTask = &CancelTask{TaskString: TaskCancel}
+
+func (CancelTask) Action(w http.ResponseWriter, r *http.Request) {
+	CommentEditPostCancelPage(w, r)
+}

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -179,7 +179,8 @@ func (TestMailTask) Action(w http.ResponseWriter, r *http.Request) {
 		handlers.TaskErrorAcknowledgementPage(w, r)
 		return
 	}
-	if err := emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, user.Idusers, addr, pageURL, "update", nil); err != nil {
+	n := emailutil.New(queries, provider)
+	if err := n.CreateEmailTemplateAndQueue(r.Context(), user.Idusers, addr, pageURL, "update", nil); err != nil {
 		log.Printf("notify Error: %s", err)
 	}
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
@@ -217,7 +218,7 @@ func (AddEmailTask) Action(w http.ResponseWriter, r *http.Request) {
 	}
 	cd := r.Context().Value(common.KeyCoreData).(*common.CoreData)
 	evt := cd.Event()
-  evt.Data["page"] = page
+	evt.Data["page"] = page
 	// _ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, uid, emailAddr, page, TaskUserEmailVerification, nil) TODO Make addEmailTask sendSelf
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }

--- a/internal/notifications/dlq.go
+++ b/internal/notifications/dlq.go
@@ -7,7 +7,7 @@ import (
 	"github.com/arran4/goa4web/internal/dlq/db"
 )
 
-func dlqRecordAndNotify(ctx context.Context, q dlq.DLQ, n Notifier, msg string) error {
+func dlqRecordAndNotify(ctx context.Context, q dlq.DLQ, n *Notifier, msg string) error {
 	if q == nil {
 		return fmt.Errorf("no dlq provider")
 	}
@@ -16,7 +16,7 @@ func dlqRecordAndNotify(ctx context.Context, q dlq.DLQ, n Notifier, msg string) 
 			if count, err := dbq.Queries.CountDeadLetters(ctx); err == nil {
 				if isPow10(count) {
 					// TODO create template and data
-					err := NotifyAdmins(ctx, n, &EmailTemplates{
+					err := n.NotifyAdmins(ctx, &EmailTemplates{
 						Text:    EmailTextTemplateFilenameGenerator("dlqMultiFailure"),
 						HTML:    EmailHTMLTemplateFilenameGenerator("dlqMultiFailure"),
 						Subject: EmailSubjectTemplateFilenameGenerator("dlqMultiFailure"),

--- a/internal/notifications/email.go
+++ b/internal/notifications/email.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/arran4/goa4web/internal/eventbus"
-	"github.com/arran4/goa4web/internal/tasks"
 	"strings"
 
 	"github.com/arran4/goa4web/config"
@@ -13,28 +12,31 @@ import (
 )
 
 // TODO: make private once call sites are updated.
-func CreateEmailTemplateAndQueue(ctx context.Context, q *db.Queries, userID int32, emailAddr, page, action string, item interface{}) error {
-	if q == nil {
+func (n *Notifier) CreateEmailTemplateAndQueue(ctx context.Context, userID int32, emailAddr, page, action string, item interface{}) error {
+	if n.Queries == nil {
 		return fmt.Errorf("no query")
 	}
-	msg, _, err := CreateEmailFromTemplates(ctx, emailAddr, page, action, item)
+	prefix := strings.ToLower(action) + "Email"
+	et := NewEmailTemplates(prefix)
+	data := map[string]any{"page": page, "item": item}
+	msg, err := n.RenderEmailFromTemplates(ctx, emailAddr, et, data)
 	if err != nil {
 		return err
 	}
-	return queueEmail(ctx, q, userID, msg)
+	return n.queueEmail(ctx, userID, msg)
 }
 
 // RenderAndQueueEmailFromTemplates renders the provided templates and queues the result.
 // TODO: make private and unify call sites.
-func RenderAndQueueEmailFromTemplates(ctx context.Context, q *db.Queries, userID int32, emailAddr string, et *EmailTemplates, data interface{}) error {
-	if q == nil {
+func (n *Notifier) RenderAndQueueEmailFromTemplates(ctx context.Context, userID int32, emailAddr string, et *EmailTemplates, data interface{}) error {
+	if n.Queries == nil {
 		return fmt.Errorf("no query")
 	}
-	msg, err := RenderEmailFromTemplates(ctx, q, emailAddr, et, data)
+	msg, err := n.RenderEmailFromTemplates(ctx, emailAddr, et, data)
 	if err != nil {
 		return err
 	}
-	return queueEmail(ctx, q, userID, msg)
+	return n.queueEmail(ctx, userID, msg)
 }
 
 type EmailData struct {
@@ -46,7 +48,7 @@ type EmailData struct {
 
 // RenderEmailFromTemplates returns the rendered email message using the provided templates.
 // TODO: evaluate exposing this via EmailTemplates.CreateEmail instead.
-func RenderEmailFromTemplates(ctx context.Context, q *db.Queries, emailAddr string, et *EmailTemplates, item interface{}) ([]byte, error) {
+func (n *Notifier) RenderEmailFromTemplates(ctx context.Context, emailAddr string, et *EmailTemplates, item interface{}) ([]byte, error) {
 	if emailAddr == "" {
 		return nil, fmt.Errorf("no email specified")
 	}
@@ -71,21 +73,21 @@ func RenderEmailFromTemplates(ctx context.Context, q *db.Queries, emailAddr stri
 	var textBody, htmlBody string
 	subject := "[" + subjectPrefix + "] Website Update Notification"
 	if et.Subject != "" {
-		bs, err := renderEmailSubject(ctx, q, et.Subject, data)
+		bs, err := n.renderEmailSubject(ctx, et.Subject, data)
 		if err != nil {
 			return nil, err
 		}
 		subject = strings.TrimSpace(string(bs))
 	}
 	if et.Text != "" {
-		tb, err := renderEmailText(ctx, q, et.Subject, data)
+		tb, err := n.renderEmailText(ctx, et.Subject, data)
 		if err != nil {
 			return nil, err
 		}
 		textBody = strings.TrimSpace(string(tb))
 	}
 	if et.HTML != "" {
-		hb, err := renderEmailHtml(ctx, q, et.HTML, data)
+		hb, err := n.renderEmailHtml(ctx, et.HTML, data)
 		if err != nil {
 			return nil, err
 		}
@@ -94,15 +96,15 @@ func RenderEmailFromTemplates(ctx context.Context, q *db.Queries, emailAddr stri
 	return email.BuildMessage(from, to, subject, textBody, htmlBody)
 }
 
-func queueEmail(ctx context.Context, q *db.Queries, userID int32, msg []byte) error {
-	if q == nil {
+func (n *Notifier) queueEmail(ctx context.Context, userID int32, msg []byte) error {
+	if n.Queries == nil {
 		return fmt.Errorf("no query")
 	}
-	return q.InsertPendingEmail(ctx, db.InsertPendingEmailParams{ToUserID: userID, Body: string(msg)})
+	return n.Queries.InsertPendingEmail(ctx, db.InsertPendingEmailParams{ToUserID: userID, Body: string(msg)})
 }
 
 // sendSubscriberEmail queues an email notification for a subscriber.
-func sendSubscriberEmail(ctx context.Context, n Notifier, userID int32, evt eventbus.Event, et *EmailTemplates) error {
+func (n *Notifier) sendSubscriberEmail(ctx context.Context, userID int32, evt eventbus.Event, et *EmailTemplates) error {
 	user, err := n.Queries.GetUserById(ctx, userID)
 	if err != nil || !user.Email.Valid || user.Email.String == "" {
 		notifyMissingEmail(ctx, n.Queries, userID)
@@ -111,5 +113,5 @@ func sendSubscriberEmail(ctx context.Context, n Notifier, userID int32, evt even
 	if et == nil {
 		return nil
 	}
-	return RenderAndQueueEmailFromTemplates(ctx, n.Queries, userID, user.Email.String, et, evt.Data)
+	return n.RenderAndQueueEmailFromTemplates(ctx, userID, user.Email.String, et, evt.Data)
 }

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -41,13 +41,16 @@ func NotificationsFeed(r *http.Request, notifications []*db.Notification) *feeds
 }
 
 // notificationPurgeWorker periodically removes old read notifications.
-func NotificationPurgeWorker(ctx context.Context, q *db.Queries, interval time.Duration) {
+func (n *Notifier) NotificationPurgeWorker(ctx context.Context, interval time.Duration) {
+	if n.Queries == nil {
+		return
+	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			if err := q.PurgeReadNotifications(ctx); err != nil {
+			if err := n.Queries.PurgeReadNotifications(ctx); err != nil {
 				log.Printf("purge notifications: %v", err)
 			}
 		case <-ctx.Done():

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -82,8 +82,8 @@ func TestNotifierNotifyAdmins(t *testing.T) {
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(int32(1), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO notifications").WithArgs(int32(1), sqlmock.AnyArg(), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 	rec := &dummyProvider{}
-	n := Notifier{EmailProvider: rec, Queries: q}
-	NotifyAdmins(context.Background(), n, &EmailTemplates{}, EmailData{})
+	n := New(q, rec)
+	n.NotifyAdmins(context.Background(), &EmailTemplates{}, EmailData{})
 	if rec.to != "" {
 		t.Fatalf("expected no direct mail got %s", rec.to)
 	}

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -3,21 +3,56 @@ package notifications
 import (
 	"context"
 	"log"
+	"sync"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/templates"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
+	htemplate "html/template"
 )
 
 // Notifier dispatches updates via email and internal notifications.
 // Notifier dispatches updates via email and internal notifications.
 type Notifier struct {
-	EmailProvider email.Provider
-	Queries       *dbpkg.Queries
+	EmailProvider  email.Provider
+	Queries        *dbpkg.Queries
+	noteOnce       sync.Once
+	noteTmpls      *htemplate.Template
+	emailTextOnce  sync.Once
+	emailTextTmpls *htemplate.Template
+	emailHTMLOnce  sync.Once
+	emailHTMLTmpls *htemplate.Template
+}
+
+// New constructs a Notifier with the provided dependencies.
+func New(q *dbpkg.Queries, p email.Provider) *Notifier {
+	return &Notifier{Queries: q, EmailProvider: p}
+}
+
+func (n *Notifier) notificationTemplates() *htemplate.Template {
+	n.noteOnce.Do(func() {
+		n.noteTmpls = templates.GetCompiledNotificationTemplates(map[string]any{})
+	})
+	return n.noteTmpls
+}
+
+func (n *Notifier) emailTextTemplates() *htemplate.Template {
+	n.emailTextOnce.Do(func() {
+		n.emailTextTmpls = templates.GetCompiledEmailTextTemplates(map[string]any{})
+	})
+	return n.emailTextTmpls
+}
+
+func (n *Notifier) emailHTMLTemplates() *htemplate.Template {
+	n.emailHTMLOnce.Do(func() {
+		n.emailHTMLTmpls = templates.GetCompiledEmailHtmlTemplates(map[string]any{})
+	})
+	return n.emailHTMLTmpls
 }
 
 // NotifyAdmins sends a generic update notice to administrator accounts.
-func NotifyAdmins(ctx context.Context, n Notifier, et *EmailTemplates, data EmailData) error {
+func (n *Notifier) NotifyAdmins(ctx context.Context, et *EmailTemplates, data EmailData) error {
 	if !config.AdminNotificationsEnabled() {
 		return nil
 	}
@@ -31,7 +66,7 @@ func NotifyAdmins(ctx context.Context, n Notifier, et *EmailTemplates, data Emai
 				continue
 			}
 		}
-		if err := RenderAndQueueEmailFromTemplates(ctx, n.Queries, uid, addr, et, data); err != nil {
+		if err := n.RenderAndQueueEmailFromTemplates(ctx, uid, addr, et, data); err != nil {
 			log.Printf("notify admin %s: %v", addr, err)
 		}
 	}

--- a/internal/notifications/templates.go
+++ b/internal/notifications/templates.go
@@ -3,11 +3,9 @@ package notifications
 import (
 	"bytes"
 	"context"
-	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/internal/db"
 	htemplate "html/template"
 	"io"
-	ttemplate "text/template"
 )
 
 type TemplateEngine interface {
@@ -34,10 +32,6 @@ func renderTemplate[TE TemplateEngine](ctx context.Context, q *db.Queries, filen
 	return buf.Bytes(), nil
 }
 
-func TextTemplatesNew(s string) NewTemplateEngine[*ttemplate.Template] {
-	return ttemplate.New(s)
-}
-
 func HTMLTemplatesNew(s string) NewTemplateEngine[*htemplate.Template] {
 	return htemplate.New(s)
 }
@@ -60,22 +54,22 @@ func EmailSubjectTemplateFilenameGenerator(base string) string {
 
 // renderNotification renders the notification template associated with task.
 // Database overrides are respected when present.
-func renderNotification(ctx context.Context, q *db.Queries, filename string, data any) ([]byte, error) {
-	tmpls := templates.GetCompiledNotificationTemplates(map[string]any{})
-	return renderTemplate[*ttemplate.Template](ctx, q, filename, data, tmpls, TextTemplatesNew)
+func (n *Notifier) renderNotification(ctx context.Context, filename string, data any) ([]byte, error) {
+	tmpls := n.notificationTemplates()
+	return renderTemplate[*htemplate.Template](ctx, n.Queries, filename, data, tmpls, HTMLTemplatesNew)
 }
 
-func renderEmailSubject(ctx context.Context, q *db.Queries, filename string, data any) ([]byte, error) {
-	tmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
-	return renderTemplate[*ttemplate.Template](ctx, q, filename, data, tmpls, TextTemplatesNew)
+func (n *Notifier) renderEmailSubject(ctx context.Context, filename string, data any) ([]byte, error) {
+	tmpls := n.emailTextTemplates()
+	return renderTemplate[*htemplate.Template](ctx, n.Queries, filename, data, tmpls, HTMLTemplatesNew)
 }
 
-func renderEmailText(ctx context.Context, q *db.Queries, filename string, data any) ([]byte, error) {
-	tmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
-	return renderTemplate[*ttemplate.Template](ctx, q, filename, data, tmpls, TextTemplatesNew)
+func (n *Notifier) renderEmailText(ctx context.Context, filename string, data any) ([]byte, error) {
+	tmpls := n.emailTextTemplates()
+	return renderTemplate[*htemplate.Template](ctx, n.Queries, filename, data, tmpls, HTMLTemplatesNew)
 }
 
-func renderEmailHtml(ctx context.Context, q *db.Queries, filename string, data any) ([]byte, error) {
-	tmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
-	return renderTemplate[*htemplate.Template](ctx, q, filename, data, tmpls, HTMLTemplatesNew)
+func (n *Notifier) renderEmailHtml(ctx context.Context, filename string, data any) ([]byte, error) {
+	tmpls := n.emailHTMLTemplates()
+	return renderTemplate[*htemplate.Template](ctx, n.Queries, filename, data, tmpls, HTMLTemplatesNew)
 }


### PR DESCRIPTION
## Summary
- convert notifier helpers to pointer methods
- lazily load templates inside Notifier
- wire notifier into workers and handlers
- add missing task structs for blog comment routes

## Testing
- `go vet ./...` *(fails: undefined task symbols)*
- `golangci-lint run ./...` *(fails: vet errors from handlers packages)*
- `go test ./...` *(fails to build forum and writings packages)*


------
https://chatgpt.com/codex/tasks/task_e_687a63cfa24c832f8ee01b89b99b5722