### PR TITLE
Add role login/admin flags

### DIFF
--- a/core/common/coredata_allroles_test.go
+++ b/core/common/coredata_allroles_test.go
@@ -15,11 +15,11 @@ func TestAllRolesLazy(t *testing.T) {
 	}
 	defer db.Close()
 
-	rows := sqlmock.NewRows([]string{"id", "name"}).
-		AddRow(int32(1), "user").
-		AddRow(int32(2), "administrator")
+	rows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin"}).
+		AddRow(int32(1), "user", true, false).
+		AddRow(int32(2), "administrator", true, true)
 
-	mock.ExpectQuery("SELECT id, name FROM roles ORDER BY id").WillReturnRows(rows)
+	mock.ExpectQuery("SELECT id, name, can_login, is_admin FROM roles ORDER BY id").WillReturnRows(rows)
 
 	cd := NewCoreData(context.Background(), dbpkg.New(db))
 

--- a/handlers/auth/loginPage.go
+++ b/handlers/auth/loginPage.go
@@ -107,7 +107,7 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := queries.UserHasRole(r.Context(), db.UserHasRoleParams{UsersIdusers: row.Idusers, Name: "user"}); err != nil {
+	if _, err := queries.UserHasLoginRole(r.Context(), row.Idusers); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			renderLoginForm(w, r, "approval is pending")
 		} else {

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -5,7 +5,7 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 45
+	ExpectedSchemaVersion = 46
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -353,8 +353,10 @@ type Preference struct {
 }
 
 type Role struct {
-	ID   int32
-	Name string
+	ID       int32
+	Name     string
+	CanLogin bool
+	IsAdmin  bool
 }
 
 type SchemaVersion struct {

--- a/internal/db/queries-permissions.sql
+++ b/internal/db/queries-permissions.sql
@@ -38,7 +38,7 @@ WHERE iduser_roles = ?;
 SELECT ur.*
 FROM user_roles ur
 JOIN roles r ON ur.role_id = r.id
-WHERE ur.users_idusers = ? AND r.name = 'administrator';
+WHERE ur.users_idusers = ? AND r.is_admin = 1;
 
 
 
@@ -100,6 +100,13 @@ SELECT 1
 FROM user_roles ur
 JOIN roles r ON ur.role_id = r.id
 WHERE ur.users_idusers = ? AND r.name = ?
+LIMIT 1;
+
+-- name: UserHasLoginRole :one
+SELECT 1
+FROM user_roles ur
+JOIN roles r ON ur.role_id = r.id
+WHERE ur.users_idusers = ? AND r.can_login = 1
 LIMIT 1;
 
 -- name: GetPermissionsByUserID :many

--- a/internal/db/queries-permissions.sql.go
+++ b/internal/db/queries-permissions.sql.go
@@ -159,7 +159,7 @@ const getAdministratorUserRole = `-- name: GetAdministratorUserRole :one
 SELECT ur.iduser_roles, ur.users_idusers, ur.role_id
 FROM user_roles ur
 JOIN roles r ON ur.role_id = r.id
-WHERE ur.users_idusers = ? AND r.name = 'administrator'
+WHERE ur.users_idusers = ? AND r.is_admin = 1
 `
 
 func (q *Queries) GetAdministratorUserRole(ctx context.Context, usersIdusers int32) (*UserRole, error) {
@@ -442,6 +442,21 @@ type UpdatePermissionParams struct {
 func (q *Queries) UpdatePermission(ctx context.Context, arg UpdatePermissionParams) error {
 	_, err := q.db.ExecContext(ctx, updatePermission, arg.Name, arg.IduserRoles)
 	return err
+}
+
+const userHasLoginRole = `-- name: UserHasLoginRole :one
+SELECT 1
+FROM user_roles ur
+JOIN roles r ON ur.role_id = r.id
+WHERE ur.users_idusers = ? AND r.can_login = 1
+LIMIT 1
+`
+
+func (q *Queries) UserHasLoginRole(ctx context.Context, usersIdusers int32) (int32, error) {
+	row := q.db.QueryRowContext(ctx, userHasLoginRole, usersIdusers)
+	var column_1 int32
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const userHasRole = `-- name: UserHasRole :one

--- a/internal/db/queries-roles.sql
+++ b/internal/db/queries-roles.sql
@@ -1,5 +1,5 @@
 -- name: ListRoles :many
-SELECT id, name FROM roles ORDER BY id;
+SELECT id, name, can_login, is_admin FROM roles ORDER BY id;
 
 -- name: ListRolesWithUsers :many
 SELECT r.id, r.name, GROUP_CONCAT(u.username ORDER BY u.username) AS users

--- a/internal/db/queries-roles.sql.go
+++ b/internal/db/queries-roles.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const listRoles = `-- name: ListRoles :many
-SELECT id, name FROM roles ORDER BY id
+SELECT id, name, can_login, is_admin FROM roles ORDER BY id
 `
 
 func (q *Queries) ListRoles(ctx context.Context) ([]*Role, error) {
@@ -23,7 +23,12 @@ func (q *Queries) ListRoles(ctx context.Context) ([]*Role, error) {
 	var items []*Role
 	for rows.Next() {
 		var i Role
-		if err := rows.Scan(&i.ID, &i.Name); err != nil {
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.CanLogin,
+			&i.IsAdmin,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/internal/db/queries-stats.sql
+++ b/internal/db/queries-stats.sql
@@ -65,7 +65,7 @@ SELECT u.idusers, u.username,
        MIN(s.created_at) AS created_at
 FROM users u
 LEFT JOIN user_roles ur ON ur.users_idusers = u.idusers
-LEFT JOIN roles r ON ur.role_id = r.id AND r.name = 'administrator'
+LEFT JOIN roles r ON ur.role_id = r.id AND r.is_admin = 1
 LEFT JOIN sessions s ON s.users_idusers = u.idusers
 GROUP BY u.idusers
 ORDER BY u.idusers;

--- a/internal/db/queries-stats.sql.go
+++ b/internal/db/queries-stats.sql.go
@@ -194,7 +194,7 @@ SELECT u.idusers, u.username,
        MIN(s.created_at) AS created_at
 FROM users u
 LEFT JOIN user_roles ur ON ur.users_idusers = u.idusers
-LEFT JOIN roles r ON ur.role_id = r.id AND r.name = 'administrator'
+LEFT JOIN roles r ON ur.role_id = r.id AND r.is_admin = 1
 LEFT JOIN sessions s ON s.users_idusers = u.idusers
 GROUP BY u.idusers
 ORDER BY u.idusers

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -96,7 +96,7 @@ SELECT (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.ver
 FROM users u
 JOIN user_roles ur ON ur.users_idusers = u.idusers
 JOIN roles r ON ur.role_id = r.id
-WHERE ur.section = 'all' and r.name = 'administrator';
+WHERE r.is_admin = 1;
 
 -- name: UpdateUserEmail :exec
 UPDATE user_emails SET email = ? WHERE user_id = ?;
@@ -108,7 +108,7 @@ FROM users u
 WHERE NOT EXISTS (
     SELECT 1 FROM user_roles ur
     JOIN roles r ON ur.role_id = r.id
-    WHERE ur.users_idusers = u.idusers AND r.name IN ('user','rejected')
+    WHERE ur.users_idusers = u.idusers AND (r.can_login = 1 OR r.name = 'rejected')
 )
 ORDER BY u.idusers;
 

--- a/internal/db/queries-users.sql.go
+++ b/internal/db/queries-users.sql.go
@@ -139,7 +139,7 @@ SELECT (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.ver
 FROM users u
 JOIN user_roles ur ON ur.users_idusers = u.idusers
 JOIN roles r ON ur.role_id = r.id
-WHERE ur.section = 'all' and r.name = 'administrator'
+WHERE r.is_admin = 1
 `
 
 func (q *Queries) ListAdministratorEmails(ctx context.Context) ([]string, error) {
@@ -172,7 +172,7 @@ FROM users u
 WHERE NOT EXISTS (
     SELECT 1 FROM user_roles ur
     JOIN roles r ON ur.role_id = r.id
-    WHERE ur.users_idusers = u.idusers AND r.name IN ('user','rejected')
+    WHERE ur.users_idusers = u.idusers AND (r.can_login = 1 OR r.name = 'rejected')
 )
 ORDER BY u.idusers
 `

--- a/internal/db/queries_dynamic.go
+++ b/internal/db/queries_dynamic.go
@@ -142,9 +142,9 @@ func (q *Queries) ListUsersFiltered(ctx context.Context, arg ListUsersFilteredPa
 	if arg.Status != "" {
 		switch arg.Status {
 		case "pending":
-			cond = append(cond, "NOT EXISTS (SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = u.idusers AND r.name IN ('user','rejected'))")
+			cond = append(cond, "NOT EXISTS (SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = u.idusers AND (r.can_login = 1 OR r.name = 'rejected'))")
 		case "active":
-			cond = append(cond, "EXISTS (SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = u.idusers AND r.name = 'user')")
+			cond = append(cond, "EXISTS (SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = u.idusers AND r.can_login = 1)")
 		case "rejected":
 			cond = append(cond, "EXISTS (SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = u.idusers AND r.name = 'rejected')")
 		}
@@ -195,9 +195,9 @@ func (q *Queries) SearchUsersFiltered(ctx context.Context, arg SearchUsersFilter
 	if arg.Status != "" {
 		switch arg.Status {
 		case "pending":
-			cond = append(cond, "NOT EXISTS (SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = u.idusers AND r.name IN ('user','rejected'))")
+			cond = append(cond, "NOT EXISTS (SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = u.idusers AND (r.can_login = 1 OR r.name = 'rejected'))")
 		case "active":
-			cond = append(cond, "EXISTS (SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = u.idusers AND r.name = 'user')")
+			cond = append(cond, "EXISTS (SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = u.idusers AND r.can_login = 1)")
 		case "rejected":
 			cond = append(cond, "EXISTS (SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = u.idusers AND r.name = 'rejected')")
 		}

--- a/migrations/0046.sql
+++ b/migrations/0046.sql
@@ -1,0 +1,13 @@
+-- Add login and admin flags to roles
+ALTER TABLE roles
+    ADD COLUMN can_login TINYINT(1) NOT NULL DEFAULT 0,
+    ADD COLUMN is_admin TINYINT(1) NOT NULL DEFAULT 0;
+
+-- Grant login ability to regular roles
+UPDATE roles SET can_login = 1 WHERE name IN ('user','content writer','moderator','administrator');
+
+-- Mark administrator role
+UPDATE roles SET is_admin = 1 WHERE name = 'administrator';
+
+-- Update schema version
+UPDATE schema_version SET version = 46 WHERE version = 45;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -203,6 +203,8 @@ CREATE TABLE `linker_search` (
 CREATE TABLE `roles` (
   `id` int(10) NOT NULL AUTO_INCREMENT,
   `name` tinytext NOT NULL,
+  `can_login` tinyint(1) NOT NULL DEFAULT 0,
+  `is_admin` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `roles_name_idx` (`name`(255))
 );

--- a/seed.sql
+++ b/seed.sql
@@ -1,12 +1,12 @@
 -- Basic role definitions
-INSERT INTO roles (name) VALUES
-  ('anonymous'),
-  ('user'),
-  ('content writer'),
-  ('moderator'),
-  ('administrator'),
-  ('rejected')
-ON DUPLICATE KEY UPDATE name = VALUES(name);
+INSERT INTO roles (name, can_login, is_admin) VALUES
+  ('anonymous', 0, 0),
+  ('user', 1, 0),
+  ('content writer', 1, 0),
+  ('moderator', 1, 0),
+  ('administrator', 1, 1),
+  ('rejected', 0, 0)
+ON DUPLICATE KEY UPDATE name = VALUES(name), can_login = VALUES(can_login), is_admin = VALUES(is_admin);
 
 -- Grant user role to all users without any role
 INSERT INTO user_roles (users_idusers, role_id)

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -12,6 +12,11 @@ Roles define high level capabilities that can be assigned to users. The standard
 - **moderator** – moderation abilities
 - **administrator** – full access
 
+Each role includes the following flags:
+
+- **can_login** – whether accounts assigned the role are permitted to authenticate
+- **is_admin** – marks administrator roles that bypass permission checks
+
 Users can hold multiple roles through the `user_roles` table. Role inheritance is
 modelled via entries in the `grants` table with `section = 'role'`. For example,
 `administrator` inherits `moderator` and `content writer` which in turn inherit


### PR DESCRIPTION
## Summary
- allow roles to control login and admin status via new columns
- check login permission via new query
- bump schema version to 46
- document new role flags
- fix unit test expectations for updated roles query

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f6b0d24d8832f858d443ee3223bbf