### PR TITLE
Replace LevelMax terminology with starting roles

### DIFF
--- a/core/templates/site/forum/adminTopicCreatePage.gohtml
+++ b/core/templates/site/forum/adminTopicCreatePage.gohtml
@@ -11,7 +11,7 @@ View: <select name="view">{{- range $.Roles }}<option value="{{.ID}}">{{.Name}}<
 Reply: <select name="reply">{{- range $.Roles }}<option value="{{.ID}}">{{.Name}}</option>{{- end }}</select><br>
 New thread: <select name="newthread">{{- range $.Roles }}<option value="{{.ID}}">{{.Name}}</option>{{- end }}</select><br>
 See: <select name="see">{{- range $.Roles }}<option value="{{.ID}}">{{.Name}}</option>{{- end }}</select><br>
-Invite: <select name="invite">{{- range $.Roles }}<option value="{{.ID}}">{{.Name}}</option>{{- end }}</select><br>
+Starting roles: <select name="startingRoles">{{- range $.Roles }}<option value="{{.ID}}">{{.Name}}</option>{{- end }}</select><br>
 Read: <select name="read">{{- range $.Roles }}<option value="{{.ID}}">{{.Name}}</option>{{- end }}</select><br>
 Moderator: <select name="mod">{{- range $.Roles }}<option value="{{.ID}}">{{.Name}}</option>{{- end }}</select><br>
 Administrator: <select name="admin">{{- range $.Roles }}<option value="{{.ID}}">{{.Name}}</option>{{- end }}</select><br>

--- a/core/templates/site/forum/adminTopicEditPage.gohtml
+++ b/core/templates/site/forum/adminTopicEditPage.gohtml
@@ -11,7 +11,7 @@ View: <select name="view">{{- range $.Roles }}<option value="{{.ID}}" {{if $.Res
 Reply: <select name="reply">{{- range $.Roles }}<option value="{{.ID}}" {{if $.Restriction}}{{if eq $.Restriction.ReplyRoleID.Int32 .ID}}selected{{end}}{{end}}>{{.Name}}</option>{{- end }}</select><br>
 New thread: <select name="newthread">{{- range $.Roles }}<option value="{{.ID}}" {{if $.Restriction}}{{if eq $.Restriction.NewthreadRoleID.Int32 .ID}}selected{{end}}{{end}}>{{.Name}}</option>{{- end }}</select><br>
 See: <select name="see">{{- range $.Roles }}<option value="{{.ID}}" {{if $.Restriction}}{{if eq $.Restriction.SeeRoleID.Int32 .ID}}selected{{end}}{{end}}>{{.Name}}</option>{{- end }}</select><br>
-Invite: <select name="invite">{{- range $.Roles }}<option value="{{.ID}}" {{if $.Restriction}}{{if eq $.Restriction.InviteRoleID.Int32 .ID}}selected{{end}}{{end}}>{{.Name}}</option>{{- end }}</select><br>
+Starting roles: <select name="startingRoles">{{- range $.Roles }}<option value="{{.ID}}" {{if $.Restriction}}{{if eq $.Restriction.InviteRoleID.Int32 .ID}}selected{{end}}{{end}}>{{.Name}}</option>{{- end }}</select><br>
 Read: <select name="read">{{- range $.Roles }}<option value="{{.ID}}" {{if $.Restriction}}{{if eq $.Restriction.ReadRoleID.Int32 .ID}}selected{{end}}{{end}}>{{.Name}}</option>{{- end }}</select><br>
 Moderator: <select name="mod">{{- range $.Roles }}<option value="{{.ID}}" {{if $.Restriction}}{{if eq $.Restriction.ModRoleID.Int32 .ID}}selected{{end}}{{end}}>{{.Name}}</option>{{- end }}</select><br>
 Administrator: <select name="admin">{{- range $.Roles }}<option value="{{.ID}}" {{if $.Restriction}}{{if eq $.Restriction.AdminRoleID.Int32 .ID}}selected{{end}}{{end}}>{{.Name}}</option>{{- end }}</select><br>

--- a/core/templates/site/forum/adminUserPage.gohtml
+++ b/core/templates/site/forum/adminUserPage.gohtml
@@ -10,7 +10,7 @@
             <th>Topic</th>
             <th>Forum</th>
             <th>Level</th>
-            <th>Invite Level Max</th>
+            <th>Starting roles</th>
             <th>Expiration</th>
             <th>Options</th>
         </tr>
@@ -22,7 +22,7 @@
                 <td><input type="hidden" name="tid" value="{{ .Idforumtopic }}">{{ .Title.String }}</td>
                 <td>{{ with index $.Categories .ForumcategoryIdforumcategory }}{{ .Title.String }}{{ end }}</td>
                 <td><input name="level" value="{{ .Level.Int32 }}" size="8"></td>
-                <td><input name="inviteMax" value="{{ .Invitemax.Int32 }}" size="8"></td>
+                <td><input name="startingRoles" value="{{ .Invitemax.Int32 }}" size="8"></td>
                 <td><input type="date" name="expiresAt" value="{{ if .ExpiresAt.Valid }}{{ .ExpiresAt.Time.Format "2006-01-02" }}{{ end }}"></td>
                 <td>
                     <input type="submit" name="task" value="Update role">

--- a/core/templates/site/topicRestrictions.gohtml
+++ b/core/templates/site/topicRestrictions.gohtml
@@ -7,7 +7,7 @@
             <th>reply level
             <th>new thread level
             <th>see level
-            <th>invite level
+            <th>Starting roles
             <th>read level
             <th>Moderator Level
             <th>Administrator level

--- a/core/templates/site/user/topicRestrictions.gohtml
+++ b/core/templates/site/user/topicRestrictions.gohtml
@@ -5,7 +5,7 @@
             <th>Topic
             <th>User
             <th>Level
-            <th>Max Invite
+            <th>Starting roles
             <th>Options
         </tr>
         {{- range .TopicRestrictions }}
@@ -15,7 +15,7 @@
                 <td><input type="hidden" name="tid" value="{{ .ForumTopicID }}">{{ .Title }}
                 <td><input type="hidden" name="uid" value="{{ .UserID }}">{{ .Username }}
                 <td><input name="level" value="{{ .Level }}" size="8">
-                <td><input name="invitemax" value="{{ .InviteMax }}" size="8">
+                <td><input name="startingRoles" value="{{ .InviteMax }}" size="8">
                 <td>
                     <input type="submit" name="task" value="Update role">
                     <input type="submit" name="task" value="Revoke role">
@@ -28,13 +28,13 @@
                 <td><input type="hidden" name="tid" value="{{ .TopicID }}">
                 <td><input name="username" value="USERNAME">
                 <td><input name="level" value="0" size="8">
-                <td><input name="invitemax" value="0" size="8">
+                <td><input name="startingRoles" value="0" size="8">
                 <td>
                     <input type="submit" name="task" value="Grant role">
             </tr>
         </form>
     </table><br>
-    The most you can give someone as their level or maxinvite level is {{ .MaxInvite }}.<br>
+    The most you can give someone as their level or starting role(s) is {{ .MaxInvite }}.<br>
     Current restiction levels:
     <ul>
         <li>Level {{ .ViewLevel }} to View threads


### PR DESCRIPTION
## Summary
- update forum admin topic templates to label starting roles
- update topic restriction template to label starting roles

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c78421a34832fb9766b556652faac