### PR TITLE
Move login task types

### DIFF
--- a/handlers/auth/loginPage.go
+++ b/handlers/auth/loginPage.go
@@ -17,28 +17,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/tasks"
 )
-
-// LoginTask handles rendering and processing of the login form.
-type LoginTask struct {
-	tasks.TaskString
-}
-
-var loginTask = &LoginTask{TaskString: TaskLogin}
-
-// ensure LoginTask conforms to tasks.Task
-var _ tasks.Task = (*LoginTask)(nil)
-
-// VerifyPasswordTask verifies reset codes during login.
-type VerifyPasswordTask struct {
-	tasks.TaskString
-}
-
-var verifyPasswordTask = &VerifyPasswordTask{TaskString: TaskPasswordVerify}
-
-// ensure VerifyPasswordTask conforms to tasks.Task
-var _ tasks.Task = (*VerifyPasswordTask)(nil)
 
 func renderLoginForm(w http.ResponseWriter, r *http.Request, errMsg string) {
 	type Data struct {

--- a/handlers/auth/loginTasks.go
+++ b/handlers/auth/loginTasks.go
@@ -1,0 +1,23 @@
+package auth
+
+import "github.com/arran4/goa4web/internal/tasks"
+
+// LoginTask handles rendering and processing of the login form.
+type LoginTask struct {
+	tasks.TaskString
+}
+
+var loginTask = &LoginTask{TaskString: TaskLogin}
+
+// ensure LoginTask conforms to tasks.Task
+var _ tasks.Task = (*LoginTask)(nil)
+
+// VerifyPasswordTask verifies reset codes during login.
+type VerifyPasswordTask struct {
+	tasks.TaskString
+}
+
+var verifyPasswordTask = &VerifyPasswordTask{TaskString: TaskPasswordVerify}
+
+// ensure VerifyPasswordTask conforms to tasks.Task
+var _ tasks.Task = (*VerifyPasswordTask)(nil)


### PR DESCRIPTION
## Summary
- add `handlers/auth/loginTasks.go`
- move `LoginTask` and `VerifyPasswordTask` type definitions to the new file
- clean `handlers/auth/loginPage.go` imports

## Testing
- `go mod tidy`
- `go fmt ./...` *(fails: import cycle not allowed)*
- `go vet ./...` *(fails: import cycle not allowed)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: import cycle not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68801ad413e4832f90c9481e57f5f732