### PR TITLE
Clean up redundant comments

### DIFF
--- a/handlers/notifications.go
+++ b/handlers/notifications.go
@@ -2,7 +2,6 @@ package handlers
 
 import "github.com/arran4/goa4web/config"
 
-// NotificationsEnabled reports if the internal notification system should run.
 // NotificationsEnabled reports if the internal notification system should run
 // according to the runtime configuration.
 func NotificationsEnabled() bool {

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -390,7 +390,5 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 			evt.Data[searchworker.EventKey] = searchworker.IndexEventData{Type: searchworker.TypeComment, ID: 0, Text: text}
 		}
 	}
-	//??? if _, done := SearchWordIdsFromText(w, r, text, queries); done {
-
 	handlers.TaskDoneAutoRefreshPage(w, r)
 }


### PR DESCRIPTION
## Summary
- remove duplicate description from `NotificationsEnabled`
- drop leftover commented-out search indexing call

## Testing
- `go vet ./...` *(fails: html/template mismatch)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails to build notifications and handlers)*

------
https://chatgpt.com/codex/tasks/task_e_687c630485b4832fb1f8feb23edfa84d