### PR TITLE
Apply generic task handler to forum

### DIFF
--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -2,7 +2,6 @@ package forum
 
 import (
 	"github.com/arran4/goa4web/handlers/forum/comments"
-	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 	"net/http"
 
@@ -23,19 +22,19 @@ func RegisterRoutes(r *mux.Router) {
 	fr.HandleFunc("", Page).Methods("GET")
 	fr.HandleFunc("/category/{category}", Page).Methods("GET")
 	fr.HandleFunc("/topic/{topic}", TopicsPage).Methods("GET")
-	fr.HandleFunc("/topic/{topic}/subscribe", tasks.Action(subscribeTopicTaskAction)).Methods("POST").MatcherFunc(subscribeTopicTaskAction.Matcher())
-	fr.HandleFunc("/topic/{topic}/unsubscribe", tasks.Action(unsubscribeTopicTaskAction)).Methods("POST").MatcherFunc(unsubscribeTopicTaskAction.Matcher())
+	fr.HandleFunc("/topic/{topic}/subscribe", handlers.TaskHandler(subscribeTopicTaskAction)).Methods("POST").MatcherFunc(subscribeTopicTaskAction.Matcher())
+	fr.HandleFunc("/topic/{topic}/unsubscribe", handlers.TaskHandler(unsubscribeTopicTaskAction)).Methods("POST").MatcherFunc(unsubscribeTopicTaskAction.Matcher())
 	fr.HandleFunc("/topic/{topic}/thread", createThreadTask.Page).Methods("GET")
-	fr.HandleFunc("/topic/{topic}/thread", tasks.Action(createThreadTask)).Methods("POST").MatcherFunc(createThreadTask.Matcher())
+	fr.HandleFunc("/topic/{topic}/thread", handlers.TaskHandler(createThreadTask)).Methods("POST").MatcherFunc(createThreadTask.Matcher())
 	fr.HandleFunc("/topic/{topic}/thread/cancel", ThreadNewCancelPage).Methods("GET")
-	fr.HandleFunc("/topic/{topic}/thread/cancel", tasks.Action(threadNewCancelAction)).Methods("POST").MatcherFunc(threadNewCancelAction.Matcher())
-	fr.HandleFunc("/topic/{topic}/thread", tasks.Action(threadNewCancelAction)).Methods("POST").MatcherFunc(threadNewCancelAction.Matcher())
+	fr.HandleFunc("/topic/{topic}/thread/cancel", handlers.TaskHandler(threadNewCancelAction)).Methods("POST").MatcherFunc(threadNewCancelAction.Matcher())
+	fr.HandleFunc("/topic/{topic}/thread", handlers.TaskHandler(threadNewCancelAction)).Methods("POST").MatcherFunc(threadNewCancelAction.Matcher())
 	fr.Handle("/topic/{topic}/thread/{thread}", RequireThreadAndTopic(http.HandlerFunc(ThreadPage))).Methods("GET")
 	fr.Handle("/topic/{topic}/thread/{thread}", RequireThreadAndTopic(http.HandlerFunc(handlers.TaskDoneAutoRefreshPage))).Methods("POST")
-	fr.Handle("/topic/{topic}/thread/{thread}/reply", RequireThreadAndTopic(http.HandlerFunc(tasks.Action(replyTask)))).Methods("POST").MatcherFunc(replyTask.Matcher())
-	fr.Handle("/topic/{topic}/thread/{thread}/reply", RequireThreadAndTopic(http.HandlerFunc(tasks.Action(topicThreadReplyCancel)))).Methods("POST").MatcherFunc(topicThreadReplyCancel.Matcher())
-	fr.Handle("/topic/{topic}/thread/{thread}/comment/{comment}", RequireThreadAndTopic(comments.RequireCommentAuthor(http.HandlerFunc(tasks.Action(topicThreadCommentEditAction))))).Methods("POST").MatcherFunc(topicThreadCommentEditAction.Matcher())
-	fr.Handle("/topic/{topic}/thread/{thread}/comment/{comment}", RequireThreadAndTopic(comments.RequireCommentAuthor(http.HandlerFunc(tasks.Action(topicThreadCommentEditActionCancel))))).Methods("POST").MatcherFunc(topicThreadCommentEditActionCancel.Matcher())
+	fr.Handle("/topic/{topic}/thread/{thread}/reply", RequireThreadAndTopic(http.HandlerFunc(handlers.TaskHandler(replyTask)))).Methods("POST").MatcherFunc(replyTask.Matcher())
+	fr.Handle("/topic/{topic}/thread/{thread}/reply", RequireThreadAndTopic(http.HandlerFunc(handlers.TaskHandler(topicThreadReplyCancel)))).Methods("POST").MatcherFunc(topicThreadReplyCancel.Matcher())
+	fr.Handle("/topic/{topic}/thread/{thread}/comment/{comment}", RequireThreadAndTopic(comments.RequireCommentAuthor(http.HandlerFunc(handlers.TaskHandler(topicThreadCommentEditAction))))).Methods("POST").MatcherFunc(topicThreadCommentEditAction.Matcher())
+	fr.Handle("/topic/{topic}/thread/{thread}/comment/{comment}", RequireThreadAndTopic(comments.RequireCommentAuthor(http.HandlerFunc(handlers.TaskHandler(topicThreadCommentEditActionCancel))))).Methods("POST").MatcherFunc(topicThreadCommentEditActionCancel.Matcher())
 }
 
 // Register registers the forum router module.

--- a/handlers/forum/routes_admin.go
+++ b/handlers/forum/routes_admin.go
@@ -4,7 +4,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/tasks"
 )
 
 // RegisterAdminRoutes attaches forum admin endpoints to ar.
@@ -25,6 +24,6 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	far.HandleFunc("/conversations", AdminThreadsPage).Methods("GET")
 	far.HandleFunc("/thread/{thread}/delete", AdminThreadDeletePage).Methods("POST").MatcherFunc(threadDeleteTask.Matcher())
 	far.HandleFunc("/topic/{topic}/grants", AdminTopicGrantsPage).Methods("GET")
-	far.HandleFunc("/topic/{topic}/grant", tasks.Action(topicGrantCreateTask)).Methods("POST").MatcherFunc(topicGrantCreateTask.Matcher())
-	far.HandleFunc("/topic/{topic}/grant/delete", tasks.Action(topicGrantDeleteTask)).Methods("POST").MatcherFunc(topicGrantDeleteTask.Matcher())
+	far.HandleFunc("/topic/{topic}/grant", handlers.TaskHandler(topicGrantCreateTask)).Methods("POST").MatcherFunc(topicGrantCreateTask.Matcher())
+	far.HandleFunc("/topic/{topic}/grant/delete", handlers.TaskHandler(topicGrantDeleteTask)).Methods("POST").MatcherFunc(topicGrantDeleteTask.Matcher())
 }


### PR DESCRIPTION
## Summary
- use `TaskHandler` in forum routes for consistent task execution
- return errors or redirects from forum tasks instead of direct HTTP calls

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68803bc30294832fabd59d36ca35562e