### PR TITLE
Add role checks to admin reload and shutdown

### DIFF
--- a/handlers/admin/adminReloadConfigPage.go
+++ b/handlers/admin/adminReloadConfigPage.go
@@ -16,13 +16,19 @@ import (
 )
 
 func AdminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd == nil || !cd.HasRole("administrator") {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
 	data := struct {
 		*common.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Back:     "/admin",
 	}
 

--- a/handlers/admin/adminShutdownPage.go
+++ b/handlers/admin/adminShutdownPage.go
@@ -12,13 +12,19 @@ import (
 )
 
 func AdminShutdownPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd == nil || !cd.HasRole("administrator") {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
 	data := struct {
 		*common.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Back:     "/admin",
 	}
 

--- a/handlers/admin/reload_shutdown_test.go
+++ b/handlers/admin/reload_shutdown_test.go
@@ -1,0 +1,41 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+)
+
+func TestAdminReloadConfigPage_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest("POST", "/admin/reload", nil)
+	cd := common.NewCoreData(req.Context(), nil)
+	cd.SetRoles([]string{"anonymous"})
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	AdminReloadConfigPage(rr, req)
+
+	if rr.Result().StatusCode != http.StatusForbidden {
+		t.Fatalf("expected %d got %d", http.StatusForbidden, rr.Result().StatusCode)
+	}
+}
+
+func TestAdminShutdownPage_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
+	cd := common.NewCoreData(req.Context(), nil)
+	cd.SetRoles([]string{"anonymous"})
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	AdminShutdownPage(rr, req)
+
+	if rr.Result().StatusCode != http.StatusForbidden {
+		t.Fatalf("expected %d got %d", http.StatusForbidden, rr.Result().StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure reload and shutdown endpoints verify the requester is an administrator
- test non-admin access for these handlers

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`
- `go mod tidy`

------
https://chatgpt.com/codex/tasks/task_e_688051dbe700832fa1f00312cdae9d68