### PR TITLE
Implement self email verification

### DIFF
--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -32,6 +32,7 @@ type TestMailTask struct{ tasks.TaskString }
 
 var _ tasks.Task = (*TestMailTask)(nil)
 var _ notif.SelfNotificationTemplateProvider = (*TestMailTask)(nil)
+var _ notif.SelfNotificationTemplateProvider = (*AddEmailTask)(nil)
 
 func (ResendEmailTask) Action(w http.ResponseWriter, r *http.Request) { addEmailTask.Resend(w, r) }
 
@@ -212,7 +213,6 @@ func (AddEmailTask) Action(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	evt := cd.Event()
 	evt.Data["page"] = page
-	// _ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, uid, emailAddr, page, TaskUserEmailVerification, nil) TODO Make addEmailTask sendSelf
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }
 
@@ -246,7 +246,6 @@ func (AddEmailTask) Resend(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	evt := cd.Event()
 	evt.Data["page"] = page
-	// _ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, uid, ue.Email, page, TaskUserEmailVerification, nil) TODO make AddEmailTask sendSelf
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }
 
@@ -291,6 +290,15 @@ func (AddEmailTask) Notify(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = queries.SetNotificationPriority(r.Context(), db.SetNotificationPriorityParams{NotificationPriority: maxPr + 1, ID: int32(id)})
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
+}
+
+func (AddEmailTask) SelfEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("verifyEmail")
+}
+
+func (AddEmailTask) SelfInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("verifyEmail")
+	return &v
 }
 
 func userEmailVerifyCodePage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/user/userEmailPage_test.go
+++ b/handlers/user/userEmailPage_test.go
@@ -22,6 +22,22 @@ func requireEmailTemplates(t *testing.T, prefix string) {
 	}
 }
 
+func requireNotificationTemplate(t *testing.T, name *string) {
+	if name == nil {
+		return
+	}
+	tmpl := templates.GetCompiledNotificationTemplates(map[string]any{})
+	if tmpl.Lookup(*name) == nil {
+		t.Errorf("missing notification template %s", *name)
+	}
+}
+
 func TestTestMailTemplatesExist(t *testing.T) {
 	requireEmailTemplates(t, "testEmail")
+}
+
+func TestAddEmailTaskTemplates(t *testing.T) {
+	var task AddEmailTask
+	requireEmailTemplates(t, "verifyEmail")
+	requireNotificationTemplate(t, task.SelfInternalNotificationTemplate())
 }


### PR DESCRIPTION
## Summary
- implement `SelfNotificationTemplateProvider` for AddEmailTask
- add tests to ensure verify email templates compile
- remove unused TODO comments

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: ResendQueueTask redeclared)*
- `golangci-lint run ./...` *(fails: ResendQueueTask redeclared)*
- `go test ./...` *(fails: ResendQueueTask redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_687c619413d4832fbd38a392aff1efef