### PR TITLE
Rename user level references to role

### DIFF
--- a/core/templates/notifications/delete_user_level.gotxt
+++ b/core/templates/notifications/delete_user_level.gotxt
@@ -1,1 +1,0 @@
-User level deleted via {{.Path}}

--- a/core/templates/notifications/delete_user_role.gotxt
+++ b/core/templates/notifications/delete_user_role.gotxt
@@ -1,0 +1,1 @@
+User role deleted via {{.Path}}

--- a/core/templates/notifications/set_user_level.gotxt
+++ b/core/templates/notifications/set_user_level.gotxt
@@ -1,1 +1,0 @@
-User level set via {{.Path}}

--- a/core/templates/notifications/set_user_role.gotxt
+++ b/core/templates/notifications/set_user_role.gotxt
@@ -1,0 +1,1 @@
+User role set via {{.Path}}

--- a/core/templates/notifications/update_user_level.gotxt
+++ b/core/templates/notifications/update_user_level.gotxt
@@ -1,1 +1,0 @@
-User level updated via {{.Path}}

--- a/core/templates/notifications/update_user_role.gotxt
+++ b/core/templates/notifications/update_user_role.gotxt
@@ -1,0 +1,1 @@
+User role updated via {{.Path}}

--- a/core/templates/site/admin/usersPermissionsPage.gohtml
+++ b/core/templates/site/admin/usersPermissionsPage.gohtml
@@ -17,7 +17,7 @@
             <td>{{.IduserRoles}}</td>
             <td class="username">{{.Username.String}}</td>
             <td class="email">{{.Email.String}}</td>
-            <td class="level">{{.Role}}</td>
+            <td class="role">{{.Role}}</td>
             <td><button class="edit-btn" data-id="{{.IduserRoles}}">Edit</button></td>
             <td><button class="delete-btn" data-id="{{.IduserRoles}}">Delete</button></td>
         </tr>
@@ -56,17 +56,17 @@
         btn.addEventListener('click', function(e){
             e.preventDefault();
             var tr = btn.closest('tr');
-            var levelCell = tr.querySelector('.level');
-            var curLevel = levelCell.textContent.trim();
-            levelCell.innerHTML = document.getElementById('roleOptions').innerHTML;
-            levelCell.querySelector('select').value = curLevel;
+            var roleCell = tr.querySelector('.role');
+            var curRole = roleCell.textContent.trim();
+            roleCell.innerHTML = document.getElementById('roleOptions').innerHTML;
+            roleCell.querySelector('select').value = curRole;
             btn.textContent = 'Save';
             btn.addEventListener('click', function(ev){
                 ev.preventDefault();
                 var data = new URLSearchParams();
                 data.set('task','Update permission');
                 data.set('permid',btn.dataset.id);
-                data.set('role',levelCell.querySelector('select').value);
+                data.set('role',roleCell.querySelector('select').value);
                 post(data).then(function(){ location.reload(); });
             }, {once:true});
         }, {once:true});

--- a/core/templates/site/linker/adminUserLevelsPage.gohtml
+++ b/core/templates/site/linker/adminUserLevelsPage.gohtml
@@ -13,8 +13,8 @@
             <th>Email</th>
             <th>Role</th>
         </tr>
-        {{- if .UserLevels }}
-            {{- range $result := .UserLevels }}
+        {{- if .UserRoles }}
+            {{- range $result := .UserRoles }}
                 <tr>
                     <td><input type="checkbox" name="permids" value="{{ $result.ID }}"></td>
                     <td>{{ $result.ID }}</td>

--- a/core/templates/site/news/adminUserLevelsPage.gohtml
+++ b/core/templates/site/news/adminUserLevelsPage.gohtml
@@ -7,8 +7,8 @@
             <th>Role</th>
             <th>Delete?</th>
         </tr>
-        {{- if .UserLevels }}
-            {{- range .UserLevels }}
+        {{- if .UserRoles }}
+            {{- range .UserRoles }}
                 <tr>
                     <td>{{ .IduserRoles }}</td>
                     <td>{{ .Username.String }}</td>

--- a/core/templates/site/writings/adminUserLevelsPage.gohtml
+++ b/core/templates/site/writings/adminUserLevelsPage.gohtml
@@ -7,7 +7,7 @@
             <th>Role</th>
             <th>Delete?</th>
         </tr>
-        {{- range .UserLevels }}
+        {{- range .UserRoles }}
         <tr>
             <td>{{ .IduserRoles }}</td>
             <td>{{ .Username.String }}</td>

