### PR TITLE
Move linker category tasks to new files

### DIFF
--- a/handlers/linker/create_category_task.go
+++ b/handlers/linker/create_category_task.go
@@ -1,0 +1,33 @@
+package linker
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+type createCategoryTask struct{ tasks.TaskString }
+
+var CreateCategoryTask = &createCategoryTask{TaskString: TaskCreateCategory}
+var _ tasks.Task = (*createCategoryTask)(nil)
+
+func (createCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	title := r.PostFormValue("title")
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	rows, _ := cd.LinkerCategoryCounts()
+	pos := len(rows) + 1
+	if err := queries.CreateLinkerCategory(r.Context(), db.CreateLinkerCategoryParams{
+		Title:    sql.NullString{Valid: true, String: title},
+		Position: int32(pos),
+	}); err != nil {
+		return fmt.Errorf("create linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	return nil
+}

--- a/handlers/linker/delete_category_task.go
+++ b/handlers/linker/delete_category_task.go
@@ -1,0 +1,42 @@
+package linker
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+type deleteCategoryTask struct{ tasks.TaskString }
+
+var DeleteCategoryTask = &deleteCategoryTask{TaskString: TaskDeleteCategory}
+var _ tasks.Task = (*deleteCategoryTask)(nil)
+
+func (deleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	rows, _ := cd.LinkerCategoryCounts()
+	for _, c := range rows {
+		if int(c.Idlinkercategory) == cid && c.Linkcount > 0 {
+			http.Error(w, "Category in use", http.StatusBadRequest)
+			return nil
+		}
+	}
+	count, err := queries.CountLinksByCategory(r.Context(), int32(cid))
+	if err != nil {
+		return fmt.Errorf("count links fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	if count > 0 {
+		http.Error(w, "Category in use", http.StatusBadRequest)
+		return nil
+	}
+	if err := queries.DeleteLinkerCategory(r.Context(), int32(cid)); err != nil {
+		return fmt.Errorf("delete linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	return nil
+}

--- a/handlers/linker/linkerAdminCategoriesPage.go
+++ b/handlers/linker/linkerAdminCategoriesPage.go
@@ -3,16 +3,13 @@ package linker
 import (
 	"database/sql"
 	"errors"
-	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/internal/tasks"
 )
 
 func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
@@ -39,101 +36,4 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	data.Categories = categoryRows
 
 	handlers.TemplateHandler(w, r, "categoriesPage.gohtml", data)
-}
-
-type updateCategoryTask struct{ tasks.TaskString }
-
-var UpdateCategoryTask = &updateCategoryTask{TaskString: TaskUpdate}
-var _ tasks.Task = (*updateCategoryTask)(nil)
-
-func (updateCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
-	title := r.PostFormValue("title")
-	pos, _ := strconv.Atoi(r.PostFormValue("position"))
-	if err := queries.RenameLinkerCategory(r.Context(), db.RenameLinkerCategoryParams{
-		Title:            sql.NullString{Valid: true, String: title},
-		Position:         int32(pos),
-		Idlinkercategory: int32(cid),
-	}); err != nil {
-		return fmt.Errorf("rename linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-	}
-	order, _ := strconv.Atoi(r.PostFormValue("order"))
-	if err := queries.UpdateLinkerCategorySortOrder(r.Context(), db.UpdateLinkerCategorySortOrderParams{
-		Sortorder:        int32(order),
-		Idlinkercategory: int32(cid),
-	}); err != nil {
-		return fmt.Errorf("update linker category sort order fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-	}
-	return nil
-}
-
-type renameCategoryTask struct{ tasks.TaskString }
-
-var RenameCategoryTask = &renameCategoryTask{TaskString: TaskRenameCategory}
-var _ tasks.Task = (*renameCategoryTask)(nil)
-
-func (renameCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
-	title := r.PostFormValue("title")
-	pos, _ := strconv.Atoi(r.PostFormValue("position"))
-	if err := queries.RenameLinkerCategory(r.Context(), db.RenameLinkerCategoryParams{
-		Title:            sql.NullString{Valid: true, String: title},
-		Position:         int32(pos),
-		Idlinkercategory: int32(cid),
-	}); err != nil {
-		return fmt.Errorf("rename linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-	}
-	return nil
-}
-
-type deleteCategoryTask struct{ tasks.TaskString }
-
-var DeleteCategoryTask = &deleteCategoryTask{TaskString: TaskDeleteCategory}
-var _ tasks.Task = (*deleteCategoryTask)(nil)
-
-func (deleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	rows, _ := cd.LinkerCategoryCounts()
-	for _, c := range rows {
-		if int(c.Idlinkercategory) == cid && c.Linkcount > 0 {
-			http.Error(w, "Category in use", http.StatusBadRequest)
-			return nil
-		}
-	}
-	count, err := queries.CountLinksByCategory(r.Context(), int32(cid))
-	if err != nil {
-		return fmt.Errorf("count links fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-	}
-	if count > 0 {
-		http.Error(w, "Category in use", http.StatusBadRequest)
-		return nil
-	}
-	if err := queries.DeleteLinkerCategory(r.Context(), int32(cid)); err != nil {
-		return fmt.Errorf("delete linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-	}
-	return nil
-}
-
-type createCategoryTask struct{ tasks.TaskString }
-
-var CreateCategoryTask = &createCategoryTask{TaskString: TaskCreateCategory}
-var _ tasks.Task = (*createCategoryTask)(nil)
-
-func (createCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	title := r.PostFormValue("title")
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	rows, _ := cd.LinkerCategoryCounts()
-	pos := len(rows) + 1
-	if err := queries.CreateLinkerCategory(r.Context(), db.CreateLinkerCategoryParams{
-		Title:    sql.NullString{Valid: true, String: title},
-		Position: int32(pos),
-	}); err != nil {
-		return fmt.Errorf("create linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-	}
-	return nil
 }

--- a/handlers/linker/rename_category_task.go
+++ b/handlers/linker/rename_category_task.go
@@ -1,0 +1,34 @@
+package linker
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+type renameCategoryTask struct{ tasks.TaskString }
+
+var RenameCategoryTask = &renameCategoryTask{TaskString: TaskRenameCategory}
+var _ tasks.Task = (*renameCategoryTask)(nil)
+
+func (renameCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
+	title := r.PostFormValue("title")
+	pos, _ := strconv.Atoi(r.PostFormValue("position"))
+	if err := queries.RenameLinkerCategory(r.Context(), db.RenameLinkerCategoryParams{
+		Title:            sql.NullString{Valid: true, String: title},
+		Position:         int32(pos),
+		Idlinkercategory: int32(cid),
+	}); err != nil {
+		return fmt.Errorf("rename linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	return nil
+}

--- a/handlers/linker/update_category_task.go
+++ b/handlers/linker/update_category_task.go
@@ -1,0 +1,41 @@
+package linker
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+type updateCategoryTask struct{ tasks.TaskString }
+
+var UpdateCategoryTask = &updateCategoryTask{TaskString: TaskUpdate}
+var _ tasks.Task = (*updateCategoryTask)(nil)
+
+func (updateCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
+	title := r.PostFormValue("title")
+	pos, _ := strconv.Atoi(r.PostFormValue("position"))
+	if err := queries.RenameLinkerCategory(r.Context(), db.RenameLinkerCategoryParams{
+		Title:            sql.NullString{Valid: true, String: title},
+		Position:         int32(pos),
+		Idlinkercategory: int32(cid),
+	}); err != nil {
+		return fmt.Errorf("rename linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	order, _ := strconv.Atoi(r.PostFormValue("order"))
+	if err := queries.UpdateLinkerCategorySortOrder(r.Context(), db.UpdateLinkerCategorySortOrderParams{
+		Sortorder:        int32(order),
+		Idlinkercategory: int32(cid),
+	}); err != nil {
+		return fmt.Errorf("update linker category sort order fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- break out linker category tasks into individual source files
- keep admin categories page focused on page rendering

## Testing
- `go vet ./...`
- `go test ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880b8776750832f8a4ba216f4d624de