### PR TITLE
Remove obsolete notify code in imagebbs reply handler

### DIFF
--- a/handlers/imagebbs/auto_subscribe_test.go
+++ b/handlers/imagebbs/auto_subscribe_test.go
@@ -1,0 +1,14 @@
+package imagebbs
+
+import (
+	"testing"
+
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+// Test that replyTask auto subscribes commenters so they see responses.
+func TestReplyTaskAutoSubscribe(t *testing.T) {
+	if _, ok := interface{}(replyTask).(notif.AutoSubscribeProvider); !ok {
+		t.Fatalf("ReplyTask should implement AutoSubscribeProvider so commenters are notified about replies")
+	}
+}

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -294,20 +294,6 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) {
 
 	endUrl := fmt.Sprintf("/imagebbss/imagebbs/%d/comments", bid)
 
-	//if rows, err := queries.SomethingNotifyImagebbss(r.Context(), SomethingNotifyImagebbssParams{
-	//	Idusers: uid,
-	//	Idimagebbss: int32(bid),
-	//}); err != nil {
-	//	log.Printf("Error: listUsersSubscribedToThread: %s", err)
-	//} else {
-	//	for _, row := range rows {
-	//		if err := notifyChange(r.Context(), getEmailProvider(), row.String, endUrl); err != nil {
-	//			log.Printf("Error: notifyChange: %s", err)
-	//
-	//		}
-	//	}
-	//}
-
 	cid, err := queries.CreateComment(r.Context(), db.CreateCommentParams{
 		LanguageIdlanguage: int32(languageId),
 		UsersIdusers:       uid,


### PR DESCRIPTION
## Summary
- drop commented notification logic from `imagebbsBoardThreadPage`
- add `imagebbs` auto-subscribe test ensuring reply task participates in notification system

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ccd06d750832f8269016ef691aba9