### PR TITLE
Fix auth template tests

### DIFF
--- a/handlers/auth/forgotPassword_test.go
+++ b/handlers/auth/forgotPassword_test.go
@@ -11,10 +11,10 @@ func requireEmailTemplates(t *testing.T, prefix string) {
 	t.Helper()
 	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
 	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
-	if htmlTmpls.Lookup(notifications.EmailTextTemplateFilenameGenerator(prefix)) == nil {
+	if htmlTmpls.Lookup(notifications.EmailHTMLTemplateFilenameGenerator(prefix)) == nil {
 		t.Errorf("missing html template %s.gohtml", prefix)
 	}
-	if textTmpls.Lookup(notifications.EmailHTMLTemplateFilenameGenerator(prefix)) == nil {
+	if textTmpls.Lookup(notifications.EmailTextTemplateFilenameGenerator(prefix)) == nil {
 		t.Errorf("missing text template %s.gotxt", prefix)
 	}
 	if textTmpls.Lookup(notifications.EmailSubjectTemplateFilenameGenerator(prefix)) == nil {

--- a/handlers/auth/templates/adminNotificationUserRequestPasswordResetEmail.gohtml
+++ b/handlers/auth/templates/adminNotificationUserRequestPasswordResetEmail.gohtml
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Hi the user {{.Item.Username}},</p>
+<p>Is attempting a password reset.</p>
+</body>
+</html>

--- a/handlers/auth/templates/adminNotificationUserRequestPasswordResetEmail.gotxt
+++ b/handlers/auth/templates/adminNotificationUserRequestPasswordResetEmail.gotxt
@@ -1,0 +1,2 @@
+Hi the user {{.Item.Username}},
+Is attempting a password reset.

--- a/handlers/auth/templates/adminNotificationUserRequestPasswordResetEmailSubject.gotxt
+++ b/handlers/auth/templates/adminNotificationUserRequestPasswordResetEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] User Password Reset Requested

--- a/handlers/auth/templates/passwordResetEmail.gohtml
+++ b/handlers/auth/templates/passwordResetEmail.gohtml
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Hi {{.Item.Username}},</p>
+<p>Use code <b>{{.Item.Code}}</b> when logging in with your new password.</p>
+<p>If you didn't request this change, you can ignore this email.</p>
+</body>
+</html>

--- a/handlers/auth/templates/passwordResetEmail.gotxt
+++ b/handlers/auth/templates/passwordResetEmail.gotxt
@@ -1,0 +1,7 @@
+To: {{.To}}
+From: {{.From}}
+Subject: [{{.SubjectPrefix}}] Password reset request
+
+Hi {{.Item.Username}},
+Use code {{.Item.Code}} when logging in with your new password.
+If you didn't request this change, you can ignore this email.

--- a/handlers/auth/templates/passwordResetEmailSubject.gotxt
+++ b/handlers/auth/templates/passwordResetEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Password reset request


### PR DESCRIPTION
## Summary
- ensure password reset email templates are present under `handlers/auth/templates`
- fix ForgotPassword tests to lookup the correct template names

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./handlers/auth`


------
https://chatgpt.com/codex/tasks/task_e_687b613a1230832f8a4778581ecb4bff