### PR TITLE
Refactor FAQ tasks

### DIFF
--- a/handlers/faq/admin_answer.go
+++ b/handlers/faq/admin_answer.go
@@ -11,52 +11,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	notif "github.com/arran4/goa4web/internal/notifications"
-	"github.com/arran4/goa4web/internal/tasks"
-	"github.com/gorilla/mux"
 )
-
-type AnswerTask struct{ tasks.TaskString }
-type RemoveQuestionTask struct{ tasks.TaskString }
-
-var answerTask = &AnswerTask{TaskString: TaskAnswer}
-
-var _ tasks.Task = (*AnswerTask)(nil)
-var removeQuestionTask = &RemoveQuestionTask{TaskString: TaskRemoveRemove}
-
-var _ tasks.Task = (*RemoveQuestionTask)(nil)
-
-// Implementing these interfaces means answering a FAQ automatically notifies
-// the original asker and the administrators. From a user's perspective this
-// ensures they are kept in the loop once their question is addressed.
-var _ notif.AdminEmailTemplateProvider = (*AnswerTask)(nil)
-var _ notif.SelfNotificationTemplateProvider = (*AnswerTask)(nil)
-
-func (AnswerTask) AdminEmailTemplate() *notif.EmailTemplates {
-	return notif.NewEmailTemplates("faqAnsweredEmail")
-}
-
-func (AnswerTask) AdminInternalNotificationTemplate() *string {
-	v := notif.NotificationTemplateFilenameGenerator("faq_answered")
-	return &v
-}
-
-func (AnswerTask) SelfEmailTemplate() *notif.EmailTemplates {
-	return notif.NewEmailTemplates("faqAnsweredEmail")
-}
-
-func (AnswerTask) SelfInternalNotificationTemplate() *string {
-	v := notif.NotificationTemplateFilenameGenerator("faq_answered")
-	return &v
-}
-
-func (AnswerTask) Match(r *http.Request, m *mux.RouteMatch) bool {
-	return tasks.HasTask(TaskAnswer)(r, m)
-}
-
-func (RemoveQuestionTask) Match(req *http.Request, m *mux.RouteMatch) bool {
-	return tasks.HasTask(TaskRemoveRemove)(req, m)
-}
 
 func AdminAnswerPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
@@ -94,53 +49,4 @@ func AdminAnswerPage(w http.ResponseWriter, r *http.Request) {
 	data.Rows = rows
 
 	handlers.TemplateHandler(w, r, "adminAnswerPage.gohtml", data)
-}
-
-func (AnswerTask) Action(w http.ResponseWriter, r *http.Request) {
-	question := r.PostFormValue("question")
-	answer := r.PostFormValue("answer")
-	category, err := strconv.Atoi(r.PostFormValue("category"))
-	if err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-	faq, err := strconv.Atoi(r.PostFormValue("faq"))
-	if err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-
-	if err := queries.UpdateFAQQuestionAnswer(r.Context(), db.UpdateFAQQuestionAnswerParams{
-		Answer:                       sql.NullString{Valid: true, String: answer},
-		Question:                     sql.NullString{Valid: true, String: question},
-		FaqcategoriesIdfaqcategories: int32(category),
-		Idfaq:                        int32(faq),
-	}); err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-
-	handlers.TaskDoneAutoRefreshPage(w, r)
-}
-
-func (RemoveQuestionTask) Action(w http.ResponseWriter, r *http.Request) {
-	faq, err := strconv.Atoi(r.PostFormValue("faq"))
-	if err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-
-	if err := queries.DeleteFAQ(r.Context(), int32(faq)); err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-
-	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/faq/admin_categories.go
+++ b/handlers/faq/admin_categories.go
@@ -11,32 +11,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/tasks"
-	"github.com/gorilla/mux"
 )
-
-type RenameCategoryTask struct{ tasks.TaskString }
-type DeleteCategoryTask struct{ tasks.TaskString }
-type CreateCategoryTask struct{ tasks.TaskString }
-
-var renameCategoryTask = &RenameCategoryTask{TaskString: TaskRenameCategory}
-var _ tasks.Task = (*RenameCategoryTask)(nil)
-var deleteCategoryTask = &DeleteCategoryTask{TaskString: TaskDeleteCategory}
-var _ tasks.Task = (*DeleteCategoryTask)(nil)
-var createCategoryTask = &CreateCategoryTask{TaskString: TaskCreateCategory}
-var _ tasks.Task = (*CreateCategoryTask)(nil)
-
-func (RenameCategoryTask) Match(r *http.Request, m *mux.RouteMatch) bool {
-	return tasks.HasTask(TaskRenameCategory)(r, m)
-}
-
-func (DeleteCategoryTask) Match(r *http.Request, m *mux.RouteMatch) bool {
-	return tasks.HasTask(TaskDeleteCategory)(r, m)
-}
-
-func (CreateCategoryTask) Match(r *http.Request, m *mux.RouteMatch) bool {
-	return tasks.HasTask(TaskCreateCategory)(r, m)
-}
 
 func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
