### PR TITLE
Implement RenderErrorPage and use in panic recovery

### DIFF
--- a/handlers/errorpage.go
+++ b/handlers/errorpage.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/core/templates"
+)
+
+// RenderErrorPage displays err using the standard error acknowledgment page.
+func RenderErrorPage(w http.ResponseWriter, r *http.Request, err error) {
+	cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd == nil {
+		cd = &common.CoreData{}
+	}
+	data := struct {
+		*common.CoreData
+		Error   string
+		BackURL string
+	}{
+		CoreData: cd,
+		Error:    err.Error(),
+		BackURL:  r.Referer(),
+	}
+	if err := templates.GetCompiledSiteTemplates(cd.Funcs(r)).ExecuteTemplate(w, "taskErrorAcknowledgementPage.gohtml", data); err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -145,8 +145,7 @@ func RecoverMiddleware(next http.Handler) http.Handler {
 			}
 			if rec := recover(); rec != nil {
 				log.Printf("panic: %v", rec)
-				// TODO ensure it uses the error page template here and everywhere there is an error like this
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				handlers.RenderErrorPage(w, r, fmt.Errorf("%v", rec))
 			}
 		}()
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
## Summary
- add `RenderErrorPage` helper to show the acknowledgement template
- call this helper from `RecoverMiddleware`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688051e2adc0832fa0cfe1b29b90956c