### PR TITLE
Fix role event data assignments

### DIFF
--- a/handlers/admin/news_user_tasks.go
+++ b/handlers/admin/news_user_tasks.go
@@ -62,7 +62,7 @@ func (NewsUserAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 			}
 			evt.Data["targetUserID"] = u.Idusers
 			evt.Data["Username"] = u.Username.String
-			evt.Data["Role"] = level
+			evt.Data["Role"] = role
 		}
 	}
 	handlers.TaskDoneAutoRefreshPage(w, r)

--- a/handlers/blogs/blogsUserPermissionsPage.go
+++ b/handlers/blogs/blogsUserPermissionsPage.go
@@ -183,7 +183,7 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 			}
 			evt.Data["targetUserID"] = u.Idusers
 			evt.Data["Username"] = u.Username.String
-			evt.Data["Role"] = level
+			evt.Data["Role"] = role
 		}
 	}
 

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -111,7 +111,7 @@ func (userAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 				}
 				evt.Data["targetUserID"] = u.Idusers
 				evt.Data["Username"] = u.Username.String
-				evt.Data["Role"] = level
+				evt.Data["Role"] = role
 			}
 		}
 	}

--- a/handlers/writings/writingsUserPermissionsPage.go
+++ b/handlers/writings/writingsUserPermissionsPage.go
@@ -72,7 +72,7 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 			}
 			evt.Data["targetUserID"] = u.Idusers
 			evt.Data["Username"] = u.Username.String
-			evt.Data["Role"] = level
+			evt.Data["Role"] = role
 		}
 	}
 


### PR DESCRIPTION
## Summary
- fix user role event context: use `role` not `level`
- correct notification data for user role operations

## Testing
- `go vet ./...`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_687c8bea75f4832f9a7cfe502fe12e31