### PR TITLE
Remove unnecessary alias for notifications package

### DIFF
--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -18,7 +18,7 @@ import (
 	userhandlers "github.com/arran4/goa4web/handlers/user"
 	db "github.com/arran4/goa4web/internal/db"
 	logProv "github.com/arran4/goa4web/internal/email/log"
-	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/notifications"
 )
 
 func init() { logProv.Register() }
@@ -132,7 +132,7 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	config.AppRuntimeConfig.AdminEmails = "a@test.com,b@test.com"
 	defer func() { config.AppRuntimeConfig.AdminEmails = origEmails }()
 	rec := &recordAdminMail{}
-	notif.Notifier{EmailProvider: rec}.NotifyAdmins(context.Background(), "page")
+	notifications.Notifier{EmailProvider: rec}.NotifyAdmins(context.Background(), "page")
 	if len(rec.to) != 2 {
 		t.Fatalf("expected 2 mails, got %d", len(rec.to))
 	}
@@ -155,7 +155,7 @@ func TestNotifyAdminsDisabled(t *testing.T) {
 	config.AppRuntimeConfig.AdminEmails = "a@test.com"
 	defer func() { config.AppRuntimeConfig.AdminEmails = origEmails }()
 	rec := &recordAdminMail{}
-	notif.Notifier{EmailProvider: rec}.NotifyAdmins(context.Background(), "page")
+	notifications.Notifier{EmailProvider: rec}.NotifyAdmins(context.Background(), "page")
 	if len(rec.to) != 0 {
 		t.Fatalf("expected 0 mails, got %d", len(rec.to))
 	}

--- a/handlers/auth/forgotPassword.go
+++ b/handlers/auth/forgotPassword.go
@@ -9,7 +9,7 @@ import (
 
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/notifications"
 )
 
 func ForgotPasswordPage(w http.ResponseWriter, r *http.Request) {
@@ -59,7 +59,7 @@ func ForgotPasswordActionPage(w http.ResponseWriter, r *http.Request) {
 				if evt.Data == nil {
 					evt.Data = map[string]any{}
 				}
-				evt.Data["reset"] = notif.PasswordResetInfo{Username: row.Username.String, Code: code}
+				evt.Data["reset"] = notifications.PasswordResetInfo{Username: row.Username.String, Code: code}
 			}
 		}
 		// OLD _ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, page, hcommon.TaskUserResetPassword, code)

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	db "github.com/arran4/goa4web/internal/db"
-	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/notifications"
 
 	"github.com/arran4/goa4web/config"
 	hcommon "github.com/arran4/goa4web/handlers/common"
@@ -116,7 +116,7 @@ func RegisterActionPage(w http.ResponseWriter, r *http.Request) {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data["signup"] = notif.SignupInfo{Username: username}
+			evt.Data["signup"] = notifications.SignupInfo{Username: username}
 		}
 	}
 

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -12,7 +12,7 @@ import (
 	common "github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/notifications"
 	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
 
 	"github.com/arran4/goa4web/config"
@@ -87,7 +87,7 @@ func ThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data["thread"] = notif.ThreadInfo{TopicTitle: topicTitle, Author: author}
+			evt.Data["thread"] = notifications.ThreadInfo{TopicTitle: topicTitle, Author: author}
 		}
 	}
 
@@ -129,7 +129,7 @@ func ThreadNewActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO remove and replace with proper eventbus notification
-	notif.Notifier{EmailProvider: provider, Queries: queries}.NotifyThreadSubscribers(r.Context(), int32(threadId), uid, endUrl)
+	notifications.Notifier{EmailProvider: provider, Queries: queries}.NotifyThreadSubscribers(r.Context(), int32(threadId), uid, endUrl)
 
 	http.Redirect(w, r, endUrl, http.StatusTemporaryRedirect)
 }

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -15,7 +15,7 @@ import (
 	"github.com/arran4/goa4web/core"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/notifications"
 	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
 )
 
@@ -33,7 +33,7 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data["reply"] = notif.ForumReplyInfo{TopicTitle: topicRow.Title.String, ThreadID: threadRow.Idforumthread, Thread: threadRow}
+			evt.Data["reply"] = notifications.ForumReplyInfo{TopicTitle: topicRow.Title.String, ThreadID: threadRow.Idforumthread, Thread: threadRow}
 		}
 	}
 
@@ -105,7 +105,7 @@ func TopicThreadReplyPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO remove and replace with proper eventbus notification
-	notif.Notifier{EmailProvider: provider, Queries: queries}.NotifyThreadSubscribers(r.Context(), threadRow.Idforumthread, uid, endUrl)
+	notifications.Notifier{EmailProvider: provider, Queries: queries}.NotifyThreadSubscribers(r.Context(), threadRow.Idforumthread, uid, endUrl)
 
 	http.Redirect(w, r, endUrl, http.StatusTemporaryRedirect)
 }

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -22,7 +22,7 @@ import (
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
 	email "github.com/arran4/goa4web/internal/email"
-	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/utils/emailutil"
 	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
 )
@@ -450,7 +450,7 @@ func NewsPostNewActionPage(w http.ResponseWriter, r *http.Request) {
 				if evt.Data == nil {
 					evt.Data = map[string]any{}
 				}
-				evt.Data["blog"] = notif.BlogPostInfo{Author: u.Username.String}
+				evt.Data["blog"] = notifications.BlogPostInfo{Author: u.Username.String}
 			}
 		}
 	}

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -10,7 +10,7 @@ import (
 	common "github.com/arran4/goa4web/handlers/common"
 	hcommon "github.com/arran4/goa4web/handlers/common"
 	db "github.com/arran4/goa4web/internal/db"
-	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/notifications"
 	searchutil "github.com/arran4/goa4web/internal/utils/searchutil"
 
 	"github.com/arran4/goa4web/core"
@@ -77,7 +77,7 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data["writing"] = notif.WritingInfo{Title: title, Author: author}
+			evt.Data["writing"] = notifications.WritingInfo{Title: title, Author: author}
 		}
 	}
 

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -22,7 +22,7 @@ import (
 	"github.com/arran4/goa4web/internal/eventbus"
 	middleware "github.com/arran4/goa4web/internal/middleware"
 	csrfmw "github.com/arran4/goa4web/internal/middleware/csrf"
-	notifications "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/notifications"
 	routerpkg "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/internal/server"
 	startup "github.com/arran4/goa4web/internal/startup"


### PR DESCRIPTION
## Summary
- drop `notif` alias from imports
- update code references to use `notifications`
- remove redundant alias in `internal/app/run.go`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687b9f9c1d74832fb1ca0a3e9e21f8f1