### PR TITLE
Fix user language page error handling

### DIFF
--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -50,8 +50,17 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := r.Context().Value(consts.KeyQueries).(*db.Queries)
 
-	pref, _ := cd.Preference()
-	userLangs, _ := queries.GetUserLanguages(r.Context(), cd.UserID)
+	pref, err := cd.Preference()
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	userLangs, err := queries.GetUserLanguages(r.Context(), cd.UserID)
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
 
 	langs, err := cd.Languages()
 	if err != nil {


### PR DESCRIPTION
## Summary
- check for errors when loading preferences or user languages

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: import cycle not allowed)*
- `golangci-lint run`
- `go test ./...` *(fails: import cycle and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_687cf153aecc832f8221535f777f45aa