### PR TITLE
Add TargetUsersNotificationProvider support

### DIFF
--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -109,6 +109,16 @@ func (n *Notifier) processEvent(ctx context.Context, evt eventbus.Event, q dlq.D
 
 	}
 
+	if tp, ok := evt.Task.(TargetUsersNotificationProvider); ok {
+		if err := n.notifyTargetUsers(ctx, evt, tp); err != nil {
+			if dlqErr := dlqRecordAndNotify(ctx, q, n, fmt.Sprintf("notify target users: %v", err)); dlqErr != nil {
+				return dlqErr
+			}
+			return err
+		}
+
+	}
+
 	if tp, ok := evt.Task.(SubscribersNotificationTemplateProvider); ok {
 		if err := n.notifySubscribers(ctx, evt, tp); err != nil {
 			if dlqErr := dlqRecordAndNotify(ctx, q, n, fmt.Sprintf("notify subscribers: %v", err)); dlqErr != nil {
@@ -154,6 +164,41 @@ func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.Event, tp SelfNo
 				Message:      sql.NullString{String: string(msg), Valid: true},
 			}); err != nil {
 				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.Event, tp TargetUsersNotificationProvider) error {
+	for _, id := range tp.TargetUserIDs(evt) {
+		user, err := n.Queries.GetUserById(ctx, id)
+		if err != nil || !user.Email.Valid || user.Email.String == "" {
+			notifyMissingEmail(ctx, n.Queries, id)
+		} else {
+			if et := tp.TargetEmailTemplate(); et != nil {
+				if err := n.RenderAndQueueEmailFromTemplates(ctx, id, user.Email.String, et, evt.Data); err != nil {
+					return err
+				}
+			}
+		}
+		if nt := tp.TargetInternalNotificationTemplate(); nt != nil {
+			data := struct {
+				eventbus.Event
+				Item interface{}
+			}{Event: evt, Item: evt.Data}
+			msg, err := n.renderNotification(ctx, *nt, data)
+			if err != nil {
+				return err
+			}
+			if len(msg) > 0 {
+				if err := n.Queries.InsertNotification(ctx, dbpkg.InsertNotificationParams{
+					UsersIdusers: id,
+					Link:         sql.NullString{String: evt.Path, Valid: true},
+					Message:      sql.NullString{String: string(msg), Valid: true},
+				}); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/internal/notifications/subscriptionsinterfaces.go
+++ b/internal/notifications/subscriptionsinterfaces.go
@@ -47,3 +47,11 @@ type AutoSubscribeProvider interface {
 	// the path.
 	AutoSubscribePath(evt eventbus.Event) (string, string)
 }
+
+// TargetUsersNotificationProvider indicates the notification should be delivered
+// to the returned user IDs.
+type TargetUsersNotificationProvider interface {
+	TargetUserIDs(evt eventbus.Event) []int32
+	TargetEmailTemplate() *EmailTemplates
+	TargetInternalNotificationTemplate() *string
+}


### PR DESCRIPTION
## Summary
- define `TargetUsersNotificationProvider` for notifying arbitrary users
- handle the new interface in `processEvent`
- add helper `notifyTargetUsers`
- test notifying multiple target users

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c68995af4832fabe0890f5c7a7c4c