### PR TITLE
Remove unused forum admin matchers

### DIFF
--- a/handlers/forum/matchers.go
+++ b/handlers/forum/matchers.go
@@ -79,17 +79,3 @@ func RequireThreadAndTopic(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
-
-// TargetUsersLevelNotHigherThanAdminsMax verifies the target user's level does not exceed the admin's maximum.
-func TargetUsersLevelNotHigherThanAdminsMax() mux.MatcherFunc {
-	return func(r *http.Request, m *mux.RouteMatch) bool {
-		return true
-	}
-}
-
-// AdminUsersMaxLevelNotLowerThanTargetLevel ensures the admin's max level exceeds the requested level values.
-func AdminUsersMaxLevelNotLowerThanTargetLevel() mux.MatcherFunc {
-	return func(r *http.Request, m *mux.RouteMatch) bool {
-		return true
-	}
-}


### PR DESCRIPTION
## Summary
- delete `TargetUsersLevelNotHigherThanAdminsMax` and `AdminUsersMaxLevelNotLowerThanTargetLevel`
- clean up unused code in `handlers/forum/matchers.go`

## Testing
- `go vet ./...` *(fails: RenderAndQueueEmailFromTemplates undefined)*
- `golangci-lint run ./...` *(fails: RenderAndQueueEmailFromTemplates undefined)*
- `go test ./...` *(fails: RenderAndQueueEmailFromTemplates undefined)*

------
https://chatgpt.com/codex/tasks/task_e_687c6f171878832f8787b2a549d5f99f