### PR TITLE
Implement ActionResultV2 and wrapper

### DIFF
--- a/internal/tasks/action.go
+++ b/internal/tasks/action.go
@@ -1,9 +1,14 @@
 package tasks
 
 import (
+	"errors"
+	"log"
 	"net/http"
+	"net/url"
 
+	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 )
 
 // eventTaskSetter defines the minimal interface needed to record the task on the event.
@@ -24,5 +29,39 @@ func Action(t Task) func(http.ResponseWriter, *http.Request) {
 			}
 		}
 		t.Action(w, r)
+	}
+}
+
+// ActionV2 wraps t.Action to record the task on the request event and handle the
+// returned ActionResult and error.
+func ActionV2(t ActionResultV2) func(http.ResponseWriter, *http.Request) {
+	if nt, ok := t.(NamedTask); ok {
+		Register(nt)
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		if v := r.Context().Value(consts.KeyCoreData); v != nil {
+			if s, ok := v.(eventTaskSetter); ok {
+				s.SetEventTask(t)
+			}
+		}
+		result, err := t.Action(w, r)
+		if err != nil {
+			var ue *common.UserError
+			if errors.As(err, &ue) {
+				if msg := ue.ErrorMessage; msg != "" {
+					r.URL.RawQuery = "error=" + url.QueryEscape(msg)
+				} else {
+					r.URL.RawQuery = "error=" + url.QueryEscape(err.Error())
+				}
+				handlers.TaskErrorAcknowledgementPage(w, r)
+				return
+			}
+			log.Printf("task action: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+		if result != nil {
+			result.Action(w, r)
+		}
 	}
 }

--- a/internal/tasks/task_event.go
+++ b/internal/tasks/task_event.go
@@ -21,6 +21,17 @@ type Name interface {
 	Name() string
 }
 
+// ActionResult represents a follow-up action to execute after a task completes.
+type ActionResult interface {
+	Action(w http.ResponseWriter, r *http.Request)
+}
+
+// ActionResultV2 is implemented by tasks that may return a follow-up ActionResult
+// along with an error.
+type ActionResultV2 interface {
+	Action(w http.ResponseWriter, r *http.Request) (ActionResult, error)
+}
+
 type TaskString string
 
 func (t TaskString) Name() string {
@@ -35,3 +46,4 @@ func (t TaskString) Matcher() mux.MatcherFunc {
 
 var _ TaskMatcher = (TaskString)("")
 var _ Name = (TaskString)("")
+var _ Task = (TaskString)("")


### PR DESCRIPTION
## Summary
- define `ActionResult` and `ActionResultV2` in the tasks package
- add compile-time check for `TaskString` implementing `tasks.Task`
- introduce `ActionV2` wrapper handling user errors via `TaskErrorAcknowledgementPage`

## Testing
- `go mod tidy`
- `go fmt ./...` *(fails: import cycle not allowed)*
- `go vet ./...` *(fails: import cycle not allowed)*
- `golangci-lint run ./...` *(fails: import cycle not allowed and other typecheck issues)*
- `go test ./...` *(fails: import cycle not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_687f8fa90fbc832fb7972a6d665652aa