### PR TITLE
Handle admin emails without user records

### DIFF
--- a/cmd/goa4web/email_queue_list.go
+++ b/cmd/goa4web/email_queue_list.go
@@ -42,7 +42,9 @@ func (c *emailQueueListCmd) Run() error {
 	}
 	ids := make([]int32, 0, len(rows))
 	for _, e := range rows {
-		ids = append(ids, e.ToUserID)
+		if e.ToUserID.Valid {
+			ids = append(ids, e.ToUserID.Int32)
+		}
 	}
 	users := make(map[int32]*dbpkg.GetUserByIdRow)
 	for _, id := range ids {
@@ -52,8 +54,10 @@ func (c *emailQueueListCmd) Run() error {
 	}
 	for _, e := range rows {
 		emailStr := ""
-		if u, ok := users[e.ToUserID]; ok && u.Email.Valid && u.Email.String != "" {
-			emailStr = u.Email.String
+		if e.ToUserID.Valid {
+			if u, ok := users[e.ToUserID.Int32]; ok && u.Email.Valid && u.Email.String != "" {
+				emailStr = u.Email.String
+			}
 		}
 		subj := ""
 		if m, err := mail.ReadMessage(strings.NewReader(e.Body)); err == nil {

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -168,7 +169,7 @@ func (TestTemplateTask) Action(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	if err := queries.InsertPendingEmail(r.Context(), db.InsertPendingEmailParams{ToUserID: urow.Idusers, Body: string(msg)}); err != nil {
+	if err := queries.InsertPendingEmail(r.Context(), db.InsertPendingEmailParams{ToUserID: sql.NullInt32{Int32: urow.Idusers, Valid: true}, Body: string(msg), DirectEmail: false}); err != nil {
 		log.Printf("queue email: %v", err)
 	}
 	http.Redirect(w, r, "/admin/email/template", http.StatusSeeOther)

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -5,7 +5,7 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 44
+	ExpectedSchemaVersion = 45
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -324,12 +324,13 @@ type Password struct {
 }
 
 type PendingEmail struct {
-	ID         int32
-	ToUserID   int32
-	Body       string
-	ErrorCount int32
-	CreatedAt  time.Time
-	SentAt     sql.NullTime
+	ID          int32
+	ToUserID    sql.NullInt32
+	DirectEmail bool
+	Body        string
+	ErrorCount  int32
+	CreatedAt   time.Time
+	SentAt      sql.NullTime
 }
 
 type PendingPassword struct {

--- a/internal/db/queries-pending_emails.sql
+++ b/internal/db/queries-pending_emails.sql
@@ -1,9 +1,9 @@
 -- name: InsertPendingEmail :exec
-INSERT INTO pending_emails (to_user_id, body)
-VALUES (?, ?);
+INSERT INTO pending_emails (to_user_id, body, direct_email)
+VALUES (?, ?, ?);
 
 -- name: FetchPendingEmails :many
-SELECT id, to_user_id, body, error_count
+SELECT id, to_user_id, body, error_count, direct_email
 FROM pending_emails
 WHERE sent_at IS NULL
 ORDER BY id
@@ -13,13 +13,13 @@ LIMIT ?;
 UPDATE pending_emails SET sent_at = NOW() WHERE id = ?;
 
 -- name: ListUnsentPendingEmails :many
-SELECT id, to_user_id, body, error_count, created_at
+SELECT id, to_user_id, body, error_count, created_at, direct_email
 FROM pending_emails
 WHERE sent_at IS NULL
 ORDER BY id;
 
 -- name: GetPendingEmailByID :one
-SELECT id, to_user_id, body, error_count
+SELECT id, to_user_id, body, error_count, direct_email
 FROM pending_emails
 WHERE id = ?;
 

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -140,7 +140,7 @@ func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, tp Se
 			emails, err := n.Queries.ListVerifiedEmailsByUserID(ctx, evt.UserID)
 			if err == nil {
 				for _, e := range emails {
-					if err := n.renderAndQueueEmailFromTemplates(ctx, evt.UserID, e.Email, et, evt.Data); err != nil {
+					if err := n.renderAndQueueEmailFromTemplates(ctx, evt.UserID, e.Email, et, evt.Data, false); err != nil {
 						return err
 					}
 				}
@@ -150,7 +150,7 @@ func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, tp Se
 			if err != nil {
 				notifyMissingEmail(ctx, n.Queries, evt.UserID)
 			} else {
-				if err := n.renderAndQueueEmailFromTemplates(ctx, evt.UserID, ue.Email, et, evt.Data); err != nil {
+				if err := n.renderAndQueueEmailFromTemplates(ctx, evt.UserID, ue.Email, et, evt.Data, false); err != nil {
 					return err
 				}
 			}
@@ -184,7 +184,7 @@ func (n *Notifier) notifyDirectEmail(ctx context.Context, evt eventbus.TaskEvent
 		return nil
 	}
 	if et := tp.DirectEmailTemplate(); et != nil {
-		if err := n.renderAndQueueEmailFromTemplates(ctx, evt.UserID, addr, et, evt.Data); err != nil {
+		if err := n.renderAndQueueEmailFromTemplates(ctx, 0, addr, et, evt.Data, true); err != nil {
 			return err
 		}
 	}
@@ -198,7 +198,7 @@ func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.TaskEvent
 			notifyMissingEmail(ctx, n.Queries, id)
 		} else {
 			if et := tp.TargetEmailTemplate(); et != nil {
-				if err := n.renderAndQueueEmailFromTemplates(ctx, id, user.Email.String, et, evt.Data); err != nil {
+				if err := n.renderAndQueueEmailFromTemplates(ctx, id, user.Email.String, et, evt.Data, false); err != nil {
 					return err
 				}
 			}
@@ -337,7 +337,7 @@ func (n *Notifier) notifyAdmins(ctx context.Context, evt eventbus.TaskEvent, tp 
 			}
 		}
 		if et := tp.AdminEmailTemplate(); et != nil {
-			if err := n.renderAndQueueEmailFromTemplates(ctx, uid, addr, et, evt.Data); err != nil {
+			if err := n.renderAndQueueEmailFromTemplates(ctx, uid, addr, et, evt.Data, false); err != nil {
 				return err
 			}
 		}

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -79,7 +79,7 @@ func TestNotifierNotifyAdmins(t *testing.T) {
 	mock.ExpectQuery("UserByEmail").
 		WithArgs(sql.NullString{String: "a@test", Valid: true}).
 		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test", "a"))
-	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(int32(1), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 1, Valid: true}, sqlmock.AnyArg(), false).WillReturnResult(sqlmock.NewResult(1, 1))
 	rec := &dummyProvider{}
 	n := New(WithQueries(q), WithEmailProvider(rec))
 	n.NotifyAdmins(context.Background(), &EmailTemplates{}, EmailData{})

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -97,7 +97,7 @@ func (n *Notifier) NotifyAdmins(ctx context.Context, et *EmailTemplates, data Em
 				continue
 			}
 		}
-		if err := n.renderAndQueueEmailFromTemplates(ctx, uid, addr, et, data); err != nil {
+		if err := n.renderAndQueueEmailFromTemplates(ctx, uid, addr, et, data, false); err != nil {
 			log.Printf("notify admin %s: %v", addr, err)
 		}
 	}

--- a/migrations/0045.sql
+++ b/migrations/0045.sql
@@ -1,0 +1,7 @@
+-- Allow direct emails in queue
+ALTER TABLE pending_emails
+    MODIFY COLUMN to_user_id INT NULL,
+    ADD COLUMN direct_email TINYINT(1) NOT NULL DEFAULT 0;
+
+-- Update schema version
+UPDATE schema_version SET version = 45 WHERE version = 44;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -379,7 +379,8 @@ CREATE TABLE IF NOT EXISTS `subscriptions` (
 -- Queue outbound emails.
 CREATE TABLE IF NOT EXISTS `pending_emails` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `to_user_id` int NOT NULL,
+  `to_user_id` int DEFAULT NULL,
+  `direct_email` tinyint(1) NOT NULL DEFAULT 0,
   `body` text NOT NULL,
   `error_count` int NOT NULL DEFAULT 0,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/specs/email_queue.md
+++ b/specs/email_queue.md
@@ -10,7 +10,7 @@ sending mail.
 result with `InsertPendingEmail`:
 
 ```go
-_ = queries.InsertPendingEmail(ctx, db.InsertPendingEmailParams{ToUserID: uid, Body: string(msg)})
+_ = queries.InsertPendingEmail(ctx, db.InsertPendingEmailParams{ToUserID: sql.NullInt32{Int32: uid, Valid: true}, Body: string(msg), DirectEmail: false})
 ```
 
 The admin interface uses the same method when previewing templates. Rows in the


### PR DESCRIPTION
## Summary
- add `direct_email` column and make `pending_emails.to_user_id` nullable
- generate SQL code and bump schema version
- support direct queued emails via `ResolveQueuedEmailAddress`
- adjust notifier to insert null user IDs for direct mails
- update CLI and admin interfaces for new types
- fix related tests and documentation

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: core/templates and auth package tests)*

------
https://chatgpt.com/codex/tasks/task_e_687ee25e8964832f823f58e3122deb08