### PR TITLE
Drop stored args from CLI commands

### DIFF
--- a/cmd/goa4web/audit.go
+++ b/cmd/goa4web/audit.go
@@ -16,18 +16,15 @@ type auditCmd struct {
 	*rootCmd
 	fs    *flag.FlagSet
 	Limit int
-	args  []string
 }
 
 func parseAuditCmd(parent *rootCmd, args []string) (*auditCmd, error) {
 	c := &auditCmd{rootCmd: parent, Limit: defaultAuditLimit}
-	fs := flag.NewFlagSet("audit", flag.ContinueOnError)
-	fs.IntVar(&c.Limit, "limit", defaultAuditLimit, "number of rows to display")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("audit")
+	c.fs.IntVar(&c.Limit, "limit", defaultAuditLimit, "number of rows to display")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
 	return c, nil
 }
 
@@ -46,4 +43,8 @@ func (c *auditCmd) Run() error {
 		fmt.Printf("%d\t%s\t%s\t%s\n", r.ID, r.Username.String, r.Action, r.CreatedAt.Format(time.RFC3339))
 	}
 	return nil
+}
+
+func (c *auditCmd) Usage() {
+	executeUsage(c.fs.Output(), templateString("audit_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/blog.go
+++ b/cmd/goa4web/blog.go
@@ -1,81 +1,75 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/blog_usage.txt
-var blogUsageTemplate string
-
 // blogCmd handles blog management subcommands.
 type blogCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseBlogCmd(parent *rootCmd, args []string) (*blogCmd, error) {
 	c := &blogCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("blog", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("blog")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *blogCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing blog command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "create":
-		cmd, err := parseBlogCreateCmd(c, c.args[1:])
+		cmd, err := parseBlogCreateCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("create: %w", err)
 		}
 		return cmd.Run()
 	case "list":
-		cmd, err := parseBlogListCmd(c, c.args[1:])
+		cmd, err := parseBlogListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	case "read":
-		cmd, err := parseBlogReadCmd(c, c.args[1:])
+		cmd, err := parseBlogReadCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("read: %w", err)
 		}
 		return cmd.Run()
 	case "comments":
-		cmd, err := parseBlogCommentsCmd(c, c.args[1:])
+		cmd, err := parseBlogCommentsCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("comments: %w", err)
 		}
 		return cmd.Run()
 	case "update":
-		cmd, err := parseBlogUpdateCmd(c, c.args[1:])
+		cmd, err := parseBlogUpdateCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("update: %w", err)
 		}
 		return cmd.Run()
 	case "deactivate":
-		cmd, err := parseBlogDeactivateCmd(c, c.args[1:])
+		cmd, err := parseBlogDeactivateCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("deactivate: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown blog command %q", c.args[0])
+		return fmt.Errorf("unknown blog command %q", args[0])
 	}
 }
 
 func (c *blogCmd) Usage() {
-	executeUsage(c.fs.Output(), blogUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("blog_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/blog_comments.go
+++ b/cmd/goa4web/blog_comments.go
@@ -1,57 +1,51 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/blog_comments_usage.txt
-var blogCommentsUsageTemplate string
-
 // blogCommentsCmd handles "blog comments".
 type blogCommentsCmd struct {
 	*blogCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseBlogCommentsCmd(parent *blogCmd, args []string) (*blogCommentsCmd, error) {
 	c := &blogCommentsCmd{blogCmd: parent}
-	fs := flag.NewFlagSet("comments", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("comments")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *blogCommentsCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing comments command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "list":
-		cmd, err := parseBlogCommentsListCmd(c, c.args[1:])
+		cmd, err := parseBlogCommentsListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	case "read":
-		cmd, err := parseBlogCommentsReadCmd(c, c.args[1:])
+		cmd, err := parseBlogCommentsReadCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("read: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown comments command %q", c.args[0])
+		return fmt.Errorf("unknown comments command %q", args[0])
 	}
 }
 
 func (c *blogCommentsCmd) Usage() {
-	executeUsage(c.fs.Output(), blogCommentsUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("blog_comments_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/blog_comments_list.go
+++ b/cmd/goa4web/blog_comments_list.go
@@ -16,23 +16,22 @@ type blogCommentsListCmd struct {
 	fs     *flag.FlagSet
 	ID     int
 	UserID int
-	args   []string
 }
 
 func parseBlogCommentsListCmd(parent *blogCommentsCmd, args []string) (*blogCommentsListCmd, error) {
 	c := &blogCommentsListCmd{blogCommentsCmd: parent}
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "blog id")
-	fs.IntVar(&c.UserID, "user", 0, "viewer user id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("list")
+	c.fs.IntVar(&c.ID, "id", 0, "blog id")
+	c.fs.IntVar(&c.UserID, "user", 0, "viewer user id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
-	if c.ID == 0 && len(c.args) > 0 {
-		if id, err := strconv.Atoi(c.args[0]); err == nil {
+
+	rest := c.fs.Args()
+	if c.ID == 0 && len(rest) > 0 {
+		if id, err := strconv.Atoi(rest[0]); err == nil {
 			c.ID = id
-			c.args = c.args[1:]
+			rest = rest[1:]
 		}
 	}
 	return c, nil

--- a/cmd/goa4web/blog_comments_read.go
+++ b/cmd/goa4web/blog_comments_read.go
@@ -18,33 +18,32 @@ type blogCommentsReadCmd struct {
 	CommentID int
 	UserID    int
 	All       bool
-	args      []string
 }
 
 func parseBlogCommentsReadCmd(parent *blogCommentsCmd, args []string) (*blogCommentsReadCmd, error) {
 	c := &blogCommentsReadCmd{blogCommentsCmd: parent}
-	fs := flag.NewFlagSet("read", flag.ContinueOnError)
-	fs.IntVar(&c.BlogID, "id", 0, "blog id")
-	fs.IntVar(&c.CommentID, "comment", 0, "comment id")
-	fs.IntVar(&c.UserID, "user", 0, "viewer user id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("read")
+	c.fs.IntVar(&c.BlogID, "id", 0, "blog id")
+	c.fs.IntVar(&c.CommentID, "comment", 0, "comment id")
+	c.fs.IntVar(&c.UserID, "user", 0, "viewer user id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
-	if c.BlogID == 0 && len(c.args) > 0 {
-		if id, err := strconv.Atoi(c.args[0]); err == nil {
+
+	rest := c.fs.Args()
+	if c.BlogID == 0 && len(rest) > 0 {
+		if id, err := strconv.Atoi(rest[0]); err == nil {
 			c.BlogID = id
-			c.args = c.args[1:]
+			rest = rest[1:]
 		}
 	}
-	if len(c.args) > 0 {
-		if c.args[0] == "all" {
+	if len(rest) > 0 {
+		if rest[0] == "all" {
 			c.All = true
-			c.args = c.args[1:]
-		} else if id, err := strconv.Atoi(c.args[0]); err == nil {
+			rest = rest[1:]
+		} else if id, err := strconv.Atoi(rest[0]); err == nil {
 			c.CommentID = id
-			c.args = c.args[1:]
+			rest = rest[1:]
 		}
 	}
 	return c, nil

--- a/cmd/goa4web/blog_create.go
+++ b/cmd/goa4web/blog_create.go
@@ -16,20 +16,18 @@ type blogCreateCmd struct {
 	UserID int
 	LangID int
 	Text   string
-	args   []string
 }
 
 func parseBlogCreateCmd(parent *blogCmd, args []string) (*blogCreateCmd, error) {
 	c := &blogCreateCmd{blogCmd: parent}
-	fs := flag.NewFlagSet("create", flag.ContinueOnError)
-	fs.IntVar(&c.UserID, "user", 0, "user id")
-	fs.IntVar(&c.LangID, "lang", 0, "language id")
-	fs.StringVar(&c.Text, "text", "", "blog text")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("create")
+	c.fs.IntVar(&c.UserID, "user", 0, "user id")
+	c.fs.IntVar(&c.LangID, "lang", 0, "language id")
+	c.fs.StringVar(&c.Text, "text", "", "blog text")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/blog_deactivate.go
+++ b/cmd/goa4web/blog_deactivate.go
@@ -12,20 +12,18 @@ import (
 // blogDeactivateCmd implements "blog deactivate".
 type blogDeactivateCmd struct {
 	*blogCmd
-	fs   *flag.FlagSet
-	ID   int
-	args []string
+	fs *flag.FlagSet
+	ID int
 }
 
 func parseBlogDeactivateCmd(parent *blogCmd, args []string) (*blogDeactivateCmd, error) {
 	c := &blogDeactivateCmd{blogCmd: parent}
-	fs := flag.NewFlagSet("deactivate", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "blog id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("deactivate")
+	c.fs.IntVar(&c.ID, "id", 0, "blog id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/blog_list.go
+++ b/cmd/goa4web/blog_list.go
@@ -15,20 +15,18 @@ type blogListCmd struct {
 	UserID int
 	Limit  int
 	Offset int
-	args   []string
 }
 
 func parseBlogListCmd(parent *blogCmd, args []string) (*blogListCmd, error) {
 	c := &blogListCmd{blogCmd: parent}
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	fs.IntVar(&c.UserID, "user", 0, "user id")
-	fs.IntVar(&c.Limit, "limit", 10, "limit")
-	fs.IntVar(&c.Offset, "offset", 0, "offset")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("list")
+	c.fs.IntVar(&c.UserID, "user", 0, "user id")
+	c.fs.IntVar(&c.Limit, "limit", 10, "limit")
+	c.fs.IntVar(&c.Offset, "offset", 0, "offset")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/blog_read.go
+++ b/cmd/goa4web/blog_read.go
@@ -13,24 +13,22 @@ import (
 // blogReadCmd implements "blog read".
 type blogReadCmd struct {
 	*blogCmd
-	fs   *flag.FlagSet
-	ID   int
-	args []string
+	fs *flag.FlagSet
+	ID int
 }
 
 func parseBlogReadCmd(parent *blogCmd, args []string) (*blogReadCmd, error) {
 	c := &blogReadCmd{blogCmd: parent}
-	fs := flag.NewFlagSet("read", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "blog id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("read")
+	c.fs.IntVar(&c.ID, "id", 0, "blog id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
-	if c.ID == 0 && len(c.args) > 0 {
-		if id, err := strconv.Atoi(c.args[0]); err == nil {
+
+	rest := c.fs.Args()
+	if c.ID == 0 && len(rest) > 0 {
+		if id, err := strconv.Atoi(rest[0]); err == nil {
 			c.ID = id
-			c.args = c.args[1:]
 		}
 	}
 	return c, nil

--- a/cmd/goa4web/blog_update.go
+++ b/cmd/goa4web/blog_update.go
@@ -16,20 +16,18 @@ type blogUpdateCmd struct {
 	ID     int
 	LangID int
 	Text   string
-	args   []string
 }
 
 func parseBlogUpdateCmd(parent *blogCmd, args []string) (*blogUpdateCmd, error) {
 	c := &blogUpdateCmd{blogCmd: parent}
-	fs := flag.NewFlagSet("update", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "blog id")
-	fs.IntVar(&c.LangID, "lang", 0, "language id")
-	fs.StringVar(&c.Text, "text", "", "blog text")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("update")
+	c.fs.IntVar(&c.ID, "id", 0, "blog id")
+	c.fs.IntVar(&c.LangID, "lang", 0, "language id")
+	c.fs.StringVar(&c.Text, "text", "", "blog text")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/board.go
+++ b/cmd/goa4web/board.go
@@ -1,70 +1,64 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/board_usage.txt
-var boardUsageTemplate string
-
 // boardCmd handles board management subcommands.
 type boardCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseBoardCmd(parent *rootCmd, args []string) (*boardCmd, error) {
 	c := &boardCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("board", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("board")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *boardCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing board command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "list":
-		cmd, err := parseBoardListCmd(c, c.args[1:])
+		cmd, err := parseBoardListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	case "create":
-		cmd, err := parseBoardCreateCmd(c, c.args[1:])
+		cmd, err := parseBoardCreateCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("create: %w", err)
 		}
 		return cmd.Run()
 	case "delete":
-		cmd, err := parseBoardDeleteCmd(c, c.args[1:])
+		cmd, err := parseBoardDeleteCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("delete: %w", err)
 		}
 		return cmd.Run()
 	case "update":
-		cmd, err := parseBoardUpdateCmd(c, c.args[1:])
+		cmd, err := parseBoardUpdateCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("update: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown board command %q", c.args[0])
+		return fmt.Errorf("unknown board command %q", args[0])
 	}
 }
 
 // Usage prints command usage information with examples.
 func (c *boardCmd) Usage() {
-	executeUsage(c.fs.Output(), boardUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("board_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/board_create.go
+++ b/cmd/goa4web/board_create.go
@@ -16,20 +16,18 @@ type boardCreateCmd struct {
 	Parent      int
 	Name        string
 	Description string
-	args        []string
 }
 
 func parseBoardCreateCmd(parent *boardCmd, args []string) (*boardCreateCmd, error) {
 	c := &boardCreateCmd{boardCmd: parent}
-	fs := flag.NewFlagSet("create", flag.ContinueOnError)
-	fs.IntVar(&c.Parent, "parent", 0, "parent board id")
-	fs.StringVar(&c.Name, "name", "", "board name")
-	fs.StringVar(&c.Description, "description", "", "board description")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("create")
+	c.fs.IntVar(&c.Parent, "parent", 0, "parent board id")
+	c.fs.StringVar(&c.Name, "name", "", "board name")
+	c.fs.StringVar(&c.Description, "description", "", "board description")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/board_delete.go
+++ b/cmd/goa4web/board_delete.go
@@ -11,29 +11,21 @@ import (
 // boardDeleteCmd implements "board delete".
 type boardDeleteCmd struct {
 	*boardCmd
-	fs   *flag.FlagSet
-	ID   int
-	args []string
+	fs *flag.FlagSet
+	ID int
 }
 
 func parseBoardDeleteCmd(parent *boardCmd, args []string) (*boardDeleteCmd, error) {
 	c := &boardDeleteCmd{boardCmd: parent}
-	fs := flag.NewFlagSet("delete", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "board id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("delete")
+	c.fs.IntVar(&c.ID, "id", 0, "board id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	if c.ID == 0 && fs.NArg() > 0 {
-		_, err := fmt.Sscan(fs.Arg(0), &c.ID)
-		if err == nil {
-			c.args = fs.Args()[1:]
-		} else {
-			c.args = fs.Args()
-		}
-	} else {
-		c.args = fs.Args()
+	if c.ID == 0 && c.fs.NArg() > 0 {
+		_, _ = fmt.Sscan(c.fs.Arg(0), &c.ID)
 	}
-	c.fs = fs
+
 	return c, nil
 }
 

--- a/cmd/goa4web/board_list.go
+++ b/cmd/goa4web/board_list.go
@@ -11,18 +11,16 @@ import (
 // boardListCmd implements "board list".
 type boardListCmd struct {
 	*boardCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseBoardListCmd(parent *boardCmd, args []string) (*boardListCmd, error) {
 	c := &boardListCmd{boardCmd: parent}
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("list")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/board_update.go
+++ b/cmd/goa4web/board_update.go
@@ -18,12 +18,11 @@ type boardUpdateCmd struct {
 	Name           string
 	Description    string
 	ApprovalNeeded bool
-	args           []string
 }
 
 func parseBoardUpdateCmd(parent *boardCmd, args []string) (*boardUpdateCmd, error) {
 	c := &boardUpdateCmd{boardCmd: parent}
-	fs, rest, err := parseFlags("update", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("update", args, func(fs *flag.FlagSet) {
 		fs.IntVar(&c.ID, "id", 0, "board id")
 		fs.IntVar(&c.Parent, "parent", 0, "parent board id")
 		fs.StringVar(&c.Name, "name", "", "board name")
@@ -34,7 +33,6 @@ func parseBoardUpdateCmd(parent *boardCmd, args []string) (*boardUpdateCmd, erro
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/config.go
+++ b/cmd/goa4web/config.go
@@ -1,106 +1,100 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/config_usage.txt
-var configUsageTemplate string
-
 // configCmd handles configuration utilities.
 type configCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseConfigCmd(parent *rootCmd, args []string) (*configCmd, error) {
 	c := &configCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("config", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("config")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *configCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing config command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "reload":
-		cmd, err := parseConfigReloadCmd(c, c.args[1:])
+		cmd, err := parseConfigReloadCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("reload: %w", err)
 		}
 		return cmd.Run()
 	case "as-env":
-		cmd, err := parseConfigAsCmd(c, "as-env", c.args[1:])
+		cmd, err := parseConfigAsCmd(c, "as-env", args[1:])
 		if err != nil {
 			return fmt.Errorf("as-env: %w", err)
 		}
 		return cmd.asEnv()
 	case "as-env-file":
-		cmd, err := parseConfigAsCmd(c, "as-env-file", c.args[1:])
+		cmd, err := parseConfigAsCmd(c, "as-env-file", args[1:])
 		if err != nil {
 			return fmt.Errorf("as-env-file: %w", err)
 		}
 		return cmd.asEnvFile()
 	case "as-json":
-		cmd, err := parseConfigAsCmd(c, "as-json", c.args[1:])
+		cmd, err := parseConfigAsCmd(c, "as-json", args[1:])
 		if err != nil {
 			return fmt.Errorf("as-json: %w", err)
 		}
 		return cmd.asJSON()
 	case "as-cli":
-		cmd, err := parseConfigAsCmd(c, "as-cli", c.args[1:])
+		cmd, err := parseConfigAsCmd(c, "as-cli", args[1:])
 		if err != nil {
 			return fmt.Errorf("as-cli: %w", err)
 		}
 		return cmd.asCLI()
 	case "add-json":
-		cmd, err := parseConfigJSONAddCmd(c, c.args[1:])
+		cmd, err := parseConfigJSONAddCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("add-json: %w", err)
 		}
 		return cmd.Run()
 	case "options":
-		cmd, err := parseConfigOptionsCmd(c, c.args[1:])
+		cmd, err := parseConfigOptionsCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("options: %w", err)
 		}
 		return cmd.Run()
 	case "test":
-		cmd, err := parseConfigTestCmd(c, c.args[1:])
+		cmd, err := parseConfigTestCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("test: %w", err)
 		}
 		return cmd.Run()
 	case "show":
-		cmd, err := parseConfigShowCmd(c, c.args[1:])
+		cmd, err := parseConfigShowCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("show: %w", err)
 		}
 		return cmd.Run()
 	case "set":
-		cmd, err := parseConfigSetCmd(c, c.args[1:])
+		cmd, err := parseConfigSetCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("set: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown config command %q", c.args[0])
+		return fmt.Errorf("unknown config command %q", args[0])
 	}
 }
 
 // Usage prints command usage information with examples.
 func (c *configCmd) Usage() {
-	executeUsage(c.fs.Output(), configUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("config_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/config_as.go
+++ b/cmd/goa4web/config_as.go
@@ -15,18 +15,16 @@ type configAsCmd struct {
 	*configCmd
 	fs       *flag.FlagSet
 	extended bool
-	args     []string
 }
 
 func parseConfigAsCmd(parent *configCmd, name string, args []string) (*configAsCmd, error) {
 	c := &configAsCmd{configCmd: parent}
-	fs := flag.NewFlagSet(name, flag.ContinueOnError)
-	fs.BoolVar(&c.extended, "extended", false, "include extended usage")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet(name)
+	c.fs.BoolVar(&c.extended, "extended", false, "include extended usage")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/config_json_add.go
+++ b/cmd/goa4web/config_json_add.go
@@ -13,18 +13,16 @@ type configJSONAddCmd struct {
 	*configCmd
 	fs   *flag.FlagSet
 	File string
-	args []string
 }
 
 func parseConfigJSONAddCmd(parent *configCmd, args []string) (*configJSONAddCmd, error) {
 	c := &configJSONAddCmd{configCmd: parent}
-	fs := flag.NewFlagSet("add-json", flag.ContinueOnError)
-	fs.StringVar(&c.File, "file", "", "json file to update")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("add-json")
+	c.fs.StringVar(&c.File, "file", "", "json file to update")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/config_options.go
+++ b/cmd/goa4web/config_options.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 	"os"
@@ -11,28 +10,23 @@ import (
 	"github.com/arran4/goa4web/config"
 )
 
-//go:embed templates/config_options.txt
-var configOptionsDefaultTemplate string
-
 // configOptionsCmd implements "config options".
 type configOptionsCmd struct {
 	*configCmd
 	fs       *flag.FlagSet
 	template string
 	extended bool
-	args     []string
 }
 
 func parseConfigOptionsCmd(parent *configCmd, args []string) (*configOptionsCmd, error) {
 	c := &configOptionsCmd{configCmd: parent}
-	fs := flag.NewFlagSet("options", flag.ContinueOnError)
-	fs.StringVar(&c.template, "template", "", "template file")
-	fs.BoolVar(&c.extended, "extended", false, "include extended usage")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("options")
+	c.fs.StringVar(&c.template, "template", "", "template file")
+	c.fs.BoolVar(&c.extended, "extended", false, "include extended usage")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 
@@ -68,7 +62,7 @@ func (c *configOptionsCmd) Run() error {
 			Extended: e,
 		})
 	}
-	tmplText := configOptionsDefaultTemplate
+	tmplText := templateString("config_options.txt")
 	if c.template != "" {
 		b, err := os.ReadFile(c.template)
 		if err != nil {

--- a/cmd/goa4web/config_reload.go
+++ b/cmd/goa4web/config_reload.go
@@ -14,18 +14,16 @@ import (
 // configReloadCmd implements "config reload".
 type configReloadCmd struct {
 	*configCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseConfigReloadCmd(parent *configCmd, args []string) (*configReloadCmd, error) {
 	c := &configReloadCmd{configCmd: parent}
-	fs := flag.NewFlagSet("reload", flag.ContinueOnError)
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("reload")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/config_set.go
+++ b/cmd/goa4web/config_set.go
@@ -14,19 +14,17 @@ type configSetCmd struct {
 	fs    *flag.FlagSet
 	Key   string
 	Value string
-	args  []string
 }
 
 func parseConfigSetCmd(parent *configCmd, args []string) (*configSetCmd, error) {
 	c := &configSetCmd{configCmd: parent}
-	fs := flag.NewFlagSet("set", flag.ContinueOnError)
-	fs.StringVar(&c.Key, "key", "", "configuration key")
-	fs.StringVar(&c.Value, "value", "", "configuration value")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("set")
+	c.fs.StringVar(&c.Key, "key", "", "configuration key")
+	c.fs.StringVar(&c.Value, "value", "", "configuration value")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/config_show.go
+++ b/cmd/goa4web/config_show.go
@@ -9,18 +9,16 @@ import (
 // configShowCmd implements "config show".
 type configShowCmd struct {
 	*configCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseConfigShowCmd(parent *configCmd, args []string) (*configShowCmd, error) {
 	c := &configShowCmd{configCmd: parent}
-	fs := flag.NewFlagSet("show", flag.ContinueOnError)
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("show")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/config_test_cmd.go
+++ b/cmd/goa4web/config_test_cmd.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	_ "embed"
+
 	"flag"
 	"fmt"
 	"net/mail"
@@ -16,77 +16,70 @@ import (
 	coretemplates "github.com/arran4/goa4web/core/templates"
 )
 
-//go:embed templates/config_test_usage.txt
-var configTestUsageTemplate string
-
 // configTestCmd implements "config test".
 type configTestCmd struct {
 	*configCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseConfigTestCmd(parent *configCmd, args []string) (*configTestCmd, error) {
 	c := &configTestCmd{configCmd: parent}
-	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("test")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *configTestCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing test command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "email":
-		cmd, err := parseConfigTestEmailCmd(c, c.args[1:])
+		cmd, err := parseConfigTestEmailCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("email: %w", err)
 		}
 		return cmd.Run()
 	case "db":
-		cmd, err := parseConfigTestDBCmd(c, c.args[1:])
+		cmd, err := parseConfigTestDBCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("db: %w", err)
 		}
 		return cmd.Run()
 	case "dlq":
-		cmd, err := parseConfigTestDLQCmd(c, c.args[1:])
+		cmd, err := parseConfigTestDLQCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("dlq: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown test command %q", c.args[0])
+		return fmt.Errorf("unknown test command %q", args[0])
 	}
 }
 
 // Usage prints command usage information with examples.
 func (c *configTestCmd) Usage() {
-	executeUsage(c.fs.Output(), configTestUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("config_test_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }
 
 type configTestEmailCmd struct {
 	*configTestCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseConfigTestEmailCmd(parent *configTestCmd, args []string) (*configTestEmailCmd, error) {
 	c := &configTestEmailCmd{configTestCmd: parent}
-	fs := flag.NewFlagSet("email", flag.ContinueOnError)
-	c.fs = fs
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("email")
+
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
@@ -136,18 +129,16 @@ func (c *configTestEmailCmd) Run() error {
 
 type configTestDBCmd struct {
 	*configTestCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseConfigTestDBCmd(parent *configTestCmd, args []string) (*configTestDBCmd, error) {
 	c := &configTestDBCmd{configTestCmd: parent}
-	fs := flag.NewFlagSet("db", flag.ContinueOnError)
-	c.fs = fs
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("db")
+
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
@@ -164,18 +155,16 @@ func (c *configTestDBCmd) Run() error {
 
 type configTestDLQCmd struct {
 	*configTestCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseConfigTestDLQCmd(parent *configTestCmd, args []string) (*configTestDLQCmd, error) {
 	c := &configTestDLQCmd{configTestCmd: parent}
-	fs := flag.NewFlagSet("dlq", flag.ContinueOnError)
-	c.fs = fs
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("dlq")
+
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 

--- a/cmd/goa4web/db.go
+++ b/cmd/goa4web/db.go
@@ -1,70 +1,64 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/db_usage.txt
-var dbUsageTemplate string
-
 // dbCmd handles database utilities like migrations.
 type dbCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseDbCmd(parent *rootCmd, args []string) (*dbCmd, error) {
 	c := &dbCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("db", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("db")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *dbCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing db command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "migrate":
-		cmd, err := parseDbMigrateCmd(c, c.args[1:])
+		cmd, err := parseDbMigrateCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("migrate: %w", err)
 		}
 		return cmd.Run()
 	case "backup":
-		cmd, err := parseDbBackupCmd(c, c.args[1:])
+		cmd, err := parseDbBackupCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("backup: %w", err)
 		}
 		return cmd.Run()
 	case "restore":
-		cmd, err := parseDbRestoreCmd(c, c.args[1:])
+		cmd, err := parseDbRestoreCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("restore: %w", err)
 		}
 		return cmd.Run()
 	case "seed":
-		cmd, err := parseDbSeedCmd(c, c.args[1:])
+		cmd, err := parseDbSeedCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("seed: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown db command %q", c.args[0])
+		return fmt.Errorf("unknown db command %q", args[0])
 	}
 }
 
 // Usage prints command usage information with examples.
 func (c *dbCmd) Usage() {
-	executeUsage(c.fs.Output(), dbUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("db_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/db_backup.go
+++ b/cmd/goa4web/db_backup.go
@@ -12,18 +12,16 @@ type dbBackupCmd struct {
 	*dbCmd
 	fs   *flag.FlagSet
 	File string
-	args []string
 }
 
 func parseDbBackupCmd(parent *dbCmd, args []string) (*dbBackupCmd, error) {
 	c := &dbBackupCmd{dbCmd: parent}
-	fs := flag.NewFlagSet("backup", flag.ContinueOnError)
-	fs.StringVar(&c.File, "file", "", "output SQL file")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("backup")
+	c.fs.StringVar(&c.File, "file", "", "output SQL file")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/db_migrate.go
+++ b/cmd/goa4web/db_migrate.go
@@ -36,20 +36,18 @@ func openDB(cfg config.RuntimeConfig) (*sql.DB, error) {
 // dbMigrateCmd implements "db migrate".
 type dbMigrateCmd struct {
 	*dbCmd
-	fs   *flag.FlagSet
-	Dir  string
-	args []string
+	fs  *flag.FlagSet
+	Dir string
 }
 
 func parseDbMigrateCmd(parent *dbCmd, args []string) (*dbMigrateCmd, error) {
 	c := &dbMigrateCmd{dbCmd: parent}
-	fs := flag.NewFlagSet("migrate", flag.ContinueOnError)
-	fs.StringVar(&c.Dir, "dir", "migrations", "directory containing SQL migrations")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("migrate")
+	c.fs.StringVar(&c.Dir, "dir", "migrations", "directory containing SQL migrations")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/db_restore.go
+++ b/cmd/goa4web/db_restore.go
@@ -12,18 +12,16 @@ type dbRestoreCmd struct {
 	*dbCmd
 	fs   *flag.FlagSet
 	File string
-	args []string
 }
 
 func parseDbRestoreCmd(parent *dbCmd, args []string) (*dbRestoreCmd, error) {
 	c := &dbRestoreCmd{dbCmd: parent}
-	fs := flag.NewFlagSet("restore", flag.ContinueOnError)
-	fs.StringVar(&c.File, "file", "", "SQL file to restore")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("restore")
+	c.fs.StringVar(&c.File, "file", "", "SQL file to restore")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/db_seed.go
+++ b/cmd/goa4web/db_seed.go
@@ -17,18 +17,16 @@ type dbSeedCmd struct {
 	*dbCmd
 	fs   *flag.FlagSet
 	File string
-	args []string
 }
 
 func parseDbSeedCmd(parent *dbCmd, args []string) (*dbSeedCmd, error) {
 	c := &dbSeedCmd{dbCmd: parent}
-	fs := flag.NewFlagSet("seed", flag.ContinueOnError)
-	fs.StringVar(&c.File, "file", "seed.sql", "SQL seed file")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("seed")
+	c.fs.StringVar(&c.File, "file", "seed.sql", "SQL seed file")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/email.go
+++ b/cmd/goa4web/email.go
@@ -1,52 +1,46 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/email_usage.txt
-var emailUsageTemplate string
-
 // emailCmd handles email-related subcommands.
 type emailCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseEmailCmd(parent *rootCmd, args []string) (*emailCmd, error) {
 	c := &emailCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("email", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("email")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *emailCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing email command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "queue":
-		cmd, err := parseEmailQueueCmd(c, c.args[1:])
+		cmd, err := parseEmailQueueCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("queue: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown email command %q", c.args[0])
+		return fmt.Errorf("unknown email command %q", args[0])
 	}
 }
 
 // Usage prints command usage information with examples.
 func (c *emailCmd) Usage() {
-	executeUsage(c.fs.Output(), emailUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("email_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/email_queue.go
+++ b/cmd/goa4web/email_queue.go
@@ -1,64 +1,58 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/email_queue_usage.txt
-var emailQueueUsageTemplate string
-
 // emailQueueCmd handles email queue operations.
 type emailQueueCmd struct {
 	*emailCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseEmailQueueCmd(parent *emailCmd, args []string) (*emailQueueCmd, error) {
 	c := &emailQueueCmd{emailCmd: parent}
-	fs := flag.NewFlagSet("queue", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("queue")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *emailQueueCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing queue command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "list":
-		cmd, err := parseEmailQueueListCmd(c, c.args[1:])
+		cmd, err := parseEmailQueueListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	case "resend":
-		cmd, err := parseEmailQueueResendCmd(c, c.args[1:])
+		cmd, err := parseEmailQueueResendCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("resend: %w", err)
 		}
 		return cmd.Run()
 	case "delete":
-		cmd, err := parseEmailQueueDeleteCmd(c, c.args[1:])
+		cmd, err := parseEmailQueueDeleteCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("delete: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown queue command %q", c.args[0])
+		return fmt.Errorf("unknown queue command %q", args[0])
 	}
 }
 
 // Usage prints command usage information with examples.
 func (c *emailQueueCmd) Usage() {
-	executeUsage(c.fs.Output(), emailQueueUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("email_queue_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/email_queue_delete.go
+++ b/cmd/goa4web/email_queue_delete.go
@@ -11,20 +11,18 @@ import (
 // emailQueueDeleteCmd implements "email queue delete".
 type emailQueueDeleteCmd struct {
 	*emailQueueCmd
-	fs   *flag.FlagSet
-	ID   int
-	args []string
+	fs *flag.FlagSet
+	ID int
 }
 
 func parseEmailQueueDeleteCmd(parent *emailQueueCmd, args []string) (*emailQueueDeleteCmd, error) {
 	c := &emailQueueDeleteCmd{emailQueueCmd: parent}
-	fs := flag.NewFlagSet("delete", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "pending email id")
-	c.fs = fs
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("delete")
+	c.fs.IntVar(&c.ID, "id", 0, "pending email id")
+
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 

--- a/cmd/goa4web/email_queue_list.go
+++ b/cmd/goa4web/email_queue_list.go
@@ -14,18 +14,16 @@ import (
 // emailQueueListCmd implements "email queue list".
 type emailQueueListCmd struct {
 	*emailQueueCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseEmailQueueListCmd(parent *emailQueueCmd, args []string) (*emailQueueListCmd, error) {
 	c := &emailQueueListCmd{emailQueueCmd: parent}
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	c.fs = fs
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("list")
+
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 

--- a/cmd/goa4web/email_queue_resend.go
+++ b/cmd/goa4web/email_queue_resend.go
@@ -14,20 +14,18 @@ import (
 // emailQueueResendCmd implements "email queue resend".
 type emailQueueResendCmd struct {
 	*emailQueueCmd
-	fs   *flag.FlagSet
-	ID   int
-	args []string
+	fs *flag.FlagSet
+	ID int
 }
 
 func parseEmailQueueResendCmd(parent *emailQueueCmd, args []string) (*emailQueueResendCmd, error) {
 	c := &emailQueueResendCmd{emailQueueCmd: parent}
-	fs := flag.NewFlagSet("resend", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "pending email id")
-	c.fs = fs
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("resend")
+	c.fs.IntVar(&c.ID, "id", 0, "pending email id")
+
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 

--- a/cmd/goa4web/faq.go
+++ b/cmd/goa4web/faq.go
@@ -1,57 +1,51 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/faq_usage.txt
-var faqUsageTemplate string
-
 // faqCmd handles FAQ management subcommands.
 type faqCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseFaqCmd(parent *rootCmd, args []string) (*faqCmd, error) {
 	c := &faqCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("faq", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("faq")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *faqCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing faq command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "tree":
-		cmd, err := parseFaqTreeCmd(c, c.args[1:])
+		cmd, err := parseFaqTreeCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("tree: %w", err)
 		}
 		return cmd.Run()
 	case "read":
-		cmd, err := parseFaqReadCmd(c, c.args[1:])
+		cmd, err := parseFaqReadCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("read: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown faq command %q", c.args[0])
+		return fmt.Errorf("unknown faq command %q", args[0])
 	}
 }
 
 func (c *faqCmd) Usage() {
-	executeUsage(c.fs.Output(), faqUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("faq_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/faq_read.go
+++ b/cmd/goa4web/faq_read.go
@@ -12,24 +12,22 @@ import (
 // faqReadCmd implements "faq read".
 type faqReadCmd struct {
 	*faqCmd
-	fs   *flag.FlagSet
-	ID   int
-	args []string
+	fs *flag.FlagSet
+	ID int
 }
 
 func parseFaqReadCmd(parent *faqCmd, args []string) (*faqReadCmd, error) {
 	c := &faqReadCmd{faqCmd: parent}
-	fs := flag.NewFlagSet("read", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "faq id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("read")
+	c.fs.IntVar(&c.ID, "id", 0, "faq id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
-	if c.ID == 0 && len(c.args) > 0 {
-		if id, err := strconv.Atoi(c.args[0]); err == nil {
+
+	rest := c.fs.Args()
+	if c.ID == 0 && len(rest) > 0 {
+		if id, err := strconv.Atoi(rest[0]); err == nil {
 			c.ID = id
-			c.args = c.args[1:]
 		}
 	}
 	return c, nil

--- a/cmd/goa4web/faq_tree.go
+++ b/cmd/goa4web/faq_tree.go
@@ -11,18 +11,16 @@ import (
 // faqTreeCmd implements "faq tree".
 type faqTreeCmd struct {
 	*faqCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseFaqTreeCmd(parent *faqCmd, args []string) (*faqTreeCmd, error) {
 	c := &faqTreeCmd{faqCmd: parent}
-	fs := flag.NewFlagSet("tree", flag.ContinueOnError)
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("tree")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/grant_add.go
+++ b/cmd/goa4web/grant_add.go
@@ -19,23 +19,21 @@ type grantAddCmd struct {
 	Item    string
 	Action  string
 	ItemID  int
-	args    []string
 }
 
 func parseGrantAddCmd(parent *grantCmd, args []string) (*grantAddCmd, error) {
 	c := &grantAddCmd{grantCmd: parent}
-	fs := flag.NewFlagSet("add", flag.ContinueOnError)
-	fs.IntVar(&c.User, "user-id", 0, "user id")
-	fs.StringVar(&c.Role, "role", "", "role name")
-	fs.StringVar(&c.Section, "section", "", "section name")
-	fs.StringVar(&c.Item, "item", "", "item name")
-	fs.StringVar(&c.Action, "action", "", "action name")
-	fs.IntVar(&c.ItemID, "item-id", 0, "item id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("add")
+	c.fs.IntVar(&c.User, "user-id", 0, "user id")
+	c.fs.StringVar(&c.Role, "role", "", "role name")
+	c.fs.StringVar(&c.Section, "section", "", "section name")
+	c.fs.StringVar(&c.Item, "item", "", "item name")
+	c.fs.StringVar(&c.Action, "action", "", "action name")
+	c.fs.IntVar(&c.ItemID, "item-id", 0, "item id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/grant_delete.go
+++ b/cmd/goa4web/grant_delete.go
@@ -11,20 +11,18 @@ import (
 // grantDeleteCmd implements "grant delete".
 type grantDeleteCmd struct {
 	*grantCmd
-	fs   *flag.FlagSet
-	ID   int
-	args []string
+	fs *flag.FlagSet
+	ID int
 }
 
 func parseGrantDeleteCmd(parent *grantCmd, args []string) (*grantDeleteCmd, error) {
 	c := &grantDeleteCmd{grantCmd: parent}
-	fs := flag.NewFlagSet("delete", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "grant id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("delete")
+	c.fs.IntVar(&c.ID, "id", 0, "grant id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/grant_list.go
+++ b/cmd/goa4web/grant_list.go
@@ -11,18 +11,16 @@ import (
 // grantListCmd implements "grant list".
 type grantListCmd struct {
 	*grantCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseGrantListCmd(parent *grantCmd, args []string) (*grantListCmd, error) {
 	c := &grantListCmd{grantCmd: parent}
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("list")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/grant_rule.go
+++ b/cmd/goa4web/grant_rule.go
@@ -1,63 +1,57 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/grant_usage.txt
-var grantUsageTemplate string
-
 // grantCmd implements "grant" top-level command.
 type grantCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseGrantCmd(parent *rootCmd, args []string) (*grantCmd, error) {
 	c := &grantCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("grant", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("grant")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *grantCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing grant command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "add":
-		cmd, err := parseGrantAddCmd(c, c.args[1:])
+		cmd, err := parseGrantAddCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("add: %w", err)
 		}
 		return cmd.Run()
 	case "list":
-		cmd, err := parseGrantListCmd(c, c.args[1:])
+		cmd, err := parseGrantListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	case "delete":
-		cmd, err := parseGrantDeleteCmd(c, c.args[1:])
+		cmd, err := parseGrantDeleteCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("delete: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown grant command %q", c.args[0])
+		return fmt.Errorf("unknown grant command %q", args[0])
 	}
 }
 
 func (c *grantCmd) Usage() {
-	executeUsage(c.fs.Output(), grantUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("grant_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/help.go
+++ b/cmd/goa4web/help.go
@@ -1,39 +1,33 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/help_usage.txt
-var helpUsageTemplate string
-
 // helpCmd displays usage information for commands.
 type helpCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseHelpCmd(parent *rootCmd, args []string) (*helpCmd, error) {
 	c := &helpCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("help", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("help")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *helpCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.rootCmd.fs.Usage()
 		return nil
 	}
-	return c.showHelp(c.args)
+	return c.showHelp(args)
 }
 
 func (c *helpCmd) showHelp(args []string) error {
@@ -180,5 +174,5 @@ func (c *helpCmd) showHelp(args []string) error {
 }
 
 func (c *helpCmd) Usage() {
-	executeUsage(c.fs.Output(), helpUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("help_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/images.go
+++ b/cmd/goa4web/images.go
@@ -15,33 +15,31 @@ import (
 // imagesCmd implements image cache management utilities.
 type imagesCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseImagesCmd(parent *rootCmd, args []string) (*imagesCmd, error) {
 	c := &imagesCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("images", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("images")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *imagesCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing images command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "cache":
-		return c.runCache(c.args[1:])
+		return c.runCache(args[1:])
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown images command %q", c.args[0])
+		return fmt.Errorf("unknown images command %q", args[0])
 	}
 }
 
@@ -100,5 +98,5 @@ func listCache(dir string) error {
 }
 
 func (c *imagesCmd) Usage() {
-	fmt.Fprintln(c.fs.Output(), "images cache [prune|list|delete <id>|open <id>]")
+	executeUsage(c.fs.Output(), templateString("images_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/ipban.go
+++ b/cmd/goa4web/ipban.go
@@ -1,70 +1,64 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/ipban_usage.txt
-var ipBanUsageTemplate string
-
 // ipBanCmd implements IP ban management commands.
 type ipBanCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseIpBanCmd(parent *rootCmd, args []string) (*ipBanCmd, error) {
 	c := &ipBanCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("ipban", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("ipban")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *ipBanCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing ipban command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "add":
-		cmd, err := parseIpBanAddCmd(c, c.args[1:])
+		cmd, err := parseIpBanAddCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("add: %w", err)
 		}
 		return cmd.Run()
 	case "list":
-		cmd, err := parseIpBanListCmd(c, c.args[1:])
+		cmd, err := parseIpBanListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	case "delete":
-		cmd, err := parseIpBanDeleteCmd(c, c.args[1:])
+		cmd, err := parseIpBanDeleteCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("delete: %w", err)
 		}
 		return cmd.Run()
 	case "update":
-		cmd, err := parseIpBanUpdateCmd(c, c.args[1:])
+		cmd, err := parseIpBanUpdateCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("update: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown ipban command %q", c.args[0])
+		return fmt.Errorf("unknown ipban command %q", args[0])
 	}
 }
 
 // Usage prints command usage information with examples.
 func (c *ipBanCmd) Usage() {
-	executeUsage(c.fs.Output(), ipBanUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("ipban_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/ipban_add.go
+++ b/cmd/goa4web/ipban_add.go
@@ -17,12 +17,11 @@ type ipBanAddCmd struct {
 	IP      string
 	Reason  string
 	Expires string
-	args    []string
 }
 
 func parseIpBanAddCmd(parent *ipBanCmd, args []string) (*ipBanAddCmd, error) {
 	c := &ipBanAddCmd{ipBanCmd: parent}
-	fs, rest, err := parseFlags("add", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("add", args, func(fs *flag.FlagSet) {
 		fs.StringVar(&c.IP, "ip", "", "ip or cidr")
 		fs.StringVar(&c.Reason, "reason", "", "ban reason")
 		fs.StringVar(&c.Expires, "expires", "", "expiry date YYYY-MM-DD")
@@ -31,7 +30,6 @@ func parseIpBanAddCmd(parent *ipBanCmd, args []string) (*ipBanAddCmd, error) {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/ipban_delete.go
+++ b/cmd/goa4web/ipban_delete.go
@@ -11,21 +11,19 @@ import (
 // ipBanDeleteCmd implements "ipban delete".
 type ipBanDeleteCmd struct {
 	*ipBanCmd
-	fs   *flag.FlagSet
-	IP   string
-	args []string
+	fs *flag.FlagSet
+	IP string
 }
 
 func parseIpBanDeleteCmd(parent *ipBanCmd, args []string) (*ipBanDeleteCmd, error) {
 	c := &ipBanDeleteCmd{ipBanCmd: parent}
-	fs, rest, err := parseFlags("delete", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("delete", args, func(fs *flag.FlagSet) {
 		fs.StringVar(&c.IP, "ip", "", "ip or cidr")
 	})
 	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/ipban_list.go
+++ b/cmd/goa4web/ipban_list.go
@@ -11,18 +11,16 @@ import (
 // ipBanListCmd implements "ipban list".
 type ipBanListCmd struct {
 	*ipBanCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseIpBanListCmd(parent *ipBanCmd, args []string) (*ipBanListCmd, error) {
 	c := &ipBanListCmd{ipBanCmd: parent}
-	fs, rest, err := parseFlags("list", args, nil)
+	fs, _, err := parseFlags("list", args, nil)
 	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/ipban_update.go
+++ b/cmd/goa4web/ipban_update.go
@@ -17,12 +17,11 @@ type ipBanUpdateCmd struct {
 	ID      int
 	Reason  string
 	Expires string
-	args    []string
 }
 
 func parseIpBanUpdateCmd(parent *ipBanCmd, args []string) (*ipBanUpdateCmd, error) {
 	c := &ipBanUpdateCmd{ipBanCmd: parent}
-	fs, rest, err := parseFlags("update", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("update", args, func(fs *flag.FlagSet) {
 		fs.IntVar(&c.ID, "id", 0, "ban id")
 		fs.StringVar(&c.Reason, "reason", "", "ban reason")
 		fs.StringVar(&c.Expires, "expires", "", "expiry date YYYY-MM-DD")
@@ -31,7 +30,6 @@ func parseIpBanUpdateCmd(parent *ipBanCmd, args []string) (*ipBanUpdateCmd, erro
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/lang.go
+++ b/cmd/goa4web/lang.go
@@ -1,62 +1,57 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/lang_usage.txt
-var langUsageTemplate string
-
 type langCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseLangCmd(parent *rootCmd, args []string) (*langCmd, error) {
 	c := &langCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("lang", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("lang")
+
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *langCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing lang command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "add":
-		cmd, err := parseLangAddCmd(c, c.args[1:])
+		cmd, err := parseLangAddCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("add: %w", err)
 		}
 		return cmd.Run()
 	case "list":
-		cmd, err := parseLangListCmd(c, c.args[1:])
+		cmd, err := parseLangListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	case "update":
-		cmd, err := parseLangUpdateCmd(c, c.args[1:])
+		cmd, err := parseLangUpdateCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("update: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown lang command %q", c.args[0])
+		return fmt.Errorf("unknown lang command %q", args[0])
 	}
 }
 
 func (c *langCmd) Usage() {
-	executeUsage(c.fs.Output(), langUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("lang_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/lang_add.go
+++ b/cmd/goa4web/lang_add.go
@@ -15,19 +15,17 @@ type langAddCmd struct {
 	fs   *flag.FlagSet
 	Code string
 	Name string
-	args []string
 }
 
 func parseLangAddCmd(parent *langCmd, args []string) (*langAddCmd, error) {
 	c := &langAddCmd{langCmd: parent}
-	fs := flag.NewFlagSet("add", flag.ContinueOnError)
-	fs.StringVar(&c.Code, "code", "", "language code")
-	fs.StringVar(&c.Name, "name", "", "language name")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("add")
+	c.fs.StringVar(&c.Code, "code", "", "language code")
+	c.fs.StringVar(&c.Name, "name", "", "language name")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/lang_list.go
+++ b/cmd/goa4web/lang_list.go
@@ -11,18 +11,16 @@ import (
 // langListCmd implements "lang list".
 type langListCmd struct {
 	*langCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseLangListCmd(parent *langCmd, args []string) (*langListCmd, error) {
 	c := &langListCmd{langCmd: parent}
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("list")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/lang_update.go
+++ b/cmd/goa4web/lang_update.go
@@ -15,19 +15,17 @@ type langUpdateCmd struct {
 	fs   *flag.FlagSet
 	ID   int
 	Name string
-	args []string
 }
 
 func parseLangUpdateCmd(parent *langCmd, args []string) (*langUpdateCmd, error) {
 	c := &langUpdateCmd{langCmd: parent}
-	fs := flag.NewFlagSet("update", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "language id")
-	fs.StringVar(&c.Name, "name", "", "new name")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("update")
+	c.fs.IntVar(&c.ID, "id", 0, "language id")
+	c.fs.StringVar(&c.Name, "name", "", "new name")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/news.go
+++ b/cmd/goa4web/news.go
@@ -1,64 +1,59 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/news_usage.txt
-var newsUsageTemplate string
-
 // newsCmd handles news management subcommands.
 type newsCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseNewsCmd(parent *rootCmd, args []string) (*newsCmd, error) {
 	c := &newsCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("news", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("news")
+
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *newsCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing news command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "list":
-		cmd, err := parseNewsListCmd(c, c.args[1:])
+		cmd, err := parseNewsListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	case "read":
-		cmd, err := parseNewsReadCmd(c, c.args[1:])
+		cmd, err := parseNewsReadCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("read: %w", err)
 		}
 		return cmd.Run()
 	case "comments":
-		cmd, err := parseNewsCommentsCmd(c, c.args[1:])
+		cmd, err := parseNewsCommentsCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("comments: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown news command %q", c.args[0])
+		return fmt.Errorf("unknown news command %q", args[0])
 	}
 }
 
 // Usage prints command usage information with examples.
 func (c *newsCmd) Usage() {
-	executeUsage(c.fs.Output(), newsUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("news_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/news_comments.go
+++ b/cmd/goa4web/news_comments.go
@@ -1,57 +1,52 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/news_comments_usage.txt
-var newsCommentsUsageTemplate string
-
 // newsCommentsCmd handles "news comments".
 type newsCommentsCmd struct {
 	*newsCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseNewsCommentsCmd(parent *newsCmd, args []string) (*newsCommentsCmd, error) {
 	c := &newsCommentsCmd{newsCmd: parent}
-	fs := flag.NewFlagSet("comments", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("comments")
+
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *newsCommentsCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing comments command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "list":
-		cmd, err := parseNewsCommentsListCmd(c, c.args[1:])
+		cmd, err := parseNewsCommentsListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	case "read":
-		cmd, err := parseNewsCommentsReadCmd(c, c.args[1:])
+		cmd, err := parseNewsCommentsReadCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("read: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown comments command %q", c.args[0])
+		return fmt.Errorf("unknown comments command %q", args[0])
 	}
 }
 
 func (c *newsCommentsCmd) Usage() {
-	executeUsage(c.fs.Output(), newsCommentsUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("news_comments_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/news_comments_list.go
+++ b/cmd/goa4web/news_comments_list.go
@@ -16,23 +16,22 @@ type newsCommentsListCmd struct {
 	fs     *flag.FlagSet
 	ID     int
 	UserID int
-	args   []string
 }
 
 func parseNewsCommentsListCmd(parent *newsCommentsCmd, args []string) (*newsCommentsListCmd, error) {
 	c := &newsCommentsListCmd{newsCommentsCmd: parent}
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "news id")
-	fs.IntVar(&c.UserID, "user", 0, "viewer user id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("list")
+	c.fs.IntVar(&c.ID, "id", 0, "news id")
+	c.fs.IntVar(&c.UserID, "user", 0, "viewer user id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
-	if c.ID == 0 && len(c.args) > 0 {
-		if id, err := strconv.Atoi(c.args[0]); err == nil {
+
+	rest := c.fs.Args()
+	if c.ID == 0 && len(rest) > 0 {
+		if id, err := strconv.Atoi(rest[0]); err == nil {
 			c.ID = id
-			c.args = c.args[1:]
+			rest = rest[1:]
 		}
 	}
 	return c, nil

--- a/cmd/goa4web/news_comments_read.go
+++ b/cmd/goa4web/news_comments_read.go
@@ -18,33 +18,32 @@ type newsCommentsReadCmd struct {
 	CommentID int
 	UserID    int
 	All       bool
-	args      []string
 }
 
 func parseNewsCommentsReadCmd(parent *newsCommentsCmd, args []string) (*newsCommentsReadCmd, error) {
 	c := &newsCommentsReadCmd{newsCommentsCmd: parent}
-	fs := flag.NewFlagSet("read", flag.ContinueOnError)
-	fs.IntVar(&c.NewsID, "id", 0, "news id")
-	fs.IntVar(&c.CommentID, "comment", 0, "comment id")
-	fs.IntVar(&c.UserID, "user", 0, "viewer user id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("read")
+	c.fs.IntVar(&c.NewsID, "id", 0, "news id")
+	c.fs.IntVar(&c.CommentID, "comment", 0, "comment id")
+	c.fs.IntVar(&c.UserID, "user", 0, "viewer user id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
-	if c.NewsID == 0 && len(c.args) > 0 {
-		if id, err := strconv.Atoi(c.args[0]); err == nil {
+
+	rest := c.fs.Args()
+	if c.NewsID == 0 && len(rest) > 0 {
+		if id, err := strconv.Atoi(rest[0]); err == nil {
 			c.NewsID = id
-			c.args = c.args[1:]
+			rest = rest[1:]
 		}
 	}
-	if len(c.args) > 0 {
-		if c.args[0] == "all" {
+	if len(rest) > 0 {
+		if rest[0] == "all" {
 			c.All = true
-			c.args = c.args[1:]
-		} else if id, err := strconv.Atoi(c.args[0]); err == nil {
+			rest = rest[1:]
+		} else if id, err := strconv.Atoi(rest[0]); err == nil {
 			c.CommentID = id
-			c.args = c.args[1:]
+			rest = rest[1:]
 		}
 	}
 	return c, nil

--- a/cmd/goa4web/news_list.go
+++ b/cmd/goa4web/news_list.go
@@ -15,19 +15,17 @@ type newsListCmd struct {
 	fs     *flag.FlagSet
 	Limit  int
 	Offset int
-	args   []string
 }
 
 func parseNewsListCmd(parent *newsCmd, args []string) (*newsListCmd, error) {
 	c := &newsListCmd{newsCmd: parent}
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	fs.IntVar(&c.Limit, "limit", 10, "limit")
-	fs.IntVar(&c.Offset, "offset", 0, "offset")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("list")
+	c.fs.IntVar(&c.Limit, "limit", 10, "limit")
+	c.fs.IntVar(&c.Offset, "offset", 0, "offset")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/news_read.go
+++ b/cmd/goa4web/news_read.go
@@ -14,24 +14,22 @@ import (
 // newsReadCmd implements "news read".
 type newsReadCmd struct {
 	*newsCmd
-	fs   *flag.FlagSet
-	ID   int
-	args []string
+	fs *flag.FlagSet
+	ID int
 }
 
 func parseNewsReadCmd(parent *newsCmd, args []string) (*newsReadCmd, error) {
 	c := &newsReadCmd{newsCmd: parent}
-	fs := flag.NewFlagSet("read", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "news id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("read")
+	c.fs.IntVar(&c.ID, "id", 0, "news id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
-	if c.ID == 0 && len(c.args) > 0 {
-		if id, err := strconv.Atoi(c.args[0]); err == nil {
+
+	rest := c.fs.Args()
+	if c.ID == 0 && len(rest) > 0 {
+		if id, err := strconv.Atoi(rest[0]); err == nil {
 			c.ID = id
-			c.args = c.args[1:]
 		}
 	}
 	return c, nil

--- a/cmd/goa4web/notifications.go
+++ b/cmd/goa4web/notifications.go
@@ -1,52 +1,47 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/notifications_usage.txt
-var notificationsUsageTemplate string
-
 // notificationsCmd handles notification-related subcommands.
 type notificationsCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseNotificationsCmd(parent *rootCmd, args []string) (*notificationsCmd, error) {
 	c := &notificationsCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("notifications", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("notifications")
+
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *notificationsCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing notifications command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "tasks":
-		cmd, err := parseNotificationsTasksCmd(c, c.args[1:])
+		cmd, err := parseNotificationsTasksCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("tasks: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown notifications command %q", c.args[0])
+		return fmt.Errorf("unknown notifications command %q", args[0])
 	}
 }
 
 // Usage prints command usage information with examples.
 func (c *notificationsCmd) Usage() {
-	executeUsage(c.fs.Output(), notificationsUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("notifications_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/notifications_tasks.go
+++ b/cmd/goa4web/notifications_tasks.go
@@ -1,37 +1,31 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"strings"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 )
 
-//go:embed templates/notifications_tasks_usage.txt
-var notificationsTasksUsageTemplate string
-
 // notificationsTasksCmd implements "notifications tasks".
 type notificationsTasksCmd struct {
 	*notificationsCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 // Usage prints command usage information with examples.
 func (c *notificationsTasksCmd) Usage() {
-	executeUsage(c.fs.Output(), notificationsTasksUsageTemplate, c.fs, c.notificationsCmd.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("notifications_tasks_usage.txt"), c.fs, c.notificationsCmd.rootCmd.fs.Name())
 }
 
 func parseNotificationsTasksCmd(parent *notificationsCmd, args []string) (*notificationsTasksCmd, error) {
 	c := &notificationsTasksCmd{notificationsCmd: parent}
-	fs := flag.NewFlagSet("tasks", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("tasks")
+
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 

--- a/cmd/goa4web/perm.go
+++ b/cmd/goa4web/perm.go
@@ -1,69 +1,64 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/perm_usage.txt
-var permUsageTemplate string
-
 type permCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parsePermCmd(parent *rootCmd, args []string) (*permCmd, error) {
 	c := &permCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("perm", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("perm")
+
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *permCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing perm command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "grant":
-		cmd, err := parsePermGrantCmd(c, c.args[1:])
+		cmd, err := parsePermGrantCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("grant: %w", err)
 		}
 		return cmd.Run()
 	case "revoke":
-		cmd, err := parsePermRevokeCmd(c, c.args[1:])
+		cmd, err := parsePermRevokeCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("revoke: %w", err)
 		}
 		return cmd.Run()
 	case "update":
-		cmd, err := parsePermUpdateCmd(c, c.args[1:])
+		cmd, err := parsePermUpdateCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("update: %w", err)
 		}
 		return cmd.Run()
 	case "list":
-		cmd, err := parsePermListCmd(c, c.args[1:])
+		cmd, err := parsePermListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown perm command %q", c.args[0])
+		return fmt.Errorf("unknown perm command %q", args[0])
 	}
 }
 
 // Usage prints command usage information with examples.
 func (c *permCmd) Usage() {
-	executeUsage(c.fs.Output(), permUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("perm_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/perm_grant.go
+++ b/cmd/goa4web/perm_grant.go
@@ -16,19 +16,17 @@ type permGrantCmd struct {
 	fs   *flag.FlagSet
 	User string
 	Role string
-	args []string
 }
 
 func parsePermGrantCmd(parent *permCmd, args []string) (*permGrantCmd, error) {
 	c := &permGrantCmd{permCmd: parent}
-	fs := flag.NewFlagSet("grant", flag.ContinueOnError)
-	fs.StringVar(&c.User, "user", "", "username")
-	fs.StringVar(&c.Role, "role", "", "permission role")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("grant")
+	c.fs.StringVar(&c.User, "user", "", "username")
+	c.fs.StringVar(&c.Role, "role", "", "permission role")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/perm_list.go
+++ b/cmd/goa4web/perm_list.go
@@ -14,18 +14,16 @@ type permListCmd struct {
 	*permCmd
 	fs   *flag.FlagSet
 	User string
-	args []string
 }
 
 func parsePermListCmd(parent *permCmd, args []string) (*permListCmd, error) {
 	c := &permListCmd{permCmd: parent}
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	fs.StringVar(&c.User, "user", "", "username filter")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("list")
+	c.fs.StringVar(&c.User, "user", "", "username filter")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/perm_revoke.go
+++ b/cmd/goa4web/perm_revoke.go
@@ -11,20 +11,18 @@ import (
 // permRevokeCmd implements "perm revoke".
 type permRevokeCmd struct {
 	*permCmd
-	fs   *flag.FlagSet
-	ID   int
-	args []string
+	fs *flag.FlagSet
+	ID int
 }
 
 func parsePermRevokeCmd(parent *permCmd, args []string) (*permRevokeCmd, error) {
 	c := &permRevokeCmd{permCmd: parent}
-	fs := flag.NewFlagSet("revoke", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "permission id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("revoke")
+	c.fs.IntVar(&c.ID, "id", 0, "permission id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/perm_update.go
+++ b/cmd/goa4web/perm_update.go
@@ -14,19 +14,17 @@ type permUpdateCmd struct {
 	fs   *flag.FlagSet
 	ID   int
 	Role string
-	args []string
 }
 
 func parsePermUpdateCmd(parent *permCmd, args []string) (*permUpdateCmd, error) {
 	c := &permUpdateCmd{permCmd: parent}
-	fs := flag.NewFlagSet("update", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "permission id")
-	fs.StringVar(&c.Role, "role", "", "permission role")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("update")
+	c.fs.IntVar(&c.ID, "id", 0, "permission id")
+	c.fs.StringVar(&c.Role, "role", "", "permission role")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/serve.go
+++ b/cmd/goa4web/serve.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	_ "embed"
+
 	"errors"
 	"flag"
 	"fmt"
@@ -15,25 +15,19 @@ import (
 	"github.com/arran4/goa4web/internal/app"
 )
 
-//go:embed templates/serve_usage.txt
-var serveUsageTemplate string
-
 // serveCmd starts the web server.
 type serveCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseServeCmd(parent *rootCmd, args []string) (*serveCmd, error) {
 	c := &serveCmd{rootCmd: parent}
-	fs := config.NewRuntimeFlagSet("serve")
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = config.NewRuntimeFlagSet("serve")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
 	return c, nil
 }
 
@@ -65,5 +59,5 @@ func (c *serveCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *serveCmd) Usage() {
-	executeUsage(c.fs.Output(), serveUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("serve_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/server.go
+++ b/cmd/goa4web/server.go
@@ -1,52 +1,47 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/server_usage.txt
-var serverUsageTemplate string
-
 // serverCmd handles server management commands.
 type serverCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseServerCmd(parent *rootCmd, args []string) (*serverCmd, error) {
 	c := &serverCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("server", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("server")
+
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *serverCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing server command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "shutdown":
-		cmd, err := parseServerShutdownCmd(c, c.args[1:])
+		cmd, err := parseServerShutdownCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("shutdown: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown server command %q", c.args[0])
+		return fmt.Errorf("unknown server command %q", args[0])
 	}
 }
 
 // Usage prints command usage information with examples.
 func (c *serverCmd) Usage() {
-	executeUsage(c.fs.Output(), serverUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("server_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/server_shutdown.go
+++ b/cmd/goa4web/server_shutdown.go
@@ -14,18 +14,16 @@ type serverShutdownCmd struct {
 	*serverCmd
 	fs      *flag.FlagSet
 	Timeout time.Duration
-	args    []string
 }
 
 func parseServerShutdownCmd(parent *serverCmd, args []string) (*serverShutdownCmd, error) {
 	c := &serverShutdownCmd{serverCmd: parent}
-	fs := flag.NewFlagSet("shutdown", flag.ContinueOnError)
-	fs.DurationVar(&c.Timeout, "timeout", 5*time.Second, "shutdown timeout")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("shutdown")
+	c.fs.DurationVar(&c.Timeout, "timeout", 5*time.Second, "shutdown timeout")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/templates/audit_usage.txt
+++ b/cmd/goa4web/templates/audit_usage.txt
@@ -1,0 +1,8 @@
+Usage:
+  {{.Prog}} audit [flags]
+
+Examples:
+  {{.Prog}} audit --limit 50
+
+Flags:
+{{template "flags" .Flags}}

--- a/cmd/goa4web/templates/images_usage.txt
+++ b/cmd/goa4web/templates/images_usage.txt
@@ -1,0 +1,5 @@
+Usage:
+  {{.Prog}} images cache [prune|list|delete <id>|open <id>]
+
+Flags:
+{{template "flags" .Flags}}

--- a/cmd/goa4web/templates_fs.go
+++ b/cmd/goa4web/templates_fs.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"embed"
+	"fmt"
+)
+
+// templatesFS contains all CLI usage templates.
+//
+//go:embed templates/*.txt
+var templatesFS embed.FS
+
+// templateString returns the contents of the named template file.
+func templateString(name string) string {
+	b, err := templatesFS.ReadFile("templates/" + name)
+	if err != nil {
+		panic(fmt.Errorf("read template %s: %w", name, err))
+	}
+	return string(b)
+}

--- a/cmd/goa4web/user.go
+++ b/cmd/goa4web/user.go
@@ -1,129 +1,124 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/user_usage.txt
-var userUsageTemplate string
-
 type userCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseUserCmd(parent *rootCmd, args []string) (*userCmd, error) {
 	c := &userCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("user", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("user")
+
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *userCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing user command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "add":
-		cmd, err := parseUserAddCmd(c, c.args[1:])
+		cmd, err := parseUserAddCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("add: %w", err)
 		}
 		return cmd.Run()
 	case "add-admin":
-		cmd, err := parseUserAddAdminCmd(c, c.args[1:])
+		cmd, err := parseUserAddAdminCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("add-admin: %w", err)
 		}
 		return cmd.Run()
 	case "make-admin":
-		cmd, err := parseUserMakeAdminCmd(c, c.args[1:])
+		cmd, err := parseUserMakeAdminCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("make-admin: %w", err)
 		}
 		return cmd.Run()
 	case "add-role":
-		cmd, err := parseUserAddRoleCmd(c, c.args[1:])
+		cmd, err := parseUserAddRoleCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("add-role: %w", err)
 		}
 		return cmd.Run()
 	case "remove-role":
-		cmd, err := parseUserRemoveRoleCmd(c, c.args[1:])
+		cmd, err := parseUserRemoveRoleCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("remove-role: %w", err)
 		}
 		return cmd.Run()
 	case "list-roles":
-		cmd, err := parseUserListRolesCmd(c, c.args[1:])
+		cmd, err := parseUserListRolesCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list-roles: %w", err)
 		}
 		return cmd.Run()
 	case "list":
-		cmd, err := parseUserListCmd(c, c.args[1:])
+		cmd, err := parseUserListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	case "deactivate":
-		cmd, err := parseUserDeactivateCmd(c, c.args[1:])
+		cmd, err := parseUserDeactivateCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("deactivate: %w", err)
 		}
 		return cmd.Run()
 	case "activate":
-		cmd, err := parseUserActivateCmd(c, c.args[1:])
+		cmd, err := parseUserActivateCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("activate: %w", err)
 		}
 		return cmd.Run()
 	case "approve":
-		cmd, err := parseUserApproveCmd(c, c.args[1:])
+		cmd, err := parseUserApproveCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("approve: %w", err)
 		}
 		return cmd.Run()
 	case "reject":
-		cmd, err := parseUserRejectCmd(c, c.args[1:])
+		cmd, err := parseUserRejectCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("reject: %w", err)
 		}
 		return cmd.Run()
 	case "comments":
-		cmd, err := parseUserCommentsCmd(c, c.args[1:])
+		cmd, err := parseUserCommentsCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("comments: %w", err)
 		}
 		return cmd.Run()
 	case "roles":
-		cmd, err := parseUserRolesCmd(c, c.args[1:])
+		cmd, err := parseUserRolesCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("roles: %w", err)
 		}
 		return cmd.Run()
 	case "profile":
-		cmd, err := parseUserProfileCmd(c, c.args[1:])
+		cmd, err := parseUserProfileCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("profile: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown user command %q", c.args[0])
+		return fmt.Errorf("unknown user command %q", args[0])
 	}
 }
 
 // Usage prints command usage information with examples.
 func (c *userCmd) Usage() {
-	executeUsage(c.fs.Output(), userUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("user_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/user_activate.go
+++ b/cmd/goa4web/user_activate.go
@@ -15,12 +15,11 @@ type userActivateCmd struct {
 	fs       *flag.FlagSet
 	ID       int
 	Username string
-	args     []string
 }
 
 func parseUserActivateCmd(parent *userCmd, args []string) (*userActivateCmd, error) {
 	c := &userActivateCmd{userCmd: parent}
-	fs, rest, err := parseFlags("activate", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("activate", args, func(fs *flag.FlagSet) {
 		fs.IntVar(&c.ID, "id", 0, "user id")
 		fs.StringVar(&c.Username, "username", "", "username")
 	})
@@ -28,7 +27,6 @@ func parseUserActivateCmd(parent *userCmd, args []string) (*userActivateCmd, err
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_add.go
+++ b/cmd/goa4web/user_add.go
@@ -21,12 +21,11 @@ type userAddCmd struct {
 	Email    string
 	Password string
 	Admin    bool
-	args     []string
 }
 
 func parseUserAddCmd(parent *userCmd, args []string) (*userAddCmd, error) {
 	c := &userAddCmd{userCmd: parent}
-	fs, rest, err := parseFlags("add", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("add", args, func(fs *flag.FlagSet) {
 		fs.StringVar(&c.Username, "username", "", "username")
 		fs.StringVar(&c.Email, "email", "", "email address")
 		fs.StringVar(&c.Password, "password", "", "password (leave empty to prompt)")
@@ -36,7 +35,6 @@ func parseUserAddCmd(parent *userCmd, args []string) (*userAddCmd, error) {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_add_admin.go
+++ b/cmd/goa4web/user_add_admin.go
@@ -13,12 +13,11 @@ type userAddAdminCmd struct {
 	Username string
 	Email    string
 	Password string
-	args     []string
 }
 
 func parseUserAddAdminCmd(parent *userCmd, args []string) (*userAddAdminCmd, error) {
 	c := &userAddAdminCmd{userCmd: parent}
-	fs, rest, err := parseFlags("add-admin", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("add-admin", args, func(fs *flag.FlagSet) {
 		fs.StringVar(&c.Username, "username", "", "username")
 		fs.StringVar(&c.Email, "email", "", "email address")
 		fs.StringVar(&c.Password, "password", "", "password (leave empty to prompt)")
@@ -27,7 +26,6 @@ func parseUserAddAdminCmd(parent *userCmd, args []string) (*userAddAdminCmd, err
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_add_role.go
+++ b/cmd/goa4web/user_add_role.go
@@ -16,12 +16,11 @@ type userAddRoleCmd struct {
 	fs       *flag.FlagSet
 	Username string
 	Role     string
-	args     []string
 }
 
 func parseUserAddRoleCmd(parent *userCmd, args []string) (*userAddRoleCmd, error) {
 	c := &userAddRoleCmd{userCmd: parent}
-	fs, rest, err := parseFlags("add-role", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("add-role", args, func(fs *flag.FlagSet) {
 		fs.StringVar(&c.Username, "username", "", "username")
 		fs.StringVar(&c.Role, "role", "", "role name")
 	})
@@ -29,7 +28,6 @@ func parseUserAddRoleCmd(parent *userCmd, args []string) (*userAddRoleCmd, error
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_approve.go
+++ b/cmd/goa4web/user_approve.go
@@ -15,12 +15,11 @@ type userApproveCmd struct {
 	fs       *flag.FlagSet
 	ID       int
 	Username string
-	args     []string
 }
 
 func parseUserApproveCmd(parent *userCmd, args []string) (*userApproveCmd, error) {
 	c := &userApproveCmd{userCmd: parent}
-	fs, rest, err := parseFlags("approve", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("approve", args, func(fs *flag.FlagSet) {
 		fs.IntVar(&c.ID, "id", 0, "user id")
 		fs.StringVar(&c.Username, "username", "", "username")
 	})
@@ -28,7 +27,6 @@ func parseUserApproveCmd(parent *userCmd, args []string) (*userApproveCmd, error
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_comments.go
+++ b/cmd/goa4web/user_comments.go
@@ -1,57 +1,52 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/user_comments_usage.txt
-var userCommentsUsageTemplate string
-
 // userCommentsCmd handles "user comments".
 type userCommentsCmd struct {
 	*userCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseUserCommentsCmd(parent *userCmd, args []string) (*userCommentsCmd, error) {
 	c := &userCommentsCmd{userCmd: parent}
-	fs := flag.NewFlagSet("comments", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("comments")
+
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *userCommentsCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing comments command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "list":
-		cmd, err := parseUserCommentsListCmd(c, c.args[1:])
+		cmd, err := parseUserCommentsListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	case "add":
-		cmd, err := parseUserCommentsAddCmd(c, c.args[1:])
+		cmd, err := parseUserCommentsAddCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("add: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown comments command %q", c.args[0])
+		return fmt.Errorf("unknown comments command %q", args[0])
 	}
 }
 
 func (c *userCommentsCmd) Usage() {
-	executeUsage(c.fs.Output(), userCommentsUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("user_comments_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/user_comments_add.go
+++ b/cmd/goa4web/user_comments_add.go
@@ -17,12 +17,11 @@ type userCommentsAddCmd struct {
 	ID       int
 	Username string
 	Comment  string
-	args     []string
 }
 
 func parseUserCommentsAddCmd(parent *userCommentsCmd, args []string) (*userCommentsAddCmd, error) {
 	c := &userCommentsAddCmd{userCommentsCmd: parent}
-	fs, rest, err := parseFlags("add", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("add", args, func(fs *flag.FlagSet) {
 		fs.IntVar(&c.ID, "id", 0, "user id")
 		fs.StringVar(&c.Username, "username", "", "username")
 		fs.StringVar(&c.Comment, "comment", "", "comment text")
@@ -31,7 +30,6 @@ func parseUserCommentsAddCmd(parent *userCommentsCmd, args []string) (*userComme
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_comments_list.go
+++ b/cmd/goa4web/user_comments_list.go
@@ -15,12 +15,11 @@ type userCommentsListCmd struct {
 	fs       *flag.FlagSet
 	ID       int
 	Username string
-	args     []string
 }
 
 func parseUserCommentsListCmd(parent *userCommentsCmd, args []string) (*userCommentsListCmd, error) {
 	c := &userCommentsListCmd{userCommentsCmd: parent}
-	fs, rest, err := parseFlags("list", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("list", args, func(fs *flag.FlagSet) {
 		fs.IntVar(&c.ID, "id", 0, "user id")
 		fs.StringVar(&c.Username, "username", "", "username")
 	})
@@ -28,7 +27,6 @@ func parseUserCommentsListCmd(parent *userCommentsCmd, args []string) (*userComm
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -15,19 +15,17 @@ type userDeactivateCmd struct {
 	*userCmd
 	fs       *flag.FlagSet
 	Username string
-	args     []string
 }
 
 func parseUserDeactivateCmd(parent *userCmd, args []string) (*userDeactivateCmd, error) {
 	c := &userDeactivateCmd{userCmd: parent}
-	fs, rest, err := parseFlags("deactivate", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("deactivate", args, func(fs *flag.FlagSet) {
 		fs.StringVar(&c.Username, "username", "", "username")
 	})
 	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_list.go
+++ b/cmd/goa4web/user_list.go
@@ -18,12 +18,11 @@ type userListCmd struct {
 	showAdmin   bool
 	showCreated bool
 	jsonOut     bool
-	args        []string
 }
 
 func parseUserListCmd(parent *userCmd, args []string) (*userListCmd, error) {
 	c := &userListCmd{userCmd: parent}
-	fs, rest, err := parseFlags("list", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("list", args, func(fs *flag.FlagSet) {
 		fs.BoolVar(&c.showAdmin, "admin", false, "include admin status")
 		fs.BoolVar(&c.showCreated, "created", false, "include creation date")
 		fs.BoolVar(&c.jsonOut, "json", false, "machine-readable JSON output")
@@ -32,7 +31,6 @@ func parseUserListCmd(parent *userCmd, args []string) (*userListCmd, error) {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_list_roles.go
+++ b/cmd/goa4web/user_list_roles.go
@@ -11,18 +11,16 @@ import (
 // userListRolesCmd implements the "user list-roles" command.
 type userListRolesCmd struct {
 	*userCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseUserListRolesCmd(parent *userCmd, args []string) (*userListRolesCmd, error) {
 	c := &userListRolesCmd{userCmd: parent}
-	fs, rest, err := parseFlags("list-roles", args, nil)
+	fs, _, err := parseFlags("list-roles", args, nil)
 	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_make_admin.go
+++ b/cmd/goa4web/user_make_admin.go
@@ -15,19 +15,17 @@ type userMakeAdminCmd struct {
 	*userCmd
 	fs       *flag.FlagSet
 	Username string
-	args     []string
 }
 
 func parseUserMakeAdminCmd(parent *userCmd, args []string) (*userMakeAdminCmd, error) {
 	c := &userMakeAdminCmd{userCmd: parent}
-	fs, rest, err := parseFlags("make-admin", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("make-admin", args, func(fs *flag.FlagSet) {
 		fs.StringVar(&c.Username, "username", "", "username")
 	})
 	if err != nil {
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_profile.go
+++ b/cmd/goa4web/user_profile.go
@@ -15,12 +15,11 @@ type userProfileCmd struct {
 	fs       *flag.FlagSet
 	ID       int
 	Username string
-	args     []string
 }
 
 func parseUserProfileCmd(parent *userCmd, args []string) (*userProfileCmd, error) {
 	c := &userProfileCmd{userCmd: parent}
-	fs, rest, err := parseFlags("profile", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("profile", args, func(fs *flag.FlagSet) {
 		fs.IntVar(&c.ID, "id", 0, "user id")
 		fs.StringVar(&c.Username, "username", "", "username")
 	})
@@ -28,7 +27,6 @@ func parseUserProfileCmd(parent *userCmd, args []string) (*userProfileCmd, error
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_reject.go
+++ b/cmd/goa4web/user_reject.go
@@ -16,12 +16,11 @@ type userRejectCmd struct {
 	ID       int
 	Username string
 	Reason   string
-	args     []string
 }
 
 func parseUserRejectCmd(parent *userCmd, args []string) (*userRejectCmd, error) {
 	c := &userRejectCmd{userCmd: parent}
-	fs, rest, err := parseFlags("reject", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("reject", args, func(fs *flag.FlagSet) {
 		fs.IntVar(&c.ID, "id", 0, "user id")
 		fs.StringVar(&c.Username, "username", "", "username")
 		fs.StringVar(&c.Reason, "reason", "", "rejection reason")
@@ -30,7 +29,6 @@ func parseUserRejectCmd(parent *userCmd, args []string) (*userRejectCmd, error) 
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_remove_role.go
+++ b/cmd/goa4web/user_remove_role.go
@@ -15,12 +15,11 @@ type userRemoveRoleCmd struct {
 	fs       *flag.FlagSet
 	Username string
 	Role     string
-	args     []string
 }
 
 func parseUserRemoveRoleCmd(parent *userCmd, args []string) (*userRemoveRoleCmd, error) {
 	c := &userRemoveRoleCmd{userCmd: parent}
-	fs, rest, err := parseFlags("remove-role", args, func(fs *flag.FlagSet) {
+	fs, _, err := parseFlags("remove-role", args, func(fs *flag.FlagSet) {
 		fs.StringVar(&c.Username, "username", "", "username")
 		fs.StringVar(&c.Role, "role", "", "role name")
 	})
@@ -28,7 +27,6 @@ func parseUserRemoveRoleCmd(parent *userCmd, args []string) (*userRemoveRoleCmd,
 		return nil, err
 	}
 	c.fs = fs
-	c.args = rest
 	return c, nil
 }
 

--- a/cmd/goa4web/user_roles.go
+++ b/cmd/goa4web/user_roles.go
@@ -2,32 +2,26 @@ package main
 
 import (
 	"context"
-	_ "embed"
+
 	"flag"
 	"fmt"
 
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
 
-//go:embed templates/user_roles_usage.txt
-var userRolesUsageTemplate string
-
 // userRolesCmd implements "user roles".
 type userRolesCmd struct {
 	*userCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseUserRolesCmd(parent *userCmd, args []string) (*userRolesCmd, error) {
 	c := &userRolesCmd{userCmd: parent}
-	fs := flag.NewFlagSet("roles", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("roles")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
@@ -53,5 +47,5 @@ func (c *userRolesCmd) Run() error {
 }
 
 func (c *userRolesCmd) Usage() {
-	executeUsage(c.fs.Output(), userRolesUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("user_roles_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/writing.go
+++ b/cmd/goa4web/writing.go
@@ -1,70 +1,65 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/writing_usage.txt
-var writingUsageTemplate string
-
 // writingCmd handles writing management subcommands.
 type writingCmd struct {
 	*rootCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseWritingCmd(parent *rootCmd, args []string) (*writingCmd, error) {
 	c := &writingCmd{rootCmd: parent}
-	fs := flag.NewFlagSet("writing", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("writing")
+
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *writingCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing writing command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "tree":
-		cmd, err := parseWritingTreeCmd(c, c.args[1:])
+		cmd, err := parseWritingTreeCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("tree: %w", err)
 		}
 		return cmd.Run()
 	case "list":
-		cmd, err := parseWritingListCmd(c, c.args[1:])
+		cmd, err := parseWritingListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	case "read":
-		cmd, err := parseWritingReadCmd(c, c.args[1:])
+		cmd, err := parseWritingReadCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("read: %w", err)
 		}
 		return cmd.Run()
 	case "comments":
-		cmd, err := parseWritingCommentsCmd(c, c.args[1:])
+		cmd, err := parseWritingCommentsCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("comments: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown writing command %q", c.args[0])
+		return fmt.Errorf("unknown writing command %q", args[0])
 	}
 }
 
 // Usage prints command usage information with examples.
 func (c *writingCmd) Usage() {
-	executeUsage(c.fs.Output(), writingUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("writing_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/writing_comments.go
+++ b/cmd/goa4web/writing_comments.go
@@ -1,57 +1,52 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 )
 
-//go:embed templates/writing_comments_usage.txt
-var writingCommentsUsageTemplate string
-
 // writingCommentsCmd handles "writing comments".
 type writingCommentsCmd struct {
 	*writingCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseWritingCommentsCmd(parent *writingCmd, args []string) (*writingCommentsCmd, error) {
 	c := &writingCommentsCmd{writingCmd: parent}
-	fs := flag.NewFlagSet("comments", flag.ContinueOnError)
-	c.fs = fs
-	fs.Usage = c.Usage
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("comments")
+
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.args = fs.Args()
 	return c, nil
 }
 
 func (c *writingCommentsCmd) Run() error {
-	if len(c.args) == 0 {
+	args := c.fs.Args()
+	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing comments command")
 	}
-	switch c.args[0] {
+	switch args[0] {
 	case "list":
-		cmd, err := parseWritingCommentsListCmd(c, c.args[1:])
+		cmd, err := parseWritingCommentsListCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("list: %w", err)
 		}
 		return cmd.Run()
 	case "read":
-		cmd, err := parseWritingCommentsReadCmd(c, c.args[1:])
+		cmd, err := parseWritingCommentsReadCmd(c, args[1:])
 		if err != nil {
 			return fmt.Errorf("read: %w", err)
 		}
 		return cmd.Run()
 	default:
 		c.fs.Usage()
-		return fmt.Errorf("unknown comments command %q", c.args[0])
+		return fmt.Errorf("unknown comments command %q", args[0])
 	}
 }
 
 func (c *writingCommentsCmd) Usage() {
-	executeUsage(c.fs.Output(), writingCommentsUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), templateString("writing_comments_usage.txt"), c.fs, c.rootCmd.fs.Name())
 }

--- a/cmd/goa4web/writing_comments_list.go
+++ b/cmd/goa4web/writing_comments_list.go
@@ -16,23 +16,22 @@ type writingCommentsListCmd struct {
 	fs     *flag.FlagSet
 	ID     int
 	UserID int
-	args   []string
 }
 
 func parseWritingCommentsListCmd(parent *writingCommentsCmd, args []string) (*writingCommentsListCmd, error) {
 	c := &writingCommentsListCmd{writingCommentsCmd: parent}
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "writing id")
-	fs.IntVar(&c.UserID, "user", 0, "viewer user id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("list")
+	c.fs.IntVar(&c.ID, "id", 0, "writing id")
+	c.fs.IntVar(&c.UserID, "user", 0, "viewer user id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
-	if c.ID == 0 && len(c.args) > 0 {
-		if id, err := strconv.Atoi(c.args[0]); err == nil {
+
+	rest := c.fs.Args()
+	if c.ID == 0 && len(rest) > 0 {
+		if id, err := strconv.Atoi(rest[0]); err == nil {
 			c.ID = id
-			c.args = c.args[1:]
+			rest = rest[1:]
 		}
 	}
 	return c, nil

--- a/cmd/goa4web/writing_comments_read.go
+++ b/cmd/goa4web/writing_comments_read.go
@@ -18,33 +18,32 @@ type writingCommentsReadCmd struct {
 	CommentID int
 	UserID    int
 	All       bool
-	args      []string
 }
 
 func parseWritingCommentsReadCmd(parent *writingCommentsCmd, args []string) (*writingCommentsReadCmd, error) {
 	c := &writingCommentsReadCmd{writingCommentsCmd: parent}
-	fs := flag.NewFlagSet("read", flag.ContinueOnError)
-	fs.IntVar(&c.WritingID, "id", 0, "writing id")
-	fs.IntVar(&c.CommentID, "comment", 0, "comment id")
-	fs.IntVar(&c.UserID, "user", 0, "viewer user id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("read")
+	c.fs.IntVar(&c.WritingID, "id", 0, "writing id")
+	c.fs.IntVar(&c.CommentID, "comment", 0, "comment id")
+	c.fs.IntVar(&c.UserID, "user", 0, "viewer user id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
-	if c.WritingID == 0 && len(c.args) > 0 {
-		if id, err := strconv.Atoi(c.args[0]); err == nil {
+
+	rest := c.fs.Args()
+	if c.WritingID == 0 && len(rest) > 0 {
+		if id, err := strconv.Atoi(rest[0]); err == nil {
 			c.WritingID = id
-			c.args = c.args[1:]
+			rest = rest[1:]
 		}
 	}
-	if len(c.args) > 0 {
-		if c.args[0] == "all" {
+	if len(rest) > 0 {
+		if rest[0] == "all" {
 			c.All = true
-			c.args = c.args[1:]
-		} else if id, err := strconv.Atoi(c.args[0]); err == nil {
+			rest = rest[1:]
+		} else if id, err := strconv.Atoi(rest[0]); err == nil {
 			c.CommentID = id
-			c.args = c.args[1:]
+			rest = rest[1:]
 		}
 	}
 	return c, nil

--- a/cmd/goa4web/writing_list.go
+++ b/cmd/goa4web/writing_list.go
@@ -17,21 +17,19 @@ type writingListCmd struct {
 	Category int
 	Limit    int
 	Offset   int
-	args     []string
 }
 
 func parseWritingListCmd(parent *writingCmd, args []string) (*writingListCmd, error) {
 	c := &writingListCmd{writingCmd: parent}
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	fs.IntVar(&c.UserID, "user", 0, "user id")
-	fs.IntVar(&c.Category, "category", 0, "category id")
-	fs.IntVar(&c.Limit, "limit", 10, "limit")
-	fs.IntVar(&c.Offset, "offset", 0, "offset")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("list")
+	c.fs.IntVar(&c.UserID, "user", 0, "user id")
+	c.fs.IntVar(&c.Category, "category", 0, "category id")
+	c.fs.IntVar(&c.Limit, "limit", 10, "limit")
+	c.fs.IntVar(&c.Offset, "offset", 0, "offset")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 

--- a/cmd/goa4web/writing_read.go
+++ b/cmd/goa4web/writing_read.go
@@ -13,24 +13,22 @@ import (
 // writingReadCmd implements "writing read".
 type writingReadCmd struct {
 	*writingCmd
-	fs   *flag.FlagSet
-	ID   int
-	args []string
+	fs *flag.FlagSet
+	ID int
 }
 
 func parseWritingReadCmd(parent *writingCmd, args []string) (*writingReadCmd, error) {
 	c := &writingReadCmd{writingCmd: parent}
-	fs := flag.NewFlagSet("read", flag.ContinueOnError)
-	fs.IntVar(&c.ID, "id", 0, "writing id")
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("read")
+	c.fs.IntVar(&c.ID, "id", 0, "writing id")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
-	if c.ID == 0 && len(c.args) > 0 {
-		if id, err := strconv.Atoi(c.args[0]); err == nil {
+
+	rest := c.fs.Args()
+	if c.ID == 0 && len(rest) > 0 {
+		if id, err := strconv.Atoi(rest[0]); err == nil {
 			c.ID = id
-			c.args = c.args[1:]
 		}
 	}
 	return c, nil

--- a/cmd/goa4web/writing_tree.go
+++ b/cmd/goa4web/writing_tree.go
@@ -11,18 +11,16 @@ import (
 // writingTreeCmd implements "writing tree".
 type writingTreeCmd struct {
 	*writingCmd
-	fs   *flag.FlagSet
-	args []string
+	fs *flag.FlagSet
 }
 
 func parseWritingTreeCmd(parent *writingCmd, args []string) (*writingTreeCmd, error) {
 	c := &writingTreeCmd{writingCmd: parent}
-	fs := flag.NewFlagSet("tree", flag.ContinueOnError)
-	if err := fs.Parse(args); err != nil {
+	c.fs = newFlagSet("tree")
+	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
-	c.fs = fs
-	c.args = fs.Args()
+
 	return c, nil
 }
 


### PR DESCRIPTION
## Summary
- remove args slices from command structs
- reference flagset arguments directly via `fs.Args()`
- clean up unused variables in parsing helpers

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ed20f6480832fa87529c05fd07204