### PR TITLE
Fix news search scan mismatch

### DIFF
--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -27,7 +27,7 @@ WITH RECURSIVE role_ids(id) AS (
     JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
     JOIN roles r2 ON r2.name = g.action
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.*, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
@@ -52,7 +52,7 @@ WITH RECURSIVE role_ids(id) AS (
     JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
     JOIN roles r2 ON r2.name = g.action
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.*, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
@@ -77,7 +77,7 @@ WITH RECURSIVE role_ids(id) AS (
     JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
     JOIN roles r2 ON r2.name = g.action
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.*, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
@@ -102,7 +102,7 @@ WITH RECURSIVE role_ids(id) AS (
     JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
     JOIN roles r2 ON r2.name = g.action
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.*, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -82,7 +82,7 @@ WITH RECURSIVE role_ids(id) AS (
     JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
     JOIN roles r2 ON r2.name = g.action
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.idsitenews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.last_index, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
@@ -114,7 +114,6 @@ type GetNewsPostByIdWithWriterIdAndThreadCommentCountRow struct {
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
-	LastIndex          sql.NullTime
 	Comments           sql.NullInt32
 }
 
@@ -130,7 +129,6 @@ func (q *Queries) GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx context.C
 		&i.UsersIdusers,
 		&i.News,
 		&i.Occurred,
-		&i.LastIndex,
 		&i.Comments,
 	)
 	return &i, err
@@ -145,7 +143,7 @@ WITH RECURSIVE role_ids(id) AS (
     JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
     JOIN roles r2 ON r2.name = g.action
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.idsitenews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.last_index, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
@@ -177,7 +175,6 @@ type GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow struct {
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
-	LastIndex          sql.NullTime
 	Comments           sql.NullInt32
 }
 
@@ -211,7 +208,6 @@ func (q *Queries) GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount(ctx 
 			&i.UsersIdusers,
 			&i.News,
 			&i.Occurred,
-			&i.LastIndex,
 			&i.Comments,
 		); err != nil {
 			return nil, err
@@ -236,7 +232,7 @@ WITH RECURSIVE role_ids(id) AS (
     JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
     JOIN roles r2 ON r2.name = g.action
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.idsitenews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.last_index, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
@@ -268,7 +264,6 @@ type GetNewsPostsByIdsWithWriterIdAndThreadCommentCountRow struct {
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
-	LastIndex          sql.NullTime
 	Comments           sql.NullInt32
 }
 
@@ -302,7 +297,6 @@ func (q *Queries) GetNewsPostsByIdsWithWriterIdAndThreadCommentCount(ctx context
 			&i.UsersIdusers,
 			&i.News,
 			&i.Occurred,
-			&i.LastIndex,
 			&i.Comments,
 		); err != nil {
 			return nil, err
@@ -327,7 +321,7 @@ WITH RECURSIVE role_ids(id) AS (
     JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
     JOIN roles r2 ON r2.name = g.action
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.idsitenews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.last_index, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
@@ -361,7 +355,6 @@ type GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow struct {
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
-	LastIndex          sql.NullTime
 	Comments           sql.NullInt32
 }
 
@@ -388,7 +381,6 @@ func (q *Queries) GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(
 			&i.UsersIdusers,
 			&i.News,
 			&i.Occurred,
-			&i.LastIndex,
 			&i.Comments,
 		); err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary
- fix search queries in `news.sql` to omit `last_index`
- regenerate sqlc code

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./handlers/news`
- `go test ./...` *(fails: TestPublicWritingsLazy, TestCoreDataLatestWritingsLazy, TestNotifyAdminsEnv, TestForgotPasswordTemplatesExist, TestAskActionPage_AdminEvent, TestLinkerApproveAddsToSearch, TestRequireWritingAuthorArticleVar, TestTaskEventMiddleware, TestTaskEventQueue, TestProcessEventDLQ, TestProcessEventSubscribeSelf, TestProcessEventNoAutoSubscribe, TestProcessEventAdminNotify, TestProcessEventWritingSubscribers, TestBusWorker, TestNotifierNotifyAdmins)*

------
https://chatgpt.com/codex/tasks/task_e_687b613e32c4832fba5840579e0e2864