### PR TITLE
Fix role variable and update tests

### DIFF
--- a/handlers/admin/news_user_tasks.go
+++ b/handlers/admin/news_user_tasks.go
@@ -62,7 +62,7 @@ func (NewsUserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 			}
 			evt.Data["targetUserID"] = u.Idusers
 			evt.Data["Username"] = u.Username.String
-			evt.Data["Role"] = level
+			evt.Data["Role"] = role
 		}
 	}
 	handlers.TaskDoneAutoRefreshPage(w, r)

--- a/handlers/blogs/blogsUserPermissionsPage.go
+++ b/handlers/blogs/blogsUserPermissionsPage.go
@@ -183,7 +183,7 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 			}
 			evt.Data["targetUserID"] = u.Idusers
 			evt.Data["Username"] = u.Username.String
-			evt.Data["Role"] = level
+			evt.Data["Role"] = role
 		}
 	}
 

--- a/handlers/forum/tasks.go
+++ b/handlers/forum/tasks.go
@@ -75,7 +75,7 @@ const (
 	// TaskTopicGrantDelete removes an existing forum topic grant.
 	TaskTopicGrantDelete tasks.TaskString = "Delete grant"
 
-  // TaskSubscribeToTopic subscribes the user to new threads in a topic.
+	// TaskSubscribeToTopic subscribes the user to new threads in a topic.
 	TaskSubscribeToTopic tasks.TaskString = "Subscribe To Topic"
 
 	// TaskUnsubscribeFromTopic removes topic thread notifications.

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -111,7 +111,7 @@ func (userAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 				}
 				evt.Data["targetUserID"] = u.Idusers
 				evt.Data["Username"] = u.Username.String
-				evt.Data["Role"] = level
+				evt.Data["Role"] = role
 			}
 		}
 	}

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -54,7 +54,7 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"idlinker", "language_idlanguage", "users_idusers", "linkercategory_idlinkerCategory", "forumthread_idforumthread", "title", "url", "description", "listed", "username", "title_2"}).
 		AddRow(1, 1, 1, 1, 0, "Foo", "http://foo", "Bar", time.Now(), "u", "c")
-	mock.ExpectQuery("SELECT l.idlinker").WithArgs(int32(1)).WillReturnRows(rows)
+	mock.ExpectQuery("WITH RECURSIVE role_ids").WithArgs(int32(0), int32(1), sql.NullInt32{}).WillReturnRows(rows)
 
 	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").WithArgs("foo").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT IGNORE INTO linker_search").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))

--- a/handlers/user/admin_permissions.go
+++ b/handlers/user/admin_permissions.go
@@ -70,7 +70,6 @@ func (PermissionUserAllowTask) AdminInternalNotificationTemplate() *string {
 
 var _ notif.TargetUsersNotificationProvider = (*PermissionUserAllowTask)(nil)
 
-
 func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	username := r.PostFormValue("username")
@@ -97,10 +96,10 @@ func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 				evt.Data = map[string]any{}
 			}
 			evt.Data["Username"] = username
-			evt.Data["Permission"] = level
+			evt.Data["Permission"] = role
 			evt.Data["targetUserID"] = u.Idusers
 			evt.Data["Username"] = u.Username.String
-			evt.Data["Role"] = level
+			evt.Data["Role"] = role
 		}
 	}
 	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
@@ -126,7 +125,6 @@ func (PermissionUserDisallowTask) AdminInternalNotificationTemplate() *string {
 
 var _ notif.TargetUsersNotificationProvider = (*PermissionUserDisallowTask)(nil)
 
-
 func (PermissionUserDisallowTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	permid := r.PostFormValue("permid")
@@ -143,10 +141,12 @@ func (PermissionUserDisallowTask) Action(w http.ResponseWriter, r *http.Request)
 		data.Errors = append(data.Errors, fmt.Errorf("strconv.Atoi: %w", err).Error())
 	} else {
 		var uname, role string
+		var userID int32
 		if rows, err := queries.GetUserRoles(r.Context()); err == nil {
 			for _, row := range rows {
 				if row.IduserRoles == int32(permidi) {
 					role = row.Role
+					userID = row.UsersIdusers
 					if u, err := queries.GetUserById(r.Context(), row.UsersIdusers); err == nil && u.Username.Valid {
 						uname = u.Username.String
 					}
@@ -163,9 +163,8 @@ func (PermissionUserDisallowTask) Action(w http.ResponseWriter, r *http.Request)
 				}
 				evt.Data["Username"] = uname
 				evt.Data["Permission"] = role
-					evt.Data["targetUserID"] = id
-					evt.Data["Username"] = username
-					evt.Data["Role"] = role
+				evt.Data["targetUserID"] = userID
+				evt.Data["Role"] = role
 			}
 		}
 	}
@@ -201,7 +200,7 @@ func (PermissionUpdateTask) Action(w http.ResponseWriter, r *http.Request) {
 		infoID, username, _, err2 := roleInfoByPermID(r.Context(), queries, int32(id))
 		if err := queries.UpdatePermission(r.Context(), db.UpdatePermissionParams{
 			IduserRoles: int32(id),
-			Name:        level,
+			Name:        role,
 		}); err != nil {
 			data.Errors = append(data.Errors, fmt.Errorf("UpdatePermission: %w", err).Error())
 		} else if err2 == nil {
@@ -212,7 +211,7 @@ func (PermissionUpdateTask) Action(w http.ResponseWriter, r *http.Request) {
 					}
 					evt.Data["targetUserID"] = infoID
 					evt.Data["Username"] = username
-					evt.Data["Role"] = level
+					evt.Data["Role"] = role
 				}
 			}
 		} else {

--- a/handlers/writings/writingsUserPermissionsPage.go
+++ b/handlers/writings/writingsUserPermissionsPage.go
@@ -72,7 +72,7 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 			}
 			evt.Data["targetUserID"] = u.Idusers
 			evt.Data["Username"] = u.Username.String
-			evt.Data["Role"] = level
+			evt.Data["Role"] = role
 		}
 	}
 


### PR DESCRIPTION
## Summary
- use `role` when setting event data for permission tasks
- ensure removal tasks include a valid user ID
- adjust admin permissions update to use role instead of level
- update user permissions tests for new SQL query
- run gofmt

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c9c3ab858832fbe2c9bd66b2cf2a8