### PR TITLE
Apply task handler pattern to user module

### DIFF
--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/middleware"
 	"github.com/arran4/goa4web/internal/notifications"
-	"github.com/arran4/goa4web/internal/tasks"
 )
 
 func TestPermissionUserTasksTemplates(t *testing.T) {
@@ -69,7 +69,7 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
-	handler := middleware.TaskEventMiddleware(http.HandlerFunc(tasks.Action(permissionUserAllowTask)))
+	handler := middleware.TaskEventMiddleware(http.HandlerFunc(handlers.TaskHandler(permissionUserAllowTask)))
 	handler.ServeHTTP(rr, req)
 
 	select {

--- a/handlers/user/deleteSubscriptionTask.go
+++ b/handlers/user/deleteSubscriptionTask.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -8,6 +9,7 @@ import (
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -22,25 +24,21 @@ var _ tasks.Task = (*DeleteTask)(nil)
 func (DeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
-		return nil
+		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
 	if err := r.ParseForm(); err != nil {
-		http.Redirect(w, r, "/usr/subscriptions?error="+err.Error(), http.StatusSeeOther)
-		return nil
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	idStr := r.PostFormValue("id")
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	if idStr == "" {
-		http.Redirect(w, r, "/usr/subscriptions?error=missing id", http.StatusSeeOther)
-		return nil
+		return handlers.RedirectHandler("/usr/subscriptions?error=missing id")
 	}
 	id, _ := strconv.Atoi(idStr)
 	if err := queries.DeleteSubscriptionByID(r.Context(), db.DeleteSubscriptionByIDParams{UsersIdusers: uid, ID: int32(id)}); err != nil {
 		log.Printf("delete sub: %v", err)
-		http.Redirect(w, r, "/usr/subscriptions?error="+err.Error(), http.StatusSeeOther)
-		return nil
+		return fmt.Errorf("delete subscription fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	http.Redirect(w, r, "/usr/subscriptions", http.StatusSeeOther)
-	return nil
+	return handlers.RedirectHandler("/usr/subscriptions")
 }

--- a/handlers/user/resendVerificationEmailTask.go
+++ b/handlers/user/resendVerificationEmailTask.go
@@ -17,8 +17,7 @@ var _ tasks.Task = (*ResendVerificationEmailTask)(nil)
 var _ notif.DirectEmailNotificationTemplateProvider = (*ResendVerificationEmailTask)(nil)
 
 func (ResendVerificationEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
-	addEmailTask.Resend(w, r)
-	return nil
+	return addEmailTask.Resend(w, r)
 }
 
 func (ResendVerificationEmailTask) DirectEmailTemplate() *notif.EmailTemplates {

--- a/handlers/user/routes.go
+++ b/handlers/user/routes.go
@@ -1,7 +1,6 @@
 package user
 
 import (
-	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 	"net/http"
 
@@ -16,27 +15,27 @@ func RegisterRoutes(r *mux.Router) {
 	ur.HandleFunc("", userPage).Methods(http.MethodGet)
 	ur.HandleFunc("/logout", userLogoutPage).Methods(http.MethodGet)
 	ur.HandleFunc("/lang", userLangPage).Methods(http.MethodGet).MatcherFunc(handlers.RequiresAnAccount())
-	ur.HandleFunc("/lang", tasks.Action(saveLanguagesTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(saveLanguagesTask.Matcher())
-	ur.HandleFunc("/lang", tasks.Action(saveLanguageTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(saveLanguageTask.Matcher())
-	ur.HandleFunc("/lang", tasks.Action(saveAllTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(saveAllTask.Matcher())
+	ur.HandleFunc("/lang", handlers.TaskHandler(saveLanguagesTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(saveLanguagesTask.Matcher())
+	ur.HandleFunc("/lang", handlers.TaskHandler(saveLanguageTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(saveLanguageTask.Matcher())
+	ur.HandleFunc("/lang", handlers.TaskHandler(saveAllTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(saveAllTask.Matcher())
 	ur.HandleFunc("/email", userEmailPage).Methods(http.MethodGet).MatcherFunc(handlers.RequiresAnAccount())
-	ur.HandleFunc("/email", tasks.Action(saveEmailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(saveEmailTask.Matcher())
-	ur.HandleFunc("/email/add", tasks.Action(addEmailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(addEmailTask.Matcher())
-	ur.HandleFunc("/email/resend", tasks.Action(resendVerificationEmailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(resendVerificationEmailTask.Matcher())
-	ur.HandleFunc("/email/delete", tasks.Action(deleteEmailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(deleteEmailTask.Matcher())
+	ur.HandleFunc("/email", handlers.TaskHandler(saveEmailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(saveEmailTask.Matcher())
+	ur.HandleFunc("/email/add", handlers.TaskHandler(addEmailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(addEmailTask.Matcher())
+	ur.HandleFunc("/email/resend", handlers.TaskHandler(resendVerificationEmailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(resendVerificationEmailTask.Matcher())
+	ur.HandleFunc("/email/delete", handlers.TaskHandler(deleteEmailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(deleteEmailTask.Matcher())
 	ur.HandleFunc("/email/notify", addEmailTask.Notify).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(addEmailTask.Matcher())
 	ur.HandleFunc("/email/verify", userEmailVerifyCodePage).Methods(http.MethodGet, http.MethodPost)
-	ur.HandleFunc("/email", tasks.Action(testMailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(testMailTask.Matcher())
+	ur.HandleFunc("/email", handlers.TaskHandler(testMailTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(testMailTask.Matcher())
 	ur.HandleFunc("/paging", userPagingPage).Methods(http.MethodGet).MatcherFunc(handlers.RequiresAnAccount())
-	ur.HandleFunc("/paging", tasks.Action(pagingSaveTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(pagingSaveTask.Matcher())
+	ur.HandleFunc("/paging", handlers.TaskHandler(pagingSaveTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(pagingSaveTask.Matcher())
 	ur.HandleFunc("/notifications", userNotificationsPage).Methods(http.MethodGet).MatcherFunc(handlers.RequiresAnAccount())
-	ur.HandleFunc("/notifications", tasks.Action(saveAllTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(saveAllTask.Matcher())
-	ur.HandleFunc("/notifications/dismiss", tasks.Action(dismissTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(dismissTask.Matcher())
+	ur.HandleFunc("/notifications", handlers.TaskHandler(saveAllTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(saveAllTask.Matcher())
+	ur.HandleFunc("/notifications/dismiss", handlers.TaskHandler(dismissTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(dismissTask.Matcher())
 	ur.HandleFunc("/notifications/rss", notificationsRssPage).Methods(http.MethodGet).MatcherFunc(handlers.RequiresAnAccount())
 	ur.HandleFunc("/notifications/gallery", userGalleryPage).Methods(http.MethodGet).MatcherFunc(handlers.RequiresAnAccount())
 	ur.HandleFunc("/subscriptions", userSubscriptionsPage).Methods(http.MethodGet).MatcherFunc(handlers.RequiresAnAccount())
-	ur.HandleFunc("/subscriptions/update", tasks.Action(updateSubscriptionsTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(updateSubscriptionsTask.Matcher())
-	ur.HandleFunc("/subscriptions/delete", tasks.Action(deleteTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(deleteTask.Matcher())
+	ur.HandleFunc("/subscriptions/update", handlers.TaskHandler(updateSubscriptionsTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(updateSubscriptionsTask.Matcher())
+	ur.HandleFunc("/subscriptions/delete", handlers.TaskHandler(deleteTask)).Methods(http.MethodPost).MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(deleteTask.Matcher())
 
 	// legacy redirects
 	r.HandleFunc("/user/lang", handlers.RedirectPermanent("/usr/lang"))

--- a/handlers/user/routes_admin.go
+++ b/handlers/user/routes_admin.go
@@ -3,8 +3,8 @@ package user
 import (
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/handlers"
 	nav "github.com/arran4/goa4web/internal/navigation"
-	"github.com/arran4/goa4web/internal/tasks"
 )
 
 // RegisterAdminRoutes attaches user admin endpoints to the router.
@@ -21,7 +21,7 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	ar.HandleFunc("/sessions/delete", adminSessionsDeletePage).Methods("POST")
 	ar.HandleFunc("/login/attempts", adminLoginAttemptsPage).Methods("GET")
 	ar.HandleFunc("/users/permissions", adminUsersPermissionsPage).Methods("GET")
-	ar.HandleFunc("/users/permissions", tasks.Action(permissionUserAllowTask)).Methods("POST").MatcherFunc(permissionUserAllowTask.Matcher())
-	ar.HandleFunc("/users/permissions", tasks.Action(permissionUserDisallowTask)).Methods("POST").MatcherFunc(permissionUserDisallowTask.Matcher())
-	ar.HandleFunc("/users/permissions", tasks.Action(permissionUpdateTask)).Methods("POST").MatcherFunc(permissionUpdateTask.Matcher())
+	ar.HandleFunc("/users/permissions", handlers.TaskHandler(permissionUserAllowTask)).Methods("POST").MatcherFunc(permissionUserAllowTask.Matcher())
+	ar.HandleFunc("/users/permissions", handlers.TaskHandler(permissionUserDisallowTask)).Methods("POST").MatcherFunc(permissionUserDisallowTask.Matcher())
+	ar.HandleFunc("/users/permissions", handlers.TaskHandler(permissionUpdateTask)).Methods("POST").MatcherFunc(permissionUpdateTask.Matcher())
 }

--- a/handlers/user/saveLanguagesTask.go
+++ b/handlers/user/saveLanguagesTask.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
@@ -21,13 +22,12 @@ var _ tasks.Task = (*SaveLanguagesTask)(nil)
 func (SaveLanguagesTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err := r.ParseForm(); err != nil {
 		log.Printf("ParseForm Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return nil
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
-		return nil
+		return handlers.SessionFetchFail{}
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	uid, _ := session.Values["UID"].(int32)
@@ -35,10 +35,8 @@ func (SaveLanguagesTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	if err := updateLanguageSelections(r, cd, queries, uid); err != nil {
 		log.Printf("Save languages Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return nil
+		return fmt.Errorf("save languages fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	handlers.TaskDoneAutoRefreshPage(w, r)
 	return nil
 }

--- a/handlers/user/testMailTask.go
+++ b/handlers/user/testMailTask.go
@@ -3,7 +3,6 @@ package user
 import (
 	"errors"
 	"net/http"
-	"net/url"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
@@ -27,22 +26,17 @@ func (TestMailTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	user, _ := cd.CurrentUser()
 	if user == nil {
-		http.Error(w, "email unknown", http.StatusBadRequest)
-		return nil
+		return common.UserError{ErrorMessage: "email unknown"}
 	}
 	if cd.EmailProvider() == nil {
-		q := url.QueryEscape(ErrMailNotConfigured.Error())
-		r.URL.RawQuery = "error=" + q
-		handlers.TaskErrorAcknowledgementPage(w, r)
-		return nil
+		return common.UserError{ErrorMessage: ErrMailNotConfigured.Error()}
 	}
 	if evt := cd.Event(); evt != nil {
 		if evt.Data == nil {
 			evt.Data = map[string]any{}
 		}
 	}
-	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
-	return nil
+	return handlers.RedirectHandler("/usr/email")
 }
 
 func (TestMailTask) SelfEmailTemplate() *notif.EmailTemplates {

--- a/handlers/user/updateSubscriptionsTask.go
+++ b/handlers/user/updateSubscriptionsTask.go
@@ -1,12 +1,14 @@
 package user
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -21,19 +23,17 @@ var _ tasks.Task = (*UpdateSubscriptionsTask)(nil)
 func (UpdateSubscriptionsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
-		return nil
+		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
 	if err := r.ParseForm(); err != nil {
-		http.Redirect(w, r, "/usr/subscriptions?error="+err.Error(), http.StatusSeeOther)
-		return nil
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	existing, err := queries.ListSubscriptionsByUser(r.Context(), uid)
 	if err != nil {
 		log.Printf("list subs: %v", err)
-		http.Redirect(w, r, "/usr/subscriptions?error="+err.Error(), http.StatusSeeOther)
-		return nil
+		return fmt.Errorf("list subscriptions fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	have := make(map[string]bool)
 	for _, s := range existing {
@@ -48,18 +48,15 @@ func (UpdateSubscriptionsTask) Action(w http.ResponseWriter, r *http.Request) an
 			if want && !have[hkey] {
 				if err := queries.InsertSubscription(r.Context(), db.InsertSubscriptionParams{UsersIdusers: uid, Pattern: opt.Pattern, Method: m}); err != nil {
 					log.Printf("insert sub: %v", err)
-					http.Redirect(w, r, "/usr/subscriptions?error="+err.Error(), http.StatusSeeOther)
-					return nil
+					return fmt.Errorf("insert subscription fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 				}
 			} else if !want && have[hkey] {
 				if err := queries.DeleteSubscription(r.Context(), db.DeleteSubscriptionParams{UsersIdusers: uid, Pattern: opt.Pattern, Method: m}); err != nil {
 					log.Printf("delete sub: %v", err)
-					http.Redirect(w, r, "/usr/subscriptions?error="+err.Error(), http.StatusSeeOther)
-					return nil
+					return fmt.Errorf("delete subscription fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 				}
 			}
 		}
 	}
-	http.Redirect(w, r, "/usr/subscriptions", http.StatusSeeOther)
-	return nil
+	return handlers.RedirectHandler("/usr/subscriptions")
 }

--- a/handlers/user/userEmailPage_event_test.go
+++ b/handlers/user/userEmailPage_event_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/gorilla/sessions"
@@ -52,9 +53,9 @@ func TestAddEmailTaskEventData(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
-	addEmailTask.Action(rr, req)
+	handlers.TaskHandler(addEmailTask)(rr, req)
 
-	if rr.Code != http.StatusSeeOther {
+	if rr.Code != http.StatusTemporaryRedirect {
 		t.Fatalf("status=%d", rr.Code)
 	}
 	if _, ok := evt.Data["URL"]; !ok {
@@ -154,9 +155,9 @@ func TestResendVerificationEmailTaskEventData(t *testing.T) {
 
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
-	resendVerificationEmailTask.Action(rr, req)
+	handlers.TaskHandler(resendVerificationEmailTask)(rr, req)
 
-	if rr.Code != http.StatusSeeOther {
+	if rr.Code != http.StatusTemporaryRedirect {
 		t.Fatalf("status=%d", rr.Code)
 	}
 	if _, ok := evt.Data["page"]; !ok {

--- a/handlers/user/userNotificationsPage.go
+++ b/handlers/user/userNotificationsPage.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -65,12 +66,11 @@ func (DismissTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
-		return nil
+		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
 	if err := r.ParseForm(); err != nil {
-		http.Redirect(w, r, "/usr/notifications", http.StatusSeeOther)
-		return nil
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	id, _ := strconv.Atoi(r.FormValue("id"))
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
@@ -85,8 +85,7 @@ func (DismissTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 		}
 	}
-	http.Redirect(w, r, "/usr/notifications", http.StatusSeeOther)
-	return nil
+	return handlers.RedirectHandler("/usr/notifications")
 }
 
 func notificationsRssPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/arran4/goa4web/handlers"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/sessions"
 
@@ -60,7 +62,7 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()
-	testMailTask.Action(rr, req)
+	handlers.TaskHandler(testMailTask)(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d", rr.Code)
@@ -91,9 +93,9 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()
-	testMailTask.Action(rr, req)
+	handlers.TaskHandler(testMailTask)(rr, req)
 
-	if rr.Code != http.StatusSeeOther {
+	if rr.Code != http.StatusTemporaryRedirect {
 		t.Fatalf("status=%d", rr.Code)
 	}
 	if loc := rr.Header().Get("Location"); loc != "/usr/email" {


### PR DESCRIPTION
## Summary
- refactor user task actions to return results instead of writing responses
- update user routes to use `handlers.TaskHandler`
- adapt tests for new task handler behaviour

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68803bec41b0832f90600ef79668e6b1