### PR TITLE
Implement email verification confirmation

### DIFF
--- a/core/templates/site/user/emailVerifiedPage.gohtml
+++ b/core/templates/site/user/emailVerifiedPage.gohtml
@@ -1,0 +1,3 @@
+{{ template "head" $ }}
+Your email address is already verified.
+{{ template "tail" $ }}

--- a/core/templates/site/user/emailVerifyConfirmPage.gohtml
+++ b/core/templates/site/user/emailVerifyConfirmPage.gohtml
@@ -1,0 +1,8 @@
+{{ template "head" $ }}
+<p>Please confirm verification of your email address {{ .Email }}.</p>
+<form method="post">
+    {{ csrfField }}
+    <input type="hidden" name="code" value="{{ .Code }}">
+    <input type="submit" name="task" value="Confirm">
+</form>
+{{ template "tail" $ }}

--- a/handlers/user/routes.go
+++ b/handlers/user/routes.go
@@ -25,7 +25,7 @@ func RegisterRoutes(r *mux.Router) {
 	ur.HandleFunc("/email/resend", tasks.Action(resendVerificationEmailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(resendVerificationEmailTask.Matcher())
 	ur.HandleFunc("/email/delete", tasks.Action(deleteEmailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(deleteEmailTask.Matcher())
 	ur.HandleFunc("/email/notify", addEmailTask.Notify).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(addEmailTask.Matcher())
-	ur.HandleFunc("/email/verify", userEmailVerifyCodePage).Methods(http.MethodGet).MatcherFunc(handlers.RequiresAnAccount())
+	ur.HandleFunc("/email/verify", userEmailVerifyCodePage).Methods(http.MethodGet, http.MethodPost)
 	ur.HandleFunc("/email", tasks.Action(testMailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(testMailTask.Matcher())
 	ur.HandleFunc("/paging", userPagingPage).Methods(http.MethodGet).MatcherFunc(handlers.RequiresAnAccount())
 	ur.HandleFunc("/paging", tasks.Action(pagingSaveTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(pagingSaveTask.Matcher())


### PR DESCRIPTION
## Summary
- add templates for confirming and acknowledging email verification
- extend `/usr/email/verify` to support GET/POST confirmation flow
- allow `/usr/email/verify` for anonymous users and redirect to login
- update email verification tests
- show the email address on the confirmation page

## Testing
- `go vet ./...` *(fails: import cycle not allowed in test)*
- `golangci-lint run ./...` *(fails: import cycle not allowed in test)*
- `go test ./...` *(fails: import cycle)*
- `go test ./handlers/... ./internal/... ./config/...` *(fails: writings tests 500)*

------
https://chatgpt.com/codex/tasks/task_e_687cf23bf154832f8a7ce22000b53aea