### PR TITLE
Remove redundant direct flag in email notifications

### DIFF
--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -145,7 +145,7 @@ func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, tp Se
 			emails, err := n.Queries.ListVerifiedEmailsByUserID(ctx, evt.UserID)
 			if err == nil {
 				for _, e := range emails {
-					if err := n.renderAndQueueEmailFromTemplates(ctx, &evt.UserID, e.Email, et, evt.Data, false); err != nil {
+					if err := n.renderAndQueueEmailFromTemplates(ctx, &evt.UserID, e.Email, et, evt.Data); err != nil {
 						return err
 					}
 				}
@@ -157,7 +157,7 @@ func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, tp Se
 					log.Printf("notify missing email: %v", nmErr)
 				}
 			} else {
-				if err := n.renderAndQueueEmailFromTemplates(ctx, &evt.UserID, ue.Email, et, evt.Data, false); err != nil {
+				if err := n.renderAndQueueEmailFromTemplates(ctx, &evt.UserID, ue.Email, et, evt.Data); err != nil {
 					return err
 				}
 			}
@@ -194,7 +194,7 @@ func (n *Notifier) notifyDirectEmail(ctx context.Context, evt eventbus.TaskEvent
 		return nil
 	}
 	if et := tp.DirectEmailTemplate(); et != nil {
-		if err := n.renderAndQueueEmailFromTemplates(ctx, nil, addr, et, evt.Data, true); err != nil {
+		if err := n.renderAndQueueEmailFromTemplates(ctx, nil, addr, et, evt.Data); err != nil {
 			return err
 		}
 	}
@@ -214,7 +214,7 @@ func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.TaskEvent
 			}
 		} else {
 			if et := tp.TargetEmailTemplate(); et != nil {
-				if err := n.renderAndQueueEmailFromTemplates(ctx, &id, user.Email.String, et, evt.Data, false); err != nil {
+				if err := n.renderAndQueueEmailFromTemplates(ctx, &id, user.Email.String, et, evt.Data); err != nil {
 					return err
 				}
 			}

--- a/internal/notifications/email.go
+++ b/internal/notifications/email.go
@@ -31,8 +31,8 @@ func (n *Notifier) createEmailTemplateAndQueue(ctx context.Context, userID *int3
 }
 
 // renderAndQueueEmailFromTemplates renders the provided templates and queues the result.
-func (n *Notifier) renderAndQueueEmailFromTemplates(ctx context.Context, userID *int32, emailAddr string, et *EmailTemplates, data interface{}, direct bool) error {
-	// TODO "direct" isn't necessary as userID is a pointer
+func (n *Notifier) renderAndQueueEmailFromTemplates(ctx context.Context, userID *int32, emailAddr string, et *EmailTemplates, data interface{}) error {
+	// userID == nil implies the email is direct
 	if n.Queries == nil {
 		return fmt.Errorf("no query")
 	}
@@ -40,6 +40,7 @@ func (n *Notifier) renderAndQueueEmailFromTemplates(ctx context.Context, userID 
 	if err != nil {
 		return err
 	}
+	direct := userID == nil
 	return n.queueEmail(ctx, userID, direct, msg)
 }
 
@@ -153,5 +154,5 @@ func (n *Notifier) sendSubscriberEmail(ctx context.Context, userID int32, evt ev
 	if et == nil {
 		return nil
 	}
-	return n.renderAndQueueEmailFromTemplates(ctx, &userID, user.Email.String, et, evt.Data, false)
+	return n.renderAndQueueEmailFromTemplates(ctx, &userID, user.Email.String, et, evt.Data)
 }

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -106,7 +106,7 @@ func (n *Notifier) notifyAdmins(ctx context.Context, et *EmailTemplates, nt *str
 			log.Printf("notify admin %s: %v", addr, err)
 		}
 		if et != nil {
-			if err := n.renderAndQueueEmailFromTemplates(ctx, uid, addr, et, data, false); err != nil {
+			if err := n.renderAndQueueEmailFromTemplates(ctx, uid, addr, et, data); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary
- simplify `renderAndQueueEmailFromTemplates` by determining direct emails via `userID == nil`
- update all callers to match the new signature

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688051f1b604832fbeec1fdc626749b7