### PR TITLE
Fix news search test for last_index column

### DIFF
--- a/handlers/news/search_test.go
+++ b/handlers/news/search_test.go
@@ -31,8 +31,9 @@ func TestNewsSearchFiltersUnauthorized(t *testing.T) {
 
 	newsRows := sqlmock.NewRows([]string{
 		"writerName", "writerId", "idsitenews", "forumthread_id",
-		"language_idlanguage", "users_idusers", "news", "occurred", "Comments",
-	}).AddRow("bob", 1, 1, 0, 1, 1, "text", time.Unix(0, 0), 0)
+		"language_idlanguage", "users_idusers", "news", "occurred",
+		"last_index", "Comments",
+	}).AddRow("bob", 1, 1, 0, 1, 1, "text", time.Unix(0, 0), nil, 0)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.username AS writerName")).
 		WithArgs(int32(1), int32(1), int32(2), sql.NullInt32{Int32: 1, Valid: true}).
 		WillReturnRows(newsRows)


### PR DESCRIPTION
## Summary
- include `last_index` column when mocking results in the news search test

## Testing
- `go vet ./handlers/news`
- `go test ./handlers/news -run TestNewsSearchFiltersUnauthorized -v`
- `go test ./handlers/news`


------
https://chatgpt.com/codex/tasks/task_e_687b64b64ef0832f804fd46e5e75baf5