### PR TITLE
Add email preferences link

### DIFF
--- a/core/templates/site/user/notifications.gohtml
+++ b/core/templates/site/user/notifications.gohtml
@@ -13,14 +13,5 @@
     <div id="notifications-empty">No notifications</div>
 {{ end }}
 </div>
-<form method="post" action="/usr/notifications">
-    {{ csrfField }}
-    <select name="email_id">
-        <option value="">In-app only</option>
-        {{- range .Emails }}
-        <option value="{{ .ID }}" {{ if eq .NotificationPriority $.MaxPriority }}selected{{ end }}>{{ .Email }}</option>
-        {{- end }}
-    </select>
-    <input type="submit" name="task" value="SaveAll">
-</form>
+<p>Change your email address under <a href="/usr/email">Email and notification settings</a>.</p>
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- add a link to email settings from the notifications page
- remove unused email preference form on the notifications page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: undefined identifiers in handlers)*
- `golangci-lint run ./...` *(fails: typecheck issues)*
- `go test ./...` *(fails: build errors in handlers)*

------
https://chatgpt.com/codex/tasks/task_e_687c8d132b34832f8ab825d84c109098