### PR TITLE
Split news permission tasks

### DIFF
--- a/handlers/news/user_allow_task.go
+++ b/handlers/news/user_allow_task.go
@@ -1,0 +1,57 @@
+package news
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// UserAllowTask grants a user a role.
+type UserAllowTask struct{ tasks.TaskString }
+
+var userAllowTask = &UserAllowTask{TaskString: TaskUserAllow}
+
+var _ tasks.Task = (*UserAllowTask)(nil)
+var _ notif.AdminEmailTemplateProvider = (*UserAllowTask)(nil)
+
+func (UserAllowTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("adminNotificationNewsUserAllowEmail")
+}
+
+func (UserAllowTask) AdminInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsUserAllowEmail")
+	return &v
+}
+
+func (UserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	username := r.PostFormValue("username")
+	role := r.PostFormValue("role")
+	data := struct {
+		*common.CoreData
+		Errors   []string
+		Messages []string
+		Back     string
+	}{
+		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		Back:     "/news",
+	}
+	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("GetUserByUsername: %w", err).Error())
+	} else if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
+		UsersIdusers: u.Idusers,
+		Name:         role,
+	}); err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
+	}
+
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+	return nil
+}

--- a/handlers/news/user_disallow_task.go
+++ b/handlers/news/user_disallow_task.go
@@ -1,35 +1,18 @@
 package news
 
 import (
-	"database/sql"
 	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
-type UserAllowTask struct{ tasks.TaskString }
-
-var userAllowTask = &UserAllowTask{TaskString: TaskUserAllow}
-
-var _ tasks.Task = (*UserAllowTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*UserAllowTask)(nil)
-
-func (UserAllowTask) AdminEmailTemplate() *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationNewsUserAllowEmail")
-}
-
-func (UserAllowTask) AdminInternalNotificationTemplate() *string {
-	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsUserAllowEmail")
-	return &v
-}
-
+// UserDisallowTask removes a user's role.
 type UserDisallowTask struct{ tasks.TaskString }
 
 var userDisallowTask = &UserDisallowTask{TaskString: TaskUserDisallow}
@@ -44,32 +27,6 @@ func (UserDisallowTask) AdminEmailTemplate() *notif.EmailTemplates {
 func (UserDisallowTask) AdminInternalNotificationTemplate() *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsUserDisallowEmail")
 	return &v
-}
-
-func (UserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	username := r.PostFormValue("username")
-	role := r.PostFormValue("role")
-	data := struct {
-		*common.CoreData
-		Errors   []string
-		Messages []string
-		Back     string
-	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		Back:     "/news",
-	}
-	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("GetUserByUsername: %w", err).Error())
-	} else if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
-		UsersIdusers: u.Idusers,
-		Name:         role,
-	}); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
-	}
-
-	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
-	return nil
 }
 
 func (UserDisallowTask) Action(w http.ResponseWriter, r *http.Request) any {


### PR DESCRIPTION
## Summary
- move user permission tasks into dedicated files under `handlers/news`
- keep task constants untouched

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880b88dec50832fbc5a95784e645358