### PR TITLE
Move notifications to user panel

### DIFF
--- a/core/templates/site/index.gohtml
+++ b/core/templates/site/index.gohtml
@@ -1,12 +1,6 @@
 {{- define "index"}}
     {{- template "indexItems" $ }}
-    {{ if $.UserID }}
-        <hr>
-        <a href="/usr/logout">Logout</a><br>
-    {{ else }}
-        <a href="/register">Register</a><br>
-        <a href="/login">Login</a><br>
-    {{ end }}
+    {{- template "userPanel" $ }}
     {{ range $i := $.CustomIndexItems }}
         <a href="{{ addmode $i.Link }}">{{ $i.Name }}</a><br>
     {{ end }}

--- a/core/templates/site/userPanel.gohtml
+++ b/core/templates/site/userPanel.gohtml
@@ -1,0 +1,12 @@
+{{ define "userPanel" }}
+    {{ if $.UserID }}
+        <hr>
+        <a href="/usr">Preferences</a><br>
+        <a href="/usr/notifications" id="notif-index">Notifications{{ if gt $.NotificationCount 0 }} ({{ $.NotificationCount }}){{ end }}</a><br>
+        <a href="/usr/logout">Logout</a><br>
+    {{ else }}
+        <hr>
+        <a href="/register">Register</a><br>
+        <a href="/login">Login</a><br>
+    {{ end }}
+{{ end }}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -84,19 +84,13 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 		_ = cd.UserRoles()
 
 		idx := nav.IndexItems()
-		if uid != 0 {
-			idx = append(idx, common.IndexItem{Name: "Preferences", Link: "/usr"})
-		}
 		cd.IndexItems = idx
 		cd.Title = "Arran's Site"
 		cd.FeedsEnabled = config.AppRuntimeConfig.FeedsEnabled
 		cd.AdminMode = r.URL.Query().Get("mode") == "admin"
 		if uid != 0 && handlers.NotificationsEnabled() {
-			if c := cd.UnreadNotificationCount(); c > 0 {
-				idx = append(idx, common.IndexItem{Name: fmt.Sprintf("Notifications (%d)", c), Link: "/usr/notifications"})
-			}
+			cd.NotificationCount = int32(cd.UnreadNotificationCount())
 		}
-		cd.IndexItems = idx
 		ctx := context.WithValue(r.Context(), consts.KeyCoreData, cd)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})


### PR DESCRIPTION
## Summary
- create a user panel template with logout, preferences and notifications
- display the user panel next to normal menu items
- keep unread notification count in CoreData

## Testing
- `go vet ./...` *(fails: undefined variables in unrelated packages)*
- `golangci-lint run ./...` *(fails: typecheck errors in unrelated packages)*
- `go test ./...` *(fails: undefined variables in unrelated packages)*

------
https://chatgpt.com/codex/tasks/task_e_687c8c91ef44832f9c651c06a5fefdf5