### PR TITLE
Notify imagebbs via subscriptions

### DIFF
--- a/handlers/imagebbs/auto_subscribe_test.go
+++ b/handlers/imagebbs/auto_subscribe_test.go
@@ -1,0 +1,14 @@
+package imagebbs
+
+import (
+	"testing"
+
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+// Ensure reply tasks auto subscribe commenters.
+func TestReplyTaskAutoSubscribe(t *testing.T) {
+	if _, ok := interface{}(replyTask).(notif.AutoSubscribeProvider); !ok {
+		t.Fatalf("ReplyTask should implement AutoSubscribeProvider so commenters get updates")
+	}
+}

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -293,21 +293,6 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) {
 	uid, _ = session.Values["UID"].(int32)
 
 	endUrl := fmt.Sprintf("/imagebbss/imagebbs/%d/comments", bid)
-
-	//if rows, err := queries.SomethingNotifyImagebbss(r.Context(), SomethingNotifyImagebbssParams{
-	//	Idusers: uid,
-	//	Idimagebbss: int32(bid),
-	//}); err != nil {
-	//	log.Printf("Error: listUsersSubscribedToThread: %s", err)
-	//} else {
-	//	for _, row := range rows {
-	//		if err := notifyChange(r.Context(), getEmailProvider(), row.String, endUrl); err != nil {
-	//			log.Printf("Error: notifyChange: %s", err)
-	//
-	//		}
-	//	}
-	//}
-
 	cid, err := queries.CreateComment(r.Context(), db.CreateCommentParams{
 		LanguageIdlanguage: int32(languageId),
 		UsersIdusers:       uid,


### PR DESCRIPTION
## Summary
- remove direct notification helper and test from imagebbs
- rely on subscription-based notifications
- add AutoSubscribeProvider test for image board replies

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cccfcf4c4832fbb553ff27b11ba49