### PR TITLE
Add startup check for news templates

### DIFF
--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -1,20 +1,36 @@
 package news
 
 import (
+	"fmt"
+	htemplate "html/template"
+	"net/http"
+	"sync"
+
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers/forum/comments"
 	"github.com/arran4/goa4web/internal/tasks"
-	"net/http"
 
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/router"
 
 	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
+var (
+	siteTemplates     *htemplate.Template
+	loadTemplatesOnce sync.Once
+)
+
 func runTemplate(name string) http.HandlerFunc {
+	loadTemplatesOnce.Do(func() {
+		siteTemplates = templates.GetCompiledSiteTemplates(map[string]any{})
+	})
+	if siteTemplates.Lookup(name) == nil {
+		panic(fmt.Sprintf("missing template %s", name))
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		handlers.TemplateHandler(w, r, name, r.Context().Value(consts.KeyCoreData))
 	}


### PR DESCRIPTION
## Summary
- panic early if a news template isn't found at startup

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c78bd26d4832fb0b00b4095e33ba4