### PR TITLE
Fix permission check for announcements

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -397,7 +397,10 @@ func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsRow {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		row, err := cd.queries.GetActiveAnnouncementWithNews(cd.ctx)
+		row, err := cd.queries.GetActiveAnnouncementWithNews(cd.ctx, db.GetActiveAnnouncementWithNewsParams{
+			ViewerID: cd.UserID,
+			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -16,10 +16,28 @@ LIMIT 1;
 UPDATE site_announcements SET active = ? WHERE id = ?;
 
 -- name: GetActiveAnnouncementWithNews :one
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
 SELECT a.id, n.idsiteNews, n.news
 FROM site_announcements a
 JOIN site_news n ON n.idsiteNews = a.site_news_id
 WHERE a.active = 1
+  AND EXISTS (
+      SELECT 1 FROM grants g
+      WHERE g.section='news'
+        AND g.item='post'
+        AND g.action='view'
+        AND g.active=1
+        AND g.item_id = n.idsiteNews
+        AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+        AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
 ORDER BY a.created_at DESC
 LIMIT 1;
 

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -322,15 +322,15 @@ func (n *Notifier) notifySubscribers(ctx context.Context, evt eventbus.TaskEvent
 }
 
 func (n *Notifier) handleAutoSubscribe(ctx context.Context, evt eventbus.TaskEvent, tp AutoSubscribeProvider) error {
-	auto := true
-	email := false
-	if pref, err := n.Queries.GetPreferenceByUserID(ctx, evt.UserID); err == nil {
-		auto = pref.AutoSubscribeReplies
-		if pref.Emailforumupdates.Valid {
-			email = pref.Emailforumupdates.Bool
-		}
-	} else {
+	var auto bool
+	var email bool
+	pref, err := n.Queries.GetPreferenceByUserID(ctx, evt.UserID)
+	if err != nil {
 		return fmt.Errorf("get preference by user_id: %w", err)
+	}
+	auto = pref.AutoSubscribeReplies
+	if pref.Emailforumupdates.Valid {
+		email = pref.Emailforumupdates.Bool
 	}
 	if auto {
 		task, path, err := tp.AutoSubscribePath(evt)


### PR DESCRIPTION
## Summary
- restrict active announcements by user permissions
- adjust CoreData to supply user context for announcements
- fix a linter issue in the notifier
- regenerate sqlc code

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: remaining expectation which was not matched)*

------
https://chatgpt.com/codex/tasks/task_e_6880db2589f0832f8ced10b3e8e0c871