### PR TITLE
Improve CLI help for subcommands

### DIFF
--- a/cmd/goa4web/blog.go
+++ b/cmd/goa4web/blog.go
@@ -27,6 +27,9 @@ func (c *blogCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing blog command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "create":
 		cmd, err := parseBlogCreateCmd(c, args[1:])

--- a/cmd/goa4web/blog_comments.go
+++ b/cmd/goa4web/blog_comments.go
@@ -27,6 +27,9 @@ func (c *blogCommentsCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing comments command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "list":
 		cmd, err := parseBlogCommentsListCmd(c, args[1:])

--- a/cmd/goa4web/board.go
+++ b/cmd/goa4web/board.go
@@ -27,6 +27,9 @@ func (c *boardCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing board command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "list":
 		cmd, err := parseBoardListCmd(c, args[1:])

--- a/cmd/goa4web/config.go
+++ b/cmd/goa4web/config.go
@@ -27,6 +27,9 @@ func (c *configCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing config command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "reload":
 		cmd, err := parseConfigReloadCmd(c, args[1:])

--- a/cmd/goa4web/config_test_cmd.go
+++ b/cmd/goa4web/config_test_cmd.go
@@ -38,6 +38,9 @@ func (c *configTestCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing test command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "email":
 		cmd, err := parseConfigTestEmailCmd(c, args[1:])

--- a/cmd/goa4web/db.go
+++ b/cmd/goa4web/db.go
@@ -27,6 +27,9 @@ func (c *dbCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing db command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "migrate":
 		cmd, err := parseDbMigrateCmd(c, args[1:])

--- a/cmd/goa4web/email.go
+++ b/cmd/goa4web/email.go
@@ -27,6 +27,9 @@ func (c *emailCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing email command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "queue":
 		cmd, err := parseEmailQueueCmd(c, args[1:])

--- a/cmd/goa4web/email_queue.go
+++ b/cmd/goa4web/email_queue.go
@@ -27,6 +27,9 @@ func (c *emailQueueCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing queue command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "list":
 		cmd, err := parseEmailQueueListCmd(c, args[1:])

--- a/cmd/goa4web/faq.go
+++ b/cmd/goa4web/faq.go
@@ -27,6 +27,9 @@ func (c *faqCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing faq command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "tree":
 		cmd, err := parseFaqTreeCmd(c, args[1:])

--- a/cmd/goa4web/grant_rule.go
+++ b/cmd/goa4web/grant_rule.go
@@ -27,6 +27,9 @@ func (c *grantCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing grant command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "add":
 		cmd, err := parseGrantAddCmd(c, args[1:])

--- a/cmd/goa4web/help.go
+++ b/cmd/goa4web/help.go
@@ -35,6 +35,9 @@ func (c *helpCmd) showHelp(args []string) error {
 		c.rootCmd.fs.Usage()
 		return nil
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "serve":
 		_, err := parseServeCmd(c.rootCmd, append(args[1:], "-h"))
@@ -169,6 +172,7 @@ func (c *helpCmd) showHelp(args []string) error {
 		}
 		return nil
 	default:
+		c.fs.Usage()
 		return fmt.Errorf("unknown help topic %q", args[0])
 	}
 }

--- a/cmd/goa4web/helpflag.go
+++ b/cmd/goa4web/helpflag.go
@@ -1,0 +1,15 @@
+package main
+
+import "flag"
+
+// usageIfHelp prints usage if the first argument is a help keyword.
+// It returns flag.ErrHelp when usage was shown.
+func usageIfHelp(fs *flag.FlagSet, args []string) error {
+	if len(args) > 0 {
+		if args[0] == "help" || args[0] == "usage" {
+			fs.Usage()
+			return flag.ErrHelp
+		}
+	}
+	return nil
+}

--- a/cmd/goa4web/images.go
+++ b/cmd/goa4web/images.go
@@ -34,6 +34,9 @@ func (c *imagesCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing images command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "cache":
 		return c.runCache(args[1:])
@@ -47,6 +50,9 @@ func (c *imagesCmd) runCache(args []string) error {
 	if len(args) == 0 {
 		c.fs.Usage()
 		return fmt.Errorf("missing cache command")
+	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
 	}
 	dir := config.AppRuntimeConfig.ImageCacheDir
 	switch args[0] {

--- a/cmd/goa4web/ipban.go
+++ b/cmd/goa4web/ipban.go
@@ -27,6 +27,9 @@ func (c *ipBanCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing ipban command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "add":
 		cmd, err := parseIpBanAddCmd(c, args[1:])

--- a/cmd/goa4web/lang.go
+++ b/cmd/goa4web/lang.go
@@ -27,6 +27,9 @@ func (c *langCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing lang command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "add":
 		cmd, err := parseLangAddCmd(c, args[1:])

--- a/cmd/goa4web/news.go
+++ b/cmd/goa4web/news.go
@@ -28,6 +28,9 @@ func (c *newsCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing news command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "list":
 		cmd, err := parseNewsListCmd(c, args[1:])

--- a/cmd/goa4web/news_comments.go
+++ b/cmd/goa4web/news_comments.go
@@ -28,6 +28,9 @@ func (c *newsCommentsCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing comments command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "list":
 		cmd, err := parseNewsCommentsListCmd(c, args[1:])

--- a/cmd/goa4web/notifications.go
+++ b/cmd/goa4web/notifications.go
@@ -28,6 +28,9 @@ func (c *notificationsCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing notifications command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "tasks":
 		cmd, err := parseNotificationsTasksCmd(c, args[1:])

--- a/cmd/goa4web/perm.go
+++ b/cmd/goa4web/perm.go
@@ -27,6 +27,9 @@ func (c *permCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing perm command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "grant":
 		cmd, err := parsePermGrantCmd(c, args[1:])

--- a/cmd/goa4web/role.go
+++ b/cmd/goa4web/role.go
@@ -33,6 +33,9 @@ func (c *roleCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing role command")
 	}
+	if err := usageIfHelp(c.fs, c.args); err != nil {
+		return err
+	}
 	switch c.args[0] {
 	case "users":
 		cmd, err := parseRoleUsersCmd(c, c.args[1:])

--- a/cmd/goa4web/server.go
+++ b/cmd/goa4web/server.go
@@ -28,6 +28,9 @@ func (c *serverCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing server command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "shutdown":
 		cmd, err := parseServerShutdownCmd(c, args[1:])

--- a/cmd/goa4web/user.go
+++ b/cmd/goa4web/user.go
@@ -27,6 +27,9 @@ func (c *userCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing user command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "add":
 		cmd, err := parseUserAddCmd(c, args[1:])

--- a/cmd/goa4web/user_comments.go
+++ b/cmd/goa4web/user_comments.go
@@ -28,6 +28,9 @@ func (c *userCommentsCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing comments command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "list":
 		cmd, err := parseUserCommentsListCmd(c, args[1:])

--- a/cmd/goa4web/user_password_cmd.go
+++ b/cmd/goa4web/user_password_cmd.go
@@ -33,6 +33,9 @@ func (c *userPasswordCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing password command")
 	}
+	if err := usageIfHelp(c.fs, c.args); err != nil {
+		return err
+	}
 	switch c.args[0] {
 	case "clear-expired":
 		cmd, err := parseUserPasswordClearExpiredCmd(c, c.args[1:])

--- a/cmd/goa4web/writing.go
+++ b/cmd/goa4web/writing.go
@@ -28,6 +28,9 @@ func (c *writingCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing writing command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "tree":
 		cmd, err := parseWritingTreeCmd(c, args[1:])

--- a/cmd/goa4web/writing_comments.go
+++ b/cmd/goa4web/writing_comments.go
@@ -28,6 +28,9 @@ func (c *writingCommentsCmd) Run() error {
 		c.fs.Usage()
 		return fmt.Errorf("missing comments command")
 	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
 	switch args[0] {
 	case "list":
 		cmd, err := parseWritingCommentsListCmd(c, args[1:])

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -67,7 +67,7 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-  // TODO find a way of avoid tests which impact global state
+	// TODO find a way of avoid tests which impact global state
 	defer SetDBPool(nil, 0)
 	SetDBPool(db, 0)
 	mock.MatchExpectationsInOrder(false)


### PR DESCRIPTION
## Summary
- add `usageIfHelp` helper to detect "help" or "usage" arguments
- call `usageIfHelp` in all command handlers
- show usage for unknown help topics

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f46bf68a0832f8953c99d7851c2d7