### PR TITLE
Remove outdated TODO comments

### DIFF
--- a/internal/notifications/email.go
+++ b/internal/notifications/email.go
@@ -47,8 +47,6 @@ type EmailData struct {
 }
 
 // RenderEmailFromTemplates returns the rendered email message using the provided templates.
-// TODO: evaluate exposing this via EmailTemplates.CreateEmail instead.
-// TODO: this should be a receiver on EmailTemplates
 func (n *Notifier) RenderEmailFromTemplates(ctx context.Context, emailAddr string, et *EmailTemplates, item interface{}) ([]byte, error) {
 	if emailAddr == "" {
 		return nil, fmt.Errorf("no email specified")


### PR DESCRIPTION
## Summary
- remove TODO lines about moving RenderEmailFromTemplates

## Testing
- `go mod tidy`
- `go vet ./...` *(fails: ResendQueueTask redeclared)*
- `golangci-lint run` *(fails: typecheck issues)*
- `go test ./...` *(fails: build errors in handlers/admin)*

------
https://chatgpt.com/codex/tasks/task_e_687c5fb68fa8832f93b2ed1789923b12