### PR TITLE
Implement admin notifications for new image boards

### DIFF
--- a/core/templates/email/adminNotificationImageBoardNewEmail.gohtml
+++ b/core/templates/email/adminNotificationImageBoardNewEmail.gohtml
@@ -1,0 +1,3 @@
+<p>User {{.Item.Username}} created a new image board.</p>
+<p>{{/* TODO add URL back to board here */}}</p>
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationImageBoardNewEmail.gotxt
+++ b/core/templates/email/adminNotificationImageBoardNewEmail.gotxt
@@ -1,0 +1,4 @@
+User {{.Item.Username}} created a new image board.
+
+{{/* TODO add URL back to board here */}}
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/adminNotificationImageBoardNewEmailSubject.gotxt
+++ b/core/templates/email/adminNotificationImageBoardNewEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] New image board created

--- a/core/templates/email/imageBoardNewEmail.gohtml
+++ b/core/templates/email/imageBoardNewEmail.gohtml
@@ -1,0 +1,3 @@
+<p>A new image board "{{.Item.Title.String}}" has been created.</p>
+<p>{{/* TODO add URL back to board here */}}</p>
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/imageBoardNewEmail.gotxt
+++ b/core/templates/email/imageBoardNewEmail.gotxt
@@ -1,0 +1,4 @@
+A new image board "{{.Item.Title.String}}" has been created.
+
+{{/* TODO add URL back to board here */}}
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/imageBoardNewEmailSubject.gotxt
+++ b/core/templates/email/imageBoardNewEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Image board created

--- a/core/templates/notifications/image_board_new.gotxt
+++ b/core/templates/notifications/image_board_new.gotxt
@@ -1,0 +1,1 @@
+A new image board has been created by {{.Item.Username}}.

--- a/handlers/imagebbs/imagebbsAdminNewBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminNewBoardPage.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
+	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -18,6 +19,18 @@ import (
 type NewBoardTask struct{ tasks.TaskString }
 
 var newBoardTask = &NewBoardTask{TaskString: TaskNewBoard}
+
+var _ tasks.Task = (*NewBoardTask)(nil)
+var _ notif.AdminEmailTemplateProvider = (*NewBoardTask)(nil)
+
+func (NewBoardTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("adminNotificationImageBoardNewEmail")
+}
+
+func (NewBoardTask) AdminInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("adminNotificationImageBoardNewEmail")
+	return &v
+}
 
 func AdminNewBoardPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {

--- a/handlers/imagebbs/imagebbsTemplates_test.go
+++ b/handlers/imagebbs/imagebbsTemplates_test.go
@@ -1,0 +1,33 @@
+package imagebbs
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/core/templates"
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+func requireEmailTemplates(t *testing.T, prefix string) {
+	t.Helper()
+	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
+	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
+	if htmlTmpls.Lookup(notif.EmailHTMLTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing html template %s.gohtml", prefix)
+	}
+	if textTmpls.Lookup(notif.EmailTextTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing text template %s.gotxt", prefix)
+	}
+	if textTmpls.Lookup(notif.EmailSubjectTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing subject template %sSubject.gotxt", prefix)
+	}
+}
+
+func TestImageBbsTemplatesExist(t *testing.T) {
+	prefixes := []string{
+		"imageBoardNewEmail",
+		"adminNotificationImageBoardNewEmail",
+	}
+	for _, p := range prefixes {
+		requireEmailTemplates(t, p)
+	}
+}


### PR DESCRIPTION
## Summary
- notify admins when a new image board is created
- provide `imageBoardNewEmail.*` templates
- add notification template `image_board_new.gotxt`
- check that image board email templates exist

## Testing
- `go vet ./...` *(fails: ReplyTask and others do not implement AutoSubscribeProvider)*
- `golangci-lint run ./...` *(fails: typecheck errors for blog/news/forum tasks)*
- `go test ./...` *(fails to build blog/news/forum packages)*

------
https://chatgpt.com/codex/tasks/task_e_687ba01648b4832f9963cce9a47bece6