### PR TITLE
Add IP ban admin notification templates

### DIFF
--- a/core/templates/email/adminAddIPBanEmail.gohtml
+++ b/core/templates/email/adminAddIPBanEmail.gohtml
@@ -1,0 +1,5 @@
+<p>Moderator {{.Item.Moderator}} banned {{.Item.IP}}.</p>
+{{- if .Item.Reason}}
+<p>Reason: {{.Item.Reason}}</p>
+{{- end}}
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/adminAddIPBanEmail.gotxt
+++ b/core/templates/email/adminAddIPBanEmail.gotxt
@@ -1,0 +1,3 @@
+Moderator {{.Item.Moderator}} banned {{.Item.IP}}.
+{{- if .Item.Reason}} Reason: {{.Item.Reason}}{{- end}}
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/adminAddIPBanEmailSubject.gotxt
+++ b/core/templates/email/adminAddIPBanEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] IP banned

--- a/core/templates/email/adminRemoveIPBanEmail.gohtml
+++ b/core/templates/email/adminRemoveIPBanEmail.gohtml
@@ -1,0 +1,2 @@
+<p>Moderator {{.Item.Moderator}} removed ban for {{.Item.IP}}.</p>
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/adminRemoveIPBanEmail.gotxt
+++ b/core/templates/email/adminRemoveIPBanEmail.gotxt
@@ -1,0 +1,2 @@
+Moderator {{.Item.Moderator}} removed ban for {{.Item.IP}}.
+Manage notifications: {{.UnsubURL}}

--- a/core/templates/email/adminRemoveIPBanEmailSubject.gotxt
+++ b/core/templates/email/adminRemoveIPBanEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] IP ban removed

--- a/core/templates/notifications/adminAddIPBanEmail.gotxt
+++ b/core/templates/notifications/adminAddIPBanEmail.gotxt
@@ -1,0 +1,2 @@
+Moderator {{.Item.Moderator}} banned {{.Item.IP}}
+{{- if .Item.Reason}} Reason: {{.Item.Reason}}{{- end}}

--- a/core/templates/notifications/adminRemoveIPBanEmail.gotxt
+++ b/core/templates/notifications/adminRemoveIPBanEmail.gotxt
@@ -1,0 +1,1 @@
+Moderator {{.Item.Moderator}} removed ban for {{.Item.IP}}

--- a/handlers/admin/adminIPBanTemplates_test.go
+++ b/handlers/admin/adminIPBanTemplates_test.go
@@ -1,0 +1,33 @@
+package admin
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/core/templates"
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+func checkIPBanEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
+	t.Helper()
+	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
+	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
+	if htmlTmpls.Lookup(et.HTML) == nil {
+		t.Errorf("missing html template %s", et.HTML)
+	}
+	if textTmpls.Lookup(et.Text) == nil {
+		t.Errorf("missing text template %s", et.Text)
+	}
+	if textTmpls.Lookup(et.Subject) == nil {
+		t.Errorf("missing subject template %s", et.Subject)
+	}
+}
+
+func TestAdminIPBanTemplatesExist(t *testing.T) {
+	admins := []notif.AdminEmailTemplateProvider{
+		&AddIPBanTask{TaskString: TaskAdd},
+		&DeleteIPBanTask{TaskString: TaskDelete},
+	}
+	for _, p := range admins {
+		checkIPBanEmailTemplates(t, p.AdminEmailTemplate())
+	}
+}


### PR DESCRIPTION
## Summary
- notify admins when IP bans change
- provide templates for add/remove IP ban emails and notifications
- fill event data with IP ban details
- test that IP ban templates compile

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c74046268832f82213da8d258e75b