### PR TITLE
Remove unused VerifyRef function

### DIFF
--- a/internal/images/sign.go
+++ b/internal/images/sign.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -71,44 +70,6 @@ func SignedRef(ref string) string {
 	}
 	ts, sig := sign(prefix + id)
 	return fmt.Sprintf("%s%s?ts=%d&sig=%s", prefix, id, ts, sig)
-}
-
-// VerifyRef checks the signature on ref and returns the cleaned reference
-// without query parameters. The returned bool indicates whether the signature
-// was valid.
-func VerifyRef(ref string) (string, bool) {
-	var prefix, rest string
-	switch {
-	case strings.HasPrefix(ref, "image:"):
-		prefix = "image:"
-		rest = strings.TrimPrefix(ref, "image:")
-	case strings.HasPrefix(ref, "img:"):
-		prefix = "image:"
-		rest = strings.TrimPrefix(ref, "img:")
-	case strings.HasPrefix(ref, "cache:"):
-		prefix = "cache:"
-		rest = strings.TrimPrefix(ref, "cache:")
-	default:
-		return ref, false
-	}
-	parts := strings.SplitN(rest, "?", 2)
-	id := parts[0]
-	if len(parts) != 2 {
-		return prefix + id, false
-	}
-	vals, err := url.ParseQuery(parts[1])
-	if err != nil {
-		return prefix + id, false
-	}
-	ts := vals.Get("ts")
-	sig := vals.Get("sig")
-	if ts == "" || sig == "" {
-		return prefix + id, false
-	}
-	if Verify(prefix+id, ts, sig) {
-		return prefix + id, true
-	}
-	return prefix + id, false
 }
 
 // MapURL converts image references to signed HTTP URLs.

--- a/internal/images/sign_test.go
+++ b/internal/images/sign_test.go
@@ -2,21 +2,6 @@ package images
 
 import "testing"
 
-func TestSignedAndVerifyRef(t *testing.T) {
-	SetSigningKey("k")
-	ref := SignedRef("image:abc")
-	if ref == "image:abc" {
-		t.Fatal("signature not added")
-	}
-	clean, ok := VerifyRef(ref)
-	if !ok {
-		t.Fatal("verify failed")
-	}
-	if clean != "image:abc" {
-		t.Fatalf("got %s", clean)
-	}
-}
-
 func TestMapURLUploading(t *testing.T) {
 	SetSigningKey("k")
 	got := MapURL("img", "uploading:abc")

--- a/specs/images.md
+++ b/specs/images.md
@@ -15,6 +15,6 @@ Each helper appends `ts` and `sig` query parameters to the host configured in `H
 
 ## Verification
 
-Requests to `/images/image/{id}` and `/images/cache/{id}` pass through `verifyMiddleware` which extracts the query parameters and calls `Verify`. Template code may also check references using `VerifyRef` which strips the parameters and reports whether they were valid.
+Requests to `/images/image/{id}` and `/images/cache/{id}` pass through `verifyMiddleware` which extracts the query parameters and calls `Verify`.
 
 Only URLs produced by `SignedURL` or `SignedCacheURL` (or `SignedRef`) will pass verification.


### PR DESCRIPTION
## Summary
- drop the `VerifyRef` helper from the image signing code
- delete the related unit test
- update documentation about verification

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ca8e72650832fa8564138eb6a88cb