### PR TITLE
Fix linker search test

### DIFF
--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -95,6 +95,7 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	for _, c := range w.Result().Cookies() {
 		req.AddCookie(c)
 	}
+	bus := eventbus.NewBus()
 	q := db.New(dbconn)
 	evt := &eventbus.TaskEvent{Path: "/faq/ask", Task: tasks.TaskString(TaskAsk), UserID: 1}
 	cd := common.NewCoreData(req.Context(), q)
@@ -104,7 +105,7 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
-	handler := middleware.TaskEventMiddleware(http.HandlerFunc(handlers.TaskHandler(askTask)))
+	handler := middleware.TaskEventMiddlewareWithBus(bus)(http.HandlerFunc(handlers.TaskHandler(askTask)))
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -38,8 +38,6 @@ func TestPermissionUserTasksTemplates(t *testing.T) {
 
 func TestPermissionUserAllowEventData(t *testing.T) {
 	bus := eventbus.NewBus()
-	eventbus.DefaultBus = bus
-	defer func() { eventbus.DefaultBus = eventbus.NewBus() }()
 
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -69,7 +67,7 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
-	handler := middleware.TaskEventMiddleware(http.HandlerFunc(handlers.TaskHandler(permissionUserAllowTask)))
+	handler := middleware.TaskEventMiddlewareWithBus(bus)(http.HandlerFunc(handlers.TaskHandler(permissionUserAllowTask)))
 	handler.ServeHTTP(rr, req)
 
 	select {


### PR DESCRIPTION
## Summary
- inject event bus via middleware function
- update tests to use TaskEventMiddlewareWithBus
- wire up run.go to pass DefaultBus to middleware
- remove leftover default bus use by creating a bus and passing to worker startup

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68809ac65884832f9c7e133172956ad4