### PR TITLE
Fix admin page size template reference

### DIFF
--- a/handlers/admin/adminPageSizePage.go
+++ b/handlers/admin/adminPageSizePage.go
@@ -49,5 +49,5 @@ func AdminPageSizePage(w http.ResponseWriter, r *http.Request) {
 		Max:      config.AppRuntimeConfig.PageSizeMax,
 		Default:  config.AppRuntimeConfig.PageSizeDefault,
 	}
-	handlers.TemplateHandler(w, r, "admin/pageSizePage.gohtml", data)
+	handlers.TemplateHandler(w, r, "pageSizePage.gohtml", data)
 }


### PR DESCRIPTION
## Summary
- correct template name used when rendering page size admin page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: expectations for SQL mock not met)*

------
https://chatgpt.com/codex/tasks/task_e_68818f03b7c4832fa1291c8ea3ee44ba