### PR TITLE
Add CLI for clearing pending passwords

### DIFF
--- a/cmd/goa4web/help.go
+++ b/cmd/goa4web/help.go
@@ -165,6 +165,15 @@ func (c *helpCmd) showHelp(args []string) error {
 			_ = cmd.Run()
 		}
 		return nil
+	case "password":
+		cmd, err := parsePasswordCmd(c.rootCmd, append(args[1:], "-h"))
+		if err != nil && err != flag.ErrHelp {
+			return fmt.Errorf("password: %w", err)
+		}
+		if err == nil {
+			_ = cmd.Run()
+		}
+		return nil
 	case "config":
 		cmd, err := parseConfigCmd(c.rootCmd, append(args[1:], "-h"))
 		if err != nil && err != flag.ErrHelp {

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -156,6 +156,12 @@ func (r *rootCmd) Run() error {
 			return fmt.Errorf("user: %w", err)
 		}
 		return c.Run()
+	case "password":
+		c, err := parsePasswordCmd(r, r.args[1:])
+		if err != nil {
+			return fmt.Errorf("password: %w", err)
+		}
+		return c.Run()
 	case "email":
 		c, err := parseEmailCmd(r, r.args[1:])
 		if err != nil {

--- a/cmd/goa4web/password_clear_expired.go
+++ b/cmd/goa4web/password_clear_expired.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// passwordClearExpiredCmd implements "password clear-expired".
+type passwordClearExpiredCmd struct {
+	*passwordCmd
+	fs    *flag.FlagSet
+	Hours int
+	args  []string
+}
+
+func parsePasswordClearExpiredCmd(parent *passwordCmd, args []string) (*passwordClearExpiredCmd, error) {
+	c := &passwordClearExpiredCmd{passwordCmd: parent, Hours: 24}
+	fs := flag.NewFlagSet("clear-expired", flag.ContinueOnError)
+	fs.IntVar(&c.Hours, "hours", 24, "expiration age in hours")
+	c.fs = fs
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *passwordClearExpiredCmd) Run() error {
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	expiry := time.Now().Add(-time.Duration(c.Hours) * time.Hour)
+	if err := queries.PurgePasswordResetsBefore(ctx, expiry); err != nil {
+		return fmt.Errorf("clear expired: %w", err)
+	}
+	return nil
+}

--- a/cmd/goa4web/password_clear_user.go
+++ b/cmd/goa4web/password_clear_user.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// passwordClearUserCmd implements "password clear-user".
+type passwordClearUserCmd struct {
+	*passwordCmd
+	fs       *flag.FlagSet
+	Username string
+	args     []string
+}
+
+func parsePasswordClearUserCmd(parent *passwordCmd, args []string) (*passwordClearUserCmd, error) {
+	c := &passwordClearUserCmd{passwordCmd: parent}
+	fs := flag.NewFlagSet("clear-user", flag.ContinueOnError)
+	fs.StringVar(&c.Username, "username", "", "username")
+	c.fs = fs
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *passwordClearUserCmd) Run() error {
+	if c.Username == "" {
+		return fmt.Errorf("username required")
+	}
+	db, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := dbpkg.New(db)
+	user, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+	if err != nil {
+		return fmt.Errorf("get user: %w", err)
+	}
+	if err := queries.DeletePasswordResetsByUser(ctx, user.Idusers); err != nil {
+		return fmt.Errorf("delete resets: %w", err)
+	}
+	return nil
+}

--- a/cmd/goa4web/password_cmd.go
+++ b/cmd/goa4web/password_cmd.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	_ "embed"
+	"flag"
+	"fmt"
+)
+
+//go:embed templates/password_usage.txt
+var passwordUsageTemplate string
+
+// passwordCmd handles pending password operations.
+type passwordCmd struct {
+	*rootCmd
+	fs   *flag.FlagSet
+	args []string
+}
+
+func parsePasswordCmd(parent *rootCmd, args []string) (*passwordCmd, error) {
+	c := &passwordCmd{rootCmd: parent}
+	fs := flag.NewFlagSet("password", flag.ContinueOnError)
+	c.fs = fs
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *passwordCmd) Run() error {
+	if len(c.args) == 0 {
+		c.fs.Usage()
+		return fmt.Errorf("missing password command")
+	}
+	switch c.args[0] {
+	case "clear-expired":
+		cmd, err := parsePasswordClearExpiredCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("clear-expired: %w", err)
+		}
+		return cmd.Run()
+	case "clear-user":
+		cmd, err := parsePasswordClearUserCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("clear-user: %w", err)
+		}
+		return cmd.Run()
+	default:
+		c.fs.Usage()
+		return fmt.Errorf("unknown password command %q", c.args[0])
+	}
+}
+
+// Usage prints command usage information with examples.
+func (c *passwordCmd) Usage() {
+	executeUsage(c.fs.Output(), passwordUsageTemplate, c.fs, c.rootCmd.fs.Name())
+}

