### PR TITLE
Move announcement tasks

### DIFF
--- a/handlers/news/announcement_add_task.go
+++ b/handlers/news/announcement_add_task.go
@@ -1,0 +1,48 @@
+package news
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"github.com/arran4/goa4web/core/consts"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// AnnouncementAddTask enables an announcement for a news post.
+type AnnouncementAddTask struct{ tasks.TaskString }
+
+var announcementAddTask = &AnnouncementAddTask{TaskString: TaskAdd}
+
+var _ tasks.Task = (*AnnouncementAddTask)(nil)
+
+func (AnnouncementAddTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	vars := mux.Vars(r)
+	pid, _ := strconv.Atoi(vars["post"])
+
+	ann, err := cd.NewsAnnouncement(int32(pid))
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("get announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+	}
+	if ann == nil {
+		if err := queries.CreateAnnouncement(r.Context(), int32(pid)); err != nil {
+			return fmt.Errorf("create announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+	} else if !ann.Active {
+		if err := queries.SetAnnouncementActive(r.Context(), db.SetAnnouncementActiveParams{Active: true, ID: ann.ID}); err != nil {
+			return fmt.Errorf("activate announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+	}
+	return nil
+}

--- a/handlers/news/announcement_delete_task.go
+++ b/handlers/news/announcement_delete_task.go
@@ -1,0 +1,45 @@
+package news
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"github.com/arran4/goa4web/core/consts"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// AnnouncementDeleteTask disables the announcement for a news post.
+type AnnouncementDeleteTask struct{ tasks.TaskString }
+
+var announcementDeleteTask = &AnnouncementDeleteTask{TaskString: TaskDelete}
+
+var _ tasks.Task = (*AnnouncementDeleteTask)(nil)
+
+func (AnnouncementDeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	vars := mux.Vars(r)
+	pid, _ := strconv.Atoi(vars["post"])
+
+	ann, err := cd.NewsAnnouncement(int32(pid))
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("announcement for news fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		return nil
+	}
+	if ann != nil && ann.Active {
+		if err := queries.SetAnnouncementActive(r.Context(), db.SetAnnouncementActiveParams{Active: false, ID: ann.ID}); err != nil {
+			return fmt.Errorf("deactivate announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+	}
+	return nil
+}

--- a/handlers/news/newsAnnouncementTasks.go
+++ b/handlers/news/newsAnnouncementTasks.go
@@ -1,23 +1,9 @@
 package news
 
 import (
-	"database/sql"
-	"errors"
-	"fmt"
-	"github.com/arran4/goa4web/core/consts"
-	"net/http"
-	"strconv"
-
-	"github.com/gorilla/mux"
-
-	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
-
-type AnnouncementAddTask struct{ tasks.TaskString }
 
 var _ tasks.Task = (*AnnouncementAddTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*AnnouncementAddTask)(nil)
@@ -31,12 +17,6 @@ func (AnnouncementAddTask) AdminInternalNotificationTemplate() *string {
 	return &v
 }
 
-var announcementAddTask = &AnnouncementAddTask{TaskString: TaskAdd}
-
-type AnnouncementDeleteTask struct{ tasks.TaskString }
-
-var announcementDeleteTask = &AnnouncementDeleteTask{TaskString: TaskDelete}
-
 var _ tasks.Task = (*AnnouncementDeleteTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*AnnouncementDeleteTask)(nil)
 
@@ -47,49 +27,4 @@ func (AnnouncementDeleteTask) AdminEmailTemplate() *notif.EmailTemplates {
 func (AnnouncementDeleteTask) AdminInternalNotificationTemplate() *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsDeleteEmail")
 	return &v
-}
-
-func (AnnouncementAddTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	vars := mux.Vars(r)
-	pid, _ := strconv.Atoi(vars["post"])
-
-	ann, err := cd.NewsAnnouncement(int32(pid))
-	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("get announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-		}
-	}
-	if ann == nil {
-		if err := queries.CreateAnnouncement(r.Context(), int32(pid)); err != nil {
-			return fmt.Errorf("create announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-		}
-	} else if !ann.Active {
-		if err := queries.SetAnnouncementActive(r.Context(), db.SetAnnouncementActiveParams{Active: true, ID: ann.ID}); err != nil {
-			return fmt.Errorf("activate announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-		}
-	}
-	return nil
-}
-
-func (AnnouncementDeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	vars := mux.Vars(r)
-	pid, _ := strconv.Atoi(vars["post"])
-
-	ann, err := cd.NewsAnnouncement(int32(pid))
-	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("announcement for news fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-		}
-		return nil
-	}
-	if ann != nil && ann.Active {
-		if err := queries.SetAnnouncementActive(r.Context(), db.SetAnnouncementActiveParams{Active: false, ID: ann.ID}); err != nil {
-			return fmt.Errorf("deactivate announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
## Summary
- split out announcement add/delete tasks to separate files
- keep helper functions in original file

## Testing
- `go vet ./...`
- `go test ./... -p 1`


------
https://chatgpt.com/codex/tasks/task_e_6880b8934018832f93bd91229f0549e6