### PR TITLE
Remove TaskAllow and TaskRemoveLower constants

### DIFF
--- a/handlers/admin/tasks.go
+++ b/handlers/admin/tasks.go
@@ -245,12 +245,6 @@ const (
 	// TaskUserEmailVerification verifies a user's email address.
 	TaskUserEmailVerification tasks.TaskString = "Email Verification"
 
-	// TaskAllow approves a news user level.
-	TaskAllow tasks.TaskString = "allow"
-
-	// TaskRemoveLower removes a news user level.
-	TaskRemoveLower tasks.TaskString = "remove"
-
 	// TaskWritingCategoryChange changes a writing category name.
 	TaskWritingCategoryChange tasks.TaskString = "writing category change"
 

--- a/handlers/blogs/tasks.go
+++ b/handlers/blogs/tasks.go
@@ -243,12 +243,6 @@ const (
 	// TaskUserEmailVerification verifies a user's email address.
 	TaskUserEmailVerification = "Email Verification"
 
-	// TaskAllow approves a news user level.
-	TaskAllow = "allow"
-
-	// TaskRemoveLower removes a news user level.
-	TaskRemoveLower = "remove"
-
 	// TaskWritingCategoryChange changes a writing category name.
 	TaskWritingCategoryChange = "writing category change"
 


### PR DESCRIPTION
## Summary
- delete unused `TaskAllow` and `TaskRemoveLower` constants in admin and blog handlers
- run `go mod tidy`, `go fmt`, `go vet`, `golangci-lint`, and `go test`

`go vet`, `golangci-lint`, and `go test` currently fail due to existing issues in unrelated packages.

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: redeclared symbols and unused imports)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails to build and run tests)*

------
https://chatgpt.com/codex/tasks/task_e_687b4ee4f528832f95c7ef782addd332