### PR TITLE
Fix go tests

### DIFF
--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -63,8 +63,6 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 	mock.ExpectExec("UPDATE linker SET last_index").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	bus := eventbus.NewBus()
-	eventbus.DefaultBus = bus
-	defer func() { eventbus.DefaultBus = eventbus.NewBus() }()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go searchworker.Worker(ctx, bus, queries)
@@ -78,7 +76,7 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 	rr := httptest.NewRecorder()
 	ApproveTask.Action(rr, req)
 
-	if err := eventbus.DefaultBus.Publish(*evt); err != nil {
+	if err := bus.Publish(*evt); err != nil {
 		t.Fatalf("publish: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- avoid global DefaultBus usage in linker test to prevent cross-package race

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880b8598014832fbedbc126ba5d0781