@@ -62,63 +37,4 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	data.Rows = rows
 
 	handlers.TemplateHandler(w, r, "adminCategoriesPage.gohtml", data)
-}
-
-func (RenameCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
-	text := r.PostFormValue("cname")
-	cid, err := strconv.Atoi(r.PostFormValue("cid"))
-	if err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-
-	if err := queries.RenameFAQCategory(r.Context(), db.RenameFAQCategoryParams{
-		Name: sql.NullString{
-			String: text,
-			Valid:  true,
-		},
-		Idfaqcategories: int32(cid),
-	}); err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-
-	handlers.TaskDoneAutoRefreshPage(w, r)
-}
-
-func (DeleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
-	cid, err := strconv.Atoi(r.PostFormValue("cid"))
-	if err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-
-	if err := queries.DeleteFAQCategory(r.Context(), int32(cid)); err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-
-	handlers.TaskDoneAutoRefreshPage(w, r)
-}
-
-func (CreateCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
-	text := r.PostFormValue("cname")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-
-	if err := queries.CreateFAQCategory(r.Context(), sql.NullString{
-		String: text,
-		Valid:  true,
-	}); err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-
-	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/faq/admin_question.go
+++ b/handlers/faq/admin_question.go
@@ -12,32 +12,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/tasks"
-	"github.com/gorilla/mux"
 )
-
-type EditQuestionTask struct{ tasks.TaskString }
-type DeleteQuestionTask struct{ tasks.TaskString }
-type CreateQuestionTask struct{ tasks.TaskString }
-
-var editQuestionTask = &EditQuestionTask{TaskString: TaskEdit}
-var _ tasks.Task = (*EditQuestionTask)(nil)
-var deleteQuestionTask = &DeleteQuestionTask{TaskString: TaskRemoveRemove}
-var _ tasks.Task = (*DeleteQuestionTask)(nil)
-var createQuestionTask = &CreateQuestionTask{TaskString: TaskCreate}
-var _ tasks.Task = (*CreateQuestionTask)(nil)
-
-func (EditQuestionTask) Match(r *http.Request, m *mux.RouteMatch) bool {
-	return tasks.HasTask(TaskEdit)(r, m)
-}
-
-func (DeleteQuestionTask) Match(r *http.Request, m *mux.RouteMatch) bool {
-	return tasks.HasTask(TaskRemoveRemove)(r, m)
-}
-
-func (CreateQuestionTask) Match(r *http.Request, m *mux.RouteMatch) bool {
-	return tasks.HasTask(TaskCreate)(r, m)
-}
 
 func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
@@ -75,83 +50,4 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 	data.Rows = rows
 
 	handlers.TemplateHandler(w, r, "adminQuestionPage.gohtml", data)
