### PR TITLE
Fix sqlc user language columns

### DIFF
--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -69,8 +69,14 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	selected := make(map[int32]bool)
-	for _, ul := range userLangs {
-		selected[ul.LanguageIdlanguage] = true
+	if len(userLangs) == 0 {
+		for _, l := range langs {
+			selected[l.Idlanguage] = true
+		}
+	} else {
+		for _, ul := range userLangs {
+			selected[ul.LanguageIdlanguage] = true
+		}
 	}
 
 	var opts []LanguageOption

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -419,7 +419,7 @@ type UserEmail struct {
 }
 
 type UserLanguage struct {
-	IduserLanguage     int32
+	Iduserlang         int32
 	UsersIdusers       int32
 	LanguageIdlanguage int32
 }

--- a/internal/db/queries-user_languages.sql
+++ b/internal/db/queries-user_languages.sql
@@ -1,5 +1,5 @@
 -- name: GetUserLanguages :many
-SELECT iduser_language, users_idusers, language_idlanguage
+SELECT iduserlang, users_idusers, language_idlanguage
 FROM user_language
 WHERE users_idusers = ?;
 

--- a/internal/db/queries-user_languages.sql.go
+++ b/internal/db/queries-user_languages.sql.go
@@ -19,7 +19,7 @@ func (q *Queries) DeleteUserLanguagesByUser(ctx context.Context, usersIdusers in
 }
 
 const getUserLanguages = `-- name: GetUserLanguages :many
-SELECT iduser_language, users_idusers, language_idlanguage
+SELECT iduserlang, users_idusers, language_idlanguage
 FROM user_language
 WHERE users_idusers = ?
 `
@@ -33,7 +33,7 @@ func (q *Queries) GetUserLanguages(ctx context.Context, usersIdusers int32) ([]*
 	var items []*UserLanguage
 	for rows.Next() {
 		var i UserLanguage
-		if err := rows.Scan(&i.IduserLanguage, &i.UsersIdusers, &i.LanguageIdlanguage); err != nil {
+		if err := rows.Scan(&i.Iduserlang, &i.UsersIdusers, &i.LanguageIdlanguage); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -283,10 +283,10 @@ CREATE TABLE `site_news_search` (
 
 
 CREATE TABLE `user_language` (
-  `iduser_language` int(10) NOT NULL AUTO_INCREMENT,
+  `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `language_idlanguage` int(10) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`iduser_language`),
+  PRIMARY KEY (`iduserlang`),
   KEY `userpref_FKIndex1` (`language_idlanguage`),
   KEY `userpref_FKIndex2` (`users_idusers`)
 );


### PR DESCRIPTION
## Summary
- remove erroneous migration that renamed `iduserlang`
- keep schema version constant at 42
- update schema definition and queries to use existing `iduserlang` column
- regenerate sqlc code
- maintain language selection when user has no preferences

## Testing
- `go vet ./...` *(fails: import cycle not allowed in test)*
- `golangci-lint run ./...` *(fails: typecheck issues in tests)*
- `go mod tidy`
- `go test ./...` *(fails: import cycle not allowed in test)*

------
https://chatgpt.com/codex/tasks/task_e_687e255de3cc832fabfb936c1c46c4bd