### PR TITLE
Split admin email queue tasks

### DIFF
--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -1,41 +1,16 @@
 package admin
 
 import (
-	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
 	"net/mail"
-	"strconv"
 	"strings"
 
 	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/internal/tasks"
-
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/email"
-	"github.com/arran4/goa4web/workers/emailqueue"
 )
-
-// ResendQueueTask triggers sending queued emails immediately.
-type ResendQueueTask struct{ tasks.TaskString }
-
-var resendQueueTask = &ResendQueueTask{TaskString: TaskResend}
-
-// ensure ResendQueueTask satisfies the tasks.Task interface
-var _ tasks.Task = (*ResendQueueTask)(nil)
-var _ tasks.AuditableTask = (*ResendQueueTask)(nil)
-
-// DeleteQueueTask removes queued emails without sending.
-type DeleteQueueTask struct{ tasks.TaskString }
-
-var deleteQueueTask = &DeleteQueueTask{TaskString: TaskDelete}
-
-// ensure DeleteQueueTask satisfies the tasks.Task interface
-var _ tasks.Task = (*DeleteQueueTask)(nil)
-var _ tasks.AuditableTask = (*DeleteQueueTask)(nil)
 
 func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 	type EmailItem struct {
@@ -83,92 +58,4 @@ func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 		data.Emails = append(data.Emails, EmailItem{e, emailStr, subj})
 	}
 	handlers.TemplateHandler(w, r, "emailQueuePage.gohtml", data)
