### PR TITLE
Move notifier query checks to function top

### DIFF
--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -324,24 +324,25 @@ func (n *Notifier) handleAutoSubscribe(ctx context.Context, evt eventbus.TaskEve
 }
 
 func (n *Notifier) notifyAdmins(ctx context.Context, evt eventbus.TaskEvent, tp AdminEmailTemplateProvider) error {
+	if n.Queries == nil {
+		return nil
+	}
 	if !config.AdminNotificationsEnabled() {
 		return nil
 	}
 	for _, addr := range config.GetAdminEmails(ctx, n.Queries) {
 		var uid int32
-		if n.Queries != nil {
-			if u, err := n.Queries.UserByEmail(ctx, addr); err == nil {
-				uid = u.Idusers
-			} else {
-				log.Printf("user by email %s: %v", addr, err)
-			}
+		if u, err := n.Queries.UserByEmail(ctx, addr); err == nil {
+			uid = u.Idusers
+		} else {
+			log.Printf("user by email %s: %v", addr, err)
 		}
 		if et := tp.AdminEmailTemplate(); et != nil {
 			if err := n.renderAndQueueEmailFromTemplates(ctx, uid, addr, et, evt.Data); err != nil {
 				return err
 			}
 		}
-		if nt := tp.AdminInternalNotificationTemplate(); nt != nil && n.Queries != nil {
+		if nt := tp.AdminInternalNotificationTemplate(); nt != nil {
 			data := struct {
 				eventbus.TaskEvent
 				Item interface{}

--- a/internal/notifications/dlq.go
+++ b/internal/notifications/dlq.go
@@ -13,34 +13,36 @@ func dlqRecordAndNotify(ctx context.Context, q dlq.DLQ, n *Notifier, msg string)
 	if q == nil {
 		return fmt.Errorf("no dlq provider")
 	}
-	if err := q.Record(ctx, msg); err == nil {
-		if dbq, ok := q.(db.DLQ); ok {
-			if count, err := dbq.Queries.CountDeadLetters(ctx); err == nil {
-				if isPow10(count) {
-					data := EmailData{
-						Item: struct {
-							Message string
-						}{Message: msg},
-					}
-					et := &EmailTemplates{
-						Text:    EmailTextTemplateFilenameGenerator("dlqMultiFailure"),
-						HTML:    EmailHTMLTemplateFilenameGenerator("dlqMultiFailure"),
-						Subject: EmailSubjectTemplateFilenameGenerator("dlqMultiFailure"),
-					}
-					if err := n.NotifyAdmins(ctx, et, data); err != nil {
-						return err
-					}
-					if config.AdminNotificationsEnabled() && n.Queries != nil {
-						nt, err := n.renderNotification(ctx, NotificationTemplateFilenameGenerator("dlqMultiFailure"), data)
-						if err == nil {
-							for _, addr := range config.GetAdminEmails(ctx, n.Queries) {
-								u, err := n.Queries.UserByEmail(ctx, addr)
-								if err != nil {
-									continue
-								}
-								_ = sendInternalNotification(ctx, n.Queries, u.Idusers, "", string(nt))
-							}
+	if err := q.Record(ctx, msg); err != nil {
+		return err
+	}
+	if n.Queries == nil || !config.AdminNotificationsEnabled() {
+		return nil
+	}
+	if dbq, ok := q.(db.DLQ); ok {
+		if count, err := dbq.Queries.CountDeadLetters(ctx); err == nil {
+			if isPow10(count) {
+				data := EmailData{
+					Item: struct {
+						Message string
+					}{Message: msg},
+				}
+				et := &EmailTemplates{
+					Text:    EmailTextTemplateFilenameGenerator("dlqMultiFailure"),
+					HTML:    EmailHTMLTemplateFilenameGenerator("dlqMultiFailure"),
+					Subject: EmailSubjectTemplateFilenameGenerator("dlqMultiFailure"),
+				}
+				if err := n.NotifyAdmins(ctx, et, data); err != nil {
+					return err
+				}
+				nt, err := n.renderNotification(ctx, NotificationTemplateFilenameGenerator("dlqMultiFailure"), data)
+				if err == nil {
+					for _, addr := range config.GetAdminEmails(ctx, n.Queries) {
+						u, err := n.Queries.UserByEmail(ctx, addr)
+						if err != nil {
+							continue
 						}
+						_ = sendInternalNotification(ctx, n.Queries, u.Idusers, "", string(nt))
 					}
 				}
 			}

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -84,18 +84,19 @@ func (n *Notifier) emailHTMLTemplates() *htemplate.Template {
 
 // NotifyAdmins sends a generic update notice to administrator accounts.
 func (n *Notifier) NotifyAdmins(ctx context.Context, et *EmailTemplates, data EmailData) error {
+	if n.Queries == nil {
+		return nil
+	}
 	if !config.AdminNotificationsEnabled() {
 		return nil
 	}
 	for _, addr := range config.GetAdminEmails(ctx, n.Queries) {
 		var uid int32
-		if n.Queries != nil {
-			if u, err := n.Queries.UserByEmail(ctx, addr); err == nil {
-				uid = u.Idusers
-			} else {
-				log.Printf("notify admin %s: %v", addr, err)
-				continue
-			}
+		if u, err := n.Queries.UserByEmail(ctx, addr); err == nil {
+			uid = u.Idusers
+		} else {
+			log.Printf("notify admin %s: %v", addr, err)
+			continue
 		}
 		if err := n.renderAndQueueEmailFromTemplates(ctx, uid, addr, et, data); err != nil {
 			log.Printf("notify admin %s: %v", addr, err)


### PR DESCRIPTION
## Summary
- prevent nested checks by returning early if `Notifier.Queries` is nil
- apply this early return pattern in `NotifyAdmins`, `notifyAdmins`, and `dlqRecordAndNotify`

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: TestEmailTemplatesExecute, TestForgotPasswordEventData, TestForgotPasswordRateLimit, TestForgotPasswordReplaceOld)*

------
https://chatgpt.com/codex/tasks/task_e_687ee1a0df40832f8a4ecb293e147e94