### PR TITLE
Add password reset confirmation page

### DIFF
--- a/core/templates/email/adminNotificationEmailAssociationRequestEmail.gohtml
+++ b/core/templates/email/adminNotificationEmailAssociationRequestEmail.gohtml
@@ -1,5 +1,5 @@
 <p>User {{.Item.Username}} requested an email association.</p>
 <p>Email: {{.Item.Email}}</p>
 <p>Reason: {{.Item.Reason}}</p>
-<p><a href="{{.UserURL}}">User page</a></p>
+<p><a href="{{.Item.UserURL}}">User page</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationEmailAssociationRequestEmail.gotxt
+++ b/core/templates/email/adminNotificationEmailAssociationRequestEmail.gotxt
@@ -3,5 +3,5 @@ Email: {{.Item.Email}}
 Reason: {{.Item.Reason}}
 
 User page:
-{{.UserURL}}
+{{.Item.UserURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/site/forgotPasswordEmailSentPage.gohtml
+++ b/core/templates/site/forgotPasswordEmailSentPage.gohtml
@@ -1,0 +1,3 @@
+{{ template "head" $ }}
+<p>Password reset recorded. Please check your email for the verification code.</p>
+{{ template "tail" $ }}

--- a/handlers/auth/forgotPassword.go
+++ b/handlers/auth/forgotPassword.go
@@ -148,7 +148,7 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	http.Redirect(w, r, "/login", http.StatusSeeOther)
+	handlers.TemplateHandler(w, r, "forgotPasswordEmailSentPage.gohtml", r.Context().Value(consts.KeyCoreData))
 }
 
 func (EmailAssociationRequestTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/auth/forgotPassword_event_test.go
+++ b/handlers/auth/forgotPassword_event_test.go
@@ -25,7 +25,7 @@ func TestForgotPasswordEventData(t *testing.T) {
 	defer db.Close()
 	q := dbpkg.New(db)
 	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test.com", "u"))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, passwd")).WithArgs(int32(1)).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, passwd")).WithArgs(int32(1), sqlmock.AnyArg()).WillReturnError(sql.ErrNoRows)
 	mock.ExpectExec("INSERT INTO pending_passwords").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
@@ -39,7 +39,7 @@ func TestForgotPasswordEventData(t *testing.T) {
 	rr := httptest.NewRecorder()
 	forgotPasswordTask.Action(rr, req)
 
-	if rr.Code != http.StatusSeeOther {
+	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d", rr.Code)
 	}
 	if _, ok := evt.Data["reset"]; !ok {


### PR DESCRIPTION
## Summary
- show a confirmation page after requesting a password reset
- add template for the confirmation message
- fix admin email templates to use `Item.UserURL`
- update template execution test accordingly

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go mod tidy`
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ee159f98c832f8e5e8ee0fc739a1a