### PR TITLE
Fix CoreData creation in task events

### DIFF
--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -84,14 +84,12 @@ func (r *statusRecorder) WriteHeader(code int) {
 func TaskEventMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		task := r.PostFormValue("task")
-		uid := int32(0)
 		cd, ok := r.Context().Value(corecommon.KeyCoreData).(*corecommon.CoreData)
 		if !ok || cd == nil {
-			log.Printf("task event middleware: missing core data")
-			http.Error(w, "internal error", http.StatusInternalServerError)
-			return
+			cd = &corecommon.CoreData{}
+			r = r.WithContext(context.WithValue(r.Context(), corecommon.KeyCoreData, cd))
 		}
-		uid = cd.UserID
+		uid := cd.UserID
 		admin := strings.Contains(r.URL.Path, "/admin")
 		_ = admin
 		evt := &eventbus.Event{


### PR DESCRIPTION
## Summary
- ensure TaskEventMiddleware sets up CoreData when missing
- queue task events only after successful responses
- run gofmt, go vet, golangci-lint, and go tests

## Testing
- `go vet ./internal/middleware`
- `golangci-lint run`
- `go test ./internal/middleware -v`


------
https://chatgpt.com/codex/tasks/task_e_687b64b9f6f4832f962d0faf17dc3612