### PR TITLE
Fix whitespace in site gohtml templates

### DIFF
--- a/core/templates/site/admin/forumPage.gohtml
+++ b/core/templates/site/admin/forumPage.gohtml
@@ -1,16 +1,16 @@
 {{ template "head" $ }}
     [<a href="/admin">Admin:</a> <a href="/admin/forum">(This page/Refresh)</a>]<br />
-			<strong>What shall we do?</strong><br>
+            <strong>What shall we do?</strong><br>
                         View something:<br>
                         <a href="/admin/forum/list">Complete word list</a><br>
                         <a href="/admin/forum/flagged">Flagged posts</a><br>
                         <a href="/admin/forum/modlog">Moderator logs</a><br>
-			<br>
+            <br>
                         Perform something:<br>
-			<form method="post">
+            <form method="post">
         {{ csrfField }}
-				<input type="submit" name="task" value="Remake statistic information on forumthread"><br>
-				<input type="submit" name="task" value="Remake statistic information on forumtopic"><br>
-				<!-- <input type="submit" name="task" value="Remake writing search"> -->
-			</form>
+                <input type="submit" name="task" value="Remake statistic information on forumthread"><br>
+                <input type="submit" name="task" value="Remake statistic information on forumtopic"><br>
+                <!-- <input type="submit" name="task" value="Remake writing search"> -->
+            </form>
 {{ template "tail" $ }}

--- a/core/templates/site/admin/forumWordListPage.gohtml
+++ b/core/templates/site/admin/forumWordListPage.gohtml
@@ -1,8 +1,8 @@
 {{ template "head" $ }}
     [<a href="/admin">Admin:</a> <a href="/admin/forum/list">(This page/Refresh)</a>]<br />
-			Complete word list:<ul>
-			{{range $.Rows}}
-				<li>{{- .String}}</li>
-			{{- end}}
-			</ul>
+            Complete word list:<ul>
+            {{range $.Rows}}
+                <li>{{- .String}}</li>
+            {{- end}}
+            </ul>
 {{ template "tail" $ }}

--- a/core/templates/site/admin/languagesPage.gohtml
+++ b/core/templates/site/admin/languagesPage.gohtml
@@ -1,38 +1,38 @@
 {{ template "head" $ }}
     [<a href="/admin">Admin:</a> <a href="/admin/languages">(This page/Refresh)</a>]<br />
-		<table>
-			<tr>
-				<th>ID</th>
-				<th>Name</th>
-				<th>Options</th>
-			</tr>
-			{{range $.Rows}}
-				<tr>
-					<td>{{.Idlanguage}}</td>
-					<td>
-						<form method="post">
+        <table>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Options</th>
+            </tr>
+            {{range $.Rows}}
+                <tr>
+                    <td>{{.Idlanguage}}</td>
+                    <td>
+                        <form method="post">
         {{ csrfField }}
-							<input type="hidden" name="cid" value="{{.Idlanguage}}">
-							<input name="cname" value="{{.Nameof.String}}">
-					</td>
-					<td>
-						<input type="submit" name="task" value="Rename Language">
-						<input type="submit" name="task" value="Delete Language">
-						</form>
-					</td>
-				</tr>
-			{{end}}
-			<tr>
-				<td>NEW</td>
-				<td>
-					<form method="post">
+                            <input type="hidden" name="cid" value="{{.Idlanguage}}">
+                            <input name="cname" value="{{.Nameof.String}}">
+                    </td>
+                    <td>
+                        <input type="submit" name="task" value="Rename Language">
+                        <input type="submit" name="task" value="Delete Language">
+                        </form>
+                    </td>
+                </tr>
+            {{end}}
+            <tr>
+                <td>NEW</td>
+                <td>
+                    <form method="post">
         {{ csrfField }}
-						<input name="cname" value="">
-				</td>
-				<td>
-					<input type="submit" name="task" value="Create Language">
-					</form>
-				</td>
-			</tr>
-		</table>
+                        <input name="cname" value="">
+                </td>
+                <td>
+                    <input type="submit" name="task" value="Create Language">
+                    </form>
+                </td>
+            </tr>
+        </table>
 {{ template "tail" $ }}

