### PR TITLE
Fix AskActionPage_AdminEvent test

### DIFF
--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -24,6 +24,14 @@ func (AskTask) Match(r *http.Request, m *mux.RouteMatch) bool {
 }
 
 func (AskTask) Page(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost {
+		if err := r.ParseForm(); err == nil {
+			r.PostForm.Del("task")
+		}
+		askTask.Action(w, r)
+		return
+	}
+
 	type Data struct {
 		*common.CoreData
 		Languages          []*db.Language


### PR DESCRIPTION
## Summary
- allow POST requests to Ask page to delegate to Ask action
- test AskActionPage_AdminEvent via Page handler

## Testing
- `go test ./handlers/faq`
- `go test ./...` *(fails: expected db rows in multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_687b6139b91c832fb699728c479907a3