### PR TITLE
Update forum reply cancel route

### DIFF
--- a/core/templates/site/forum/reply.gohtml
+++ b/core/templates/site/forum/reply.gohtml
@@ -5,7 +5,8 @@
         {{ csrfField }}
 				<textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>
                 {{ template "languageCombobox" $ }}
-				<input type="submit" name="task" value="Reply">
-			</form>
+                                <input type="submit" name="task" value="Reply">
+                                <input type="submit" name="task" formaction="cancel" value="Cancel">
+                        </form>
 		{{end}}
 {{ end }}

--- a/handlers/admin/announcementTemplates_test.go
+++ b/handlers/admin/announcementTemplates_test.go
@@ -24,8 +24,8 @@ func checkEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
 
 func TestAnnouncementTemplatesExist(t *testing.T) {
 	admins := []notif.AdminEmailTemplateProvider{
-		AddAnnouncementTask,
-		DeleteAnnouncementTask,
+		AddAnnouncementTask{},
+		DeleteAnnouncementTask{},
 	}
 	for _, p := range admins {
 		checkEmailTemplates(t, p.AdminEmailTemplate())

--- a/handlers/admin/task_events.go
+++ b/handlers/admin/task_events.go
@@ -6,9 +6,7 @@ import (
 
 // TODO move these into their appropriate files closer to their struct definitions
 
-// ResendQueueTask triggers sending queued emails immediately.
-type ResendQueueTask struct{ tasks.TaskString }
-
+// resendQueueTask triggers sending queued emails immediately.
 var resendQueueTask = &ResendQueueTask{TaskString: TaskResend}
 
 var deleteQueueTask = &DeleteQueueTask{TaskString: TaskDelete}
@@ -33,6 +31,6 @@ var addIPBanTask = &AddIPBanTask{TaskString: TaskAdd}
 
 var deleteIPBanTask = &DeleteIPBanTask{TaskString: TaskDelete}
 
-var newsUserAllowTask = newsUserAllowTask{TaskString: tasks.TaskString("allow")}
+var NewsUserAllowTask = newsUserAllowTask{TaskString: tasks.TaskString("allow")}
 
-var newsUserRemoveTask = newsUserRemoveTask{TaskString: tasks.TaskString("remove")}
+var NewsUserRemoveTask = newsUserRemoveTask{TaskString: tasks.TaskString("remove")}

--- a/handlers/forum/forumCancelTasks.go
+++ b/handlers/forum/forumCancelTasks.go
@@ -33,6 +33,10 @@ var topicThreadReplyCancel = &topicThreadReplyCancelTask{TaskString: TaskCancel}
 
 var _ tasks.Task = (*topicThreadReplyCancelTask)(nil)
 
+func (topicThreadReplyCancelTask) Page(w http.ResponseWriter, r *http.Request) {
+	TopicThreadReplyCancelPage(w, r)
+}
+
 func (topicThreadReplyCancelTask) Action(w http.ResponseWriter, r *http.Request) {
 	threadRow := r.Context().Value(consts.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
 	topicRow := r.Context().Value(consts.KeyTopic).(*db.GetForumTopicByIdForUserRow)

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -31,7 +31,9 @@ func RegisterRoutes(r *mux.Router) {
 	fr.Handle("/topic/{topic}/thread/{thread}", RequireThreadAndTopic(http.HandlerFunc(ThreadPage))).Methods("GET")
 	fr.Handle("/topic/{topic}/thread/{thread}", RequireThreadAndTopic(http.HandlerFunc(handlers.TaskDoneAutoRefreshPage))).Methods("POST")
 	fr.Handle("/topic/{topic}/thread/{thread}/reply", RequireThreadAndTopic(http.HandlerFunc(tasks.Action(replyTask)))).Methods("POST").MatcherFunc(replyTask.Matcher())
-	fr.Handle("/topic/{topic}/thread/{thread}/reply", RequireThreadAndTopic(http.HandlerFunc(tasks.Action(topicThreadReplyCancel)))).Methods("POST").MatcherFunc(topicThreadReplyCancel.Matcher())                                                                    // TODO make this form
+	fr.Handle("/topic/{topic}/thread/{thread}/reply/cancel", RequireThreadAndTopic(http.HandlerFunc(topicThreadReplyCancel.Page))).Methods("GET")
+	fr.Handle("/topic/{topic}/thread/{thread}/reply/cancel", RequireThreadAndTopic(http.HandlerFunc(tasks.Action(topicThreadReplyCancel)))).Methods("POST").MatcherFunc(topicThreadReplyCancel.Matcher())
+	fr.Handle("/topic/{topic}/thread/{thread}/reply", RequireThreadAndTopic(http.HandlerFunc(tasks.Action(topicThreadReplyCancel)))).Methods("POST").MatcherFunc(topicThreadReplyCancel.Matcher())
 	fr.Handle("/topic/{topic}/thread/{thread}/comment/{comment}", RequireThreadAndTopic(comments.RequireCommentAuthor(http.HandlerFunc(tasks.Action(topicThreadCommentEditAction))))).Methods("POST").MatcherFunc(topicThreadCommentEditAction.Matcher())             // TODO make this form
 	fr.Handle("/topic/{topic}/thread/{thread}/comment/{comment}", RequireThreadAndTopic(comments.RequireCommentAuthor(http.HandlerFunc(tasks.Action(topicThreadCommentEditActionCancel))))).Methods("POST").MatcherFunc(topicThreadCommentEditActionCancel.Matcher()) // TODO make this form
 }


### PR DESCRIPTION
## Summary
- add a page method to the reply cancel task
- wire up /reply/cancel GET/POST endpoints
- add cancel button to the reply template

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c6162b4e8832fbc591f75aeea131c