### PR TITLE
Fix admin password reset email

### DIFF
--- a/handlers/auth/forgotPassword.go
+++ b/handlers/auth/forgotPassword.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -96,6 +97,7 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) {
 				}
 				evt.Data["reset"] = notif.PasswordResetInfo{Username: row.Username.String, Code: code}
 				evt.Data["ResetURL"] = cd.AbsoluteURL("/login?code=" + code)
+				evt.Data["UserURL"] = cd.AbsoluteURL(fmt.Sprintf("/admin/user/%d", row.Idusers))
 			}
 		}
 	}

--- a/handlers/auth/forgotPassword_event_test.go
+++ b/handlers/auth/forgotPassword_event_test.go
@@ -45,6 +45,9 @@ func TestForgotPasswordEventData(t *testing.T) {
 	if _, ok := evt.Data["ResetURL"]; !ok {
 		t.Fatalf("missing ResetURL data")
 	}
+	if _, ok := evt.Data["UserURL"]; !ok {
+		t.Fatalf("missing UserURL data")
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -24,6 +24,9 @@ func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
 	defer db.Close()
 	mock.MatchExpectationsInOrder(false)
 
+	SetDBPool(db, 0)
+	t.Cleanup(func() { SetDBPool(nil, 0) })
+
 	mock.ExpectExec("INSERT INTO sessions").WithArgs("sessid", int32(1)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	rows := sqlmock.NewRows([]string{"iduser_roles", "users_idusers", "name"}).
@@ -63,6 +66,9 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 	}
 	defer db.Close()
 	mock.MatchExpectationsInOrder(false)
+
+	SetDBPool(db, 0)
+	t.Cleanup(func() { SetDBPool(nil, 0) })
 
 	mock.ExpectExec("DELETE FROM sessions").WithArgs("sessid").
 		WillReturnResult(sqlmock.NewResult(0, 0))


### PR DESCRIPTION
## Summary
- include user profile link in password reset event data
- update tests to expect new field
- set DBPool in middleware tests to avoid nil panics

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687e3c5e12c0832f9a7789b21403ade4