### PR TITLE
Add blog permission admin templates

### DIFF
--- a/core/templates/email/blogPermissionEmail.gohtml
+++ b/core/templates/email/blogPermissionEmail.gohtml
@@ -1,0 +1,2 @@
+<p>Blog permissions updated.</p>
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/blogPermissionEmail.gotxt
+++ b/core/templates/email/blogPermissionEmail.gotxt
@@ -1,0 +1,3 @@
+Blog permissions updated.
+
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/blogPermissionEmailSubject.gotxt
+++ b/core/templates/email/blogPermissionEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Blog permission updated

--- a/core/templates/notifications/blog_permission.gotxt
+++ b/core/templates/notifications/blog_permission.gotxt
@@ -1,0 +1,1 @@
+Blog permissions updated

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -14,12 +14,13 @@ import (
 	common "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/tasks"
 
+	notif "github.com/arran4/goa4web/internal/notifications"
+
 	handlers "github.com/arran4/goa4web/handlers"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
 	db "github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/internal/email"
 )
 
@@ -27,17 +28,10 @@ type saveTemplateTask struct{ tasks.TaskString }
 type testTemplateTask struct{ tasks.TaskString }
 
 func getUpdateEmailText(ctx context.Context) string {
-	if q, ok := ctx.Value(common.KeyQueries).(*db.Queries); ok && q != nil {
-		if body, err := q.GetTemplateOverride(ctx, "updateEmail"); err == nil && body != "" {
-			return body
-		}
+	if q, ok := ctx.Value(common.KeyQueries).(*db.Queries); ok {
+		return notif.GetUpdateEmailText(ctx, q)
 	}
-	tmpl := templates.GetCompiledEmailTextTemplates(map[string]any{})
-	var buf bytes.Buffer
-	if err := tmpl.ExecuteTemplate(&buf, "updateEmail.gotxt", nil); err != nil {
-		return ""
-	}
-	return buf.String()
+	return notif.GetUpdateEmailText(ctx, nil)
 }
 
 // AdminEmailTemplatePage allows administrators to edit the update email template.

--- a/handlers/blogs/blog_autosubscribe_test.go
+++ b/handlers/blogs/blog_autosubscribe_test.go
@@ -1,0 +1,13 @@
+package blogs
+
+import (
+	"testing"
+
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+func TestReplyBlogTaskImplementsAutoSubscribe(t *testing.T) {
+	if _, ok := interface{}(replyBlogTask).(notif.AutoSubscribeProvider); !ok {
+		t.Fatalf("ReplyBlogTask must auto subscribe as users will want updates")
+	}
+}

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -18,6 +18,8 @@ import (
 	"github.com/arran4/goa4web/workers/postcountworker"
 	"github.com/arran4/goa4web/workers/searchworker"
 	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/internal/eventbus"
 )
 
 // ReplyBlogTask posts a comment reply on a blog.
@@ -38,8 +40,8 @@ func (ReplyBlogTask) SubscribedInternalNotificationTemplate() *string {
 	return &s
 }
 
-func (ReplyBlogTask) AutoSubscribePath() (string, string) {
-	return TaskReply, ""
+func (ReplyBlogTask) AutoSubscribePath(evt eventbus.Event) (string, string) {
+	return TaskReply, evt.Path
 }
 
 func (ReplyBlogTask) IndexType() string { return searchworker.TypeComment }

--- a/handlers/blogs/blogsUserPermissionsPage.go
+++ b/handlers/blogs/blogsUserPermissionsPage.go
@@ -25,12 +25,16 @@ var userAllowTask = &UserAllowTask{TaskString: TaskUserAllow}
 var _ tasks.Task = (*UserAllowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*UserAllowTask)(nil)
 
+// AdminEmailTemplate ensures admins receive a consistent message when
+// permissions are granted so they stay informed about changes.
 func (UserAllowTask) AdminEmailTemplate() *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationBlogUserAllowEmail")
+	return notif.NewEmailTemplates("blogPermissionEmail")
 }
 
+// AdminInternalNotificationTemplate pairs with the admin email so the
+// dashboard also reflects the permission update.
 func (UserAllowTask) AdminInternalNotificationTemplate() *string {
-	v := notif.NotificationTemplateFilenameGenerator("adminNotificationBlogUserAllowEmail")
+	v := notif.NotificationTemplateFilenameGenerator("blog_permission")
 	return &v
 }
 
@@ -46,12 +50,16 @@ var userDisallowTask = &UserDisallowTask{TaskString: TaskUserDisallow}
 var _ tasks.Task = (*UserDisallowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*UserDisallowTask)(nil)
 
+// AdminEmailTemplate notifies administrators when a blog permission is
+// revoked, keeping them in the loop if access is removed.
 func (UserDisallowTask) AdminEmailTemplate() *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationBlogUserDisallowEmail")
+	return notif.NewEmailTemplates("blogPermissionEmail")
 }
 
+// AdminInternalNotificationTemplate mirrors the email so in-app alerts show
+// the permission revocation too.
 func (UserDisallowTask) AdminInternalNotificationTemplate() *string {
-	v := notif.NotificationTemplateFilenameGenerator("adminNotificationBlogUserDisallowEmail")
+	v := notif.NotificationTemplateFilenameGenerator("blog_permission")
 	return &v
 }
 
@@ -67,12 +75,16 @@ var usersAllowTask = &UsersAllowTask{TaskString: TaskUsersAllow}
 var _ tasks.Task = (*UsersAllowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*UsersAllowTask)(nil)
 
+// AdminEmailTemplate informs admins when many users receive access so they
+// can audit bulk changes easily.
 func (UsersAllowTask) AdminEmailTemplate() *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationBlogUsersAllowEmail")
+	return notif.NewEmailTemplates("blogPermissionEmail")
 }
 
