### PR TITLE
Fix blank admin permissions page

### DIFF
--- a/handlers/user/admin_permissions.go
+++ b/handlers/user/admin_permissions.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 
 	"github.com/arran4/goa4web/core/common"
-
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 )
 
@@ -41,4 +41,6 @@ func adminUsersPermissionsPage(w http.ResponseWriter, r *http.Request) {
 		return rows[i].Username.String < rows[j].Username.String
 	})
 	data.Rows = rows
+
+	handlers.TemplateHandler(w, r, "usersPermissionsPage.gohtml", data)
 }


### PR DESCRIPTION
## Summary
- render the admin permissions page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68818f59aabc832fb3d4525119c85aaf