### PR TITLE
Update admin notifications with usernames

### DIFF
--- a/core/templates/site/admin/notificationsPage.gohtml
+++ b/core/templates/site/admin/notificationsPage.gohtml
@@ -22,7 +22,7 @@
     <tr>
         <td><input type="checkbox" name="id" value="{{ .ID }}"></td>
         <td>{{ .ID }}</td>
-        <td>{{ .UsersIdusers }}</td>
+        <td>{{ with $name := index $.Usernames .UsersIdusers }}<a href="/admin/user/{{ .UsersIdusers }}">{{ $name }}</a>{{ else }}{{ .UsersIdusers }}{{ end }}</td>
         <td>{{ .Message.String }}</td>
         <td>{{ .Link.String }}</td>
         <td>{{ if .ReadAt.Valid }}yes{{ else }}no{{ end }}</td>

--- a/handlers/admin/adminNotificationsPage.go
+++ b/handlers/admin/adminNotificationsPage.go
@@ -18,6 +18,7 @@ func AdminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		Total         int
 		Unread        int
 		Roles         []*db.Role
+		Usernames     map[int32]string
 	}
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
@@ -33,6 +34,22 @@ func AdminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		log.Printf("recent notifications: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
+	}
+	ids := make([]int32, 0, len(items))
+	seen := map[int32]struct{}{}
+	for _, n := range items {
+		if _, ok := seen[n.UsersIdusers]; !ok {
+			seen[n.UsersIdusers] = struct{}{}
+			ids = append(ids, n.UsersIdusers)
+		}
+	}
+	data.Usernames = map[int32]string{}
+	if rows, err := queries.UsersByID(r.Context(), ids); err == nil {
+		for _, r := range rows {
+			if r.Username.Valid {
+				data.Usernames[r.Idusers] = r.Username.String
+			}
+		}
 	}
 	unread := 0
 	for _, n := range items {


### PR DESCRIPTION
## Summary
- fetch usernames for notifications in admin handler
- display username as link to user profile in admin notifications

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68818dc8914c832f882f3e9bd250cb93