### PR TITLE
Fix username missing in email verification message

### DIFF
--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -217,7 +217,13 @@ func (AddEmailTask) Action(w http.ResponseWriter, r *http.Request) {
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	evt := cd.Event()
+	if evt.Data == nil {
+		evt.Data = map[string]any{}
+	}
 	evt.Data["URL"] = page
+	if user, err := cd.CurrentUser(); err == nil && user != nil {
+		evt.Data["Username"] = user.Username.String
+	}
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }
 
@@ -250,7 +256,13 @@ func (AddEmailTask) Resend(w http.ResponseWriter, r *http.Request) {
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	evt := cd.Event()
+	if evt.Data == nil {
+		evt.Data = map[string]any{}
+	}
 	evt.Data["URL"] = page
+	if user, err := cd.CurrentUser(); err == nil && user != nil {
+		evt.Data["Username"] = user.Username.String
+	}
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }
 

--- a/handlers/user/userEmailPage_event_test.go
+++ b/handlers/user/userEmailPage_event_test.go
@@ -26,6 +26,9 @@ func TestAddEmailTaskEventData(t *testing.T) {
 	q := dbpkg.New(db)
 	mock.ExpectQuery("SELECT id, user_id, email").WillReturnError(sql.ErrNoRows)
 	mock.ExpectExec("INSERT INTO user_emails").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT u.idusers").WithArgs(int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).
+			AddRow(1, nil, "alice"))
 
 	store := sessions.NewCookieStore([]byte("test"))
 	sess := sessions.NewSession(store, "test")
@@ -36,6 +39,7 @@ func TestAddEmailTaskEventData(t *testing.T) {
 	evt := &eventbus.Event{Data: map[string]any{}}
 	ctx := context.WithValue(context.Background(), consts.KeyQueries, q)
 	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt))
+	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	req := httptest.NewRequest("POST", "http://example.com/usr/email", strings.NewReader("new_email=a@example.com"))
@@ -49,6 +53,9 @@ func TestAddEmailTaskEventData(t *testing.T) {
 	}
 	if _, ok := evt.Data["URL"]; !ok {
 		t.Fatalf("missing URL event data: %+v", evt.Data)
+	}
+	if evt.Data["Username"] != "alice" {
+		t.Fatalf("username not set: %+v", evt.Data)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)


### PR DESCRIPTION
## Summary
- include `Username` in email verification events so templates render correctly
- update tests for new behavior

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cd7dda3f0832f94712ebfccc20f5f