### PR TITLE
Display message for empty forum category list

### DIFF
--- a/core/templates/site/forum/categories.gohtml
+++ b/core/templates/site/forum/categories.gohtml
@@ -47,5 +47,7 @@
                 </tr>
             {{ end }}
         </table>
+    {{ else }}
+        <p>No categories to show.</p>
     {{ end }}
 {{ end }}


### PR DESCRIPTION
## Summary
- show a fallback message when the forum has no categories

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: import cycle and undefined vars)*
- `golangci-lint run ./...` *(fails: typecheck issues)*
- `go test ./...` *(fails: import cycle and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687cf27c9870832f8d5cd963f1fff475