### PR TITLE
Disable SES provider in default build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.22-alpine AS build
 WORKDIR /src
 COPY . .
-RUN go build -o /goa4web ./cmd/goa4web
+RUN go build -tags=ses -o /goa4web ./cmd/goa4web
 
 FROM scratch
 # Install the application into the final image.

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -7,7 +7,7 @@ builds:
       - CGO_ENABLED=0
     goos: [linux, darwin, windows]
     goarch: [amd64, arm64]
-    flags: ["-trimpath"]
+    flags: ["-trimpath", "-tags=ses"]
 archives:
   - format_overrides:
       - goos: windows

--- a/goreleaser_gitlab.yaml
+++ b/goreleaser_gitlab.yaml
@@ -7,7 +7,7 @@ builds:
       - CGO_ENABLED=0
     goos: [linux, darwin, windows]
     goarch: [amd64, arm64]
-    flags: ["-trimpath"]
+    flags: ["-trimpath", "-tags=ses"]
 archives:
   - format_overrides:
       - goos: windows

--- a/handlers/user/userEmailPage_event_test.go
+++ b/handlers/user/userEmailPage_event_test.go
@@ -33,7 +33,7 @@ func TestAddEmailTaskEventData(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).
 			AddRow(1, nil, "alice"))
 
-	store := sessions.NewCookieStore([]byte("test"))
+	store = sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = "test"
 	sess, _ := store.Get(httptest.NewRequest(http.MethodGet, "http://example.com", nil), core.SessionName)
@@ -76,7 +76,7 @@ func TestVerifyRemovesDuplicates(t *testing.T) {
 	defer db.Close()
 	q := dbpkg.New(db)
 
-	store := sessions.NewCookieStore([]byte("test"))
+	store = sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = "test"
 	sess, _ := store.Get(httptest.NewRequest(http.MethodGet, "http://example.com", nil), core.SessionName)
@@ -88,7 +88,6 @@ func TestVerifyRemovesDuplicates(t *testing.T) {
 	ctx := context.WithValue(context.Background(), consts.KeyQueries, q)
 	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt))
 	cd.UserID = 1
-	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	rows := sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).
 		AddRow(1, 1, "a@example.com", nil, "code", time.Now().Add(time.Hour), 0)
@@ -102,8 +101,8 @@ func TestVerifyRemovesDuplicates(t *testing.T) {
 		WithArgs("a@example.com", int32(1)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	store := sessions.NewCookieStore([]byte("test"))
-	sess := sessions.NewSession(store, "test")
+	store = sessions.NewCookieStore([]byte("test"))
+	sess = sessions.NewSession(store, "test")
 	sess.Values = map[interface{}]interface{}{"UID": int32(1)}
 	core.Store = store
 	core.SessionName = "test"
@@ -111,9 +110,9 @@ func TestVerifyRemovesDuplicates(t *testing.T) {
 	form := url.Values{"code": {"code"}}
 	req := httptest.NewRequest(http.MethodPost, "/usr/email/verify", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	ctx := context.WithValue(req.Context(), consts.KeyQueries, q)
+	ctx = context.WithValue(req.Context(), consts.KeyQueries, q)
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess))
+	cd = common.NewCoreData(ctx, q, common.WithSession(sess))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/internal/email/emaildefaults/email_ses_test.go
+++ b/internal/email/emaildefaults/email_ses_test.go
@@ -1,0 +1,22 @@
+//go:build ses
+// +build ses
+
+package emaildefaults_test
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/internal/email"
+	sesProv "github.com/arran4/goa4web/internal/email/ses"
+)
+
+func init() {
+	sesProv.Register()
+}
+
+func TestGetEmailProviderSESNoCreds(t *testing.T) {
+	if p := email.ProviderFromConfig(config.RuntimeConfig{EmailProvider: "ses", EmailAWSRegion: "us-east-1"}); p != nil {
+		t.Errorf("expected nil provider, got %#v", p)
+	}
+}

--- a/internal/email/emaildefaults/email_test.go
+++ b/internal/email/emaildefaults/email_test.go
@@ -18,7 +18,6 @@ import (
 	localProv "github.com/arran4/goa4web/internal/email/local"
 	logProv "github.com/arran4/goa4web/internal/email/log"
 	mockemail "github.com/arran4/goa4web/internal/email/mock"
-	sesProv "github.com/arran4/goa4web/internal/email/ses"
 	smtpProv "github.com/arran4/goa4web/internal/email/smtp"
 	"strings"
 )
@@ -28,7 +27,6 @@ func init() {
 	smtpProv.Register()
 	localProv.Register()
 	jmapProv.Register()
-	sesProv.Register()
 }
 
 func TestGetEmailProviderLog(t *testing.T) {

--- a/internal/email/ses/ses.go
+++ b/internal/email/ses/ses.go
@@ -1,3 +1,6 @@
+//go:build ses
+// +build ses
+
 package ses
 
 import (
@@ -19,6 +22,9 @@ type Provider struct {
 	Client sesiface.SESAPI
 	From   string
 }
+
+// Built indicates whether the SES provider is compiled in.
+const Built = true
 
 func (s Provider) Send(ctx context.Context, to mail.Address, rawEmailMessage []byte) error {
 	input := &ses.SendRawEmailInput{

--- a/internal/email/ses/ses_stub.go
+++ b/internal/email/ses/ses_stub.go
@@ -1,0 +1,16 @@
+//go:build !ses
+
+package ses
+
+import (
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/internal/email"
+)
+
+// Built indicates whether the SES provider is compiled in.
+const Built = false
+
+func providerFromConfig(config.RuntimeConfig) email.Provider { return nil }
+
+// Register is a no-op when the ses build tag is not present.
+func Register() { email.RegisterProvider("ses", providerFromConfig) }

--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,7 @@ When using SQLite you must compile the binary with the `sqlite` build tag.
 Email notifications can be sent via several backends. Set `EMAIL_PROVIDER` to select one of the following modes:
 
 - `ses` (default): Amazon SES. Requires valid AWS credentials and `AWS_REGION`.
+  The provider is built only when the `ses` build tag is enabled.
 - `smtp`: Standard SMTP server using `SMTP_HOST`, optional `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_AUTH`, `SMTP_STARTTLS` and `SMTP_TLS`.
 - `local`: Uses the local `sendmail` binary.
 - `jmap`: Sends mail using JMAP. Requires `JMAP_ENDPOINT`, `JMAP_USER`, `JMAP_PASS`,


### PR DESCRIPTION
## Summary
- skip SES test unless `ses` build tag is used
- provide stub implementation of SES provider
- tweak email provider docs
- fix vet finding in user email tests
- ensure release binaries are built with the SES tag

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687e2ab23078832fb810c841a615adc0