### PR TITLE
Remove TaskString Action comment

### DIFF
--- a/internal/tasks/task_event.go
+++ b/internal/tasks/task_event.go
@@ -27,7 +27,6 @@ func (t TaskString) Name() string {
 	return string(t)
 }
 
-// Action implements the Task interface. TODO: evaluate if this is required.
 func (t TaskString) Action(http.ResponseWriter, *http.Request) {}
 
 func (t TaskString) Matcher() mux.MatcherFunc {


### PR DESCRIPTION
## Summary
- remove the comment above TaskString.Action so the function remains a simple no-op

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c56b00858832f81f3b2438beea0a9