### PR TITLE
Update bookmarks handler to use TaskHandler

### DIFF
--- a/handlers/bookmarks/createTask.go
+++ b/handlers/bookmarks/createTask.go
@@ -2,11 +2,13 @@ package bookmarks
 
 import (
 	"database/sql"
+	"fmt"
 	"net/http"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -24,7 +26,7 @@ func (CreateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
-		return nil
+		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
 
@@ -35,11 +37,7 @@ func (CreateTask) Action(w http.ResponseWriter, r *http.Request) any {
 		},
 		UsersIdusers: uid,
 	}); err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return nil
+		return fmt.Errorf("create bookmarks fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-
-	http.Redirect(w, r, "/bookmarks/mine", http.StatusTemporaryRedirect)
-
-	return nil
+	return handlers.RedirectHandler("/bookmarks/mine")
 }

--- a/handlers/bookmarks/routes.go
+++ b/handlers/bookmarks/routes.go
@@ -1,8 +1,6 @@
 package bookmarks
 
 import (
-	"github.com/arran4/goa4web/internal/tasks"
-
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/handlers"
@@ -19,9 +17,8 @@ func RegisterRoutes(r *mux.Router) {
 	br.HandleFunc("", Page).Methods("GET")
 	br.HandleFunc("/mine", MinePage).Methods("GET").MatcherFunc(handlers.RequiresAnAccount())
 	br.HandleFunc("/edit", saveTask.Page).Methods("GET").MatcherFunc(handlers.RequiresAnAccount())
-	br.HandleFunc("/edit", tasks.Action(saveTask)).Methods("POST").MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(saveTask.Matcher())
-	br.HandleFunc("/edit", tasks.Action(createTask)).Methods("POST").MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(createTask.Matcher())
-	br.HandleFunc("/edit", handlers.TaskDoneAutoRefreshPage).Methods("POST").MatcherFunc(handlers.RequiresAnAccount())
+	br.HandleFunc("/edit", handlers.TaskHandler(saveTask)).Methods("POST").MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(saveTask.Matcher())
+	br.HandleFunc("/edit", handlers.TaskHandler(createTask)).Methods("POST").MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(createTask.Matcher())
 }
 
 // Register registers the bookmarks router module.

--- a/handlers/bookmarks/saveTask.go
+++ b/handlers/bookmarks/saveTask.go
@@ -3,6 +3,7 @@ package bookmarks
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -61,7 +62,7 @@ func (SaveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
-		return nil
+		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
 
@@ -72,11 +73,7 @@ func (SaveTask) Action(w http.ResponseWriter, r *http.Request) any {
 		},
 		UsersIdusers: uid,
 	}); err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return nil
+		return fmt.Errorf("update bookmarks fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-
-	http.Redirect(w, r, "/bookmarks/mine", http.StatusTemporaryRedirect)
-
-	return nil
+	return handlers.RedirectHandler("/bookmarks/mine")
 }


### PR DESCRIPTION
## Summary
- refactor bookmarks create/save tasks to return RedirectHandler or errors
- switch bookmarks routes to use handlers.TaskHandler

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68803bbd27cc832f8fa42f420d0dc509