### PR TITLE
Implement usageData for CLI help

### DIFF
--- a/cmd/goa4web/audit.go
+++ b/cmd/goa4web/audit.go
@@ -46,5 +46,11 @@ func (c *auditCmd) Run() error {
 }
 
 func (c *auditCmd) Usage() {
-	executeUsage(c.fs.Output(), "audit_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "audit_usage.txt", c)
 }
+
+func (c *auditCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*auditCmd)(nil)

--- a/cmd/goa4web/blog.go
+++ b/cmd/goa4web/blog.go
@@ -74,5 +74,11 @@ func (c *blogCmd) Run() error {
 }
 
 func (c *blogCmd) Usage() {
-	executeUsage(c.fs.Output(), "blog_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "blog_usage.txt", c)
 }
+
+func (c *blogCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*blogCmd)(nil)

--- a/cmd/goa4web/blog_comments.go
+++ b/cmd/goa4web/blog_comments.go
@@ -50,5 +50,11 @@ func (c *blogCommentsCmd) Run() error {
 }
 
 func (c *blogCommentsCmd) Usage() {
-	executeUsage(c.fs.Output(), "blog_comments_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "blog_comments_usage.txt", c)
 }
+
+func (c *blogCommentsCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*blogCommentsCmd)(nil)

--- a/cmd/goa4web/board.go
+++ b/cmd/goa4web/board.go
@@ -63,5 +63,11 @@ func (c *boardCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *boardCmd) Usage() {
-	executeUsage(c.fs.Output(), "board_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "board_usage.txt", c)
 }
+
+func (c *boardCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*boardCmd)(nil)

--- a/cmd/goa4web/config.go
+++ b/cmd/goa4web/config.go
@@ -99,5 +99,11 @@ func (c *configCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *configCmd) Usage() {
-	executeUsage(c.fs.Output(), "config_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "config_usage.txt", c)
 }
+
+func (c *configCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*configCmd)(nil)

--- a/cmd/goa4web/config_options.go
+++ b/cmd/goa4web/config_options.go
@@ -60,5 +60,11 @@ func (c *configOptionsCmd) Run() error {
 			Extended: e,
 		})
 	}
-	return executeUsage(bytes.NewBuffer(nil), "config_options.txt", c.fs, c.rootCmd.fs.Name())
+	return executeUsage(bytes.NewBuffer(nil), "config_options.txt", c)
 }
+
+func (c *configOptionsCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*configOptionsCmd)(nil)

--- a/cmd/goa4web/config_test_cmd.go
+++ b/cmd/goa4web/config_test_cmd.go
@@ -68,8 +68,14 @@ func (c *configTestCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *configTestCmd) Usage() {
-	executeUsage(c.fs.Output(), "config_test_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "config_test_usage.txt", c)
 }
+
+func (c *configTestCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*configTestCmd)(nil)
 
 type configTestEmailCmd struct {
 	*configTestCmd

--- a/cmd/goa4web/db.go
+++ b/cmd/goa4web/db.go
@@ -63,5 +63,11 @@ func (c *dbCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *dbCmd) Usage() {
-	executeUsage(c.fs.Output(), "db_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "db_usage.txt", c)
 }
+
+func (c *dbCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*dbCmd)(nil)

--- a/cmd/goa4web/email.go
+++ b/cmd/goa4web/email.go
@@ -45,5 +45,11 @@ func (c *emailCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *emailCmd) Usage() {
-	executeUsage(c.fs.Output(), "email_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "email_usage.txt", c)
 }
+
+func (c *emailCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*emailCmd)(nil)

--- a/cmd/goa4web/email_queue.go
+++ b/cmd/goa4web/email_queue.go
@@ -57,5 +57,11 @@ func (c *emailQueueCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *emailQueueCmd) Usage() {
-	executeUsage(c.fs.Output(), "email_queue_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "email_queue_usage.txt", c)
 }
+
+func (c *emailQueueCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*emailQueueCmd)(nil)

--- a/cmd/goa4web/faq.go
+++ b/cmd/goa4web/faq.go
@@ -50,5 +50,11 @@ func (c *faqCmd) Run() error {
 }
 
 func (c *faqCmd) Usage() {
-	executeUsage(c.fs.Output(), "faq_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "faq_usage.txt", c)
 }
+
+func (c *faqCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*faqCmd)(nil)

--- a/cmd/goa4web/flagutil_test.go
+++ b/cmd/goa4web/flagutil_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestExecuteUsageWithGroups(t *testing.T) {
+	r := &rootCmd{}
+	r.fs = newFlagSet("prog")
+	r.fs.String("config", "", "config file")
+
+	var buf bytes.Buffer
+	if err := executeUsage(&buf, "root_usage.txt", r); err != nil {
+		t.Fatalf("executeUsage: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Global Flags") {
+		t.Errorf("missing global flags: %s", out)
+	}
+}

--- a/cmd/goa4web/grant_rule.go
+++ b/cmd/goa4web/grant_rule.go
@@ -56,5 +56,11 @@ func (c *grantCmd) Run() error {
 }
 
 func (c *grantCmd) Usage() {
-	executeUsage(c.fs.Output(), "grant_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "grant_usage.txt", c)
 }
+
+func (c *grantCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*grantCmd)(nil)

--- a/cmd/goa4web/help.go
+++ b/cmd/goa4web/help.go
@@ -206,5 +206,11 @@ func (c *helpCmd) showHelp(args []string) error {
 }
 
 func (c *helpCmd) Usage() {
-	executeUsage(c.fs.Output(), "help_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "help_usage.txt", c)
 }
+
+func (c *helpCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*helpCmd)(nil)

--- a/cmd/goa4web/images.go
+++ b/cmd/goa4web/images.go
@@ -104,5 +104,11 @@ func listCache(dir string) error {
 }
 
 func (c *imagesCmd) Usage() {
-	executeUsage(c.fs.Output(), "images_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "images_usage.txt", c)
 }
+
+func (c *imagesCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*imagesCmd)(nil)

--- a/cmd/goa4web/ipban.go
+++ b/cmd/goa4web/ipban.go
@@ -63,5 +63,11 @@ func (c *ipBanCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *ipBanCmd) Usage() {
-	executeUsage(c.fs.Output(), "ipban_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "ipban_usage.txt", c)
 }
+
+func (c *ipBanCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*ipBanCmd)(nil)

--- a/cmd/goa4web/lang.go
+++ b/cmd/goa4web/lang.go
@@ -56,5 +56,11 @@ func (c *langCmd) Run() error {
 }
 
 func (c *langCmd) Usage() {
-	executeUsage(c.fs.Output(), "lang_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "lang_usage.txt", c)
 }
+
+func (c *langCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*langCmd)(nil)

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -309,5 +309,13 @@ func (r *rootCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (r *rootCmd) Usage() {
-	executeUsage(r.fs.Output(), "root_usage.txt", r.fs, r.fs.Name())
+	executeUsage(r.fs.Output(), "root_usage.txt", r)
 }
+
+func (r *rootCmd) FlagGroups() []flagGroup {
+	return []flagGroup{{Title: "Global Flags", Flags: flagInfos(r.fs)}}
+}
+
+func (r *rootCmd) Prog() string { return r.fs.Name() }
+
+var _ usageData = (*rootCmd)(nil)

--- a/cmd/goa4web/news.go
+++ b/cmd/goa4web/news.go
@@ -58,5 +58,11 @@ func (c *newsCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *newsCmd) Usage() {
-	executeUsage(c.fs.Output(), "news_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "news_usage.txt", c)
 }
+
+func (c *newsCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*newsCmd)(nil)

--- a/cmd/goa4web/news_comments.go
+++ b/cmd/goa4web/news_comments.go
@@ -51,5 +51,11 @@ func (c *newsCommentsCmd) Run() error {
 }
 
 func (c *newsCommentsCmd) Usage() {
-	executeUsage(c.fs.Output(), "news_comments_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "news_comments_usage.txt", c)
 }
+
+func (c *newsCommentsCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*newsCommentsCmd)(nil)

--- a/cmd/goa4web/notifications.go
+++ b/cmd/goa4web/notifications.go
@@ -46,5 +46,11 @@ func (c *notificationsCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *notificationsCmd) Usage() {
-	executeUsage(c.fs.Output(), "notifications_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "notifications_usage.txt", c)
 }
+
+func (c *notificationsCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*notificationsCmd)(nil)

--- a/cmd/goa4web/notifications_tasks.go
+++ b/cmd/goa4web/notifications_tasks.go
@@ -15,8 +15,14 @@ type notificationsTasksCmd struct {
 
 // Usage prints command usage information with examples.
 func (c *notificationsTasksCmd) Usage() {
-	executeUsage(c.fs.Output(), "notifications_tasks_usage.txt", c.fs, c.notificationsCmd.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "notifications_tasks_usage.txt", c)
 }
+
+func (c *notificationsTasksCmd) FlagGroups() []flagGroup {
+	return append(c.notificationsCmd.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*notificationsTasksCmd)(nil)
 
 func parseNotificationsTasksCmd(parent *notificationsCmd, args []string) (*notificationsTasksCmd, error) {
 	c := &notificationsTasksCmd{notificationsCmd: parent}

--- a/cmd/goa4web/perm.go
+++ b/cmd/goa4web/perm.go
@@ -63,5 +63,11 @@ func (c *permCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *permCmd) Usage() {
-	executeUsage(c.fs.Output(), "perm_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "perm_usage.txt", c)
 }
+
+func (c *permCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*permCmd)(nil)

--- a/cmd/goa4web/role.go
+++ b/cmd/goa4web/role.go
@@ -50,5 +50,11 @@ func (c *roleCmd) Run() error {
 }
 
 func (c *roleCmd) Usage() {
-	executeUsage(c.fs.Output(), roleUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), roleUsageTemplate, c)
 }
+
+func (c *roleCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*roleCmd)(nil)

--- a/cmd/goa4web/role_users.go
+++ b/cmd/goa4web/role_users.go
@@ -53,5 +53,11 @@ func (c *roleUsersCmd) Run() error {
 }
 
 func (c *roleUsersCmd) Usage() {
-	executeUsage(c.fs.Output(), roleUsersUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), roleUsersUsageTemplate, c)
 }
+
+func (c *roleUsersCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*roleUsersCmd)(nil)

--- a/cmd/goa4web/serve.go
+++ b/cmd/goa4web/serve.go
@@ -59,5 +59,11 @@ func (c *serveCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *serveCmd) Usage() {
-	executeUsage(c.fs.Output(), "serve_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "serve_usage.txt", c)
 }
+
+func (c *serveCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*serveCmd)(nil)

--- a/cmd/goa4web/server.go
+++ b/cmd/goa4web/server.go
@@ -46,5 +46,11 @@ func (c *serverCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *serverCmd) Usage() {
-	executeUsage(c.fs.Output(), "server_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "server_usage.txt", c)
 }
+
+func (c *serverCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*serverCmd)(nil)

--- a/cmd/goa4web/templates/audit_usage.txt
+++ b/cmd/goa4web/templates/audit_usage.txt
@@ -4,4 +4,4 @@ Usage:
 Examples:
   {{.Prog}} audit --limit 50
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/blog_comments_usage.txt
+++ b/cmd/goa4web/templates/blog_comments_usage.txt
@@ -10,4 +10,4 @@ Examples:
   {{.Prog}} blog comments read 3 1
   {{.Prog}} blog comments read 3 all
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/blog_usage.txt
+++ b/cmd/goa4web/templates/blog_usage.txt
@@ -17,4 +17,4 @@ Examples:
   {{.Prog}} blog update -id 1 -text 'changed'
   {{.Prog}} blog deactivate -id 1
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/board_usage.txt
+++ b/cmd/goa4web/templates/board_usage.txt
@@ -13,4 +13,4 @@ Examples:
   {{.Prog}} board delete -id 1
   {{.Prog}} board update -id 1 -name new
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/config_test_usage.txt
+++ b/cmd/goa4web/templates/config_test_usage.txt
@@ -11,4 +11,4 @@ Examples:
   {{.Prog}} config test db
   {{.Prog}} config test dlq
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/config_usage.txt
+++ b/cmd/goa4web/templates/config_usage.txt
@@ -23,4 +23,4 @@ Examples:
   {{.Prog}} config options --extended
   {{.Prog}} config test email
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/db_usage.txt
+++ b/cmd/goa4web/templates/db_usage.txt
@@ -13,4 +13,4 @@ Examples:
   {{.Prog}} db restore -i backup.sql
   {{.Prog}} db seed
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/email_queue_usage.txt
+++ b/cmd/goa4web/templates/email_queue_usage.txt
@@ -11,4 +11,4 @@ Examples:
   {{.Prog}} email queue resend -id 1
   {{.Prog}} email queue delete -id 1
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/email_usage.txt
+++ b/cmd/goa4web/templates/email_usage.txt
@@ -7,4 +7,4 @@ Commands:
 Examples:
   {{.Prog}} email queue list
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/faq_usage.txt
+++ b/cmd/goa4web/templates/faq_usage.txt
@@ -9,4 +9,4 @@ Examples:
   {{.Prog}} faq tree
   {{.Prog}} faq read 1
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/flags.txt
+++ b/cmd/goa4web/templates/flags.txt
@@ -4,9 +4,14 @@
 {{end}}
 {{end}}
 
-{{define "flags_section"}}
-{{if .}}
-Flags:
-{{template "flags" .}}
+{{define "flag_group"}}
+{{if .Title}}{{.Title}}:
+{{end}}
+{{template "flags" .Flags}}
+{{end}}
+
+{{define "flag_groups_section"}}
+{{range .}}
+{{template "flag_group" .}}
 {{end}}
 {{end}}

--- a/cmd/goa4web/templates/grant_usage.txt
+++ b/cmd/goa4web/templates/grant_usage.txt
@@ -6,4 +6,4 @@ Commands:
   delete   delete a grant rule
   list     list grant rules
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/help_usage.txt
+++ b/cmd/goa4web/templates/help_usage.txt
@@ -5,4 +5,4 @@ Examples:
   {{.Prog}} help serve
   {{.Prog}} help config set
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/images_usage.txt
+++ b/cmd/goa4web/templates/images_usage.txt
@@ -1,4 +1,4 @@
 Usage:
   {{.Prog}} images cache [prune|list|delete <id>|open <id>]
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/ipban_usage.txt
+++ b/cmd/goa4web/templates/ipban_usage.txt
@@ -12,4 +12,4 @@ Examples:
   {{.Prog}} ipban list
   {{.Prog}} ipban update -id 1 -reason updated
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/lang_usage.txt
+++ b/cmd/goa4web/templates/lang_usage.txt
@@ -11,4 +11,4 @@ Examples:
   {{.Prog}} lang add --code en --name English
   {{.Prog}} lang update -id 1 -name New
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/news_comments_usage.txt
+++ b/cmd/goa4web/templates/news_comments_usage.txt
@@ -10,4 +10,4 @@ Examples:
   {{.Prog}} news comments read 3 1
   {{.Prog}} news comments read 3 all
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/news_usage.txt
+++ b/cmd/goa4web/templates/news_usage.txt
@@ -11,4 +11,4 @@ Examples:
   {{.Prog}} news read 1
   {{.Prog}} news comments list 1
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/notifications_tasks_usage.txt
+++ b/cmd/goa4web/templates/notifications_tasks_usage.txt
@@ -3,4 +3,4 @@ Usage:
 
 Displays a table of tasks and their notification templates.
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/notifications_usage.txt
+++ b/cmd/goa4web/templates/notifications_usage.txt
@@ -7,4 +7,4 @@ Commands:
 Examples:
   {{.Prog}} notifications tasks
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/perm_usage.txt
+++ b/cmd/goa4web/templates/perm_usage.txt
@@ -10,4 +10,4 @@ Examples:
   {{.Prog}} perm grant -user bob -section forum -role read
   {{.Prog}} perm list
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/role_usage.txt
+++ b/cmd/goa4web/templates/role_usage.txt
@@ -7,4 +7,4 @@ Commands:
 Examples:
   {{.Prog}} role users
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/role_users_usage.txt
+++ b/cmd/goa4web/templates/role_users_usage.txt
@@ -7,4 +7,4 @@ Description:
 Examples:
   {{.Prog}} role users
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/root_usage.txt
+++ b/cmd/goa4web/templates/root_usage.txt
@@ -39,4 +39,7 @@ Examples:
   {{.Prog}} lang list
   {{.Prog}} config show
 
-{{template "flags_section" .Flags}}
+Flags apply to the subcommand they follow.
+For example: {{.Prog}} board list -verbosity 1
+
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/serve_usage.txt
+++ b/cmd/goa4web/templates/serve_usage.txt
@@ -1,4 +1,4 @@
 Usage:
   {{.Prog}} serve [flags]
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/server_usage.txt
+++ b/cmd/goa4web/templates/server_usage.txt
@@ -7,4 +7,4 @@ Commands:
 Examples:
   {{.Prog}} server shutdown --timeout 5s
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/user_comments_usage.txt
+++ b/cmd/goa4web/templates/user_comments_usage.txt
@@ -9,4 +9,4 @@ Examples:
   {{.Prog}} user comments list -id 3
   {{.Prog}} user comments add -id 3 -comment "needs review"
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/user_password_usage.txt
+++ b/cmd/goa4web/templates/user_password_usage.txt
@@ -9,4 +9,4 @@ Examples:
   {{.Prog}} user password clear-expired
   {{.Prog}} user password clear-user -username bob
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/user_roles_usage.txt
+++ b/cmd/goa4web/templates/user_roles_usage.txt
@@ -7,4 +7,4 @@ Description:
 Examples:
   {{.Prog}} user roles
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/user_usage.txt
+++ b/cmd/goa4web/templates/user_usage.txt
@@ -28,4 +28,4 @@ Examples:
   {{.Prog}} user roles
   {{.Prog}} user password clear-expired
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/writing_comments_usage.txt
+++ b/cmd/goa4web/templates/writing_comments_usage.txt
@@ -10,4 +10,4 @@ Examples:
   {{.Prog}} writing comments read 3 1
   {{.Prog}} writing comments read 3 all
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/writing_usage.txt
+++ b/cmd/goa4web/templates/writing_usage.txt
@@ -13,4 +13,4 @@ Examples:
   {{.Prog}} writing read 1
   {{.Prog}} writing comments list 1
 
-{{template "flags_section" .Flags}}
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/user.go
+++ b/cmd/goa4web/user.go
@@ -129,5 +129,11 @@ func (c *userCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *userCmd) Usage() {
-	executeUsage(c.fs.Output(), "user_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "user_usage.txt", c)
 }
+
+func (c *userCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*userCmd)(nil)

--- a/cmd/goa4web/user_comments.go
+++ b/cmd/goa4web/user_comments.go
@@ -51,5 +51,11 @@ func (c *userCommentsCmd) Run() error {
 }
 
 func (c *userCommentsCmd) Usage() {
-	executeUsage(c.fs.Output(), "user_comments_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "user_comments_usage.txt", c)
 }
+
+func (c *userCommentsCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*userCommentsCmd)(nil)

--- a/cmd/goa4web/user_password_cmd.go
+++ b/cmd/goa4web/user_password_cmd.go
@@ -57,5 +57,11 @@ func (c *userPasswordCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *userPasswordCmd) Usage() {
-	executeUsage(c.fs.Output(), userPasswordUsageTemplate, c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), userPasswordUsageTemplate, c)
 }
+
+func (c *userPasswordCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*userPasswordCmd)(nil)

--- a/cmd/goa4web/user_roles.go
+++ b/cmd/goa4web/user_roles.go
@@ -47,5 +47,11 @@ func (c *userRolesCmd) Run() error {
 }
 
 func (c *userRolesCmd) Usage() {
-	executeUsage(c.fs.Output(), "user_roles_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "user_roles_usage.txt", c)
 }
+
+func (c *userRolesCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*userRolesCmd)(nil)

--- a/cmd/goa4web/writing.go
+++ b/cmd/goa4web/writing.go
@@ -64,5 +64,11 @@ func (c *writingCmd) Run() error {
 
 // Usage prints command usage information with examples.
 func (c *writingCmd) Usage() {
-	executeUsage(c.fs.Output(), "writing_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "writing_usage.txt", c)
 }
+
+func (c *writingCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*writingCmd)(nil)

--- a/cmd/goa4web/writing_comments.go
+++ b/cmd/goa4web/writing_comments.go
@@ -51,5 +51,11 @@ func (c *writingCommentsCmd) Run() error {
 }
 
 func (c *writingCommentsCmd) Usage() {
-	executeUsage(c.fs.Output(), "writing_comments_usage.txt", c.fs, c.rootCmd.fs.Name())
+	executeUsage(c.fs.Output(), "writing_comments_usage.txt", c)
 }
+
+func (c *writingCommentsCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*writingCommentsCmd)(nil)


### PR DESCRIPTION
## Summary
- introduce `usageData` interface to supply Prog and flag groups
- update executeUsage and command helpers to use usageData
- adjust templates to reference `FlagGroups`
- add compile-time checks and update tests

## Testing
- `go mod tidy`
- `go fmt ./cmd/goa4web/...`
- `go vet ./...` *(fails: import cycle not allowed)*
- `golangci-lint run ./...` *(fails with typecheck errors)*
- `go test ./...` *(fails: import cycle not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68801aaff188832f8938823a48b68c5e