### PR TITLE
Implement blogger count query page

### DIFF
--- a/core/templates/site/blogs/bloggersBloggerPage.gohtml
+++ b/core/templates/site/blogs/bloggersBloggerPage.gohtml
@@ -1,2 +1,9 @@
 {{ template "head" $ }}
+    {{if .Rows}}
+        {{range .Rows}}
+            Blogger: <a href="/blogs/blogger/{{.Username.String}}">{{.Username.String}}</a> has {{.Count}} blogs.<br>
+        {{end}}
+    {{else}}
+        No bloggers here.
+    {{end}}
 {{ template "tail" $ }}

--- a/handlers/blogs/blogsBloggersBloggerPage_test.go
+++ b/handlers/blogs/blogsBloggersBloggerPage_test.go
@@ -1,0 +1,43 @@
+package blogs
+
+import (
+	"context"
+	"github.com/arran4/goa4web/core/consts"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	common "github.com/arran4/goa4web/core/common"
+	db "github.com/arran4/goa4web/internal/db"
+)
+
+func TestBloggersBloggerPage(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+	q := db.New(sqldb)
+
+	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
+	mock.ExpectQuery(regexp.QuoteMeta("WITH RECURSIVE role_ids")).
+		WithArgs(int32(0), int32(0), int32(0), nil, int32(1000), int32(0)).
+		WillReturnRows(rows)
+
+	req := httptest.NewRequest("GET", "/blogs/bloggers/blogger", nil)
+	ctx := context.WithValue(req.Context(), consts.KeyQueries, q)
+	cd := common.NewCoreData(ctx, q)
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	BloggersBloggerPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Result().StatusCode != 200 {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- implement blogger count query with viewer restrictions
- test that handler executes the paginated query

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ccd149ecc832f86424b1985cb8dcd