### PR TITLE
Fix linker search test

### DIFF
--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -95,6 +95,7 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	for _, c := range w.Result().Cookies() {
 		req.AddCookie(c)
 	}
+	bus := eventbus.NewBus()
 	q := db.New(dbconn)
 	evt := &eventbus.TaskEvent{Path: "/faq/ask", Task: tasks.TaskString(TaskAsk), UserID: 1}
 	cd := common.NewCoreData(req.Context(), q)
@@ -104,7 +105,7 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
-	handler := middleware.TaskEventMiddleware(http.HandlerFunc(handlers.TaskHandler(askTask)))
+	handler := middleware.TaskEventMiddlewareWithBus(bus)(http.HandlerFunc(handlers.TaskHandler(askTask)))
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -38,8 +38,6 @@ func TestPermissionUserTasksTemplates(t *testing.T) {
 
 func TestPermissionUserAllowEventData(t *testing.T) {
 	bus := eventbus.NewBus()
-	eventbus.DefaultBus = bus
-	defer func() { eventbus.DefaultBus = eventbus.NewBus() }()
 
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -69,7 +67,7 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
-	handler := middleware.TaskEventMiddleware(http.HandlerFunc(handlers.TaskHandler(permissionUserAllowTask)))
+	handler := middleware.TaskEventMiddlewareWithBus(bus)(http.HandlerFunc(handlers.TaskHandler(permissionUserAllowTask)))
 	handler.ServeHTTP(rr, req)
 
 	select {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -81,6 +81,8 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 		}()
 	}
 
+	bus := eventbus.DefaultBus
+
 	r := mux.NewRouter()
 	routerpkg.RegisterRoutes(r)
 
@@ -88,7 +90,7 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 		middleware.RecoverMiddleware,
 		middleware.CoreAdderMiddleware,
 		middleware.RequestLoggerMiddleware,
-		middleware.TaskEventMiddleware,
+		middleware.TaskEventMiddlewareWithBus(bus),
 		middleware.SecurityHeadersMiddleware,
 	).Wrap(r)
 	if csrfmw.CSRFEnabled() {
@@ -110,7 +112,7 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 
 	workerCtx, workerCancel := context.WithCancel(context.Background())
 	defer workerCancel()
-	workers.Start(workerCtx, dbPool, emailProvider, dlqProvider, cfg)
+	workers.Start(workerCtx, dbPool, emailProvider, dlqProvider, cfg, bus)
 
 	if err := server.Run(ctx, srv, cfg.HTTPListen); err != nil {
 		return fmt.Errorf("run server: %w", err)
@@ -119,7 +121,7 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := eventbus.DefaultBus.Shutdown(shutdownCtx); err != nil {
+	if err := bus.Shutdown(shutdownCtx); err != nil {
 		log.Printf("eventbus shutdown: %v", err)
 	}
 	workerCancel()

--- a/workers/workers.go
+++ b/workers/workers.go
@@ -35,10 +35,13 @@ func safeGo(fn func()) {
 }
 
 // Start launches all background workers using the given configuration.
-func Start(ctx context.Context, db *sql.DB, provider email.Provider, dlqProvider dlq.DLQ, cfg config.RuntimeConfig) {
+func Start(ctx context.Context, db *sql.DB, provider email.Provider, dlqProvider dlq.DLQ, cfg config.RuntimeConfig, bus *eventbus.Bus) {
+	if bus == nil {
+		bus = eventbus.DefaultBus
+	}
 	log.Printf("Starting email worker")
 	safeGo(func() {
-		emailqueue.EmailQueueWorker(ctx, dbpkg.New(db), provider, dlqProvider, eventbus.DefaultBus, time.Duration(cfg.EmailWorkerInterval)*time.Second)
+		emailqueue.EmailQueueWorker(ctx, dbpkg.New(db), provider, dlqProvider, bus, time.Duration(cfg.EmailWorkerInterval)*time.Second)
 	})
 	log.Printf("Starting notification purger worker")
 	safeGo(func() {
@@ -49,19 +52,19 @@ func Start(ctx context.Context, db *sql.DB, provider email.Provider, dlqProvider
 		n.NotificationPurgeWorker(ctx, time.Hour)
 	})
 	log.Printf("Starting event bus logger worker")
-	safeGo(func() { logworker.Worker(ctx, eventbus.DefaultBus) })
+	safeGo(func() { logworker.Worker(ctx, bus) })
 	log.Printf("Starting audit worker")
-	safeGo(func() { auditworker.Worker(ctx, eventbus.DefaultBus, dbpkg.New(db)) })
+	safeGo(func() { auditworker.Worker(ctx, bus, dbpkg.New(db)) })
 	log.Printf("Starting notification bus worker")
 	safeGo(func() {
 		n := notifications.New(
 			notifications.WithQueries(dbpkg.New(db)),
 			notifications.WithEmailProvider(provider),
 		)
-		n.BusWorker(ctx, eventbus.DefaultBus, dlqProvider)
+		n.BusWorker(ctx, bus, dlqProvider)
 	})
 	log.Printf("Starting search index worker")
-	safeGo(func() { searchworker.Worker(ctx, eventbus.DefaultBus, dbpkg.New(db)) })
+	safeGo(func() { searchworker.Worker(ctx, bus, dbpkg.New(db)) })
 	log.Printf("Starting post count worker")
-	safeGo(func() { postcountworker.Worker(ctx, eventbus.DefaultBus, dbpkg.New(db)) })
+	safeGo(func() { postcountworker.Worker(ctx, bus, dbpkg.New(db)) })
 }


### PR DESCRIPTION
## Summary
- inject event bus via middleware function
- update tests to use TaskEventMiddlewareWithBus
- wire up run.go to pass DefaultBus to middleware
- inject event bus into workers to reduce reliance on global DefaultBus

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68809ac65884832f9c7e133172956ad4