### PR TITLE
Implement linker permissions

### DIFF
--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 41
+	ExpectedSchemaVersion = 42
 )

--- a/handlers/linker/linkerCategoriesPage.go
+++ b/handlers/linker/linkerCategoriesPage.go
@@ -24,7 +24,11 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 
-	categories, err := queries.GetAllLinkerCategories(r.Context())
+	cd := data.CoreData
+	categories, err := queries.GetAllLinkerCategoriesForUser(r.Context(), db.GetAllLinkerCategoriesForUserParams{
+		ViewerID:     cd.UserID,
+		ViewerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+	})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/linker/linkerCategoryPage.go
+++ b/handlers/linker/linkerCategoryPage.go
@@ -23,7 +23,7 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 		CatId       int
 		CommentOnId int
 		ReplyToId   int
-		Links       []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow
+		Links       []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserRow
 	}
 
 	data := Data{
@@ -39,7 +39,12 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 
-	linkerPosts, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(data.CatId)})
+	uid := data.CoreData.UserID
+	linkerPosts, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUser(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserParams{
+		ViewerID:         uid,
+		Idlinkercategory: int32(data.CatId),
+		ViewerUserID:     sql.NullInt32{Int32: uid, Valid: uid != 0},
+	})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -50,7 +55,12 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	data.Links = linkerPosts
+	for _, row := range linkerPosts {
+		if !data.CoreData.HasGrant("linker", "link", "see", row.Idlinker) {
+			continue
+		}
+		data.Links = append(data.Links, row)
+	}
 
 	handlers.TemplateHandler(w, r, "linkerCategoryPage", data)
 }

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -88,7 +88,9 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !cd.HasGrant("linker", "link", "view", link.Idlinker) {
+	if !(cd.HasGrant("linker", "link", "view", link.Idlinker) ||
+		cd.HasGrant("linker", "link", "comment", link.Idlinker) ||
+		cd.HasGrant("linker", "link", "reply", link.Idlinker)) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -209,7 +211,9 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !cd.HasGrant("linker", "link", "view", link.Idlinker) {
+	if !(cd.HasGrant("linker", "link", "view", link.Idlinker) ||
+		cd.HasGrant("linker", "link", "comment", link.Idlinker) ||
+		cd.HasGrant("linker", "link", "reply", link.Idlinker)) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}

--- a/handlers/linker/linkerPage.go
+++ b/handlers/linker/linkerPage.go
@@ -64,7 +64,10 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		data.Links = append(data.Links, row)
 	}
 
-	categories, err := queries.GetAllLinkerCategories(r.Context())
+	categories, err := queries.GetAllLinkerCategoriesForUser(r.Context(), db.GetAllLinkerCategoriesForUserParams{
+		ViewerID:     uid,
+		ViewerUserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
+	})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -33,7 +33,11 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
 	}
 
-	categoryRows, err := queries.GetAllLinkerCategories(r.Context())
+	uid := data.CoreData.UserID
+	categoryRows, err := queries.GetAllLinkerCategoriesForUser(r.Context(), db.GetAllLinkerCategoriesForUserParams{
+		ViewerID:     uid,
+		ViewerUserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
+	})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/migrations/0042.sql
+++ b/migrations/0042.sql
@@ -1,0 +1,50 @@
+-- Seed grants for linker permissions
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'linker', 'category', 'allow', 'see', 1
+FROM roles r
+WHERE r.name = 'anonymous'
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'linker', 'category', 'allow', 'view', 1
+FROM roles r
+WHERE r.name = 'anonymous'
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'linker', 'link', 'allow', 'see', 1
+FROM roles r
+WHERE r.name = 'anonymous'
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'linker', 'link', 'allow', 'view', 1
+FROM roles r
+WHERE r.name = 'anonymous'
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'linker', 'link', 'allow', 'comment', 1
+FROM roles r
+WHERE r.name = 'user'
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'linker', 'link', 'allow', 'reply', 1
+FROM roles r
+WHERE r.name = 'user'
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'linker', 'link', 'allow', 'post', 1
+FROM roles r
+WHERE r.name IN ('content writer','administrator')
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'linker', 'link', 'allow', 'edit', 1
+FROM roles r
+WHERE r.name = 'administrator'
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+UPDATE schema_version SET version = 42 WHERE version = 41;

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -169,6 +169,31 @@ Many queries now filter results directly in SQL using `viewer_id` together with 
 | `imagebbs` | `board` | `post` | `viewer_id` | viewer role ID | grant requiring both user and role |
 | `imagebbs` | `board` | `post` | `NULL` | viewer role ID | role-based grant |
 | `imagebbs` | `board` | `post` | `NULL` | `NULL` | public grant for everyone |
