### PR TITLE
Implement email template registry page

### DIFF
--- a/core/templates/site/admin/emailTemplateEditPage.gohtml
+++ b/core/templates/site/admin/emailTemplateEditPage.gohtml
@@ -1,13 +1,14 @@
 {{ template "head" $ }}
 {{- if $.Error }}
-    <p style="color:red;">{{ $.Error }}</p>
+<p style="color:red;">{{ $.Error }}</p>
 {{- end }}
 <form method="post">
     {{ csrfField }}
+    <input type="hidden" name="name" value="{{ $.Name }}">
     <textarea name="body" cols="60" rows="15">{{ $.Body }}</textarea><br>
     <input type="submit" name="task" value="Update">
-    <input type="submit" name="task" value="Test mail">
+    <input type="submit" name="task" value="Delete">
 </form>
-<h3>Preview</h3>
-<pre>{{ $.Preview }}</pre>
+<h3>Default</h3>
+<pre>{{ $.Default }}</pre>
 {{ template "tail" $ }}

--- a/core/templates/site/admin/emailTemplateListPage.gohtml
+++ b/core/templates/site/admin/emailTemplateListPage.gohtml
@@ -1,0 +1,17 @@
+{{ template "head" $ }}
+[<a href="/admin">Admin</a>]<br />
+<table border="1">
+<tr><th>Task</th><th>Self Email</th><th>Self Internal</th><th>Subscribed Email</th><th>Subscribed Internal</th><th>Admin Email</th><th>Admin Internal</th></tr>
+{{- range .Infos }}
+<tr>
+    <td>{{ .Task }}</td>
+    <td>{{ range $i, $t := .SelfEmail }}{{ if $i }}, {{ end }}<a href="/admin/email/template?name={{ $t }}">{{ $t }}</a>{{ end }}</td>
+    <td>{{ if .SelfInternal }}<a href="/admin/email/template?name={{ .SelfInternal }}">{{ .SelfInternal }}</a>{{ end }}</td>
+    <td>{{ range $i, $t := .SubEmail }}{{ if $i }}, {{ end }}<a href="/admin/email/template?name={{ $t }}">{{ $t }}</a>{{ end }}</td>
+    <td>{{ if .SubInternal }}<a href="/admin/email/template?name={{ .SubInternal }}">{{ .SubInternal }}</a>{{ end }}</td>
+    <td>{{ range $i, $t := .AdminEmail }}{{ if $i }}, {{ end }}<a href="/admin/email/template?name={{ $t }}">{{ $t }}</a>{{ end }}</td>
+    <td>{{ if .AdminInternal }}<a href="/admin/email/template?name={{ .AdminInternal }}">{{ .AdminInternal }}</a>{{ end }}</td>
+</tr>
+{{- end }}
+</table>
+{{ template "tail" $ }}

--- a/handlers/admin/delete_template_task.go
+++ b/handlers/admin/delete_template_task.go
@@ -1,0 +1,46 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// DeleteTemplateTask removes a template override.
+type DeleteTemplateTask struct{ tasks.TaskString }
+
+var deleteTemplateTask = &DeleteTemplateTask{TaskString: TaskDelete}
+
+var _ tasks.Task = (*DeleteTemplateTask)(nil)
+var _ tasks.AuditableTask = (*DeleteTemplateTask)(nil)
+
+func (DeleteTemplateTask) Action(w http.ResponseWriter, r *http.Request) any {
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	name := r.PostFormValue("name")
+	q := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	if err := q.DeleteTemplateOverride(r.Context(), name); err != nil {
+		return fmt.Errorf("db delete template fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+		if evt := cd.Event(); evt != nil {
+			if evt.Data == nil {
+				evt.Data = map[string]any{}
+			}
+			evt.Data["Template"] = name
+		}
+	}
+	return handlers.RefreshDirectHandler{TargetURL: "/admin/email/template?name=" + name}
+}
+
+func (DeleteTemplateTask) AuditRecord(data map[string]any) string {
+	if t, ok := data["Template"].(string); ok {
+		return "deleted template override " + t
+	}
+	return "deleted template override"
+}

