### PR TITLE
Add cancel button for forum replies

### DIFF
--- a/core/templates/site/forum/reply.gohtml
+++ b/core/templates/site/forum/reply.gohtml
@@ -5,7 +5,8 @@
         {{ csrfField }}
 				<textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>
                 {{ template "languageCombobox" $ }}
-				<input type="submit" name="task" value="Reply">
-			</form>
-		{{end}}
+                                <input type="submit" name="task" value="Reply">
+                                <input type="submit" name="task" value="Cancel">
+                        </form>
+                {{end}}
 {{ end }}


### PR DESCRIPTION
## Summary
- provide a Cancel button in the forum reply form

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: ResendQueueTask redeclared)*
- `golangci-lint run ./...` *(fails: typecheck issues in admin handlers)*
- `go test ./...` *(fails: build errors in admin handlers)*

------
https://chatgpt.com/codex/tasks/task_e_687c61658534832faff0cfa070ba5ce9