### PR TITLE
Fix go vet and go test failures

### DIFF
--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -25,8 +25,8 @@ func TestCoreDataLatestNewsLazy(t *testing.T) {
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
 		"writerName", "writerId", "idsitenews", "forumthread_id", "language_idlanguage",
-		"users_idusers", "news", "occurred", "last_index", "comments",
-	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, now, 0)
+		"users_idusers", "news", "occurred", "comments",
+	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, 0)
 
 	mock.ExpectQuery("SELECT u.username").WithArgs(int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
 	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -48,8 +48,8 @@ func TestLatestNewsRespectsPermissions(t *testing.T) {
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
 		"writerName", "writerId", "idsitenews", "forumthread_id", "language_idlanguage",
-		"users_idusers", "news", "occurred", "last_index", "comments",
-	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, now, 0).AddRow("w", 1, 2, 0, 1, 1, "b", now, now, 0)
+		"users_idusers", "news", "occurred", "comments",
+	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, 0).AddRow("w", 1, 2, 0, 1, 1, "b", now, 0)
 
 	mock.ExpectQuery("SELECT u.username").WithArgs(int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
 

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -153,12 +153,12 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	origEmails := config.AppRuntimeConfig.AdminEmails
 	config.AppRuntimeConfig.AdminEmails = "a@test.com,b@test.com"
 	defer func() { config.AppRuntimeConfig.AdminEmails = origEmails }()
-	sqldb, mock, err := sqlmock.New()
+	sqldb, mock, err = sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer sqldb.Close()
-	q := db.New(sqldb)
+	q = db.New(sqldb)
 	rows := sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test.com", "a")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username FROM users u JOIN user_emails ue ON ue.user_id = u.idusers WHERE ue.email = ? LIMIT 1")).WithArgs("a@test.com").WillReturnRows(rows)
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(int32(1), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/handlers/news/search_test.go
+++ b/handlers/news/search_test.go
@@ -32,8 +32,8 @@ func TestNewsSearchFiltersUnauthorized(t *testing.T) {
 	newsRows := sqlmock.NewRows([]string{
 		"writerName", "writerId", "idsitenews", "forumthread_id",
 		"language_idlanguage", "users_idusers", "news", "occurred",
-		"last_index", "Comments",
-	}).AddRow("bob", 1, 1, 0, 1, 1, "text", time.Unix(0, 0), nil, 0)
+		"Comments",
+	}).AddRow("bob", 1, 1, 0, 1, 1, "text", time.Unix(0, 0), 0)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.username AS writerName")).
 		WithArgs(int32(1), int32(1), int32(2), sql.NullInt32{Int32: 1, Valid: true}).
 		WillReturnRows(newsRows)

--- a/internal/notifications/bus_worker_test.go
+++ b/internal/notifications/bus_worker_test.go
@@ -186,7 +186,7 @@ func TestProcessEventWritingSubscribers(t *testing.T) {
 	config.AppRuntimeConfig.NotificationsEnabled = true
 	config.AppRuntimeConfig.EmailFrom = "from@example.com"
 	t.Cleanup(func() { config.AppRuntimeConfig = origCfg })
-	db, _, err := sqlmock.New()
+	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}


### PR DESCRIPTION
## Summary
- fix variable reuse in admin email template tests
- return sqlmock handle in notifications tests
- sync test columns with generated SQL

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687b81d2afe4832fa4c12b5e6dba03ff