### PR TITLE
Refine image upload task handler

### DIFF
--- a/handlers/images/routes.go
+++ b/handlers/images/routes.go
@@ -2,7 +2,6 @@ package images
 
 import (
 	"bytes"
-	"github.com/arran4/goa4web/internal/tasks"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -40,7 +39,7 @@ func verifyMiddleware(prefix string) mux.MiddlewareFunc {
 func RegisterRoutes(r *mux.Router) {
 	ir := r.PathPrefix("/images").Subrouter()
 	ir.Use(handlers.IndexMiddleware(CustomIndex))
-	ir.HandleFunc("/upload/image", tasks.Action(uploadImageTask)).
+	ir.HandleFunc("/upload/image", handlers.TaskHandler(uploadImageTask)).
 		Methods(http.MethodPost).
 		MatcherFunc(handlers.RequiresAnAccount()).
 		MatcherFunc(uploadImageTask.Matcher())

--- a/handlers/taskhandler.go
+++ b/handlers/taskhandler.go
@@ -24,6 +24,11 @@ func TaskHandler(t tasks.Task) func(http.ResponseWriter, *http.Request) {
 		switch result := result.(type) {
 		case RedirectHandler:
 			http.Redirect(w, r, string(result), http.StatusTemporaryRedirect)
+		case TextByteWriter:
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			if _, err := w.Write([]byte(result)); err != nil {
+				log.Printf("write response: %v", err)
+			}
 		case http.HandlerFunc:
 			result(w, r)
 		case http.Handler:

--- a/handlers/taskresulthandlers.go
+++ b/handlers/taskresulthandlers.go
@@ -1,3 +1,6 @@
 package handlers
 
 type RedirectHandler string
+
+// TextByteWriter responds with a plain text byte slice.
+type TextByteWriter []byte


### PR DESCRIPTION
## Summary
- introduce `handlers.TextByteWriter` result type
- handle `TextByteWriter` in `handlers.TaskHandler`
- return `TextByteWriter` from image upload task

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68803bcf9440832f93a2f168df8d05e3