### PR TITLE
Fix email template tests and provider check

### DIFF
--- a/handlers/user/userEmailPage_test.go
+++ b/handlers/user/userEmailPage_test.go
@@ -11,10 +11,10 @@ func requireEmailTemplates(t *testing.T, prefix string) {
 	t.Helper()
 	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
 	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
-	if htmlTmpls.Lookup(notif.EmailTextTemplateFilenameGenerator(prefix)) == nil {
+	if htmlTmpls.Lookup(notif.EmailHTMLTemplateFilenameGenerator(prefix)) == nil {
 		t.Errorf("missing html template %s.gohtml", prefix)
 	}
-	if textTmpls.Lookup(notif.EmailHTMLTemplateFilenameGenerator(prefix)) == nil {
+	if textTmpls.Lookup(notif.EmailTextTemplateFilenameGenerator(prefix)) == nil {
 		t.Errorf("missing text template %s.gotxt", prefix)
 	}
 	if textTmpls.Lookup(notif.EmailSubjectTemplateFilenameGenerator(prefix)) == nil {

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/arran4/goa4web/core"
 	common "github.com/arran4/goa4web/core/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/email"
 	logProv "github.com/arran4/goa4web/internal/email/log"
 )
 
@@ -51,7 +52,7 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
-	cd := common.NewCoreData(ctx, queries)
+	cd := common.NewCoreData(ctx, queries, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -82,7 +83,7 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := context.WithValue(req.Context(), common.KeyQueries, queries)
-	cd := common.NewCoreData(ctx, queries)
+	cd := common.NewCoreData(ctx, queries, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, common.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -14,6 +14,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/email"
 	imagesign "github.com/arran4/goa4web/internal/images"
 	nav "github.com/arran4/goa4web/internal/navigation"
 	"github.com/gorilla/sessions"
@@ -70,7 +71,8 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 
 		cd := common.NewCoreData(r.Context(), queries,
 			common.WithImageURLMapper(imagesign.MapURL),
-			common.WithSession(session))
+			common.WithSession(session),
+			common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)))
 		cd.UserID = uid
 		_ = cd.UserRoles()
 


### PR DESCRIPTION
## Summary
- provide a mail provider through CoreData via `WithEmailProvider`
- update the test mail task to check `CoreData.EmailProvider`
- inject the provider in middleware and tests

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687b8bc19408832fb5bf962d4005408a