### PR TITLE
Rename user level tasks to role actions

### DIFF
--- a/core/templates/site/forum/adminUserPage.gohtml
+++ b/core/templates/site/forum/adminUserPage.gohtml
@@ -25,8 +25,8 @@
                 <td><input name="inviteMax" value="{{ .Invitemax.Int32 }}" size="8"></td>
                 <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format "2006-01-02" }}{{ end }}"></td>
                 <td>
-                    <input type="submit" name="task" value="Update user level">
-                    <input type="submit" name="task" value="Delete user level">
+                    <input type="submit" name="task" value="Update role">
+                    <input type="submit" name="task" value="Revoke role">
                 </td>
             </form>
         </tr>

--- a/core/templates/site/user/topicRestrictions.gohtml
+++ b/core/templates/site/user/topicRestrictions.gohtml
@@ -17,8 +17,8 @@
                 <td><input name="level" value="{{ .Level }}" size="8">
                 <td><input name="invitemax" value="{{ .InviteMax }}" size="8">
                 <td>
-                    <input type="submit" name="task" value="Update user level">
-                    <input type="submit" name="task" value="Delete user level">
+                    <input type="submit" name="task" value="Update role">
+                    <input type="submit" name="task" value="Revoke role">
             </tr>
         </form>
         {{- end }}
@@ -30,7 +30,7 @@
                 <td><input name="level" value="0" size="8">
                 <td><input name="invitemax" value="0" size="8">
                 <td>
-                    <input type="submit" name="task" value="Add user level">
+                    <input type="submit" name="task" value="Grant role">
             </tr>
         </form>
     </table><br>

--- a/handlers/admin/tasks.go
+++ b/handlers/admin/tasks.go
@@ -57,8 +57,8 @@ const (
 	// TaskDeleteUserApproval deletes a user's approval entry.
 	TaskDeleteUserApproval tasks.TaskString = "Delete user approval"
 
-	// TaskDeleteUserLevel deletes a user's access level.
-	TaskDeleteUserLevel tasks.TaskString = "Delete user level"
+	// TaskRevokeRole revokes a role from a user.
+	TaskRevokeRole tasks.TaskString = "Revoke role"
 
 	// TaskEdit modifies an existing item.
 	TaskEdit tasks.TaskString = "Edit"
@@ -173,8 +173,8 @@ const (
 	// TaskCopyTopicRestriction copies restriction levels from one topic to another.
 	TaskCopyTopicRestriction tasks.TaskString = "Copy topic restriction"
 
-	// TaskSetUserLevel sets a user's access level.
-	TaskSetUserLevel tasks.TaskString = "Set user level"
+	// TaskGrantRole grants a role to a user.
+	TaskGrantRole tasks.TaskString = "Grant role"
 
 	// TaskSubmitWriting submits a new writing.
 	TaskSubmitWriting tasks.TaskString = "Submit writing"
@@ -200,8 +200,8 @@ const (
 	// TaskUpdateUserApproval updates a writing user's approval state.
 	TaskUpdateUserApproval tasks.TaskString = "Update user approval"
 
-	// TaskUpdateUserLevel updates a user's access level.
-	TaskUpdateUserLevel tasks.TaskString = "Update user level"
+	// TaskUpdateRole updates an existing user role grant.
+	TaskUpdateRole tasks.TaskString = "Update role"
 
 	// TaskBulkApprove approves multiple queued items at once.
 	TaskBulkApprove tasks.TaskString = "Bulk Approve"

--- a/handlers/blogs/tasks.go
+++ b/handlers/blogs/tasks.go
@@ -58,8 +58,8 @@ const (
 	// TaskDeleteUserApproval deletes a user's approval entry.
 	TaskDeleteUserApproval = "Delete user approval"
 
-	// TaskDeleteUserLevel deletes a user's access level.
-	TaskDeleteUserLevel = "Delete user level"
+	// TaskRevokeRole revokes a role from a user.
+	TaskRevokeRole = "Revoke role"
 
 	// TaskEdit modifies an existing item.
 	TaskEdit = "Edit"
@@ -177,8 +177,8 @@ const (
 	// TaskCopyTopicRestriction copies restriction levels from one topic to another.
 	TaskCopyTopicRestriction = "Copy topic restriction"
 
-	// TaskSetUserLevel sets a user's access level.
-	TaskSetUserLevel = "Set user level"
+	// TaskGrantRole grants a role to a user.
+	TaskGrantRole = "Grant role"
 
 	// TaskSubmitWriting submits a new writing.
 	TaskSubmitWriting = "Submit writing"
@@ -204,8 +204,8 @@ const (
 	// TaskUpdateUserApproval updates a writing user's approval state.
 	TaskUpdateUserApproval = "Update user approval"
 
-	// TaskUpdateUserLevel updates a user's access level.
-	TaskUpdateUserLevel = "Update user level"
+	// TaskUpdateRole updates an existing user role grant.
+	TaskUpdateRole = "Update role"
 
 	// TaskBulkApprove approves multiple queued items at once.
 	TaskBulkApprove = "Bulk Approve"

--- a/handlers/forum/tasks.go
+++ b/handlers/forum/tasks.go
@@ -21,14 +21,14 @@ const (
 	// TaskCancel cancels the current operation and returns to the previous page.
 	TaskCancel tasks.TaskString = "Cancel"
 
-	// TaskSetUserLevel sets a user's forum access level.
-	TaskSetUserLevel = "Set user level"
+	// TaskGrantRole grants a role to a forum user.
+	TaskGrantRole = "Grant role"
 
-	// TaskUpdateUserLevel updates a user's forum access level.
-	TaskUpdateUserLevel = "Update user level"
+	// TaskUpdateRole updates an existing forum role grant.
+	TaskUpdateRole = "Update role"
 
-	// TaskDeleteUserLevel deletes a user's forum access level.
-	TaskDeleteUserLevel = "Delete user level"
+	// TaskRevokeRole revokes a role from a forum user.
+	TaskRevokeRole = "Revoke role"
 
 	// TaskSetTopicRestriction adds a topic restriction.
 	TaskSetTopicRestriction = "Set topic restriction"

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -177,7 +177,7 @@ func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.Event, tp
 			notifyMissingEmail(ctx, n.Queries, id)
 		} else {
 			if et := tp.TargetEmailTemplate(); et != nil {
-				if err := n.RenderAndQueueEmailFromTemplates(ctx, id, user.Email.String, et, evt.Data); err != nil {
+				if err := n.renderAndQueueEmailFromTemplates(ctx, id, user.Email.String, et, evt.Data); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
## Summary
- rename task constants for granting user roles
- adjust descriptions and templates to use the new role terminology
- correct notifier to call the proper email helper

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c6f07feec832fb80237f8ea421918