### PR TITLE
Fix emaildefaults test imports

### DIFF
--- a/internal/email/emaildefaults/email_test.go
+++ b/internal/email/emaildefaults/email_test.go
@@ -20,7 +20,6 @@ import (
 	mockemail "github.com/arran4/goa4web/internal/email/mock"
 	sesProv "github.com/arran4/goa4web/internal/email/ses"
 	smtpProv "github.com/arran4/goa4web/internal/email/smtp"
-	emailutil "github.com/arran4/goa4web/internal/notifications"
 	"strings"
 )
 


### PR DESCRIPTION
## Summary
- cleanup unused import `emailutil` from `emaildefaults/email_test.go`
- run linters and go commands

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: EditReplyTask redeclared)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `golangci-lint run internal/email/emaildefaults -v`
- `go test ./...` *(fails: various build errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b5516ecd4832fb5166dbb71b227e3