### PR TITLE
Fix test failures

### DIFF
--- a/core/templates/embedded.go
+++ b/core/templates/embedded.go
@@ -5,7 +5,8 @@ package templates
 
 import (
 	"embed"
-	"html/template"
+	htemplate "html/template"
+	ttemplate "text/template"
 )
 
 var (
@@ -27,20 +28,20 @@ var (
 	notificationsJSData []byte
 )
 
-func GetCompiledSiteTemplates(funcs template.FuncMap) *template.Template {
-	return template.Must(template.New("").Funcs(funcs).ParseFS(siteTemplatesFS, "site/*.gohtml", "site/*/*.gohtml"))
+func GetCompiledSiteTemplates(funcs htemplate.FuncMap) *htemplate.Template {
+	return htemplate.Must(htemplate.New("").Funcs(funcs).ParseFS(siteTemplatesFS, "site/*.gohtml", "site/*/*.gohtml"))
 }
 
-func GetCompiledNotificationTemplates(funcs template.FuncMap) *template.Template {
-	return template.Must(template.New("").Funcs(funcs).ParseFS(notificationTemplatesFS, "notifications/*.gotxt"))
+func GetCompiledNotificationTemplates(funcs ttemplate.FuncMap) *ttemplate.Template {
+	return ttemplate.Must(ttemplate.New("").Funcs(funcs).ParseFS(notificationTemplatesFS, "notifications/*.gotxt"))
 }
 
-func GetCompiledEmailHtmlTemplates(funcs template.FuncMap) *template.Template {
-	return template.Must(template.New("").Funcs(funcs).ParseFS(emailHtmlTemplatesFS, "email/*.gohtml"))
+func GetCompiledEmailHtmlTemplates(funcs htemplate.FuncMap) *htemplate.Template {
+	return htemplate.Must(htemplate.New("").Funcs(funcs).ParseFS(emailHtmlTemplatesFS, "email/*.gohtml"))
 }
 
-func GetCompiledEmailTextTemplates(funcs template.FuncMap) *template.Template {
-	return template.Must(template.New("").Funcs(funcs).ParseFS(emailTextTemplatesFS, "email/*.gotxt"))
+func GetCompiledEmailTextTemplates(funcs ttemplate.FuncMap) *ttemplate.Template {
+	return ttemplate.Must(ttemplate.New("").Funcs(funcs).ParseFS(emailTextTemplatesFS, "email/*.gotxt"))
 }
 
 func GetMainCSSData() []byte {

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -28,7 +28,7 @@ type saveTemplateTask struct{ tasks.TaskString }
 type testTemplateTask struct{ tasks.TaskString }
 
 func getUpdateEmailText(ctx context.Context) string {
-	if q, ok := ctx.Value(common.KeyQueries).(*db.Queries); ok && q != nil {
+	if q, ok := ctx.Value(consts.KeyQueries).(*db.Queries); ok && q != nil {
 		if body, err := q.GetTemplateOverride(ctx, "updateEmail.gotxt"); err == nil && body != "" {
 			return body
 		}

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -21,7 +21,7 @@ import (
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
 	logProv "github.com/arran4/goa4web/internal/email/log"
-	"github.com/arran4/goa4web/internal/notifications"
+	notif "github.com/arran4/goa4web/internal/notifications"
 )
 
 func init() { logProv.Register() }
@@ -62,8 +62,6 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "u@example.com", "u")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
 		WithArgs(int32(1)).WillReturnRows(rows)
-	mock.ExpectQuery("SELECT body FROM template_overrides WHERE name = ?").
-		WithArgs("updateEmail").WillReturnError(sql.ErrNoRows)
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(int32(1), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 

--- a/handlers/auth/forgotPassword.go
+++ b/handlers/auth/forgotPassword.go
@@ -13,7 +13,7 @@ import (
 	common "github.com/arran4/goa4web/core/common"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/notifications"
+	notif "github.com/arran4/goa4web/internal/notifications"
 )
 
 type ForgotPasswordTask struct {
@@ -94,7 +94,7 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) {
 				if evt.Data == nil {
 					evt.Data = map[string]any{}
 				}
-				evt.Data["reset"] = notifications.PasswordResetInfo{Username: row.Username.String, Code: code}
+				evt.Data["reset"] = notif.PasswordResetInfo{Username: row.Username.String, Code: code}
 			}
 		}
 		// OLD _ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, page, handlers.TaskUserResetPassword, code)

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -11,7 +11,7 @@ import (
 	"github.com/arran4/goa4web/core"
 	common "github.com/arran4/goa4web/core/common"
 	db "github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/notifications"
+	notif "github.com/arran4/goa4web/internal/notifications"
 	postcountworker "github.com/arran4/goa4web/workers/postcountworker"
 	searchworker "github.com/arran4/goa4web/workers/searchworker"
 
@@ -34,27 +34,9 @@ var _ notif.SubscribersNotificationTemplateProvider = (*ReplyTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*ReplyTask)(nil)
 var _ notif.AutoSubscribeProvider = (*ReplyTask)(nil)
 
-
 // Build time checks so replying to a thread always triggers subscription and
 // notification delivery using the standard templates, keeping readers in the
 // conversation.
-var replyTask = &ReplyTask{TaskString: TaskReply}
-
-// Compile-time interface checks with user focused reasoning. Subscribing allows
-// thread followers to hear about replies while administrators are alerted to new
-// content. AutoSubscribeProvider ensures the author is kept in the loop.
-var _ tasks.Task = (*ReplyTask)(nil)
-
-// ReplyTask notifies thread subscribers and automatically subscribes the author
-// to keep them in the conversation.
-var _ notif.SubscribersNotificationTemplateProvider = (*ReplyTask)(nil)
-
-// admins track replies across the forum
-var _ notif.AdminEmailTemplateProvider = (*ReplyTask)(nil)
-
-// participants expect to automatically follow discussions they reply to
-var _ notif.AutoSubscribeProvider = (*ReplyTask)(nil)
-
 var replyTask = &ReplyTask{TaskString: TaskReply}
 
 func (ReplyTask) IndexType() string { return searchworker.TypeComment }
@@ -86,30 +68,13 @@ func (ReplyTask) AdminInternalNotificationTemplate() *string {
 	return &v
 }
 
-var _ searchworker.IndexedTask = ReplyTask{}
-
 // AutoSubscribePath ensures authors automatically receive updates on replies.
-var _ searchworker.IndexedTask = ReplyTask{}
-
-func (ReplyTask) SubscribedEmailTemplate() *notif.EmailTemplates {
-	return notif.NewEmailTemplates("forumReplyEmail")
-}
-
-func (ReplyTask) SubscribedInternalNotificationTemplate() *string {
-	s := notif.NotificationTemplateFilenameGenerator("forum_reply")
-	return &s
-}
-
-// AutoSubscribePath implements notif.AutoSubscribeProvider. The subscription is
-// created for the originating forum thread when that information is available.
 func (ReplyTask) AutoSubscribePath(evt eventbus.Event) (string, string) {
 	if data, ok := evt.Data[postcountworker.EventKey].(postcountworker.UpdateEventData); ok {
 		return string(TaskReply), fmt.Sprintf("/forum/topic/%d/thread/%d", data.TopicID, data.ThreadID)
 	}
 	return string(TaskReply), evt.Path
 }
-
-var _ searchworker.IndexedTask = ReplyTask{}
 
 func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) {
 	session, ok := core.GetSessionOrFail(w, r)
@@ -125,7 +90,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data["reply"] = notifications.ForumReplyInfo{TopicTitle: topicRow.Title.String, ThreadID: threadRow.Idforumthread, Thread: threadRow}
+			evt.Data["reply"] = notif.ForumReplyInfo{TopicTitle: topicRow.Title.String, ThreadID: threadRow.Idforumthread, Thread: threadRow}
 		}
 	}
 

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -22,7 +22,7 @@ import (
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
-	"github.com/arran4/goa4web/internal/notifications"
+	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 	postcountworker "github.com/arran4/goa4web/workers/postcountworker"
 	searchworker "github.com/arran4/goa4web/workers/searchworker"
@@ -91,8 +91,8 @@ func (ReplyTask) AdminInternalNotificationTemplate() *string {
 
 // AutoSubscribePath registers this reply so the author automatically follows
 // subsequent comments on the news post.
-	// When users reply to a news post we automatically subscribe them so
-	// they receive updates to the thread they just engaged with.
+// When users reply to a news post we automatically subscribe them so
+// they receive updates to the thread they just engaged with.
 // AutoSubscribePath allows commenters to automatically watch for further replies.
 // AutoSubscribePath implements notif.AutoSubscribeProvider. A subscription to
 // the underlying discussion thread is created using event data when available.
@@ -161,8 +161,8 @@ func (NewPostTask) SubscribedInternalNotificationTemplate() *string {
 
 // AutoSubscribePath links the newly created post so that any future replies
 // notify the author by default.
-	// Subscribing the poster ensures they are notified when readers engage
-	// with their new thread.
+// Subscribing the poster ensures they are notified when readers engage
+// with their new thread.
 // AutoSubscribePath keeps authors in the loop on new post discussions.
 // AutoSubscribePath implements notif.AutoSubscribeProvider. Subscriptions use
 // the thread path derived from postcountworker data when possible.
@@ -570,7 +570,7 @@ func (NewPostTask) Action(w http.ResponseWriter, r *http.Request) {
 				if evt.Data == nil {
 					evt.Data = map[string]any{}
 				}
-				evt.Data["blog"] = notifications.BlogPostInfo{Author: u.Username.String}
+				evt.Data["blog"] = notif.BlogPostInfo{Author: u.Username.String}
 			}
 		}
 	}

--- a/handlers/writings/reply_task_test.go
+++ b/handlers/writings/reply_task_test.go
@@ -6,7 +6,7 @@ import (
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
 
-func TestRepliesMustAutoSubscribe(t *testing.T) {
+func TestReplyTaskAutoSubscribe(t *testing.T) {
 	var task ReplyTask
 	if _, ok := interface{}(task).(notif.AutoSubscribeProvider); !ok {
 		t.Fatalf("AutoSubscribeProvider must auto subscribe as users will want updates")

--- a/handlers/writings/task_structs.go
+++ b/handlers/writings/task_structs.go
@@ -86,19 +86,6 @@ func (ReplyTask) AutoSubscribePath(evt eventbus.Event) (string, string) {
 var _ searchworker.IndexedTask = ReplyTask{}
 var _ notif.AutoSubscribeProvider = (*ReplyTask)(nil)
 
-func (ReplyTask) SubscribedEmailTemplate() *notif.EmailTemplates {
-	return notif.NewEmailTemplates("replyEmail")
-}
-
-func (ReplyTask) SubscribedInternalNotificationTemplate() *string {
-	s := notif.NotificationTemplateFilenameGenerator("reply")
-	return &s
-}
-
-func (ReplyTask) AutoSubscribePath(evt eventbus.Event) (string, string) {
-	return string(TaskReply), evt.Path
-}
-
 func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) { ArticleReplyActionPage(w, r) }
 
 // EditReplyTask updates an existing comment.

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -22,7 +22,6 @@ import (
 	imagesign "github.com/arran4/goa4web/internal/images"
 	middleware "github.com/arran4/goa4web/internal/middleware"
 	csrfmw "github.com/arran4/goa4web/internal/middleware/csrf"
-	"github.com/arran4/goa4web/internal/notifications"
 	routerpkg "github.com/arran4/goa4web/internal/router"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"

--- a/internal/notifications/update_email.go
+++ b/internal/notifications/update_email.go
@@ -5,14 +5,14 @@ import (
 
 	coretemplates "github.com/arran4/goa4web/core/templates"
 	db "github.com/arran4/goa4web/internal/db"
-	htemplate "html/template"
+	ttemplate "text/template"
 )
 
 // GetUpdateEmailText returns the update email text template after applying any
 // database overrides.
 func GetUpdateEmailText(ctx context.Context, q *db.Queries) string {
 	tmpls := coretemplates.GetCompiledEmailTextTemplates(map[string]any{})
-	b, err := renderTemplate[*htemplate.Template](ctx, q, EmailTextTemplateFilenameGenerator("updateEmail"), nil, tmpls, HTMLTemplatesNew)
+	b, err := renderTemplate[*ttemplate.Template](ctx, q, EmailTextTemplateFilenameGenerator("updateEmail"), nil, tmpls, TextTemplatesNew)
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
## Summary
- fix type mismatches in embedded templates and notifier functions
- clean up forum handler duplicates and alias imports
- fix admin email template test and other notifications
- trim unused import in run.go
- update tests to avoid duplicate names

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c3d1ebf78832f8c29aba1cc9b43e4