### PR TITLE
Fix notifications permission check

### DIFF
--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -33,6 +33,7 @@ var (
 	_ tasks.Task                                    = (*ReplyBlogTask)(nil)
 	_ notif.SubscribersNotificationTemplateProvider = (*ReplyBlogTask)(nil)
 	_ notif.AutoSubscribeProvider                   = (*ReplyBlogTask)(nil)
+	_ notif.GrantsRequiredProvider                  = (*ReplyBlogTask)(nil)
 )
 
 func (ReplyBlogTask) SubscribedEmailTemplate() *notif.EmailTemplates {
@@ -42,6 +43,14 @@ func (ReplyBlogTask) SubscribedEmailTemplate() *notif.EmailTemplates {
 func (ReplyBlogTask) SubscribedInternalNotificationTemplate() *string {
 	s := notif.NotificationTemplateFilenameGenerator("reply")
 	return &s
+}
+
+// GrantsRequired implements notif.GrantsRequiredProvider for blog replies.
+func (ReplyBlogTask) GrantsRequired(evt eventbus.TaskEvent) []notif.GrantRequirement {
+	if t, ok := evt.Data["target"].(notif.Target); ok {
+		return []notif.GrantRequirement{{Section: "blogs", Item: "entry", ItemID: t.ID, Action: "view"}}
+	}
+	return nil
 }
 
 // AutoSubscribePath records the reply so the commenter automatically watches
@@ -196,6 +205,7 @@ func BlogReplyPostPage(w http.ResponseWriter, r *http.Request) {
 			}
 			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{ThreadID: pthid, TopicID: ptid}
 			evt.Data["CommentURL"] = cd.AbsoluteURL(endUrl)
+			evt.Data["target"] = notif.Target{Type: "blog", ID: int32(bid)}
 		}
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/writings/task_structs.go
+++ b/handlers/writings/task_structs.go
@@ -20,6 +20,7 @@ var _ tasks.Task = (*SubmitWritingTask)(nil)
 
 // followers of an author should be alerted when new writing is submitted
 var _ notif.SubscribersNotificationTemplateProvider = (*SubmitWritingTask)(nil)
+var _ notif.GrantsRequiredProvider = (*SubmitWritingTask)(nil)
 
 func (SubmitWritingTask) Page(w http.ResponseWriter, r *http.Request)   { ArticleAddPage(w, r) }
 func (SubmitWritingTask) Action(w http.ResponseWriter, r *http.Request) { ArticleAddActionPage(w, r) }
@@ -31,6 +32,15 @@ func (SubmitWritingTask) SubscribedEmailTemplate() *notif.EmailTemplates {
 func (SubmitWritingTask) SubscribedInternalNotificationTemplate() *string {
 	s := notif.NotificationTemplateFilenameGenerator("writing")
 	return &s
+}
+
+// GrantsRequired implements notif.GrantsRequiredProvider. The newly created article
+// is referenced in evt.Data under the "target" key by the page handler.
+func (SubmitWritingTask) GrantsRequired(evt eventbus.TaskEvent) []notif.GrantRequirement {
+	if t, ok := evt.Data["target"].(notif.Target); ok {
+		return []notif.GrantRequirement{{Section: "writing", Item: "article", ItemID: t.ID, Action: "view"}}
+	}
+	return nil
 }
 
 // ReplyTask posts a comment reply.
@@ -46,6 +56,7 @@ var _ notif.AutoSubscribeProvider = (*ReplyTask)(nil)
 var replyTask = &ReplyTask{TaskString: TaskReply}
 
 var _ tasks.Task = (*ReplyTask)(nil)
+var _ notif.GrantsRequiredProvider = (*ReplyTask)(nil)
 
 // replying should notify anyone following the discussion
 var _ notif.SubscribersNotificationTemplateProvider = (*ReplyTask)(nil)
@@ -71,6 +82,14 @@ func (ReplyTask) SubscribedEmailTemplate() *notif.EmailTemplates {
 func (ReplyTask) SubscribedInternalNotificationTemplate() *string {
 	s := notif.NotificationTemplateFilenameGenerator("reply")
 	return &s
+}
+
+// GrantsRequired implements notif.GrantsRequiredProvider for replies.
+func (ReplyTask) GrantsRequired(evt eventbus.TaskEvent) []notif.GrantRequirement {
+	if t, ok := evt.Data["target"].(notif.Target); ok {
+		return []notif.GrantRequirement{{Section: "writing", Item: "article", ItemID: t.ID, Action: "view"}}
+	}
+	return nil
 }
 
 // AutoSubscribePath implements notif.AutoSubscribeProvider. It builds the
@@ -132,6 +151,7 @@ var updateWritingTask = &UpdateWritingTask{TaskString: TaskUpdateWriting}
 
 var _ tasks.Task = (*UpdateWritingTask)(nil)
 var _ notif.SubscribersNotificationTemplateProvider = (*UpdateWritingTask)(nil)
+var _ notif.GrantsRequiredProvider = (*UpdateWritingTask)(nil)
 
 func (UpdateWritingTask) Page(w http.ResponseWriter, r *http.Request) { ArticleEditPage(w, r) }
 
@@ -144,6 +164,14 @@ func (UpdateWritingTask) SubscribedEmailTemplate() *notif.EmailTemplates {
 func (UpdateWritingTask) SubscribedInternalNotificationTemplate() *string {
 	s := notif.NotificationTemplateFilenameGenerator("writing_update")
 	return &s
+}
+
+// GrantsRequired implements notif.GrantsRequiredProvider for article updates.
+func (UpdateWritingTask) GrantsRequired(evt eventbus.TaskEvent) []notif.GrantRequirement {
+	if t, ok := evt.Data["target"].(notif.Target); ok {
+		return []notif.GrantRequirement{{Section: "writing", Item: "article", ItemID: t.ID, Action: "view"}}
+	}
+	return nil
 }
 
 // UserAllowTask grants a user a permission.

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -79,6 +79,7 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 				evt.Data = map[string]any{}
 			}
 			evt.Data["writing"] = notifications.WritingInfo{Title: title, Author: author}
+			evt.Data["target"] = notifications.Target{Type: "writing", ID: int32(articleId)}
 		}
 	}
 

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -93,6 +93,7 @@ func ArticleEditActionPage(w http.ResponseWriter, r *http.Request) {
 			}
 			evt.Data["writing"] = notif.WritingInfo{Title: title, Author: author}
 			evt.Data["PostURL"] = cd.AbsoluteURL(fmt.Sprintf("/writings/article/%d", writing.Idwriting))
+			evt.Data["target"] = notif.Target{Type: "writing", ID: writing.Idwriting}
 		}
 	}
 

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -49,21 +49,6 @@ func collectSubscribers(ctx context.Context, q *dbpkg.Queries, patterns []string
 	return subs, nil
 }
 
