### PR TITLE
Fix news search test

### DIFF
--- a/handlers/news/search_test.go
+++ b/handlers/news/search_test.go
@@ -31,8 +31,8 @@ func TestNewsSearchFiltersUnauthorized(t *testing.T) {
 
 	newsRows := sqlmock.NewRows([]string{
 		"writerName", "writerId", "idsitenews", "forumthread_id",
-		"language_idlanguage", "users_idusers", "news", "occurred", "Comments",
-	}).AddRow("bob", 1, 1, 0, 1, 1, "text", time.Unix(0, 0), 0)
+		"language_idlanguage", "users_idusers", "news", "occurred", "last_index", "Comments",
+	}).AddRow("bob", 1, 1, 0, 1, 1, "text", time.Unix(0, 0), time.Unix(0, 0), 0)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.username AS writerName")).
 		WithArgs(int32(1), int32(1), int32(2), sql.NullInt32{Int32: 1, Valid: true}).
 		WillReturnRows(newsRows)


### PR DESCRIPTION
## Summary
- update `search_test.go` to include `last_index` column

## Testing
- `go test ./handlers/news`
- `go test ./...` *(fails: TestNotifierNotifyAdmins, TestProcessEventDLQ, TestProcessEventSubscribeSelf, TestProcessEventNoAutoSubscribe, TestProcessEventAdminNotify, TestProcessEventWritingSubscribers)*

------
https://chatgpt.com/codex/tasks/task_e_687b63228a38832f82e1bd138b82f419