### PR TITLE
Allow duplicate unverified emails

### DIFF
--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -5,5 +5,5 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 41
+	ExpectedSchemaVersion = 42
 )

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -205,7 +205,7 @@ func (AddEmailTask) Action(w http.ResponseWriter, r *http.Request) {
 	code := hex.EncodeToString(buf[:])
 	expire := time.Now().Add(24 * time.Hour)
 	if err := queries.InsertUserEmail(r.Context(), db.InsertUserEmailParams{UserID: uid, Email: emailAddr, VerifiedAt: sql.NullTime{}, LastVerificationCode: sql.NullString{String: code, Valid: true}, VerificationExpiresAt: sql.NullTime{Time: expire, Valid: true}, NotificationPriority: 0}); err != nil {
-		// TODO better error for NOT Duplicate entry  for key 'user_emails_email_idx'
+		// TODO better error for NOT Duplicate entry for key 'user_emails_email_code_idx'
 		log.Printf("insert user email: %v", err)
 		http.Redirect(w, r, "/usr/email?error=email+exists", http.StatusSeeOther)
 		return
@@ -319,5 +319,6 @@ func userEmailVerifyCodePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = queries.UpdateUserEmailVerification(r.Context(), db.UpdateUserEmailVerificationParams{VerifiedAt: sql.NullTime{Time: time.Now(), Valid: true}, ID: ue.ID})
+	_ = queries.DeleteUserEmailsByEmailExceptID(r.Context(), db.DeleteUserEmailsByEmailExceptIDParams{Email: ue.Email, ID: ue.ID})
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }

--- a/handlers/user/userEmailPage_event_test.go
+++ b/handlers/user/userEmailPage_event_test.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/core"
@@ -49,6 +51,40 @@ func TestAddEmailTaskEventData(t *testing.T) {
 	}
 	if _, ok := evt.Data["URL"]; !ok {
 		t.Fatalf("missing URL event data: %+v", evt.Data)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestVerifyRemovesDuplicates(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := dbpkg.New(db)
+
+	rows := sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).
+		AddRow(1, 1, "a@example.com", nil, "code", time.Now().Add(time.Hour), 0)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, email, verified_at, last_verification_code, verification_expires_at, notification_priority\nFROM user_emails\nWHERE last_verification_code = ?")).
+		WithArgs(sql.NullString{String: "code", Valid: true}).
+		WillReturnRows(rows)
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE user_emails\nSET verified_at = ?, last_verification_code = NULL, verification_expires_at = NULL\nWHERE id = ?")).
+		WithArgs(sqlmock.AnyArg(), int32(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM user_emails WHERE email = ? AND id != ?")).
+		WithArgs("a@example.com", int32(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	req := httptest.NewRequest(http.MethodGet, "/usr/email/verify?code=code", nil)
+	ctx := context.WithValue(req.Context(), consts.KeyQueries, q)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	userEmailVerifyCodePage(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d", rr.Code)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)

--- a/internal/db/queries-user_emails.sql
+++ b/internal/db/queries-user_emails.sql
@@ -48,3 +48,7 @@ WHERE last_verification_code = ?;
 
 -- name: GetMaxNotificationPriority :one
 SELECT COALESCE(MAX(notification_priority),0) AS maxp FROM user_emails WHERE user_id = ?;
+
+-- name: DeleteUserEmailsByEmailExceptID :exec
+DELETE FROM user_emails WHERE email = ? AND id != ?;
+

--- a/internal/db/queries-user_emails.sql.go
+++ b/internal/db/queries-user_emails.sql.go
@@ -28,6 +28,20 @@ func (q *Queries) DeleteUserEmail(ctx context.Context, id int32) error {
 	return err
 }
 
+const deleteUserEmailsByEmailExceptID = `-- name: DeleteUserEmailsByEmailExceptID :exec
+DELETE FROM user_emails WHERE email = ? AND id != ?
+`
+
+type DeleteUserEmailsByEmailExceptIDParams struct {
+	Email string
+	ID    int32
+}
+
+func (q *Queries) DeleteUserEmailsByEmailExceptID(ctx context.Context, arg DeleteUserEmailsByEmailExceptIDParams) error {
+	_, err := q.db.ExecContext(ctx, deleteUserEmailsByEmailExceptID, arg.Email, arg.ID)
+	return err
+}
+
 const getMaxNotificationPriority = `-- name: GetMaxNotificationPriority :one
 SELECT COALESCE(MAX(notification_priority),0) AS maxp FROM user_emails WHERE user_id = ?
 `

--- a/migrations/0042.sql
+++ b/migrations/0042.sql
@@ -1,0 +1,7 @@
+-- Allow non-unique unverified emails
+ALTER TABLE user_emails
+    DROP INDEX user_emails_email_idx,
+    ADD UNIQUE KEY user_emails_email_code_idx (email(255), last_verification_code);
+
+-- Update schema version
+UPDATE schema_version SET version = 42 WHERE version = 41;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -318,7 +318,7 @@ CREATE TABLE `user_emails` (
   `verification_expires_at` datetime DEFAULT NULL,
   `notification_priority` int NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `user_emails_email_idx` (`email`(255)),
+  UNIQUE KEY `user_emails_email_code_idx` (`email`(255),`last_verification_code`),
   KEY `user_emails_user_idx` (`user_id`)
 );
 


### PR DESCRIPTION
## Summary
- drop email uniqueness in favor of a combined index on email and verification code
- delete duplicate addresses once one is confirmed
- bump expected schema version
- regenerate schema

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cd85256d8832f917d099e40bb60f5