--- a/core/templates/site/admin/searchPage.gohtml
+++ b/core/templates/site/admin/searchPage.gohtml
@@ -24,7 +24,7 @@
                         <input type="submit" name="task" value="Remake comments search"><br>
                         <input type="submit" name="task" value="Remake news search"><br>
                         <input type="submit" name="task" value="Remake blog search"><br>
-			<input type="submit" name="task" value="Remake linker search"><br>
+            <input type="submit" name="task" value="Remake linker search"><br>
                         <input type="submit" name="task" value="Remake writing search"><br>
                         <input type="submit" name="task" value="Remake image search">
                 </form>

--- a/core/templates/site/blogs/blogEditPage.gohtml
+++ b/core/templates/site/blogs/blogEditPage.gohtml
@@ -9,6 +9,6 @@
             <input type="submit" name="task" value="{{ .Mode }}">
         </form>
     {{ else }}
-		Dead. No BLOG!
+        Dead. No BLOG!
     {{ end }}
 {{ template "tail" $ }}

--- a/core/templates/site/blogs/blogPage.gohtml
+++ b/core/templates/site/blogs/blogPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
-		<font size="5"><a href="/blogs/blogger/{{$.Blog.Username.String}}">{{$.Blog.Username.String}}'s Blog</a>:</font><br>
-		<table width="100%">
+        <font size="5"><a href="/blogs/blogger/{{$.Blog.Username.String}}">{{$.Blog.Username.String}}'s Blog</a>:</font><br>
+        <table width="100%">
                 <tr>
                     <th bgcolor="lightgrey">{{$.Blog.Written}}</th>
                 </tr>
@@ -10,5 +10,5 @@
                         {{if .EditUrl}} - [<a href="{{.EditUrl}}">EDIT</a>]{{end}}
                     </td>
                 </tr>
-		</table><br>
+        </table><br>
 {{ template "tail" $ }}

--- a/core/templates/site/blogs/blogReply.gohtml
+++ b/core/templates/site/blogs/blogReply.gohtml
@@ -1,11 +1,11 @@
 {{ define "blogReply" }}
-		{{if $.IsReplyable}}
-			<font size="4">Reply:</font><br>
-			<form method="post" action="/blogs/blog/{{$.Blog.Idblogs}}/reply">
+        {{if $.IsReplyable}}
+            <font size="4">Reply:</font><br>
+            <form method="post" action="/blogs/blog/{{$.Blog.Idblogs}}/reply">
         {{ csrfField }}
-				<textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>
+                <textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>
                 {{ template "languageCombobox" $ }}
-				<input type="submit" name="task" value="Reply">
-			</form>
-		{{end}}
+                <input type="submit" name="task" value="Reply">
+            </form>
+        {{end}}
 {{ end }}

--- a/core/templates/site/blogs/bloggerPostsPage.gohtml
+++ b/core/templates/site/blogs/bloggerPostsPage.gohtml
@@ -1,36 +1,36 @@
 {{ template "head" $ }}
-		{{if .Rows}}
+        {{if .Rows}}
                         {{if .UID}}
                                 <font size="5"><a href="/blogs/blogger/{{(index $.Rows 0).Username.String}}">{{(index $.Rows 0).Username.String}}</a>'s blogs.</font><br>
-			{{else}}
-				<font size="5"><a href="/blogs/bloggers">All bloggers</a>' blogs.</font><br>
-			{{end}}
-			<table width="100%">
-				{{range .Rows}}
-					<tr>
-						<th bgcolor="lightgrey">{{.Written}}</th>
-					</tr>
-					<tr>
-						<td>
+            {{else}}
+                <font size="5"><a href="/blogs/bloggers">All bloggers</a>' blogs.</font><br>
+            {{end}}
+            <table width="100%">
+                {{range .Rows}}
+                    <tr>
+                        <th bgcolor="lightgrey">{{.Written}}</th>
+                    </tr>
+                    <tr>
+                        <td>
                             {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]
                                                         {{if .EditUrl}} - [<a href="{{.EditUrl}}">EDIT</a>]{{end}}
