### PR TITLE
Fix usage stats page loading time

### DIFF
--- a/core/templates/site/admin/usageStatsPage.gohtml
+++ b/core/templates/site/admin/usageStatsPage.gohtml
@@ -1,4 +1,12 @@
 {{ template "head" $ }}
+{{- if $.Errors }}
+    Errors occurred:
+    <ul>
+    {{- range $.Errors }}
+        <li>{{ . }}</li>
+    {{- end }}
+    </ul>
+{{- end }}
 <h2>Usage Statistics</h2>
 
 <h3>Threads per Forum Topic</h3>


### PR DESCRIPTION
## Summary
- run usage statistic queries concurrently
- log query errors and show them on the usage statistics page

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68818f29683c832fa5f316655548f151