### PR TITLE
Fix linker pagination

### DIFF
--- a/handlers/linker/linkerCategoryPage.go
+++ b/handlers/linker/linkerCategoryPage.go
@@ -23,7 +23,7 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 		CatId       int
 		CommentOnId int
 		ReplyToId   int
-		Links       []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow
+		Links       []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow
 	}
 
 	data := Data{
@@ -39,7 +39,11 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 
-	linkerPosts, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(data.CatId)})
+	linkerPosts, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedParams{
+		Idlinkercategory: int32(data.CatId),
+		Limit:            15,
+		Offset:           int32(data.Offset),
+	})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/linker/linkerPage.go
+++ b/handlers/linker/linkerPage.go
@@ -25,7 +25,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		CatId       int
 		CommentOnId int
 		ReplyToId   int
-		Links       []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserRow
+		Links       []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow
 		Categories  []*db.LinkerCategory
 	}
 
@@ -42,10 +42,12 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 
 	uid := data.CoreData.UserID
-	linkerPosts, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUser(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserParams{
+	linkerPosts, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginated(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedParams{
 		ViewerID:         uid,
 		Idlinkercategory: int32(data.CatId),
 		ViewerUserID:     sql.NullInt32{Int32: uid, Valid: uid != 0},
+		Limit:            15,
+		Offset:           int32(data.Offset),
 	})
 	if err != nil {
 		switch {

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -84,7 +84,7 @@ func TestPageTemplatesRender(t *testing.T) {
 			CatId       int
 			CommentOnId int
 			ReplyToId   int
-			Links       []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow
+			Links       []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow
 		}{&common.CoreData{}, 0, false, 0, 0, 0, nil}},
 		{"writingsCategoryPage", struct {
 			*common.CoreData

--- a/internal/db/queries-linker.sql
+++ b/internal/db/queries-linker.sql
@@ -224,3 +224,41 @@ SELECT COUNT(*) FROM linker WHERE linker_category_id = ?;
 -- name: SetLinkerLastIndex :exec
 UPDATE linker SET last_index = NOW() WHERE idlinker = ?;
 
+
+-- name: GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated :many
+SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+FROM linker l
+LEFT JOIN users u ON l.users_idusers = u.idusers
+LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
+LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercategory) = 0)
+ORDER BY l.listed DESC
+LIMIT ? OFFSET ?;
+
+-- name: GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginated :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+FROM linker l
+LEFT JOIN users u ON l.users_idusers = u.idusers
+LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
+LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercategory) = 0)
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='linker'
+      AND g.item='link'
+      AND g.action='see'
+      AND g.active=1
+      AND g.item_id = l.idlinker
+      AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
+ORDER BY l.listed DESC
+LIMIT ? OFFSET ?;

--- a/internal/db/queries-linker.sql.go
+++ b/internal/db/queries-linker.sql.go
@@ -346,6 +346,174 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 	return items, nil
 }
 
+const getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginated = `-- name: GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginated :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+FROM linker l
+LEFT JOIN users u ON l.users_idusers = u.idusers
+LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
+LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+WHERE (lc.idlinkerCategory = ? OR ? = 0)
+  AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='linker'
+      AND g.item='link'
+      AND g.action='see'
+      AND g.active=1
+      AND g.item_id = l.idlinker
+      AND (g.user_id = ? OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
+ORDER BY l.listed DESC
+LIMIT ? OFFSET ?
+`
+
+type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedParams struct {
+	ViewerID         int32
+	Idlinkercategory int32
+	ViewerUserID     sql.NullInt32
+	Limit            int32
+	Offset           int32
+}
+
+type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow struct {
+	Idlinker           int32
+	LanguageIdlanguage int32
+	UsersIdusers       int32
+	LinkerCategoryID   int32
+	ForumthreadID      int32
+	Title              sql.NullString
+	Url                sql.NullString
+	Description        sql.NullString
+	Listed             sql.NullTime
+	Comments           sql.NullInt32
+	CategoryTitle      sql.NullString
+	Posterusername     sql.NullString
+}
+
+func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginated(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginated,
+		arg.ViewerID,
+		arg.Idlinkercategory,
+		arg.Idlinkercategory,
+		arg.ViewerUserID,
+		arg.Limit,
+		arg.Offset,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow
+	for rows.Next() {
+		var i GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow
+		if err := rows.Scan(
+			&i.Idlinker,
+			&i.LanguageIdlanguage,
+			&i.UsersIdusers,
+			&i.LinkerCategoryID,
+			&i.ForumthreadID,
+			&i.Title,
+			&i.Url,
+			&i.Description,
+			&i.Listed,
+			&i.Comments,
+			&i.CategoryTitle,
+			&i.Posterusername,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated = `-- name: GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated :many
+SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+FROM linker l
+LEFT JOIN users u ON l.users_idusers = u.idusers
+LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
+LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+WHERE (lc.idlinkerCategory = ? OR ? = 0)
+ORDER BY l.listed DESC
+LIMIT ? OFFSET ?
+`
+
+type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedParams struct {
+	Idlinkercategory int32
+	Limit            int32
+	Offset           int32
+}
+
+type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow struct {
+	Idlinker           int32
+	LanguageIdlanguage int32
+	UsersIdusers       int32
+	LinkerCategoryID   int32
+	ForumthreadID      int32
+	Title              sql.NullString
+	Url                sql.NullString
+	Description        sql.NullString
+	Listed             sql.NullTime
+	Comments           sql.NullInt32
+	CategoryTitle      sql.NullString
+	Posterusername     sql.NullString
+}
+
+func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated,
+		arg.Idlinkercategory,
+		arg.Idlinkercategory,
+		arg.Limit,
+		arg.Offset,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow
+	for rows.Next() {
+		var i GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow
+		if err := rows.Scan(
+			&i.Idlinker,
+			&i.LanguageIdlanguage,
+			&i.UsersIdusers,
+			&i.LinkerCategoryID,
+			&i.ForumthreadID,
+			&i.Title,
+			&i.Url,
+			&i.Description,
+			&i.Listed,
+			&i.Comments,
+			&i.CategoryTitle,
+			&i.Posterusername,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails = `-- name: GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails :many
 SELECT l.idlinkerqueue, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.title, l.url, l.description, u.username, c.title as category_title, c.idlinkerCategory
 FROM linker_queue l


### PR DESCRIPTION
## Summary
- add paginated queries for linker categories
- paginate `/linker` and `/linker/category/{id}` routes
- regenerate sqlc code

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cd495d734832fa270bff71671494a