### PR TITLE
Add admin notifications for new FAQ questions

### DIFF
--- a/core/templates/email/adminNotificationFaqAskEmail.gohtml
+++ b/core/templates/email/adminNotificationFaqAskEmail.gohtml
@@ -1,0 +1,3 @@
+<p>New FAQ question submitted.</p>
+<p>{{.Question}}</p>
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationFaqAskEmail.gotxt
+++ b/core/templates/email/adminNotificationFaqAskEmail.gotxt
@@ -1,0 +1,4 @@
+New FAQ question submitted.
+
+{{.Question}}
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/adminNotificationFaqAskEmailSubject.gotxt
+++ b/core/templates/email/adminNotificationFaqAskEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] New FAQ question

--- a/core/templates/notifications/adminNotificationFaqAskEmail.gotxt
+++ b/core/templates/notifications/adminNotificationFaqAskEmail.gotxt
@@ -1,0 +1,1 @@
+New FAQ question submitted: {{.Question}}

--- a/handlers/faq/faqTemplates_test.go
+++ b/handlers/faq/faqTemplates_test.go
@@ -39,3 +39,9 @@ func TestAnswerTaskTemplatesCompile(t *testing.T) {
 	requireEmailTemplates(t, task.SelfEmailTemplate())
 	requireNotificationTemplate(t, task.SelfInternalNotificationTemplate())
 }
+
+func TestAskTaskTemplatesCompile(t *testing.T) {
+	var task AskTask
+	requireEmailTemplates(t, task.AdminEmailTemplate())
+	requireNotificationTemplate(t, task.AdminInternalNotificationTemplate())
+}


### PR DESCRIPTION
## Summary
- alert admins when a FAQ question is asked by implementing `AdminEmailTemplateProvider` in `AskTask`
- supply new email and internal notification templates for admin FAQ asks
- verify templates compile in tests

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c7420f564832f8dd31c708168a04d