### PR TITLE
Refactor admin request tasks

### DIFF
--- a/handlers/admin/accept_request_task.go
+++ b/handlers/admin/accept_request_task.go
@@ -1,0 +1,25 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// AcceptRequestTask accepts a queued request.
+type AcceptRequestTask struct{ tasks.TaskString }
+
+var acceptRequestTask = &AcceptRequestTask{TaskString: TaskAccept}
+
+var _ tasks.Task = (*AcceptRequestTask)(nil)
+var _ tasks.AuditableTask = (*AcceptRequestTask)(nil)
+
+func (AcceptRequestTask) Action(w http.ResponseWriter, r *http.Request) any {
+	handleRequestAction(w, r, "accepted")
+	return nil
+}
+
+// AuditRecord summarises a request queue action.
+func (AcceptRequestTask) AuditRecord(data map[string]any) string {
+	return requestAuditSummary("accepted", data)
+}

--- a/handlers/admin/adminRequestQueuePage.go
+++ b/handlers/admin/adminRequestQueuePage.go
@@ -10,31 +10,8 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 )
-
-// AcceptRequestTask accepts a queued request.
-type AcceptRequestTask struct{ tasks.TaskString }
-
-var acceptRequestTask = &AcceptRequestTask{TaskString: TaskAccept}
-
-// RejectRequestTask rejects a queued request.
-type RejectRequestTask struct{ tasks.TaskString }
-
-var rejectRequestTask = &RejectRequestTask{TaskString: TaskReject}
-
-// QueryRequestTask asks for more information about a request.
-type QueryRequestTask struct{ tasks.TaskString }
-
-var queryRequestTask = &QueryRequestTask{TaskString: TaskQuery}
-
-var _ tasks.Task = (*AcceptRequestTask)(nil)
-var _ tasks.AuditableTask = (*AcceptRequestTask)(nil)
-var _ tasks.Task = (*RejectRequestTask)(nil)
-var _ tasks.AuditableTask = (*RejectRequestTask)(nil)
-var _ tasks.Task = (*QueryRequestTask)(nil)
-var _ tasks.AuditableTask = (*QueryRequestTask)(nil)
 
 func AdminRequestQueuePage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
@@ -164,32 +141,6 @@ func handleRequestAction(w http.ResponseWriter, r *http.Request, status string) 
 		Back:     "/admin/requests",
 	}
 	handlers.TemplateHandler(w, r, "admin/runTaskPage.gohtml", data)
-}
-
-func (AcceptRequestTask) Action(w http.ResponseWriter, r *http.Request) any {
-	handleRequestAction(w, r, "accepted")
-	return nil
-}
-func (RejectRequestTask) Action(w http.ResponseWriter, r *http.Request) any {
-	handleRequestAction(w, r, "rejected")
-	return nil
-}
-func (QueryRequestTask) Action(w http.ResponseWriter, r *http.Request) any {
-	handleRequestAction(w, r, "query")
-	return nil
-}
-
-// AuditRecord summarises a request queue action.
-func (AcceptRequestTask) AuditRecord(data map[string]any) string {
-	return requestAuditSummary("accepted", data)
-}
-
-func (RejectRequestTask) AuditRecord(data map[string]any) string {
-	return requestAuditSummary("rejected", data)
-}
-
-func (QueryRequestTask) AuditRecord(data map[string]any) string {
-	return requestAuditSummary("query", data)
 }
 
 func requestAuditSummary(action string, data map[string]any) string {

--- a/handlers/admin/query_request_task.go
+++ b/handlers/admin/query_request_task.go
@@ -1,0 +1,25 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// QueryRequestTask asks for more information about a request.
+type QueryRequestTask struct{ tasks.TaskString }
+
+var queryRequestTask = &QueryRequestTask{TaskString: TaskQuery}
+
+var _ tasks.Task = (*QueryRequestTask)(nil)
+var _ tasks.AuditableTask = (*QueryRequestTask)(nil)
+
+func (QueryRequestTask) Action(w http.ResponseWriter, r *http.Request) any {
+	handleRequestAction(w, r, "query")
+	return nil
+}
+
+// AuditRecord summarises a request queue action.
+func (QueryRequestTask) AuditRecord(data map[string]any) string {
+	return requestAuditSummary("query", data)
+}

--- a/handlers/admin/reject_request_task.go
+++ b/handlers/admin/reject_request_task.go
@@ -1,0 +1,25 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// RejectRequestTask rejects a queued request.
+type RejectRequestTask struct{ tasks.TaskString }
+
+var rejectRequestTask = &RejectRequestTask{TaskString: TaskReject}
+
+var _ tasks.Task = (*RejectRequestTask)(nil)
+var _ tasks.AuditableTask = (*RejectRequestTask)(nil)
+
+func (RejectRequestTask) Action(w http.ResponseWriter, r *http.Request) any {
+	handleRequestAction(w, r, "rejected")
+	return nil
+}
+
+// AuditRecord summarises a request queue action.
+func (RejectRequestTask) AuditRecord(data map[string]any) string {
+	return requestAuditSummary("rejected", data)
+}


### PR DESCRIPTION
## Summary
- move request queue tasks into dedicated files
- keep page handlers in `adminRequestQueuePage.go`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880b8881d6c832face7e246cb4f0f61