### PR TITLE
Fix permission flag in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -375,7 +375,7 @@ go build -o goa4web ./cmd/goa4web
 
 ```bash
 # grant a permission
-./goa4web perm grant --user alice --section forum --level moderator
+./goa4web perm grant --user alice --section forum --role moderator
 
 # list all permissions
 ./goa4web perm list


### PR DESCRIPTION
## Summary
- document `--role` flag in permission example

## Testing
- `go vet ./...` *(fails: RenderAndQueueEmailFromTemplates undefined)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: RenderAndQueueEmailFromTemplates undefined)*
- `go mod tidy`
- `go fmt ./...`

------
https://chatgpt.com/codex/tasks/task_e_687c6f82e974832f85c0b3f87d9e8a9f