### PR TITLE
Fix admin notifier test expectations

### DIFF
--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"net/mail"
@@ -54,10 +55,13 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 	}
 	defer sqldb.Close()
 	q := db.New(sqldb)
-	rows := sqlmock.NewRows([]string{"idusers", "email", "username"}).
-		AddRow(1, "u@example.com", "u")
+	rows := sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "u@example.com", "u")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
 		WithArgs(int32(1)).WillReturnRows(rows)
+	mock.ExpectQuery("SELECT body FROM template_overrides WHERE name = ?").
+		WithArgs("updateEmail.gotxt").WillReturnError(sql.ErrNoRows)
+	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(int32(1), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
 	ctx := context.WithValue(req.Context(), common.KeyCoreData, &common.CoreData{UserID: 1})
@@ -124,6 +128,7 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	config.AppRuntimeConfig.AdminEmails = "a@test.com,b@test.com"
 	config.AppRuntimeConfig.AdminNotify = true
 	config.AppRuntimeConfig.EmailEnabled = true
+	config.AppRuntimeConfig.EmailFrom = "from@example.com"
 	t.Cleanup(func() { config.AppRuntimeConfig = cfgOrig })
 	os.Setenv(config.EnvAdminEmails, "a@test.com,b@test.com")
 	config.AppRuntimeConfig.AdminEmails = "a@test.com,b@test.com"
@@ -131,11 +136,27 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	origEmails := config.AppRuntimeConfig.AdminEmails
 	config.AppRuntimeConfig.AdminEmails = "a@test.com,b@test.com"
 	defer func() { config.AppRuntimeConfig.AdminEmails = origEmails }()
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+	q := db.New(sqldb)
+	rows := sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test.com", "a")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username FROM users u JOIN user_emails ue ON ue.user_id = u.idusers WHERE ue.email = ? LIMIT 1")).WithArgs("a@test.com").WillReturnRows(rows)
+	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(int32(1), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	rows2 := sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(2, "b@test.com", "b")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username FROM users u JOIN user_emails ue ON ue.user_id = u.idusers WHERE ue.email = ? LIMIT 1")).WithArgs("b@test.com").WillReturnRows(rows2)
+	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(int32(2), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+
 	rec := &recordAdminMail{}
-	n := notif.New(nil, rec)
+	n := notif.New(q, rec)
 	n.NotifyAdmins(context.Background(), &notif.EmailTemplates{}, notif.EmailData{})
-	if len(rec.to) != 2 {
-		t.Fatalf("expected 2 mails, got %d", len(rec.to))
+	if len(rec.to) != 0 {
+		t.Fatalf("expected 0 direct mails, got %d", len(rec.to))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expect: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix unit tests in `admin_email_template_test.go`
- ensure template override and email queue calls are mocked
- provide SQL expectations for admin notifications

## Testing
- `go vet ./handlers/admin`
- `go test ./handlers/admin`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_687b64abb714832faa71a0a30de78497