### PR TITLE
Handle missing CoreData in TaskEventMiddleware

### DIFF
--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -87,9 +87,7 @@ func TaskEventMiddleware(next http.Handler) http.Handler {
 		task := r.PostFormValue("task")
 		cd, ok := r.Context().Value(coreconsts.KeyCoreData).(*common.CoreData)
 		if !ok || cd == nil {
-			// TODO make panic
-			cd = &common.CoreData{}
-			r = r.WithContext(context.WithValue(r.Context(), coreconsts.KeyCoreData, cd))
+			log.Panicf("TaskEventMiddleware: missing CoreData for %s", r.URL.Path)
 		}
 		uid := cd.UserID
 		admin := strings.Contains(r.URL.Path, "/admin")

--- a/internal/middleware/taskbus_test.go
+++ b/internal/middleware/taskbus_test.go
@@ -164,3 +164,20 @@ func TestTaskEventMiddleware_EventProvided(t *testing.T) {
 		t.Fatalf("status=%d", rec.Code)
 	}
 }
+
+func TestTaskEventMiddleware_NoCoreDataPanic(t *testing.T) {
+	handler := TaskEventMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("inner handler should not run")
+	}))
+
+	req := httptest.NewRequest("GET", "/p", nil)
+	rec := httptest.NewRecorder()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+
+	handler.ServeHTTP(rec, req)
+}


### PR DESCRIPTION
## Summary
- panic if TaskEventMiddleware sees no CoreData
- test that middleware panics when CoreData is missing

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688051df89b8832f8aba410169dc84bc