### PR TITLE
Clean subscription tasks

### DIFF
--- a/handlers/admin/tasks.go
+++ b/handlers/admin/tasks.go
@@ -262,16 +262,4 @@ const (
 
 	// TaskPurge removes old records.
 	TaskPurge tasks.TaskString = "Purge"
-
-	// TaskSubscribeBlogs subscribes a user to all blog posts.
-	TaskSubscribeBlogs tasks.TaskString = "Subscribe blogs"
-
-	// TaskSubscribeWritings subscribes a user to all writing posts.
-	TaskSubscribeWritings tasks.TaskString = "Subscribe writings"
-
-	// TaskSubscribeNews subscribes a user to all news posts.
-	TaskSubscribeNews tasks.TaskString = "Subscribe news"
-
-	// TaskSubscribeImages subscribes a user to all image board posts.
-	TaskSubscribeImages tasks.TaskString = "Subscribe images"
 )

--- a/handlers/blogs/tasks.go
+++ b/handlers/blogs/tasks.go
@@ -260,16 +260,4 @@ const (
 
 	// TaskPurge removes old records.
 	TaskPurge = "Purge"
-
-	// TaskSubscribeBlogs subscribes a user to all blog posts.
-	TaskSubscribeBlogs = "Subscribe blogs"
-
-	// TaskSubscribeWritings subscribes a user to all writing posts.
-	TaskSubscribeWritings = "Subscribe writings"
-
-	// TaskSubscribeNews subscribes a user to all news posts.
-	TaskSubscribeNews = "Subscribe news"
-
-	// TaskSubscribeImages subscribes a user to all image board posts.
-	TaskSubscribeImages = "Subscribe images"
 )


### PR DESCRIPTION
## Summary
- remove unused subscription constants from `admin` and `blogs` tasks

## Testing
- `go vet ./...` *(fails: EditReplyTask redeclared)*
- `go test ./...` *(fails: EditReplyTask redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_687b4ee24b38832fbea58d5eb749b57a