### PR TITLE
Enable websockets by default

### DIFF
--- a/cmd/goa4web/modules_websocket.go
+++ b/cmd/goa4web/modules_websocket.go
@@ -1,5 +1,3 @@
-//go:build websocket
-
 package main
 
 import (

--- a/internal/websocket/notifications_stub.go
+++ b/internal/websocket/notifications_stub.go
@@ -1,8 +1,0 @@
-//go:build !websocket
-
-package websocket
-
-import "github.com/arran4/goa4web/internal/eventbus"
-
-// SetBus is a no-op when websocket build tags are disabled.
-func SetBus(_ *eventbus.Bus) {}

--- a/internal/websocket/static.go
+++ b/internal/websocket/static.go
@@ -1,5 +1,3 @@
-//go:build websocket
-
 package websocket
 
 import (

--- a/readme.md
+++ b/readme.md
@@ -445,11 +445,10 @@ docker compose -f examples/docker-compose.yaml up
 
 ## Flutter Client Notifications
 
-When built with the `websocket` build tag the server exposes a WebSocket
-endpoint at `/ws/notifications`. Clients must include the normal session
-cookie when connecting. Events published on the server's event bus are sent
-in JSON format only when the connected user is subscribed to the matching
-event pattern.
+The server exposes a WebSocket endpoint at `/ws/notifications`.
+Clients must include the normal session cookie when connecting.
+Events published on the server's event bus are sent in JSON format only
+when the connected user is subscribed to the matching event pattern.
 
 Example Dart usage:
 ```dart


### PR DESCRIPTION
## Summary
- remove `websocket` build constraint and stub implementations
- update notification websocket code to work without build tags
- document that websocket endpoint is always available

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68818da19dc4832f9e11df0d74d3f884