-						</td>
-					</tr>
-				{{end}}
-			</table><br>
-		{{else}}
-			{{if .IsOffset}}
-				{{if .UID}}
-					There are no more blogs under this user.<br>
-				{{else}}
-					There are no more blogs.<br>
-				{{end}}
-			{{else}}
-				{{if .UID}}
-					Nothing under this blog.<br>
-				{{else}}
-					There are no blogs here.<br>
-				{{end}}
-			{{end}}
-		{{end}}
+                        </td>
+                    </tr>
+                {{end}}
+            </table><br>
+        {{else}}
+            {{if .IsOffset}}
+                {{if .UID}}
+                    There are no more blogs under this user.<br>
+                {{else}}
+                    There are no more blogs.<br>
+                {{end}}
+            {{else}}
+                {{if .UID}}
+                    Nothing under this blog.<br>
+                {{else}}
+                    There are no blogs here.<br>
+                {{end}}
+            {{end}}
+        {{end}}
 {{ template "tail" $ }}

--- a/core/templates/site/blogs/commentPage.gohtml
+++ b/core/templates/site/blogs/commentPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
-		<font size="5"><a href="/blogs/blogger/{{$.Blog.Username.String}}">{{$.Blog.Username.String}}'s Blog</a>:</font><br>
-		<table width="100%">
+        <font size="5"><a href="/blogs/blogger/{{$.Blog.Username.String}}">{{$.Blog.Username.String}}'s Blog</a>:</font><br>
+        <table width="100%">
                 <tr>
                     <th bgcolor="lightgrey">{{$.Blog.Written}}</th>
                 </tr>
@@ -10,7 +10,7 @@
                         {{if .EditUrl}} - [<a href="{{.EditUrl}}">EDIT</a>]{{end}}
                     </td>
                 </tr>
-		</table><br>
-		{{ template "threadComments" $ }}
-		{{ template "blogReply" $ }}
+        </table><br>
+        {{ template "threadComments" $ }}
+        {{ template "blogReply" $ }}
 {{ template "tail" $ }}

--- a/core/templates/site/blogs/page.gohtml
+++ b/core/templates/site/blogs/page.gohtml
@@ -1,38 +1,38 @@
 {{ define "blogsPage" }}
     {{ template "head" $ }}
-		{{if .Rows}}
+        {{if .Rows}}
                         {{if .UID}}
                                 <font size="5"><a href="/blogs/blogger/{{(index $.Blogs 0).Username.String}}">{{(index $.Blogs 0).Username.String}}</a>'s blogs.</font><br>
-			{{else}}
-				<font size="5"><a href="/blogs/bloggers">All bloggers</a>' blogs.</font><br>
-			{{end}}
-			<table width="100%">
-				{{range .Rows}}
-					<tr>
-						<th bgcolor="lightgrey">{{.Written}}</th>
-					</tr>
-					<tr>
-						<td>
+            {{else}}
+                <font size="5"><a href="/blogs/bloggers">All bloggers</a>' blogs.</font><br>
+            {{end}}
+            <table width="100%">
+                {{range .Rows}}
+                    <tr>
+                        <th bgcolor="lightgrey">{{.Written}}</th>
+                    </tr>
+                    <tr>
+                        <td>
                             {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]
                                                         {{if .EditUrl}} - [<a href="{{.EditUrl}}">EDIT</a>]{{end}}
-						</td>
-					</tr>
-				{{end}}
-			</table><br>
-		{{else}}
-			{{if .IsOffset}}
-				{{if .UID}}
-					There are no more blogs under this user.<br>
-				{{else}}
-					There are no more blogs.<br>
-				{{end}}
-			{{else}}
-				{{if .UID}}
-					Nothing under this blog.<br>
-				{{else}}
-					There are no blogs here.<br>
-				{{end}}
-			{{end}}
-		{{end}}
+                        </td>
+                    </tr>
+                {{end}}
+            </table><br>
+        {{else}}
+            {{if .IsOffset}}
+                {{if .UID}}
+                    There are no more blogs under this user.<br>
+                {{else}}
+                    There are no more blogs.<br>
+                {{end}}
+            {{else}}
+                {{if .UID}}
+                    Nothing under this blog.<br>
+                {{else}}
+                    There are no blogs here.<br>
+                {{end}}
+            {{end}}
+        {{end}}
     {{ template "tail" $ }}
 {{ end }}

--- a/core/templates/site/bookmarks/page.gohtml
+++ b/core/templates/site/bookmarks/page.gohtml
@@ -1,11 +1,11 @@
 {{ define "bookmarksPage" }}
     {{ template "head" $ }}
