### PR TITLE
Add login requirement for email verification

### DIFF
--- a/handlers/user/routes.go
+++ b/handlers/user/routes.go
@@ -25,7 +25,7 @@ func RegisterRoutes(r *mux.Router) {
 	ur.HandleFunc("/email/resend", tasks.Action(resendEmailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(resendEmailTask.Matcher())
 	ur.HandleFunc("/email/delete", tasks.Action(deleteEmailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(deleteEmailTask.Matcher())
 	ur.HandleFunc("/email/notify", addEmailTask.Notify).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(addEmailTask.Matcher())
-	ur.HandleFunc("/email/verify", userEmailVerifyCodePage).Methods(http.MethodGet)
+	ur.HandleFunc("/email/verify", userEmailVerifyCodePage).Methods(http.MethodGet).MatcherFunc(handlers.RequiresAnAccount())
 	ur.HandleFunc("/email", tasks.Action(testMailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(testMailTask.Matcher())
 	ur.HandleFunc("/paging", userPagingPage).Methods(http.MethodGet).MatcherFunc(handlers.RequiresAnAccount())
 	ur.HandleFunc("/paging", tasks.Action(pagingSaveTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(pagingSaveTask.Matcher())

--- a/handlers/user/userEmailVerify_test.go
+++ b/handlers/user/userEmailVerify_test.go
@@ -1,0 +1,91 @@
+package user
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/core"
+	common "github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+func TestUserEmailVerifyCodePage_Forbidden(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := dbpkg.New(db)
+	code := "abc"
+	rows := sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).
+		AddRow(1, 1, "e@example.com", nil, code, nil, 0)
+	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(sql.NullString{String: code, Valid: true}).WillReturnRows(rows)
+
+	store := sessions.NewCookieStore([]byte("test"))
+	sess := sessions.NewSession(store, "test")
+	sess.Values = map[interface{}]interface{}{"UID": int32(2)}
+	core.Store = store
+	core.SessionName = "test"
+
+	ctx := context.WithValue(context.Background(), consts.KeyQueries, q)
+	ctx = context.WithValue(ctx, common.ContextValues("session"), sess)
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess))
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+
+	req := httptest.NewRequest("GET", "/usr/email/verify?code="+code, nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+	userEmailVerifyCodePage(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestUserEmailVerifyCodePage_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := dbpkg.New(db)
+	code := "xyz"
+	rows := sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).
+		AddRow(1, 1, "e@example.com", nil, code, nil, 0)
+	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(sql.NullString{String: code, Valid: true}).WillReturnRows(rows)
+	mock.ExpectExec("UPDATE user_emails").WithArgs(sqlmock.AnyArg(), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	store := sessions.NewCookieStore([]byte("test"))
+	sess := sessions.NewSession(store, "test")
+	sess.Values = map[interface{}]interface{}{"UID": int32(1)}
+	core.Store = store
+	core.SessionName = "test"
+
+	ctx := context.WithValue(context.Background(), consts.KeyQueries, q)
+	ctx = context.WithValue(ctx, common.ContextValues("session"), sess)
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess))
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+
+	req := httptest.NewRequest("GET", "/usr/email/verify?code="+code, nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+	userEmailVerifyCodePage(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	if loc := rr.Header().Get("Location"); loc != "/usr/email" {
+		t.Fatalf("location=%q", loc)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- secure email verification by requiring the user to be logged in
- deny verification if code belongs to a different user
- add tests for email verification logic

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cd14204cc832fb63d7bc8bf3e1c5b