### PR TITLE
Add admin language notification templates and tests

### DIFF
--- a/core/templates/email/adminNotificationLanguageCreateEmail.gohtml
+++ b/core/templates/email/adminNotificationLanguageCreateEmail.gohtml
@@ -1,0 +1,4 @@
+<p>User {{.Item.Username}} created a new language {{.LanguageName}} (ID {{.LanguageID}}).</p>
+
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>
+

--- a/core/templates/email/adminNotificationLanguageCreateEmail.gotxt
+++ b/core/templates/email/adminNotificationLanguageCreateEmail.gotxt
@@ -1,0 +1,4 @@
+User {{.Item.Username}} created a new language {{.LanguageName}} (ID {{.LanguageID}}).
+
+Manage notifications: {{.UnsubURL}}
+

--- a/core/templates/email/adminNotificationLanguageCreateEmailSubject.gotxt
+++ b/core/templates/email/adminNotificationLanguageCreateEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Language created

--- a/core/templates/email/adminNotificationLanguageDeleteEmail.gohtml
+++ b/core/templates/email/adminNotificationLanguageDeleteEmail.gohtml
@@ -1,0 +1,4 @@
+<p>User {{.Item.Username}} deleted language {{.LanguageName}} (ID {{.LanguageID}}).</p>
+
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>
+

--- a/core/templates/email/adminNotificationLanguageDeleteEmail.gotxt
+++ b/core/templates/email/adminNotificationLanguageDeleteEmail.gotxt
@@ -1,0 +1,4 @@
+User {{.Item.Username}} deleted language {{.LanguageName}} (ID {{.LanguageID}}).
+
+Manage notifications: {{.UnsubURL}}
+

--- a/core/templates/email/adminNotificationLanguageDeleteEmailSubject.gotxt
+++ b/core/templates/email/adminNotificationLanguageDeleteEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Language deleted

--- a/core/templates/email/adminNotificationLanguageRenameEmail.gohtml
+++ b/core/templates/email/adminNotificationLanguageRenameEmail.gohtml
@@ -1,0 +1,4 @@
+<p>User {{.Item.Username}} renamed language {{.LanguageID}} to {{.LanguageName}}.</p>
+
+<p><a href="{{.UnsubURL}}">Manage notifications</a></p>
+

--- a/core/templates/email/adminNotificationLanguageRenameEmail.gotxt
+++ b/core/templates/email/adminNotificationLanguageRenameEmail.gotxt
@@ -1,0 +1,4 @@
+User {{.Item.Username}} renamed language {{.LanguageID}} to {{.LanguageName}}.
+
+Manage notifications: {{.UnsubURL}}
+

--- a/core/templates/email/adminNotificationLanguageRenameEmailSubject.gotxt
+++ b/core/templates/email/adminNotificationLanguageRenameEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Language renamed

--- a/core/templates/notifications/adminNotificationLanguageCreateEmail.gotxt
+++ b/core/templates/notifications/adminNotificationLanguageCreateEmail.gotxt
@@ -1,0 +1,2 @@
+Language {{.LanguageName}} (ID {{.LanguageID}}) created by {{.Item.Username}}
+

--- a/core/templates/notifications/adminNotificationLanguageDeleteEmail.gotxt
+++ b/core/templates/notifications/adminNotificationLanguageDeleteEmail.gotxt
@@ -1,0 +1,2 @@
+Language {{.LanguageName}} (ID {{.LanguageID}}) deleted by {{.Item.Username}}
+

--- a/core/templates/notifications/adminNotificationLanguageRenameEmail.gotxt
+++ b/core/templates/notifications/adminNotificationLanguageRenameEmail.gotxt
@@ -1,0 +1,2 @@
+Language {{.LanguageID}} renamed to {{.LanguageName}} by {{.Item.Username}}
+

--- a/handlers/languages/languagesTemplates_test.go
+++ b/handlers/languages/languagesTemplates_test.go
@@ -1,0 +1,45 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/core/templates"
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+func requireEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
+	t.Helper()
+	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
+	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
+	if htmlTmpls.Lookup(et.HTML) == nil {
+		t.Errorf("missing html template %s", et.HTML)
+	}
+	if textTmpls.Lookup(et.Text) == nil {
+		t.Errorf("missing text template %s", et.Text)
+	}
+	if textTmpls.Lookup(et.Subject) == nil {
+		t.Errorf("missing subject template %s", et.Subject)
+	}
+}
+
+func requireNotificationTemplate(t *testing.T, name *string) {
+	if name == nil {
+		return
+	}
+	tmpl := templates.GetCompiledNotificationTemplates(map[string]any{})
+	if tmpl.Lookup(*name) == nil {
+		t.Errorf("missing notification template %s", *name)
+	}
+}
+
+func TestLanguageTaskTemplates(t *testing.T) {
+	admins := []notif.AdminEmailTemplateProvider{
+		renameLanguageTask,
+		deleteLanguageTask,
+		createLanguageTask,
+	}
+	for _, a := range admins {
+		requireEmailTemplates(t, a.AdminEmailTemplate())
+		requireNotificationTemplate(t, a.AdminInternalNotificationTemplate())
+	}
+}

--- a/handlers/languages/task_events.go
+++ b/handlers/languages/task_events.go
@@ -3,6 +3,7 @@ package languages
 import (
 	"net/http"
 
+	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -14,12 +15,30 @@ func (RenameLanguageTask) Action(w http.ResponseWriter, r *http.Request) {
 	adminLanguagesRenamePage(w, r)
 }
 
+func (RenameLanguageTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("adminNotificationLanguageRenameEmail")
+}
+
+func (RenameLanguageTask) AdminInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("adminNotificationLanguageRenameEmail")
+	return &v
+}
+
 type DeleteLanguageTask struct{ tasks.TaskString }
 
 var deleteLanguageTask = &DeleteLanguageTask{TaskString: tasks.TaskString("Delete Language")}
 
 func (DeleteLanguageTask) Action(w http.ResponseWriter, r *http.Request) {
 	adminLanguagesDeletePage(w, r)
+}
+
+func (DeleteLanguageTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("adminNotificationLanguageDeleteEmail")
+}
+
+func (DeleteLanguageTask) AdminInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("adminNotificationLanguageDeleteEmail")
+	return &v
 }
 
 type CreateLanguageTask struct{ tasks.TaskString }
@@ -29,3 +48,21 @@ var createLanguageTask = &CreateLanguageTask{TaskString: tasks.TaskString("Creat
 func (CreateLanguageTask) Action(w http.ResponseWriter, r *http.Request) {
 	adminLanguagesCreatePage(w, r)
 }
+
+func (CreateLanguageTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("adminNotificationLanguageCreateEmail")
+}
+
+func (CreateLanguageTask) AdminInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("adminNotificationLanguageCreateEmail")
+	return &v
+}
+
+var (
+	_ tasks.Task                       = (*RenameLanguageTask)(nil)
+	_ notif.AdminEmailTemplateProvider = (*RenameLanguageTask)(nil)
+	_ tasks.Task                       = (*DeleteLanguageTask)(nil)
+	_ notif.AdminEmailTemplateProvider = (*DeleteLanguageTask)(nil)
+	_ tasks.Task                       = (*CreateLanguageTask)(nil)
+	_ notif.AdminEmailTemplateProvider = (*CreateLanguageTask)(nil)
+)


### PR DESCRIPTION
## Summary
- add admin email/notification templates for language create/rename/delete
- implement AdminEmailTemplateProvider for language tasks
- include language ID and name in event data
- ensure compile-time interface assertions
- test that language templates compile

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c74066148832f82aff6d5b6c39068