-}
-
-func (DeleteQuestionTask) Action(w http.ResponseWriter, r *http.Request) {
-	faq, err := strconv.Atoi(r.PostFormValue("faq"))
-	if err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-
-	if err := queries.DeleteFAQ(r.Context(), int32(faq)); err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-
-	handlers.TaskDoneAutoRefreshPage(w, r)
-}
-
-func (EditQuestionTask) Action(w http.ResponseWriter, r *http.Request) {
-	question := r.PostFormValue("question")
-	answer := r.PostFormValue("answer")
-	category, err := strconv.Atoi(r.PostFormValue("category"))
-	if err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-	faq, err := strconv.Atoi(r.PostFormValue("faq"))
-	if err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-
-	if err := queries.UpdateFAQQuestionAnswer(r.Context(), db.UpdateFAQQuestionAnswerParams{
-		Answer:                       sql.NullString{Valid: true, String: answer},
-		Question:                     sql.NullString{Valid: true, String: question},
-		FaqcategoriesIdfaqcategories: int32(category),
-		Idfaq:                        int32(faq),
-	}); err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-
-	handlers.TaskDoneAutoRefreshPage(w, r)
-}
-
-func (CreateQuestionTask) Action(w http.ResponseWriter, r *http.Request) {
-	question := r.PostFormValue("question")
-	answer := r.PostFormValue("answer")
-	category, err := strconv.Atoi(r.PostFormValue("category"))
-	if err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	session, ok := core.GetSessionOrFail(w, r)
-	if !ok {
-		return
-	}
-	uid, _ := session.Values["UID"].(int32)
-
-	if _, err := queries.DB().ExecContext(r.Context(),
-		"INSERT INTO faq (question, answer, faqCategories_idfaqCategories, users_idusers, language_idlanguage) VALUES (?, ?, ?, ?, ?)",
-		sql.NullString{String: question, Valid: true},
-		sql.NullString{String: answer, Valid: true},
-		int32(category), uid, 1,
-	); err != nil {
-		log.Printf("Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-
-	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/faq/faqAnswerTasks.go
+++ b/handlers/faq/faqAnswerTasks.go
@@ -1,0 +1,110 @@
+package faq
+
+import (
+	"database/sql"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/gorilla/mux"
+)
+
+// AnswerTask submits an answer in the FAQ admin interface.
+type AnswerTask struct{ tasks.TaskString }
+
+// RemoveQuestionTask deletes a question from the FAQ list.
+type RemoveQuestionTask struct{ tasks.TaskString }
+
+var answerTask = &AnswerTask{TaskString: TaskAnswer}
+
+var _ tasks.Task = (*AnswerTask)(nil)
+var removeQuestionTask = &RemoveQuestionTask{TaskString: TaskRemoveRemove}
+
+var _ tasks.Task = (*RemoveQuestionTask)(nil)
+
+// Implementing these interfaces means answering a FAQ automatically notifies
+// the original asker and the administrators. From a user's perspective this
+// ensures they are kept in the loop once their question is addressed.
+var _ notif.AdminEmailTemplateProvider = (*AnswerTask)(nil)
+var _ notif.SelfNotificationTemplateProvider = (*AnswerTask)(nil)
+
+func (AnswerTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("faqAnsweredEmail")
+}
+
+func (AnswerTask) AdminInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("faq_answered")
+	return &v
+}
+
+func (AnswerTask) SelfEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("faqAnsweredEmail")
+}
+
+func (AnswerTask) SelfInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("faq_answered")
+	return &v
+}
+
+func (AnswerTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskAnswer)(r, m)
+}
+
+func (RemoveQuestionTask) Match(req *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskRemoveRemove)(req, m)
+}
+
+func (AnswerTask) Action(w http.ResponseWriter, r *http.Request) {
+	question := r.PostFormValue("question")
+	answer := r.PostFormValue("answer")
+	category, err := strconv.Atoi(r.PostFormValue("category"))
+	if err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	faq, err := strconv.Atoi(r.PostFormValue("faq"))
+	if err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+
+	if err := queries.UpdateFAQQuestionAnswer(r.Context(), db.UpdateFAQQuestionAnswerParams{
+		Answer:                       sql.NullString{Valid: true, String: answer},
+		Question:                     sql.NullString{Valid: true, String: question},
+		FaqcategoriesIdfaqcategories: int32(category),
+		Idfaq:                        int32(faq),
+	}); err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	handlers.TaskDoneAutoRefreshPage(w, r)
+}
+
+func (RemoveQuestionTask) Action(w http.ResponseWriter, r *http.Request) {
+	faq, err := strconv.Atoi(r.PostFormValue("faq"))
+	if err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+
+	if err := queries.DeleteFAQ(r.Context(), int32(faq)); err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	handlers.TaskDoneAutoRefreshPage(w, r)
+}

--- a/handlers/faq/faqCategoryTasks.go
+++ b/handlers/faq/faqCategoryTasks.go
@@ -1,0 +1,102 @@
+package faq
+
+import (
+	"database/sql"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/gorilla/mux"
+)
+
+// RenameCategoryTask renames a category.
+type RenameCategoryTask struct{ tasks.TaskString }
+
+// DeleteCategoryTask removes a category.
+type DeleteCategoryTask struct{ tasks.TaskString }
+
+// CreateCategoryTask adds a new category entry.
+type CreateCategoryTask struct{ tasks.TaskString }
+
+var renameCategoryTask = &RenameCategoryTask{TaskString: TaskRenameCategory}
+var _ tasks.Task = (*RenameCategoryTask)(nil)
+var deleteCategoryTask = &DeleteCategoryTask{TaskString: TaskDeleteCategory}
+var _ tasks.Task = (*DeleteCategoryTask)(nil)
+var createCategoryTask = &CreateCategoryTask{TaskString: TaskCreateCategory}
+var _ tasks.Task = (*CreateCategoryTask)(nil)
+
+func (RenameCategoryTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskRenameCategory)(r, m)
+}
+
+func (DeleteCategoryTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskDeleteCategory)(r, m)
+}
+
+func (CreateCategoryTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskCreateCategory)(r, m)
+}
+
+func (RenameCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
+	text := r.PostFormValue("cname")
+	cid, err := strconv.Atoi(r.PostFormValue("cid"))
+	if err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+
+	if err := queries.RenameFAQCategory(r.Context(), db.RenameFAQCategoryParams{
+		Name: sql.NullString{
+			String: text,
+			Valid:  true,
+		},
+		Idfaqcategories: int32(cid),
+	}); err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	handlers.TaskDoneAutoRefreshPage(w, r)
+}
+
+func (DeleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
+	cid, err := strconv.Atoi(r.PostFormValue("cid"))
+	if err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+
+	if err := queries.DeleteFAQCategory(r.Context(), int32(cid)); err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	handlers.TaskDoneAutoRefreshPage(w, r)
+}
+
+func (CreateCategoryTask) Action(w http.ResponseWriter, r *http.Request) {
+	text := r.PostFormValue("cname")
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+
+	if err := queries.CreateFAQCategory(r.Context(), sql.NullString{
+		String: text,
+		Valid:  true,
+	}); err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	handlers.TaskDoneAutoRefreshPage(w, r)
+}

