### PR TITLE
Update AutoSubscribe interface

### DIFF
--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -216,7 +216,7 @@ func (n *Notifier) handleAutoSubscribe(ctx context.Context, evt eventbus.Event, 
 		}
 	}
 	if auto {
-		task, path := tp.AutoSubscribePath()
+		task, path := tp.AutoSubscribePath(evt)
 		pattern := buildPatterns(tasks.TaskString(task), path)[0]
 		if config.AppRuntimeConfig.NotificationsEnabled {
 			ensureSubscription(ctx, n.Queries, evt.UserID, pattern, "internal")

--- a/internal/notifications/subscriptionsinterfaces.go
+++ b/internal/notifications/subscriptionsinterfaces.go
@@ -1,5 +1,7 @@
 package notifications
 
+import "github.com/arran4/goa4web/internal/eventbus"
+
 type EmailTemplates struct {
 	Text    string
 	HTML    string
@@ -41,6 +43,7 @@ type SubscribersNotificationTemplateProvider interface {
 // subscription when user preferences allow.
 type AutoSubscribeProvider interface {
 	// AutoSubscribePath returns the action name and URI used when creating the
-	// subscription.
-	AutoSubscribePath() (string, string)
+	// subscription. The event may provide additional context required to build
+	// the path.
+	AutoSubscribePath(evt eventbus.Event) (string, string)
 }


### PR DESCRIPTION
## Summary
- pass Event to `AutoSubscribeProvider.AutoSubscribePath`
- adjust notifier to send event to new method

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: EditReplyTask redeclared)*
- `golangci-lint run ./...` *(fails: typecheck issues in handlers)*
- `go test ./...` *(fails: build errors and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687b59c3dd70832fa8858c3709c9e87a