### PR TITLE
Fix middleware unit tests

### DIFF
--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -22,6 +22,7 @@ func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
+	SetDBPool(db, 0)
 	mock.MatchExpectationsInOrder(false)
 
 	mock.ExpectExec("INSERT INTO sessions").WithArgs("sessid", int32(1)).
@@ -62,6 +63,7 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
+	SetDBPool(db, 0)
 	mock.MatchExpectationsInOrder(false)
 
 	mock.ExpectExec("DELETE FROM sessions").WithArgs("sessid").


### PR DESCRIPTION
## Summary
- fix `TestCoreAdderMiddlewareUserRoles` and `TestCoreAdderMiddlewareAnonymous`
- ensure tests set database pool before invoking middleware

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./internal/middleware -run TestCoreAdderMiddleware -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687e3ae95d3c832fbdb2a1b30bbe6214