### PR TITLE
Add verbose listing for password reset cleanup

### DIFF
--- a/cmd/goa4web/user_password_clear_expired.go
+++ b/cmd/goa4web/user_password_clear_expired.go
@@ -15,6 +15,7 @@ type userPasswordClearExpiredCmd struct {
 	*userPasswordCmd
 	fs    *flag.FlagSet
 	Hours int
+	List  bool
 	args  []string
 }
 
@@ -22,6 +23,7 @@ func parseUserPasswordClearExpiredCmd(parent *userPasswordCmd, args []string) (*
 	c := &userPasswordClearExpiredCmd{userPasswordCmd: parent, Hours: 24}
 	fs := flag.NewFlagSet("clear-expired", flag.ContinueOnError)
 	fs.IntVar(&c.Hours, "hours", 24, "expiration age in hours")
+	fs.BoolVar(&c.List, "list", false, "list removed reset requests")
 	c.fs = fs
 	if err := fs.Parse(args); err != nil {
 		return nil, err
@@ -38,8 +40,25 @@ func (c *userPasswordClearExpiredCmd) Run() error {
 	ctx := context.Background()
 	queries := dbpkg.New(db)
 	expiry := time.Now().Add(-time.Duration(c.Hours) * time.Hour)
-	if err := queries.PurgePasswordResetsBefore(ctx, expiry); err != nil {
+	var details []*dbpkg.ListPasswordResetsBeforeRow
+	if c.List {
+		var err error
+		details, err = queries.ListPasswordResetsBefore(ctx, expiry)
+		if err != nil {
+			return fmt.Errorf("list resets: %w", err)
+		}
+	}
+	res, err := queries.PurgePasswordResetsBefore(ctx, expiry)
+	if err != nil {
 		return fmt.Errorf("clear expired: %w", err)
+	}
+	if rows, err := res.RowsAffected(); err == nil {
+		c.rootCmd.Infof("deleted %d expired password reset requests", rows)
+	}
+	if c.List {
+		for _, r := range details {
+			c.rootCmd.Infof("removed id=%d code=%s created=%s", r.ID, r.VerificationCode, r.CreatedAt.Format(time.RFC3339))
+		}
 	}
 	return nil
 }

--- a/cmd/goa4web/user_password_clear_user.go
+++ b/cmd/goa4web/user_password_clear_user.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"time"
 
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
@@ -15,6 +16,7 @@ type userPasswordClearUserCmd struct {
 	*userPasswordCmd
 	fs       *flag.FlagSet
 	Username string
+	List     bool
 	args     []string
 }
 
@@ -22,6 +24,7 @@ func parseUserPasswordClearUserCmd(parent *userPasswordCmd, args []string) (*use
 	c := &userPasswordClearUserCmd{userPasswordCmd: parent}
 	fs := flag.NewFlagSet("clear-user", flag.ContinueOnError)
 	fs.StringVar(&c.Username, "username", "", "username")
+	fs.BoolVar(&c.List, "list", false, "list removed reset requests")
 	c.fs = fs
 	if err := fs.Parse(args); err != nil {
 		return nil, err
@@ -44,8 +47,25 @@ func (c *userPasswordClearUserCmd) Run() error {
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}
-	if err := queries.DeletePasswordResetsByUser(ctx, user.Idusers); err != nil {
+	var details []*dbpkg.ListPasswordResetsByUserRow
+	if c.List {
+		var err error
+		details, err = queries.ListPasswordResetsByUser(ctx, user.Idusers)
+		if err != nil {
+			return fmt.Errorf("list resets: %w", err)
+		}
+	}
+	res, err := queries.DeletePasswordResetsByUser(ctx, user.Idusers)
+	if err != nil {
 		return fmt.Errorf("delete resets: %w", err)
+	}
+	if rows, err := res.RowsAffected(); err == nil {
+		c.rootCmd.Infof("deleted %d password reset requests", rows)
+	}
+	if c.List {
+		for _, r := range details {
+			c.rootCmd.Infof("removed id=%d code=%s created=%s", r.ID, r.VerificationCode, r.CreatedAt.Format(time.RFC3339))
+		}
 	}
 	return nil
 }

--- a/internal/db/queries-password_resets.sql
+++ b/internal/db/queries-password_resets.sql
@@ -20,9 +20,23 @@ UPDATE pending_passwords SET verified_at = NOW() WHERE id = ?;
 -- name: DeletePasswordReset :exec
 DELETE FROM pending_passwords WHERE id = ?;
 
--- name: DeletePasswordResetsByUser :exec
+-- name: DeletePasswordResetsByUser :execresult
+-- Delete all password reset entries for the given user and return the result
 DELETE FROM pending_passwords WHERE user_id = ?;
 
--- name: PurgePasswordResetsBefore :exec
+-- name: PurgePasswordResetsBefore :execresult
+-- Remove password reset entries that have expired or were already verified
 DELETE FROM pending_passwords
+WHERE created_at < ? OR verified_at IS NOT NULL;
+
+-- name: ListPasswordResetsByUser :many
+-- List password reset entries for the specified user
+SELECT id, user_id, verification_code, created_at, verified_at
+FROM pending_passwords
+WHERE user_id = ?;
+
+-- name: ListPasswordResetsBefore :many
+-- List password reset entries that have expired or were already verified
+SELECT id, user_id, verification_code, created_at, verified_at
+FROM pending_passwords
 WHERE created_at < ? OR verified_at IS NOT NULL;


### PR DESCRIPTION
## Summary
- show list of removed password reset records with `-list`
- expose helper queries for listing reset requests

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f64c7ba1c832f907e888835678f6c