### PR TITLE
Fix linker search test

### DIFF
--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -95,6 +95,7 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	for _, c := range w.Result().Cookies() {
 		req.AddCookie(c)
 	}
+	bus := eventbus.NewBus()
 	q := db.New(dbconn)
 	evt := &eventbus.TaskEvent{Path: "/faq/ask", Task: tasks.TaskString(TaskAsk), UserID: 1}
 	cd := common.NewCoreData(req.Context(), q)
@@ -104,7 +105,7 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
-	handler := middleware.TaskEventMiddleware(http.HandlerFunc(handlers.TaskHandler(askTask)))
+	handler := middleware.TaskEventMiddlewareWithBus(bus)(http.HandlerFunc(handlers.TaskHandler(askTask)))
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -38,8 +38,6 @@ func TestPermissionUserTasksTemplates(t *testing.T) {
 
 func TestPermissionUserAllowEventData(t *testing.T) {
 	bus := eventbus.NewBus()
-	eventbus.DefaultBus = bus
-	defer func() { eventbus.DefaultBus = eventbus.NewBus() }()
 
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -69,7 +67,7 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
-	handler := middleware.TaskEventMiddleware(http.HandlerFunc(handlers.TaskHandler(permissionUserAllowTask)))
+	handler := middleware.TaskEventMiddlewareWithBus(bus)(http.HandlerFunc(handlers.TaskHandler(permissionUserAllowTask)))
 	handler.ServeHTTP(rr, req)
 
 	select {

--- a/internal/eventbus/eventbus.go
+++ b/internal/eventbus/eventbus.go
@@ -135,14 +135,3 @@ func (b *Bus) Shutdown(ctx context.Context) error {
 	}
 	return nil
 }
-
-var (
-	// DefaultBus is the global event bus used across the application.
-	DefaultBus = NewBus()
-)
-
-// ReopenDefaultBus creates a new DefaultBus instance. Callers should publish
-// any queued events to the returned bus once subscribers are registered.
-func ReopenDefaultBus() {
-	DefaultBus = NewBus()
-}

--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -14,7 +14,7 @@ import (
 	"github.com/arran4/goa4web/internal/eventbus"
 )
 
-// TaskEventMiddleware records form tasks on the event bus after processing.
+// TaskEventMiddlewareWithBus records form tasks on the provided event bus after processing.
 
 // statusRecorder captures the response status for later inspection.
 type statusRecorder struct {
@@ -31,10 +31,11 @@ type eventQueue struct {
 	mu       sync.Mutex
 	capacity int
 	events   []eventbus.TaskEvent
+	bus      *eventbus.Bus
 }
 
-func newEventQueue(capacity int) *eventQueue {
-	return &eventQueue{capacity: capacity}
+func newEventQueue(capacity int, bus *eventbus.Bus) *eventQueue {
+	return &eventQueue{capacity: capacity, bus: bus}
 }
 
 func (q *eventQueue) enqueue(evt eventbus.TaskEvent) {
@@ -63,7 +64,14 @@ func (q *eventQueue) flush(ctx context.Context) {
 			q.mu.Unlock()
 			return
 		}
-		if err := eventbus.DefaultBus.Publish(e); err != nil {
+		bus := q.bus
+		if bus == nil {
+			q.mu.Lock()
+			q.events = append(events[i:], q.events...)
+			q.mu.Unlock()
+			return
+		}
+		if err := bus.Publish(e); err != nil {
 			if err == eventbus.ErrBusClosed {
 				q.mu.Lock()
 				q.events = append(events[i:], q.events...)
@@ -75,42 +83,48 @@ func (q *eventQueue) flush(ctx context.Context) {
 	}
 }
 
-var taskQueue = newEventQueue(maxQueuedTaskEvents)
+var taskQueue = newEventQueue(maxQueuedTaskEvents, nil)
 
 func (r *statusRecorder) WriteHeader(code int) {
 	r.status = code
 	r.ResponseWriter.WriteHeader(code)
 }
 
-func TaskEventMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		task := r.PostFormValue("task")
-		cd, ok := r.Context().Value(coreconsts.KeyCoreData).(*common.CoreData)
-		if !ok || cd == nil {
-			log.Panicf("TaskEventMiddleware: missing CoreData for %s", r.URL.Path)
-		}
-		uid := cd.UserID
-		admin := strings.Contains(r.URL.Path, "/admin")
-		_ = admin
-		evt := &eventbus.TaskEvent{
-			Path:   r.URL.Path,
-			Task:   tasks.TaskString("MISSING"),
-			UserID: uid,
-			Time:   time.Now(),
-			Data:   map[string]any{},
-		}
-		cd.SetEvent(evt)
-		sr := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
-		next.ServeHTTP(sr, r)
-		if task != "" && sr.status < http.StatusBadRequest {
-			if err := eventbus.DefaultBus.Publish(*evt); err != nil {
-				if err == eventbus.ErrBusClosed {
-					taskQueue.enqueue(*evt)
-				} else {
-					log.Printf("publish task event: %v", err)
+func TaskEventMiddlewareWithBus(bus *eventbus.Bus) func(http.Handler) http.Handler {
+	if bus == nil {
+		panic("TaskEventMiddleware requires a bus")
+	}
+	taskQueue.bus = bus
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			task := r.PostFormValue("task")
+			cd, ok := r.Context().Value(coreconsts.KeyCoreData).(*common.CoreData)
+			if !ok || cd == nil {
+				log.Panicf("TaskEventMiddleware: missing CoreData for %s", r.URL.Path)
+			}
+			uid := cd.UserID
+			admin := strings.Contains(r.URL.Path, "/admin")
+			_ = admin
+			evt := &eventbus.TaskEvent{
+				Path:   r.URL.Path,
+				Task:   tasks.TaskString("MISSING"),
+				UserID: uid,
+				Time:   time.Now(),
+				Data:   map[string]any{},
+			}
+			cd.SetEvent(evt)
+			sr := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+			next.ServeHTTP(sr, r)
+			if task != "" && sr.status < http.StatusBadRequest {
+				if err := bus.Publish(*evt); err != nil {
+					if err == eventbus.ErrBusClosed {
+						taskQueue.enqueue(*evt)
+					} else {
+						log.Printf("publish task event: %v", err)
+					}
 				}
 			}
-		}
-		taskQueue.flush(r.Context())
-	})
+			taskQueue.flush(r.Context())
+		})
+	}
 }

--- a/internal/notifications/email.go
+++ b/internal/notifications/email.go
@@ -136,8 +136,10 @@ func (n *Notifier) queueEmail(ctx context.Context, userID *int32, direct bool, m
 		return err
 	}
 	evt := eventbus.EmailQueueEvent{Time: time.Now()}
-	if err := eventbus.DefaultBus.Publish(evt); err != nil && err != eventbus.ErrBusClosed {
-		log.Printf("publish email queue event: %v", err)
+	if n.Bus != nil {
+		if err := n.Bus.Publish(evt); err != nil && err != eventbus.ErrBusClosed {
+			log.Printf("publish email queue event: %v", err)
+		}
 	}
 	return nil
 }

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -12,12 +12,14 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
+	"github.com/arran4/goa4web/internal/eventbus"
 	htemplate "html/template"
 )
 
 // Notifier dispatches updates via email and internal notifications.
 // Notifier dispatches updates via email and internal notifications.
 type Notifier struct {
+	Bus            *eventbus.Bus
 	EmailProvider  email.Provider
 	Queries        *dbpkg.Queries
 	noteOnce       sync.Once
@@ -36,6 +38,9 @@ func WithQueries(q *dbpkg.Queries) Option { return func(n *Notifier) { n.Queries
 
 // WithEmailProvider sets the email provider dependency.
 func WithEmailProvider(p email.Provider) Option { return func(n *Notifier) { n.EmailProvider = p } }
+
+// WithBus sets the event bus dependency used to publish email queue events.
+func WithBus(b *eventbus.Bus) Option { return func(n *Notifier) { n.Bus = b } }
 
 // WithConfig derives dependencies from cfg when they are not supplied.
 func WithConfig(cfg config.RuntimeConfig) Option {

--- a/internal/websocket/notifications.go
+++ b/internal/websocket/notifications.go
@@ -21,11 +21,16 @@ import (
 	routerpkg "github.com/arran4/goa4web/internal/router"
 )
 
+var wsBus *eventbus.Bus
+
 // NotificationsHandler provides a websocket endpoint streaming bus events.
 type NotificationsHandler struct {
 	Bus      *eventbus.Bus      // event source
 	Upgrader websocket.Upgrader // websocket upgrader
 }
+
+// SetBus sets the event bus used by websocket handlers.
+func SetBus(b *eventbus.Bus) { wsBus = b }
 
 func buildPatterns(task, path string) []string {
 	name := strings.ToLower(task)
@@ -147,7 +152,7 @@ func (h *NotificationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 // RegisterRoutes attaches the websocket handler to r.
 func RegisterRoutes(r *mux.Router) {
-	h := NewNotificationsHandler(eventbus.DefaultBus)
+	h := NewNotificationsHandler(wsBus)
 	r.Handle("/ws/notifications", h).Methods(http.MethodGet)
 	r.HandleFunc("/notifications.js", NotificationsJS).Methods(http.MethodGet)
 }

--- a/internal/websocket/notifications_stub.go
+++ b/internal/websocket/notifications_stub.go
@@ -1,0 +1,8 @@
+//go:build !websocket
+
+package websocket
+
+import "github.com/arran4/goa4web/internal/eventbus"
+
+// SetBus is a no-op when websocket build tags are disabled.
+func SetBus(_ *eventbus.Bus) {}


### PR DESCRIPTION
## Summary
- inject event bus via SetBus when websockets are enabled
- remove DefaultBus global instance
- require TaskEventMiddlewareWithBus to take a bus
- publish email queue events on the injected bus
- update workers and notifier options for bus

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68809ac65884832f9c7e133172956ad4