-// parseEvent identifies a subscription target from the request path.
-// It returns the item type and id if recognised.
-func parseEvent(evt eventbus.TaskEvent) (string, int32, bool) {
-	if evt.Data == nil {
-		return "", 0, false
-	}
-	if v, ok := evt.Data["target"]; ok {
-		if t, ok := v.(SubscriptionTarget); ok {
-			typ, id := t.SubscriptionTarget()
-			return typ, id, true
-		}
-	}
-	return "", 0, false
-}
-
 func (n *Notifier) BusWorker(ctx context.Context, bus *eventbus.Bus, q dlq.DLQ) {
 	if bus == nil || n.Queries == nil {
 		return
@@ -250,6 +235,31 @@ func (n *Notifier) notifySubscribers(ctx context.Context, evt eventbus.TaskEvent
 
 	delete(emailSubs, evt.UserID)
 	delete(internalSubs, evt.UserID)
+
+	if gp, ok := evt.Task.(GrantsRequiredProvider); ok {
+		reqs := gp.GrantsRequired(evt)
+		if len(reqs) != 0 {
+			filterSubs := func(m map[int32]struct{}) {
+				for id := range m {
+					for _, g := range reqs {
+						if _, err := n.Queries.CheckGrant(ctx, dbpkg.CheckGrantParams{
+							ViewerID: id,
+							Section:  g.Section,
+							Item:     sql.NullString{String: g.Item, Valid: g.Item != ""},
+							Action:   g.Action,
+							ItemID:   sql.NullInt32{Int32: g.ItemID, Valid: g.ItemID != 0},
+							UserID:   sql.NullInt32{Int32: id, Valid: id != 0},
+						}); err != nil {
+							delete(m, id)
+							break
+						}
+					}
+				}
+			}
+			filterSubs(emailSubs)
+			filterSubs(internalSubs)
+		}
+	}
 
 	var msg []byte
 	data := struct {

--- a/internal/notifications/bus_worker_test.go
+++ b/internal/notifications/bus_worker_test.go
@@ -52,25 +52,6 @@ func TestBuildPatterns(t *testing.T) {
 	}
 }
 
-func TestParseEvent(t *testing.T) {
-	evt := eventbus.TaskEvent{Data: map[string]any{"target": Target{Type: "thread", ID: 42}}}
-	typ, id, ok := parseEvent(evt)
-	if !ok || typ != "thread" || id != 42 {
-		t.Fatalf("thread parse got %s %d %v", typ, id, ok)
-	}
-	evt = eventbus.TaskEvent{Data: map[string]any{"target": Target{Type: "writing", ID: 7}}}
-	typ, id, ok = parseEvent(evt)
-	if !ok || typ != "writing" || id != 7 {
-		t.Fatalf("writing parse got %s %d %v", typ, id, ok)
-	}
-	if _, _, ok := parseEvent(eventbus.TaskEvent{Path: "/bad/path"}); ok {
-		t.Fatalf("unexpected match")
-	}
-	if _, _, ok := parseEvent(eventbus.TaskEvent{Path: "/news/news/9"}); ok {
-		t.Fatalf("unexpected match with path")
-	}
-}
-
 const TaskTest = tasks.TaskString("TaskTest")
 
 type TestTask struct {

--- a/internal/notifications/subscriptionsinterfaces.go
+++ b/internal/notifications/subscriptionsinterfaces.go
@@ -64,3 +64,10 @@ type TargetUsersNotificationProvider interface {
 	TargetEmailTemplate() *EmailTemplates
 	TargetInternalNotificationTemplate() *string
 }
+
+// GrantsRequiredProvider exposes the permission context for subscription
+// notifications. Implementations return one or more GrantRequirement values
+// checked with `CheckGrant` before delivering a message.
+type GrantsRequiredProvider interface {
+	GrantsRequired(evt eventbus.TaskEvent) []GrantRequirement
+}

--- a/internal/notifications/types.go
+++ b/internal/notifications/types.go
@@ -61,3 +61,11 @@ type Target struct {
 
 // SubscriptionTarget implements SubscriptionTarget.
 func (t Target) SubscriptionTarget() (string, int32) { return t.Type, t.ID }
+
+// GrantRequirement describes a single permission check.
+type GrantRequirement struct {
+	Section string
+	Item    string
+	ItemID  int32
+	Action  string
+}


### PR DESCRIPTION
## Summary
- ensure notifications respect grants when sending to subscribers
- allow tasks to provide multiple grants via GrantsRequiredProvider interface
- add permission requirements for blog and writing tasks
- filter subscribers against grants before sending notifications

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: import cycle not allowed in test)*
- `golangci-lint run ./...` *(fails: typecheck issues in handlers/user)*
- `go test ./...` *(fails: build and query argument errors)*

------
https://chatgpt.com/codex/tasks/task_e_687cf30661f0832fbceca92d2054cd26