### PR TITLE
Fix linker approval search indexing

### DIFF
--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	common "github.com/arran4/goa4web/core/common"
 	db "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+	searchworker "github.com/arran4/goa4web/workers/searchworker"
 )
 
 func TestLinkerFeed(t *testing.T) {
@@ -40,11 +42,11 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
+	mock.MatchExpectationsInOrder(false)
 	defer sqldb.Close()
 
 	queries := db.New(sqldb)
 
-	// Approve item from queue id 1
 	mock.ExpectExec("INSERT INTO linker").
 		WithArgs(int32(1)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -57,13 +59,33 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 	mock.ExpectExec("INSERT IGNORE INTO linker_search").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").WithArgs("bar").WillReturnResult(sqlmock.NewResult(2, 1))
 	mock.ExpectExec("INSERT IGNORE INTO linker_search").WithArgs(int32(1), int32(2)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE linker SET last_index").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	bus := eventbus.NewBus()
+	eventbus.DefaultBus = bus
+	defer func() { eventbus.DefaultBus = eventbus.NewBus() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go searchworker.Worker(ctx, bus, queries)
+
+	evt := &eventbus.Event{Data: map[string]any{}}
+	cd := &common.CoreData{}
+	cd.SetEvent(evt)
 
 	req := httptest.NewRequest("POST", "/admin/queue?qid=1", nil)
-	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
-	ctx = context.WithValue(ctx, common.KeyCoreData, &common.CoreData{})
-	req = req.WithContext(ctx)
+	ctxreq := context.WithValue(req.Context(), common.KeyQueries, queries)
+	ctxreq = context.WithValue(ctxreq, common.KeyCoreData, cd)
+	req = req.WithContext(ctxreq)
 	rr := httptest.NewRecorder()
 	ApproveTask.Action(rr, req)
+
+	if err := eventbus.DefaultBus.Publish(*evt); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	bus.Shutdown(context.Background())
+	time.Sleep(20 * time.Millisecond)
+	cancel()
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)


### PR DESCRIPTION
## Summary
- update approval test to run the search index worker
- allow unordered sqlmock expectations

## Testing
- `go vet ./handlers/linker`
- `go test ./handlers/linker`


------
https://chatgpt.com/codex/tasks/task_e_687b64b44bcc832f85fb7822b4698cc9