### PR TITLE
Fix email templates to reference item fields

### DIFF
--- a/core/templates/email/adminNotificationBlogAddEmail.gohtml
+++ b/core/templates/email/adminNotificationBlogAddEmail.gohtml
@@ -1,4 +1,4 @@
 <p>User {{.Item.Username}} added a new blog post.</p>
 
-<p><a href="{{.PostURL}}">View post</a></p>
+<p><a href="{{.Item.PostURL}}">View post</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationBlogAddEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogAddEmail.gotxt
@@ -1,5 +1,5 @@
 User {{.Item.Username}} added a new blog post.
 
 View post:
-{{.PostURL}}
+{{.Item.PostURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationBlogCommentCancelEmail.gohtml
+++ b/core/templates/email/adminNotificationBlogCommentCancelEmail.gohtml
@@ -1,5 +1,5 @@
 <p>User {{.Item.Username}} canceled editing a blog comment.</p>
 
 
-<p><a href="{{.CommentURL}}">View comment</a></p>
+<p><a href="{{.Item.CommentURL}}">View comment</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationBlogCommentCancelEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogCommentCancelEmail.gotxt
@@ -1,6 +1,6 @@
 User {{.Item.Username}} canceled editing a blog comment.
 
 View comment:
-{{.CommentURL}}
+{{.Item.CommentURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogCommentEditEmail.gohtml
+++ b/core/templates/email/adminNotificationBlogCommentEditEmail.gohtml
@@ -1,5 +1,5 @@
 <p>User {{.Item.Username}} edited a blog comment.</p>
 
 
-<p><a href="{{.CommentURL}}">View comment</a></p>
+<p><a href="{{.Item.CommentURL}}">View comment</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationBlogCommentEditEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogCommentEditEmail.gotxt
@@ -1,6 +1,6 @@
 User {{.Item.Username}} edited a blog comment.
 
 View comment:
-{{.CommentURL}}
+{{.Item.CommentURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogEditEmail.gohtml
+++ b/core/templates/email/adminNotificationBlogEditEmail.gohtml
@@ -1,5 +1,5 @@
 <p>User {{.Item.Username}} edited a blog post.</p>
 
 
-<p><a href="{{.PostURL}}">View post</a></p>
+<p><a href="{{.Item.PostURL}}">View post</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationBlogEditEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogEditEmail.gotxt
@@ -1,6 +1,6 @@
 User {{.Item.Username}} edited a blog post.
 
 View post:
-{{.PostURL}}
+{{.Item.PostURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogReplyEmail.gohtml
+++ b/core/templates/email/adminNotificationBlogReplyEmail.gohtml
@@ -1,5 +1,5 @@
 <p>User {{.Item.Username}} replied to a blog post.</p>
 
 
-<p><a href="{{.PostURL}}">View post</a></p>
+<p><a href="{{.Item.PostURL}}">View post</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationBlogReplyEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogReplyEmail.gotxt
@@ -1,6 +1,6 @@
 User {{.Item.Username}} replied to a blog post.
 
 View post:
-{{.PostURL}}
+{{.Item.PostURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogUserAllowEmail.gohtml
+++ b/core/templates/email/adminNotificationBlogUserAllowEmail.gohtml
@@ -1,5 +1,5 @@
 <p>User {{.Item.Username}} granted blog permissions.</p>
 
 
-<p><a href="{{.BlogURL}}">Blog section</a></p>
+<p><a href="{{.Item.BlogURL}}">Blog section</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationBlogUserAllowEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogUserAllowEmail.gotxt
@@ -1,6 +1,6 @@
 User {{.Item.Username}} granted blog permissions.
 
 Blog section:
-{{.BlogURL}}
+{{.Item.BlogURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogUserDisallowEmail.gohtml
+++ b/core/templates/email/adminNotificationBlogUserDisallowEmail.gohtml
@@ -1,5 +1,5 @@
 <p>User {{.Item.Username}} revoked blog permissions.</p>
 
 
-<p><a href="{{.BlogURL}}">Blog section</a></p>
+<p><a href="{{.Item.BlogURL}}">Blog section</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationBlogUserDisallowEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogUserDisallowEmail.gotxt
@@ -1,6 +1,6 @@
 User {{.Item.Username}} revoked blog permissions.
 
 Blog section:
-{{.BlogURL}}
+{{.Item.BlogURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogUsersAllowEmail.gohtml
+++ b/core/templates/email/adminNotificationBlogUsersAllowEmail.gohtml
@@ -1,5 +1,5 @@
 <p>Multiple users were granted blog permissions.</p>
 
 
-<p><a href="{{.BlogURL}}">Blog section</a></p>
+<p><a href="{{.Item.BlogURL}}">Blog section</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationBlogUsersAllowEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogUsersAllowEmail.gotxt
@@ -1,6 +1,6 @@
 Multiple users were granted blog permissions.
 
 Blog section:
-{{.BlogURL}}
+{{.Item.BlogURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogUsersDisallowEmail.gohtml
+++ b/core/templates/email/adminNotificationBlogUsersDisallowEmail.gohtml
@@ -1,5 +1,5 @@
 <p>Multiple users had blog permissions revoked.</p>
 
 
-<p><a href="{{.BlogURL}}">Blog section</a></p>
+<p><a href="{{.Item.BlogURL}}">Blog section</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationBlogUsersDisallowEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogUsersDisallowEmail.gotxt
@@ -1,6 +1,6 @@
 Multiple users had blog permissions revoked.
 
 Blog section:
-{{.BlogURL}}
+{{.Item.BlogURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationFaqAskEmail.gohtml
+++ b/core/templates/email/adminNotificationFaqAskEmail.gohtml
@@ -1,3 +1,3 @@
 <p>New FAQ question submitted.</p>
-<p>{{.Question}}</p>
+<p>{{.Item.Question}}</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationFaqAskEmail.gotxt
+++ b/core/templates/email/adminNotificationFaqAskEmail.gotxt
@@ -1,4 +1,4 @@
 New FAQ question submitted.
 
-{{.Question}}
+{{.Item.Question}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationForumReplyEmail.gohtml
+++ b/core/templates/email/adminNotificationForumReplyEmail.gohtml
@@ -1,4 +1,4 @@
 <p>User {{.Item.Username}} replied to a forum thread.</p>
 
-<p><a href="{{.CommentURL}}">View comment</a></p>
+<p><a href="{{.Item.CommentURL}}">View comment</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationForumReplyEmail.gotxt
+++ b/core/templates/email/adminNotificationForumReplyEmail.gotxt
@@ -1,5 +1,5 @@
 User {{.Item.Username}} replied to a forum thread.
 
 View comment:
-{{.CommentURL}}
+{{.Item.CommentURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationForumThreadCreateEmail.gohtml
+++ b/core/templates/email/adminNotificationForumThreadCreateEmail.gohtml
@@ -1,4 +1,4 @@
 <p>User {{.Item.Username}} created a new forum thread.</p>
 
-<p><a href="{{.ThreadURL}}">View thread</a></p>
+<p><a href="{{.Item.ThreadURL}}">View thread</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationForumThreadCreateEmail.gotxt
+++ b/core/templates/email/adminNotificationForumThreadCreateEmail.gotxt
@@ -1,5 +1,5 @@
 User {{.Item.Username}} created a new forum thread.
 
 View thread:
-{{.ThreadURL}}
+{{.Item.ThreadURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationImageBoardNewEmail.gohtml
+++ b/core/templates/email/adminNotificationImageBoardNewEmail.gohtml
@@ -1,3 +1,3 @@
 <p>User {{.Item.Username}} created a new image board.</p>
-<p><a href="{{.BoardURL}}">View board</a></p>
+<p><a href="{{.Item.BoardURL}}">View board</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationImageBoardNewEmail.gotxt
+++ b/core/templates/email/adminNotificationImageBoardNewEmail.gotxt
@@ -1,5 +1,5 @@
 User {{.Item.Username}} created a new image board.
 
 Board link:
-{{.BoardURL}}
+{{.Item.BoardURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationLanguageCreateEmail.gohtml
+++ b/core/templates/email/adminNotificationLanguageCreateEmail.gohtml
@@ -1,4 +1,4 @@
-<p>User {{.Item.Username}} created a new language {{.LanguageName}} (ID {{.LanguageID}}).</p>
+<p>User {{.Item.Username}} created a new language {{.Item.LanguageName}} (ID {{.Item.LanguageID}}).</p>
 
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/adminNotificationLanguageCreateEmail.gotxt
+++ b/core/templates/email/adminNotificationLanguageCreateEmail.gotxt
@@ -1,4 +1,4 @@
-User {{.Item.Username}} created a new language {{.LanguageName}} (ID {{.LanguageID}}).
+User {{.Item.Username}} created a new language {{.Item.LanguageName}} (ID {{.Item.LanguageID}}).
 
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationLanguageDeleteEmail.gohtml
+++ b/core/templates/email/adminNotificationLanguageDeleteEmail.gohtml
@@ -1,4 +1,4 @@
-<p>User {{.Item.Username}} deleted language {{.LanguageName}} (ID {{.LanguageID}}).</p>
+<p>User {{.Item.Username}} deleted language {{.Item.LanguageName}} (ID {{.Item.LanguageID}}).</p>
 
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/adminNotificationLanguageDeleteEmail.gotxt
+++ b/core/templates/email/adminNotificationLanguageDeleteEmail.gotxt
@@ -1,4 +1,4 @@
-User {{.Item.Username}} deleted language {{.LanguageName}} (ID {{.LanguageID}}).
+User {{.Item.Username}} deleted language {{.Item.LanguageName}} (ID {{.Item.LanguageID}}).
 
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationLanguageRenameEmail.gohtml
+++ b/core/templates/email/adminNotificationLanguageRenameEmail.gohtml
@@ -1,4 +1,4 @@
-<p>User {{.Item.Username}} renamed language {{.LanguageID}} to {{.LanguageName}}.</p>
+<p>User {{.Item.Username}} renamed language {{.Item.LanguageID}} to {{.Item.LanguageName}}.</p>
 
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/adminNotificationLanguageRenameEmail.gotxt
+++ b/core/templates/email/adminNotificationLanguageRenameEmail.gotxt
@@ -1,4 +1,4 @@
-User {{.Item.Username}} renamed language {{.LanguageID}} to {{.LanguageName}}.
+User {{.Item.Username}} renamed language {{.Item.LanguageID}} to {{.Item.LanguageName}}.
 
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationLinkerAddEmail.gohtml
+++ b/core/templates/email/adminNotificationLinkerAddEmail.gohtml
@@ -1,4 +1,4 @@
 <p>User {{.Item.Username}} added a new link.</p>
 
-<p><a href="{{.LinkURL}}">View link</a></p>
+<p><a href="{{.Item.LinkURL}}">View link</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationLinkerAddEmail.gotxt
+++ b/core/templates/email/adminNotificationLinkerAddEmail.gotxt
@@ -1,5 +1,5 @@
 User {{.Item.Username}} added a new link.
 
 View link:
-{{.LinkURL}}
+{{.Item.LinkURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationLinkerApprovedEmail.gohtml
+++ b/core/templates/email/adminNotificationLinkerApprovedEmail.gohtml
@@ -1,3 +1,3 @@
 <p>Moderator {{.Item.Moderator}} approved the link "{{.Item.Title}}".</p>
-<p><a href="{{.LinkURL}}">View link</a></p>
-<p><a href="{{.UnsubURL}}">Manage notifications</a></p>
+<p><a href="{{.Item.LinkURL}}">View link</a></p>
+<p><a href="{{.Item.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationLinkerApprovedEmail.gotxt
+++ b/core/templates/email/adminNotificationLinkerApprovedEmail.gotxt
@@ -1,5 +1,5 @@
 Moderator {{.Item.Moderator}} approved the link "{{.Item.Title}}".
 
 View link:
-{{.LinkURL}}
-Manage notifications: {{.UnsubURL}}
+{{.Item.LinkURL}}
+Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/adminNotificationLinkerRejectedEmail.gohtml
+++ b/core/templates/email/adminNotificationLinkerRejectedEmail.gohtml
@@ -1,3 +1,3 @@
 <p>Moderator {{.Item.Moderator}} rejected the link "{{.Item.Title}}".</p>
-<p><a href="{{.LinkURL}}">View link</a></p>
-<p><a href="{{.UnsubURL}}">Manage notifications</a></p>
+<p><a href="{{.Item.LinkURL}}">View link</a></p>
+<p><a href="{{.Item.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationLinkerRejectedEmail.gotxt
+++ b/core/templates/email/adminNotificationLinkerRejectedEmail.gotxt
@@ -1,5 +1,5 @@
 Moderator {{.Item.Moderator}} rejected the link "{{.Item.Title}}".
 
 View link:
-{{.LinkURL}}
-Manage notifications: {{.UnsubURL}}
+{{.Item.LinkURL}}
+Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/adminNotificationNewsAddEmail.gohtml
+++ b/core/templates/email/adminNotificationNewsAddEmail.gohtml
@@ -1,5 +1,5 @@
 <p>User {{.Item.Username}} added a news post.</p>
 
-<p><a href="{{.PostURL}}">View post</a></p>
+<p><a href="{{.Item.PostURL}}">View post</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/adminNotificationNewsAddEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsAddEmail.gotxt
@@ -1,6 +1,6 @@
 User {{.Item.Username}} added a news post.
 
 View post:
-{{.PostURL}}
+{{.Item.PostURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsCommentCancelEmail.gohtml
+++ b/core/templates/email/adminNotificationNewsCommentCancelEmail.gohtml
@@ -1,5 +1,5 @@
 <p>Comment edit cancelled by {{.Item.Username}}.</p>
 
-<p><a href="{{.CommentURL}}">View comment</a></p>
+<p><a href="{{.Item.CommentURL}}">View comment</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/adminNotificationNewsCommentCancelEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsCommentCancelEmail.gotxt
@@ -1,6 +1,6 @@
 Comment edit cancelled by {{.Item.Username}}.
 
 View comment:
-{{.CommentURL}}
+{{.Item.CommentURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsCommentEditEmail.gohtml
+++ b/core/templates/email/adminNotificationNewsCommentEditEmail.gohtml
@@ -1,5 +1,5 @@
 <p>Comment edited by {{.Item.Username}}.</p>
 
-<p><a href="{{.CommentURL}}">View comment</a></p>
+<p><a href="{{.Item.CommentURL}}">View comment</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/adminNotificationNewsCommentEditEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsCommentEditEmail.gotxt
@@ -1,6 +1,6 @@
 Comment edited by {{.Item.Username}}.
 
 View comment:
-{{.CommentURL}}
+{{.Item.CommentURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsDeleteEmail.gohtml
+++ b/core/templates/email/adminNotificationNewsDeleteEmail.gohtml
@@ -1,5 +1,5 @@
 <p>Announcement removed by {{.Item.Username}}.</p>
 
-<p><a href="{{.PostURL}}">View post</a></p>
+<p><a href="{{.Item.PostURL}}">View post</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/adminNotificationNewsDeleteEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsDeleteEmail.gotxt
@@ -1,6 +1,6 @@
 Announcement removed by {{.Item.Username}}.
 
 View post:
-{{.PostURL}}
+{{.Item.PostURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsEditEmail.gohtml
+++ b/core/templates/email/adminNotificationNewsEditEmail.gohtml
@@ -1,5 +1,5 @@
 <p>News post edited by {{.Item.Username}}.</p>
 
-<p><a href="{{.PostURL}}">View post</a></p>
+<p><a href="{{.Item.PostURL}}">View post</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/adminNotificationNewsEditEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsEditEmail.gotxt
@@ -1,6 +1,6 @@
 News post edited by {{.Item.Username}}.
 
 View post:
-{{.PostURL}}
+{{.Item.PostURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsReplyEmail.gohtml
+++ b/core/templates/email/adminNotificationNewsReplyEmail.gohtml
@@ -1,5 +1,5 @@
 <p>User {{.Item.Username}} replied to a news post.</p>
 
-<p><a href="{{.PostURL}}">View post</a></p>
+<p><a href="{{.Item.PostURL}}">View post</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/adminNotificationNewsReplyEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsReplyEmail.gotxt
@@ -1,6 +1,6 @@
 User {{.Item.Username}} replied to a news post.
 
 View post:
-{{.PostURL}}
+{{.Item.PostURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsUserAllowEmail.gohtml
+++ b/core/templates/email/adminNotificationNewsUserAllowEmail.gohtml
@@ -1,5 +1,5 @@
 <p>User {{.Item.Username}} was granted news permissions.</p>
 
-<p><a href="{{.UserPermissionsURL}}">Permissions</a></p>
+<p><a href="{{.Item.UserPermissionsURL}}">Permissions</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/adminNotificationNewsUserAllowEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsUserAllowEmail.gotxt
@@ -1,6 +1,6 @@
 User {{.Item.Username}} was granted news permissions.
 
 Permissions:
-{{.UserPermissionsURL}}
+{{.Item.UserPermissionsURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsUserDisallowEmail.gohtml
+++ b/core/templates/email/adminNotificationNewsUserDisallowEmail.gohtml
@@ -1,5 +1,5 @@
 <p>User {{.Item.Username}} had news permissions revoked.</p>
 
-<p><a href="{{.UserPermissionsURL}}">Permissions</a></p>
+<p><a href="{{.Item.UserPermissionsURL}}">Permissions</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/adminNotificationNewsUserDisallowEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsUserDisallowEmail.gotxt
@@ -1,6 +1,6 @@
 User {{.Item.Username}} had news permissions revoked.
 
 Permissions:
-{{.UserPermissionsURL}}
+{{.Item.UserPermissionsURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationUserRequestPasswordResetEmail.gohtml
+++ b/core/templates/email/adminNotificationUserRequestPasswordResetEmail.gohtml
@@ -1,5 +1,5 @@
 <p>Hi the user {{.Item.Username}},</p>
 <p>Is attempting a password reset.</p>
 
-<p><a href="{{.UserURL}}">User page</a></p>
+<p><a href="{{.Item.UserURL}}">User page</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationUserRequestPasswordResetEmail.gotxt
+++ b/core/templates/email/adminNotificationUserRequestPasswordResetEmail.gotxt
@@ -2,5 +2,5 @@ Hi the user {{.Item.Username}},
 Is attempting a password reset.
 
 User page:
-{{.UserURL}}
+{{.Item.UserURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminPermissionAllowEmail.gohtml
+++ b/core/templates/email/adminPermissionAllowEmail.gohtml
@@ -1,2 +1,2 @@
 <p>User {{.Item.Username}} granted the {{.Item.Permission}} permission.</p>
-<p><a href="{{.UnsubURL}}">Manage notifications</a></p>
+<p><a href="{{.Item.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/adminPermissionAllowEmail.gotxt
+++ b/core/templates/email/adminPermissionAllowEmail.gotxt
@@ -1,3 +1,3 @@
 User {{.Item.Username}} granted the {{.Item.Permission}} permission.
 
-Manage notifications: {{.UnsubURL}}
+Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/adminPermissionDisallowEmail.gohtml
+++ b/core/templates/email/adminPermissionDisallowEmail.gohtml
@@ -1,2 +1,2 @@
 <p>User {{.Item.Username}} revoked the {{.Item.Permission}} permission.</p>
-<p><a href="{{.UnsubURL}}">Manage notifications</a></p>
+<p><a href="{{.Item.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/adminPermissionDisallowEmail.gotxt
+++ b/core/templates/email/adminPermissionDisallowEmail.gotxt
@@ -1,3 +1,3 @@
 User {{.Item.Username}} revoked the {{.Item.Permission}} permission.
 
-Manage notifications: {{.UnsubURL}}
+Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/blogAddEmail.gohtml
+++ b/core/templates/email/blogAddEmail.gohtml
@@ -1,5 +1,5 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your blog post has been created successfully.</p>
 
-<p><a href="{{.PostURL}}">View post</a></p>
+<p><a href="{{.Item.PostURL}}">View post</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/blogAddEmail.gotxt
+++ b/core/templates/email/blogAddEmail.gotxt
@@ -2,5 +2,5 @@ Hi {{.Item.Username}},
 Your blog post has been created successfully.
 
 View post:
-{{.PostURL}}
+{{.Item.PostURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/blogCommentCancelEmail.gohtml
+++ b/core/templates/email/blogCommentCancelEmail.gohtml
@@ -2,5 +2,5 @@
 <p>Your comment edit was canceled.</p>
 
 
-<p><a href="{{.CommentURL}}">View comment</a></p>
+<p><a href="{{.Item.CommentURL}}">View comment</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/blogCommentCancelEmail.gotxt
+++ b/core/templates/email/blogCommentCancelEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 Your comment edit was canceled.
 
 View comment:
-{{.CommentURL}}
+{{.Item.CommentURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogCommentEditEmail.gohtml
+++ b/core/templates/email/blogCommentEditEmail.gohtml
@@ -2,5 +2,5 @@
 <p>Your comment has been updated.</p>
 
 
-<p><a href="{{.CommentURL}}">View comment</a></p>
+<p><a href="{{.Item.CommentURL}}">View comment</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/blogCommentEditEmail.gotxt
+++ b/core/templates/email/blogCommentEditEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 Your comment has been updated.
 
 View comment:
-{{.CommentURL}}
+{{.Item.CommentURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogEditEmail.gohtml
+++ b/core/templates/email/blogEditEmail.gohtml
@@ -2,5 +2,5 @@
 <p>Your blog post has been updated successfully.</p>
 
 
-<p><a href="{{.PostURL}}">View post</a></p>
+<p><a href="{{.Item.PostURL}}">View post</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/blogEditEmail.gotxt
+++ b/core/templates/email/blogEditEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 Your blog post has been updated successfully.
 
 View post:
-{{.PostURL}}
+{{.Item.PostURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogReplyEmail.gohtml
+++ b/core/templates/email/blogReplyEmail.gohtml
@@ -2,5 +2,5 @@
 <p>Your comment has been posted.</p>
 
 
-<p><a href="{{.CommentURL}}">View comment</a></p>
+<p><a href="{{.Item.CommentURL}}">View comment</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/blogReplyEmail.gotxt
+++ b/core/templates/email/blogReplyEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 Your comment has been posted.
 
 View comment:
-{{.CommentURL}}
+{{.Item.CommentURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogUserAllowEmail.gohtml
+++ b/core/templates/email/blogUserAllowEmail.gohtml
@@ -2,5 +2,5 @@
 <p>You have been granted blog permissions.</p>
 
 
-<p><a href="{{.BlogURL}}">Blog section</a></p>
+<p><a href="{{.Item.BlogURL}}">Blog section</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/blogUserAllowEmail.gotxt
+++ b/core/templates/email/blogUserAllowEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 You have been granted blog permissions.
 
 Blog section:
-{{.BlogURL}}
+{{.Item.BlogURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogUserDisallowEmail.gohtml
+++ b/core/templates/email/blogUserDisallowEmail.gohtml
@@ -2,5 +2,5 @@
 <p>Your blog permissions were revoked.</p>
 
 
-<p><a href="{{.BlogURL}}">Blog section</a></p>
+<p><a href="{{.Item.BlogURL}}">Blog section</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/blogUserDisallowEmail.gotxt
+++ b/core/templates/email/blogUserDisallowEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 Your blog permissions were revoked.
 
 Blog section:
-{{.BlogURL}}
+{{.Item.BlogURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogUsersAllowEmail.gohtml
+++ b/core/templates/email/blogUsersAllowEmail.gohtml
@@ -2,5 +2,5 @@
 <p>Multiple users have been granted blog permissions.</p>
 
 
-<p><a href="{{.BlogURL}}">Blog section</a></p>
+<p><a href="{{.Item.BlogURL}}">Blog section</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/blogUsersAllowEmail.gotxt
+++ b/core/templates/email/blogUsersAllowEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 Multiple users have been granted blog permissions.
 
 Blog section:
-{{.BlogURL}}
+{{.Item.BlogURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogUsersDisallowEmail.gohtml
+++ b/core/templates/email/blogUsersDisallowEmail.gohtml
@@ -2,5 +2,5 @@
 <p>Multiple users had blog permissions revoked.</p>
 
 
-<p><a href="{{.BlogURL}}">Blog section</a></p>
+<p><a href="{{.Item.BlogURL}}">Blog section</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/blogUsersDisallowEmail.gotxt
+++ b/core/templates/email/blogUsersDisallowEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 Multiple users had blog permissions revoked.
 
 Blog section:
-{{.BlogURL}}
+{{.Item.BlogURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/deleteUserRoleEmail.gohtml
+++ b/core/templates/email/deleteUserRoleEmail.gohtml
@@ -1,3 +1,3 @@
 <p>Hi {{.Item.Username}},</p>
 <p>The "{{.Item.Role}}" role has been removed from your account.</p>
-<p><a href="{{.UnsubURL}}">Manage notifications</a></p>
+<p><a href="{{.Item.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/deleteUserRoleEmail.gotxt
+++ b/core/templates/email/deleteUserRoleEmail.gotxt
@@ -1,4 +1,4 @@
 Hi {{.Item.Username}},
 The "{{.Item.Role}}" role has been removed from your account.
 
-Manage notifications: {{.UnsubURL}}
+Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/forumReplyEmail.gohtml
+++ b/core/templates/email/forumReplyEmail.gohtml
@@ -1,5 +1,5 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your reply has been posted.</p>
 
-<p><a href="{{.CommentURL}}">View comment</a></p>
+<p><a href="{{.Item.CommentURL}}">View comment</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/forumReplyEmail.gotxt
+++ b/core/templates/email/forumReplyEmail.gotxt
@@ -2,5 +2,5 @@ Hi {{.Item.Username}},
 Your reply has been posted.
 
 View comment:
-{{.CommentURL}}
+{{.Item.CommentURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/forumThreadCreateEmail.gohtml
+++ b/core/templates/email/forumThreadCreateEmail.gohtml
@@ -1,5 +1,5 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your forum thread has been created successfully.</p>
 
-<p><a href="{{.ThreadURL}}">View thread</a></p>
+<p><a href="{{.Item.ThreadURL}}">View thread</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/forumThreadCreateEmail.gotxt
+++ b/core/templates/email/forumThreadCreateEmail.gotxt
@@ -2,5 +2,5 @@ Hi {{.Item.Username}},
 Your forum thread has been created successfully.
 
 View thread:
-{{.ThreadURL}}
+{{.Item.ThreadURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/imageBoardNewEmail.gohtml
+++ b/core/templates/email/imageBoardNewEmail.gohtml
@@ -1,3 +1,3 @@
 <p>A new image board "{{.Item.Title.String}}" has been created.</p>
-<p><a href="{{.BoardURL}}">View board</a></p>
+<p><a href="{{.Item.BoardURL}}">View board</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/imageBoardNewEmail.gotxt
+++ b/core/templates/email/imageBoardNewEmail.gotxt
@@ -1,5 +1,5 @@
 A new image board "{{.Item.Title.String}}" has been created.
 
 Board link:
-{{.BoardURL}}
+{{.Item.BoardURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/imagePostApprovedEmail.gohtml
+++ b/core/templates/email/imagePostApprovedEmail.gohtml
@@ -1,5 +1,5 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your image post has been approved.</p>
 
-<p><a href="{{.PostURL}}">View post</a></p>
+<p><a href="{{.Item.PostURL}}">View post</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/imagePostApprovedEmail.gotxt
+++ b/core/templates/email/imagePostApprovedEmail.gotxt
@@ -2,5 +2,5 @@ Hi {{.Item.Username}},
 Your image post has been approved.
 
 View post:
-{{.PostURL}}
+{{.Item.PostURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/linkerAddEmail.gohtml
+++ b/core/templates/email/linkerAddEmail.gohtml
@@ -1,5 +1,5 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your link has been submitted successfully.</p>
 
-<p><a href="{{.LinkURL}}">View link</a></p>
+<p><a href="{{.Item.LinkURL}}">View link</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/linkerAddEmail.gotxt
+++ b/core/templates/email/linkerAddEmail.gotxt
@@ -2,5 +2,5 @@ Hi {{.Item.Username}},
 Your link has been submitted successfully.
 
 View link:
-{{.LinkURL}}
+{{.Item.LinkURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/linkerApprovedEmail.gohtml
+++ b/core/templates/email/linkerApprovedEmail.gohtml
@@ -1,4 +1,4 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your link "{{.Item.Title}}" has been approved by {{.Item.Moderator}}.</p>
-<p><a href="{{.LinkURL}}">View link</a></p>
-<p><a href="{{.UnsubURL}}">Manage notifications</a></p>
+<p><a href="{{.Item.LinkURL}}">View link</a></p>
+<p><a href="{{.Item.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/linkerApprovedEmail.gotxt
+++ b/core/templates/email/linkerApprovedEmail.gotxt
@@ -2,5 +2,5 @@ Hi {{.Item.Username}},
 Your link "{{.Item.Title}}" has been approved by {{.Item.Moderator}}.
 
 View link:
-{{.LinkURL}}
-Manage notifications: {{.UnsubURL}}
+{{.Item.LinkURL}}
+Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/linkerRejectedEmail.gohtml
+++ b/core/templates/email/linkerRejectedEmail.gohtml
@@ -1,4 +1,4 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your link "{{.Item.Title}}" was rejected by {{.Item.Moderator}}.</p>
-<p><a href="{{.LinkURL}}">View link</a></p>
-<p><a href="{{.UnsubURL}}">Manage notifications</a></p>
+<p><a href="{{.Item.LinkURL}}">View link</a></p>
+<p><a href="{{.Item.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/linkerRejectedEmail.gotxt
+++ b/core/templates/email/linkerRejectedEmail.gotxt
@@ -2,5 +2,5 @@ Hi {{.Item.Username}},
 Your link "{{.Item.Title}}" was rejected by {{.Item.Moderator}}.
 
 View link:
-{{.LinkURL}}
-Manage notifications: {{.UnsubURL}}
+{{.Item.LinkURL}}
+Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/newsAddEmail.gohtml
+++ b/core/templates/email/newsAddEmail.gohtml
@@ -1,6 +1,6 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your news post has been created.</p>
 
-<p><a href="{{.PostURL}}">View post</a></p>
+<p><a href="{{.Item.PostURL}}">View post</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/newsAddEmail.gotxt
+++ b/core/templates/email/newsAddEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 Your news post has been created.
 
 View post:
-{{.PostURL}}
+{{.Item.PostURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/newsCommentCancelEmail.gohtml
+++ b/core/templates/email/newsCommentCancelEmail.gohtml
@@ -1,6 +1,6 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your comment edit was cancelled.</p>
 
-<p><a href="{{.CommentURL}}">View comment</a></p>
+<p><a href="{{.Item.CommentURL}}">View comment</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/newsCommentCancelEmail.gotxt
+++ b/core/templates/email/newsCommentCancelEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 Your comment edit was cancelled.
 
 View comment:
-{{.CommentURL}}
+{{.Item.CommentURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/newsCommentEditEmail.gohtml
+++ b/core/templates/email/newsCommentEditEmail.gohtml
@@ -1,6 +1,6 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your comment has been updated.</p>
 
-<p><a href="{{.CommentURL}}">View comment</a></p>
+<p><a href="{{.Item.CommentURL}}">View comment</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/newsCommentEditEmail.gotxt
+++ b/core/templates/email/newsCommentEditEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 Your comment has been updated.
 
 View comment:
-{{.CommentURL}}
+{{.Item.CommentURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/newsCommentEditedEmail.gohtml
+++ b/core/templates/email/newsCommentEditedEmail.gohtml
@@ -1,4 +1,4 @@
 <p>Comment edited by {{.Item.Username}}.</p>
 
-<p><a href="{{.CommentURL}}">View comment</a></p>
+<p><a href="{{.Item.CommentURL}}">View comment</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/newsCommentEditedEmail.gotxt
+++ b/core/templates/email/newsCommentEditedEmail.gotxt
@@ -1,5 +1,5 @@
 Comment edited by {{.Item.Username}}.
 
 View comment:
-{{.CommentURL}}
+{{.Item.CommentURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/newsEditEmail.gohtml
+++ b/core/templates/email/newsEditEmail.gohtml
@@ -1,6 +1,6 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your news post has been updated.</p>
 
-<p><a href="{{.PostURL}}">View post</a></p>
+<p><a href="{{.Item.PostURL}}">View post</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/newsEditEmail.gotxt
+++ b/core/templates/email/newsEditEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 Your news post has been updated.
 
 View post:
-{{.PostURL}}
+{{.Item.PostURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/newsReplyEmail.gohtml
+++ b/core/templates/email/newsReplyEmail.gohtml
@@ -1,6 +1,6 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your comment has been posted.</p>
 
-<p><a href="{{.CommentURL}}">View comment</a></p>
+<p><a href="{{.Item.CommentURL}}">View comment</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/newsReplyEmail.gotxt
+++ b/core/templates/email/newsReplyEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 Your comment has been posted.
 
 View comment:
-{{.CommentURL}}
+{{.Item.CommentURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/newsUserAllowEmail.gohtml
+++ b/core/templates/email/newsUserAllowEmail.gohtml
@@ -1,6 +1,6 @@
 <p>Hi {{.Item.Username}},</p>
 <p>You have been granted news permissions.</p>
 
-<p><a href="{{.NewsURL}}">News section</a></p>
+<p><a href="{{.Item.NewsURL}}">News section</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/newsUserAllowEmail.gotxt
+++ b/core/templates/email/newsUserAllowEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 You have been granted news permissions.
 
 News section:
-{{.NewsURL}}
+{{.Item.NewsURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/newsUserDisallowEmail.gohtml
+++ b/core/templates/email/newsUserDisallowEmail.gohtml
@@ -1,6 +1,6 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your news permissions have been revoked.</p>
 
-<p><a href="{{.NewsURL}}">News section</a></p>
+<p><a href="{{.Item.NewsURL}}">News section</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 

--- a/core/templates/email/newsUserDisallowEmail.gotxt
+++ b/core/templates/email/newsUserDisallowEmail.gotxt
@@ -2,6 +2,6 @@ Hi {{.Item.Username}},
 Your news permissions have been revoked.
 
 News section:
-{{.NewsURL}}
+{{.Item.NewsURL}}
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/passwordResetEmail.gohtml
+++ b/core/templates/email/passwordResetEmail.gohtml
@@ -2,5 +2,5 @@
 <p>Use code <b>{{.Item.Code}}</b> when logging in with your new password.</p>
 <p>If you didn't request this change, you can ignore this email.</p>
 
-<p><a href="{{.ResetURL}}">Reset password</a></p>
+<p><a href="{{.Item.ResetURL}}">Reset password</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/passwordResetEmail.gotxt
+++ b/core/templates/email/passwordResetEmail.gotxt
@@ -3,5 +3,5 @@ Use code {{.Item.Code}} when logging in with your new password.
 If you didn't request this change, you can ignore this email.
 
 Reset link:
-{{.ResetURL}}
+{{.Item.ResetURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/replyEmail.gohtml
+++ b/core/templates/email/replyEmail.gohtml
@@ -2,7 +2,7 @@
 <html>
 <body>
 <p>Hi {{.Item.Thread.Lastposterusername.String}},</p>
-<p>A new reply was posted in "{{.Item.TopicTitle}}" (thread #{{.Item.ThreadID}}) on {{.Time}}.</p>
+<p>A new reply was posted in "{{.Item.TopicTitle}}" (thread #{{.Item.ThreadID}}) on {{.Item.Time}}.</p>
 <p>There are now {{.Item.Thread.Comments.Int32}} comments in the discussion.</p>
 <p>Read it <a href="{{.URL}}">here</a>.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/replyEmail.gotxt
+++ b/core/templates/email/replyEmail.gotxt
@@ -1,6 +1,6 @@
 Hi {{.Item.Thread.Lastposterusername.String}},
 
-A new reply was posted in "{{.Item.TopicTitle}}" (thread #{{.Item.ThreadID}}) on {{.Time}}.
+A new reply was posted in "{{.Item.TopicTitle}}" (thread #{{.Item.ThreadID}}) on {{.Item.Time}}.
 There are now {{.Item.Thread.Comments.Int32}} comments in the discussion.
 
 View it here:

--- a/core/templates/email/setUserRoleEmail.gohtml
+++ b/core/templates/email/setUserRoleEmail.gohtml
@@ -1,3 +1,3 @@
 <p>Hi {{.Item.Username}},</p>
 <p>You have been assigned the "{{.Item.Role}}" role.</p>
-<p><a href="{{.UnsubURL}}">Manage notifications</a></p>
+<p><a href="{{.Item.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/setUserRoleEmail.gotxt
+++ b/core/templates/email/setUserRoleEmail.gotxt
@@ -1,4 +1,4 @@
 Hi {{.Item.Username}},
 You have been assigned the "{{.Item.Role}}" role.
 
-Manage notifications: {{.UnsubURL}}
+Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/signupEmail.gohtml
+++ b/core/templates/email/signupEmail.gohtml
@@ -2,7 +2,7 @@
 <html>
 <body>
 <p>Hello,</p>
-<p>A new user {{.Item.Username}} has registered at {{.Time}}.</p>
+<p>A new user {{.Item.Username}} has registered at {{.Item.Time}}.</p>
 <p>Please add them to the user group to approve the account.</p>
 <p>Review the account <a href="{{.URL}}">here</a>.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/signupEmail.gotxt
+++ b/core/templates/email/signupEmail.gotxt
@@ -1,6 +1,6 @@
 Hello,
 
-A new user {{.Item.Username}} has registered at {{.Time}}.
+A new user {{.Item.Username}} has registered at {{.Item.Time}}.
 Please add them to the user group to approve the account.
 
 Review the account here:

--- a/core/templates/email/threadEmail.gohtml
+++ b/core/templates/email/threadEmail.gohtml
@@ -2,7 +2,7 @@
 <html>
 <body>
 <p>Hello,</p>
-<p>A new thread "{{.Item.TopicTitle}}" was started at {{.Path}}.</p>
+<p>A new thread "{{.Item.TopicTitle}}" was started at {{.Item.Path}}.</p>
 <p>You can view it <a href="{{.URL}}">here</a>.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 {{- if .SignOff}}

--- a/core/templates/email/threadEmail.gotxt
+++ b/core/templates/email/threadEmail.gotxt
@@ -1,6 +1,6 @@
 Hello,
 
-A new thread "{{.Item.TopicTitle}}" was started at {{.Path}}.
+A new thread "{{.Item.TopicTitle}}" was started at {{.Item.Path}}.
 
 View it here:
 {{.URL}}

--- a/core/templates/email/updateEmail.gohtml
+++ b/core/templates/email/updateEmail.gohtml
@@ -2,7 +2,7 @@
 <html>
 <body>
 <p>Hello,</p>
-<p>{{.Action}} occurred at <a href="{{.URL}}">{{.URL}}</a> on {{.Time}}.</p>
+<p>{{.Item.Action}} occurred at <a href="{{.URL}}">{{.URL}}</a> on {{.Item.Time}}.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 {{- if .SignOff}}
 <p>{{.SignOffHTML}}</p>

--- a/core/templates/email/updateEmail.gotxt
+++ b/core/templates/email/updateEmail.gotxt
@@ -1,6 +1,6 @@
 Hello,
 
-{{.Action}} occurred at {{.URL}} on {{.Time}}.
+{{.Item.Action}} occurred at {{.URL}} on {{.Item.Time}}.
 
 {{if .URL}}View details here:
 {{.URL}}

--- a/core/templates/email/updateEmailSubject.gotxt
+++ b/core/templates/email/updateEmailSubject.gotxt
@@ -1,1 +1,1 @@
-[{{.SubjectPrefix}}] {{.Action}}
+[{{.SubjectPrefix}}] {{.Item.Action}}

--- a/core/templates/email/updateUserRoleEmail.gohtml
+++ b/core/templates/email/updateUserRoleEmail.gohtml
@@ -1,3 +1,3 @@
 <p>Hi {{.Item.Username}},</p>
 <p>Your role has been updated to "{{.Item.Role}}".</p>
-<p><a href="{{.UnsubURL}}">Manage notifications</a></p>
+<p><a href="{{.Item.UnsubURL}}">Manage notifications</a></p>

--- a/core/templates/email/updateUserRoleEmail.gotxt
+++ b/core/templates/email/updateUserRoleEmail.gotxt
@@ -1,4 +1,4 @@
 Hi {{.Item.Username}},
 Your role has been updated to "{{.Item.Role}}".
 
-Manage notifications: {{.UnsubURL}}
+Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/writingUpdateEmail.gohtml
+++ b/core/templates/email/writingUpdateEmail.gohtml
@@ -1,3 +1,3 @@
 <p>Writing {{.Item.Title}} was updated.</p>
-<p><a href="{{.PostURL}}">View article</a></p>
+<p><a href="{{.Item.PostURL}}">View article</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/writingUpdateEmail.gotxt
+++ b/core/templates/email/writingUpdateEmail.gotxt
@@ -1,4 +1,4 @@
 Writing "{{.Item.Title}}" was updated.
 View article:
-{{.PostURL}}
+{{.Item.PostURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email_execute_test.go
+++ b/core/templates/email_execute_test.go
@@ -1,0 +1,93 @@
+package templates
+
+import (
+	htemplate "html/template"
+	"io"
+	"strings"
+	"testing"
+)
+
+type emailData struct {
+	URL            string
+	SubjectPrefix  string
+	UnsubscribeUrl string
+	SignOff        string
+	SignOffHTML    htemplate.HTML
+	Item           interface{}
+}
+
+func sampleEmailData() emailData {
+	item := map[string]interface{}{
+		"Action":       "action",
+		"Author":       "author",
+		"BlogURL":      "https://example.com/blog",
+		"BoardURL":     "https://example.com/board",
+		"Code":         "code",
+		"CommentURL":   "https://example.com/comment",
+		"IP":           "127.0.0.1",
+		"LanguageID":   "en",
+		"LanguageName": "English",
+		"LinkURL":      "https://example.com/link",
+		"Message":      "message",
+		"Moderator":    "mod",
+		"NewsURL":      "https://example.com/news",
+		"Path":         "/path",
+		"Permission":   "perm",
+		"PostURL":      "https://example.com/post",
+		"Question":     "question",
+		"Reason":       "reason",
+		"ResetURL":     "https://example.com/reset",
+		"Role":         "role",
+		"Thread": map[string]interface{}{
+			"Lastposterusername": map[string]interface{}{"String": "poster"},
+			"Comments":           map[string]interface{}{"Int32": 1},
+		},
+		"ThreadID":           1,
+		"ThreadURL":          "https://example.com/thread",
+		"Time":               "time",
+		"Title":              map[string]interface{}{"String": "title"},
+		"TopicTitle":         "topic title",
+		"UnsubURL":           "https://example.com/unsub",
+		"UserPermissionsURL": "https://example.com/perm",
+		"UserURL":            "https://example.com/user",
+		"Username":           "username",
+	}
+	return emailData{
+		URL:            "https://example.com",
+		SubjectPrefix:  "prefix",
+		UnsubscribeUrl: "https://example.com/unsubscribe",
+		SignOff:        "signoff",
+		SignOffHTML:    htemplate.HTML("signoff"),
+		Item:           item,
+	}
+}
+
+func TestEmailTemplatesExecute(t *testing.T) {
+	htmlT := GetCompiledEmailHtmlTemplates(nil)
+	textT := GetCompiledEmailTextTemplates(nil)
+	data := sampleEmailData()
+
+	for _, tmpl := range htmlT.Templates() {
+		name := tmpl.Name()
+		if !strings.HasSuffix(name, ".gohtml") {
+			continue
+		}
+		t.Run("html/"+name, func(t *testing.T) {
+			if err := tmpl.Execute(io.Discard, data); err != nil {
+				t.Errorf("execute %s: %v", name, err)
+			}
+		})
+	}
+
+	for _, tmpl := range textT.Templates() {
+		name := tmpl.Name()
+		if !strings.HasSuffix(name, ".gotxt") {
+			continue
+		}
+		t.Run("text/"+name, func(t *testing.T) {
+			if err := tmpl.Execute(io.Discard, data); err != nil {
+				t.Errorf("execute %s: %v", name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- update email templates to reference custom fields via `.Item`
- keep common fields like `URL` and `UnsubscribeUrl` at the root of `EmailData`
- add a test that executes every email template with sample data

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ed6c86e98832f8977b2fb12281c05