### PR TITLE
Allow trailing slash on /linker

### DIFF
--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -23,6 +23,7 @@ func RegisterRoutes(r *mux.Router) {
 	lr.HandleFunc("/rss", RssPage).Methods("GET")
 	lr.HandleFunc("/atom", AtomPage).Methods("GET")
 	lr.HandleFunc("", Page).Methods("GET")
+	lr.HandleFunc("/", Page).Methods("GET")
 	lr.HandleFunc("/linker/{username}", UserPage).Methods("GET")
 	lr.HandleFunc("/linker/{username}/", UserPage).Methods("GET")
 	lr.HandleFunc("/categories", CategoriesPage).Methods("GET")


### PR DESCRIPTION
## Summary
- serve `/linker/` the same as `/linker`

## Testing
- `go mod tidy`
- `go vet ./...` *(fails: import cycle not allowed in test)*
- `golangci-lint run ./...` *(fails: vet: handlers/user/userEmailPage_event_test.go:96:14: undefined: evt)*
- `go test ./...` *(fails: multiple package test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687cf29c21d8832fab714e41ed1a4e02