### PR TITLE
Fix CSRF form validation

### DIFF
--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,4 +6,10 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	ExpectedSchemaVersion = 42
+
+	// CSRFField is the name of the hidden field used by gorilla/csrf.
+	CSRFField = "gorilla.csrf.Token"
+
+	// TaskField is used by submit buttons to indicate the chosen task.
+	TaskField = "task"
 )

--- a/handlers/form.go
+++ b/handlers/form.go
@@ -12,7 +12,10 @@ func ValidateForm(r *http.Request, allowed, required []string) error {
 	if err := r.ParseForm(); err != nil {
 		return err
 	}
-	allowedSet := make(map[string]struct{}, len(allowed))
+	allowedSet := make(map[string]struct{}, len(allowed)+2)
+	// Always allow CSRF and task fields which are automatically added by forms.
+	allowedSet[CSRFField] = struct{}{}
+	allowedSet[TaskField] = struct{}{}
 	for _, k := range allowed {
 		allowedSet[k] = struct{}{}
 	}


### PR DESCRIPTION
## Summary
- allow default CSRF and submit button fields during form validation

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: import cycle not allowed in test)*
- `golangci-lint run ./...` *(fails: typecheck issues in tests)*
- `go test ./...` *(fails: import cycle in tests and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687cf2608aec832fa3461b036e911253