### PR TITLE
Apply new TaskHandler flow to linker

### DIFF
--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -3,6 +3,7 @@ package linker
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -90,12 +91,8 @@ func (addTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Url:              sql.NullString{Valid: true, String: url},
 		Description:      sql.NullString{Valid: true, String: description},
 	}); err != nil {
-		log.Printf("createLinkerItem Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return nil
+		return fmt.Errorf("create linker item fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-
-	handlers.TaskDoneAutoRefreshPage(w, r)
 
 	return nil
 }

--- a/handlers/linker/linkerAdminCategoriesPage.go
+++ b/handlers/linker/linkerAdminCategoriesPage.go
@@ -3,6 +3,7 @@ package linker
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -55,20 +56,15 @@ func (updateCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Position:         int32(pos),
 		Idlinkercategory: int32(cid),
 	}); err != nil {
-		log.Printf("renameLinkerCategory Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return nil
+		return fmt.Errorf("rename linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	order, _ := strconv.Atoi(r.PostFormValue("order"))
 	if err := queries.UpdateLinkerCategorySortOrder(r.Context(), db.UpdateLinkerCategorySortOrderParams{
 		Sortorder:        int32(order),
 		Idlinkercategory: int32(cid),
 	}); err != nil {
-		log.Printf("updateLinkerCategorySortOrder Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return nil
+		return fmt.Errorf("update linker category sort order fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }
 
@@ -87,11 +83,8 @@ func (renameCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Position:         int32(pos),
 		Idlinkercategory: int32(cid),
 	}); err != nil {
-		log.Printf("renameLinkerCategory Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return nil
+		return fmt.Errorf("rename linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }
 
@@ -113,20 +106,15 @@ func (deleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	count, err := queries.CountLinksByCategory(r.Context(), int32(cid))
 	if err != nil {
-		log.Printf("countLinks Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return nil
+		return fmt.Errorf("count links fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if count > 0 {
 		http.Error(w, "Category in use", http.StatusBadRequest)
 		return nil
 	}
 	if err := queries.DeleteLinkerCategory(r.Context(), int32(cid)); err != nil {
-		log.Printf("renameLinkerCategory Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return nil
+		return fmt.Errorf("delete linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }
 
@@ -145,10 +133,7 @@ func (createCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Title:    sql.NullString{Valid: true, String: title},
 		Position: int32(pos),
 	}); err != nil {
-		log.Printf("renameLinkerCategory Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return nil
+		return fmt.Errorf("create linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }

--- a/handlers/linker/linkerAdminQueuePage.go
+++ b/handlers/linker/linkerAdminQueuePage.go
@@ -143,9 +143,7 @@ func (deleteTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	if err := queries.DeleteLinkerQueuedItem(r.Context(), int32(qid)); err != nil {
-		log.Printf("updateLinkerQueuedItem Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return nil
+		return fmt.Errorf("delete linker queued item fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if link != nil {
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
@@ -165,7 +163,6 @@ func (deleteTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 		}
 	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }
 
@@ -234,9 +231,7 @@ func (approveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	qid, _ := strconv.Atoi(r.URL.Query().Get("qid"))
 	lid, err := queries.SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId(r.Context(), int32(qid))
 	if err != nil {
-		log.Printf("updateLinkerQueuedItem Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return nil
+		return fmt.Errorf("approve linker item fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
@@ -246,9 +241,7 @@ func (approveTask) Action(w http.ResponseWriter, r *http.Request) any {
 		ViewerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	})
 	if err != nil {
-		log.Printf("getLinkerItemById Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return nil
+		return fmt.Errorf("get linker item fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
 	text := strings.Join([]string{link.Title.String, link.Description.String}, " ")
@@ -269,7 +262,6 @@ func (approveTask) Action(w http.ResponseWriter, r *http.Request) any {
 			evt.Data[searchworker.EventKey] = searchworker.IndexEventData{Type: searchworker.TypeLinker, ID: int32(lid), Text: text}
 		}
 	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }
 
@@ -331,7 +323,6 @@ func (bulkDeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 		}
 	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }
 
@@ -435,7 +426,6 @@ func (bulkApproveTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 		}
 	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }
 

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -117,7 +117,6 @@ func (userAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 		}
 	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }
 
@@ -155,7 +154,6 @@ func (userDisallowTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 		}
 	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }
 

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -3,6 +3,7 @@ package linker
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -89,11 +90,8 @@ func (SuggestTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Url:              sql.NullString{Valid: true, String: url},
 		Description:      sql.NullString{Valid: true, String: description},
 	}); err != nil {
-		log.Printf("createLinkerQueuedItem Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return nil
+		return fmt.Errorf("create linker queued item fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -2,7 +2,6 @@ package linker
 
 import (
 	"github.com/arran4/goa4web/handlers/forum/comments"
-	"github.com/arran4/goa4web/internal/tasks"
 	"net/http"
 
 	"github.com/arran4/goa4web/handlers"
@@ -29,12 +28,12 @@ func RegisterRoutes(r *mux.Router) {
 	lr.HandleFunc("/categories", CategoriesPage).Methods("GET")
 	lr.HandleFunc("/category/{category}", CategoryPage).Methods("GET")
 	lr.HandleFunc("/comments/{link}", replyTaskEvent.Page).Methods("GET")
-	lr.HandleFunc("/comments/{link}", tasks.Action(replyTaskEvent)).Methods("POST").MatcherFunc(replyTaskEvent.Matcher())
+	lr.HandleFunc("/comments/{link}", handlers.TaskHandler(replyTaskEvent)).Methods("POST").MatcherFunc(replyTaskEvent.Matcher())
 	lr.Handle("/comments/{link}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(commentEditAction.Page))).Methods("POST").MatcherFunc(commentEditAction.Matcher())
 	lr.Handle("/comments/{link}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(commentEditActionCancel.Page))).Methods("POST").MatcherFunc(commentEditActionCancel.Matcher())
 	lr.HandleFunc("/show/{link}", replyTaskEvent.Page).Methods("GET")
 	lr.HandleFunc("/suggest", suggestTask.Page).Methods("GET")
-	lr.HandleFunc("/suggest", tasks.Action(suggestTask)).Methods("POST").MatcherFunc(suggestTask.Matcher())
+	lr.HandleFunc("/suggest", handlers.TaskHandler(suggestTask)).Methods("POST").MatcherFunc(suggestTask.Matcher())
 
 	if legacyRedirectsEnabled {
 		// legacy redirects

--- a/handlers/linker/routes_admin.go
+++ b/handlers/linker/routes_admin.go
@@ -1,7 +1,7 @@
 package linker
 
 import (
-	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/gorilla/mux"
 )
 
@@ -9,19 +9,19 @@ import (
 func RegisterAdminRoutes(ar *mux.Router) {
 	lar := ar.PathPrefix("/linker").Subrouter()
 	lar.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")
-	lar.HandleFunc("/categories", tasks.Action(UpdateCategoryTask)).Methods("POST").MatcherFunc(UpdateCategoryTask.Matcher())
-	lar.HandleFunc("/categories", tasks.Action(RenameCategoryTask)).Methods("POST").MatcherFunc(RenameCategoryTask.Matcher())
-	lar.HandleFunc("/categories", tasks.Action(DeleteCategoryTask)).Methods("POST").MatcherFunc(DeleteCategoryTask.Matcher())
-	lar.HandleFunc("/categories", tasks.Action(CreateCategoryTask)).Methods("POST").MatcherFunc(CreateCategoryTask.Matcher())
+	lar.HandleFunc("/categories", handlers.TaskHandler(UpdateCategoryTask)).Methods("POST").MatcherFunc(UpdateCategoryTask.Matcher())
+	lar.HandleFunc("/categories", handlers.TaskHandler(RenameCategoryTask)).Methods("POST").MatcherFunc(RenameCategoryTask.Matcher())
+	lar.HandleFunc("/categories", handlers.TaskHandler(DeleteCategoryTask)).Methods("POST").MatcherFunc(DeleteCategoryTask.Matcher())
+	lar.HandleFunc("/categories", handlers.TaskHandler(CreateCategoryTask)).Methods("POST").MatcherFunc(CreateCategoryTask.Matcher())
 	lar.HandleFunc("/add", AdminAddPage).Methods("GET")
-	lar.HandleFunc("/add", tasks.Action(AddTask)).Methods("POST").MatcherFunc(AddTask.Matcher())
+	lar.HandleFunc("/add", handlers.TaskHandler(AddTask)).Methods("POST").MatcherFunc(AddTask.Matcher())
 	lar.HandleFunc("/queue", AdminQueuePage).Methods("GET")
-	lar.HandleFunc("/queue", tasks.Action(DeleteTask)).Methods("POST").MatcherFunc(DeleteTask.Matcher())
-	lar.HandleFunc("/queue", tasks.Action(ApproveTask)).Methods("POST").MatcherFunc(ApproveTask.Matcher())
-	lar.HandleFunc("/queue", tasks.Action(UpdateCategoryTask)).Methods("POST").MatcherFunc(UpdateCategoryTask.Matcher())
-	lar.HandleFunc("/queue", tasks.Action(BulkApproveTask)).Methods("POST").MatcherFunc(BulkApproveTask.Matcher())
-	lar.HandleFunc("/queue", tasks.Action(BulkDeleteTask)).Methods("POST").MatcherFunc(BulkDeleteTask.Matcher())
+	lar.HandleFunc("/queue", handlers.TaskHandler(DeleteTask)).Methods("POST").MatcherFunc(DeleteTask.Matcher())
+	lar.HandleFunc("/queue", handlers.TaskHandler(ApproveTask)).Methods("POST").MatcherFunc(ApproveTask.Matcher())
+	lar.HandleFunc("/queue", handlers.TaskHandler(UpdateCategoryTask)).Methods("POST").MatcherFunc(UpdateCategoryTask.Matcher())
+	lar.HandleFunc("/queue", handlers.TaskHandler(BulkApproveTask)).Methods("POST").MatcherFunc(BulkApproveTask.Matcher())
+	lar.HandleFunc("/queue", handlers.TaskHandler(BulkDeleteTask)).Methods("POST").MatcherFunc(BulkDeleteTask.Matcher())
 	lar.HandleFunc("/users/roles", AdminUserRolesPage).Methods("GET")
-	lar.HandleFunc("/users/roles", tasks.Action(UserAllowTask)).Methods("POST").MatcherFunc(UserAllowTask.Matcher())
-	lar.HandleFunc("/users/roles", tasks.Action(UserDisallowTask)).Methods("POST").MatcherFunc(UserDisallowTask.Matcher())
+	lar.HandleFunc("/users/roles", handlers.TaskHandler(UserAllowTask)).Methods("POST").MatcherFunc(UserAllowTask.Matcher())
+	lar.HandleFunc("/users/roles", handlers.TaskHandler(UserDisallowTask)).Methods("POST").MatcherFunc(UserDisallowTask.Matcher())
 }


### PR DESCRIPTION
## Summary
- convert linker task handlers to return results instead of writing responses
- remove explicit TaskDoneAutoRefreshPage calls
- register linker routes with `TaskHandler`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68803bd9fc6c832f8bb9ec2146cae28d