### PR TITLE
Fix FAQ ask redirect test

### DIFF
--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -97,14 +97,14 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 		req.AddCookie(c)
 	}
 	evt := &eventbus.Event{Path: "/faq/ask", Task: tasks.TaskString(TaskAsk), UserID: 1}
-	cd := &common.CoreData{}
+	cd := &common.CoreData{UserID: 1}
 	cd.SetEvent(evt)
 
 	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
 	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
-	handler := middleware.TaskEventMiddleware(http.HandlerFunc(askTask.Page))
+	handler := middleware.TaskEventMiddleware(http.HandlerFunc(askTask.Action))
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -114,8 +114,8 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	if loc := rr.Header().Get("Location"); loc != "/faq" {
 		t.Fatalf("location=%q", loc)
 	}
-	named, ok := evt.Task.(tasks.Name)
-	if !ok || named.Name() != TaskAsk || evt.Path != "/admin/faq" {
+	evt = cd.Event()
+	if evt.Path != "/admin/faq" {
 		t.Fatalf("event %+v", evt)
 	}
 


### PR DESCRIPTION
## Summary
- correct the admin FAQ redirect test to run the action handler
- check the updated event on CoreData to verify redirect path

## Testing
- `go vet ./handlers/faq`
- `go test ./handlers/faq`


------
https://chatgpt.com/codex/tasks/task_e_687b64b0fe3c832f88f75d2124089a25