+| `linker` | `category` | `see` | `viewer_id` | `NULL` | grant specific to that user |
+| `linker` | `category` | `see` | `viewer_id` | viewer role ID | grant requiring both user and role |
+| `linker` | `category` | `see` | `NULL` | viewer role ID | role-based grant |
+| `linker` | `category` | `see` | `NULL` | `NULL` | public grant for everyone |
+| `linker` | `category` | `view` | `viewer_id` | `NULL` | grant specific to that user |
+| `linker` | `category` | `view` | `viewer_id` | viewer role ID | grant requiring both user and role |
+| `linker` | `category` | `view` | `NULL` | viewer role ID | role-based grant |
+| `linker` | `category` | `view` | `NULL` | `NULL` | public grant for everyone |
+| `linker` | `link` | `see` | `viewer_id` | `NULL` | grant specific to that user |
+| `linker` | `link` | `see` | `viewer_id` | viewer role ID | grant requiring both user and role |
+| `linker` | `link` | `see` | `NULL` | viewer role ID | role-based grant |
+| `linker` | `link` | `see` | `NULL` | `NULL` | public grant for everyone |
+| `linker` | `link` | `view` | `viewer_id` | `NULL` | grant specific to that user |
+| `linker` | `link` | `view` | `viewer_id` | viewer role ID | grant requiring both user and role |
+| `linker` | `link` | `view` | `NULL` | viewer role ID | role-based grant |
+| `linker` | `link` | `view` | `NULL` | `NULL` | public grant for everyone |
+| `linker` | `link` | `comment` | `viewer_id` | `NULL` | grant specific to that user |
+| `linker` | `link` | `comment` | `viewer_id` | viewer role ID | grant requiring both user and role |
+| `linker` | `link` | `comment` | `NULL` | viewer role ID | role-based grant |
+| `linker` | `link` | `reply` | `viewer_id` | `NULL` | grant specific to that user |
+| `linker` | `link` | `reply` | `viewer_id` | viewer role ID | grant requiring both user and role |
+| `linker` | `link` | `reply` | `NULL` | viewer role ID | role-based grant |
+| `linker` | `link` | `post` | `viewer_id` | `NULL` | grant specific to that user |
+| `linker` | `link` | `post` | `viewer_id` | viewer role ID | grant requiring both user and role |
+| `linker` | `link` | `post` | `NULL` | viewer role ID | role-based grant |
 | `forum` | `topic` | `see` | `viewer_id` | `NULL` | grant specific to that user |
 | `forum` | `topic` | `see` | `viewer_id` | viewer role ID | grant requiring both user and role |
 | `forum` | `topic` | `see` | `NULL` | viewer role ID | role-based grant |


### PR DESCRIPTION
## Summary
- enforce per-user linker category listings
- restrict categories page and suggestions by user grants
- fetch category links using viewer-aware query
- allow comment and reply rights to permit viewing links
- add migration for default linker permissions
- document linker permission model
- bump expected schema version

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`
- `go mod tidy`


------
https://chatgpt.com/codex/tasks/task_e_687cd5b234dc832fa0e4c4e3ae0e141d