### PR TITLE
Fix verify email notifications

### DIFF
--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -217,7 +217,7 @@ func (AddEmailTask) Action(w http.ResponseWriter, r *http.Request) {
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	evt := cd.Event()
-	evt.Data["page"] = page
+	evt.Data["URL"] = page
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }
 
@@ -250,7 +250,7 @@ func (AddEmailTask) Resend(w http.ResponseWriter, r *http.Request) {
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	evt := cd.Event()
-	evt.Data["page"] = page
+	evt.Data["URL"] = page
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }
 

--- a/handlers/user/userEmailPage_event_test.go
+++ b/handlers/user/userEmailPage_event_test.go
@@ -47,8 +47,8 @@ func TestAddEmailTaskEventData(t *testing.T) {
 	if rr.Code != http.StatusSeeOther {
 		t.Fatalf("status=%d", rr.Code)
 	}
-	if _, ok := evt.Data["page"]; !ok {
-		t.Fatalf("missing page event data: %+v", evt.Data)
+	if _, ok := evt.Data["URL"]; !ok {
+		t.Fatalf("missing URL event data: %+v", evt.Data)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)

--- a/internal/notifications/email.go
+++ b/internal/notifications/email.go
@@ -41,6 +41,7 @@ func (n *Notifier) renderAndQueueEmailFromTemplates(ctx context.Context, userID 
 
 type EmailData struct {
 	any
+	URL            string
 	SubjectPrefix  string
 	UnsubscribeUrl string
 	SignOff        string
@@ -70,8 +71,22 @@ func (n *Notifier) RenderEmailFromTemplates(ctx context.Context, emailAddr strin
 	htmlSignOff := html.EscapeString(signOff)
 	htmlSignOff = strings.ReplaceAll(htmlSignOff, "\n", "<br />")
 
+	var urlStr string
+	if m, ok := item.(map[string]any); ok {
+		if v, ok := m["URL"]; ok {
+			if s, ok := v.(string); ok {
+				urlStr = s
+			}
+		} else if v, ok := m["page"]; ok {
+			if s, ok := v.(string); ok {
+				urlStr = s
+			}
+		}
+	}
+
 	data := EmailData{
 		any:            item,
+		URL:            urlStr,
 		SubjectPrefix:  subjectPrefix,
 		UnsubscribeUrl: unsub,
 		SignOff:        signOff,


### PR DESCRIPTION
## Summary
- include `URL` in `EmailData`
- store verification link in event data under `URL`
- check for `URL` in `AddEmailTask` event test

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cd1389670832faed27f1d28dcd386