### PR TITLE
Fix root usage output without subcommand

### DIFF
--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -121,14 +121,14 @@ func parseRoot(args []string) (*rootCmd, error) {
 		}
 		return nil, fmt.Errorf("load config file: %w", err)
 	}
-	fs := config.NewRuntimeFlagSet(args[0])
-	fs.StringVar(&cfgPath, "config-file", cfgPath, "path to config file")
-	fs.IntVar(&r.Verbosity, "verbosity", 0, "verbosity level")
-	_ = fs.Parse(args[1:])
-	r.fs = fs
-	r.args = fs.Args()
+	r.fs = config.NewRuntimeFlagSet(args[0])
+	r.fs.StringVar(&cfgPath, "config-file", cfgPath, "path to config file")
+	r.fs.IntVar(&r.Verbosity, "verbosity", 0, "verbosity level")
+	r.fs.Usage = r.Usage
+	_ = r.fs.Parse(args[1:])
+	r.args = r.fs.Args()
 	r.ConfigFile = cfgPath
-	r.cfg = config.GenerateRuntimeConfig(fs, fileVals, os.Getenv)
+	r.cfg = config.GenerateRuntimeConfig(r.fs, fileVals, os.Getenv)
 	return r, nil
 }
 

--- a/cmd/goa4web/templates/db_usage.txt
+++ b/cmd/goa4web/templates/db_usage.txt
@@ -1,0 +1,17 @@
+Usage:
+  {{.Prog}} db <command> [<args>]
+
+Commands:
+  migrate    run database migrations
+  backup     create a database backup
+  restore    restore a database backup
+  seed       load seed data
+
+Examples:
+  {{.Prog}} db migrate
+  {{.Prog}} db backup -o backup.sql
+  {{.Prog}} db restore -i backup.sql
+  {{.Prog}} db seed
+
+Flags:
+{{template "flags" .Flags}}


### PR DESCRIPTION
## Summary
- hook root flag set earlier to show subcommands
- add usage output for the `db` command

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ec9bd7e10832f9d2992586b793d71