### PR TITLE
Fix email page sections and notification form

### DIFF
--- a/core/templates/site/user/emailPage.gohtml
+++ b/core/templates/site/user/emailPage.gohtml
@@ -2,7 +2,7 @@
 {{- if $.Error }}
     <p style="color:red;">{{ $.Error }}</p>
 {{- end }}
-    <form method="post">
+    <form method="post" action="/usr/email/add">
         {{ csrfField }}
         Add Email: <input type="email" name="new_email">
         <input type="submit" name="task" value="Add">
@@ -12,21 +12,25 @@
     <table border="1">
     {{ range .Verified }}
         <tr><td>{{ .Email }}</td><td>{{ if .VerifiedAt.Valid }}{{ .VerifiedAt.Time }}{{ end }}</td><td>
-            <form method="post" action="/usr/email/delete" style="display:inline">{{ csrfField }}<input type="hidden" name="id" value="{{ .ID }}"><input type="submit" value="Delete"></form>
-            <form method="post" action="/usr/email/notify" style="display:inline">{{ csrfField }}<input type="hidden" name="id" value="{{ .ID }}"><input type="submit" value="Make notification email"></form>
+            <form method="post" action="/usr/email/delete" style="display:inline">{{ csrfField }}<input type="hidden" name="id" value="{{ .ID }}"><input type="hidden" name="task" value="Delete"><input type="submit" value="Delete"></form>
+            <form method="post" action="/usr/email/notify" style="display:inline">{{ csrfField }}<input type="hidden" name="id" value="{{ .ID }}"><input type="hidden" name="task" value="Add"><input type="submit" value="Make notification email"></form>
         </td></tr>
+    {{ else }}
+        <tr><td colspan="3">No verified emails - you won't receive notifications.</td></tr>
     {{ end }}
     </table>
 
+    {{- if .Unverified }}
     <h3>Unverified Emails</h3>
     <table border="1">
     {{ range .Unverified }}
         <tr><td>{{ .Email }}</td><td>
-            <form method="post" action="/usr/email/delete" style="display:inline">{{ csrfField }}<input type="hidden" name="id" value="{{ .ID }}"><input type="submit" value="Delete"></form>
-            <form method="post" action="/usr/email/resend" style="display:inline">{{ csrfField }}<input type="hidden" name="id" value="{{ .ID }}"><input type="submit" value="Send verification code again"></form>
+            <form method="post" action="/usr/email/delete" style="display:inline">{{ csrfField }}<input type="hidden" name="id" value="{{ .ID }}"><input type="hidden" name="task" value="Delete"><input type="submit" value="Delete"></form>
+            <form method="post" action="/usr/email/resend" style="display:inline">{{ csrfField }}<input type="hidden" name="id" value="{{ .ID }}"><input type="hidden" name="task" value="Resend"><input type="submit" value="Send verification code again"></form>
         </td></tr>
     {{ end }}
     </table>
+    {{- end }}
 
     <form method="post">
         {{ csrfField }}


### PR DESCRIPTION
## Summary
- fix /usr/email notification form action and task fields
- hide unverified section when empty
- warn when no verified emails
- add tests for email page behaviour

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: undefined vars in unrelated packages)*
- `golangci-lint run ./...` *(fails: vet errors in unrelated packages)*
- `go test ./...` *(fails: build errors in unrelated packages)*

------
https://chatgpt.com/codex/tasks/task_e_687c8c39ccb0832f9b9e0c81d4a99aff