### PR TITLE
Fix forgot password template test

### DIFF
--- a/handlers/auth/forgotPassword_test.go
+++ b/handlers/auth/forgotPassword_test.go
@@ -11,10 +11,10 @@ func requireEmailTemplates(t *testing.T, prefix string) {
 	t.Helper()
 	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
 	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
-	if htmlTmpls.Lookup(notifications.EmailTextTemplateFilenameGenerator(prefix)) == nil {
+	if htmlTmpls.Lookup(notifications.EmailHTMLTemplateFilenameGenerator(prefix)) == nil {
 		t.Errorf("missing html template %s.gohtml", prefix)
 	}
-	if textTmpls.Lookup(notifications.EmailHTMLTemplateFilenameGenerator(prefix)) == nil {
+	if textTmpls.Lookup(notifications.EmailTextTemplateFilenameGenerator(prefix)) == nil {
 		t.Errorf("missing text template %s.gotxt", prefix)
 	}
 	if textTmpls.Lookup(notifications.EmailSubjectTemplateFilenameGenerator(prefix)) == nil {


### PR DESCRIPTION
## Summary
- correct template lookup functions in forgot password tests
- verify password reset templates are embedded

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go vet ./handlers/auth`
- `go test ./handlers/auth`

------
https://chatgpt.com/codex/tasks/task_e_687b64af5270832fa5e011bad0f86321