### PR TITLE
Remove outdated TODO comment

### DIFF
--- a/workers/searchworker/postupdate.go
+++ b/workers/searchworker/postupdate.go
@@ -13,7 +13,6 @@ import (
 // the search tables.
 type IndexedTask interface {
 	// IndexType returns the search index type to update.
-	// TODO consider adding this field directly to IndexEventData.
 	IndexType() string
 	// IndexData extracts the pieces of data to index from the event payload.
 	// Returning nil indicates there is nothing to index.


### PR DESCRIPTION
## Summary
- cleanup: remove TODO comment referencing a field that already exists

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c65832224832fb2db0e4049cff431