### PR TITLE
Add update notification for writings

### DIFF
--- a/core/templates/email/writingUpdateEmail.gohtml
+++ b/core/templates/email/writingUpdateEmail.gohtml
@@ -1,0 +1,3 @@
+<p>Writing {{.Item.Title}} was updated.</p>
+<p><a href="{{.PostURL}}">View article</a></p>
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/writingUpdateEmail.gotxt
+++ b/core/templates/email/writingUpdateEmail.gotxt
@@ -1,0 +1,4 @@
+Writing "{{.Item.Title}}" was updated.
+View article:
+{{.PostURL}}
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/writingUpdateEmailSubject.gotxt
+++ b/core/templates/email/writingUpdateEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Writing updated

--- a/core/templates/notifications/writing_update.gotxt
+++ b/core/templates/notifications/writing_update.gotxt
@@ -1,0 +1,1 @@
+Writing "{{.Item.Title}}" updated

--- a/handlers/writings/task_structs.go
+++ b/handlers/writings/task_structs.go
@@ -131,10 +131,20 @@ type UpdateWritingTask struct{ tasks.TaskString }
 var updateWritingTask = &UpdateWritingTask{TaskString: TaskUpdateWriting}
 
 var _ tasks.Task = (*UpdateWritingTask)(nil)
+var _ notif.SubscribersNotificationTemplateProvider = (*UpdateWritingTask)(nil)
 
 func (UpdateWritingTask) Page(w http.ResponseWriter, r *http.Request) { ArticleEditPage(w, r) }
 
 func (UpdateWritingTask) Action(w http.ResponseWriter, r *http.Request) { ArticleEditActionPage(w, r) }
+
+func (UpdateWritingTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("writingUpdateEmail")
+}
+
+func (UpdateWritingTask) SubscribedInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("writing_update")
+	return &s
+}
 
 // UserAllowTask grants a user a permission.
 type UserAllowTask struct{ tasks.TaskString }

--- a/handlers/writings/writingsTemplates_test.go
+++ b/handlers/writings/writingsTemplates_test.go
@@ -25,6 +25,7 @@ func checkEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
 func TestWritingsTemplatesExist(t *testing.T) {
 	providers := []notif.SubscribersNotificationTemplateProvider{
 		submitWritingTask,
+		updateWritingTask,
 		replyTask,
 	}
 	for _, p := range providers {


### PR DESCRIPTION
## Summary
- notify subscribers when a writing is edited
- embed templates for writing update emails and notifications
- send article title and link with update events
- check UpdateWritingTask templates in tests

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c7418460c832f88d3dae9f470245d