### PR TITLE
Add Select All to admin notifications

### DIFF
--- a/core/templates/site/admin/notificationsPage.gohtml
+++ b/core/templates/site/admin/notificationsPage.gohtml
@@ -17,7 +17,9 @@
 <form method="post">
     {{ csrfField }}
 <table border="1">
-    <tr><th>Select</th><th>ID</th><th>User</th><th>Message</th><th>Link</th><th>Read</th></tr>
+    <tr><th><label><input type="checkbox" id="select-all"> All</label>
+        <button type="button" id="select-none">None</button>
+        <button type="button" id="select-invert">Invert</button></th><th>ID</th><th>User</th><th>Message</th><th>Link</th><th>Read</th></tr>
     {{- range .Notifications }}
     <tr>
         <td><input type="checkbox" name="id" value="{{ .ID }}"></td>
@@ -30,6 +32,52 @@
     {{- end }}
 </table>
 <input type="submit" name="task" value="Dismiss">
-<input type="submit" name="task" value="Purge">
+<input type="submit" name="task" value="Mark unread">
+<input type="submit" name="task" value="Delete notification">
+<button type="submit" name="task" value="Purge">Purge read notifications</button>
 </form>
+<script>
+(() => {
+    const selectAll = document.getElementById('select-all');
+    const selectNone = document.getElementById('select-none');
+    const selectInvert = document.getElementById('select-invert');
+    const boxes = Array.from(document.querySelectorAll('input[type="checkbox"][name="id"]'));
+    let last;
+
+    function updateAll() {
+        selectAll.checked = boxes.every(cb => cb.checked);
+    }
+
+    selectAll.addEventListener('change', () => {
+        boxes.forEach(cb => { cb.checked = selectAll.checked; });
+        updateAll();
+    });
+
+    selectNone.addEventListener('click', () => {
+        boxes.forEach(cb => { cb.checked = false; });
+        updateAll();
+    });
+
+    selectInvert.addEventListener('click', () => {
+        boxes.forEach(cb => { cb.checked = !cb.checked; });
+        updateAll();
+    });
+
+    boxes.forEach(cb => {
+        cb.addEventListener('click', e => {
+            if (last && e.shiftKey) {
+                const start = boxes.indexOf(last);
+                const end = boxes.indexOf(cb);
+                const [s, eIdx] = start < end ? [start, end] : [end, start];
+                for (let i = s; i <= eIdx; i++) {
+                    boxes[i].checked = cb.checked;
+                }
+            }
+            last = cb;
+            updateAll();
+        });
+        cb.addEventListener('change', updateAll);
+    });
+})();
+</script>
 {{ template "tail" $ }}

--- a/handlers/admin/delete_notification_task.go
+++ b/handlers/admin/delete_notification_task.go
@@ -1,0 +1,49 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// DeleteNotificationTask deletes notifications entirely.
+type DeleteNotificationTask struct{ tasks.TaskString }
+
+var deleteNotificationTask = &DeleteNotificationTask{TaskString: TaskDeleteNotification}
+
+var _ tasks.Task = (*DeleteNotificationTask)(nil)
+var _ tasks.AuditableTask = (*DeleteNotificationTask)(nil)
+
+func (DeleteNotificationTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	for _, idStr := range r.Form["id"] {
+		id, _ := strconv.Atoi(idStr)
+		if err := queries.DeleteNotification(r.Context(), int32(id)); err != nil {
+			return fmt.Errorf("delete notification fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+			if evt := cd.Event(); evt != nil {
+				if evt.Data == nil {
+					evt.Data = map[string]any{}
+				}
+				evt.Data["DeletedID"] = appendID(evt.Data["DeletedID"], id)
+			}
+		}
+	}
+	return nil
+}
+
+func (DeleteNotificationTask) AuditRecord(data map[string]any) string {
+	if ids, ok := data["DeletedID"].(string); ok {
+		return "deleted notifications " + ids
+	}
+	return "deleted notifications"
+}