--- a/cmd/goa4web/templates/password_usage.txt
+++ b/cmd/goa4web/templates/password_usage.txt
@@ -1,0 +1,13 @@
+Usage:
+  {{.Prog}} password <command> [<args>]
+
+Commands:
+  clear-expired delete expired pending password resets
+  clear-user    delete pending password resets for a user
+
+Examples:
+  {{.Prog}} password clear-expired
+  {{.Prog}} password clear-user -username bob
+
+Flags:
+{{template "flags" .Flags}}

--- a/cmd/goa4web/templates/root_usage.txt
+++ b/cmd/goa4web/templates/root_usage.txt
@@ -16,6 +16,7 @@ Commands:
   db      manage database
   lang    manage languages
   server  manage the running server
+  password manage pending password resets
   email   manage emails
   config  manage configuration
 

--- a/internal/db/queries-password_resets.sql
+++ b/internal/db/queries-password_resets.sql
@@ -19,3 +19,10 @@ UPDATE pending_passwords SET verified_at = NOW() WHERE id = ?;
 
 -- name: DeletePasswordReset :exec
 DELETE FROM pending_passwords WHERE id = ?;
+
+-- name: DeletePasswordResetsByUser :exec
+DELETE FROM pending_passwords WHERE user_id = ?;
+
+-- name: PurgePasswordResetsBefore :exec
+DELETE FROM pending_passwords
+WHERE created_at < ? OR verified_at IS NOT NULL;

--- a/internal/db/queries-password_resets.sql.go
+++ b/internal/db/queries-password_resets.sql.go
@@ -7,6 +7,7 @@ package db
 
 import (
 	"context"
+	"time"
 )
 
 const createPasswordReset = `-- name: CreatePasswordReset :exec
@@ -37,6 +38,15 @@ DELETE FROM pending_passwords WHERE id = ?
 
 func (q *Queries) DeletePasswordReset(ctx context.Context, id int32) error {
 	_, err := q.db.ExecContext(ctx, deletePasswordReset, id)
+	return err
+}
+
+const deletePasswordResetsByUser = `-- name: DeletePasswordResetsByUser :exec
+DELETE FROM pending_passwords WHERE user_id = ?
+`
+
+func (q *Queries) DeletePasswordResetsByUser(ctx context.Context, userID int32) error {
+	_, err := q.db.ExecContext(ctx, deletePasswordResetsByUser, userID)
 	return err
 }
 
@@ -90,5 +100,15 @@ UPDATE pending_passwords SET verified_at = NOW() WHERE id = ?
 
 func (q *Queries) MarkPasswordResetVerified(ctx context.Context, id int32) error {
 	_, err := q.db.ExecContext(ctx, markPasswordResetVerified, id)
+	return err
+}
+
+const purgePasswordResetsBefore = `-- name: PurgePasswordResetsBefore :exec
+DELETE FROM pending_passwords
+WHERE created_at < ? OR verified_at IS NOT NULL
+`
+
+func (q *Queries) PurgePasswordResetsBefore(ctx context.Context, createdAt time.Time) error {
+	_, err := q.db.ExecContext(ctx, purgePasswordResetsBefore, createdAt)
 	return err
 }


### PR DESCRIPTION
## Summary
- support clearing pending passwords for single users or all expired
- expose new `password` command in help and usage
- document usage for the new command
- generate sqlc methods for deleting password resets

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ed4bc04d8832f992b6916191ee4a4