--- a/handlers/faq/faqQuestionTasks.go
+++ b/handlers/faq/faqQuestionTasks.go
@@ -1,0 +1,123 @@
+package faq
+
+import (
+	"database/sql"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/gorilla/mux"
+)
+
+// EditQuestionTask modifies an existing FAQ entry.
+type EditQuestionTask struct{ tasks.TaskString }
+
+// DeleteQuestionTask removes a question from the FAQ.
+type DeleteQuestionTask struct{ tasks.TaskString }
+
+// CreateQuestionTask creates a new FAQ entry.
+type CreateQuestionTask struct{ tasks.TaskString }
+
+var editQuestionTask = &EditQuestionTask{TaskString: TaskEdit}
+var _ tasks.Task = (*EditQuestionTask)(nil)
+var deleteQuestionTask = &DeleteQuestionTask{TaskString: TaskRemoveRemove}
+var _ tasks.Task = (*DeleteQuestionTask)(nil)
+var createQuestionTask = &CreateQuestionTask{TaskString: TaskCreate}
+var _ tasks.Task = (*CreateQuestionTask)(nil)
+
+func (EditQuestionTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskEdit)(r, m)
+}
+
+func (DeleteQuestionTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskRemoveRemove)(r, m)
+}
+
+func (CreateQuestionTask) Match(r *http.Request, m *mux.RouteMatch) bool {
+	return tasks.HasTask(TaskCreate)(r, m)
+}
+
+func (DeleteQuestionTask) Action(w http.ResponseWriter, r *http.Request) {
+	faq, err := strconv.Atoi(r.PostFormValue("faq"))
+	if err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+
+	if err := queries.DeleteFAQ(r.Context(), int32(faq)); err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	handlers.TaskDoneAutoRefreshPage(w, r)
+}
+
+func (EditQuestionTask) Action(w http.ResponseWriter, r *http.Request) {
+	question := r.PostFormValue("question")
+	answer := r.PostFormValue("answer")
+	category, err := strconv.Atoi(r.PostFormValue("category"))
+	if err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	faq, err := strconv.Atoi(r.PostFormValue("faq"))
+	if err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+
+	if err := queries.UpdateFAQQuestionAnswer(r.Context(), db.UpdateFAQQuestionAnswerParams{
+		Answer:                       sql.NullString{Valid: true, String: answer},
+		Question:                     sql.NullString{Valid: true, String: question},
+		FaqcategoriesIdfaqcategories: int32(category),
+		Idfaq:                        int32(faq),
+	}); err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	handlers.TaskDoneAutoRefreshPage(w, r)
+}
+
+func (CreateQuestionTask) Action(w http.ResponseWriter, r *http.Request) {
+	question := r.PostFormValue("question")
+	answer := r.PostFormValue("answer")
+	category, err := strconv.Atoi(r.PostFormValue("category"))
+	if err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	session, ok := core.GetSessionOrFail(w, r)
+	if !ok {
+		return
+	}
+	uid, _ := session.Values["UID"].(int32)
+
+	if _, err := queries.DB().ExecContext(r.Context(),
+		"INSERT INTO faq (question, answer, faqCategories_idfaqCategories, users_idusers, language_idlanguage) VALUES (?, ?, ?, ?, ?)",
+		sql.NullString{String: question, Valid: true},
+		sql.NullString{String: answer, Valid: true},
+		int32(category), uid, 1,
+	); err != nil {
+		log.Printf("Error: %s", err)
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	handlers.TaskDoneAutoRefreshPage(w, r)
+}


### PR DESCRIPTION
## Summary
- move FAQ admin tasks to separate files
- clean up original admin pages

## Testing
- `go vet ./...` *(fails: import cycle not allowed)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: import cycle not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68801ad90f10832fa934eeeeb10077ce