### PR TITLE
Add tasks.Task assertions for various handlers

### DIFF
--- a/handlers/admin/adminDLQPage.go
+++ b/handlers/admin/adminDLQPage.go
@@ -20,6 +20,9 @@ type DeleteDLQTask struct{ tasks.TaskString }
 
 var deleteDLQTask = &DeleteDLQTask{TaskString: TaskDelete}
 
+// compile-time interface check so DeleteDLQTask is usable as a generic task.
+var _ tasks.Task = (*DeleteDLQTask)(nil)
+
 func AdminDLQPage(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		*common.CoreData

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -22,10 +22,16 @@ type ResendQueueTask struct{ tasks.TaskString }
 
 var resendQueueTask = &ResendQueueTask{TaskString: TaskResend}
 
+// ensure ResendQueueTask satisfies the tasks.Task interface
+var _ tasks.Task = (*ResendQueueTask)(nil)
+
 // DeleteQueueTask removes queued emails without sending.
 type DeleteQueueTask struct{ tasks.TaskString }
 
 var deleteQueueTask = &DeleteQueueTask{TaskString: TaskDelete}
+
+// ensure DeleteQueueTask satisfies the tasks.Task interface
+var _ tasks.Task = (*DeleteQueueTask)(nil)
 
 func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 	type EmailItem struct {

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -29,10 +29,16 @@ type SaveTemplateTask struct{ tasks.TaskString }
 
 var saveTemplateTask = &SaveTemplateTask{TaskString: TaskUpdate}
 
+// compile-time interface check for SaveTemplateTask
+var _ tasks.Task = (*SaveTemplateTask)(nil)
+
 // TestTemplateTask queues an email using the template for preview.
 type TestTemplateTask struct{ tasks.TaskString }
 
 var testTemplateTask = &TestTemplateTask{TaskString: TaskTestMail}
+
+// compile-time interface check for TestTemplateTask
+var _ tasks.Task = (*TestTemplateTask)(nil)
 
 func getUpdateEmailText(ctx context.Context) string {
 	if q, ok := ctx.Value(consts.KeyQueries).(*db.Queries); ok && q != nil {

--- a/handlers/admin/adminNotificationsPage.go
+++ b/handlers/admin/adminNotificationsPage.go
@@ -20,15 +20,24 @@ type MarkReadTask struct{ tasks.TaskString }
 
 var markReadTask = &MarkReadTask{TaskString: TaskDismiss}
 
+// ensures MarkReadTask implements the tasks.Task interface
+var _ tasks.Task = (*MarkReadTask)(nil)
+
 // PurgeNotificationsTask removes old read notifications.
 type PurgeNotificationsTask struct{ tasks.TaskString }
 
 var purgeNotificationsTask = &PurgeNotificationsTask{TaskString: TaskPurge}
 
+// ensures PurgeNotificationsTask implements the tasks.Task interface
+var _ tasks.Task = (*PurgeNotificationsTask)(nil)
+
 // SendNotificationTask creates a site notification for users.
 type SendNotificationTask struct{ tasks.TaskString }
 
 var sendNotificationTask = &SendNotificationTask{TaskString: TaskNotify}
+
+// ensures SendNotificationTask implements the tasks.Task interface
+var _ tasks.Task = (*SendNotificationTask)(nil)
 
 func AdminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {

--- a/handlers/auth/loginPage.go
+++ b/handlers/auth/loginPage.go
@@ -27,12 +27,18 @@ type LoginTask struct {
 
 var loginTask = &LoginTask{TaskString: TaskLogin}
 
+// ensure LoginTask conforms to tasks.Task
+var _ tasks.Task = (*LoginTask)(nil)
+
 // VerifyPasswordTask verifies reset codes during login.
 type VerifyPasswordTask struct {
 	tasks.TaskString
 }
 
 var verifyPasswordTask = &VerifyPasswordTask{TaskString: TaskPasswordVerify}
+
+// ensure VerifyPasswordTask conforms to tasks.Task
+var _ tasks.Task = (*VerifyPasswordTask)(nil)
 
 func renderLoginForm(w http.ResponseWriter, r *http.Request, errMsg string) {
 	type Data struct {

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -25,6 +25,9 @@ type RegisterTask struct {
 // registerTask handles user registration.
 var registerTask = &RegisterTask{TaskString: TaskRegister}
 
+// ensure RegisterTask satisfies tasks.Task
+var _ tasks.Task = (*RegisterTask)(nil)
+
 // RegisterPage renders the user registration form.
 func (RegisterTask) Page(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData)

--- a/handlers/bookmarks/edit.go
+++ b/handlers/bookmarks/edit.go
@@ -18,9 +18,15 @@ type SaveTask struct{ tasks.TaskString }
 
 var saveTask = &SaveTask{TaskString: TaskSave}
 
+// ensure SaveTask implements tasks.Task for routing
+var _ tasks.Task = (*SaveTask)(nil)
+
 type CreateTask struct{ tasks.TaskString }
 
 var createTask = &CreateTask{TaskString: TaskCreate}
+
+// ensure CreateTask implements tasks.Task for routing
+var _ tasks.Task = (*CreateTask)(nil)
 
 func (SaveTask) Page(w http.ResponseWriter, r *http.Request) {
 	type Data struct {

--- a/handlers/faq/admin_answer.go
+++ b/handlers/faq/admin_answer.go
@@ -20,7 +20,11 @@ type AnswerTask struct{ tasks.TaskString }
 type RemoveQuestionTask struct{ tasks.TaskString }
 
 var answerTask = &AnswerTask{TaskString: TaskAnswer}
+
+var _ tasks.Task = (*AnswerTask)(nil)
 var removeQuestionTask = &RemoveQuestionTask{TaskString: TaskRemoveRemove}
+
+var _ tasks.Task = (*RemoveQuestionTask)(nil)
 
 // Implementing these interfaces means answering a FAQ automatically notifies
 // the original asker and the administrators. From a user's perspective this

--- a/handlers/faq/admin_categories.go
+++ b/handlers/faq/admin_categories.go
@@ -20,8 +20,11 @@ type DeleteCategoryTask struct{ tasks.TaskString }
 type CreateCategoryTask struct{ tasks.TaskString }
 
 var renameCategoryTask = &RenameCategoryTask{TaskString: TaskRenameCategory}
+var _ tasks.Task = (*RenameCategoryTask)(nil)
 var deleteCategoryTask = &DeleteCategoryTask{TaskString: TaskDeleteCategory}
+var _ tasks.Task = (*DeleteCategoryTask)(nil)
 var createCategoryTask = &CreateCategoryTask{TaskString: TaskCreateCategory}
+var _ tasks.Task = (*CreateCategoryTask)(nil)
 
 func (RenameCategoryTask) Match(r *http.Request, m *mux.RouteMatch) bool {
 	return tasks.HasTask(TaskRenameCategory)(r, m)

--- a/handlers/faq/admin_question.go
+++ b/handlers/faq/admin_question.go
@@ -21,8 +21,11 @@ type DeleteQuestionTask struct{ tasks.TaskString }
 type CreateQuestionTask struct{ tasks.TaskString }
 
 var editQuestionTask = &EditQuestionTask{TaskString: TaskEdit}
+var _ tasks.Task = (*EditQuestionTask)(nil)
 var deleteQuestionTask = &DeleteQuestionTask{TaskString: TaskRemoveRemove}
+var _ tasks.Task = (*DeleteQuestionTask)(nil)
 var createQuestionTask = &CreateQuestionTask{TaskString: TaskCreate}
+var _ tasks.Task = (*CreateQuestionTask)(nil)
 
 func (EditQuestionTask) Match(r *http.Request, m *mux.RouteMatch) bool {
 	return tasks.HasTask(TaskEdit)(r, m)

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -35,6 +35,9 @@ type UploadImageTask struct{ tasks.TaskString }
 
 var uploadImageTask = &UploadImageTask{TaskString: TaskUploadImage}
 
+// UploadImageTask participates in generic task handling
+var _ tasks.Task = (*UploadImageTask)(nil)
+
 func (UploadImageTask) IndexType() string { return searchworker.TypeImage }
 
 func (UploadImageTask) IndexData(data map[string]any) []searchworker.IndexEventData {

--- a/handlers/images/upload_task.go
+++ b/handlers/images/upload_task.go
@@ -27,6 +27,9 @@ type UploadImageTask struct{ tasks.TaskString }
 
 var uploadImageTask = &UploadImageTask{TaskString: TaskUploadImage}
 
+// ensure UploadImageTask conforms to tasks.Task
+var _ tasks.Task = (*UploadImageTask)(nil)
+
 func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, int64(config.AppRuntimeConfig.ImageMaxBytes))
 	if err := r.ParseMultipartForm(int64(config.AppRuntimeConfig.ImageMaxBytes)); err != nil {

--- a/handlers/linker/linkerAdminCategoriesPage.go
+++ b/handlers/linker/linkerAdminCategoriesPage.go
@@ -43,6 +43,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 type updateCategoryTask struct{ tasks.TaskString }
 
 var UpdateCategoryTask = &updateCategoryTask{TaskString: TaskUpdate}
+var _ tasks.Task = (*updateCategoryTask)(nil)
 
 func (updateCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
@@ -73,6 +74,7 @@ func (updateCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
 type renameCategoryTask struct{ tasks.TaskString }
 
 var RenameCategoryTask = &renameCategoryTask{TaskString: TaskRenameCategory}
+var _ tasks.Task = (*renameCategoryTask)(nil)
 
 func (renameCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
@@ -94,6 +96,7 @@ func (renameCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
 type deleteCategoryTask struct{ tasks.TaskString }
 
 var DeleteCategoryTask = &deleteCategoryTask{TaskString: TaskDeleteCategory}
+var _ tasks.Task = (*deleteCategoryTask)(nil)
 
 func (deleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
@@ -127,6 +130,7 @@ func (deleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
 type createCategoryTask struct{ tasks.TaskString }
 
 var CreateCategoryTask = &createCategoryTask{TaskString: TaskCreateCategory}
+var _ tasks.Task = (*createCategoryTask)(nil)
 
 func (createCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)

--- a/handlers/linker/linkerAdminQueuePage.go
+++ b/handlers/linker/linkerAdminQueuePage.go
@@ -122,6 +122,7 @@ func AdminQueuePage(w http.ResponseWriter, r *http.Request) {
 type deleteTask struct{ tasks.TaskString }
 
 var DeleteTask = &deleteTask{TaskString: TaskDelete}
+var _ tasks.Task = (*deleteTask)(nil)
 
 var (
 	_ tasks.Task                                    = (*deleteTask)(nil)
@@ -209,6 +210,7 @@ func AdminQueueUpdateActionPage(w http.ResponseWriter, r *http.Request) {
 type approveTask struct{ tasks.TaskString }
 
 var ApproveTask = &approveTask{TaskString: TaskApprove}
+var _ tasks.Task = (*approveTask)(nil)
 
 var (
 	_ tasks.Task                                    = (*approveTask)(nil)

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -82,6 +82,7 @@ type userAllowTask struct{ tasks.TaskString }
 var UserAllowTask = &userAllowTask{TaskString: TaskUserAllow}
 
 var _ notif.TargetUsersNotificationProvider = (*userAllowTask)(nil)
+var _ tasks.Task = (*userAllowTask)(nil)
 
 func (userAllowTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
@@ -123,6 +124,7 @@ type userDisallowTask struct{ tasks.TaskString }
 var UserDisallowTask = &userDisallowTask{TaskString: TaskUserDisallow}
 
 var _ notif.TargetUsersNotificationProvider = (*userDisallowTask)(nil)
+var _ tasks.Task = (*userDisallowTask)(nil)
 
 func (userDisallowTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)

--- a/handlers/linker/linkerCommentsEditPage.go
+++ b/handlers/linker/linkerCommentsEditPage.go
@@ -21,6 +21,7 @@ import (
 type EditReplyTask struct{ tasks.TaskString }
 
 var commentEditAction = &EditReplyTask{TaskString: TaskEditReply}
+var _ tasks.Task = (*EditReplyTask)(nil)
 
 func (t EditReplyTask) Page(w http.ResponseWriter, r *http.Request) {
 	t.Action(w, r)
@@ -96,6 +97,7 @@ func CommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
 type cancelEditReplyTask struct{ tasks.TaskString }
 
 var commentEditActionCancel = &cancelEditReplyTask{TaskString: TaskCancel}
+var _ tasks.Task = (*cancelEditReplyTask)(nil)
 
 func (cancelEditReplyTask) Page(w http.ResponseWriter, r *http.Request) {
 	CommentEditActionCancelPage(w, r)

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -161,6 +161,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 type replyTask struct{ tasks.TaskString }
 
 var replyTaskEvent = &replyTask{TaskString: TaskReply}
+var _ tasks.Task = (*replyTask)(nil)
 
 func (replyTask) Page(w http.ResponseWriter, r *http.Request) { CommentsPage(w, r) }
 

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -59,6 +59,7 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 type SuggestTask struct{ tasks.TaskString }
 
 var suggestTask = SuggestTask{TaskString: TaskSuggest}
+var _ tasks.Task = (*SuggestTask)(nil)
 
 func (SuggestTask) Page(w http.ResponseWriter, r *http.Request) { SuggestPage(w, r) }
 

--- a/handlers/search/remakeBlogTask.go
+++ b/handlers/search/remakeBlogTask.go
@@ -16,6 +16,7 @@ import (
 type RemakeBlogTask struct{ tasks.TaskString }
 
 var remakeBlogTask = &RemakeBlogTask{TaskString: TaskRemakeBlogSearch}
+var _ tasks.Task = (*RemakeBlogTask)(nil)
 
 func (RemakeBlogTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)

--- a/handlers/search/remakeCommentsTask.go
+++ b/handlers/search/remakeCommentsTask.go
@@ -16,6 +16,7 @@ import (
 type RemakeCommentsTask struct{ tasks.TaskString }
 
 var remakeCommentsTask = &RemakeCommentsTask{TaskString: TaskRemakeCommentsSearch}
+var _ tasks.Task = (*RemakeCommentsTask)(nil)
 
 func (RemakeCommentsTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)

--- a/handlers/search/remakeImageTask.go
+++ b/handlers/search/remakeImageTask.go
@@ -16,6 +16,7 @@ import (
 type RemakeImageTask struct{ tasks.TaskString }
 
 var remakeImageTask = &RemakeImageTask{TaskString: TaskRemakeImageSearch}
+var _ tasks.Task = (*RemakeImageTask)(nil)
 
 func (RemakeImageTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)

--- a/handlers/search/remakeLinkerTask.go
+++ b/handlers/search/remakeLinkerTask.go
@@ -16,6 +16,7 @@ import (
 type RemakeLinkerTask struct{ tasks.TaskString }
 
 var remakeLinkerTask = &RemakeLinkerTask{TaskString: TaskRemakeLinkerSearch}
+var _ tasks.Task = (*RemakeLinkerTask)(nil)
 
 func (RemakeLinkerTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)

--- a/handlers/search/remakeNewsTask.go
+++ b/handlers/search/remakeNewsTask.go
@@ -16,6 +16,7 @@ import (
 type RemakeNewsTask struct{ tasks.TaskString }
 
 var remakeNewsTask = &RemakeNewsTask{TaskString: TaskRemakeNewsSearch}
+var _ tasks.Task = (*RemakeNewsTask)(nil)
 
 func (RemakeNewsTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)

--- a/handlers/search/remakeWritingTask.go
+++ b/handlers/search/remakeWritingTask.go
@@ -16,6 +16,7 @@ import (
 type RemakeWritingTask struct{ tasks.TaskString }
 
 var remakeWritingTask = &RemakeWritingTask{TaskString: TaskRemakeWritingSearch}
+var _ tasks.Task = (*RemakeWritingTask)(nil)
 
 func (RemakeWritingTask) Action(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)

--- a/handlers/search/searchNewsTask.go
+++ b/handlers/search/searchNewsTask.go
@@ -11,6 +11,7 @@ import (
 type SearchNewsTask struct{ tasks.TaskString }
 
 var searchNewsTask = &SearchNewsTask{TaskString: TaskSearchNews}
+var _ tasks.Task = (*SearchNewsTask)(nil)
 
 func (SearchNewsTask) Action(w http.ResponseWriter, r *http.Request) {
 	news.SearchResultNewsActionPage(w, r)

--- a/handlers/search/searchResultBlogsActionPage.go
+++ b/handlers/search/searchResultBlogsActionPage.go
@@ -20,6 +20,7 @@ import (
 type SearchBlogsTask struct{ tasks.TaskString }
 
 var searchBlogsTask = &SearchBlogsTask{TaskString: TaskSearchBlogs}
+var _ tasks.Task = (*SearchBlogsTask)(nil)
 
 func (SearchBlogsTask) Action(w http.ResponseWriter, r *http.Request) {
 	type Data struct {

--- a/handlers/search/searchResultForumActionPage.go
+++ b/handlers/search/searchResultForumActionPage.go
@@ -20,6 +20,7 @@ import (
 type SearchForumTask struct{ tasks.TaskString }
 
 var searchForumTask = &SearchForumTask{TaskString: TaskSearchForum}
+var _ tasks.Task = (*SearchForumTask)(nil)
 
 func (SearchForumTask) Action(w http.ResponseWriter, r *http.Request) {
 	type Data struct {

--- a/handlers/search/searchResultLinkerActionPage.go
+++ b/handlers/search/searchResultLinkerActionPage.go
@@ -21,6 +21,7 @@ import (
 type SearchLinkerTask struct{ tasks.TaskString }
 
 var searchLinkerTask = &SearchLinkerTask{TaskString: TaskSearchLinker}
+var _ tasks.Task = (*SearchLinkerTask)(nil)
 
 func (SearchLinkerTask) Action(w http.ResponseWriter, r *http.Request) {
 	type Data struct {

--- a/handlers/search/searchResultWritingsActionPage.go
+++ b/handlers/search/searchResultWritingsActionPage.go
@@ -21,6 +21,7 @@ import (
 type SearchWritingsTask struct{ tasks.TaskString }
 
 var searchWritingsTask = &SearchWritingsTask{TaskString: TaskSearchWritings}
+var _ tasks.Task = (*SearchWritingsTask)(nil)
 
 func (SearchWritingsTask) Action(w http.ResponseWriter, r *http.Request) {
 	type Data struct {

--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -27,6 +27,11 @@ var (
 	saveLanguageTask  = &SaveLanguageTask{TaskString: tasks.TaskString(TaskSaveLanguage)}
 	saveAllTask       = &SaveAllTask{TaskString: tasks.TaskString(TaskSaveAll)}
 )
+var (
+	_ tasks.Task = (*SaveLanguagesTask)(nil)
+	_ tasks.Task = (*SaveLanguageTask)(nil)
+	_ tasks.Task = (*SaveAllTask)(nil)
+)
 
 func userLangPage(w http.ResponseWriter, r *http.Request) {
 	type LanguageOption struct {

--- a/handlers/user/userNotificationsPage.go
+++ b/handlers/user/userNotificationsPage.go
@@ -18,6 +18,7 @@ import (
 type DismissTask struct{ tasks.TaskString }
 
 var dismissTask = &DismissTask{TaskString: tasks.TaskString(TaskDismiss)}
+var _ tasks.Task = (*DismissTask)(nil)
 
 func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 	if !handlers.NotificationsEnabled() {

--- a/handlers/user/userPageSizePage.go
+++ b/handlers/user/userPageSizePage.go
@@ -16,6 +16,7 @@ import (
 type PageSizeSaveTask struct{ tasks.TaskString }
 
 var pageSizeSaveTask = &PageSizeSaveTask{TaskString: tasks.TaskString(TaskSaveAll)}
+var _ tasks.Task = (*PageSizeSaveTask)(nil)
 
 func userPageSizePage(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {

--- a/handlers/user/userPagingPage.go
+++ b/handlers/user/userPagingPage.go
@@ -22,6 +22,7 @@ import (
 type PagingSaveTask struct{ tasks.TaskString }
 
 var pagingSaveTask = &PagingSaveTask{TaskString: tasks.TaskString(TaskSaveAll)}
+var _ tasks.Task = (*PagingSaveTask)(nil)
 
 func userPagingPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)

--- a/handlers/user/userSubscriptionsPage.go
+++ b/handlers/user/userSubscriptionsPage.go
@@ -22,6 +22,10 @@ var (
 	updateSubscriptionsTask = &UpdateSubscriptionsTask{TaskString: tasks.TaskString(TaskUpdate)}
 	deleteTask              = &DeleteTask{TaskString: tasks.TaskString(TaskDelete)}
 )
+var (
+	_ tasks.Task = (*UpdateSubscriptionsTask)(nil)
+	_ tasks.Task = (*DeleteTask)(nil)
+)
 
 type subscriptionOption struct {
 	Name    string


### PR DESCRIPTION
## Summary
- ensure many handler tasks explicitly satisfy `tasks.Task`
- this covers bookmarks, admin mail queue, FAQ admin, user pages, and search tasks

## Testing
- `go test ./...` *(fails: undefined CustomIndex in routes)*

------
https://chatgpt.com/codex/tasks/task_e_687caa393b6c832f9c8410255484f288