--- a/handlers/admin/news_user_tasks.go
+++ b/handlers/admin/news_user_tasks.go
@@ -35,7 +35,7 @@ func (NewsUserAllowTask) AdminInternalNotificationTemplate() *string {
 func (NewsUserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	username := r.PostFormValue("username")
-	level := r.PostFormValue("role")
+	role := r.PostFormValue("role")
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
 	if err != nil {
 		log.Printf("GetUserByUsername Error: %s", err)
@@ -45,7 +45,7 @@ func (NewsUserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 
 	if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
 		UsersIdusers: u.Idusers,
-		Name:         level,
+		Name:         role,
 	}); err != nil {
 		log.Printf("permissionUserAllow Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/tasks.go
+++ b/handlers/admin/tasks.go
@@ -57,8 +57,8 @@ const (
 	// TaskDeleteUserApproval deletes a user's approval entry.
 	TaskDeleteUserApproval tasks.TaskString = "Delete user approval"
 
-	// TaskDeleteUserLevel deletes a user's access level.
-	TaskDeleteUserLevel tasks.TaskString = "Delete user level"
+	// TaskDeleteUserRole deletes a user's access role.
+	TaskDeleteUserRole tasks.TaskString = "Delete user role"
 
 	// TaskEdit modifies an existing item.
 	TaskEdit tasks.TaskString = "Edit"
@@ -173,8 +173,8 @@ const (
 	// TaskCopyTopicRestriction copies restriction levels from one topic to another.
 	TaskCopyTopicRestriction tasks.TaskString = "Copy topic restriction"
 
-	// TaskSetUserLevel sets a user's access level.
-	TaskSetUserLevel tasks.TaskString = "Set user level"
+	// TaskSetUserRole sets a user's access role.
+	TaskSetUserRole tasks.TaskString = "Set user role"
 
 	// TaskSubmitWriting submits a new writing.
 	TaskSubmitWriting tasks.TaskString = "Submit writing"
@@ -200,8 +200,8 @@ const (
 	// TaskUpdateUserApproval updates a writing user's approval state.
 	TaskUpdateUserApproval tasks.TaskString = "Update user approval"
 
-	// TaskUpdateUserLevel updates a user's access level.
-	TaskUpdateUserLevel tasks.TaskString = "Update user level"
+	// TaskUpdateUserRole updates a user's access role.
+	TaskUpdateUserRole tasks.TaskString = "Update user role"
 
 	// TaskBulkApprove approves multiple queued items at once.
 	TaskBulkApprove tasks.TaskString = "Bulk Approve"

--- a/handlers/blogs/blogsUserPermissionsPage.go
+++ b/handlers/blogs/blogsUserPermissionsPage.go
@@ -118,7 +118,7 @@ func GetPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Re
 
 	data := Data{
 		CoreData: cd,
-		Filter:   r.URL.Query().Get("level"),
+		Filter:   r.URL.Query().Get("role"),
 	}
 
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
@@ -154,7 +154,7 @@ func GetPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Re
 func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	username := r.PostFormValue("username")
-	level := r.PostFormValue("role")
+	role := r.PostFormValue("role")
 	data := struct {
 		*common.CoreData
 		Errors   []string
@@ -168,7 +168,7 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 		data.Errors = append(data.Errors, fmt.Errorf("GetUserByUsername: %w", err).Error())
 	} else if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
 		UsersIdusers: u.Idusers,
-		Name:         level,
+		Name:         role,
 	}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
 	}
@@ -199,7 +199,7 @@ func UsersPermissionsDisallowPage(w http.ResponseWriter, r *http.Request) {
 func UsersPermissionsBulkAllowPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	names := strings.FieldsFunc(r.PostFormValue("usernames"), func(r rune) bool { return r == ',' || r == '\n' || r == ' ' || r == '\t' })
-	level := r.PostFormValue("role")
+	role := r.PostFormValue("role")
 	data := struct {
 		*common.CoreData
 		Errors   []string
@@ -221,7 +221,7 @@ func UsersPermissionsBulkAllowPage(w http.ResponseWriter, r *http.Request) {
 		}
 		if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
 			UsersIdusers: u.Idusers,
-			Name:         level,
+			Name:         role,
 		}); err != nil {
 			data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow %s: %w", n, err).Error())
 		}

--- a/handlers/blogs/tasks.go
+++ b/handlers/blogs/tasks.go
@@ -58,8 +58,8 @@ const (
 	// TaskDeleteUserApproval deletes a user's approval entry.
 	TaskDeleteUserApproval = "Delete user approval"
 
-	// TaskDeleteUserLevel deletes a user's access level.
-	TaskDeleteUserLevel = "Delete user level"
+	// TaskDeleteUserRole deletes a user's access role.
+	TaskDeleteUserRole = "Delete user role"
 
 	// TaskEdit modifies an existing item.
 	TaskEdit = "Edit"
@@ -177,8 +177,8 @@ const (
 	// TaskCopyTopicRestriction copies restriction levels from one topic to another.
 	TaskCopyTopicRestriction = "Copy topic restriction"
 
-	// TaskSetUserLevel sets a user's access level.
-	TaskSetUserLevel = "Set user level"
+	// TaskSetUserRole sets a user's access role.
+	TaskSetUserRole = "Set user role"
 
 	// TaskSubmitWriting submits a new writing.
 	TaskSubmitWriting = "Submit writing"
@@ -204,8 +204,8 @@ const (
 	// TaskUpdateUserApproval updates a writing user's approval state.
 	TaskUpdateUserApproval = "Update user approval"
 
-	// TaskUpdateUserLevel updates a user's access level.
-	TaskUpdateUserLevel = "Update user level"
+	// TaskUpdateUserRole updates a user's access role.
+	TaskUpdateUserRole = "Update user role"
 
 	// TaskBulkApprove approves multiple queued items at once.
 	TaskBulkApprove = "Bulk Approve"

--- a/handlers/forum/tasks.go
+++ b/handlers/forum/tasks.go
@@ -21,14 +21,14 @@ const (
 	// TaskCancel cancels the current operation and returns to the previous page.
 	TaskCancel tasks.TaskString = "Cancel"
 
-	// TaskSetUserLevel sets a user's forum access level.
-	TaskSetUserLevel = "Set user level"
+	// TaskSetUserRole sets a user's forum access role.
+	TaskSetUserRole = "Set user role"
 
-	// TaskUpdateUserLevel updates a user's forum access level.
-	TaskUpdateUserLevel = "Update user level"
+	// TaskUpdateUserRole updates a user's forum access role.
+	TaskUpdateUserRole = "Update user role"
 
-	// TaskDeleteUserLevel deletes a user's forum access level.
-	TaskDeleteUserLevel = "Delete user level"
+	// TaskDeleteUserRole deletes a user's forum access role.
+	TaskDeleteUserRole = "Delete user role"
 
 	// TaskSetTopicRestriction adds a topic restriction.
 	TaskSetTopicRestriction = "Set topic restriction"

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -24,9 +24,9 @@ func AdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 
 	type Data struct {
 		*common.CoreData
-		UserLevels []*PermissionUser
-		Search     string
-		Roles      []*db.Role
+		UserRoles []*PermissionUser
+		Search    string
+		Roles     []*db.Role
 	}
 
 	data := Data{
@@ -69,7 +69,7 @@ func AdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 		}
 		perms = filtered
 	}
-	data.UserLevels = perms
+	data.UserRoles = perms
 
 	handlers.TemplateHandler(w, r, "adminUserLevelsPage.gohtml", data)
 }
@@ -81,7 +81,7 @@ var UserAllowTask = &userAllowTask{TaskString: TaskUserAllow}
 func (userAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	usernames := r.PostFormValue("usernames")
-	level := r.PostFormValue("role")
+	role := r.PostFormValue("role")
 	fields := strings.FieldsFunc(usernames, func(r rune) bool {
 		return r == ',' || r == '\n' || r == '\r' || r == '\t' || r == ' '
 	})
@@ -96,7 +96,7 @@ func (userAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 		}
 		if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
 			UsersIdusers: u.Idusers,
-			Name:         level,
+			Name:         role,
 		}); err != nil {
 			log.Printf("permissionUserAllow Error: %s", err)
 		}

--- a/handlers/news/newsAdminUserLevelsPage.go
+++ b/handlers/news/newsAdminUserLevelsPage.go
@@ -15,8 +15,8 @@ import (
 func NewsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		UserLevels []*db.GetUserRolesRow
-		Roles      []*db.Role
+		UserRoles []*db.GetUserRolesRow
+		Roles     []*db.Role
 	}
 
 	data := Data{
@@ -37,7 +37,7 @@ func NewsAdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	data.UserLevels = rows
+	data.UserRoles = rows
 
 	handlers.TemplateHandler(w, r, "adminUserLevelsPage.gohtml", data)
 }

--- a/handlers/news/newsUserPermissionsPage.go
+++ b/handlers/news/newsUserPermissionsPage.go
@@ -86,7 +86,7 @@ func NewsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 func (UserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	username := r.PostFormValue("username")
-	level := r.PostFormValue("role")
+	role := r.PostFormValue("role")
 	data := struct {
 		*common.CoreData
 		Errors   []string
@@ -100,7 +100,7 @@ func (UserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("GetUserByUsername: %w", err).Error())
 	} else if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
 		UsersIdusers: u.Idusers,
-		Name:         level,
+		Name:         role,
 	}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
 	}

--- a/handlers/user/admin_permissions.go
+++ b/handlers/user/admin_permissions.go
@@ -55,7 +55,7 @@ var permissionUserAllowTask = &PermissionUserAllowTask{TaskString: TaskUserAllow
 func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	username := r.PostFormValue("username")
-	level := r.PostFormValue("role")
+	role := r.PostFormValue("role")
 	data := struct {
 		*common.CoreData
 		Errors   []string
@@ -69,7 +69,7 @@ func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("GetUserByUsername: %w", err).Error())
 	} else if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
 		UsersIdusers: u.Idusers,
-		Name:         level,
+		Name:         role,
 	}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
 	}
@@ -109,7 +109,7 @@ var permissionUpdateTask = &PermissionUpdateTask{TaskString: TaskUpdate}
 func (PermissionUpdateTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	permid := r.PostFormValue("permid")
-	level := r.PostFormValue("role")
+	role := r.PostFormValue("role")
 
 	data := struct {
 		*common.CoreData
@@ -125,7 +125,7 @@ func (PermissionUpdateTask) Action(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("strconv.Atoi: %w", err).Error())
 	} else if err := queries.UpdatePermission(r.Context(), db.UpdatePermissionParams{
 		IduserRoles: int32(id),
-		Name:        level,
+		Name:        role,
 	}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("UpdatePermission: %w", err).Error())
 	}

--- a/handlers/writings/writingsAdminUserLevelsPage.go
+++ b/handlers/writings/writingsAdminUserLevelsPage.go
@@ -16,8 +16,8 @@ import (
 func AdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		UserLevels []*db.GetUserRolesRow
-		Roles      []*db.Role
+		UserRoles []*db.GetUserRolesRow
+		Roles     []*db.Role
 	}
 
 	data := Data{
@@ -38,7 +38,7 @@ func AdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	data.UserLevels = rows
+	data.UserRoles = rows
 
 	handlers.TemplateHandler(w, r, "adminUserLevelsPage.gohtml", data)
 }
@@ -46,7 +46,7 @@ func AdminUserLevelsPage(w http.ResponseWriter, r *http.Request) {
 func AdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	username := r.PostFormValue("username")
-	level := r.PostFormValue("role")
+	role := r.PostFormValue("role")
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
 	if err != nil {
 		log.Printf("GetUserByUsername Error: %s", err)
@@ -56,7 +56,7 @@ func AdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) {
 
 	if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
 		UsersIdusers: u.Idusers,
-		Name:         level,
+		Name:         role,
 	}); err != nil {
 		log.Printf("permissionUserAllow Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/writings/writingsUserPermissionsPage.go
+++ b/handlers/writings/writingsUserPermissionsPage.go
@@ -46,7 +46,7 @@ func UserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	username := r.PostFormValue("username")
-	level := r.PostFormValue("role")
+	role := r.PostFormValue("role")
 	data := struct {
 		*common.CoreData
 		Errors   []string
@@ -60,7 +60,7 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 		data.Errors = append(data.Errors, fmt.Errorf("GetUserByUsername: %w", err).Error())
 	} else if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
 		UsersIdusers: u.Idusers,
-		Name:         level,
+		Name:         role,
 	}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
 	}

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -177,7 +177,7 @@ func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.Event, tp
 			notifyMissingEmail(ctx, n.Queries, id)
 		} else {
 			if et := tp.TargetEmailTemplate(); et != nil {
-				if err := n.RenderAndQueueEmailFromTemplates(ctx, id, user.Email.String, et, evt.Data); err != nil {
+				if err := n.renderAndQueueEmailFromTemplates(ctx, id, user.Email.String, et, evt.Data); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
## Summary
- rename handler parameters from `level` to `role`
- update templates and JavaScript for new `role` naming
- adjust task constant names to use `UserRole`
- update notification filenames
- fix notifier function call

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c6f5ce5f4832f87a5fa01581a52cb