-	<a href="/bookmarks/mine">View bookmarks</a><br>
-	<a href="/bookmarks/edit">Edit page.</a><br>
-	<b><u>How to use this?</u></b><br>
-	Simply. First edit your page using the keywords below then set it as your start page.<br>
-	"<URL> <Name> <Newline>" - Will create a link to URL with name, if you need to use a space make it %20 and use that.<br>
-	"Category: <name> <Newline>" - Creates a category named <name>.<br>
-	"Column <Newline>" - Creates a new column.
+    <a href="/bookmarks/mine">View bookmarks</a><br>
+    <a href="/bookmarks/edit">Edit page.</a><br>
+    <b><u>How to use this?</u></b><br>
+    Simply. First edit your page using the keywords below then set it as your start page.<br>
+    "<URL> <Name> <Newline>" - Will create a link to URL with name, if you need to use a space make it %20 and use that.<br>
+    "Category: <name> <Newline>" - Creates a category named <name>.<br>
+    "Column <Newline>" - Creates a new column.
     {{ template "tail" $ }}
 {{ end }}

--- a/core/templates/site/faq/adminAnswerPage.gohtml
+++ b/core/templates/site/faq/adminAnswerPage.gohtml
@@ -1,42 +1,42 @@
 {{ template "head" $ }}
     <font size="5">Section: Unanswered/Uncategorized Questions</font><br>
     {{- range .Rows }}
-		<form method="post" action="">
+        <form method="post" action="">
         {{ csrfField }}
-			<table width="100%">
-				<tr>
-					<th bgcolor="lightgrey">Q:
-					</th>
-				</tr>
-				<tr>
-					<td>
-						<textarea name="question" cols="60" rows="5">{{ .Question.String }}</textarea><br>
-					</td>
-				</tr>
-				<tr>
-					<th bgcolor="lightgrey">A:
-					</th>
-				</tr>
-				<tr>
-					<td>
-						<textarea name="answer" cols="60" rows="5">{{ .Answer.String }}</textarea><br>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<input type="submit" name="task" value="Answer">
-						<input type="submit" name="task" value="Remove">
-						<select name="category">
-							<option value="0">Hidden</option>
-							{{$FaqcategoriesIdfaqcategories := .FaqcategoriesIdfaqcategories }}
-							{{- range $.Categories }}
-							<option value="{{ .Idfaqcategories }}" {{if eq $FaqcategoriesIdfaqcategories .Idfaqcategories}}selected{{end}}>{{ .Name.String }} {{if eq $FaqcategoriesIdfaqcategories .Idfaqcategories}}(Current){{end}}</option>
-							{{- end }}
-						</select>
-						<input type="hidden" name="faq" value="{{ .Idfaq }}">
-					</td>
-				</tr>
-			</table>
-		</form><br>
+            <table width="100%">
+                <tr>
+                    <th bgcolor="lightgrey">Q:
+                    </th>
+                </tr>
+                <tr>
+                    <td>
+                        <textarea name="question" cols="60" rows="5">{{ .Question.String }}</textarea><br>
+                    </td>
+                </tr>
+                <tr>
+                    <th bgcolor="lightgrey">A:
+                    </th>
+                </tr>
+                <tr>
+                    <td>
+                        <textarea name="answer" cols="60" rows="5">{{ .Answer.String }}</textarea><br>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <input type="submit" name="task" value="Answer">
+                        <input type="submit" name="task" value="Remove">
+                        <select name="category">
+                            <option value="0">Hidden</option>
+                            {{$FaqcategoriesIdfaqcategories := .FaqcategoriesIdfaqcategories }}
+                            {{- range $.Categories }}
+                            <option value="{{ .Idfaqcategories }}" {{if eq $FaqcategoriesIdfaqcategories .Idfaqcategories}}selected{{end}}>{{ .Name.String }} {{if eq $FaqcategoriesIdfaqcategories .Idfaqcategories}}(Current){{end}}</option>
+                            {{- end }}
+                        </select>
+                        <input type="hidden" name="faq" value="{{ .Idfaq }}">
+                    </td>
+                </tr>
+            </table>
+        </form><br>
     {{- end }}
 {{ template "tail" $ }}

