### PR TITLE
Add user roles CLI summary

### DIFF
--- a/cmd/goa4web/templates/user_roles_usage.txt
+++ b/cmd/goa4web/templates/user_roles_usage.txt
@@ -1,0 +1,11 @@
+Usage:
+  {{.Prog}} user roles
+
+Description:
+  list usernames with their assigned roles
+
+Examples:
+  {{.Prog}} user roles
+
+Flags:
+{{template "flags" .Flags}}

--- a/cmd/goa4web/templates/user_usage.txt
+++ b/cmd/goa4web/templates/user_usage.txt
@@ -11,6 +11,7 @@ Commands:
   approve     approve a pending user
   reject      reject a pending user
   comments    manage admin comments for a user
+  roles       list user roles
   profile     show user profile information
 
 Examples:
@@ -20,6 +21,7 @@ Examples:
   {{.Prog}} user approve -id 3
   {{.Prog}} user reject -id 3 -reason spam
   {{.Prog}} user comments list -id 3
+  {{.Prog}} user roles
 
 Flags:
 {{template "flags" .Flags}}

--- a/cmd/goa4web/user.go
+++ b/cmd/goa4web/user.go
@@ -93,6 +93,12 @@ func (c *userCmd) Run() error {
 			return fmt.Errorf("comments: %w", err)
 		}
 		return cmd.Run()
+	case "roles":
+		cmd, err := parseUserRolesCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("roles: %w", err)
+		}
+		return cmd.Run()
 	case "profile":
 		cmd, err := parseUserProfileCmd(c, c.args[1:])
 		if err != nil {

--- a/cmd/goa4web/user_roles.go
+++ b/cmd/goa4web/user_roles.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	_ "embed"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+//go:embed templates/user_roles_usage.txt
+var userRolesUsageTemplate string
+
+// userRolesCmd implements "user roles".
+type userRolesCmd struct {
+	*userCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parseUserRolesCmd(parent *userCmd, args []string) (*userRolesCmd, error) {
+	c := &userRolesCmd{userCmd: parent}
+	fs := flag.NewFlagSet("roles", flag.ContinueOnError)
+	c.fs = fs
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *userRolesCmd) Run() error {
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	rows, err := queries.ListUsersWithRoles(ctx)
+	if err != nil {
+		return fmt.Errorf("list users with roles: %w", err)
+	}
+	for _, r := range rows {
+		roleList := ""
+		if r.Roles.Valid {
+			roleList = r.Roles.String
+		}
+		fmt.Printf("%s\t%s\n", r.Username.String, roleList)
+	}
+	return nil
+}
+
+func (c *userRolesCmd) Usage() {
+	executeUsage(c.fs.Output(), userRolesUsageTemplate, c.fs, c.rootCmd.fs.Name())
+}

--- a/internal/db/queries-permissions.sql
+++ b/internal/db/queries-permissions.sql
@@ -119,3 +119,10 @@ WHERE (sqlc.arg(username) = '' OR u.username = sqlc.arg(username));
 
 -- name: UpdatePermission :exec
 UPDATE user_roles SET role_id = (SELECT id FROM roles WHERE name = ?) WHERE iduser_roles = ?;
+-- name: ListUsersWithRoles :many
+SELECT u.idusers, u.username, GROUP_CONCAT(r.name ORDER BY r.name) AS roles
+FROM users u
+LEFT JOIN user_roles ur ON u.idusers = ur.users_idusers
+LEFT JOIN roles r ON r.id = ur.role_id
+GROUP BY u.idusers
+ORDER BY u.idusers;


### PR DESCRIPTION
## Summary
- add `user roles` command to print each user's role list
- document the new command in help text
- implement `ListUsersWithRoles` query to aggregate roles per user

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ec943b73c832fb7c0a7602d10ba71