### PR TITLE
Move linker user permission tasks

### DIFF
--- a/handlers/linker/user_allow_task.go
+++ b/handlers/linker/user_allow_task.go
@@ -1,0 +1,79 @@
+package linker
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// userAllowTask grants a user a role.
+type userAllowTask struct{ tasks.TaskString }
+
+// UserAllowTask is the exported instance used when registering routes.
+var UserAllowTask = &userAllowTask{TaskString: TaskUserAllow}
+
+var _ tasks.Task = (*userAllowTask)(nil)
+var _ notif.TargetUsersNotificationProvider = (*userAllowTask)(nil)
+
+func (userAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	usernames := r.PostFormValue("usernames")
+	role := r.PostFormValue("role")
+	fields := strings.FieldsFunc(usernames, func(r rune) bool {
+		return r == ',' || r == '\n' || r == '\r' || r == '\t' || r == ' '
+	})
+	for _, username := range fields {
+		if username == "" {
+			continue
+		}
+		u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
+		if err != nil {
+			log.Printf("GetUserByUsername Error: %s", err)
+			continue
+		}
+		if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
+			UsersIdusers: u.Idusers,
+			Name:         role,
+		}); err != nil {
+			log.Printf("permissionUserAllow Error: %s", err)
+		} else if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+			if evt := cd.Event(); evt != nil {
+				if evt.Data == nil {
+					evt.Data = map[string]any{}
+				}
+				evt.Data["targetUserID"] = u.Idusers
+				evt.Data["Username"] = u.Username.String
+				evt.Data["Role"] = role
+			}
+		}
+	}
+	return nil
+}
+
+func (userAllowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
+	if id, ok := evt.Data["targetUserID"].(int32); ok {
+		return []int32{id}, nil
+	}
+	if id, ok := evt.Data["targetUserID"].(int); ok {
+		return []int32{int32(id)}, nil
+	}
+	return nil, fmt.Errorf("target user id not provided")
+}
+
+func (userAllowTask) TargetEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("setUserRoleEmail")
+}
+
+func (userAllowTask) TargetInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("set_user_role")
+	return &v
+}

--- a/handlers/linker/user_disallow_task.go
+++ b/handlers/linker/user_disallow_task.go
@@ -1,0 +1,72 @@
+package linker
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/eventbus"
+	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// userDisallowTask removes a user's role.
+type userDisallowTask struct{ tasks.TaskString }
+
+// UserDisallowTask is the exported instance used when registering routes.
+var UserDisallowTask = &userDisallowTask{TaskString: TaskUserDisallow}
+
+var _ tasks.Task = (*userDisallowTask)(nil)
+var _ notif.TargetUsersNotificationProvider = (*userDisallowTask)(nil)
+
+func (userDisallowTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	r.ParseForm()
+	ids := r.Form["permids"]
+	if len(ids) == 0 {
+		if id := r.PostFormValue("permid"); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	for _, idStr := range ids {
+		permid, _ := strconv.Atoi(idStr)
+		infoID, username, role, err2 := roleInfoByPermID(r.Context(), queries, int32(permid))
+		if err := queries.DeleteUserRole(r.Context(), int32(permid)); err != nil {
+			log.Printf("permissionUserDisallow Error: %s", err)
+		} else if err2 == nil {
+			if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+				if evt := cd.Event(); evt != nil {
+					if evt.Data == nil {
+						evt.Data = map[string]any{}
+					}
+					evt.Data["targetUserID"] = infoID
+					evt.Data["Username"] = username
+					evt.Data["Role"] = role
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (userDisallowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
+	if id, ok := evt.Data["targetUserID"].(int32); ok {
+		return []int32{id}, nil
+	}
+	if id, ok := evt.Data["targetUserID"].(int); ok {
+		return []int32{int32(id)}, nil
+	}
+	return nil, fmt.Errorf("target user id not provided")
+}
+
+func (userDisallowTask) TargetEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("deleteUserRoleEmail")
+}
+
+func (userDisallowTask) TargetInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("delete_user_role")
+	return &v
+}


### PR DESCRIPTION
## Summary
- move linker user permission task types into new files
- keep roleInfoByPermID utility in linkerAdminUserLevelsPage

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestLinkerApproveAddsToSearch)*

------
https://chatgpt.com/codex/tasks/task_e_6880b895760c832f8f8f98bb373120e3