### PR TITLE
Enhance audit coverage

### DIFF
--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -26,6 +26,7 @@ var resendQueueTask = &ResendQueueTask{TaskString: TaskResend}
 
 // ensure ResendQueueTask satisfies the tasks.Task interface
 var _ tasks.Task = (*ResendQueueTask)(nil)
+var _ tasks.AuditableTask = (*ResendQueueTask)(nil)
 
 // DeleteQueueTask removes queued emails without sending.
 type DeleteQueueTask struct{ tasks.TaskString }
@@ -34,6 +35,7 @@ var deleteQueueTask = &DeleteQueueTask{TaskString: TaskDelete}
 
 // ensure DeleteQueueTask satisfies the tasks.Task interface
 var _ tasks.Task = (*DeleteQueueTask)(nil)
+var _ tasks.AuditableTask = (*DeleteQueueTask)(nil)
 
 func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 	type EmailItem struct {
@@ -101,6 +103,14 @@ func (ResendQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
 		if e.ToUserID.Valid {
 			ids = append(ids, e.ToUserID.Int32)
 		}
+		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+			if evt := cd.Event(); evt != nil {
+				if evt.Data == nil {
+					evt.Data = map[string]any{}
+				}
+				evt.Data["QueuedEmailID"] = appendID(evt.Data["QueuedEmailID"], id)
+			}
+		}
 	}
 	users := make(map[int32]*db.GetUserByIdRow)
 	for _, id := range ids {
@@ -135,6 +145,30 @@ func (DeleteQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
 		if err := queries.DeletePendingEmail(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("delete email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
+		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+			if evt := cd.Event(); evt != nil {
+				if evt.Data == nil {
+					evt.Data = map[string]any{}
+				}
+				evt.Data["DeletedEmailID"] = appendID(evt.Data["DeletedEmailID"], id)
+			}
+		}
 	}
 	return nil
+}
+
+// AuditRecord summarises queued emails being resent.
+func (ResendQueueTask) AuditRecord(data map[string]any) string {
+	if ids, ok := data["QueuedEmailID"].(string); ok {
+		return "resent queued emails " + ids
+	}
+	return "resent queued emails"
+}
+
+// AuditRecord summarises queued emails being removed.
+func (DeleteQueueTask) AuditRecord(data map[string]any) string {
+	if ids, ok := data["DeletedEmailID"].(string); ok {
+		return "deleted queued emails " + ids
+	}
+	return "deleted queued emails"
 }

--- a/handlers/admin/adminIPBanPage.go
+++ b/handlers/admin/adminIPBanPage.go
@@ -29,9 +29,11 @@ type DeleteIPBanTask struct{ tasks.TaskString }
 var deleteIPBanTask = &DeleteIPBanTask{TaskString: TaskDelete}
 
 var _ tasks.Task = (*AddIPBanTask)(nil)
+var _ tasks.AuditableTask = (*AddIPBanTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*AddIPBanTask)(nil)
 
 var _ tasks.Task = (*DeleteIPBanTask)(nil)
+var _ tasks.AuditableTask = (*DeleteIPBanTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*DeleteIPBanTask)(nil)
 
 func AdminIPBanPage(w http.ResponseWriter, r *http.Request) {
@@ -133,4 +135,22 @@ func (DeleteIPBanTask) AdminEmailTemplate() *notif.EmailTemplates {
 func (DeleteIPBanTask) AdminInternalNotificationTemplate() *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminRemoveIPBanEmail")
 	return &v
+}
+
+// AuditRecord summarises the addition of an IP ban.
+func (AddIPBanTask) AuditRecord(data map[string]any) string {
+	ip, _ := data["IP"].(string)
+	mod, _ := data["Moderator"].(string)
+	reason, _ := data["Reason"].(string)
+	if reason != "" {
+		return fmt.Sprintf("%s banned %s (%s)", mod, ip, reason)
+	}
+	return fmt.Sprintf("%s banned %s", mod, ip)
+}
+
+// AuditRecord summarises the removal of an IP ban.
+func (DeleteIPBanTask) AuditRecord(data map[string]any) string {
+	ip, _ := data["IP"].(string)
+	mod, _ := data["Moderator"].(string)
+	return fmt.Sprintf("%s removed ban on %s", mod, ip)
 }

--- a/handlers/admin/helpers.go
+++ b/handlers/admin/helpers.go
@@ -1,0 +1,10 @@
+package admin
+
+import "strconv"
+
+func appendID(existing any, id int) string {
+	if s, ok := existing.(string); ok && s != "" {
+		return s + "," + strconv.Itoa(id)
+	}
+	return strconv.Itoa(id)
+}

--- a/handlers/admin/news_user_tasks.go
+++ b/handlers/admin/news_user_tasks.go
@@ -25,6 +25,7 @@ const TaskNewsUserAllow tasks.TaskString = "allow"
 var newsUserAllow = &NewsUserAllowTask{TaskString: TaskNewsUserAllow}
 
 var _ tasks.Task = (*NewsUserAllowTask)(nil)
+var _ tasks.AuditableTask = (*NewsUserAllowTask)(nil)
 var _ notifications.AdminEmailTemplateProvider = (*NewsUserAllowTask)(nil)
 var _ notifications.TargetUsersNotificationProvider = (*NewsUserAllowTask)(nil)
 
@@ -74,6 +75,7 @@ const TaskNewsUserRemove tasks.TaskString = "remove"
 var newsUserRemove = &NewsUserRemoveTask{TaskString: TaskNewsUserRemove}
 
 var _ tasks.Task = (*NewsUserRemoveTask)(nil)
+var _ tasks.AuditableTask = (*NewsUserRemoveTask)(nil)
 var _ notifications.AdminEmailTemplateProvider = (*NewsUserRemoveTask)(nil)
 var _ notifications.TargetUsersNotificationProvider = (*NewsUserRemoveTask)(nil)
 
@@ -163,4 +165,24 @@ func (NewsUserRemoveTask) TargetEmailTemplate() *notifications.EmailTemplates {
 func (NewsUserRemoveTask) TargetInternalNotificationTemplate() *string {
 	v := notifications.NotificationTemplateFilenameGenerator("delete_user_role")
 	return &v
+}
+
+// AuditRecord summarises granting a role to a user.
+func (NewsUserAllowTask) AuditRecord(data map[string]any) string {
+	u, _ := data["Username"].(string)
+	role, _ := data["Role"].(string)
+	if u != "" && role != "" {
+		return fmt.Sprintf("granted %s to %s", role, u)
+	}
+	return "granted user role"
+}
+
+// AuditRecord summarises revoking a user role.
+func (NewsUserRemoveTask) AuditRecord(data map[string]any) string {
+	u, _ := data["Username"].(string)
+	role, _ := data["Role"].(string)
+	if u != "" && role != "" {
+		return fmt.Sprintf("revoked %s from %s", role, u)
+	}
+	return "revoked user role"
 }

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -5,7 +5,7 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 46
+	ExpectedSchemaVersion = 47
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -40,6 +40,9 @@ type AuditLog struct {
 	ID           int32
 	UsersIdusers int32
 	Action       string
+	Path         string
+	Details      sql.NullString
+	Data         sql.NullString
 	CreatedAt    time.Time
 }
 

--- a/internal/db/queries-auditlog.sql
+++ b/internal/db/queries-auditlog.sql
@@ -1,8 +1,8 @@
 -- name: InsertAuditLog :exec
-INSERT INTO audit_log (users_idusers, action) VALUES (?, ?);
+INSERT INTO audit_log (users_idusers, action, path, details, data) VALUES (?, ?, ?, ?, ?);
 
 -- name: ListAuditLogs :many
-SELECT a.id, a.users_idusers, a.action, a.created_at, u.username
+SELECT a.id, a.users_idusers, a.action, a.path, a.details, a.data, a.created_at, u.username
 FROM audit_log a
 LEFT JOIN users u ON a.users_idusers = u.idusers
 WHERE u.username LIKE sqlc.arg(username) AND a.action LIKE sqlc.arg(action)

--- a/internal/db/queries-stats.sql
+++ b/internal/db/queries-stats.sql
@@ -71,6 +71,6 @@ GROUP BY u.idusers
 ORDER BY u.idusers;
 
 -- name: GetRecentAuditLogs :many
-SELECT a.id, a.users_idusers, u.username, a.action, a.created_at
+SELECT a.id, a.users_idusers, u.username, a.action, a.path, a.details, a.data, a.created_at
 FROM audit_log a LEFT JOIN users u ON a.users_idusers = u.idusers
 ORDER BY a.id DESC LIMIT ?;

--- a/internal/db/queries-stats.sql.go
+++ b/internal/db/queries-stats.sql.go
@@ -98,7 +98,7 @@ func (q *Queries) ForumTopicThreadCounts(ctx context.Context) ([]*ForumTopicThre
 }
 
 const getRecentAuditLogs = `-- name: GetRecentAuditLogs :many
-SELECT a.id, a.users_idusers, u.username, a.action, a.created_at
+SELECT a.id, a.users_idusers, u.username, a.action, a.path, a.details, a.data, a.created_at
 FROM audit_log a LEFT JOIN users u ON a.users_idusers = u.idusers
 ORDER BY a.id DESC LIMIT ?
 `
@@ -108,6 +108,9 @@ type GetRecentAuditLogsRow struct {
 	UsersIdusers int32
 	Username     sql.NullString
 	Action       string
+	Path         string
+	Details      sql.NullString
+	Data         sql.NullString
 	CreatedAt    time.Time
 }
 
@@ -125,6 +128,9 @@ func (q *Queries) GetRecentAuditLogs(ctx context.Context, limit int32) ([]*GetRe
 			&i.UsersIdusers,
 			&i.Username,
 			&i.Action,
+			&i.Path,
+			&i.Details,
+			&i.Data,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err

--- a/internal/tasks/admin_task.go
+++ b/internal/tasks/admin_task.go
@@ -1,6 +1,8 @@
 package tasks
 
-// AdminTask marks tasks restricted to administrators.
-type AdminTask interface {
-	IsAdminTask() bool
+// AuditableTask marks a sensitive task that should be recorded in the audit log.
+// Implementations receive the event data map and should return a human readable
+// summary describing the action.
+type AuditableTask interface {
+	AuditRecord(data map[string]any) string
 }

--- a/migrations/0047.sql
+++ b/migrations/0047.sql
@@ -1,0 +1,8 @@
+-- Add path and details columns to audit_log
+ALTER TABLE audit_log
+    ADD COLUMN path text NOT NULL DEFAULT '' AFTER action,
+    ADD COLUMN details text AFTER path,
+    ADD COLUMN data text AFTER details;
+
+-- Update schema version
+UPDATE schema_version SET version = 47 WHERE version = 46;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -475,6 +475,9 @@ CREATE TABLE IF NOT EXISTS `audit_log` (
   `id` int NOT NULL AUTO_INCREMENT,
   `users_idusers` int NOT NULL,
   `action` text NOT NULL,
+  `path` text NOT NULL,
+  `details` text,
+  `data` text,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   KEY `audit_log_user_idx` (`users_idusers`)


### PR DESCRIPTION
## Summary
- implement AuditableTask for additional admin tasks
- record event details in more actions
- centralise helper for building ID lists
- add audit summaries for new tasks

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688055fccd34832fbd307d11b2d0b81b