### PR TITLE
Remove outdated forum admin restriction links

### DIFF
--- a/core/templates/site/forum/adminPage.gohtml
+++ b/core/templates/site/forum/adminPage.gohtml
@@ -6,8 +6,6 @@
     <li><a href="/forum/admin/topics">Manage Topics</a></li>
     <li><a href="/forum/admin/conversations">Manage Conversations</a></li>
     <li><a href="/forum/admin/users">Manage Users</a></li>
-    <li><a href="/forum/admin/restrictions/users">User Restrictions</a></li>
-    <li><a href="/forum/admin/restrictions/topics">Topic Restrictions</a></li>
 </ul>
 
 <p>Forum statistics:</p>

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -168,18 +168,6 @@ func CustomForumIndex(data *common.CoreData, r *http.Request) {
 				Link: "/forum/admin/users",
 			},
 		)
-		data.CustomIndexItems = append(data.CustomIndexItems,
-			common.IndexItem{
-				Name: "Administer topic restrictions",
-				Link: "/forum/admin/restrictions/topics",
-			},
-		)
-		data.CustomIndexItems = append(data.CustomIndexItems,
-			common.IndexItem{
-				Name: "Administer user restrictions",
-				Link: "/forum/admin/restrictions/users",
-			},
-		)
 	}
 	if threadId != "" && topicId != "" {
 		if tid, err := strconv.Atoi(topicId); err == nil && data.HasGrant("forum", "topic", "reply", int32(tid)) {


### PR DESCRIPTION
## Summary
- prune references to admin restrictions pages
- drop user and topic restriction menu entries

## Testing
- `go vet ./...` *(fails: RenderAndQueueEmailFromTemplates undefined)*
- `golangci-lint run ./...` *(fails: typecheck)*
- `go test ./...` *(fails: RenderAndQueueEmailFromTemplates undefined)*

------
https://chatgpt.com/codex/tasks/task_e_687c6f0dbe30832fb4f75961a1d55d89