### PR TITLE
Fix tests by providing queries

### DIFF
--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -67,7 +67,8 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
-	cd := common.NewCoreData(req.Context(), nil, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)))
+	q := db.New(sqldb)
+	cd := common.NewCoreData(req.Context(), q, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)))
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -99,7 +99,9 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 			AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), "bob", 0, true))
 
 	req := httptest.NewRequest("GET", "http://example.com/blogs/rss?rss=bob", nil)
-	ctx := req.Context()
+	q := db.New(sqldb)
+	cd := common.NewCoreData(req.Context(), q)
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 

--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/middleware"
 	"github.com/arran4/goa4web/internal/tasks"
@@ -93,12 +94,13 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	for _, c := range w.Result().Cookies() {
 		req.AddCookie(c)
 	}
+	q := db.New(dbconn)
 	evt := &eventbus.TaskEvent{Path: "/faq/ask", Task: tasks.TaskString(TaskAsk), UserID: 1}
-	cd := &common.CoreData{UserID: 1}
+	cd := common.NewCoreData(req.Context(), q)
+	cd.UserID = 1
 	cd.SetEvent(evt)
 
-	ctx := req.Context()
-	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	handler := middleware.TaskEventMiddleware(http.HandlerFunc(askTask.Action))

--- a/handlers/forum/matchers_test.go
+++ b/handlers/forum/matchers_test.go
@@ -1,6 +1,7 @@
 package forum
 
 import (
+	"context"
 	"database/sql"
 	"github.com/arran4/goa4web/core/consts"
 	"net/http"
@@ -9,6 +10,9 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/internal/db"
 )
 
 func TestRequireThreadAndTopicTrue(t *testing.T) {
@@ -32,7 +36,9 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
-	ctx := req.Context()
+	q := db.New(sqldb)
+	cd := common.NewCoreData(req.Context(), q)
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	called := false
@@ -78,7 +84,9 @@ func TestRequireThreadAndTopicFalse(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
-	ctx := req.Context()
+	q := db.New(sqldb)
+	cd := common.NewCoreData(req.Context(), q)
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	called := false
@@ -113,7 +121,9 @@ func TestRequireThreadAndTopicError(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
-	ctx := req.Context()
+	q := db.New(sqldb)
+	cd := common.NewCoreData(req.Context(), q)
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	called := false

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -69,13 +69,11 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	go searchworker.Worker(ctx, bus, queries)
 
-	evt := &eventbus.TaskEvent{Data: map[string]any{}}
-	cd := &common.CoreData{}
-	cd.SetEvent(evt)
-
 	req := httptest.NewRequest("POST", "/admin/queue?qid=1", nil)
-	ctxreq := req.Context()
-	ctxreq = context.WithValue(ctxreq, consts.KeyCoreData, cd)
+	evt := &eventbus.TaskEvent{Data: map[string]any{}}
+	cd := common.NewCoreData(req.Context(), queries)
+	cd.SetEvent(evt)
+	ctxreq := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctxreq)
 	rr := httptest.NewRecorder()
 	ApproveTask.Action(rr, req)

--- a/handlers/writings/writingsArticlePage_test.go
+++ b/handlers/writings/writingsArticlePage_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/internal/db"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
@@ -46,8 +47,9 @@ func TestArticleReplyActionPage_UsesArticleParam(t *testing.T) {
 		req.AddCookie(c)
 	}
 
-	ctx := req.Context()
-	ctx = context.WithValue(ctx, consts.KeyCoreData, &common.CoreData{})
+	q := db.New(dbconn)
+	cd := common.NewCoreData(req.Context(), q)
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT w.idwriting")).


### PR DESCRIPTION
## Summary
- fix tests to supply `db.Queries` via `common.NewCoreData`
- adjust handler tests to include CoreData with queries
- update middleware role tests to use a CoreData instance

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687e3366e208832fb45ddb046dfc59a2