-}
-
-func (ResendQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	provider := email.ProviderFromConfig(config.AppRuntimeConfig)
-	if err := r.ParseForm(); err != nil {
-		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-	}
-	var emails []*db.GetPendingEmailByIDRow
-	var ids []int32
-	for _, idStr := range r.Form["id"] {
-		id, _ := strconv.Atoi(idStr)
-		e, err := queries.GetPendingEmailByID(r.Context(), int32(id))
-		if err != nil {
-			return fmt.Errorf("get email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-		}
-		emails = append(emails, e)
-		if e.ToUserID.Valid {
-			ids = append(ids, e.ToUserID.Int32)
-		}
-		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-			if evt := cd.Event(); evt != nil {
-				if evt.Data == nil {
-					evt.Data = map[string]any{}
-				}
-				evt.Data["QueuedEmailID"] = appendID(evt.Data["QueuedEmailID"], id)
-			}
-		}
-	}
-	users := make(map[int32]*db.GetUserByIdRow)
-	for _, id := range ids {
-		if u, err := queries.GetUserById(r.Context(), id); err == nil {
-			users[id] = u
-		}
-	}
-	for _, e := range emails {
-		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
-		if err != nil {
-			return fmt.Errorf("resolve address fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-		}
-		if provider != nil {
-			if err := provider.Send(r.Context(), addr, []byte(e.Body)); err != nil {
-				return fmt.Errorf("send email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-			}
-		}
-		if err := queries.MarkEmailSent(r.Context(), e.ID); err != nil {
-			return fmt.Errorf("mark sent fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-		}
-	}
-	return nil
-}
-
-func (DeleteQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	if err := r.ParseForm(); err != nil {
-		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-	}
-	for _, idStr := range r.Form["id"] {
-		id, _ := strconv.Atoi(idStr)
-		if err := queries.DeletePendingEmail(r.Context(), int32(id)); err != nil {
-			return fmt.Errorf("delete email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-		}
-		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-			if evt := cd.Event(); evt != nil {
-				if evt.Data == nil {
-					evt.Data = map[string]any{}
-				}
-				evt.Data["DeletedEmailID"] = appendID(evt.Data["DeletedEmailID"], id)
-			}
-		}
-	}
-	return nil
-}
-
-// AuditRecord summarises queued emails being resent.
-func (ResendQueueTask) AuditRecord(data map[string]any) string {
-	if ids, ok := data["QueuedEmailID"].(string); ok {
-		return "resent queued emails " + ids
-	}
-	return "resent queued emails"
-}
-
-// AuditRecord summarises queued emails being removed.
-func (DeleteQueueTask) AuditRecord(data map[string]any) string {
-	if ids, ok := data["DeletedEmailID"].(string); ok {
-		return "deleted queued emails " + ids
-	}
-	return "deleted queued emails"
 }

--- a/handlers/admin/delete_queue_task.go
+++ b/handlers/admin/delete_queue_task.go
@@ -1,0 +1,52 @@
+package admin
+
+import (
+	"fmt"
+	"github.com/arran4/goa4web/core/consts"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/internal/tasks"
+
+	"github.com/arran4/goa4web/handlers"
+)
+
+// DeleteQueueTask removes queued emails without sending.
+type DeleteQueueTask struct{ tasks.TaskString }
+
+var deleteQueueTask = &DeleteQueueTask{TaskString: TaskDelete}
+
+// ensure DeleteQueueTask satisfies the tasks.Task interface
+var _ tasks.Task = (*DeleteQueueTask)(nil)
+var _ tasks.AuditableTask = (*DeleteQueueTask)(nil)
+
+func (DeleteQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	for _, idStr := range r.Form["id"] {
+		id, _ := strconv.Atoi(idStr)
+		if err := queries.DeletePendingEmail(r.Context(), int32(id)); err != nil {
+			return fmt.Errorf("delete email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+			if evt := cd.Event(); evt != nil {
+				if evt.Data == nil {
+					evt.Data = map[string]any{}
+				}
+				evt.Data["DeletedEmailID"] = appendID(evt.Data["DeletedEmailID"], id)
+			}
+		}
+	}
+	return nil
+}
+
+// AuditRecord summarises queued emails being removed.
+func (DeleteQueueTask) AuditRecord(data map[string]any) string {
+	if ids, ok := data["DeletedEmailID"].(string); ok {
+		return "deleted queued emails " + ids
+	}
+	return "deleted queued emails"
+}

--- a/handlers/admin/resend_queue_task.go
+++ b/handlers/admin/resend_queue_task.go
@@ -1,0 +1,84 @@
+package admin
+
+import (
+	"fmt"
+	"github.com/arran4/goa4web/core/consts"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/internal/tasks"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/workers/emailqueue"
+)
+
+// ResendQueueTask triggers sending queued emails immediately.
+type ResendQueueTask struct{ tasks.TaskString }
+
+var resendQueueTask = &ResendQueueTask{TaskString: TaskResend}
+
+// ensure ResendQueueTask satisfies the tasks.Task interface
+var _ tasks.Task = (*ResendQueueTask)(nil)
+var _ tasks.AuditableTask = (*ResendQueueTask)(nil)
+
+func (ResendQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	provider := email.ProviderFromConfig(config.AppRuntimeConfig)
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	var emails []*db.GetPendingEmailByIDRow
+	var ids []int32
+	for _, idStr := range r.Form["id"] {
+		id, _ := strconv.Atoi(idStr)
+		e, err := queries.GetPendingEmailByID(r.Context(), int32(id))
+		if err != nil {
+			return fmt.Errorf("get email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		emails = append(emails, e)
+		if e.ToUserID.Valid {
+			ids = append(ids, e.ToUserID.Int32)
+		}
+		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+			if evt := cd.Event(); evt != nil {
+				if evt.Data == nil {
+					evt.Data = map[string]any{}
+				}
+				evt.Data["QueuedEmailID"] = appendID(evt.Data["QueuedEmailID"], id)
+			}
+		}
+	}
+	users := make(map[int32]*db.GetUserByIdRow)
+	for _, id := range ids {
+		if u, err := queries.GetUserById(r.Context(), id); err == nil {
+			users[id] = u
+		}
+	}
+	for _, e := range emails {
+		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
+		if err != nil {
+			return fmt.Errorf("resolve address fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		if provider != nil {
+			if err := provider.Send(r.Context(), addr, []byte(e.Body)); err != nil {
+				return fmt.Errorf("send email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+			}
+		}
+		if err := queries.MarkEmailSent(r.Context(), e.ID); err != nil {
+			return fmt.Errorf("mark sent fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+	}
+	return nil
+}
+
+// AuditRecord summarises queued emails being resent.
+func (ResendQueueTask) AuditRecord(data map[string]any) string {
+	if ids, ok := data["QueuedEmailID"].(string); ok {
+		return "resent queued emails " + ids
+	}
+	return "resent queued emails"
+}


### PR DESCRIPTION
## Summary
- move resend/delete queue tasks into separate files
- keep email queue page handler in its file

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880b8a08f10832f8163f835c5622d69