### PR TITLE
Refactor notifier init

### DIFF
--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -80,3 +80,20 @@ func TestNotifierNotifyAdmins(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestNotifierInitialization(t *testing.T) {
+	n := New()
+	if n.Queries != nil {
+		t.Fatalf("expected nil Queries")
+	}
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := dbpkg.New(db)
+	n = New(WithQueries(q))
+	if n.Queries != q {
+		t.Fatalf("queries not set via option")
+	}
+}

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -13,8 +13,6 @@ import (
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
 	htemplate "html/template"
-
-	"github.com/arran4/goa4web/internal/app/dbstart"
 )
 
 // Notifier dispatches updates via email and internal notifications.
@@ -44,12 +42,6 @@ func WithConfig(cfg config.RuntimeConfig) Option {
 	return func(n *Notifier) {
 		if n.EmailProvider == nil {
 			n.EmailProvider = email.ProviderFromConfig(cfg)
-		}
-		if n.Queries == nil {
-			// TODO evaluate if this is the best way
-			if db := dbstart.GetDBPool(); db != nil {
-				n.Queries = dbpkg.New(db)
-			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- stop pulling db queries in `WithConfig`
- require explicit `WithQueries` option for `Notifier`
- document initialization with a new unit test

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688051eeca64832f81600b8628064a2e