### PR TITLE
Handle commands with no flags

### DIFF
--- a/cmd/goa4web/templates/audit_usage.txt
+++ b/cmd/goa4web/templates/audit_usage.txt
@@ -4,5 +4,4 @@ Usage:
 Examples:
   {{.Prog}} audit --limit 50
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/blog_comments_usage.txt
+++ b/cmd/goa4web/templates/blog_comments_usage.txt
@@ -10,5 +10,4 @@ Examples:
   {{.Prog}} blog comments read 3 1
   {{.Prog}} blog comments read 3 all
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/blog_usage.txt
+++ b/cmd/goa4web/templates/blog_usage.txt
@@ -17,5 +17,4 @@ Examples:
   {{.Prog}} blog update -id 1 -text 'changed'
   {{.Prog}} blog deactivate -id 1
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/board_usage.txt
+++ b/cmd/goa4web/templates/board_usage.txt
@@ -13,5 +13,4 @@ Examples:
   {{.Prog}} board delete -id 1
   {{.Prog}} board update -id 1 -name new
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/config_test_usage.txt
+++ b/cmd/goa4web/templates/config_test_usage.txt
@@ -11,5 +11,4 @@ Examples:
   {{.Prog}} config test db
   {{.Prog}} config test dlq
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/config_usage.txt
+++ b/cmd/goa4web/templates/config_usage.txt
@@ -23,5 +23,4 @@ Examples:
   {{.Prog}} config options --extended
   {{.Prog}} config test email
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/db_usage.txt
+++ b/cmd/goa4web/templates/db_usage.txt
@@ -13,5 +13,4 @@ Examples:
   {{.Prog}} db restore -i backup.sql
   {{.Prog}} db seed
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/email_queue_usage.txt
+++ b/cmd/goa4web/templates/email_queue_usage.txt
@@ -11,5 +11,4 @@ Examples:
   {{.Prog}} email queue resend -id 1
   {{.Prog}} email queue delete -id 1
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/email_usage.txt
+++ b/cmd/goa4web/templates/email_usage.txt
@@ -7,5 +7,4 @@ Commands:
 Examples:
   {{.Prog}} email queue list
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/faq_usage.txt
+++ b/cmd/goa4web/templates/faq_usage.txt
@@ -9,5 +9,4 @@ Examples:
   {{.Prog}} faq tree
   {{.Prog}} faq read 1
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/flags.txt
+++ b/cmd/goa4web/templates/flags.txt
@@ -3,3 +3,10 @@
     {{.Usage}}
 {{end}}
 {{end}}
+
+{{define "flags_section"}}
+{{if .}}
+Flags:
+{{template "flags" .}}
+{{end}}
+{{end}}

--- a/cmd/goa4web/templates/grant_usage.txt
+++ b/cmd/goa4web/templates/grant_usage.txt
@@ -6,5 +6,4 @@ Commands:
   delete   delete a grant rule
   list     list grant rules
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/help_usage.txt
+++ b/cmd/goa4web/templates/help_usage.txt
@@ -5,5 +5,4 @@ Examples:
   {{.Prog}} help serve
   {{.Prog}} help config set
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/images_usage.txt
+++ b/cmd/goa4web/templates/images_usage.txt
@@ -1,5 +1,4 @@
 Usage:
   {{.Prog}} images cache [prune|list|delete <id>|open <id>]
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/ipban_usage.txt
+++ b/cmd/goa4web/templates/ipban_usage.txt
@@ -12,5 +12,4 @@ Examples:
   {{.Prog}} ipban list
   {{.Prog}} ipban update -id 1 -reason updated
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/lang_usage.txt
+++ b/cmd/goa4web/templates/lang_usage.txt
@@ -11,5 +11,4 @@ Examples:
   {{.Prog}} lang add --code en --name English
   {{.Prog}} lang update -id 1 -name New
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/news_comments_usage.txt
+++ b/cmd/goa4web/templates/news_comments_usage.txt
@@ -10,5 +10,4 @@ Examples:
   {{.Prog}} news comments read 3 1
   {{.Prog}} news comments read 3 all
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/news_usage.txt
+++ b/cmd/goa4web/templates/news_usage.txt
@@ -11,5 +11,4 @@ Examples:
   {{.Prog}} news read 1
   {{.Prog}} news comments list 1
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/notifications_tasks_usage.txt
+++ b/cmd/goa4web/templates/notifications_tasks_usage.txt
@@ -3,5 +3,4 @@ Usage:
 
 Displays a table of tasks and their notification templates.
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/notifications_usage.txt
+++ b/cmd/goa4web/templates/notifications_usage.txt
@@ -7,5 +7,4 @@ Commands:
 Examples:
   {{.Prog}} notifications tasks
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/perm_usage.txt
+++ b/cmd/goa4web/templates/perm_usage.txt
@@ -10,5 +10,4 @@ Examples:
   {{.Prog}} perm grant -user bob -section forum -role read
   {{.Prog}} perm list
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/role_usage.txt
+++ b/cmd/goa4web/templates/role_usage.txt
@@ -7,5 +7,4 @@ Commands:
 Examples:
   {{.Prog}} role users
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/role_users_usage.txt
+++ b/cmd/goa4web/templates/role_users_usage.txt
@@ -7,5 +7,4 @@ Description:
 Examples:
   {{.Prog}} role users
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/root_usage.txt
+++ b/cmd/goa4web/templates/root_usage.txt
@@ -39,5 +39,4 @@ Examples:
   {{.Prog}} lang list
   {{.Prog}} config show
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/serve_usage.txt
+++ b/cmd/goa4web/templates/serve_usage.txt
@@ -1,5 +1,4 @@
 Usage:
   {{.Prog}} serve [flags]
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/server_usage.txt
+++ b/cmd/goa4web/templates/server_usage.txt
@@ -7,5 +7,4 @@ Commands:
 Examples:
   {{.Prog}} server shutdown --timeout 5s
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/user_comments_usage.txt
+++ b/cmd/goa4web/templates/user_comments_usage.txt
@@ -9,5 +9,4 @@ Examples:
   {{.Prog}} user comments list -id 3
   {{.Prog}} user comments add -id 3 -comment "needs review"
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/user_password_usage.txt
+++ b/cmd/goa4web/templates/user_password_usage.txt
@@ -9,5 +9,4 @@ Examples:
   {{.Prog}} user password clear-expired
   {{.Prog}} user password clear-user -username bob
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/user_roles_usage.txt
+++ b/cmd/goa4web/templates/user_roles_usage.txt
@@ -7,5 +7,4 @@ Description:
 Examples:
   {{.Prog}} user roles
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/user_usage.txt
+++ b/cmd/goa4web/templates/user_usage.txt
@@ -28,5 +28,4 @@ Examples:
   {{.Prog}} user roles
   {{.Prog}} user password clear-expired
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/writing_comments_usage.txt
+++ b/cmd/goa4web/templates/writing_comments_usage.txt
@@ -10,5 +10,4 @@ Examples:
   {{.Prog}} writing comments read 3 1
   {{.Prog}} writing comments read 3 all
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}

--- a/cmd/goa4web/templates/writing_usage.txt
+++ b/cmd/goa4web/templates/writing_usage.txt
@@ -13,5 +13,4 @@ Examples:
   {{.Prog}} writing read 1
   {{.Prog}} writing comments list 1
 
-Flags:
-{{template "flags" .Flags}}
+{{template "flags_section" .Flags}}


### PR DESCRIPTION
## Summary
- add `flags_section` template
- avoid printing "Flags:" if no flags exist in usage templates

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f8ead307c832fbb9fdabc6ca16cc0