### PR TITLE
Fix admin email template tests

### DIFF
--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -79,8 +79,9 @@ func TestNotifierNotifyAdmins(t *testing.T) {
 	mock.ExpectQuery("UserByEmail").
 		WithArgs(sql.NullString{String: "a@test", Valid: true}).
 		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test", "a"))
-	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(int32(1), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("INSERT INTO notifications").WithArgs(int32(1), sqlmock.AnyArg(), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO pending_emails").
+		WithArgs(int32(1), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
 	rec := &dummyProvider{}
 	n := New(q, rec)
 	n.NotifyAdmins(context.Background(), &EmailTemplates{}, EmailData{})


### PR DESCRIPTION
## Summary
- update admin email template test to expect queued emails
- ensure EmailFrom is set so queued messages render
- adjust notifications test for queued emails

## Testing
- `go test ./handlers/admin`
- `go test ./...` *(fails: TestCoreDataLatestNewsLazy, TestPublicWritingsLazy, TestCoreDataLatestWritingsLazy, TestLatestNewsRespectsPermissions, TestForgotPasswordTemplatesExist, TestAskActionPage_AdminEvent, TestLinkerApproveAddsToSearch, TestNewsSearchFiltersUnauthorized, TestRequireWritingAuthorArticleVar, TestTaskEventMiddleware, TestTaskEventQueue, TestProcessEventDLQ, TestProcessEventSubscribeSelf, TestProcessEventNoAutoSubscribe, TestProcessEventAdminNotify, TestProcessEventWritingSubscribers, TestBusWorker)*


------
https://chatgpt.com/codex/tasks/task_e_687b61384ff4832f9268c55b07137e85