### PR TITLE
Refactor forum cancel tasks

### DIFF
--- a/handlers/forum/comment_edit_action_cancel_task.go
+++ b/handlers/forum/comment_edit_action_cancel_task.go
@@ -1,0 +1,25 @@
+package forum
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// topicThreadCommentEditActionCancelTask aborts editing a comment.
+type topicThreadCommentEditActionCancelTask struct{ tasks.TaskString }
+
+var topicThreadCommentEditActionCancel = &topicThreadCommentEditActionCancelTask{TaskString: TaskCancel}
+
+var _ tasks.Task = (*topicThreadCommentEditActionCancelTask)(nil)
+
+func (topicThreadCommentEditActionCancelTask) Action(w http.ResponseWriter, r *http.Request) any {
+	threadRow := r.Context().Value(consts.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
+	topicRow := r.Context().Value(consts.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+	endURL := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
+	return handlers.RedirectHandler(endURL)
+}

--- a/handlers/forum/comment_edit_action_task.go
+++ b/handlers/forum/comment_edit_action_task.go
@@ -3,43 +3,17 @@ package forum
 import (
 	"database/sql"
 	"fmt"
-	"github.com/arran4/goa4web/core/consts"
-	"github.com/arran4/goa4web/handlers"
 	"net/http"
 	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/arran4/goa4web/workers/postcountworker"
 	"github.com/gorilla/mux"
 )
-
-// threadNewCancelTask aborts creating a new thread.
-type threadNewCancelTask struct{ tasks.TaskString }
-
-var threadNewCancelAction = &threadNewCancelTask{TaskString: TaskCancel}
-
-var _ tasks.Task = (*threadNewCancelTask)(nil)
-
-func (threadNewCancelTask) Action(w http.ResponseWriter, r *http.Request) any {
-	topicID, _ := strconv.Atoi(mux.Vars(r)["topic"])
-	return handlers.RedirectHandler(fmt.Sprintf("/forum/topic/%d", topicID))
-}
-
-// topicThreadReplyCancelTask cancels replying to a thread.
-type topicThreadReplyCancelTask struct{ tasks.TaskString }
-
-var topicThreadReplyCancel = &topicThreadReplyCancelTask{TaskString: TaskCancel}
-
-var _ tasks.Task = (*topicThreadReplyCancelTask)(nil)
-
-func (topicThreadReplyCancelTask) Action(w http.ResponseWriter, r *http.Request) any {
-	threadRow := r.Context().Value(consts.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
-	topicRow := r.Context().Value(consts.KeyTopic).(*db.GetForumTopicByIdForUserRow)
-	endURL := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
-	return handlers.RedirectHandler(endURL)
-}
 
 // topicThreadCommentEditActionTask updates a comment and refreshes thread metadata.
 type topicThreadCommentEditActionTask struct{ tasks.TaskString }
@@ -78,18 +52,4 @@ func (topicThreadCommentEditActionTask) Action(w http.ResponseWriter, r *http.Re
 	}
 
 	return handlers.RedirectHandler(fmt.Sprintf("/forum/topic/%d/thread/%d#comment-%d", topicRow.Idforumtopic, threadRow.Idforumthread, commentID))
-}
-
-// topicThreadCommentEditActionCancelTask aborts editing a comment.
-type topicThreadCommentEditActionCancelTask struct{ tasks.TaskString }
-
-var topicThreadCommentEditActionCancel = &topicThreadCommentEditActionCancelTask{TaskString: TaskCancel}
-
-var _ tasks.Task = (*topicThreadCommentEditActionCancelTask)(nil)
-
-func (topicThreadCommentEditActionCancelTask) Action(w http.ResponseWriter, r *http.Request) any {
-	threadRow := r.Context().Value(consts.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
-	topicRow := r.Context().Value(consts.KeyTopic).(*db.GetForumTopicByIdForUserRow)
-	endURL := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
-	return handlers.RedirectHandler(endURL)
 }

--- a/handlers/forum/thread_new_cancel_task.go
+++ b/handlers/forum/thread_new_cancel_task.go
@@ -1,0 +1,23 @@
+package forum
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/gorilla/mux"
+)
+
+// threadNewCancelTask aborts creating a new thread.
+type threadNewCancelTask struct{ tasks.TaskString }
+
+var threadNewCancelAction = &threadNewCancelTask{TaskString: TaskCancel}
+
+var _ tasks.Task = (*threadNewCancelTask)(nil)
+
+func (threadNewCancelTask) Action(w http.ResponseWriter, r *http.Request) any {
+	topicID, _ := strconv.Atoi(mux.Vars(r)["topic"])
+	return handlers.RedirectHandler(fmt.Sprintf("/forum/topic/%d", topicID))
+}

--- a/handlers/forum/topic_thread_reply_cancel_task.go
+++ b/handlers/forum/topic_thread_reply_cancel_task.go
@@ -1,0 +1,25 @@
+package forum
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// topicThreadReplyCancelTask cancels replying to a thread.
+type topicThreadReplyCancelTask struct{ tasks.TaskString }
+
+var topicThreadReplyCancel = &topicThreadReplyCancelTask{TaskString: TaskCancel}
+
+var _ tasks.Task = (*topicThreadReplyCancelTask)(nil)
+
+func (topicThreadReplyCancelTask) Action(w http.ResponseWriter, r *http.Request) any {
+	threadRow := r.Context().Value(consts.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
+	topicRow := r.Context().Value(consts.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+	endURL := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
+	return handlers.RedirectHandler(endURL)
+}


### PR DESCRIPTION
## Summary
- move thread new cancel task to its own file
- move topic thread reply cancel task to its own file
- move comment edit action task to its own file
- move comment edit action cancel task to its own file
- drop obsolete `forumCancelTasks.go`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880b878f9ac832f9ac09204481adc3b