### PR TITLE
Update search handler to use template wrapper

### DIFF
--- a/handlers/search/routes.go
+++ b/handlers/search/routes.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 
 	nav "github.com/arran4/goa4web/internal/navigation"
@@ -16,11 +15,11 @@ func RegisterRoutes(r *mux.Router) {
 	sr := r.PathPrefix("/search").Subrouter()
 	sr.Use(handlers.IndexMiddleware(CustomIndex))
 	sr.HandleFunc("", Page).Methods("GET")
-	sr.HandleFunc("", tasks.Action(searchForumTask)).Methods("POST").MatcherFunc(searchForumTask.Matcher())
-	sr.HandleFunc("", tasks.Action(searchNewsTask)).Methods("POST").MatcherFunc(searchNewsTask.Matcher())
-	sr.HandleFunc("", tasks.Action(searchLinkerTask)).Methods("POST").MatcherFunc(searchLinkerTask.Matcher())
-	sr.HandleFunc("", tasks.Action(searchBlogsTask)).Methods("POST").MatcherFunc(searchBlogsTask.Matcher())
-	sr.HandleFunc("", tasks.Action(searchWritingsTask)).Methods("POST").MatcherFunc(searchWritingsTask.Matcher())
+	sr.HandleFunc("", handlers.TaskHandler(searchForumTask)).Methods("POST").MatcherFunc(searchForumTask.Matcher())
+	sr.HandleFunc("", handlers.TaskHandler(searchNewsTask)).Methods("POST").MatcherFunc(searchNewsTask.Matcher())
+	sr.HandleFunc("", handlers.TaskHandler(searchLinkerTask)).Methods("POST").MatcherFunc(searchLinkerTask.Matcher())
+	sr.HandleFunc("", handlers.TaskHandler(searchBlogsTask)).Methods("POST").MatcherFunc(searchBlogsTask.Matcher())
+	sr.HandleFunc("", handlers.TaskHandler(searchWritingsTask)).Methods("POST").MatcherFunc(searchWritingsTask.Matcher())
 }
 
 // Register registers the search router module.

--- a/handlers/search/routes_admin.go
+++ b/handlers/search/routes_admin.go
@@ -1,7 +1,7 @@
 package search
 
 import (
-	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/gorilla/mux"
 )
 
