### PR TITLE
Implement self email notifications for test mail task

### DIFF
--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"log"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -20,8 +19,7 @@ import (
 	"github.com/arran4/goa4web/core"
 	db "github.com/arran4/goa4web/internal/db"
 
-	"github.com/arran4/goa4web/internal/email"
-	emailutil "github.com/arran4/goa4web/internal/notifications"
+	notif "github.com/arran4/goa4web/internal/notifications"
 
 	"github.com/arran4/goa4web/config"
 )
@@ -31,6 +29,9 @@ type AddEmailTask struct{ tasks.TaskString }
 type ResendEmailTask struct{ tasks.TaskString }
 type DeleteEmailTask struct{ tasks.TaskString }
 type TestMailTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*TestMailTask)(nil)
+var _ notif.SelfNotificationTemplateProvider = (*TestMailTask)(nil)
 
 func (ResendEmailTask) Action(w http.ResponseWriter, r *http.Request) { addEmailTask.Resend(w, r) }
 
@@ -155,35 +156,21 @@ func (TestMailTask) Action(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "email unknown", http.StatusBadRequest)
 		return
 	}
-	queries, _ := r.Context().Value(common.KeyQueries).(*db.Queries)
-	var emails []*db.UserEmail
-	var err error
-	if queries != nil {
-		emails, err = queries.GetUserEmailsByUserID(r.Context(), user.Idusers)
-	}
-	if err != nil || len(emails) == 0 {
-		http.Error(w, "email unknown", http.StatusBadRequest)
-		return
-	}
-	addr := emails[0].Email
-	base := "http://" + r.Host
-	if config.AppRuntimeConfig.HTTPHostname != "" {
-		base = strings.TrimRight(config.AppRuntimeConfig.HTTPHostname, "/")
-	}
-	pageURL := base + r.URL.Path
-	provider := email.ProviderFromConfig(config.AppRuntimeConfig)
-	if provider == nil {
-		q := url.QueryEscape(ErrMailNotConfigured.Error())
-		// Display the error without redirecting so the POST isn't repeated.
-		r.URL.RawQuery = "error=" + q
-		handlers.TaskErrorAcknowledgementPage(w, r)
-		return
-	}
-	n := emailutil.New(queries, provider)
-	if err := n.CreateEmailTemplateAndQueue(r.Context(), user.Idusers, addr, pageURL, "update", nil); err != nil {
-		log.Printf("notify Error: %s", err)
+	if evt := cd.Event(); evt != nil {
+		if evt.Data == nil {
+			evt.Data = map[string]any{}
+		}
 	}
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
+}
+
+func (TestMailTask) SelfEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("testEmail")
+}
+
+func (TestMailTask) SelfInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("testEmail")
+	return &s
 }
 
 func (AddEmailTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/user/userEmailPage_test.go
+++ b/handlers/user/userEmailPage_test.go
@@ -1,0 +1,27 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/core/templates"
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+func requireEmailTemplates(t *testing.T, prefix string) {
+	t.Helper()
+	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
+	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
+	if htmlTmpls.Lookup(notif.EmailTextTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing html template %s.gohtml", prefix)
+	}
+	if textTmpls.Lookup(notif.EmailHTMLTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing text template %s.gotxt", prefix)
+	}
+	if textTmpls.Lookup(notif.EmailSubjectTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing subject template %sSubject.gotxt", prefix)
+	}
+}
+
+func TestTestMailTemplatesExist(t *testing.T) {
+	requireEmailTemplates(t, "testEmail")
+}


### PR DESCRIPTION
## Summary
- wire self-notification templates for `TestMailTask`
- add compile-time interface checks
- add a unit test to verify test mail templates exist

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...` *(fails: LatestNews queries and other tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_687b7b86c64c832f9a613645083cfc79