### PR TITLE
Clean up messy comments in handlers

### DIFF
--- a/handlers/auth/forgotPassword.go
+++ b/handlers/auth/forgotPassword.go
@@ -97,7 +97,6 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) {
 				evt.Data["reset"] = notif.PasswordResetInfo{Username: row.Username.String, Code: code}
 			}
 		}
-		// OLD _ = emailutil.CreateEmailTemplateAndQueue(r.Context(), queries, row.Idusers, row.Email, page, handlers.TaskUserResetPassword, code)
 	}
 	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }

--- a/handlers/auth/loginPage.go
+++ b/handlers/auth/loginPage.go
@@ -60,10 +60,6 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) {
 	username := r.PostFormValue("username")
 	password := r.PostFormValue("password")
 
-	//sum := md5.Sum([]byte(password))
-	//
-	//hashedPassword := hex.EncodeToString(sum[:])
-
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 
 	row, err := queries.Login(r.Context(), sql.NullString{String: username, Valid: true})

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -81,9 +81,6 @@ func (RegisterTask) Action(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "User already exists", http.StatusForbidden)
 		return
 	}
-	//sum := md5.Sum([]byte(password))
-
-	//hashedPassword := hex.EncodeToString(sum[:])
 
 	hash, alg, err := HashPassword(password)
 	if err != nil {

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -390,7 +390,5 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 			evt.Data[searchworker.EventKey] = searchworker.IndexEventData{Type: searchworker.TypeComment, ID: 0, Text: text}
 		}
 	}
-	//??? if _, done := SearchWordIdsFromText(w, r, text, queries); done {
-
 	handlers.TaskDoneAutoRefreshPage(w, r)
 }


### PR DESCRIPTION
## Summary
- remove debugging snippets and outdated comments in handlers
- tidy whitespace after comment removals

## Testing
- `go vet ./...` *(fails: cannot use templates.GetCompiledNotificationTemplates as html/template)*
- `golangci-lint run ./...` *(fails: typecheck issues in internal/notifications)*
- `go test ./...` *(fails: cannot use templates.GetCompiledNotificationTemplates as html/template)*

------
https://chatgpt.com/codex/tasks/task_e_687c630485b4832fb1f8feb23edfa84d