### PR TITLE
Fix duplicate task methods

### DIFF
--- a/handlers/user/admin_permissions.go
+++ b/handlers/user/admin_permissions.go
@@ -92,28 +92,6 @@ func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 
-func (PermissionUserAllowTask) TargetUserIDs(evt eventbus.Event) []int32 {
-	if id, ok := evt.Data["UserID"].(int32); ok {
-		return []int32{id}
-	}
-	if id, ok := evt.Data["UserID"].(int); ok {
-		return []int32{int32(id)}
-	}
-	if id, ok := evt.Data["UserID"].(float64); ok {
-		return []int32{int32(id)}
-	}
-	return nil
-}
-
-func (PermissionUserAllowTask) TargetEmailTemplate() *notif.EmailTemplates {
-	return nil
-}
-
-func (PermissionUserAllowTask) TargetInternalNotificationTemplate() *string {
-	v := notif.NotificationTemplateFilenameGenerator("permission_user_allow")
-	return &v
-}
-
 // PermissionUserDisallowTask removes a user's permission.
 type PermissionUserDisallowTask struct{ tasks.TaskString }
 
@@ -157,28 +135,6 @@ func (PermissionUserDisallowTask) Action(w http.ResponseWriter, r *http.Request)
 		}
 	}
 	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
-}
-
-func (PermissionUserDisallowTask) TargetUserIDs(evt eventbus.Event) []int32 {
-	if id, ok := evt.Data["UserID"].(int32); ok {
-		return []int32{id}
-	}
-	if id, ok := evt.Data["UserID"].(int); ok {
-		return []int32{int32(id)}
-	}
-	if id, ok := evt.Data["UserID"].(float64); ok {
-		return []int32{int32(id)}
-	}
-	return nil
-}
-
-func (PermissionUserDisallowTask) TargetEmailTemplate() *notif.EmailTemplates {
-	return nil
-}
-
-func (PermissionUserDisallowTask) TargetInternalNotificationTemplate() *string {
-	v := notif.NotificationTemplateFilenameGenerator("permission_user_disallow")
-	return &v
 }
 
 // PermissionUpdateTask updates an existing permission entry.


### PR DESCRIPTION
## Summary
- remove duplicate Target* methods from admin permissions tasks
- update permission notification tests for new template names

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c85060020832f84454edfc1677207