### PR TITLE
Add blog link in admin email

### DIFF
--- a/core/templates/email/adminNotificationBlogAddEmail.gohtml
+++ b/core/templates/email/adminNotificationBlogAddEmail.gohtml
@@ -1,4 +1,4 @@
 <p>User {{.Item.Username}} added a new blog post.</p>
 
-{{/* TODO add URL back to item here */}}
+<p>Read it <a href="{{.URL}}">here</a>.</p>
 <p><a href="{{.UnsubURL}}">Manage notifications</a></p>


### PR DESCRIPTION
## Summary
- add a hyperlink to the new blog post in `adminNotificationBlogAddEmail.gohtml`

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687c55c726dc832f8643c5c0745e6c2c