### PR TITLE
Move site settings to config

### DIFF
--- a/core/language/language.go
+++ b/core/language/language.go
@@ -47,3 +47,23 @@ func ResolveDefaultLanguageID(ctx context.Context, q *db.Queries, name string) i
 	}
 	return id
 }
+
+// EnsureDefaultLanguage creates the default language when name is not empty and
+// the languages table currently has no entries.
+func EnsureDefaultLanguage(ctx context.Context, q *db.Queries, name string) error {
+	if name == "" {
+		return nil
+	}
+	count, err := q.CountLanguages(ctx)
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+	if err := validateLanguageName(name); err != nil {
+		return err
+	}
+	_, err = q.InsertLanguage(ctx, sql.NullString{String: name, Valid: true})
+	return err
+}

--- a/core/templates/site/admin/siteSettingsPage.gohtml
+++ b/core/templates/site/admin/siteSettingsPage.gohtml
@@ -1,19 +1,26 @@
 {{ template "head" $ }}
-<form method="post">
-        {{ csrfField }}
-    <label>
-        <input type="checkbox" name="feeds_enabled" value="1"{{ if $.FeedsEnabled }} checked{{ end }}>
-        Enable Feeds
-    </label>
-    <br>
-    Default language:
-    <select name="default_language">
-        <option value="0">Multi-lingual
-        {{ range $.Languages }}
-            <option value="{{ .Idlanguage }}"{{ if eq .Idlanguage $.SelectedLanguageId }} selected{{ end }}>{{ .Nameof.String }}
-        {{ end }}
-    </select>
-    <br>
-    <input type="submit" value="Save">
-</form>
+<p>Configuration values resolved at startup.</p>
+<p>Config file: {{ .ConfigFile }}</p>
+<table border="1">
+    <tr>
+        <th>Env</th>
+        <th>Flag</th>
+        <th>Value</th>
+        <th>Default</th>
+        <th>Source</th>
+        <th>Description</th>
+        <th>Example</th>
+    </tr>
+    {{- range .Config }}
+        <tr>
+            <td>{{ .Env }}</td>
+            <td>{{ .Flag }}</td>
+            <td>{{ .Value }}</td>
+            <td>{{ .Default }}</td>
+            <td>{{ .Source }}</td>
+            <td>{{ .Usage }}</td>
+            <td>{{- if .Example }}{{ index .Example 0 }}{{ end }}</td>
+        </tr>
+    {{- end }}
+</table>
 {{ template "tail" $ }}

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -84,9 +84,9 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 	bus.Shutdown(context.Background())
 	cancel()
 	// Wait for the worker goroutine to exit before verifying expectations.
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 	err = nil
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		err = mock.ExpectationsWereMet()
 		if err == nil {
 			break

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -63,7 +63,11 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 	}
 
 	dbPool := dbstart.GetDBPool()
-	if err := corelanguage.ValidateDefaultLanguage(context.Background(), dbpkg.New(dbPool), cfg.DefaultLanguage); err != nil {
+	queries := dbpkg.New(dbPool)
+	if err := corelanguage.EnsureDefaultLanguage(context.Background(), queries, cfg.DefaultLanguage); err != nil {
+		return fmt.Errorf("ensure default language: %w", err)
+	}
+	if err := corelanguage.ValidateDefaultLanguage(context.Background(), queries, cfg.DefaultLanguage); err != nil {
 		return fmt.Errorf("default language: %w", err)
 	}
 

--- a/internal/db/queries-languages.sql
+++ b/internal/db/queries-languages.sql
@@ -35,3 +35,6 @@ SELECT * FROM language;
 -- name: GetLanguageIDByName :one
 SELECT idlanguage FROM language WHERE nameof = ?;
 
+
+-- name: CountLanguages :one
+SELECT COUNT(*) FROM language;

--- a/internal/db/queries-languages.sql.go
+++ b/internal/db/queries-languages.sql.go
@@ -37,6 +37,17 @@ func (q *Queries) AllLanguages(ctx context.Context) ([]*Language, error) {
 	return items, nil
 }
 
+const countLanguages = `-- name: CountLanguages :one
+SELECT COUNT(*) FROM language
+`
+
+func (q *Queries) CountLanguages(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countLanguages)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createLanguage = `-- name: CreateLanguage :exec
 INSERT INTO language (nameof)
 VALUES (?)


### PR DESCRIPTION
## Summary
- load default language from config on startup
- show all runtime config values on the site settings page
- create default language when no languages exist
- stabilize linker test timing
- add details to admin settings page

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68818eee0fc4832f958c89d8ff4ad135