### PR TITLE
refactor: update writings admin tasks

### DIFF
--- a/handlers/writings/routes_admin.go
+++ b/handlers/writings/routes_admin.go
@@ -1,20 +1,21 @@
 package writings
 
 import (
-	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/handlers"
 )
 
 // RegisterAdminRoutes attaches writings admin endpoints to ar.
 func RegisterAdminRoutes(ar *mux.Router) {
 	war := ar.PathPrefix("/writings").Subrouter()
 	war.HandleFunc("/user/permissions", UserPermissionsPage).Methods("GET")
-	war.HandleFunc("/users/permissions", tasks.Action(userAllowTask)).Methods("POST").MatcherFunc(userAllowTask.Matcher())
-	war.HandleFunc("/users/permissions", tasks.Action(userDisallowTask)).Methods("POST").MatcherFunc(userDisallowTask.Matcher())
+	war.HandleFunc("/users/permissions", handlers.TaskHandler(userAllowTask)).Methods("POST").MatcherFunc(userAllowTask.Matcher())
+	war.HandleFunc("/users/permissions", handlers.TaskHandler(userDisallowTask)).Methods("POST").MatcherFunc(userDisallowTask.Matcher())
 	war.HandleFunc("/users/roles", AdminUserRolesPage).Methods("GET")
-	war.HandleFunc("/users/roles", tasks.Action(userAllowTask)).Methods("POST").MatcherFunc(userAllowTask.Matcher())
-	war.HandleFunc("/users/roles", tasks.Action(userDisallowTask)).Methods("POST").MatcherFunc(userDisallowTask.Matcher())
+	war.HandleFunc("/users/roles", handlers.TaskHandler(userAllowTask)).Methods("POST").MatcherFunc(userAllowTask.Matcher())
+	war.HandleFunc("/users/roles", handlers.TaskHandler(userDisallowTask)).Methods("POST").MatcherFunc(userDisallowTask.Matcher())
 	war.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")
-	war.HandleFunc("/categories", tasks.Action(writingCategoryChangeTask)).Methods("POST").MatcherFunc(writingCategoryChangeTask.Matcher())
-	war.HandleFunc("/categories", tasks.Action(writingCategoryCreateTask)).Methods("POST").MatcherFunc(writingCategoryCreateTask.Matcher())
+	war.HandleFunc("/categories", handlers.TaskHandler(writingCategoryChangeTask)).Methods("POST").MatcherFunc(writingCategoryChangeTask.Matcher())
+	war.HandleFunc("/categories", handlers.TaskHandler(writingCategoryCreateTask)).Methods("POST").MatcherFunc(writingCategoryCreateTask.Matcher())
 }

--- a/handlers/writings/writingsAdminCategoriesPage.go
+++ b/handlers/writings/writingsAdminCategoriesPage.go
@@ -6,7 +6,6 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
@@ -43,65 +42,4 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	data.Categories = categoryRows
 
 	handlers.TemplateHandler(w, r, "categoriesPage.gohtml", data)
-}
-
-func AdminCategoriesModifyPage(w http.ResponseWriter, r *http.Request) {
-	name := r.PostFormValue("name")
-	desc := r.PostFormValue("desc")
-	wcid, err := strconv.Atoi(r.PostFormValue("wcid"))
-	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	categoryId, err := strconv.Atoi(r.PostFormValue("cid"))
-	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-
-	if err := queries.UpdateWritingCategory(r.Context(), db.UpdateWritingCategoryParams{
-		Title: sql.NullString{
-			Valid:  true,
-			String: name,
-		},
-		Description: sql.NullString{
-			Valid:  true,
-			String: desc,
-		},
-		Idwritingcategory: int32(categoryId),
-		WritingCategoryID: int32(wcid),
-	}); err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-
-	handlers.TaskDoneAutoRefreshPage(w, r)
-}
-
-func AdminCategoriesCreatePage(w http.ResponseWriter, r *http.Request) {
-	name := r.PostFormValue("name")
-	desc := r.PostFormValue("desc")
-	pcid, err := strconv.Atoi(r.PostFormValue("pcid"))
-	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	if err := queries.InsertWritingCategory(r.Context(), db.InsertWritingCategoryParams{
-		WritingCategoryID: int32(pcid),
-		Title: sql.NullString{
-			Valid:  true,
-			String: name,
-		},
-		Description: sql.NullString{
-			Valid:  true,
-			String: desc,
-		},
-	}); err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
-		return
-	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 }

--- a/handlers/writings/writingsAdminUserLevelsPage.go
+++ b/handlers/writings/writingsAdminUserLevelsPage.go
@@ -6,7 +6,6 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
@@ -41,43 +40,4 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 	data.UserLevels = rows
 
 	handlers.TemplateHandler(w, r, "adminUserRolesPage.gohtml", data)
-}
-
-func AdminUserLevelsAllowActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	username := r.PostFormValue("username")
-	role := r.PostFormValue("role")
-	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
-	if err != nil {
-		log.Printf("GetUserByUsername Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
-	if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
-		UsersIdusers: u.Idusers,
-		Name:         role,
-	}); err != nil {
-		log.Printf("permissionUserAllow Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
-}
-
-func AdminUserLevelsRemoveActionPage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	permid := r.PostFormValue("permid")
-	permidi, err := strconv.Atoi(permid)
-	if err != nil {
-		log.Printf("strconv.Atoi(permid Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-	if err := queries.DeleteUserRole(r.Context(), int32(permidi)); err != nil {
-		log.Printf("permissionUserDisallow Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-	handlers.TaskDoneAutoRefreshPage(w, r)
 }


### PR DESCRIPTION
## Summary
- use `TaskHandler` result pattern in writings admin tasks
- drop unused admin action helpers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688047e90718832faed8ea2c8d0c3c96