### PR TITLE
Fix task event middleware core data handling

### DIFF
--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -88,8 +88,8 @@ func TaskEventMiddleware(next http.Handler) http.Handler {
 		cd, ok := r.Context().Value(corecommon.KeyCoreData).(*corecommon.CoreData)
 		if !ok || cd == nil {
 			log.Printf("task event middleware: missing core data")
-			http.Error(w, "internal error", http.StatusInternalServerError)
-			return
+			cd = corecommon.NewCoreData(r.Context(), nil)
+			r = r.WithContext(context.WithValue(r.Context(), corecommon.KeyCoreData, cd))
 		}
 		uid = cd.UserID
 		admin := strings.Contains(r.URL.Path, "/admin")


### PR DESCRIPTION
## Summary
- allow TaskEventMiddleware to create core data when missing

## Testing
- `go test ./internal/middleware`
- `go test ./...` *(fails: TestCoreDataLatestNewsLazy, TestPublicWritingsLazy, TestCoreDataLatestWritingsLazy, TestLatestNewsRespectsPermissions, TestNotifyAdminsEnv, TestForgotPasswordTemplatesExist, TestAskActionPage_AdminEvent, TestLinkerApproveAddsToSearch, TestNewsSearchFiltersUnauthorized, TestRequireWritingAuthorArticleVar, TestProcessEventDLQ, TestProcessEventSubscribeSelf, TestProcessEventNoAutoSubscribe, TestProcessEventAdminNotify, TestProcessEventWritingSubscribers, TestBusWorker, TestNotifierNotifyAdmins)*

------
https://chatgpt.com/codex/tasks/task_e_687b6168a5c4832fa472b2dff80eb31b