### PR TITLE
Fix Add Email form path

### DIFF
--- a/core/templates/site/user/emailPage.gohtml
+++ b/core/templates/site/user/emailPage.gohtml
@@ -2,7 +2,7 @@
 {{- if $.Error }}
     <p style="color:red;">{{ $.Error }}</p>
 {{- end }}
-    <form method="post">
+    <form method="post" action="/usr/email/add">
         {{ csrfField }}
         Add Email: <input type="email" name="new_email">
         <input type="submit" name="task" value="Add">


### PR DESCRIPTION
## Summary
- ensure Add Email form posts to `/usr/email/add`

## Testing
- `go vet ./...` *(fails: undefined variables in unrelated packages)*
- `golangci-lint run ./...` *(fails: vet errors)*
- `go test ./...` *(fails: undefined variables in unrelated packages)*

------
https://chatgpt.com/codex/tasks/task_e_687c8cda7050832f99b4cc1ba000e2b1