### PR TITLE
Add configurable email sign-off

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -25,6 +25,8 @@ const (
 	EnvEmailFrom = "EMAIL_FROM"
 	// EnvEmailSubjectPrefix sets the prefix used for email subjects.
 	EnvEmailSubjectPrefix = "EMAIL_SUBJECT_PREFIX"
+	// EnvEmailSignOff specifies the sign-off text appended to emails.
+	EnvEmailSignOff = "EMAIL_SIGNOFF"
 	// EnvAWSRegion is the AWS region for the SES provider.
 	EnvAWSRegion = "AWS_REGION"
 	// EnvJMAPEndpoint is the JMAP API endpoint.

--- a/config/options_runtime.go
+++ b/config/options_runtime.go
@@ -45,6 +45,7 @@ var StringOptions = []StringOption{
 	{"smtp-auth", EnvSMTPAuth, "SMTP auth method", "", nil, "", func(c *RuntimeConfig) *string { return &c.EmailSMTPAuth }},
 	{"email-from", EnvEmailFrom, "default From address", "", nil, "", func(c *RuntimeConfig) *string { return &c.EmailFrom }},
 	{"email-subject-prefix", EnvEmailSubjectPrefix, "email subject prefix", "goa4web", nil, "", func(c *RuntimeConfig) *string { return &c.EmailSubjectPrefix }},
+	{"email-signoff", EnvEmailSignOff, "email sign off", "", nil, "", func(c *RuntimeConfig) *string { return &c.EmailSignOff }},
 	{"aws-region", EnvAWSRegion, "AWS region", "", []string{"us-east-1"}, "", func(c *RuntimeConfig) *string { return &c.EmailAWSRegion }},
 	{"jmap-endpoint", EnvJMAPEndpoint, "JMAP endpoint", "", nil, "", func(c *RuntimeConfig) *string { return &c.EmailJMAPEndpoint }},
 	{"jmap-account", EnvJMAPAccount, "JMAP account", "", nil, "", func(c *RuntimeConfig) *string { return &c.EmailJMAPAccount }},

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -36,6 +36,8 @@ type RuntimeConfig struct {
 	EmailJMAPPass      string
 	EmailSendGridKey   string
 	EmailSubjectPrefix string
+	// EmailSignOff defines the optional sign-off appended to emails.
+	EmailSignOff string
 
 	// EmailEnabled toggles sending queued emails.
 	EmailEnabled bool

--- a/core/templates/email/blogEmail.gohtml
+++ b/core/templates/email/blogEmail.gohtml
@@ -2,4 +2,6 @@
 <p>A new blog post was published by {{.Item.Author}}.</p>
 <p>Read it <a href="{{.URL}}">here</a>.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
-<p>Cheers,<br>The A4Web Team</p>
+{{- if .SignOff}}
+<p>{{.SignOffHTML}}</p>
+{{- end}}

--- a/core/templates/email/blogEmail.gotxt
+++ b/core/templates/email/blogEmail.gotxt
@@ -10,6 +10,6 @@ Read it here:
 {{.URL}}
 
 Manage notifications: {{.UnsubscribeUrl}}
-
-Cheers,
-The A4Web Team
+{{- if .SignOff}}
+{{.SignOff}}
+{{- end}}

--- a/core/templates/email/replyEmail.gohtml
+++ b/core/templates/email/replyEmail.gohtml
@@ -6,6 +6,8 @@
 <p>There are now {{.Item.Thread.Comments.Int32}} comments in the discussion.</p>
 <p>Read it <a href="{{.URL}}">here</a>.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
-<p>Cheers,<br>The A4Web Team</p>
+{{- if .SignOff}}
+<p>{{.SignOffHTML}}</p>
+{{- end}}
 </body>
 </html>

--- a/core/templates/email/replyEmail.gotxt
+++ b/core/templates/email/replyEmail.gotxt
@@ -12,5 +12,6 @@ View it here:
 
 Manage notifications: {{.UnsubscribeUrl}}
 
-Cheers,
-The A4Web Team
+{{- if .SignOff}}
+{{.SignOff}}
+{{- end}}

--- a/core/templates/email/signupEmail.gohtml
+++ b/core/templates/email/signupEmail.gohtml
@@ -6,6 +6,8 @@
 <p>Please add them to the user group to approve the account.</p>
 <p>Review the account <a href="{{.URL}}">here</a>.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
-<p>Cheers,<br>The A4Web Team</p>
+{{- if .SignOff}}
+<p>{{.SignOffHTML}}</p>
+{{- end}}
 </body>
 </html>

--- a/core/templates/email/signupEmail.gotxt
+++ b/core/templates/email/signupEmail.gotxt
@@ -11,6 +11,6 @@ Review the account here:
 {{.URL}}
 
 Manage notifications: {{.UnsubscribeUrl}}
-
-Cheers,
-The A4Web Team
+{{- if .SignOff}}
+{{.SignOff}}
+{{- end}}

--- a/core/templates/email/testEmail.gohtml
+++ b/core/templates/email/testEmail.gohtml
@@ -4,6 +4,8 @@
 <p>Hello,</p>
 <p>This is a test email confirming your Goa4Web configuration.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
-<p>Cheers,<br>The A4Web Team</p>
+{{- if .SignOff}}
+<p>{{.SignOffHTML}}</p>
+{{- end}}
 </body>
 </html>

--- a/core/templates/email/testEmail.gotxt
+++ b/core/templates/email/testEmail.gotxt
@@ -4,5 +4,6 @@ This is a test email confirming your Goa4Web configuration.
 
 Manage notifications: {{.UnsubscribeUrl}}
 
-Cheers,
-The A4Web Team
+{{- if .SignOff}}
+{{.SignOff}}
+{{- end}}

--- a/core/templates/email/threadEmail.gohtml
+++ b/core/templates/email/threadEmail.gohtml
@@ -5,6 +5,8 @@
 <p>A new thread "{{.Item.TopicTitle}}" was started at {{.Path}}.</p>
 <p>You can view it <a href="{{.URL}}">here</a>.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
-<p>Cheers,<br>The A4Web Team</p>
+{{- if .SignOff}}
+<p>{{.SignOffHTML}}</p>
+{{- end}}
 </body>
 </html>

--- a/core/templates/email/threadEmail.gotxt
+++ b/core/templates/email/threadEmail.gotxt
@@ -10,6 +10,6 @@ View it here:
 {{.URL}}
 
 Manage notifications: {{.UnsubscribeUrl}}
-
-Cheers,
-The A4Web Team
+{{- if .SignOff}}
+{{.SignOff}}
+{{- end}}

--- a/core/templates/email/updateEmail.gohtml
+++ b/core/templates/email/updateEmail.gohtml
@@ -5,6 +5,8 @@
 <p>{{.Action}} occurred at <a href="{{.URL}}">{{.URL}}</a> on {{.Time}}.</p>
 {{/* URL always provided now */}}
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
-<p>Cheers,<br>The A4Web Team</p>
+{{- if .SignOff}}
+<p>{{.SignOffHTML}}</p>
+{{- end}}
 </body>
 </html>

--- a/core/templates/email/updateEmail.gotxt
+++ b/core/templates/email/updateEmail.gotxt
@@ -10,6 +10,6 @@ Hello,
 {{.URL}}
 {{end}}
 Manage notifications: {{.UnsubscribeUrl}}
-
-Cheers,
-The A4Web Team
+{{- if .SignOff}}
+{{.SignOff}}
+{{- end}}

--- a/core/templates/email/userApprovedEmail.gohtml
+++ b/core/templates/email/userApprovedEmail.gohtml
@@ -2,5 +2,7 @@
 <html><body>
 <p>Hello,</p>
 <p>Your account has been approved. You may now <a href="{{.URL}}">log in</a>.</p>
-<p>Cheers,<br>The A4Web Team</p>
+{{- if .SignOff}}
+<p>{{.SignOffHTML}}</p>
+{{- end}}
 </body></html>

--- a/core/templates/email/userApprovedEmail.gotxt
+++ b/core/templates/email/userApprovedEmail.gotxt
@@ -6,5 +6,6 @@ Hello,
 
 Your account has been approved.
 
-Cheers,
-The A4Web Team
+{{- if .SignOff}}
+{{.SignOff}}
+{{- end}}

--- a/core/templates/email/userRejectedEmail.gohtml
+++ b/core/templates/email/userRejectedEmail.gohtml
@@ -3,5 +3,7 @@
 <p>Hello,</p>
 <p>Your account request was rejected.</p>
 <p>{{.Item.Reason}}</p>
-<p>Cheers,<br>The A4Web Team</p>
+{{- if .SignOff}}
+<p>{{.SignOffHTML}}</p>
+{{- end}}
 </body></html>

--- a/core/templates/email/userRejectedEmail.gotxt
+++ b/core/templates/email/userRejectedEmail.gotxt
@@ -6,6 +6,6 @@ Hello,
 
 Your account request was rejected.
 Reason: {{.Item.Reason}}
-
-Cheers,
-The A4Web Team
+{{- if .SignOff}}
+{{.SignOff}}
+{{- end}}

--- a/core/templates/email/writingEmail.gohtml
+++ b/core/templates/email/writingEmail.gohtml
@@ -5,6 +5,8 @@
 <p>A new writing "{{.Item.Title}}" was submitted.</p>
 <p>Read it <a href="{{.URL}}">here</a>.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
-<p>Cheers,<br>The A4Web Team</p>
+{{- if .SignOff}}
+<p>{{.SignOffHTML}}</p>
+{{- end}}
 </body>
 </html>

--- a/core/templates/email/writingEmail.gotxt
+++ b/core/templates/email/writingEmail.gotxt
@@ -10,6 +10,6 @@ Read it here:
 {{.URL}}
 
 Manage notifications: {{.UnsubscribeUrl}}
-
-Cheers,
-The A4Web Team
+{{- if .SignOff}}
+{{.SignOff}}
+{{- end}}

--- a/examples/config.env
+++ b/examples/config.env
@@ -28,6 +28,8 @@ EMAIL_ENABLED=true
 EMAIL_FROM=
 # email provider (default: )
 EMAIL_PROVIDER=
+# email sign off (default: )
+EMAIL_SIGNOFF=
 # interval in seconds between email worker runs (default: 60)
 EMAIL_WORKER_INTERVAL=60
 # enable or disable feeds (default: true)

--- a/examples/config.json
+++ b/examples/config.json
@@ -14,6 +14,7 @@
   "EMAIL_ENABLED": "true",
   "EMAIL_FROM": "",
   "EMAIL_PROVIDER": "",
+  "EMAIL_SIGNOFF": "",
   "EMAIL_WORKER_INTERVAL": "60",
   "FEEDS_ENABLED": "true",
   "HOSTNAME": "http://localhost:8080",

--- a/internal/notifications/email.go
+++ b/internal/notifications/email.go
@@ -3,12 +3,14 @@ package notifications
 import (
 	"context"
 	"fmt"
-	"github.com/arran4/goa4web/internal/eventbus"
+	"html"
+	htemplate "html/template"
 	"strings"
 
 	"github.com/arran4/goa4web/config"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/internal/eventbus"
 )
 
 func (n *Notifier) createEmailTemplateAndQueue(ctx context.Context, userID int32, emailAddr, page, action string, item interface{}) error {
@@ -41,6 +43,8 @@ type EmailData struct {
 	any
 	SubjectPrefix  string
 	UnsubscribeUrl string
+	SignOff        string
+	SignOffHTML    htemplate.HTML
 	Item           interface{}
 }
 
@@ -62,10 +66,16 @@ func (n *Notifier) RenderEmailFromTemplates(ctx context.Context, emailAddr strin
 		unsub = strings.TrimRight(config.AppRuntimeConfig.HTTPHostname, "/") + unsub
 	}
 
+	signOff := config.AppRuntimeConfig.EmailSignOff
+	htmlSignOff := html.EscapeString(signOff)
+	htmlSignOff = strings.ReplaceAll(htmlSignOff, "\n", "<br />")
+
 	data := EmailData{
 		any:            item,
 		SubjectPrefix:  subjectPrefix,
 		UnsubscribeUrl: unsub,
+		SignOff:        signOff,
+		SignOffHTML:    htemplate.HTML(htmlSignOff),
 		Item:           item,
 	}
 	var textBody, htmlBody string

--- a/readme.md
+++ b/readme.md
@@ -228,6 +228,7 @@ environment variables listed below.
 | `DB_DRIVER` | `--db-driver` | Yes | `mysql` | Database driver name. |
 | `EMAIL_PROVIDER` | `--email-provider` | No | `ses` | Selects the mail sending backend. |
 | `EMAIL_FROM` | `--email-from` | No | - | Default From address for outgoing mail. Must be a valid RFC 5322 address. |
+| `EMAIL_SIGNOFF` | `--email-signoff` | No | - | Optional sign off text appended to emails. |
 | `SMTP_HOST` | `--smtp-host` | No | - | SMTP server hostname. |
 | `SMTP_PORT` | `--smtp-port` | No | - | SMTP server port. |
 | `SMTP_USER` | `--smtp-user` | No | - | SMTP username. |


### PR DESCRIPTION
## Summary
- add `EMAIL_SIGNOFF` configuration option
- expose sign off values in runtime and notifier
- update email templates to conditionally render the configured sign off
- document the setting in example configs and README
- fix newline replacement to use `<br />` for HTML mail

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c82555204832fa1091f450b0dae35