### PR TITLE
Clean up unused forum task definitions

### DIFF
--- a/handlers/forum/task_events_admin.go
+++ b/handlers/forum/task_events_admin.go
@@ -4,41 +4,6 @@ import (
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
-// SetUserLevelTask updates a user's forum access level.
-type SetUserLevelTask struct{ tasks.TaskString }
-
-var setUserLevelTask = &SetUserLevelTask{TaskString: TaskSetUserLevel}
-
-// UpdateUserLevelTask modifies a user's access level.
-type UpdateUserLevelTask struct{ tasks.TaskString }
-
-var updateUserLevelTask = &UpdateUserLevelTask{TaskString: TaskUpdateUserLevel}
-
-// DeleteUserLevelTask removes a user's access level.
-type DeleteUserLevelTask struct{ tasks.TaskString }
-
-var deleteUserLevelTask = &DeleteUserLevelTask{TaskString: TaskDeleteUserLevel}
-
-// SetTopicRestrictionTask adds a topic restriction.
-type SetTopicRestrictionTask struct{ tasks.TaskString }
-
-var setTopicRestrictionTask = &SetTopicRestrictionTask{TaskString: TaskSetTopicRestriction}
-
-// UpdateTopicRestrictionTask updates a topic restriction.
-type UpdateTopicRestrictionTask struct{ tasks.TaskString }
-
-var updateTopicRestrictionTask = &UpdateTopicRestrictionTask{TaskString: TaskUpdateTopicRestriction}
-
-// DeleteTopicRestrictionTask deletes a topic restriction.
-type DeleteTopicRestrictionTask struct{ tasks.TaskString }
-
-var deleteTopicRestrictionTask = &DeleteTopicRestrictionTask{TaskString: TaskDeleteTopicRestriction}
-
-// CopyTopicRestrictionTask copies topic restrictions between topics.
-type CopyTopicRestrictionTask struct{ tasks.TaskString }
-
-var copyTopicRestrictionTask = &CopyTopicRestrictionTask{TaskString: TaskCopyTopicRestriction}
-
 // RemakeThreadStatsTask refreshes forum thread statistics.
 type RemakeThreadStatsTask struct{ tasks.TaskString }
 
@@ -68,18 +33,3 @@ var deleteCategoryTask = &DeleteCategoryTask{TaskString: TaskDeleteCategory}
 type ThreadDeleteTask struct{ tasks.TaskString }
 
 var threadDeleteTask = &ThreadDeleteTask{TaskString: TaskForumThreadDelete}
-
-// TopicChangeTask updates a forum topic title.
-type TopicChangeTask struct{ tasks.TaskString }
-
-var topicChangeTask = &TopicChangeTask{TaskString: TaskForumTopicChange}
-
-// TopicDeleteTask removes a forum topic.
-type TopicDeleteTask struct{ tasks.TaskString }
-
-var topicDeleteTask = &TopicDeleteTask{TaskString: TaskForumTopicDelete}
-
-// TopicCreateTask creates a new forum topic.
-type TopicCreateTask struct{ tasks.TaskString }
-
-var topicCreateTask = &TopicCreateTask{TaskString: TaskForumTopicCreate}


### PR DESCRIPTION
## Summary
- remove deprecated task definitions
- keep only the tasks used by admin routes

## Testing
- `go vet ./...` *(fails: EditReplyTask redeclared in handlers/blogs)*
- `go test ./...` *(fails: EditReplyTask redeclared in handlers/blogs)*

------
https://chatgpt.com/codex/tasks/task_e_687b4edb598c832f90bf4670e0593c4a