### PR TITLE
Fix task event tests

### DIFF
--- a/internal/middleware/taskbus_test.go
+++ b/internal/middleware/taskbus_test.go
@@ -25,7 +25,8 @@ func TestTaskEventMiddleware(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	ch := bus.Subscribe()
-	successHandler.ServeHTTP(rec, req)
+	ctx := context.WithValue(req.Context(), common.KeyCoreData, &corecommon.CoreData{})
+	successHandler.ServeHTTP(rec, req.WithContext(ctx))
 	select {
 	case evt := <-ch:
 		named, ok := evt.Task.(tasks.Name)
@@ -41,7 +42,8 @@ func TestTaskEventMiddleware(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec = httptest.NewRecorder()
 	ch = bus.Subscribe()
-	successHandler.ServeHTTP(rec, req)
+	ctx = context.WithValue(req.Context(), common.KeyCoreData, &corecommon.CoreData{})
+	successHandler.ServeHTTP(rec, req.WithContext(ctx))
 	select {
 	case evt := <-ch:
 		if strings.Contains(evt.Path, "/admin") {
@@ -58,7 +60,8 @@ func TestTaskEventMiddleware(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec = httptest.NewRecorder()
 	ch = bus.Subscribe()
-	failureHandler.ServeHTTP(rec, req)
+	ctx = context.WithValue(req.Context(), common.KeyCoreData, &corecommon.CoreData{})
+	failureHandler.ServeHTTP(rec, req.WithContext(ctx))
 	select {
 	case <-ch:
 		t.Fatalf("did not expect event on failure")
@@ -81,7 +84,7 @@ func TestTaskEventMiddleware(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec = httptest.NewRecorder()
 	ch = bus.Subscribe()
-	ctx := context.WithValue(req.Context(), common.KeyCoreData, &corecommon.CoreData{})
+	ctx = context.WithValue(req.Context(), common.KeyCoreData, &corecommon.CoreData{})
 	itemHandler.ServeHTTP(rec, req.WithContext(ctx))
 	select {
 	case evt := <-ch:
@@ -112,7 +115,8 @@ func TestTaskEventQueue(t *testing.T) {
 	req := httptest.NewRequest("POST", "/p", strings.NewReader("task=Add"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
+	ctx := context.WithValue(req.Context(), common.KeyCoreData, &corecommon.CoreData{})
+	handler.ServeHTTP(rec, req.WithContext(ctx))
 
 	if len(taskQueue.events) != 1 {
 		t.Fatalf("expected queued event")


### PR DESCRIPTION
## Summary
- ensure test requests include CoreData so middleware publishes events

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./internal/middleware`


------
https://chatgpt.com/codex/tasks/task_e_687b632574e8832faab67669c568e51c