### PR TITLE
Implement self notification for image post approval

### DIFF
--- a/core/templates/email/imagePostApprovedEmail.gohtml
+++ b/core/templates/email/imagePostApprovedEmail.gohtml
@@ -1,0 +1,5 @@
+<p>Hi {{.Item.Username}},</p>
+<p>Your image post has been approved.</p>
+
+{{/* TODO add URL back to the post here */}}
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/imagePostApprovedEmail.gotxt
+++ b/core/templates/email/imagePostApprovedEmail.gotxt
@@ -1,0 +1,5 @@
+Hi {{.Item.Username}},
+Your image post has been approved.
+
+{{/* TODO add URL back to the post here */}}
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/imagePostApprovedEmailSubject.gotxt
+++ b/core/templates/email/imagePostApprovedEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Image post approved

--- a/core/templates/notifications/image_post_approved.gotxt
+++ b/core/templates/notifications/image_post_approved.gotxt
@@ -1,0 +1,1 @@
+Your image post has been approved.

--- a/handlers/imagebbs/imagebbsAdminApprove.go
+++ b/handlers/imagebbs/imagebbsAdminApprove.go
@@ -8,12 +8,16 @@ import (
 	common "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
+	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 )
 
 // ApprovePostTask marks a post as approved.
 type ApprovePostTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*ApprovePostTask)(nil)
+var _ notif.SelfNotificationTemplateProvider = (*ApprovePostTask)(nil)
 
 var approvePostTask = &ApprovePostTask{TaskString: TaskApprove}
 
@@ -27,4 +31,13 @@ func (ApprovePostTask) Action(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	handlers.TaskDoneAutoRefreshPage(w, r)
+}
+
+func (ApprovePostTask) SelfEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("imagePostApprovedEmail")
+}
+
+func (ApprovePostTask) SelfInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("image_post_approved")
+	return &s
 }

--- a/handlers/imagebbs/imagebbsTemplates_test.go
+++ b/handlers/imagebbs/imagebbsTemplates_test.go
@@ -1,0 +1,36 @@
+package imagebbs
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/core/templates"
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+func requireEmailTemplates(t *testing.T, prefix string) {
+	t.Helper()
+	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
+	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
+	if htmlTmpls.Lookup(notif.EmailHTMLTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing html template %s.gohtml", prefix)
+	}
+	if textTmpls.Lookup(notif.EmailTextTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing text template %s.gotxt", prefix)
+	}
+	if textTmpls.Lookup(notif.EmailSubjectTemplateFilenameGenerator(prefix)) == nil {
+		t.Errorf("missing subject template %sSubject.gotxt", prefix)
+	}
+}
+
+func requireNotificationTemplate(t *testing.T, name string) {
+	t.Helper()
+	nt := templates.GetCompiledNotificationTemplates(map[string]any{})
+	if nt.Lookup(name) == nil {
+		t.Errorf("missing notification template %s", name)
+	}
+}
+
+func TestImagebbsTemplatesExist(t *testing.T) {
+	requireEmailTemplates(t, "imagePostApprovedEmail")
+	requireNotificationTemplate(t, notif.NotificationTemplateFilenameGenerator("image_post_approved"))
+}


### PR DESCRIPTION
## Summary
- notify users when their image post gets approved via `SelfNotificationTemplateProvider`
- add image post approved email templates
- add notification template for image post approval
- add compile-time checks and tests for new templates

## Testing
- `go vet ./...` *(fails: ReplyBlogTask does not implement AutoSubscribeProvider)*
- `golangci-lint run ./...` *(fails: could not import handlers/blogs due to AutoSubscribePath signature)*
- `go test ./...` *(fails to build handlers/blogs for same reason)*

------
https://chatgpt.com/codex/tasks/task_e_687ba01e90fc832f966018c2803c2f0b