### PR TITLE
Make email queue helpers unexported

### DIFF
--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -133,7 +133,7 @@ func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.Event, tp SelfNo
 		notifyMissingEmail(ctx, n.Queries, evt.UserID)
 	} else {
 		if et := tp.SelfEmailTemplate(); et != nil {
-			if err := n.RenderAndQueueEmailFromTemplates(ctx, evt.UserID, user.Email.String, et, evt.Data); err != nil {
+			if err := n.renderAndQueueEmailFromTemplates(ctx, evt.UserID, user.Email.String, et, evt.Data); err != nil {
 				return err
 			}
 		}
@@ -246,7 +246,7 @@ func (n *Notifier) notifyAdmins(ctx context.Context, evt eventbus.Event, tp Admi
 			}
 		}
 		if et := tp.AdminEmailTemplate(); et != nil {
-			if err := n.RenderAndQueueEmailFromTemplates(ctx, uid, addr, et, evt.Data); err != nil {
+			if err := n.renderAndQueueEmailFromTemplates(ctx, uid, addr, et, evt.Data); err != nil {
 				return err
 			}
 		}

--- a/internal/notifications/email.go
+++ b/internal/notifications/email.go
@@ -11,8 +11,7 @@ import (
 	"github.com/arran4/goa4web/internal/email"
 )
 
-// TODO: make private once call sites are updated.
-func (n *Notifier) CreateEmailTemplateAndQueue(ctx context.Context, userID int32, emailAddr, page, action string, item interface{}) error {
+func (n *Notifier) createEmailTemplateAndQueue(ctx context.Context, userID int32, emailAddr, page, action string, item interface{}) error {
 	if n.Queries == nil {
 		return fmt.Errorf("no query")
 	}
@@ -26,9 +25,8 @@ func (n *Notifier) CreateEmailTemplateAndQueue(ctx context.Context, userID int32
 	return n.queueEmail(ctx, userID, msg)
 }
 
-// RenderAndQueueEmailFromTemplates renders the provided templates and queues the result.
-// TODO: make private and unify call sites.
-func (n *Notifier) RenderAndQueueEmailFromTemplates(ctx context.Context, userID int32, emailAddr string, et *EmailTemplates, data interface{}) error {
+// renderAndQueueEmailFromTemplates renders the provided templates and queues the result.
+func (n *Notifier) renderAndQueueEmailFromTemplates(ctx context.Context, userID int32, emailAddr string, et *EmailTemplates, data interface{}) error {
 	if n.Queries == nil {
 		return fmt.Errorf("no query")
 	}
@@ -112,5 +110,5 @@ func (n *Notifier) sendSubscriberEmail(ctx context.Context, userID int32, evt ev
 	if et == nil {
 		return nil
 	}
-	return n.RenderAndQueueEmailFromTemplates(ctx, userID, user.Email.String, et, evt.Data)
+	return n.renderAndQueueEmailFromTemplates(ctx, userID, user.Email.String, et, evt.Data)
 }

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -99,7 +99,7 @@ func (n *Notifier) NotifyAdmins(ctx context.Context, et *EmailTemplates, data Em
 				continue
 			}
 		}
-		if err := n.RenderAndQueueEmailFromTemplates(ctx, uid, addr, et, data); err != nil {
+		if err := n.renderAndQueueEmailFromTemplates(ctx, uid, addr, et, data); err != nil {
 			log.Printf("notify admin %s: %v", addr, err)
 		}
 	}


### PR DESCRIPTION
## Summary
- update email queue helpers to use unexported names
- remove outdated TODO comments
- adjust notifier calls to new names

## Testing
- `go vet ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c6572def8832f86045da12b81784c