### PR TITLE
Add FAQ answer notifications

### DIFF
--- a/core/templates/email/faqAnsweredEmail.gohtml
+++ b/core/templates/email/faqAnsweredEmail.gohtml
@@ -1,0 +1,3 @@
+<p>Hi {{.Item.Username}},</p>
+<p>Your FAQ question has been answered.</p>
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/faqAnsweredEmail.gotxt
+++ b/core/templates/email/faqAnsweredEmail.gotxt
@@ -1,0 +1,4 @@
+Hi {{.Item.Username}},
+Your FAQ question has been answered.
+
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/faqAnsweredEmailSubject.gotxt
+++ b/core/templates/email/faqAnsweredEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] FAQ answered

--- a/core/templates/notifications/faq_answered.gotxt
+++ b/core/templates/notifications/faq_answered.gotxt
@@ -1,0 +1,1 @@
+Your FAQ question has been answered.

--- a/handlers/faq/faqTemplates_test.go
+++ b/handlers/faq/faqTemplates_test.go
@@ -1,0 +1,41 @@
+package faq
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/core/templates"
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+func requireEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
+	t.Helper()
+	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
+	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
+	if htmlTmpls.Lookup(et.HTML) == nil {
+		t.Errorf("missing html template %s", et.HTML)
+	}
+	if textTmpls.Lookup(et.Text) == nil {
+		t.Errorf("missing text template %s", et.Text)
+	}
+	if textTmpls.Lookup(et.Subject) == nil {
+		t.Errorf("missing subject template %s", et.Subject)
+	}
+}
+
+func requireNotificationTemplate(t *testing.T, name *string) {
+	if name == nil {
+		return
+	}
+	tmpl := templates.GetCompiledNotificationTemplates(map[string]any{})
+	if tmpl.Lookup(*name) == nil {
+		t.Errorf("missing notification template %s", *name)
+	}
+}
+
+func TestAnswerTaskTemplatesCompile(t *testing.T) {
+	var task AnswerTask
+	requireEmailTemplates(t, task.AdminEmailTemplate())
+	requireNotificationTemplate(t, task.AdminInternalNotificationTemplate())
+	requireEmailTemplates(t, task.SelfEmailTemplate())
+	requireNotificationTemplate(t, task.SelfInternalNotificationTemplate())
+}


### PR DESCRIPTION
## Summary
- notify admins and authors when a FAQ is answered
- add FAQ answered templates
- ensure new templates compile using task providers

## Testing
- `go vet -tags nosqlite ./...` *(fails: ReplyBlogTask does not implement AutoSubscribeProvider)*
- `golangci-lint run --build-tags nosqlite ./...` *(fails with typecheck errors in other packages)*
- `go test -tags nosqlite ./...` *(fails to build handlers packages)*

------
https://chatgpt.com/codex/tasks/task_e_687ba08e28d0832fb2d0e774610e8ca9