@@ -9,12 +9,12 @@ import (
 func RegisterAdminRoutes(ar *mux.Router) {
 	sr := ar.PathPrefix("/search").Subrouter()
 	sr.HandleFunc("", adminSearchPage).Methods("GET")
-	sr.HandleFunc("", tasks.Action(remakeCommentsTask)).Methods("POST").MatcherFunc(remakeCommentsTask.Matcher())
-	sr.HandleFunc("", tasks.Action(remakeNewsTask)).Methods("POST").MatcherFunc(remakeNewsTask.Matcher())
-	sr.HandleFunc("", tasks.Action(remakeBlogTask)).Methods("POST").MatcherFunc(remakeBlogTask.Matcher())
-	sr.HandleFunc("", tasks.Action(remakeLinkerTask)).Methods("POST").MatcherFunc(remakeLinkerTask.Matcher())
-	sr.HandleFunc("", tasks.Action(remakeWritingTask)).Methods("POST").MatcherFunc(remakeWritingTask.Matcher())
-	sr.HandleFunc("", tasks.Action(remakeImageTask)).Methods("POST").MatcherFunc(remakeImageTask.Matcher())
+	sr.HandleFunc("", handlers.TaskHandler(remakeCommentsTask)).Methods("POST").MatcherFunc(remakeCommentsTask.Matcher())
+	sr.HandleFunc("", handlers.TaskHandler(remakeNewsTask)).Methods("POST").MatcherFunc(remakeNewsTask.Matcher())
+	sr.HandleFunc("", handlers.TaskHandler(remakeBlogTask)).Methods("POST").MatcherFunc(remakeBlogTask.Matcher())
+	sr.HandleFunc("", handlers.TaskHandler(remakeLinkerTask)).Methods("POST").MatcherFunc(remakeLinkerTask.Matcher())
+	sr.HandleFunc("", handlers.TaskHandler(remakeWritingTask)).Methods("POST").MatcherFunc(remakeWritingTask.Matcher())
+	sr.HandleFunc("", handlers.TaskHandler(remakeImageTask)).Methods("POST").MatcherFunc(remakeImageTask.Matcher())
 	sr.HandleFunc("/list", adminSearchWordListPage).Methods("GET")
 	sr.HandleFunc("/list.txt", adminSearchWordListDownloadPage).Methods("GET")
 }

--- a/handlers/search/searchNewsTask.go
+++ b/handlers/search/searchNewsTask.go
@@ -14,6 +14,5 @@ var searchNewsTask = &SearchNewsTask{TaskString: TaskSearchNews}
 var _ tasks.Task = (*SearchNewsTask)(nil)
 
 func (SearchNewsTask) Action(w http.ResponseWriter, r *http.Request) any {
-	news.SearchResultNewsActionPage(w, r)
-	return nil
+	return http.HandlerFunc(news.SearchResultNewsActionPage)
 }

--- a/handlers/search/searchResultBlogsActionPage.go
+++ b/handlers/search/searchResultBlogsActionPage.go
@@ -39,7 +39,7 @@ func (SearchBlogsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
-		return nil
+		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
 
@@ -66,8 +66,7 @@ func (SearchBlogsTask) Action(w http.ResponseWriter, r *http.Request) any {
 		data.EmptyWords = noResults
 	}
 
-	handlers.TemplateHandler(w, r, "resultBlogsActionPage.gohtml", data)
-	return nil
+	return handlers.TemplateWithDataHandler("resultBlogsActionPage.gohtml", data)
 }
 
 func BlogSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.Blog, bool, bool, error) {

--- a/handlers/search/searchResultForumActionPage.go
+++ b/handlers/search/searchResultForumActionPage.go
@@ -36,7 +36,7 @@ func (SearchForumTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
-		return nil
+		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
 
@@ -48,8 +48,7 @@ func (SearchForumTask) Action(w http.ResponseWriter, r *http.Request) any {
 		data.CommentsEmptyWords = noResults
 	}
 
-	handlers.TemplateHandler(w, r, "resultForumActionPage.gohtml", data)
-	return nil
+	return handlers.TemplateWithDataHandler("resultForumActionPage.gohtml", data)
 }
 
 func ForumCommentSearchNotInRestrictedTopic(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetCommentsByIdsForUserWithThreadInfoRow, bool, bool, error) {

--- a/handlers/search/searchResultLinkerActionPage.go
+++ b/handlers/search/searchResultLinkerActionPage.go
@@ -41,7 +41,7 @@ func (SearchLinkerTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
-		return nil
+		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
 
@@ -68,8 +68,7 @@ func (SearchLinkerTask) Action(w http.ResponseWriter, r *http.Request) any {
 		data.EmptyWords = noResults
 	}
 
-	handlers.TemplateHandler(w, r, "resultLinkerActionPage.gohtml", data)
-	return nil
+	return handlers.TemplateWithDataHandler("resultLinkerActionPage.gohtml", data)
 }
 
 func LinkerSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow, bool, bool, error) {

--- a/handlers/search/searchResultWritingsActionPage.go
+++ b/handlers/search/searchResultWritingsActionPage.go
@@ -40,7 +40,7 @@ func (SearchWritingsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
-		return nil
+		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
 
@@ -67,8 +67,7 @@ func (SearchWritingsTask) Action(w http.ResponseWriter, r *http.Request) any {
 		data.EmptyWords = noResults
 	}
 
-	handlers.TemplateHandler(w, r, "resultWritingsActionPage.gohtml", data)
-	return nil
+	return handlers.TemplateWithDataHandler("resultWritingsActionPage.gohtml", data)
 }
 
 func WritingSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.GetWritingsByIdsForUserDescendingByPublishedDateRow, bool, bool, error) {

--- a/handlers/taskresulthandlers.go
+++ b/handlers/taskresulthandlers.go
@@ -1,3 +1,24 @@
 package handlers
 
+import "net/http"
+
 type RedirectHandler string
+
+// templateWithDataHandler is a small wrapper that renders tmpl with the
+// provided data when ServeHTTP is called.
+type templateWithDataHandler struct {
+	tmpl string
+	data any
+}
+
+var _ http.Handler = (*templateWithDataHandler)(nil)
+
+// TemplateWithDataHandler returns an http.Handler that renders tmpl with data
+// using TemplateHandler. It is useful for returning templates from tasks.
+func TemplateWithDataHandler(tmpl string, data any) any {
+	return &templateWithDataHandler{tmpl: tmpl, data: data}
+}
+
+func (th *templateWithDataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	TemplateHandler(w, r, th.tmpl, th.data)
+}


### PR DESCRIPTION
## Summary
- provide TemplateWithDataHandler type for returning template handlers
- adapt search result tasks to use TemplateWithDataHandler

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68803be2b218832faed63d533362b8e0