--- a/core/templates/site/faq/adminQuestionPage.gohtml
+++ b/core/templates/site/faq/adminQuestionPage.gohtml
@@ -7,23 +7,23 @@
                                 <tr>
                                         <th bgcolor="lightgrey">Q:
                                         </th>
-				</tr>
-				<tr>
-					<td>
-						<textarea name="question" cols="60" rows="5">{{ .Question.String }}</textarea><br>
-					</td>
-				</tr>
-				<tr>
-					<th bgcolor="lightgrey">A:
-					</th>
-				</tr>
-				<tr>
-					<td>
-						<textarea name="answer" cols="60" rows="5">{{ .Answer.String }}</textarea><br>
-					</td>
-				</tr>
-				<tr>
-					<td>
+                </tr>
+                <tr>
+                    <td>
+                        <textarea name="question" cols="60" rows="5">{{ .Question.String }}</textarea><br>
+                    </td>
+                </tr>
+                <tr>
+                    <th bgcolor="lightgrey">A:
+                    </th>
+                </tr>
+                <tr>
+                    <td>
+                        <textarea name="answer" cols="60" rows="5">{{ .Answer.String }}</textarea><br>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                                                 <input type="submit" name="task" value="Edit">
                                                 <input type="submit" name="task" value="Remove">
                                                 <select name="category">

--- a/core/templates/site/faq/askPage.gohtml
+++ b/core/templates/site/faq/askPage.gohtml
@@ -1,9 +1,9 @@
 {{ template "head" $ }}
-		<font size="5">Add a Question of your own:</font><br>
-		<form method="post" action="">
+        <font size="5">Add a Question of your own:</font><br>
+        <form method="post" action="">
         {{ csrfField }}
-			<textarea name="text" cols="60" rows="20"></textarea><br>
+            <textarea name="text" cols="60" rows="20"></textarea><br>
             {{ template "languageCombobox" $ }}
-			<input type="submit" name="task" value="Ask">
-		</form>
+            <input type="submit" name="task" value="Ask">
+        </form>
 {{ template "tail" $ }}

--- a/core/templates/site/forum/reply.gohtml
+++ b/core/templates/site/forum/reply.gohtml
@@ -1,9 +1,9 @@
 {{ define "forumReply" }}
-		{{if $.IsReplyable}}
-			<font size="4">Reply:</font><br>
-			<form method="post" action="/forum/topic/{{$.Topic.Idforumtopic}}/thread/{{$.Thread.Idforumthread}}/reply">
+        {{if $.IsReplyable}}
+            <font size="4">Reply:</font><br>
+            <form method="post" action="/forum/topic/{{$.Topic.Idforumtopic}}/thread/{{$.Thread.Idforumthread}}/reply">
         {{ csrfField }}
-				<textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>
+                <textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>
                 {{ template "languageCombobox" $ }}
                                 <input type="submit" name="task" value="Reply">
                                 <input type="submit" name="task" value="Cancel">

--- a/core/templates/site/head.gohtml
+++ b/core/templates/site/head.gohtml
@@ -11,11 +11,11 @@
        {{ if $.AutoRefresh }}
             <meta http-equiv="refresh" content="1">
         {{ end }}
-	</head>
-	<body>
-			{{template "header"}}
-			<br>
-		<table border=0>
-			<tr valign=top>
-				<td width=200px>{{template "index" $}}
-				<td>{{end}}
+    </head>
+    <body>
+            {{template "header"}}
+            <br>
+        <table border=0>
+            <tr valign=top>
+                <td width=200px>{{template "index" $}}
+                <td>{{end}}

--- a/core/templates/site/imagebbs/boardThreadPage.gohtml
+++ b/core/templates/site/imagebbs/boardThreadPage.gohtml
@@ -8,7 +8,7 @@
         </table><br>
     {{ end }}
     {{ if .Comments }}
-		{{ template "threadComments" $ }}
+        {{ template "threadComments" $ }}
     {{ end }}
     {{ if .Replyable }}
         <font size="4">Reply:</font><br>

--- a/core/templates/site/postImage.gohtml
+++ b/core/templates/site/postImage.gohtml
@@ -1,5 +1,5 @@
 {{ define "postImage" }}
-		<font size="4">Post image</font>:<br>
+        <font size="4">Post image</font>:<br>
                 <form method="post" enctype="multipart/form-data">
         {{ csrfField }}
                         Image file: <input type="file" name="image"><br>

