### PR TITLE
Notify admins on forum structure changes

### DIFF
--- a/core/templates/email/adminNotificationForumCategoryChangeEmail.gohtml
+++ b/core/templates/email/adminNotificationForumCategoryChangeEmail.gohtml
@@ -1,0 +1,2 @@
+<p>User {{.Item.Username}} renamed a forum category.</p>
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationForumCategoryChangeEmail.gotxt
+++ b/core/templates/email/adminNotificationForumCategoryChangeEmail.gotxt
@@ -1,0 +1,3 @@
+User {{.Item.Username}} renamed a forum category.
+
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/adminNotificationForumCategoryChangeEmailSubject.gotxt
+++ b/core/templates/email/adminNotificationForumCategoryChangeEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Forum category renamed

--- a/core/templates/email/adminNotificationForumCategoryCreateEmail.gohtml
+++ b/core/templates/email/adminNotificationForumCategoryCreateEmail.gohtml
@@ -1,0 +1,2 @@
+<p>User {{.Item.Username}} created a new forum category.</p>
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationForumCategoryCreateEmail.gotxt
+++ b/core/templates/email/adminNotificationForumCategoryCreateEmail.gotxt
@@ -1,0 +1,3 @@
+User {{.Item.Username}} created a new forum category.
+
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/adminNotificationForumCategoryCreateEmailSubject.gotxt
+++ b/core/templates/email/adminNotificationForumCategoryCreateEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] New forum category created

--- a/core/templates/email/adminNotificationForumDeleteCategoryEmail.gohtml
+++ b/core/templates/email/adminNotificationForumDeleteCategoryEmail.gohtml
@@ -1,0 +1,2 @@
+<p>User {{.Item.Username}} deleted a forum category.</p>
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationForumDeleteCategoryEmail.gotxt
+++ b/core/templates/email/adminNotificationForumDeleteCategoryEmail.gotxt
@@ -1,0 +1,3 @@
+User {{.Item.Username}} deleted a forum category.
+
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/adminNotificationForumDeleteCategoryEmailSubject.gotxt
+++ b/core/templates/email/adminNotificationForumDeleteCategoryEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Forum category deleted

--- a/core/templates/email/adminNotificationForumThreadDeleteEmail.gohtml
+++ b/core/templates/email/adminNotificationForumThreadDeleteEmail.gohtml
@@ -1,0 +1,2 @@
+<p>User {{.Item.Username}} deleted a forum thread.</p>
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationForumThreadDeleteEmail.gotxt
+++ b/core/templates/email/adminNotificationForumThreadDeleteEmail.gotxt
@@ -1,0 +1,3 @@
+User {{.Item.Username}} deleted a forum thread.
+
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/adminNotificationForumThreadDeleteEmailSubject.gotxt
+++ b/core/templates/email/adminNotificationForumThreadDeleteEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Forum thread deleted

--- a/core/templates/notifications/adminNotificationForumCategoryChangeEmail.gotxt
+++ b/core/templates/notifications/adminNotificationForumCategoryChangeEmail.gotxt
@@ -1,0 +1,1 @@
+User {{.Item.Username}} renamed a forum category.

--- a/core/templates/notifications/adminNotificationForumCategoryCreateEmail.gotxt
+++ b/core/templates/notifications/adminNotificationForumCategoryCreateEmail.gotxt
@@ -1,0 +1,1 @@
+User {{.Item.Username}} created a new forum category.

--- a/core/templates/notifications/adminNotificationForumDeleteCategoryEmail.gotxt
+++ b/core/templates/notifications/adminNotificationForumDeleteCategoryEmail.gotxt
@@ -1,0 +1,1 @@
+User {{.Item.Username}} deleted a forum category.

--- a/core/templates/notifications/adminNotificationForumThreadDeleteEmail.gotxt
+++ b/core/templates/notifications/adminNotificationForumThreadDeleteEmail.gotxt
@@ -1,0 +1,1 @@
+User {{.Item.Username}} deleted a forum thread.

--- a/handlers/forum/forumAdminTemplates_test.go
+++ b/handlers/forum/forumAdminTemplates_test.go
@@ -1,0 +1,37 @@
+package forum
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/core/templates"
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+func requireAdminEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
+	t.Helper()
+	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
+	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
+	if htmlTmpls.Lookup(et.HTML) == nil {
+		t.Errorf("missing html template %s", et.HTML)
+	}
+	if textTmpls.Lookup(et.Text) == nil {
+		t.Errorf("missing text template %s", et.Text)
+	}
+	if textTmpls.Lookup(et.Subject) == nil {
+		t.Errorf("missing subject template %s", et.Subject)
+	}
+}
+
+func TestForumAdminTemplatesExist(t *testing.T) {
+	admins := []notif.AdminEmailTemplateProvider{
+		createThreadTask,
+		replyTask,
+		categoryChangeTask,
+		categoryCreateTask,
+		deleteCategoryTask,
+		threadDeleteTask,
+	}
+	for _, p := range admins {
+		requireAdminEmailTemplates(t, p.AdminEmailTemplate())
+	}
+}

--- a/handlers/forum/task_events_admin.go
+++ b/handlers/forum/task_events_admin.go
@@ -1,6 +1,7 @@
 package forum
 
 import (
+	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -33,3 +34,50 @@ var deleteCategoryTask = &DeleteCategoryTask{TaskString: TaskDeleteCategory}
 type ThreadDeleteTask struct{ tasks.TaskString }
 
 var threadDeleteTask = &ThreadDeleteTask{TaskString: TaskForumThreadDelete}
+
+var (
+	_ tasks.Task                       = (*CategoryChangeTask)(nil)
+	_ notif.AdminEmailTemplateProvider = (*CategoryChangeTask)(nil)
+	_ tasks.Task                       = (*CategoryCreateTask)(nil)
+	_ notif.AdminEmailTemplateProvider = (*CategoryCreateTask)(nil)
+	_ tasks.Task                       = (*DeleteCategoryTask)(nil)
+	_ notif.AdminEmailTemplateProvider = (*DeleteCategoryTask)(nil)
+	_ tasks.Task                       = (*ThreadDeleteTask)(nil)
+	_ notif.AdminEmailTemplateProvider = (*ThreadDeleteTask)(nil)
+)
+
+func (CategoryChangeTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("adminNotificationForumCategoryChangeEmail")
+}
+
+func (CategoryChangeTask) AdminInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("adminNotificationForumCategoryChangeEmail")
+	return &v
+}
+
+func (CategoryCreateTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("adminNotificationForumCategoryCreateEmail")
+}
+
+func (CategoryCreateTask) AdminInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("adminNotificationForumCategoryCreateEmail")
+	return &v
+}
+
+func (DeleteCategoryTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("adminNotificationForumDeleteCategoryEmail")
+}
+
+func (DeleteCategoryTask) AdminInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("adminNotificationForumDeleteCategoryEmail")
+	return &v
+}
+
+func (ThreadDeleteTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("adminNotificationForumThreadDeleteEmail")
+}
+
+func (ThreadDeleteTask) AdminInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("adminNotificationForumThreadDeleteEmail")
+	return &v
+}


### PR DESCRIPTION
## Summary
- extend forum admin tasks with admin email template info
- provide notification and email templates for forum category updates and thread deletion
- verify admin templates compile

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c741db8e0832fb6ed6227835e48a0