### PR TITLE
Fix password reset notifications

### DIFF
--- a/handlers/auth/forgotPassword.go
+++ b/handlers/auth/forgotPassword.go
@@ -147,6 +147,9 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) {
 					evt.Data = map[string]any{}
 				}
 				evt.Data["reset"] = notif.PasswordResetInfo{Username: row.Username.String, Code: code}
+				// Expose fields directly for email templates
+				evt.Data["Username"] = row.Username.String
+				evt.Data["Code"] = code
 				evt.Data["ResetURL"] = cd.AbsoluteURL("/login?code=" + code)
 				evt.Data["UserURL"] = cd.AbsoluteURL(fmt.Sprintf("/admin/user/%d", row.Idusers))
 			}

--- a/handlers/auth/forgotPassword_event_test.go
+++ b/handlers/auth/forgotPassword_event_test.go
@@ -45,6 +45,12 @@ func TestForgotPasswordEventData(t *testing.T) {
 	if _, ok := evt.Data["reset"]; !ok {
 		t.Fatalf("missing reset data")
 	}
+	if _, ok := evt.Data["Username"]; !ok {
+		t.Fatalf("missing Username data")
+	}
+	if _, ok := evt.Data["Code"]; !ok {
+		t.Fatalf("missing Code data")
+	}
 	if _, ok := evt.Data["ResetURL"]; !ok {
 		t.Fatalf("missing ResetURL data")
 	}


### PR DESCRIPTION
## Summary
- expose username and code in password reset events
- verify event data includes Username and Code

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f641d4b04832f8754b0810d67a33d