### PR TITLE
Fix log message for image post creation

### DIFF
--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -182,7 +182,7 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) {
 		FileSize:               int32(size),
 	})
 	if err != nil {
-		log.Printf("printTopicRestrictions Error: %s", err)
+		log.Printf("CreateImagePost Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary
- correct the log message when image posts fail to create

## Testing
- `go vet ./...` *(fails: Notifier.RenderAndQueueEmailFromTemplates undefined)*
- `golangci-lint run ./...` *(fails: Notifier.RenderAndQueueEmailFromTemplates undefined)*
- `go test ./...` *(fails: Notifier.RenderAndQueueEmailFromTemplates undefined)*

------
https://chatgpt.com/codex/tasks/task_e_687c6f61be34832f91518553f5a3d44b