### PR TITLE
Add timestamps to DLQ file provider

### DIFF
--- a/internal/dlq/file/file.go
+++ b/internal/dlq/file/file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/arran4/goa4web/config"
 	dbpkg "github.com/arran4/goa4web/internal/db"
@@ -20,6 +21,16 @@ type DLQ struct {
 // fileSeparator marks the boundary around each recorded message.
 const fileSeparator = "-----"
 
+var appendFile = func(name string, data []byte) error {
+	fh, err := os.OpenFile(name, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+	_, err = fh.Write(data)
+	return err
+}
+
 // Record writes the message to the configured file.
 func (f *DLQ) Record(_ context.Context, message string) error {
 	f.mu.Lock()
@@ -27,13 +38,8 @@ func (f *DLQ) Record(_ context.Context, message string) error {
 	if f.Path == "" {
 		f.Path = "dlq.log"
 	}
-	fh, err := os.OpenFile(f.Path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer fh.Close()
-	_, err = fmt.Fprintf(fh, "%s\n%s\n%s\n", fileSeparator, message, fileSeparator)
-	return err
+	entry := fmt.Sprintf("%s\n%s\n%s\n%s\n", fileSeparator, time.Now().Format(time.RFC3339), message, fileSeparator)
+	return appendFile(f.Path, []byte(entry))
 }
 
 // Register registers the file provider.

--- a/internal/dlq/file/file_test.go
+++ b/internal/dlq/file/file_test.go
@@ -1,0 +1,41 @@
+package file
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDLQRecord(t *testing.T) {
+	orig := appendFile
+	var name string
+	var data []byte
+	appendFile = func(p string, d []byte) error {
+		name = p
+		data = append([]byte(nil), d...)
+		return nil
+	}
+	defer func() { appendFile = orig }()
+
+	dlq := &DLQ{Path: "test.log"}
+	if err := dlq.Record(context.Background(), "hello"); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if name != "test.log" {
+		t.Fatalf("path=%q", name)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("lines=%d", len(lines))
+	}
+	if lines[0] != fileSeparator || lines[3] != fileSeparator {
+		t.Fatalf("separators wrong: %v", lines)
+	}
+	if _, err := time.Parse(time.RFC3339, lines[1]); err != nil {
+		t.Fatalf("timestamp: %v", err)
+	}
+	if lines[2] != "hello" {
+		t.Fatalf("message=%q", lines[2])
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -282,7 +282,7 @@ Paths using the `s3://` scheme must include a bucket name and may specify an opt
 The `DLQ_PROVIDER` setting selects how failed messages are recorded:
 
 * `log` – writes messages to the application log (default)
-* `file` – appends messages to a file using separator lines at `DLQ_FILE`
+* `file` – appends messages to a file using separator lines at `DLQ_FILE`. Each entry begins with an RFC3339 timestamp
 * `dir` – creates one file per message under the directory `DLQ_FILE` using a KSUID name
 * `db` – stores messages in the database
 * `email` – sends messages to administrator addresses using the configured mail provider

--- a/specs/dlq.md
+++ b/specs/dlq.md
@@ -19,7 +19,7 @@ Providers implement `Record` to persist messages for later inspection.
 The `internal/dlq/dlqdefaults` package registers the stable implementations:
 
 - **log** – writes messages to the application log.
-- **file** – appends messages to a single log file specified by `DLQ_FILE`.
+- **file** – appends messages to a single log file specified by `DLQ_FILE`. Each entry begins with an RFC3339 timestamp.
 - **dir** – stores each message as a file under the directory given by `DLQ_FILE`.
 - **db** – inserts messages into the database using the `dead_letters` table.
 - **email** – emails messages to administrator addresses using the configured mail provider.


### PR DESCRIPTION
## Summary
- record timestamp for each message in the DLQ file provider
- document DLQ file timestamp behaviour in README and spec
- test DLQ file provider using in-memory file writes

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cd7a07a10832f8b47b6f63a4d5f6c