### PR TITLE
Add template section markers

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -97,10 +97,25 @@ type CoreData struct {
 	writingCategories        lazyValue[[]*db.WritingCategory]
 
 	absoluteURLBase lazyValue[string]
+	// marks records which template sections have been rendered to avoid
+	// duplicate output when re-rendering after an error.
+	marks map[string]struct{}
 }
 
 // SetRoles preloads the current user roles.
 func (cd *CoreData) SetRoles(r []string) { cd.userRoles.set(r) }
+
+// Marked returns true the first time it is called with key. Subsequent
+// calls return false. It is used to avoid re-rendering template sections
+// when streaming pages after an error.
+func (cd *CoreData) Marked(key string) bool {
+	if cd.marks == nil {
+		cd.marks = map[string]struct{}{}
+	}
+	_, marked := cd.marks[key]
+	cd.marks[key] = struct{}{}
+	return !marked
+}
 
 // CoreOption configures a new CoreData instance.
 type CoreOption func(*CoreData)

--- a/core/templates/site/head.gohtml
+++ b/core/templates/site/head.gohtml
@@ -1,6 +1,9 @@
 {{define "head"}}
+{{ if cd.Marked "html-begin" }}
 <!DOCTYPE html>
 <html>
+{{ end }}
+    {{ if cd.Marked "head" }}
         <head>
                 <title>{{cd.Title}}</title>
                 {{template "headdata"}}
@@ -12,15 +15,24 @@
             <meta http-equiv="refresh" content="{{cd.AutoRefresh}}">
         {{ end }}
     </head>
+    {{ end }}
+    {{ if cd.Marked "bodyBegin" }}
     <body>
+    {{ end }}
+        {{ if cd.Marked "header" }}
             {{template "header"}}
             <br>
+        {{ end }}
+    {{ if cd.Marked "body-table-begin" }}
         <table border=0>
             <tr valign=top>
                 <td width=200px>{{template "index" $}}
                 <td>
+    {{ end }}
+        {{ if cd.Marked "announcements" }}
                     {{- with $a := cd.AnnouncementLoaded }}{{ if $a }}
                     <a href="/news/news/{{ $a.Idsitenews }}"><strong>{{ $a.News.String }}</strong></a><br />
                     {{- end }}{{ end }}
+        {{ end }}
 
                     {{- end}}

--- a/core/templates/site/tail.gohtml
+++ b/core/templates/site/tail.gohtml
@@ -1,4 +1,5 @@
 {{define "tail"}}
+    {{ if cd.Marked "body-table-end" }}
         </table>
         <div id="bottom"></div>
                 <hr>
@@ -7,6 +8,11 @@
                                 {{template "footer"}}
                         </center>
                 </footer>
+    {{ end }}
+    {{ if cd.Marked "bodyEnd" }}
         </body>
+    {{ end }}
+{{ if cd.Marked "html-end" }}
 </html>
+{{ end }}
 {{end}}


### PR DESCRIPTION
## Summary
- add a `marks` map and `Marked` helper to `CoreData`
- guard layout sections in `head.gohtml` and `tail.gohtml`
- also protect the `<!DOCTYPE html>` and `<html>` tags

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68819b62c928832fb704db2f4f26fe27