--- a/handlers/admin/save_template_task.go
+++ b/handlers/admin/save_template_task.go
@@ -25,9 +25,10 @@ func (SaveTemplateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err := r.ParseForm(); err != nil {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
+	name := r.PostFormValue("name")
 	body := r.PostFormValue("body")
 	q := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	if err := q.SetTemplateOverride(r.Context(), db.SetTemplateOverrideParams{Name: "updateEmail", Body: body}); err != nil {
+	if err := q.SetTemplateOverride(r.Context(), db.SetTemplateOverrideParams{Name: name, Body: body}); err != nil {
 		return fmt.Errorf("db save template fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
@@ -35,10 +36,10 @@ func (SaveTemplateTask) Action(w http.ResponseWriter, r *http.Request) any {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data["Template"] = "updateEmail"
+			evt.Data["Template"] = name
 		}
 	}
-	return handlers.RefreshDirectHandler{TargetURL: "/admin/email/template"}
+	return handlers.RefreshDirectHandler{TargetURL: "/admin/email/template?name=" + name}
 }
 
 // AuditRecord summarises saving the update email template.

--- a/handlers/admin/tasks_register.go
+++ b/handlers/admin/tasks_register.go
@@ -10,6 +10,7 @@ func RegisterTasks() []tasks.NamedTask {
 		resendQueueTask,
 		deleteQueueTask,
 		saveTemplateTask,
+		deleteTemplateTask,
 		testTemplateTask,
 		deleteDLQTask,
 		markReadTask,

--- a/handlers/admin/test_template_task.go
+++ b/handlers/admin/test_template_task.go
@@ -16,6 +16,8 @@ import (
 	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/internal/tasks"
 
+	notif "github.com/arran4/goa4web/internal/notifications"
+
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
@@ -52,7 +54,7 @@ func (TestTemplateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	pageURL := base + r.URL.Path
 
 	var buf bytes.Buffer
-	tmpl, err := template.New("email").Parse(getUpdateEmailText(r.Context()))
+	tmpl, err := template.New("email").Parse(notif.GetUpdateEmailText(r.Context(), queries))
 	if err != nil {
 		return fmt.Errorf("parse template fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/internal/db/queries-stats.sql
+++ b/internal/db/queries-stats.sql
@@ -58,6 +58,9 @@ INSERT INTO template_overrides (name, body)
 VALUES (?, ?)
 ON DUPLICATE KEY UPDATE body = VALUES(body);
 
+-- name: DeleteTemplateOverride :exec
+DELETE FROM template_overrides WHERE name = ?;
+
 -- name: ListUserInfo :many
 SELECT u.idusers, u.username,
        (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,

--- a/internal/db/queries-stats.sql.go
+++ b/internal/db/queries-stats.sql.go
@@ -24,6 +24,15 @@ func (q *Queries) CountThreadsByBoard(ctx context.Context, imageboardIdimageboar
 	return count, err
 }
 
+const deleteTemplateOverride = `-- name: DeleteTemplateOverride :exec
+DELETE FROM template_overrides WHERE name = ?
+`
+
+func (q *Queries) DeleteTemplateOverride(ctx context.Context, name string) error {
+	_, err := q.db.ExecContext(ctx, deleteTemplateOverride, name)
+	return err
+}
+
 const forumCategoryThreadCounts = `-- name: ForumCategoryThreadCounts :many
 SELECT c.title, COUNT(th.idforumthread) AS count
 FROM forumcategory c

--- a/internal/db/template_override_test.go
+++ b/internal/db/template_override_test.go
@@ -30,6 +30,11 @@ func TestTemplateOverride(t *testing.T) {
 		t.Fatalf("got %q", body)
 	}
 
+	mock.ExpectExec("DELETE FROM template_overrides").WithArgs("t").WillReturnResult(sqlmock.NewResult(1, 1))
+	if err := q.DeleteTemplateOverride(context.Background(), "t"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expect: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add ability to delete template overrides
- allow saving overrides for arbitrary templates
- expose CLI template registry via admin page
- add admin templates list and edit pages
- update SQL to include DeleteTemplateOverride

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: TestLinkerApproveAddsToSearch)*

------
https://chatgpt.com/codex/tasks/task_e_68818e5f4210832fbf4a5a80625a8eea