--- a/handlers/admin/mark_unread_task.go
+++ b/handlers/admin/mark_unread_task.go
@@ -1,0 +1,49 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// MarkUnreadTask marks notifications as unread.
+type MarkUnreadTask struct{ tasks.TaskString }
+
+var markUnreadTask = &MarkUnreadTask{TaskString: TaskMarkUnread}
+
+var _ tasks.Task = (*MarkUnreadTask)(nil)
+var _ tasks.AuditableTask = (*MarkUnreadTask)(nil)
+
+func (MarkUnreadTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	for _, idStr := range r.Form["id"] {
+		id, _ := strconv.Atoi(idStr)
+		if err := queries.MarkNotificationUnread(r.Context(), int32(id)); err != nil {
+			return fmt.Errorf("mark unread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+			if evt := cd.Event(); evt != nil {
+				if evt.Data == nil {
+					evt.Data = map[string]any{}
+				}
+				evt.Data["MarkedID"] = appendID(evt.Data["MarkedID"], id)
+			}
+		}
+	}
+	return nil
+}
+
+func (MarkUnreadTask) AuditRecord(data map[string]any) string {
+	if ids, ok := data["MarkedID"].(string); ok {
+		return "marked notifications " + ids + " unread"
+	}
+	return "marked notifications unread"
+}

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -44,6 +44,8 @@ func RegisterRoutes(ar *mux.Router) {
 	ar.HandleFunc("/dlq", handlers.TaskHandler(deleteDLQTask)).Methods("POST").MatcherFunc(deleteDLQTask.Matcher())
 	ar.HandleFunc("/notifications", AdminNotificationsPage).Methods("GET")
 	ar.HandleFunc("/notifications", handlers.TaskHandler(markReadTask)).Methods("POST").MatcherFunc(markReadTask.Matcher())
+	ar.HandleFunc("/notifications", handlers.TaskHandler(markUnreadTask)).Methods("POST").MatcherFunc(markUnreadTask.Matcher())
+	ar.HandleFunc("/notifications", handlers.TaskHandler(deleteNotificationTask)).Methods("POST").MatcherFunc(deleteNotificationTask.Matcher())
 	ar.HandleFunc("/notifications", handlers.TaskHandler(purgeNotificationsTask)).Methods("POST").MatcherFunc(purgeNotificationsTask.Matcher())
 	ar.HandleFunc("/notifications", handlers.TaskHandler(sendNotificationTask)).Methods("POST").MatcherFunc(sendNotificationTask.Matcher())
 	ar.HandleFunc("/requests", AdminRequestQueuePage).Methods("GET")

--- a/handlers/admin/tasks.go
+++ b/handlers/admin/tasks.go
@@ -200,6 +200,12 @@ const (
 	// TaskDismiss marks a notification as read.
 	TaskDismiss tasks.TaskString = "Dismiss"
 
+	// TaskMarkUnread marks a notification as unread.
+	TaskMarkUnread tasks.TaskString = "Mark unread"
+
+	// TaskDeleteNotification deletes selected notifications.
+	TaskDeleteNotification tasks.TaskString = "Delete notification"
+
 	// TaskUpdate updates an existing item.
 	TaskUpdate tasks.TaskString = "Update"
 

--- a/handlers/admin/tasks_register.go
+++ b/handlers/admin/tasks_register.go
@@ -13,6 +13,8 @@ func RegisterTasks() []tasks.NamedTask {
 		testTemplateTask,
 		deleteDLQTask,
 		markReadTask,
+		markUnreadTask,
+		deleteNotificationTask,
 		purgeNotificationsTask,
 		sendNotificationTask,
 		addIPBanTask,

--- a/internal/db/queries-notifications.sql
+++ b/internal/db/queries-notifications.sql
@@ -15,6 +15,12 @@ ORDER BY id DESC;
 -- name: MarkNotificationRead :exec
 UPDATE notifications SET read_at = NOW() WHERE id = ?;
 
+-- name: MarkNotificationUnread :exec
+UPDATE notifications SET read_at = NULL WHERE id = ?;
+
+-- name: DeleteNotification :exec
+DELETE FROM notifications WHERE id = ?;
+
 -- name: PurgeReadNotifications :exec
 DELETE FROM notifications
 WHERE read_at IS NOT NULL AND read_at < (NOW() - INTERVAL 24 HOUR);

--- a/internal/db/queries-notifications.sql.go
+++ b/internal/db/queries-notifications.sql.go
@@ -22,6 +22,15 @@ func (q *Queries) CountUnreadNotifications(ctx context.Context, usersIdusers int
 	return count, err
 }
 
+const deleteNotification = `-- name: DeleteNotification :exec
+DELETE FROM notifications WHERE id = ?
+`
+
+func (q *Queries) DeleteNotification(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, deleteNotification, id)
+	return err
+}
+
 const getUnreadNotifications = `-- name: GetUnreadNotifications :many
 SELECT id, users_idusers, link, message, created_at, read_at
 FROM notifications
@@ -107,6 +116,15 @@ UPDATE notifications SET read_at = NOW() WHERE id = ?
 
 func (q *Queries) MarkNotificationRead(ctx context.Context, id int32) error {
 	_, err := q.db.ExecContext(ctx, markNotificationRead, id)
+	return err
+}
+
+const markNotificationUnread = `-- name: MarkNotificationUnread :exec
+UPDATE notifications SET read_at = NULL WHERE id = ?
+`
+
+func (q *Queries) MarkNotificationUnread(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, markNotificationUnread, id)
 	return err
 }
 


### PR DESCRIPTION
## Summary
- add a checkbox to select all notifications
- auto-toggle all checkboxes using JS
- add mark unread and delete notification actions
- support shift-click range selection
- add select none and invert selection buttons
- rename purge button to clarify it affects read notifications only

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68818d5f6bac832f981f6ec0b5173f8f