### PR TITLE
Fix email queue tests

### DIFF
--- a/internal/email/emaildefaults/email_test.go
+++ b/internal/email/emaildefaults/email_test.go
@@ -95,6 +95,10 @@ func TestInsertPendingEmail(t *testing.T) {
 }
 
 func TestEmailQueueWorker(t *testing.T) {
+	origCfg := config.AppRuntimeConfig
+	config.AppRuntimeConfig.EmailEnabled = true
+	t.Cleanup(func() { config.AppRuntimeConfig = origCfg })
+
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
@@ -126,6 +130,10 @@ func (errProvider) Send(context.Context, mail.Address, []byte) error {
 }
 
 func TestProcessPendingEmailDLQ(t *testing.T) {
+	origCfg := config.AppRuntimeConfig
+	config.AppRuntimeConfig.EmailEnabled = true
+	t.Cleanup(func() { config.AppRuntimeConfig = origCfg })
+
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)


### PR DESCRIPTION
## Summary
- enable email sending inside email queue tests

## Testing
- `go test ./internal/email/emaildefaults`
- `go test ./...` *(fails: TestCoreDataLatestNewsLazy, TestPublicWritingsLazy, TestCoreDataLatestWritingsLazy, TestLatestNewsRespectsPermissions, TestNotifyAdminsEnv, TestForgotPasswordTemplatesExist, TestAskActionPage_AdminEvent, TestLinkerApproveAddsToSearch, TestNewsSearchFiltersUnauthorized, TestRequireWritingAuthorArticleVar, TestTaskEventMiddleware, TestTaskEventQueue, TestProcessEventDLQ, TestProcessEventSubscribeSelf, TestProcessEventNoAutoSubscribe, TestProcessEventAdminNotify, TestProcessEventWritingSubscribers, TestBusWorker, TestNotifierNotifyAdmins)*

------
https://chatgpt.com/codex/tasks/task_e_687b614008a0832fbcda58087c7c1ec4