### PR TITLE
Add paging save size task

### DIFF
--- a/handlers/user/tasks.go
+++ b/handlers/user/tasks.go
@@ -13,6 +13,8 @@ const (
 	TaskSaveLanguages tasks.TaskString = "Save languages"
 	// TaskSaveLanguage saves updates to a single language.
 	TaskSaveLanguage tasks.TaskString = "Save language"
+	// TaskSaveSize saves a user's paging preference.
+	TaskSaveSize tasks.TaskString = "Save size"
 	// TaskSaveAll saves all changes in bulk.
 	TaskSaveAll tasks.TaskString = "Save all"
 	// TaskTestMail sends a test email to the current user.

--- a/handlers/user/userPagingPage.go
+++ b/handlers/user/userPagingPage.go
@@ -21,7 +21,7 @@ import (
 
 type PagingSaveTask struct{ tasks.TaskString }
 
-var pagingSaveTask = &PagingSaveTask{TaskString: tasks.TaskString(TaskSaveAll)}
+var pagingSaveTask = &PagingSaveTask{TaskString: tasks.TaskString(TaskSaveSize)}
 var _ tasks.Task = (*PagingSaveTask)(nil)
 
 func userPagingPage(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- add TaskSaveSize constant for paging
- hook paging form and route to new task
- revert button text to 'Save size'

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cd302d534832fa3f6b5128c66c024