### PR TITLE
Repeat faq commit changes for admin handlers

### DIFF
--- a/handlers/admin/adminAnnouncementsTasks.go
+++ b/handlers/admin/adminAnnouncementsTasks.go
@@ -1,7 +1,7 @@
 package admin
 
 import (
-	"log"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -36,14 +36,11 @@ func (AddAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	nid, err := strconv.Atoi(r.PostFormValue("news_id"))
 	if err != nil {
-		log.Printf("news id: %v", err)
-		handlers.TaskDoneAutoRefreshPage(w, r)
-		return nil
+		return fmt.Errorf("news id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if err := queries.CreateAnnouncement(r.Context(), int32(nid)); err != nil {
-		log.Printf("create announcement: %v", err)
+		return fmt.Errorf("create announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }
 
@@ -59,15 +56,14 @@ func (AddAnnouncementTask) AdminInternalNotificationTemplate() *string {
 func (DeleteAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	if err := r.ParseForm(); err != nil {
-		log.Printf("ParseForm: %v", err)
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
 		if err := queries.DeleteAnnouncement(r.Context(), int32(id)); err != nil {
-			log.Printf("delete announcement: %v", err)
+			return fmt.Errorf("delete announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }
 

--- a/handlers/admin/adminDLQPage.go
+++ b/handlers/admin/adminDLQPage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -43,7 +44,7 @@ func AdminDLQPage(w http.ResponseWriter, r *http.Request) {
 func (DeleteDLQTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	if err := r.ParseForm(); err != nil {
-		log.Printf("ParseForm: %v", err)
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	switch r.PostFormValue("task") {
 	case string(TaskDelete):
@@ -53,7 +54,7 @@ func (DeleteDLQTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 			id, _ := strconv.Atoi(idStr)
 			if err := queries.DeleteDeadLetter(r.Context(), int32(id)); err != nil {
-				log.Printf("delete error: %v", err)
+				return fmt.Errorf("delete error %w", handlers.ErrRedirectOnSamePageHandler(err))
 			}
 		}
 	case string(TaskPurge):
@@ -65,9 +66,8 @@ func (DeleteDLQTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 		}
 		if err := queries.PurgeDeadLettersBefore(r.Context(), t); err != nil {
-			log.Printf("purge errors: %v", err)
+			return fmt.Errorf("purge errors %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -7,17 +7,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/mail"
-	"net/url"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
-	userhandlers "github.com/arran4/goa4web/handlers/user"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
 	logProv "github.com/arran4/goa4web/internal/email/log"
@@ -36,17 +34,10 @@ func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()
-	testTemplateTask.Action(rr, req)
+	handlers.TaskHandler(testTemplateTask)(rr, req)
 
-	if rr.Code != http.StatusOK {
+	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("status=%d", rr.Code)
-	}
-	want := url.QueryEscape(userhandlers.ErrMailNotConfigured.Error())
-	if req.URL.RawQuery != "error="+want {
-		t.Fatalf("query=%q", req.URL.RawQuery)
-	}
-	if !strings.Contains(rr.Body.String(), "<a href=") {
-		t.Fatalf("body=%q", rr.Body.String())
 	}
 }
 
@@ -74,9 +65,9 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()
-	testTemplateTask.Action(rr, req)
+	handlers.TaskHandler(testTemplateTask)(rr, req)
 
-	if rr.Code != http.StatusSeeOther {
+	if rr.Code != http.StatusTemporaryRedirect {
 		t.Fatalf("status=%d", rr.Code)
 	}
 	if loc := rr.Header().Get("Location"); loc != "/admin/email/template" {

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 
 	faq "github.com/arran4/goa4web/handlers/faq"
@@ -36,33 +35,33 @@ func RegisterRoutes(ar *mux.Router) {
 	ar.HandleFunc("/", AdminPage).Methods("GET")
 	ar.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")
 	ar.HandleFunc("/email/queue", AdminEmailQueuePage).Methods("GET")
-	ar.HandleFunc("/email/queue", tasks.Action(resendQueueTask)).Methods("POST").MatcherFunc(resendQueueTask.Matcher())
-	ar.HandleFunc("/email/queue", tasks.Action(deleteQueueTask)).Methods("POST").MatcherFunc(deleteQueueTask.Matcher())
+	ar.HandleFunc("/email/queue", handlers.TaskHandler(resendQueueTask)).Methods("POST").MatcherFunc(resendQueueTask.Matcher())
+	ar.HandleFunc("/email/queue", handlers.TaskHandler(deleteQueueTask)).Methods("POST").MatcherFunc(deleteQueueTask.Matcher())
 	ar.HandleFunc("/email/template", AdminEmailTemplatePage).Methods("GET")
-	ar.HandleFunc("/email/template", tasks.Action(saveTemplateTask)).Methods("POST").MatcherFunc(saveTemplateTask.Matcher())
-	ar.HandleFunc("/email/template", tasks.Action(testTemplateTask)).Methods("POST").MatcherFunc(testTemplateTask.Matcher())
+	ar.HandleFunc("/email/template", handlers.TaskHandler(saveTemplateTask)).Methods("POST").MatcherFunc(saveTemplateTask.Matcher())
+	ar.HandleFunc("/email/template", handlers.TaskHandler(testTemplateTask)).Methods("POST").MatcherFunc(testTemplateTask.Matcher())
 	ar.HandleFunc("/dlq", AdminDLQPage).Methods("GET")
-	ar.HandleFunc("/dlq", tasks.Action(deleteDLQTask)).Methods("POST").MatcherFunc(deleteDLQTask.Matcher())
+	ar.HandleFunc("/dlq", handlers.TaskHandler(deleteDLQTask)).Methods("POST").MatcherFunc(deleteDLQTask.Matcher())
 	ar.HandleFunc("/notifications", AdminNotificationsPage).Methods("GET")
-	ar.HandleFunc("/notifications", tasks.Action(markReadTask)).Methods("POST").MatcherFunc(markReadTask.Matcher())
-	ar.HandleFunc("/notifications", tasks.Action(purgeNotificationsTask)).Methods("POST").MatcherFunc(purgeNotificationsTask.Matcher())
-	ar.HandleFunc("/notifications", tasks.Action(sendNotificationTask)).Methods("POST").MatcherFunc(sendNotificationTask.Matcher())
+	ar.HandleFunc("/notifications", handlers.TaskHandler(markReadTask)).Methods("POST").MatcherFunc(markReadTask.Matcher())
+	ar.HandleFunc("/notifications", handlers.TaskHandler(purgeNotificationsTask)).Methods("POST").MatcherFunc(purgeNotificationsTask.Matcher())
+	ar.HandleFunc("/notifications", handlers.TaskHandler(sendNotificationTask)).Methods("POST").MatcherFunc(sendNotificationTask.Matcher())
 	ar.HandleFunc("/requests", AdminRequestQueuePage).Methods("GET")
 	ar.HandleFunc("/requests/archive", AdminRequestArchivePage).Methods("GET")
 	ar.HandleFunc("/request/{id}", adminRequestPage).Methods("GET")
 	ar.HandleFunc("/request/{id}/comment", adminRequestAddCommentPage).Methods("POST")
-	ar.HandleFunc("/request/{id}/accept", tasks.Action(acceptRequestTask)).Methods("POST").MatcherFunc(acceptRequestTask.Matcher())
-	ar.HandleFunc("/request/{id}/reject", tasks.Action(rejectRequestTask)).Methods("POST").MatcherFunc(rejectRequestTask.Matcher())
-	ar.HandleFunc("/request/{id}/query", tasks.Action(queryRequestTask)).Methods("POST").MatcherFunc(queryRequestTask.Matcher())
+	ar.HandleFunc("/request/{id}/accept", handlers.TaskHandler(acceptRequestTask)).Methods("POST").MatcherFunc(acceptRequestTask.Matcher())
+	ar.HandleFunc("/request/{id}/reject", handlers.TaskHandler(rejectRequestTask)).Methods("POST").MatcherFunc(rejectRequestTask.Matcher())
+	ar.HandleFunc("/request/{id}/query", handlers.TaskHandler(queryRequestTask)).Methods("POST").MatcherFunc(queryRequestTask.Matcher())
 	ar.HandleFunc("/user", adminUserListPage).Methods("GET")
 	ar.HandleFunc("/user/{id}", adminUserProfilePage).Methods("GET")
 	ar.HandleFunc("/user/{id}/comment", adminUserAddCommentPage).Methods("POST")
 	ar.HandleFunc("/announcements", AdminAnnouncementsPage).Methods("GET")
-	ar.HandleFunc("/announcements", tasks.Action(addAnnouncementTask)).Methods("POST").MatcherFunc(addAnnouncementTask.Matcher())
-	ar.HandleFunc("/announcements", tasks.Action(deleteAnnouncementTask)).Methods("POST").MatcherFunc(deleteAnnouncementTask.Matcher())
+	ar.HandleFunc("/announcements", handlers.TaskHandler(addAnnouncementTask)).Methods("POST").MatcherFunc(addAnnouncementTask.Matcher())
+	ar.HandleFunc("/announcements", handlers.TaskHandler(deleteAnnouncementTask)).Methods("POST").MatcherFunc(deleteAnnouncementTask.Matcher())
 	ar.HandleFunc("/ipbans", AdminIPBanPage).Methods("GET")
-	ar.HandleFunc("/ipbans", tasks.Action(addIPBanTask)).Methods("POST").MatcherFunc(addIPBanTask.Matcher())
-	ar.HandleFunc("/ipbans", tasks.Action(deleteIPBanTask)).Methods("POST").MatcherFunc(deleteIPBanTask.Matcher())
+	ar.HandleFunc("/ipbans", handlers.TaskHandler(addIPBanTask)).Methods("POST").MatcherFunc(addIPBanTask.Matcher())
+	ar.HandleFunc("/ipbans", handlers.TaskHandler(deleteIPBanTask)).Methods("POST").MatcherFunc(deleteIPBanTask.Matcher())
 	ar.HandleFunc("/audit", AdminAuditLogPage).Methods("GET")
 	ar.HandleFunc("/settings", AdminSiteSettingsPage).Methods("GET", "POST")
 	ar.HandleFunc("/page-size", AdminPageSizePage).Methods("GET", "POST")
@@ -85,8 +84,8 @@ func RegisterRoutes(ar *mux.Router) {
 	// news admin
 	nar := ar.PathPrefix("/news").Subrouter()
 	nar.HandleFunc("/users/roles", news.AdminUserRolesPage).Methods("GET")
-	nar.HandleFunc("/users/roles", tasks.Action(newsUserAllow)).Methods("POST").MatcherFunc(newsUserAllow.Matcher())
-	nar.HandleFunc("/users/roles", tasks.Action(newsUserRemove)).Methods("POST").MatcherFunc(newsUserRemove.Matcher())
+	nar.HandleFunc("/users/roles", handlers.TaskHandler(newsUserAllow)).Methods("POST").MatcherFunc(newsUserAllow.Matcher())
+	nar.HandleFunc("/users/roles", handlers.TaskHandler(newsUserRemove)).Methods("POST").MatcherFunc(newsUserRemove.Matcher())
 
 	// writings admin
 	writings.RegisterAdminRoutes(ar)


### PR DESCRIPTION
## Summary
- refactor admin handlers to use `TaskHandler`
- return errors instead of triggering redirects inside tasks
- adjust admin email template tests for new TaskHandler behaviour

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68803bab5640832fa8c440e8ca30164e