+// AdminInternalNotificationTemplate complements the email with an in-app
+// notice for bulk permissions.
 func (UsersAllowTask) AdminInternalNotificationTemplate() *string {
-	v := notif.NotificationTemplateFilenameGenerator("adminNotificationBlogUsersAllowEmail")
+	v := notif.NotificationTemplateFilenameGenerator("blog_permission")
 	return &v
 }
 
@@ -88,12 +100,16 @@ var usersDisallowTask = &UsersDisallowTask{TaskString: TaskUsersDisallow}
 var _ tasks.Task = (*UsersDisallowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*UsersDisallowTask)(nil)
 
+// AdminEmailTemplate alerts administrators when multiple users have
+// permissions removed so there is an audit trail.
 func (UsersDisallowTask) AdminEmailTemplate() *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationBlogUsersDisallowEmail")
+	return notif.NewEmailTemplates("blogPermissionEmail")
 }
 
+// AdminInternalNotificationTemplate sends the same message inside the admin
+// dashboard for visibility.
 func (UsersDisallowTask) AdminInternalNotificationTemplate() *string {
-	v := notif.NotificationTemplateFilenameGenerator("adminNotificationBlogUsersDisallowEmail")
+	v := notif.NotificationTemplateFilenameGenerator("blog_permission")
 	return &v
 }
 

--- a/handlers/blogs/blogsUserPermissionsPage_test.go
+++ b/handlers/blogs/blogsUserPermissionsPage_test.go
@@ -1,0 +1,22 @@
+package blogs
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/core/templates"
+)
+
+func TestBlogPermissionTemplatesExist(t *testing.T) {
+	et := userAllowTask.AdminEmailTemplate()
+	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
+	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
+	if htmlTmpls.Lookup(et.HTML) == nil {
+		t.Errorf("missing html template %s", et.HTML)
+	}
+	if textTmpls.Lookup(et.Text) == nil {
+		t.Errorf("missing text template %s", et.Text)
+	}
+	if textTmpls.Lookup(et.Subject) == nil {
+		t.Errorf("missing subject template %s", et.Subject)
+	}
+}

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -66,20 +66,7 @@ func (CreateThreadTask) AdminInternalNotificationTemplate() *string {
 	return &v
 }
 
-func (CreateThreadTask) AutoSubscribePath() (string, string) {
-	return string(TaskCreateThread), ""
-}
-
 var _ searchworker.IndexedTask = CreateThreadTask{}