--- a/core/templates/site/search/resultLinkerActionPage.gohtml
+++ b/core/templates/site/search/resultLinkerActionPage.gohtml
@@ -1,17 +1,17 @@
 {{ template "head" $ }}
     Search linker:<br>
     {{- with .Links }}
-    	{{- if $.NoResults }}
-    		<p>Nothing found.</p>
-    	{{- else if $.EmptyWords }}
-    		<p>Not enough words, words too small, or no words. Please re-enter, add more, larger, or some words.</p>
-    	{{- else }}
-    		<ul>
-    		{{- range $i, $result := . }}
-    			<li>{{ $i }}: <a href="/linker/show/{{$result.Idlinker}}">{{ $result.Title.String }}</a></li>
-    		{{- end }}
-    		</ul>
-    	{{ end }}
+        {{- if $.NoResults }}
+            <p>Nothing found.</p>
+        {{- else if $.EmptyWords }}
+            <p>Not enough words, words too small, or no words. Please re-enter, add more, larger, or some words.</p>
+        {{- else }}
+            <ul>
+            {{- range $i, $result := . }}
+                <li>{{ $i }}: <a href="/linker/show/{{$result.Idlinker}}">{{ $result.Title.String }}</a></li>
+            {{- end }}
+            </ul>
+        {{ end }}
     {{- end }}
     <br>
     Comment search:<br>

--- a/core/templates/site/searchPage.gohtml
+++ b/core/templates/site/searchPage.gohtml
@@ -1,13 +1,13 @@
 {{ define "searchPage" }}
     {{ template "head" $ }}
-	<form method="post">
+    <form method="post">
         {{ csrfField }}
-		Search words: <input name="searchwords" value="{{.SearchWords}}">, (No keywords exist as of this moment.)<br>
-		<input type="submit" name="task" value="Search forum">
-		<input type="submit" name="task" value="Search news">
-		<input type="submit" name="task" value="Search linker">
-		<input type="submit" name="task" value="Search blogs">
-		<input type="submit" name="task" value="Search writings">
-	</form>
+        Search words: <input name="searchwords" value="{{.SearchWords}}">, (No keywords exist as of this moment.)<br>
+        <input type="submit" name="task" value="Search forum">
+        <input type="submit" name="task" value="Search news">
+        <input type="submit" name="task" value="Search linker">
+        <input type="submit" name="task" value="Search blogs">
+        <input type="submit" name="task" value="Search writings">
+    </form>
     {{ template "tail" $ }}
 {{ end }}

--- a/core/templates/site/subBoards.gohtml
+++ b/core/templates/site/subBoards.gohtml
@@ -1,12 +1,12 @@
 {{ define "subBoards" }}
-		{{ if .Boards }}
-			<font size="4">{{ if .IsSubBoard }}Sub-{{ end }}Boards:</font><br>
-			<table>
-				{{ range .Boards }}
-					<tr>
-						<th><a href="/imagebbs/board/{{ .Idimageboard }}">{{ .Title.String }}</a>
-						<td>{{ .Description.String }}
-				{{ end }}
-			</table><br>
-		{{ end }}
+        {{ if .Boards }}
+            <font size="4">{{ if .IsSubBoard }}Sub-{{ end }}Boards:</font><br>
+            <table>
+                {{ range .Boards }}
+                    <tr>
+                        <th><a href="/imagebbs/board/{{ .Idimageboard }}">{{ .Title.String }}</a>
+                        <td>{{ .Description.String }}
+                {{ end }}
+            </table><br>
+        {{ end }}
 {{ end }}

--- a/core/templates/site/tail.gohtml
+++ b/core/templates/site/tail.gohtml
@@ -1,6 +1,6 @@
 {{define "tail"}}
-		</table>
-		<div id="bottom"></div>
+        </table>
+        <div id="bottom"></div>
                 <hr>
                 <footer class="site-footer">
                         <center>

--- a/core/templates/site/threadComments.gohtml
+++ b/core/templates/site/threadComments.gohtml
@@ -3,6 +3,6 @@
         <br>Skipping {{ $.Offset }} comments.<br><br><br>
     {{ end }}
     {{range $.Comments }}
