### PR TITLE
Add admin update notifications for image boards

### DIFF
--- a/core/templates/email/imageBoardUpdateEmail.gohtml
+++ b/core/templates/email/imageBoardUpdateEmail.gohtml
@@ -1,0 +1,2 @@
+<p>Image board {{.Item.Title}} updated.</p>
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/imageBoardUpdateEmail.gotxt
+++ b/core/templates/email/imageBoardUpdateEmail.gotxt
@@ -1,0 +1,2 @@
+Image board "{{.Item.Title}}" updated.
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/imageBoardUpdateEmailSubject.gotxt
+++ b/core/templates/email/imageBoardUpdateEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Image board updated

--- a/core/templates/notifications/imageBoardUpdateEmail.gotxt
+++ b/core/templates/notifications/imageBoardUpdateEmail.gotxt
@@ -1,0 +1,1 @@
+Image board "{{.Item.Title}}" updated

--- a/handlers/imagebbs/imagebbsAdminBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardPage.go
@@ -8,6 +8,7 @@ import (
 
 	common "github.com/arran4/goa4web/core/common"
 	db "github.com/arran4/goa4web/internal/db"
+	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 )
@@ -16,6 +17,18 @@ import (
 type ModifyBoardTask struct{ tasks.TaskString }
 
 var modifyBoardTask = &ModifyBoardTask{TaskString: TaskModifyBoard}
+
+var _ tasks.Task = (*ModifyBoardTask)(nil)
+var _ notif.AdminEmailTemplateProvider = (*ModifyBoardTask)(nil)
+
+func (ModifyBoardTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("imageBoardUpdateEmail")
+}
+
+func (ModifyBoardTask) AdminInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("imageBoardUpdateEmail")
+	return &v
+}
 
 func (ModifyBoardTask) Action(w http.ResponseWriter, r *http.Request) {
 	name := r.PostFormValue("name")

--- a/handlers/imagebbs/imagebbsTemplates_test.go
+++ b/handlers/imagebbs/imagebbsTemplates_test.go
@@ -1,0 +1,32 @@
+package imagebbs
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/core/templates"
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+func requireEmailTemplates(t *testing.T, prefix string) {
+	t.Helper()
+	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
+	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
+	if htmlTmpls.Lookup(notif.EmailHTMLTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing html template %s.gohtml", prefix)
+	}
+	if textTmpls.Lookup(notif.EmailTextTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing text template %s.gotxt", prefix)
+	}
+	if textTmpls.Lookup(notif.EmailSubjectTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing subject template %sSubject.gotxt", prefix)
+	}
+}
+
+func TestImagebbsTemplatesExist(t *testing.T) {
+	prefixes := []string{
+		"imageBoardUpdateEmail",
+	}
+	for _, p := range prefixes {
+		requireEmailTemplates(t, p)
+	}
+}


### PR DESCRIPTION
## Summary
- implement admin email template provider for ModifyBoardTask
- embed image board update email templates
- test template compilation

## Testing
- `go mod tidy`
- `gofmt -w handlers/imagebbs/imagebbsAdminBoardPage.go handlers/imagebbs/imagebbsTemplates_test.go`
- `go vet ./...` *(fails: ReplyBlogTask etc. missing AutoSubscribePath(eventbus.Event))*
- `golangci-lint run ./...` *(fails: typecheck errors from blog and news packages)*
- `go fmt ./...`
- `go test ./...` *(fails to compile: AutoSubscribeProvider mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687ba01ac6c8832f8e847b5124d93be4