### PR TITLE
Fix page size preference with CoreData

### DIFF
--- a/handlers/pagesize.go
+++ b/handlers/pagesize.go
@@ -5,15 +5,16 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	common "github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
 // GetPageSize returns the preferred page size within configured bounds.
 func GetPageSize(r *http.Request) int {
-	size := config.AppRuntimeConfig.PageSizeDefault
-	if pref, _ := r.Context().Value(common.ContextValues("preference")).(*db.Preference); pref != nil && pref.PageSize != 0 {
-		size = int(pref.PageSize)
+	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok && cd != nil {
+		return cd.PageSize()
 	}
+	size := config.AppRuntimeConfig.PageSizeDefault
 	if size < config.AppRuntimeConfig.PageSizeMin {
 		size = config.AppRuntimeConfig.PageSizeMin
 	}

--- a/handlers/pagesize_test.go
+++ b/handlers/pagesize_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	common "github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	db "github.com/arran4/goa4web/internal/db"
 )
 
@@ -31,12 +32,12 @@ func TestGetPageSize(t *testing.T) {
 			config.AppRuntimeConfig.PageSizeMax = 50
 			config.AppRuntimeConfig.PageSizeDefault = 15
 
-			r := httptest.NewRequest("GET", "/", nil)
-			ctx := r.Context()
+			cd := common.NewCoreData(context.Background(), nil)
 			if tt.pref != nil {
-				ctx = context.WithValue(ctx, common.ContextValues("preference"), tt.pref)
+				common.WithPreference(tt.pref)(cd)
 			}
-			r = r.WithContext(ctx)
+			r := httptest.NewRequest("GET", "/", nil)
+			r = r.WithContext(context.WithValue(r.Context(), consts.KeyCoreData, cd))
 
 			got := GetPageSize(r)
 			if got != tt.want {


### PR DESCRIPTION
## Summary
- load pagination preferences from CoreData
- expose `WithPreference` option for CoreData
- use new `CoreData.PageSize` method and update GetPageSize
- adjust tests for the new mechanism

## Testing
- `go mod tidy`
- `go fmt ./...` *(fails: import cycle not allowed)*
- `go vet ./...` *(fails: import cycle not allowed)*
- `golangci-lint run ./...` *(fails: import cycle not allowed)*
- `go test ./...` *(fails: import cycle not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_687ce529bb6c832fbf15ce7b7b350246