### PR TITLE
Fix search event expectation in linker tests

### DIFF
--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	common "github.com/arran4/goa4web/core/common"
 	db "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/workers/searchworker"
 )
 
 func TestLinkerFeed(t *testing.T) {
@@ -53,19 +55,26 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 		AddRow(1, 1, 1, 1, 0, "Foo", "http://foo", "Bar", time.Now(), "u", "c")
 	mock.ExpectQuery("SELECT l.idlinker").WithArgs(int32(1)).WillReturnRows(rows)
 
-	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").WithArgs("foo").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("INSERT IGNORE INTO linker_search").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").WithArgs("bar").WillReturnResult(sqlmock.NewResult(2, 1))
-	mock.ExpectExec("INSERT IGNORE INTO linker_search").WithArgs(int32(1), int32(2)).WillReturnResult(sqlmock.NewResult(0, 1))
+	evt := &eventbus.Event{}
+	cd := &common.CoreData{}
+	cd.SetEvent(evt)
 
 	req := httptest.NewRequest("POST", "/admin/queue?qid=1", nil)
 	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
-	ctx = context.WithValue(ctx, common.KeyCoreData, &common.CoreData{})
+	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	ApproveTask.Action(rr, req)
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
+	}
+
+	data, ok := evt.Data[searchworker.EventKey].(searchworker.IndexEventData)
+	if !ok {
+		t.Fatalf("missing index event")
+	}
+	if data.Type != searchworker.TypeLinker || data.ID != 1 || data.Text != "Foo Bar" {
+		t.Fatalf("index data %+v", data)
 	}
 }


### PR DESCRIPTION
## Summary
- update `TestLinkerApproveAddsToSearch` to check for a search worker event instead of direct SQL inserts

## Testing
- `go test ./handlers/linker`
- `go test ./...` *(fails: TestCoreDataLatestNewsLazy, TestPublicWritingsLazy, TestCoreDataLatestWritingsLazy, TestLatestNewsRespectsPermissions, TestNotifyAdminsEnv, TestForgotPasswordTemplatesExist, TestAskActionPage_AdminEvent, TestNewsSearchFiltersUnauthorized, TestRequireWritingAuthorArticleVar)*

------
https://chatgpt.com/codex/tasks/task_e_687b63200f00832f85b3cf66e0e3b0ad