-		{{ template "comment" . }}
+        {{ template "comment" . }}
     {{end}}
 {{ end }}

--- a/core/templates/site/topicThreads.gohtml
+++ b/core/templates/site/topicThreads.gohtml
@@ -1,26 +1,26 @@
 {{ define "topicThreads" }}
     <font size="4">Threads:</font><br>
     {{- range .Threads }}
-		<table width="100%" border=1>
-			<tr>
-				<td bgcolor="lightgrey">
+        <table width="100%" border=1>
+            <tr>
+                <td bgcolor="lightgrey">
                     First poster: <font color="green">{{ .Firstpostusername.String }}</font> At <font color="green">{{ .Firstpostwritten.Time }}</font><br />
                     Contents:
-				</td>
+                </td>
             </tr>
-			<tr>
-				<td bgcolor="">
-					{{ .Firstposttext.String | a4code2html }}<br>
-				</td>
-			</tr>
-			<tr>
-				<td bgcolor="">
-					Lastposter: <font color="blue">{{ .Lastposterusername.String }}</font>
-					At <font color="blue">{{ .Lastaddition.Time }}</font>
-					[<a href="/forum/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">{{ .Comments.Int32 }} comments.</a>]
-				</td>
+            <tr>
+                <td bgcolor="">
+                    {{ .Firstposttext.String | a4code2html }}<br>
+                </td>
             </tr>
-		</table>
-		<br />
+            <tr>
+                <td bgcolor="">
+                    Lastposter: <font color="blue">{{ .Lastposterusername.String }}</font>
+                    At <font color="blue">{{ .Lastaddition.Time }}</font>
+                    [<a href="/forum/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">{{ .Comments.Int32 }} comments.</a>]
+                </td>
+            </tr>
+        </table>
+        <br />
     {{- end }}
 {{ end }}

--- a/core/templates/site/writings/userPermissionsPage.gohtml
+++ b/core/templates/site/writings/userPermissionsPage.gohtml
@@ -1,41 +1,41 @@
 {{ template "head" $ }}
-		<table border="1">
-			<tr>
-				<th>ID
-				<th>User
-				<th>Email
-				<th>Role
-				<th>Delete?
-			</tr>
-			{{range .Rows}}
-				<tr>
-					<td>{{.ID}}
-					<td>{{.Username}}
-					<td>{{.Email}}
+        <table border="1">
+            <tr>
+                <th>ID
+                <th>User
+                <th>Email
+                <th>Role
+                <th>Delete?
+            </tr>
+            {{range .Rows}}
+                <tr>
+                    <td>{{.ID}}
+                    <td>{{.Username}}
+                    <td>{{.Email}}
                                         <td>{{.Role}}
-					<td>
-						<form method="post">
+                    <td>
+                        <form method="post">
         {{ csrfField }}
                                                         <input type="hidden" name="permid" value="{{.IduserRoles}}">
-							<input type="submit" name="task" value="User Disallow">
-						</form>
-					</td>
-				</tr>
-			{{end}}
-			<tr>
-				<td><form method="post">NEW
+                            <input type="submit" name="task" value="User Disallow">
+                        </form>
+                    </td>
+                </tr>
+            {{end}}
+            <tr>
+                <td><form method="post">NEW
         {{ csrfField }}
-				<td><input name="username">
-				<td>?
-				<td>
+                <td><input name="username">
+                <td>?
+                <td>
                                         <select name="role">
                                                 {{- range $.Roles }}<option value="{{.Name}}">{{.Name}}</option>{{- end }}
                                         </select>
-				</td>
-				<td>
-					<input type="submit" name="task" value="User Allow">
-				</td>
-			</tr>
-		</table>
-		Permissions should be valid only.
+                </td>
+                <td>
+                    <input type="submit" name="task" value="User Allow">
+                </td>
+            </tr>
+        </table>
+        Permissions should be valid only.
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- convert tabs to spaces in various gohtml templates
- remove trailing spaces and ensure newline at EOF

## Testing
- `go mod tidy`
- `gofmt -w $(git ls-files '*.go')`
- `go fmt ./...`
- `go vet ./...` *(fails: undefined identifiers)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: undefined identifiers)*

------
https://chatgpt.com/codex/tasks/task_e_687c8b462d5c832fb6b271ac0283cff3