### PR TITLE
Implement preferred language support

### DIFF
--- a/core/templates/site/languageCombobox.gohtml
+++ b/core/templates/site/languageCombobox.gohtml
@@ -1,5 +1,5 @@
 {{ define "languageCombobox" }}
-    Please select used language, or leave blank for multi-lingual:
+    Please select used language:
     <select name="language">
         <option value="0">Multi-lingual
         {{range $.Languages}}

--- a/core/templates/site/user/langPage.gohtml
+++ b/core/templates/site/user/langPage.gohtml
@@ -8,6 +8,7 @@
     <br>
     Please pick your default language:
     <select name="defaultLanguage">
+        <option value="0"{{ if .DefaultIsMultilingual }} selected{{ end }}>Multi-lingual</option>
     {{ range .LanguageOptions }}
         <option value="{{ .ID }}"{{ if .IsDefault }} selected{{ end }}>{{ .Name }}</option>
     {{ end }}

--- a/handlers/admin/adminSiteSettingsPage.go
+++ b/handlers/admin/adminSiteSettingsPage.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	common "github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
@@ -15,7 +14,6 @@ import (
 )
 
 func AdminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 
 	if r.Method == http.MethodPost {
@@ -49,7 +47,7 @@ func AdminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage),
+		SelectedLanguageId: cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage),
 	}
 	data.CoreData.FeedsEnabled = config.AppRuntimeConfig.FeedsEnabled
 	if langs, err := cd.Languages(); err == nil {

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 
 	common "github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/tasks"
 
@@ -63,10 +62,9 @@ func BlogAddPage(w http.ResponseWriter, r *http.Request) {
 		Mode               string
 	}
 
-	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
 		Mode:               "Add",
 	}
 

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/tasks"
 
@@ -53,10 +52,9 @@ func BlogEditPage(w http.ResponseWriter, r *http.Request) {
 		Mode               string
 	}
 
-	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
 		Mode:               "Edit",
 	}
 

--- a/handlers/blogs/blogsBlogPage.go
+++ b/handlers/blogs/blogsBlogPage.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 
 	common "github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/config"
@@ -53,11 +52,12 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 	blogId, _ := strconv.Atoi(vars["blog"])
 
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
-		CoreData:           r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData:           cd,
 		Offset:             offset,
 		IsReplyable:        true,
-		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
 		EditUrl:            fmt.Sprintf("/blogs/blog/%d/edit", blogId),
 	}
 

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/arran4/goa4web/a4code"
 	common "github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/config"
@@ -56,11 +55,12 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 	blogId, _ := strconv.Atoi(vars["blog"])
 
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
-		CoreData:           r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData:           cd,
 		Offset:             offset,
 		IsReplyable:        true,
-		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
 		EditUrl:            fmt.Sprintf("/blogs/blog/%d/edit", blogId),
 	}
 

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -9,7 +9,6 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	common "github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
@@ -44,11 +43,10 @@ func (AskTask) Page(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int32
 	}
 
-	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage),
+		SelectedLanguageId: cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage),
 	}
 
 	languageRows, err := cd.Languages()

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -10,7 +10,6 @@ import (
 
 	common "github.com/arran4/goa4web/core/common"
 
-	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 	blogs "github.com/arran4/goa4web/handlers/blogs"
 	db "github.com/arran4/goa4web/internal/db"
@@ -92,11 +91,10 @@ func (CreateThreadTask) Page(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int
 	}
 
-	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
 	}
 
 	languageRows, err := cd.Languages()

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/arran4/goa4web/a4code"
 	common "github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 	blogs "github.com/arran4/goa4web/handlers/blogs"
 	db "github.com/arran4/goa4web/internal/db"
@@ -53,7 +52,7 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:           cd,
 		Offset:             offset,
 		IsReplyable:        true,
-		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
 	}
 
 	languageRows, err := cd.Languages()

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 
 	common "github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
@@ -29,9 +28,10 @@ func AdminAddPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
-		CoreData:           r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
+		CoreData:           cd,
+		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
 	}
 
 	categoryRows, err := queries.GetAllLinkerCategories(r.Context())

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 
 	common "github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
@@ -57,7 +56,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		CanReply:           cd.UserID != 0,
 		CanEdit:            false,
 		Offset:             offset,
-		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
 	}
 	vars := mux.Vars(r)
 	linkId, _ := strconv.Atoi(vars["link"])

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 
 	common "github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	postcountworker "github.com/arran4/goa4web/workers/postcountworker"
@@ -36,7 +35,7 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData:           cd,
 		CanReply:           cd.UserID != 0,
-		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
 	}
 	vars := mux.Vars(r)
 	linkId, _ := strconv.Atoi(vars["link"])

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 
 	common "github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 
@@ -28,9 +27,10 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
-		CoreData:           r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
+		CoreData:           cd,
+		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
 	}
 
 	categoryRows, err := queries.GetAllLinkerCategories(r.Context())

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	common "github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	"github.com/arran4/goa4web/core/templates"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
@@ -185,11 +184,12 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
-		CoreData:           r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData:           cd,
 		IsReplying:         r.URL.Query().Has("comment"),
 		IsReplyable:        true,
-		SelectedLanguageId: corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage),
+		SelectedLanguageId: cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage),
 	}
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
@@ -253,7 +253,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd = r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	languageRows, err := cd.Languages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -43,7 +43,8 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 
 	type Data struct {
 		*common.CoreData
-		LanguageOptions []LanguageOption
+		LanguageOptions       []LanguageOption
+		DefaultIsMultilingual bool
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
@@ -75,9 +76,11 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 		opts = append(opts, opt)
 	}
 
+	defaultIsMulti := pref == nil || pref.LanguageIdlanguage == 0
 	data := Data{
-		CoreData:        cd,
-		LanguageOptions: opts,
+		CoreData:              cd,
+		LanguageOptions:       opts,
+		DefaultIsMultilingual: defaultIsMulti,
 	}
 
 	handlers.TemplateHandler(w, r, "langPage.gohtml", data)

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 
 	common "github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
@@ -29,11 +28,10 @@ func ArticleEditPage(w http.ResponseWriter, r *http.Request) {
 		UserId             int32
 	}
 
-	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
 	}
 
 	// article ID is validated by the RequireWritingAuthor middleware, so we

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/arran4/goa4web/a4code"
 	common "github.com/arran4/goa4web/core/common"
-	corelanguage "github.com/arran4/goa4web/core/language"
 	handlers "github.com/arran4/goa4web/handlers"
 	db "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/notifications"
@@ -62,7 +61,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		CoreData:           cd,
 		CanReply:           cd.UserID != 0,
 		CanEdit:            false,
-		SelectedLanguageId: int(corelanguage.ResolveDefaultLanguageID(r.Context(), queries, config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
 		IsReplyable:        true,
 	}
 


### PR DESCRIPTION
## Summary
- support user language preference via `PreferredLanguageID` on `CoreData`
- show `Multi-lingual` option in language pages
- remove outdated text about blank language option

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cd436bfa8832f90b777468e451606