### PR TITLE
Implement DLQ notification email

### DIFF
--- a/core/templates/email/dlqMultiFailure.gohtml
+++ b/core/templates/email/dlqMultiFailure.gohtml
@@ -1,0 +1,3 @@
+<p>Multiple background tasks have failed.</p>
+<p>Latest error: {{.Item.Message}}</p>
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/dlqMultiFailure.gotxt
+++ b/core/templates/email/dlqMultiFailure.gotxt
@@ -1,0 +1,3 @@
+Multiple background tasks have failed.
+Latest error: {{.Item.Message}}
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/dlqMultiFailureSubject.gotxt
+++ b/core/templates/email/dlqMultiFailureSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Multiple task failures

--- a/core/templates/notifications/dlqMultiFailure.gotxt
+++ b/core/templates/notifications/dlqMultiFailure.gotxt
@@ -1,0 +1,1 @@
+Multiple background tasks have failed. Latest error: {{.Item.Message}}

--- a/internal/notifications/dlq.go
+++ b/internal/notifications/dlq.go
@@ -3,6 +3,8 @@ package notifications
 import (
 	"context"
 	"fmt"
+
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/dlq"
 	"github.com/arran4/goa4web/internal/dlq/db"
 )
@@ -15,20 +17,30 @@ func dlqRecordAndNotify(ctx context.Context, q dlq.DLQ, n *Notifier, msg string)
 		if dbq, ok := q.(db.DLQ); ok {
 			if count, err := dbq.Queries.CountDeadLetters(ctx); err == nil {
 				if isPow10(count) {
-					// TODO create template and data
-					err := n.NotifyAdmins(ctx, &EmailTemplates{
+					data := EmailData{
+						Item: struct {
+							Message string
+						}{Message: msg},
+					}
+					et := &EmailTemplates{
 						Text:    EmailTextTemplateFilenameGenerator("dlqMultiFailure"),
 						HTML:    EmailHTMLTemplateFilenameGenerator("dlqMultiFailure"),
 						Subject: EmailSubjectTemplateFilenameGenerator("dlqMultiFailure"),
-					}, EmailData{
-						Item: struct {
-							Message string
-						}{
-							Message: msg,
-						},
-					})
-					if err != nil {
+					}
+					if err := n.NotifyAdmins(ctx, et, data); err != nil {
 						return err
+					}
+					if config.AdminNotificationsEnabled() && n.Queries != nil {
+						nt, err := n.renderNotification(ctx, NotificationTemplateFilenameGenerator("dlqMultiFailure"), data)
+						if err == nil {
+							for _, addr := range config.GetAdminEmails(ctx, n.Queries) {
+								u, err := n.Queries.UserByEmail(ctx, addr)
+								if err != nil {
+									continue
+								}
+								_ = sendInternalNotification(ctx, n.Queries, u.Idusers, "", string(nt))
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- create a `dlqMultiFailure` email template set
- send DLQ multi-failure alerts to admins via `NotifyAdmins`
- send internal notifications to admins when failures persist

## Testing
- `go mod tidy`
- `go vet ./...` *(fails: cannot use html/template.Template as text/template.Template)*
- `golangci-lint run ./...` *(fails to compile)*
- `go test -tags nosqlite ./...` *(fails to compile)*


------
https://chatgpt.com/codex/tasks/task_e_687c4bd25060832f8a8db57401545350