### PR TITLE
Add notification templates for forum tasks

### DIFF
--- a/handlers/auth/forgotPassword_test.go
+++ b/handlers/auth/forgotPassword_test.go
@@ -11,10 +11,10 @@ func requireEmailTemplates(t *testing.T, prefix string) {
 	t.Helper()
 	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
 	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
-	if htmlTmpls.Lookup(notifications.EmailTextTemplateFilenameGenerator(prefix)) == nil {
+	if htmlTmpls.Lookup(notifications.EmailHTMLTemplateFilenameGenerator(prefix)) == nil {
 		t.Errorf("missing html template %s.gohtml", prefix)
 	}
-	if textTmpls.Lookup(notifications.EmailHTMLTemplateFilenameGenerator(prefix)) == nil {
+	if textTmpls.Lookup(notifications.EmailTextTemplateFilenameGenerator(prefix)) == nil {
 		t.Errorf("missing text template %s.gotxt", prefix)
 	}
 	if textTmpls.Lookup(notifications.EmailSubjectTemplateFilenameGenerator(prefix)) == nil {

--- a/handlers/forum/forumTemplates_test.go
+++ b/handlers/forum/forumTemplates_test.go
@@ -1,0 +1,27 @@
+package forum
+
+import (
+	"github.com/arran4/goa4web/core/templates"
+	notif "github.com/arran4/goa4web/internal/notifications"
+	"testing"
+)
+
+func requireEmailTemplates(t *testing.T, prefix string) {
+	t.Helper()
+	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
+	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
+	if htmlTmpls.Lookup(notif.EmailHTMLTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing html template %s.gohtml", prefix)
+	}
+	if textTmpls.Lookup(notif.EmailTextTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing text template %s.gotxt", prefix)
+	}
+	if textTmpls.Lookup(notif.EmailSubjectTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing subject template %sSubject.gotxt", prefix)
+	}
+}
+
+func TestForumEmailTemplatesExist(t *testing.T) {
+	requireEmailTemplates(t, "replyEmail")
+	requireEmailTemplates(t, "threadEmail")
+}

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -17,6 +17,7 @@ import (
 	postcountworker "github.com/arran4/goa4web/workers/postcountworker"
 	searchworker "github.com/arran4/goa4web/workers/searchworker"
 
+	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/tasks"
 
 	"github.com/arran4/goa4web/config"
@@ -26,6 +27,10 @@ import (
 
 // CreateThreadTask handles creating a new forum thread.
 type CreateThreadTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*CreateThreadTask)(nil)
+var _ notif.SubscribersNotificationTemplateProvider = (*CreateThreadTask)(nil)
+var _ notif.AutoSubscribeProvider = (*CreateThreadTask)(nil)
 
 var createThreadTask = &CreateThreadTask{TaskString: TaskCreateThread}
 
@@ -39,6 +44,19 @@ func (CreateThreadTask) IndexData(data map[string]any) []searchworker.IndexEvent
 }
 
 var _ searchworker.IndexedTask = CreateThreadTask{}
+
+func (CreateThreadTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("threadEmail")
+}
+
+func (CreateThreadTask) SubscribedInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("thread")
+	return &s
+}
+
+func (CreateThreadTask) AutoSubscribePath(evt eventbus.Event) (string, string) {
+	return string(TaskCreateThread), evt.Path
+}
 
 func (CreateThreadTask) Page(w http.ResponseWriter, r *http.Request) {
 	type Data struct {


### PR DESCRIPTION
## Summary
- implement notification template providers for forum reply and thread creation tasks
- add compile-time assertions for the new provider interfaces
- add template existence tests for forum emails
- fix template lookup generators in tests

## Testing
- `go vet ./...`
- `golangci-lint run ./... --timeout 5m`
- `go test ./...` *(fails: LatestNews Scan issues, NotifyAdminsEnv, AskActionPage_AdminEvent, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687b7b86c64c832f9a613645083cfc79