### PR TITLE
Add email subject and notification stubs

### DIFF
--- a/core/templates/email/blogEmailSubject.gotxt
+++ b/core/templates/email/blogEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] New blog post by {{.Item.Author}}

--- a/core/templates/email/replyEmailSubject.gotxt
+++ b/core/templates/email/replyEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] New reply in {{.Item.TopicTitle}}

--- a/core/templates/email/signupEmailSubject.gotxt
+++ b/core/templates/email/signupEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Signup confirmation

--- a/core/templates/email/testEmailSubject.gotxt
+++ b/core/templates/email/testEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Test email

--- a/core/templates/email/threadEmailSubject.gotxt
+++ b/core/templates/email/threadEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] New thread "{{.Item.TopicTitle}}"

--- a/core/templates/email/updateEmailSubject.gotxt
+++ b/core/templates/email/updateEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] {{.Action}}

--- a/core/templates/email/userApprovedEmailSubject.gotxt
+++ b/core/templates/email/userApprovedEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Account approved

--- a/core/templates/email/userRejectedEmailSubject.gotxt
+++ b/core/templates/email/userRejectedEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Account rejected

--- a/core/templates/email/verifyEmailSubject.gotxt
+++ b/core/templates/email/verifyEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Verify your email

--- a/core/templates/email/writingEmailSubject.gotxt
+++ b/core/templates/email/writingEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] New writing "{{.Item.Title}}"

--- a/core/templates/notifications/testEmail.gotxt
+++ b/core/templates/notifications/testEmail.gotxt
@@ -1,0 +1,1 @@
+Test email triggered via {{.Path}}

--- a/core/templates/notifications/userApprovedEmail.gotxt
+++ b/core/templates/notifications/userApprovedEmail.gotxt
@@ -1,0 +1,1 @@
+User account approved

--- a/core/templates/notifications/userRejectedEmail.gotxt
+++ b/core/templates/notifications/userRejectedEmail.gotxt
@@ -1,0 +1,1 @@
+User account rejected

--- a/core/templates/notifications/verifyEmail.gotxt
+++ b/core/templates/notifications/verifyEmail.gotxt
@@ -1,0 +1,1 @@
+Email verification requested for {{if .Item}}{{.Item.Username}}{{else}}{{.Path}}{{end}}


### PR DESCRIPTION
## Summary
- provide missing Subject templates for built‑in email templates
- add internal notification stubs for test/verify/user approval events

## Testing
- `go vet ./...` *(fails: cannot use html/template.Template as text/template.Template)*
- `golangci-lint run ./...` *(fails: typecheck errors in internal/notifications)*
- `go test ./...` *(fails: same typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b48f96c6c832faf2b72dec9bee18a