### PR TITLE
Remove unused ModLevel column

### DIFF
--- a/core/templates/site/imagebbs/adminBoardsPage.gohtml
+++ b/core/templates/site/imagebbs/adminBoardsPage.gohtml
@@ -6,7 +6,6 @@
                                 <th>Description
                                 <th>Parent board
                                 <th>Threads
-                                <th>Mod Level
                                 <th>Visible
                                 <th>Options?
                         {{ range .Boards }}
@@ -18,7 +17,6 @@
                                                 <td><textarea name="desc">{{ .Description.String }}</textarea>
                                                 <td>{{ $pbid := .ImageboardIdimageboard }} {{ $pbid }} <select name="pbid" value="{{ .ImageboardIdimageboard }}"><option value="0">None</option>{{ range $.Boards }}<option value="{{.Idimageboard}}" {{if eq $pbid .Idimageboard}}selected{{end}}>{{.Title.String}}</option>{{ end }}</select>
                                                 <td>{{ .Threads }}
-                                                <td>{{ .ModLevel }}
                                                 <td>{{ if .Visible }}Yes{{ else }}No{{ end }}
                                                 <td>
                                                         <input type="hidden" name="bid" value="{{ .Idimageboard }}">

--- a/handlers/imagebbs/imagebbsAdminBoardsPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardsPage.go
@@ -16,10 +16,9 @@ import (
 func AdminBoardsPage(w http.ResponseWriter, r *http.Request) {
 	type BoardRow struct {
 		*db.Imageboard
-		Threads  int32
-		ModLevel int32
-		Visible  bool
-		Nsfw     bool
+		Threads int32
+		Visible bool
+		Nsfw    bool
 	}
 	type Data struct {
 		*common.CoreData
@@ -50,7 +49,6 @@ func AdminBoardsPage(w http.ResponseWriter, r *http.Request) {
 		data.Boards = append(data.Boards, &BoardRow{
 			Imageboard: b,
 			Threads:    int32(threads),
-			ModLevel:   0,
 			Visible:    true,
 			Nsfw:       false,
 		})


### PR DESCRIPTION
## Summary
- clean up the BoardRow struct used on the admin boards page
- drop the Mod Level column from the template

## Testing
- `go vet ./...` *(fails: RenderAndQueueEmailFromTemplates undefined)*
- `golangci-lint run ./...` *(fails: typecheck errors in internal/notifications)*
- `go test ./...` *(fails: RenderAndQueueEmailFromTemplates undefined)*

------
https://chatgpt.com/codex/tasks/task_e_687c6f4b2704832fa8d8ec205200e356