### PR TITLE
Add navigation registry documentation

### DIFF
--- a/specs/navigation.md
+++ b/specs/navigation.md
@@ -1,0 +1,34 @@
+# Navigation Registry
+
+This document summarises how site sections register menu items using the `navigation` package.
+
+## Package overview
+
+The `internal/navigation/registry.go` file defines a simple registry that collects links for the index page and the admin control centre. Links are represented by a struct containing the name, URL and an integer weight. Two package level slices hold registered entries for the public index and for the admin pages.
+
+```go
+// link represents a navigation item for either index or admin control center.
+type link struct {
+    name   string
+    link   string
+    weight int
+}
+```
+
+### RegisterIndexLink
+
+`RegisterIndexLink(name, url string, weight int)` appends an entry to the index registry. Each handler package calls this function in its `RegisterRoutes` setup to expose its public section in the menu.
+
+### RegisterAdminControlCenter
+
+`RegisterAdminControlCenter(name, url string, weight int)` appends an entry to the admin registry so that the section appears in the administrator control centre menu.
+
+## Menu generation
+
+The `IndexItems()` and `AdminLinks()` functions return a slice of `corecommon.IndexItem` values sorted by the weight field. They copy the internal slice, sort it in ascending weight order and convert the results to the exported struct used by templates.
+
+Handlers declare a `SectionWeight` constant which determines the relative order of their menu entries. Lower numbers sort earlier. The README lists example weights ranging from `10` for News up to `100` for Information. Weights need not be contiguous; packages sometimes subtract or add from the base weight when registering multiple links so related links group together.
+
+## Usage
+
+When a section is initialised, typically in its `RegisterRoutes` function, it calls these registration functions. At runtime the templates call `navigation.IndexItems()` or `navigation.AdminLinks()` to obtain the assembled menus.


### PR DESCRIPTION
## Summary
- document how navigation links are registered and sorted

## Testing
- `go vet ./...` *(fails: EditReplyTask redeclared)*
- `go test -tags nosqlite ./...` *(fails: many build and test errors)*
- `golangci-lint run ./...` *(fails: typecheck issues)*

------
https://chatgpt.com/codex/tasks/task_e_687b4e133ccc832f880424452a147cf6