### PR TITLE
Add Task interface assertions

### DIFF
--- a/handlers/admin/adminAnnouncementsPage.go
+++ b/handlers/admin/adminAnnouncementsPage.go
@@ -15,7 +15,12 @@ import (
 )
 
 type addAnnouncementTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*addAnnouncementTask)(nil)
+
 type deleteAnnouncementTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*deleteAnnouncementTask)(nil)
 
 func AdminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {

--- a/handlers/admin/adminDLQPage.go
+++ b/handlers/admin/adminDLQPage.go
@@ -16,6 +16,8 @@ import (
 
 type deleteDLQTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*deleteDLQTask)(nil)
+
 func AdminDLQPage(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		*common.CoreData

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -17,7 +17,12 @@ import (
 )
 
 type resendQueueTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*resendQueueTask)(nil)
+
 type deleteQueueTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*deleteQueueTask)(nil)
 
 func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 	type EmailItem struct {

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -24,7 +24,12 @@ import (
 )
 
 type saveTemplateTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*saveTemplateTask)(nil)
+
 type testTemplateTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*testTemplateTask)(nil)
 
 func getUpdateEmailText(ctx context.Context) string {
 	if q, ok := ctx.Value(common.KeyQueries).(*db.Queries); ok && q != nil {

--- a/handlers/admin/adminIPBanPage.go
+++ b/handlers/admin/adminIPBanPage.go
@@ -16,7 +16,12 @@ import (
 )
 
 type addIPBanTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*addIPBanTask)(nil)
+
 type deleteIPBanTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*deleteIPBanTask)(nil)
 
 func AdminIPBanPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {

--- a/handlers/admin/adminNotificationsPage.go
+++ b/handlers/admin/adminNotificationsPage.go
@@ -15,8 +15,16 @@ import (
 )
 
 type markReadTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*markReadTask)(nil)
+
 type purgeNotificationsTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*purgeNotificationsTask)(nil)
+
 type sendNotificationTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*sendNotificationTask)(nil)
 
 func AdminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {

--- a/handlers/bookmarks/edit.go
+++ b/handlers/bookmarks/edit.go
@@ -15,9 +15,13 @@ import (
 
 type SaveTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*SaveTask)(nil)
+
 var saveTask = &SaveTask{TaskString: TaskSave}
 
 type CreateTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*CreateTask)(nil)
 
 var createTask = &CreateTask{TaskString: TaskCreate}
 

--- a/handlers/faq/admin_answer.go
+++ b/handlers/faq/admin_answer.go
@@ -15,7 +15,12 @@ import (
 )
 
 type AnswerTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*AnswerTask)(nil)
+
 type RemoveQuestionTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*RemoveQuestionTask)(nil)
 
 var answerTask = &AnswerTask{TaskString: TaskAnswer}
 var removeQuestionTask = &RemoveQuestionTask{TaskString: TaskRemoveRemove}

--- a/handlers/faq/admin_categories.go
+++ b/handlers/faq/admin_categories.go
@@ -15,8 +15,16 @@ import (
 )
 
 type RenameCategoryTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*RenameCategoryTask)(nil)
+
 type DeleteCategoryTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*DeleteCategoryTask)(nil)
+
 type CreateCategoryTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*CreateCategoryTask)(nil)
 
 var renameCategoryTask = &RenameCategoryTask{TaskString: TaskRenameCategory}
 var deleteCategoryTask = &DeleteCategoryTask{TaskString: TaskDeleteCategory}

--- a/handlers/faq/admin_question.go
+++ b/handlers/faq/admin_question.go
@@ -16,8 +16,16 @@ import (
 )
 
 type EditQuestionTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*EditQuestionTask)(nil)
+
 type DeleteQuestionTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*DeleteQuestionTask)(nil)
+
 type CreateQuestionTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*CreateQuestionTask)(nil)
 
 var editQuestionTask = &EditQuestionTask{TaskString: TaskEdit}
 var deleteQuestionTask = &DeleteQuestionTask{TaskString: TaskRemoveRemove}

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -17,6 +17,8 @@ import (
 
 type AskTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*AskTask)(nil)
