### PR TITLE
Fix stats template fields

### DIFF
--- a/core/templates/site/admin/usageStatsPage.gohtml
+++ b/core/templates/site/admin/usageStatsPage.gohtml
@@ -5,7 +5,7 @@
 <table border="1">
     <tr><th>Topic</th><th>Threads</th></tr>
     {{- range .ForumTopics }}
-    <tr><td>{{ .Name.String }}</td><td>{{ .Count }}</td></tr>
+    <tr><td>{{ .Title.String }}</td><td>{{ .Count }}</td></tr>
     {{- end }}
 </table>
 
@@ -13,7 +13,7 @@
 <table border="1">
     <tr><th>Category</th><th>Threads</th></tr>
     {{- range .ForumCategories }}
-    <tr><td>{{ .Name.String }}</td><td>{{ .Count }}</td></tr>
+    <tr><td>{{ .Title.String }}</td><td>{{ .Count }}</td></tr>
     {{- end }}
 </table>
 
@@ -21,7 +21,7 @@
 <table border="1">
     <tr><th>Category</th><th>Writings</th></tr>
     {{- range .WritingCategories }}
-    <tr><td>{{ .Name.String }}</td><td>{{ .Count }}</td></tr>
+    <tr><td>{{ .Title.String }}</td><td>{{ .Count }}</td></tr>
     {{- end }}
 </table>
 
@@ -37,7 +37,7 @@
 <table border="1">
     <tr><th>Board</th><th>Posts</th></tr>
     {{- range .Imageboards }}
-    <tr><td>{{ .Name.String }}</td><td>{{ .Count }}</td></tr>
+    <tr><td>{{ .Title.String }}</td><td>{{ .Count }}</td></tr>
     {{- end }}
 </table>
 


### PR DESCRIPTION
## Summary
- update usage stats template to reference `Title` fields instead of `Name`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68818f3a8300832f9d5f646046091ece