### PR TITLE
Fix admin usage stats query

### DIFF
--- a/internal/db/queries_dynamic.go
+++ b/internal/db/queries_dynamic.go
@@ -297,7 +297,7 @@ func (q *Queries) MonthlyUsageCounts(ctx context.Context, startYear int32) ([]*M
 		set    func(*MonthlyUsageRow, int64)
 	}{
 		{"blogs", "written", func(r *MonthlyUsageRow, n int64) { r.Blogs = n }},
-		{"siteNews", "occurred", func(r *MonthlyUsageRow, n int64) { r.News = n }},
+		{"site_news", "occurred", func(r *MonthlyUsageRow, n int64) { r.News = n }},
 		{"comments", "written", func(r *MonthlyUsageRow, n int64) { r.Comments = n }},
 		{"imagepost", "posted", func(r *MonthlyUsageRow, n int64) { r.Images = n }},
 		{"linker", "listed", func(r *MonthlyUsageRow, n int64) { r.Links = n }},
@@ -344,7 +344,7 @@ func (q *Queries) UserMonthlyUsageCounts(ctx context.Context, startYear int32) (
 		set    func(*UserMonthlyUsageRow, int64)
 	}{
 		{"blogs", "written", func(r *UserMonthlyUsageRow, n int64) { r.Blogs = n }},
-		{"siteNews", "occurred", func(r *UserMonthlyUsageRow, n int64) { r.News = n }},
+		{"site_news", "occurred", func(r *UserMonthlyUsageRow, n int64) { r.News = n }},
 		{"comments", "written", func(r *UserMonthlyUsageRow, n int64) { r.Comments = n }},
 		{"imagepost", "posted", func(r *UserMonthlyUsageRow, n int64) { r.Images = n }},
 		{"linker", "listed", func(r *UserMonthlyUsageRow, n int64) { r.Links = n }},


### PR DESCRIPTION
## Summary
- reference the correct `site_news` table in usage statistics queries

## Testing
- `go vet -v ./...`
- `golangci-lint run`
- `go mod tidy`
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68818f29683c832fa5f316655548f151