### PR TITLE
Update forum cancel task route

### DIFF
--- a/handlers/forum/forumCancelTasks.go
+++ b/handlers/forum/forumCancelTasks.go
@@ -17,7 +17,7 @@ import (
 // threadNewCancelTask aborts creating a new thread.
 type threadNewCancelTask struct{ tasks.TaskString }
 
-var threadNewCancel = &threadNewCancelTask{TaskString: TaskCancel}
+var threadNewCancelAction = &threadNewCancelTask{TaskString: TaskCancel}
 
 var _ tasks.Task = (*threadNewCancelTask)(nil)
 

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -25,7 +25,7 @@ func RegisterRoutes(r *mux.Router) {
 	fr.HandleFunc("/topic/{topic}", TopicsPage).Methods("GET")
 	fr.HandleFunc("/topic/{topic}/thread", createThreadTask.Page).Methods("GET")
 	fr.HandleFunc("/topic/{topic}/thread", tasks.Action(createThreadTask)).Methods("POST").MatcherFunc(createThreadTask.Matcher())
-	fr.HandleFunc("/topic/{topic}/thread", tasks.Action(threadNewCancel)).Methods("POST").MatcherFunc(threadNewCancel.Matcher()) // TODO make this form
+	fr.HandleFunc("/topic/{topic}/thread", tasks.Action(threadNewCancelAction)).Methods("POST").MatcherFunc(threadNewCancelAction.Matcher())
 	fr.Handle("/topic/{topic}/thread/{thread}", RequireThreadAndTopic(http.HandlerFunc(ThreadPage))).Methods("GET")
 	fr.Handle("/topic/{topic}/thread/{thread}", RequireThreadAndTopic(http.HandlerFunc(handlers.TaskDoneAutoRefreshPage))).Methods("POST")
 	fr.Handle("/topic/{topic}/thread/{thread}/reply", RequireThreadAndTopic(http.HandlerFunc(tasks.Action(replyTask)))).Methods("POST").MatcherFunc(replyTask.Matcher())


### PR DESCRIPTION
## Summary
- register `threadNewCancelAction` task and use it in the forum routes

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c56f76f34832fb94aa2da2f490122