-
-func (CreateThreadTask) SubscribedEmailTemplate() *notif.EmailTemplates {
-	return notif.NewEmailTemplates("threadEmail")
-}
-
-func (CreateThreadTask) SubscribedInternalNotificationTemplate() *string {
-	s := notif.NotificationTemplateFilenameGenerator("thread")
-	return &s
-}
 
 func (CreateThreadTask) AutoSubscribePath(evt eventbus.Event) (string, string) {
 	return string(TaskCreateThread), evt.Path

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -59,20 +59,7 @@ func (ReplyTask) AdminInternalNotificationTemplate() *string {
 	return &v
 }
 
-func (ReplyTask) AutoSubscribePath() (string, string) {
-	return string(TaskReply), ""
-}
-
 var _ searchworker.IndexedTask = ReplyTask{}
-
-func (ReplyTask) SubscribedEmailTemplate() *notif.EmailTemplates {
-	return notif.NewEmailTemplates("replyEmail")
-}
-
-func (ReplyTask) SubscribedInternalNotificationTemplate() *string {
-	s := notif.NotificationTemplateFilenameGenerator("reply")
-	return &s
-}
 
 func (ReplyTask) AutoSubscribePath(evt eventbus.Event) (string, string) {
 	return string(TaskReply), evt.Path

--- a/handlers/forum/forum_autosubscribe_test.go
+++ b/handlers/forum/forum_autosubscribe_test.go
@@ -1,0 +1,19 @@
+package forum
+
+import (
+	"testing"
+
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+func TestCreateThreadTaskImplementsAutoSubscribe(t *testing.T) {
+	if _, ok := interface{}(createThreadTask).(notif.AutoSubscribeProvider); !ok {
+		t.Fatalf("CreateThreadTask must auto subscribe as users will want updates")
+	}
+}
+
+func TestReplyTaskImplementsAutoSubscribe(t *testing.T) {
+	if _, ok := interface{}(replyTask).(notif.AutoSubscribeProvider); !ok {
+		t.Fatalf("ReplyTask must auto subscribe as users will want updates")
+	}
+}

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -24,6 +24,8 @@ import (
 	"github.com/arran4/goa4web/internal/tasks"
 	postcountworker "github.com/arran4/goa4web/workers/postcountworker"
 	searchworker "github.com/arran4/goa4web/workers/searchworker"
+
+	"github.com/arran4/goa4web/internal/eventbus"
 )
 
 type NewsPost struct {
@@ -71,8 +73,8 @@ func (ReplyTask) AdminInternalNotificationTemplate() *string {
 	return &v
 }
 
-func (ReplyTask) AutoSubscribePath() (string, string) {
-	return string(TaskReply), ""
+func (ReplyTask) AutoSubscribePath(evt eventbus.Event) (string, string) {
+	return string(TaskReply), evt.Path
 }
 
 type EditTask struct{ tasks.TaskString }
@@ -118,8 +120,8 @@ func (NewPostTask) SubscribedInternalNotificationTemplate() *string {
 	return &s
 }
 
-func (NewPostTask) AutoSubscribePath() (string, string) {
-	return string(TaskNewPost), ""
+func (NewPostTask) AutoSubscribePath(evt eventbus.Event) (string, string) {
+	return string(TaskNewPost), evt.Path
 }
 
 func NewsPostPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/news/news_autosubscribe_test.go
+++ b/handlers/news/news_autosubscribe_test.go
@@ -1,0 +1,16 @@
+package news
+
+import (
+	"testing"
+
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+func TestNewsTasksImplementAutoSubscribe(t *testing.T) {
+	if _, ok := interface{}(replyTask).(notif.AutoSubscribeProvider); !ok {
+		t.Fatalf("ReplyTask must auto subscribe as users will want updates")
+	}
+	if _, ok := interface{}(newPostTask).(notif.AutoSubscribeProvider); !ok {
+		t.Fatalf("NewPostTask must auto subscribe as users will want updates")
+	}
+}


### PR DESCRIPTION
## Summary
- implement admin notification template methods for blog permission tasks
- add email templates for blog permission changes
- embed new notification template
- test that blog permission templates compile
- enforce auto subscribe interface for forum/blog/news tasks
- fix admin template helper

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ba2a03c70832f878c80db2b746348