+
 var askTask = &AskTask{TaskString: TaskAsk}
 
 func (AskTask) Match(r *http.Request, m *mux.RouteMatch) bool {

--- a/handlers/forum/forumTemplates_test.go
+++ b/handlers/forum/forumTemplates_test.go
@@ -23,7 +23,7 @@ func requireEmailTemplates(t *testing.T, prefix string) {
 }
 
 func TestForumTemplatesExist(t *testing.T) {
-  // TODO make it loop over the tasks.
+	// TODO make it loop over the tasks.
 	prefixes := []string{
 		"forumThreadCreateEmail",
 		"adminNotificationForumThreadCreateEmail",

--- a/handlers/imagebbs/imagebbsAdminApprove.go
+++ b/handlers/imagebbs/imagebbsAdminApprove.go
@@ -15,6 +15,8 @@ import (
 // ApprovePostTask marks a post as approved.
 type ApprovePostTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*ApprovePostTask)(nil)
+
 var approvePostTask = &ApprovePostTask{TaskString: TaskApprove}
 
 func (ApprovePostTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/imagebbs/imagebbsAdminBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardPage.go
@@ -15,6 +15,8 @@ import (
 // ModifyBoardTask updates an existing board's settings.
 type ModifyBoardTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*ModifyBoardTask)(nil)
+
 var modifyBoardTask = &ModifyBoardTask{TaskString: TaskModifyBoard}
 
 func (ModifyBoardTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/imagebbs/imagebbsAdminNewBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminNewBoardPage.go
@@ -17,6 +17,8 @@ import (
 // NewBoardTask creates a new image board.
 type NewBoardTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*NewBoardTask)(nil)
+
 var newBoardTask = &NewBoardTask{TaskString: TaskNewBoard}
 
 func AdminNewBoardPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -32,6 +32,8 @@ import (
 // UploadImageTask handles uploading an image to a board.
 type UploadImageTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*UploadImageTask)(nil)
+
 var uploadImageTask = &UploadImageTask{TaskString: TaskUploadImage}
 
 func (UploadImageTask) IndexType() string { return searchworker.TypeImage }

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -24,6 +24,8 @@ import (
 // ReplyTask posts a reply within a thread.
 type ReplyTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*ReplyTask)(nil)
+
 var replyTask = &ReplyTask{TaskString: TaskReply}
 
 func (ReplyTask) IndexType() string { return searchworker.TypeComment }

--- a/handlers/images/upload_task.go
+++ b/handlers/images/upload_task.go
@@ -24,6 +24,8 @@ import (
 // UploadImageTask processes authenticated image uploads.
 type UploadImageTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*UploadImageTask)(nil)
+
 var uploadImageTask = &UploadImageTask{TaskString: TaskUploadImage}
 
 func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/languages/task_events.go
+++ b/handlers/languages/task_events.go
@@ -8,6 +8,8 @@ import (
 
 type RenameLanguageTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*RenameLanguageTask)(nil)
+
 var renameLanguageTask = &RenameLanguageTask{TaskString: tasks.TaskString("Rename Language")}
 
 func (RenameLanguageTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -16,6 +18,8 @@ func (RenameLanguageTask) Action(w http.ResponseWriter, r *http.Request) {
 
 type DeleteLanguageTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*DeleteLanguageTask)(nil)
+
 var deleteLanguageTask = &DeleteLanguageTask{TaskString: tasks.TaskString("Delete Language")}
 
 func (DeleteLanguageTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -23,6 +27,8 @@ func (DeleteLanguageTask) Action(w http.ResponseWriter, r *http.Request) {
 }
 
 type CreateLanguageTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*CreateLanguageTask)(nil)
 
 var createLanguageTask = &CreateLanguageTask{TaskString: tasks.TaskString("Create Language")}
 

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -57,6 +57,8 @@ func AdminAddPage(w http.ResponseWriter, r *http.Request) {
 
 type addTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*addTask)(nil)
+
 var AddTask = &addTask{TaskString: TaskAdd}
 
 func (addTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/linker/linkerAdminCategoriesPage.go
+++ b/handlers/linker/linkerAdminCategoriesPage.go
@@ -41,6 +41,8 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 type updateCategoryTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*updateCategoryTask)(nil)
+
 var UpdateCategoryTask = &updateCategoryTask{TaskString: TaskUpdate}
 
 func (updateCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -71,6 +73,8 @@ func (updateCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
 
 type renameCategoryTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*renameCategoryTask)(nil)
+
 var RenameCategoryTask = &renameCategoryTask{TaskString: TaskRenameCategory}
 
 func (renameCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -91,6 +95,8 @@ func (renameCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
 }
 
 type deleteCategoryTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*deleteCategoryTask)(nil)
 
 var DeleteCategoryTask = &deleteCategoryTask{TaskString: TaskDeleteCategory}
 
@@ -124,6 +130,8 @@ func (deleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
 }
 
 type createCategoryTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*createCategoryTask)(nil)
 
 var CreateCategoryTask = &createCategoryTask{TaskString: TaskCreateCategory}
 

--- a/handlers/linker/linkerAdminQueuePage.go
+++ b/handlers/linker/linkerAdminQueuePage.go
@@ -119,6 +119,8 @@ func AdminQueuePage(w http.ResponseWriter, r *http.Request) {
 
 type deleteTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*deleteTask)(nil)
+
 var DeleteTask = &deleteTask{TaskString: TaskDelete}
 
 func (deleteTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -154,6 +156,8 @@ func AdminQueueUpdateActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 type approveTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*approveTask)(nil)
 
 var ApproveTask = &approveTask{TaskString: TaskApprove}
 
@@ -199,6 +203,8 @@ func (approveTask) Action(w http.ResponseWriter, r *http.Request) {
 
 type bulkDeleteTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*bulkDeleteTask)(nil)
+
 var BulkDeleteTask = &bulkDeleteTask{TaskString: TaskBulkDelete}
 
 func (bulkDeleteTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -216,6 +222,8 @@ func (bulkDeleteTask) Action(w http.ResponseWriter, r *http.Request) {
 }
 
 type bulkApproveTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*bulkApproveTask)(nil)
 
 var BulkApproveTask = &bulkApproveTask{TaskString: TaskBulkApprove}
 

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -75,6 +75,8 @@ func AdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 
 type userAllowTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*userAllowTask)(nil)
+
 var UserAllowTask = &userAllowTask{TaskString: TaskUserAllow}
 
 func (userAllowTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -104,6 +106,8 @@ func (userAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 }
 
 type userDisallowTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*userDisallowTask)(nil)
 
 var UserDisallowTask = &userDisallowTask{TaskString: TaskUserDisallow}
 

--- a/handlers/linker/linkerCommentsEditPage.go
+++ b/handlers/linker/linkerCommentsEditPage.go
@@ -19,6 +19,8 @@ import (
 // CommentEditActionPage updates a comment then refreshes thread metadata.
 type EditReplyTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*EditReplyTask)(nil)
+
 var commentEditAction = &EditReplyTask{TaskString: TaskEditReply}
 
 func (t EditReplyTask) Page(w http.ResponseWriter, r *http.Request) {
@@ -93,6 +95,8 @@ func CommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
 }
 
 type cancelEditReplyTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*cancelEditReplyTask)(nil)
 
 var commentEditActionCancel = &cancelEditReplyTask{TaskString: TaskCancel}
 

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -150,6 +150,8 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 
 type replyTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*replyTask)(nil)
+
 var replyTaskEvent = &replyTask{TaskString: TaskReply}
 
 func (replyTask) Page(w http.ResponseWriter, r *http.Request) { CommentsPage(w, r) }

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -57,6 +57,8 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 
 type SuggestTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*SuggestTask)(nil)
+
 var suggestTask = SuggestTask{TaskString: TaskSuggest}
 
 func (SuggestTask) Page(w http.ResponseWriter, r *http.Request) { SuggestPage(w, r) }

--- a/handlers/search/remakeBlogTask.go
+++ b/handlers/search/remakeBlogTask.go
@@ -14,6 +14,8 @@ import (
 // RemakeBlogTask rebuilds the blog search index.
 type RemakeBlogTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*RemakeBlogTask)(nil)
+
 var remakeBlogTask = &RemakeBlogTask{TaskString: TaskRemakeBlogSearch}
 
 func (RemakeBlogTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/search/remakeCommentsTask.go
+++ b/handlers/search/remakeCommentsTask.go
@@ -14,6 +14,8 @@ import (
 // RemakeCommentsTask rebuilds the comments search index.
 type RemakeCommentsTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*RemakeCommentsTask)(nil)
+
 var remakeCommentsTask = &RemakeCommentsTask{TaskString: TaskRemakeCommentsSearch}
 
 func (RemakeCommentsTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/search/remakeImageTask.go
+++ b/handlers/search/remakeImageTask.go
@@ -14,6 +14,8 @@ import (
 // RemakeImageTask rebuilds the image search index.
 type RemakeImageTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*RemakeImageTask)(nil)
+
 var remakeImageTask = &RemakeImageTask{TaskString: TaskRemakeImageSearch}
 
 func (RemakeImageTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/search/remakeLinkerTask.go
+++ b/handlers/search/remakeLinkerTask.go
@@ -14,6 +14,8 @@ import (
 // RemakeLinkerTask rebuilds the linker search index.
 type RemakeLinkerTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*RemakeLinkerTask)(nil)
+
 var remakeLinkerTask = &RemakeLinkerTask{TaskString: TaskRemakeLinkerSearch}
 
 func (RemakeLinkerTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/search/remakeNewsTask.go
+++ b/handlers/search/remakeNewsTask.go
@@ -14,6 +14,8 @@ import (
 // RemakeNewsTask rebuilds the news search index.
 type RemakeNewsTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*RemakeNewsTask)(nil)
+
 var remakeNewsTask = &RemakeNewsTask{TaskString: TaskRemakeNewsSearch}
 
 func (RemakeNewsTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/search/remakeWritingTask.go
+++ b/handlers/search/remakeWritingTask.go
@@ -14,6 +14,8 @@ import (
 // RemakeWritingTask rebuilds the writing search index.
 type RemakeWritingTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*RemakeWritingTask)(nil)
+
 var remakeWritingTask = &RemakeWritingTask{TaskString: TaskRemakeWritingSearch}
 
 func (RemakeWritingTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/search/searchNewsTask.go
+++ b/handlers/search/searchNewsTask.go
@@ -10,6 +10,8 @@ import (
 // SearchNewsTask performs a news search.
 type SearchNewsTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*SearchNewsTask)(nil)
+
 var searchNewsTask = &SearchNewsTask{TaskString: TaskSearchNews}
 
 func (SearchNewsTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/search/searchResultBlogsActionPage.go
+++ b/handlers/search/searchResultBlogsActionPage.go
@@ -18,6 +18,8 @@ import (
 
 type SearchBlogsTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*SearchBlogsTask)(nil)
+
 var searchBlogsTask = &SearchBlogsTask{TaskString: TaskSearchBlogs}
 
 func (SearchBlogsTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/search/searchResultForumActionPage.go
+++ b/handlers/search/searchResultForumActionPage.go
@@ -18,6 +18,8 @@ import (
 
 type SearchForumTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*SearchForumTask)(nil)
+
 var searchForumTask = &SearchForumTask{TaskString: TaskSearchForum}
 
 func (SearchForumTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/search/searchResultLinkerActionPage.go
+++ b/handlers/search/searchResultLinkerActionPage.go
@@ -19,6 +19,8 @@ import (
 
 type SearchLinkerTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*SearchLinkerTask)(nil)
+
 var searchLinkerTask = &SearchLinkerTask{TaskString: TaskSearchLinker}
 
 func (SearchLinkerTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/search/searchResultWritingsActionPage.go
+++ b/handlers/search/searchResultWritingsActionPage.go
@@ -19,6 +19,8 @@ import (
 
 type SearchWritingsTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*SearchWritingsTask)(nil)
+
 var searchWritingsTask = &SearchWritingsTask{TaskString: TaskSearchWritings}
 
 func (SearchWritingsTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/user/admin_permissions.go
+++ b/handlers/user/admin_permissions.go
@@ -49,6 +49,8 @@ func adminUsersPermissionsPage(w http.ResponseWriter, r *http.Request) {
 // PermissionUserAllowTask grants a user permission.
 type PermissionUserAllowTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*PermissionUserAllowTask)(nil)
+
 var permissionUserAllowTask = &PermissionUserAllowTask{TaskString: TaskUserAllow}
 
 func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -78,6 +80,8 @@ func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 // PermissionUserDisallowTask removes a user's permission.
 type PermissionUserDisallowTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*PermissionUserDisallowTask)(nil)
+
 var permissionUserDisallowTask = &PermissionUserDisallowTask{TaskString: TaskUserDisallow}
 
 func (PermissionUserDisallowTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -102,6 +106,8 @@ func (PermissionUserDisallowTask) Action(w http.ResponseWriter, r *http.Request)
 
 // PermissionUpdateTask updates an existing permission entry.
 type PermissionUpdateTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*PermissionUpdateTask)(nil)
 
 var permissionUpdateTask = &PermissionUpdateTask{TaskString: TaskUpdate}
 

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -24,9 +24,21 @@ import (
 )
 
 type SaveEmailTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*SaveEmailTask)(nil)
+
 type AddEmailTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*AddEmailTask)(nil)
+
 type ResendEmailTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*ResendEmailTask)(nil)
+
 type DeleteEmailTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*DeleteEmailTask)(nil)
+
 type TestMailTask struct{ tasks.TaskString }
 
 var _ tasks.Task = (*TestMailTask)(nil)

--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -21,8 +21,16 @@ import (
 )
 
 type SaveLanguagesTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*SaveLanguagesTask)(nil)
+
 type SaveLanguageTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*SaveLanguageTask)(nil)
+
 type SaveAllTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*SaveAllTask)(nil)
 
 var (
 	saveLanguagesTask = &SaveLanguagesTask{TaskString: tasks.TaskString(TaskSaveLanguages)}

--- a/handlers/user/userNotificationsPage.go
+++ b/handlers/user/userNotificationsPage.go
@@ -16,6 +16,8 @@ import (
 
 type DismissTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*DismissTask)(nil)
+
 var dismissTask = &DismissTask{TaskString: tasks.TaskString(TaskDismiss)}
 
 func userNotificationsPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/user/userPageSizePage.go
+++ b/handlers/user/userPageSizePage.go
@@ -14,6 +14,8 @@ import (
 
 type PageSizeSaveTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*PageSizeSaveTask)(nil)
+
 var pageSizeSaveTask = &PageSizeSaveTask{TaskString: tasks.TaskString(TaskSaveAll)}
 
 func userPageSizePage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/user/userPagingPage.go
+++ b/handlers/user/userPagingPage.go
@@ -20,6 +20,8 @@ import (
 
 type PagingSaveTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*PagingSaveTask)(nil)
+
 var pagingSaveTask = &PagingSaveTask{TaskString: tasks.TaskString(TaskSaveAll)}
 
 func userPagingPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/user/userSubscriptionsPage.go
+++ b/handlers/user/userSubscriptionsPage.go
@@ -15,7 +15,12 @@ import (
 )
 
 type UpdateSubscriptionsTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*UpdateSubscriptionsTask)(nil)
+
 type DeleteTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*DeleteTask)(nil)
 
 var (
 	updateSubscriptionsTask = &UpdateSubscriptionsTask{TaskString: tasks.TaskString(TaskUpdate)}

--- a/handlers/writings/task_structs.go
+++ b/handlers/writings/task_structs.go
@@ -10,6 +10,8 @@ import (
 // SubmitWritingTask encapsulates creating a new writing.
 type SubmitWritingTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*SubmitWritingTask)(nil)
+
 var submitWritingTask = &SubmitWritingTask{TaskString: TaskSubmitWriting}
 
 func (SubmitWritingTask) Page(w http.ResponseWriter, r *http.Request)   { ArticleAddPage(w, r) }
@@ -17,6 +19,8 @@ func (SubmitWritingTask) Action(w http.ResponseWriter, r *http.Request) { Articl
 
 // ReplyTask posts a comment reply.
 type ReplyTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*ReplyTask)(nil)
 
 var replyTask = &ReplyTask{TaskString: TaskReply}
 
@@ -36,6 +40,8 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) { ArticleReplyAc
 // EditReplyTask updates an existing comment.
 type EditReplyTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*EditReplyTask)(nil)
+
 var editReplyTask = &EditReplyTask{TaskString: TaskEditReply}
 
 func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -44,6 +50,8 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) {
 
 // CancelTask cancels comment editing.
 type CancelTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*CancelTask)(nil)
 
 var cancelTask = &CancelTask{TaskString: TaskCancel}
 
@@ -54,6 +62,8 @@ func (CancelTask) Action(w http.ResponseWriter, r *http.Request) {
 // UpdateWritingTask applies changes to an article.
 type UpdateWritingTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*UpdateWritingTask)(nil)
+
 var updateWritingTask = &UpdateWritingTask{TaskString: TaskUpdateWriting}
 
 func (UpdateWritingTask) Page(w http.ResponseWriter, r *http.Request) { ArticleEditPage(w, r) }
@@ -62,6 +72,8 @@ func (UpdateWritingTask) Action(w http.ResponseWriter, r *http.Request) { Articl
 
 // UserAllowTask grants a user a permission.
 type UserAllowTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*UserAllowTask)(nil)
 
 var userAllowTask = &UserAllowTask{TaskString: TaskUserAllow}
 
@@ -76,6 +88,8 @@ func (UserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 // UserDisallowTask removes a user's permission.
 type UserDisallowTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*UserDisallowTask)(nil)
+
 var userDisallowTask = &UserDisallowTask{TaskString: TaskUserDisallow}
 
 func (UserDisallowTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -89,6 +103,8 @@ func (UserDisallowTask) Action(w http.ResponseWriter, r *http.Request) {
 // WritingCategoryChangeTask modifies a category.
 type WritingCategoryChangeTask struct{ tasks.TaskString }
 
+var _ tasks.Task = (*WritingCategoryChangeTask)(nil)
+
 var writingCategoryChangeTask = &WritingCategoryChangeTask{TaskString: TaskWritingCategoryChange}
 
 func (WritingCategoryChangeTask) Action(w http.ResponseWriter, r *http.Request) {
@@ -97,6 +113,8 @@ func (WritingCategoryChangeTask) Action(w http.ResponseWriter, r *http.Request) 
 
 // WritingCategoryCreateTask creates a new category.
 type WritingCategoryCreateTask struct{ tasks.TaskString }
+
+var _ tasks.Task = (*WritingCategoryCreateTask)(nil)
 
 var writingCategoryCreateTask = &WritingCategoryCreateTask{TaskString: TaskWritingCategoryCreate}
 


### PR DESCRIPTION
## Summary
- add `var _ tasks.Task = (*XTask)(nil)` assertions for several handlers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: ReplyBlogTask, ReplyTask, NewPostTask, CreateThreadTask do not implement AutoSubscribeProvider)*
- `golangci-lint run ./...` *(fails: multiple typecheck errors due to AutoSubscribeProvider mismatches)*
- `go test ./...` *(fails: typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ba232a9cc832fa2d8cbda6ff090ba