### PR TITLE
Fix goreleaser build path

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -3,6 +3,7 @@ project_name: goa4web
 builds:
   - id: goa4web
     binary: goa4web
+    main: ./cmd/goa4web
     env:
       - CGO_ENABLED=0
     goos: [linux, darwin, windows]


### PR DESCRIPTION
## Summary
- fix goreleaser build configuration to point to the real `main` package

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ec068af98832fa9943ab1b91376d7