### PR TITLE
Add error returns to notification providers

### DIFF
--- a/handlers/admin/news_user_tasks.go
+++ b/handlers/admin/news_user_tasks.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -134,14 +135,14 @@ func roleInfoByPermID(ctx context.Context, q *db.Queries, id int32) (int32, stri
 	return 0, "", "", sql.ErrNoRows
 }
 
-func (NewsUserAllowTask) TargetUserIDs(evt eventbus.TaskEvent) []int32 {
+func (NewsUserAllowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	if id, ok := evt.Data["targetUserID"].(int32); ok {
-		return []int32{id}
+		return []int32{id}, nil
 	}
 	if id, ok := evt.Data["targetUserID"].(int); ok {
-		return []int32{int32(id)}
+		return []int32{int32(id)}, nil
 	}
-	return nil
+	return nil, fmt.Errorf("target user id not provided")
 }
 
 func (NewsUserAllowTask) TargetEmailTemplate() *notifications.EmailTemplates {
@@ -153,14 +154,14 @@ func (NewsUserAllowTask) TargetInternalNotificationTemplate() *string {
 	return &v
 }
 
-func (NewsUserRemoveTask) TargetUserIDs(evt eventbus.TaskEvent) []int32 {
+func (NewsUserRemoveTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	if id, ok := evt.Data["targetUserID"].(int32); ok {
-		return []int32{id}
+		return []int32{id}, nil
 	}
 	if id, ok := evt.Data["targetUserID"].(int); ok {
-		return []int32{int32(id)}
+		return []int32{int32(id)}, nil
 	}
-	return nil
+	return nil, fmt.Errorf("target user id not provided")
 }
 
 func (NewsUserRemoveTask) TargetEmailTemplate() *notifications.EmailTemplates {

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -49,11 +49,11 @@ func (AddBlogTask) SubscribedInternalNotificationTemplate() *string {
 }
 
 // GrantsRequired implements notif.GrantsRequiredProvider for new blog entries.
-func (AddBlogTask) GrantsRequired(evt eventbus.TaskEvent) []notif.GrantRequirement {
+func (AddBlogTask) GrantsRequired(evt eventbus.TaskEvent) ([]notif.GrantRequirement, error) {
 	if t, ok := evt.Data["target"].(notif.Target); ok {
-		return []notif.GrantRequirement{{Section: "blogs", Item: "entry", ItemID: t.ID, Action: "view"}}
+		return []notif.GrantRequirement{{Section: "blogs", Item: "entry", ItemID: t.ID, Action: "view"}}, nil
 	}
-	return nil
+	return nil, fmt.Errorf("target not provided")
 }
 
 func (AddBlogTask) Page(w http.ResponseWriter, r *http.Request)   { BlogAddPage(w, r) }

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -46,11 +46,11 @@ func (ReplyBlogTask) SubscribedInternalNotificationTemplate() *string {
 }
 
 // GrantsRequired implements notif.GrantsRequiredProvider for blog replies.
-func (ReplyBlogTask) GrantsRequired(evt eventbus.TaskEvent) []notif.GrantRequirement {
+func (ReplyBlogTask) GrantsRequired(evt eventbus.TaskEvent) ([]notif.GrantRequirement, error) {
 	if t, ok := evt.Data["target"].(notif.Target); ok {
-		return []notif.GrantRequirement{{Section: "blogs", Item: "entry", ItemID: t.ID, Action: "view"}}
+		return []notif.GrantRequirement{{Section: "blogs", Item: "entry", ItemID: t.ID, Action: "view"}}, nil
 	}
-	return nil
+	return nil, fmt.Errorf("target not provided")
 }
 
 // AutoSubscribePath records the reply so the commenter automatically watches
@@ -61,11 +61,11 @@ func (ReplyBlogTask) GrantsRequired(evt eventbus.TaskEvent) []notif.GrantRequire
 // posted so participants stay in the loop.
 // AutoSubscribePath implements notif.AutoSubscribeProvider. It derives the
 // subscription path from postcountworker event data when present.
-func (ReplyBlogTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string) {
+func (ReplyBlogTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string, error) {
 	if data, ok := evt.Data[postcountworker.EventKey].(postcountworker.UpdateEventData); ok {
-		return string(TaskReply), fmt.Sprintf("/forum/topic/%d/thread/%d", data.TopicID, data.ThreadID)
+		return string(TaskReply), fmt.Sprintf("/forum/topic/%d/thread/%d", data.TopicID, data.ThreadID), nil
 	}
-	return string(TaskReply), evt.Path
+	return string(TaskReply), evt.Path, nil
 	//return TaskReply, evt.Path
 }
 

--- a/handlers/blogs/blogsUserPermissionsPage.go
+++ b/handlers/blogs/blogsUserPermissionsPage.go
@@ -303,14 +303,14 @@ func roleInfoByPermID(ctx context.Context, q *db.Queries, id int32) (int32, stri
 	return 0, "", "", sql.ErrNoRows
 }
 
-func (UserAllowTask) TargetUserIDs(evt eventbus.TaskEvent) []int32 {
+func (UserAllowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	if id, ok := evt.Data["targetUserID"].(int32); ok {
-		return []int32{id}
+		return []int32{id}, nil
 	}
 	if id, ok := evt.Data["targetUserID"].(int); ok {
-		return []int32{int32(id)}
+		return []int32{int32(id)}, nil
 	}
-	return nil
+	return nil, fmt.Errorf("target user id not provided")
 }
 
 func (UserAllowTask) TargetEmailTemplate() *notif.EmailTemplates {
@@ -322,14 +322,14 @@ func (UserAllowTask) TargetInternalNotificationTemplate() *string {
 	return &v
 }
 
-func (UserDisallowTask) TargetUserIDs(evt eventbus.TaskEvent) []int32 {
+func (UserDisallowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	if id, ok := evt.Data["targetUserID"].(int32); ok {
-		return []int32{id}
+		return []int32{id}, nil
 	}
 	if id, ok := evt.Data["targetUserID"].(int); ok {
-		return []int32{int32(id)}
+		return []int32{int32(id)}, nil
 	}
-	return nil
+	return nil, fmt.Errorf("target user id not provided")
 }
 
 func (UserDisallowTask) TargetEmailTemplate() *notif.EmailTemplates {

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -76,12 +76,11 @@ func (CreateThreadTask) AdminInternalNotificationTemplate() *string {
 // AutoSubscribePath implements notif.AutoSubscribeProvider. When the
 // postcountworker provides context, a subscription to the created thread is
 // generated.
-func (CreateThreadTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string) {
+func (CreateThreadTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string, error) {
 	if data, ok := evt.Data[postcountworker.EventKey].(postcountworker.UpdateEventData); ok {
-		return string(TaskCreateThread), fmt.Sprintf("/forum/topic/%d/thread/%d", data.TopicID, data.ThreadID)
+		return string(TaskCreateThread), fmt.Sprintf("/forum/topic/%d/thread/%d", data.TopicID, data.ThreadID), nil
 	}
-
-	return string(TaskCreateThread), evt.Path
+	return string(TaskCreateThread), evt.Path, nil
 }
 
 func (CreateThreadTask) Page(w http.ResponseWriter, r *http.Request) {

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -66,11 +66,11 @@ func (ReplyTask) AdminInternalNotificationTemplate() *string {
 // AutoSubscribePath ensures authors automatically receive updates on replies.
 // AutoSubscribePath implements notif.AutoSubscribeProvider. The subscription is
 // created for the originating forum thread when that information is available.
-func (ReplyTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string) {
+func (ReplyTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string, error) {
 	if data, ok := evt.Data[postcountworker.EventKey].(postcountworker.UpdateEventData); ok {
-		return string(TaskReply), fmt.Sprintf("/forum/topic/%d/thread/%d", data.TopicID, data.ThreadID)
+		return string(TaskReply), fmt.Sprintf("/forum/topic/%d/thread/%d", data.TopicID, data.ThreadID), nil
 	}
-	return string(TaskReply), evt.Path
+	return string(TaskReply), evt.Path, nil
 }
 
 func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) {

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -56,8 +56,8 @@ func (ReplyTask) SubscribedInternalNotificationTemplate() *string {
 	return &s
 }
 
-func (ReplyTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string) {
-	return string(TaskReply), evt.Path
+func (ReplyTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string, error) {
+	return string(TaskReply), evt.Path, nil
 }
 
 func BoardThreadPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -169,14 +170,14 @@ func roleInfoByPermID(ctx context.Context, q *db.Queries, id int32) (int32, stri
 	return 0, "", "", sql.ErrNoRows
 }
 
-func (userAllowTask) TargetUserIDs(evt eventbus.TaskEvent) []int32 {
+func (userAllowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	if id, ok := evt.Data["targetUserID"].(int32); ok {
-		return []int32{id}
+		return []int32{id}, nil
 	}
 	if id, ok := evt.Data["targetUserID"].(int); ok {
-		return []int32{int32(id)}
+		return []int32{int32(id)}, nil
 	}
-	return nil
+	return nil, fmt.Errorf("target user id not provided")
 }
 
 func (userAllowTask) TargetEmailTemplate() *notif.EmailTemplates {
@@ -188,14 +189,14 @@ func (userAllowTask) TargetInternalNotificationTemplate() *string {
 	return &v
 }
 
-func (userDisallowTask) TargetUserIDs(evt eventbus.TaskEvent) []int32 {
+func (userDisallowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	if id, ok := evt.Data["targetUserID"].(int32); ok {
-		return []int32{id}
+		return []int32{id}, nil
 	}
 	if id, ok := evt.Data["targetUserID"].(int); ok {
-		return []int32{int32(id)}
+		return []int32{int32(id)}, nil
 	}
-	return nil
+	return nil, fmt.Errorf("target user id not provided")
 }
 
 func (userDisallowTask) TargetEmailTemplate() *notif.EmailTemplates {

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -82,11 +82,11 @@ func (ReplyTask) AdminInternalNotificationTemplate() *string {
 // AutoSubscribePath allows commenters to automatically watch for further replies.
 // AutoSubscribePath implements notif.AutoSubscribeProvider. A subscription to
 // the underlying discussion thread is created using event data when available.
-func (ReplyTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string) {
+func (ReplyTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string, error) {
 	if data, ok := evt.Data[postcountworker.EventKey].(postcountworker.UpdateEventData); ok {
-		return string(TaskReply), fmt.Sprintf("/forum/topic/%d/thread/%d", data.TopicID, data.ThreadID)
+		return string(TaskReply), fmt.Sprintf("/forum/topic/%d/thread/%d", data.TopicID, data.ThreadID), nil
 	}
-	return string(TaskReply), evt.Path
+	return string(TaskReply), evt.Path, nil
 }
 
 type EditTask struct{ tasks.TaskString }
@@ -143,11 +143,11 @@ func (NewPostTask) SubscribedInternalNotificationTemplate() *string {
 // AutoSubscribePath keeps authors in the loop on new post discussions.
 // AutoSubscribePath implements notif.AutoSubscribeProvider. Subscriptions use
 // the thread path derived from postcountworker data when possible.
-func (NewPostTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string) {
+func (NewPostTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string, error) {
 	if data, ok := evt.Data[postcountworker.EventKey].(postcountworker.UpdateEventData); ok {
-		return string(TaskNewPost), fmt.Sprintf("/forum/topic/%d/thread/%d", data.TopicID, data.ThreadID)
+		return string(TaskNewPost), fmt.Sprintf("/forum/topic/%d/thread/%d", data.TopicID, data.ThreadID), nil
 	}
-	return string(TaskNewPost), evt.Path
+	return string(TaskNewPost), evt.Path, nil
 }
 
 func NewsPostPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/user/admin_permissions.go
+++ b/handlers/user/admin_permissions.go
@@ -240,14 +240,14 @@ func roleInfoByPermID(ctx context.Context, q *db.Queries, id int32) (int32, stri
 	return 0, "", "", sql.ErrNoRows
 }
 
-func (PermissionUserAllowTask) TargetUserIDs(evt eventbus.TaskEvent) []int32 {
+func (PermissionUserAllowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	if id, ok := evt.Data["targetUserID"].(int32); ok {
-		return []int32{id}
+		return []int32{id}, nil
 	}
 	if id, ok := evt.Data["targetUserID"].(int); ok {
-		return []int32{int32(id)}
+		return []int32{int32(id)}, nil
 	}
-	return nil
+	return nil, fmt.Errorf("target user id not provided")
 }
 
 func (PermissionUserAllowTask) TargetEmailTemplate() *notif.EmailTemplates {
@@ -259,14 +259,14 @@ func (PermissionUserAllowTask) TargetInternalNotificationTemplate() *string {
 	return &v
 }
 
-func (PermissionUserDisallowTask) TargetUserIDs(evt eventbus.TaskEvent) []int32 {
+func (PermissionUserDisallowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	if id, ok := evt.Data["targetUserID"].(int32); ok {
-		return []int32{id}
+		return []int32{id}, nil
 	}
 	if id, ok := evt.Data["targetUserID"].(int); ok {
-		return []int32{int32(id)}
+		return []int32{int32(id)}, nil
 	}
-	return nil
+	return nil, fmt.Errorf("target user id not provided")
 }
 
 func (PermissionUserDisallowTask) TargetEmailTemplate() *notif.EmailTemplates {
@@ -278,14 +278,14 @@ func (PermissionUserDisallowTask) TargetInternalNotificationTemplate() *string {
 	return &v
 }
 
-func (PermissionUpdateTask) TargetUserIDs(evt eventbus.TaskEvent) []int32 {
+func (PermissionUpdateTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	if id, ok := evt.Data["targetUserID"].(int32); ok {
-		return []int32{id}
+		return []int32{id}, nil
 	}
 	if id, ok := evt.Data["targetUserID"].(int); ok {
-		return []int32{int32(id)}
+		return []int32{int32(id)}, nil
 	}
-	return nil
+	return nil, fmt.Errorf("target user id not provided")
 }
 
 func (PermissionUpdateTask) TargetEmailTemplate() *notif.EmailTemplates {

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -322,26 +323,26 @@ func (AddEmailTask) DirectEmailTemplate() *notif.EmailTemplates {
 	return notif.NewEmailTemplates("verifyEmail")
 }
 
-func (AddEmailTask) DirectEmailAddress(evt eventbus.TaskEvent) string {
+func (AddEmailTask) DirectEmailAddress(evt eventbus.TaskEvent) (string, error) {
 	if evt.Data != nil {
 		if email, ok := evt.Data["email"].(string); ok {
-			return email
+			return email, nil
 		}
 	}
-	return ""
+	return "", fmt.Errorf("email not provided")
 }
 
 func (ResendVerificationEmailTask) DirectEmailTemplate() *notif.EmailTemplates {
 	return notif.NewEmailTemplates("verifyEmail")
 }
 
-func (ResendVerificationEmailTask) DirectEmailAddress(evt eventbus.TaskEvent) string {
+func (ResendVerificationEmailTask) DirectEmailAddress(evt eventbus.TaskEvent) (string, error) {
 	if evt.Data != nil {
 		if email, ok := evt.Data["email"].(string); ok {
-			return email
+			return email, nil
 		}
 	}
-	return ""
+	return "", fmt.Errorf("email not provided")
 }
 
 func userEmailVerifyCodePage(w http.ResponseWriter, r *http.Request) {

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -179,7 +179,10 @@ func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, tp Se
 }
 
 func (n *Notifier) notifyDirectEmail(ctx context.Context, evt eventbus.TaskEvent, tp DirectEmailNotificationTemplateProvider) error {
-	addr := tp.DirectEmailAddress(evt)
+	addr, err := tp.DirectEmailAddress(evt)
+	if err != nil {
+		return err
+	}
 	if addr == "" {
 		return nil
 	}
@@ -192,7 +195,11 @@ func (n *Notifier) notifyDirectEmail(ctx context.Context, evt eventbus.TaskEvent
 }
 
 func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.TaskEvent, tp TargetUsersNotificationProvider) error {
-	for _, id := range tp.TargetUserIDs(evt) {
+	ids, err := tp.TargetUserIDs(evt)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
 		user, err := n.Queries.GetUserById(ctx, id)
 		if err != nil || !user.Email.Valid || user.Email.String == "" {
 			notifyMissingEmail(ctx, n.Queries, id)
@@ -246,7 +253,10 @@ func (n *Notifier) notifySubscribers(ctx context.Context, evt eventbus.TaskEvent
 	delete(internalSubs, evt.UserID)
 
 	if gp, ok := evt.Task.(GrantsRequiredProvider); ok {
-		reqs := gp.GrantsRequired(evt)
+		reqs, err := gp.GrantsRequired(evt)
+		if err != nil {
+			return err
+		}
 		if len(reqs) != 0 {
 			filterSubs := func(m map[int32]struct{}) {
 				for id := range m {
@@ -312,7 +322,11 @@ func (n *Notifier) handleAutoSubscribe(ctx context.Context, evt eventbus.TaskEve
 		}
 	}
 	if auto {
-		task, path := tp.AutoSubscribePath(evt)
+		task, path, err := tp.AutoSubscribePath(evt)
+		if err != nil {
+			log.Printf("auto subscribe path: %v", err)
+			return
+		}
 		pattern := buildPatterns(tasks.TaskString(task), path)[0]
 		if config.AppRuntimeConfig.NotificationsEnabled {
 			ensureSubscription(ctx, n.Queries, evt.UserID, pattern, "internal")

--- a/internal/notifications/bus_worker_test.go
+++ b/internal/notifications/bus_worker_test.go
@@ -243,7 +243,7 @@ type targetTask struct{ tasks.TaskString }
 
 func (targetTask) Action(http.ResponseWriter, *http.Request) {}
 
-func (targetTask) TargetUserIDs(evt eventbus.TaskEvent) []int32 { return []int32{2, 3} }
+func (targetTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) { return []int32{2, 3}, nil }
 
 func (targetTask) TargetEmailTemplate() *EmailTemplates { return nil }
 
@@ -331,11 +331,11 @@ type autoSubTask struct{ tasks.TaskString }
 
 func (autoSubTask) Action(http.ResponseWriter, *http.Request) {}
 
-func (autoSubTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string) {
+func (autoSubTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string, error) {
 	if data, ok := evt.Data[postcountworker.EventKey].(postcountworker.UpdateEventData); ok {
-		return "AutoSub", fmt.Sprintf("/forum/topic/%d/thread/%d", data.TopicID, data.ThreadID)
+		return "AutoSub", fmt.Sprintf("/forum/topic/%d/thread/%d", data.TopicID, data.ThreadID), nil
 	}
-	return "AutoSub", evt.Path
+	return "AutoSub", evt.Path, nil
 }
 
 func TestProcessEventAutoSubscribe(t *testing.T) {

--- a/internal/notifications/subscriptionsinterfaces.go
+++ b/internal/notifications/subscriptionsinterfaces.go
@@ -43,7 +43,7 @@ type SelfEmailBroadcaster interface {
 // The address itself is obtained from the event data via DirectEmailAddress.
 // Internal notifications are not supported for this provider.
 type DirectEmailNotificationTemplateProvider interface {
-	DirectEmailAddress(evt eventbus.TaskEvent) string
+	DirectEmailAddress(evt eventbus.TaskEvent) (string, error)
 	DirectEmailTemplate() *EmailTemplates
 }
 
@@ -60,13 +60,13 @@ type AutoSubscribeProvider interface {
 	// AutoSubscribePath returns the action name and URI used when creating the
 	// subscription. The event may provide additional context required to build
 	// the path.
-	AutoSubscribePath(evt eventbus.TaskEvent) (string, string)
+	AutoSubscribePath(evt eventbus.TaskEvent) (string, string, error)
 }
 
 // TargetUsersNotificationProvider indicates the notification should be delivered
 // to the returned user IDs.
 type TargetUsersNotificationProvider interface {
-	TargetUserIDs(evt eventbus.TaskEvent) []int32
+	TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error)
 	TargetEmailTemplate() *EmailTemplates
 	TargetInternalNotificationTemplate() *string
 }
@@ -75,5 +75,5 @@ type TargetUsersNotificationProvider interface {
 // notifications. Implementations return one or more GrantRequirement values
 // checked with `CheckGrant` before delivering a message.
 type GrantsRequiredProvider interface {
-	GrantsRequired(evt eventbus.TaskEvent) []GrantRequirement
+	GrantsRequired(evt eventbus.TaskEvent) ([]GrantRequirement, error)
 }


### PR DESCRIPTION
## Summary
- update notification provider interfaces to return errors
- implement new signatures across notification tasks
- handle error results in bus worker

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f66a996dc832f977aa09eb5a28334