### PR TITLE
Fix matcher comment to mention roles

### DIFF
--- a/handlers/matchers.go
+++ b/handlers/matchers.go
@@ -9,7 +9,7 @@ import (
 	common "github.com/arran4/goa4web/core/common"
 )
 
-// RequiredAccess ensures the requestor has one of the provided access levels.
+// RequiredAccess ensures the requestor has one of the provided roles.
 func RequiredAccess(accessLevels ...string) mux.MatcherFunc {
 	return func(request *http.Request, match *mux.RouteMatch) bool {
 		return common.Allowed(request, accessLevels...)


### PR DESCRIPTION
## Summary
- adjust comment in `handlers/matchers.go` to refer to roles

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: RenderAndQueueEmailFromTemplates undefined)*
- `golangci-lint run ./...` *(fails: RenderAndQueueEmailFromTemplates undefined)*
- `go mod tidy`
- `go test ./...` *(fails: RenderAndQueueEmailFromTemplates undefined)*

------
https://chatgpt.com/codex/tasks/task_e_687c6ef038d4832f8b8c0e096d30748b