### PR TITLE
Fix search reindex tasks

### DIFF
--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -5,7 +5,7 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
-	ExpectedSchemaVersion = 47
+	ExpectedSchemaVersion = 48
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -57,9 +57,9 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 	mock.ExpectQuery("SELECT l.idlinker").WithArgs(int32(0), int32(1), sqlmock.AnyArg()).WillReturnRows(rows)
 
 	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").WithArgs("foo").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("INSERT IGNORE INTO linker_search").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO linker_search").WithArgs(int32(1), int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").WithArgs("bar").WillReturnResult(sqlmock.NewResult(2, 1))
-	mock.ExpectExec("INSERT IGNORE INTO linker_search").WithArgs(int32(1), int32(2)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO linker_search").WithArgs(int32(1), int32(2), int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("UPDATE linker SET last_index").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	bus := eventbus.NewBus()

--- a/handlers/search/reindex.go
+++ b/handlers/search/reindex.go
@@ -1,0 +1,26 @@
+package search
+
+import (
+	"context"
+	"strings"
+
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/workers/searchworker"
+)
+
+func indexText(ctx context.Context, q *db.Queries, text string, add func(context.Context, int64, int32) error) error {
+	counts := map[string]int32{}
+	for _, w := range searchworker.BreakupTextToWords(text) {
+		counts[strings.ToLower(w)]++
+	}
+	for w, c := range counts {
+		id, err := q.CreateSearchWord(ctx, w)
+		if err != nil {
+			return err
+		}
+		if err := add(ctx, id, c); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/handlers/search/remakeBlogTask.go
+++ b/handlers/search/remakeBlogTask.go
@@ -1,13 +1,16 @@
 package search
 
 import (
+	"context"
 	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"net/http"
+	"strings"
 
 	"github.com/arran4/goa4web/core/common"
 
 	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -28,11 +31,35 @@ func (RemakeBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/admin/search",
 	}
-	if err := queries.DeleteBlogsSearch(r.Context()); err != nil {
+	ctx := r.Context()
+	if err := queries.DeleteBlogsSearch(ctx); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("DeleteBlogsSearch: %w", err).Error())
 	}
-	if err := queries.RemakeBlogsSearchInsert(r.Context()); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("RemakeBlogsSearchInsert: %w", err).Error())
+
+	rows, err := queries.GetAllBlogsForIndex(ctx)
+	if err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("GetAllBlogsForIndex: %w", err).Error())
+	} else {
+		for _, row := range rows {
+			text := strings.TrimSpace(row.Blog.String)
+			if text == "" {
+				continue
+			}
+			err := indexText(ctx, queries, text, func(c context.Context, wid int64, count int32) error {
+				return queries.AddToBlogsSearch(c, db.AddToBlogsSearchParams{
+					BlogID:                         row.Idblogs,
+					SearchwordlistIdsearchwordlist: int32(wid),
+					WordCount:                      count,
+				})
+			})
+			if err != nil {
+				data.Errors = append(data.Errors, fmt.Errorf("index blog %d: %w", row.Idblogs, err).Error())
+				continue
+			}
+			if err := queries.SetBlogLastIndex(ctx, row.Idblogs); err != nil {
+				data.Errors = append(data.Errors, fmt.Errorf("SetBlogLastIndex %d: %w", row.Idblogs, err).Error())
+			}
+		}
 	}
 
 	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)

--- a/handlers/search/remakeCommentsTask.go
+++ b/handlers/search/remakeCommentsTask.go
@@ -1,13 +1,16 @@
 package search
 
 import (
+	"context"
 	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"net/http"
+	"strings"
 
 	"github.com/arran4/goa4web/core/common"
 
 	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -28,11 +31,35 @@ func (RemakeCommentsTask) Action(w http.ResponseWriter, r *http.Request) any {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/admin/search",
 	}
-	if err := queries.DeleteCommentsSearch(r.Context()); err != nil {
+	ctx := r.Context()
+	if err := queries.DeleteCommentsSearch(ctx); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("DeleteCommentsSearch: %w", err).Error())
 	}
-	if err := queries.RemakeCommentsSearchInsert(r.Context()); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("RemakeCommentsSearchInsert: %w", err).Error())
+
+	rows, err := queries.GetAllCommentsForIndex(ctx)
+	if err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("GetAllCommentsForIndex: %w", err).Error())
+	} else {
+		for _, row := range rows {
+			text := strings.TrimSpace(row.Text.String)
+			if text == "" {
+				continue
+			}
+			err := indexText(ctx, queries, text, func(c context.Context, wid int64, count int32) error {
+				return queries.AddToForumCommentSearch(c, db.AddToForumCommentSearchParams{
+					CommentID:                      row.Idcomments,
+					SearchwordlistIdsearchwordlist: int32(wid),
+					WordCount:                      count,
+				})
+			})
+			if err != nil {
+				data.Errors = append(data.Errors, fmt.Errorf("index comment %d: %w", row.Idcomments, err).Error())
+				continue
+			}
+			if err := queries.SetCommentLastIndex(ctx, row.Idcomments); err != nil {
+				data.Errors = append(data.Errors, fmt.Errorf("SetCommentLastIndex %d: %w", row.Idcomments, err).Error())
+			}
+		}
 	}
 
 	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)

--- a/handlers/search/remakeImageTask.go
+++ b/handlers/search/remakeImageTask.go
@@ -1,13 +1,16 @@
 package search
 
 import (
+	"context"
 	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"net/http"
+	"strings"
 
 	"github.com/arran4/goa4web/core/common"
 
 	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -28,11 +31,35 @@ func (RemakeImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/admin/search",
 	}
-	if err := queries.DeleteImagePostSearch(r.Context()); err != nil {
+	ctx := r.Context()
+	if err := queries.DeleteImagePostSearch(ctx); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("DeleteImagePostSearch: %w", err).Error())
 	}
-	if err := queries.RemakeImagePostSearchInsert(r.Context()); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("RemakeImagePostSearchInsert: %w", err).Error())
+
+	rows, err := queries.GetAllImagePostsForIndex(ctx)
+	if err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("GetAllImagePostsForIndex: %w", err).Error())
+	} else {
+		for _, row := range rows {
+			text := strings.TrimSpace(row.Description.String)
+			if text == "" {
+				continue
+			}
+			err := indexText(ctx, queries, text, func(c context.Context, wid int64, count int32) error {
+				return queries.AddToImagePostSearch(c, db.AddToImagePostSearchParams{
+					ImagePostID:                    row.Idimagepost,
+					SearchwordlistIdsearchwordlist: int32(wid),
+					WordCount:                      count,
+				})
+			})
+			if err != nil {
+				data.Errors = append(data.Errors, fmt.Errorf("index image %d: %w", row.Idimagepost, err).Error())
+				continue
+			}
+			if err := queries.SetImagePostLastIndex(ctx, row.Idimagepost); err != nil {
+				data.Errors = append(data.Errors, fmt.Errorf("SetImagePostLastIndex %d: %w", row.Idimagepost, err).Error())
+			}
+		}
 	}
 
 	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)

--- a/handlers/search/remakeLinkerTask.go
+++ b/handlers/search/remakeLinkerTask.go
@@ -1,13 +1,16 @@
 package search
 
 import (
+	"context"
 	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"net/http"
+	"strings"
 
 	"github.com/arran4/goa4web/core/common"
 
 	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -28,11 +31,35 @@ func (RemakeLinkerTask) Action(w http.ResponseWriter, r *http.Request) any {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/admin/search",
 	}
-	if err := queries.DeleteLinkerSearch(r.Context()); err != nil {
+	ctx := r.Context()
+	if err := queries.DeleteLinkerSearch(ctx); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("DeleteLinkerSearch: %w", err).Error())
 	}
-	if err := queries.RemakeLinkerSearchInsert(r.Context()); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("RemakeLinkerSearchInsert: %w", err).Error())
+
+	rows, err := queries.GetAllLinkersForIndex(ctx)
+	if err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("GetAllLinkersForIndex: %w", err).Error())
+	} else {
+		for _, row := range rows {
+			text := strings.TrimSpace(row.Title.String + " " + row.Description.String)
+			if text == "" {
+				continue
+			}
+			err := indexText(ctx, queries, text, func(c context.Context, wid int64, count int32) error {
+				return queries.AddToLinkerSearch(c, db.AddToLinkerSearchParams{
+					LinkerID:                       row.Idlinker,
+					SearchwordlistIdsearchwordlist: int32(wid),
+					WordCount:                      count,
+				})
+			})
+			if err != nil {
+				data.Errors = append(data.Errors, fmt.Errorf("index linker %d: %w", row.Idlinker, err).Error())
+				continue
+			}
+			if err := queries.SetLinkerLastIndex(ctx, row.Idlinker); err != nil {
+				data.Errors = append(data.Errors, fmt.Errorf("SetLinkerLastIndex %d: %w", row.Idlinker, err).Error())
+			}
+		}
 	}
 
 	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)

--- a/handlers/search/remakeNewsTask.go
+++ b/handlers/search/remakeNewsTask.go
@@ -1,13 +1,16 @@
 package search
 
 import (
+	"context"
 	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"net/http"
+	"strings"
 
 	"github.com/arran4/goa4web/core/common"
 
 	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -28,11 +31,35 @@ func (RemakeNewsTask) Action(w http.ResponseWriter, r *http.Request) any {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/admin/search",
 	}
-	if err := queries.DeleteSiteNewsSearch(r.Context()); err != nil {
+	ctx := r.Context()
+	if err := queries.DeleteSiteNewsSearch(ctx); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("DeleteSiteNewsSearch: %w", err).Error())
 	}
-	if err := queries.RemakeNewsSearchInsert(r.Context()); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("RemakeNewsSearchInsert: %w", err).Error())
+
+	rows, err := queries.GetAllSiteNewsForIndex(ctx)
+	if err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("GetAllSiteNewsForIndex: %w", err).Error())
+	} else {
+		for _, row := range rows {
+			text := strings.TrimSpace(row.News.String)
+			if text == "" {
+				continue
+			}
+			err := indexText(ctx, queries, text, func(c context.Context, wid int64, count int32) error {
+				return queries.AddToSiteNewsSearch(c, db.AddToSiteNewsSearchParams{
+					SiteNewsID:                     row.Idsitenews,
+					SearchwordlistIdsearchwordlist: int32(wid),
+					WordCount:                      count,
+				})
+			})
+			if err != nil {
+				data.Errors = append(data.Errors, fmt.Errorf("index site news %d: %w", row.Idsitenews, err).Error())
+				continue
+			}
+			if err := queries.SetSiteNewsLastIndex(ctx, row.Idsitenews); err != nil {
+				data.Errors = append(data.Errors, fmt.Errorf("SetSiteNewsLastIndex %d: %w", row.Idsitenews, err).Error())
+			}
+		}
 	}
 
 	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -69,6 +69,7 @@ type Blog struct {
 type BlogsSearch struct {
 	BlogID                         int32
 	SearchwordlistIdsearchwordlist int32
+	WordCount                      int32
 }
 
 type Bookmark struct {
@@ -91,6 +92,7 @@ type Comment struct {
 type CommentsSearch struct {
 	SearchwordlistIdsearchwordlist int32
 	CommentID                      int32
+	WordCount                      int32
 }
 
 type DeactivatedBlog struct {
@@ -259,6 +261,7 @@ type Imagepost struct {
 type ImagepostSearch struct {
 	ImagePostID                    int32
 	SearchwordlistIdsearchwordlist int32
+	WordCount                      int32
 }
 
 type Language struct {
@@ -300,6 +303,7 @@ type LinkerQueue struct {
 type LinkerSearch struct {
 	SearchwordlistIdsearchwordlist int32
 	LinkerID                       int32
+	WordCount                      int32
 }
 
 type LoginAttempt struct {
@@ -402,6 +406,7 @@ type SiteNews struct {
 type SiteNewsSearch struct {
 	SiteNewsID                     int32
 	SearchwordlistIdsearchwordlist int32
+	WordCount                      int32
 }
 
 type Subscription struct {
@@ -481,4 +486,5 @@ type WritingCategory struct {
 type WritingSearch struct {
 	SearchwordlistIdsearchwordlist int32
 	WritingID                      int32
+	WordCount                      int32
 }

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -155,3 +155,7 @@ LIMIT ? OFFSET ?;
 -- name: SetBlogLastIndex :exec
 UPDATE blogs SET last_index = NOW() WHERE idblogs = ?;
 
+
+-- name: GetAllBlogsForIndex :many
+SELECT idblogs, blog FROM blogs WHERE deleted_at IS NULL;
+

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -176,6 +176,38 @@ func (q *Queries) GetAllBlogEntriesByUser(ctx context.Context, usersIdusers int3
 	return items, nil
 }
 
+const getAllBlogsForIndex = `-- name: GetAllBlogsForIndex :many
+SELECT idblogs, blog FROM blogs WHERE deleted_at IS NULL
+`
+
+type GetAllBlogsForIndexRow struct {
+	Idblogs int32
+	Blog    sql.NullString
+}
+
+func (q *Queries) GetAllBlogsForIndex(ctx context.Context) ([]*GetAllBlogsForIndexRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllBlogsForIndex)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetAllBlogsForIndexRow
+	for rows.Next() {
+		var i GetAllBlogsForIndexRow
+		if err := rows.Scan(&i.Idblogs, &i.Blog); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getBlogEntriesByIdsDescending = `-- name: GetBlogEntriesByIdsDescending :many
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written
 FROM blogs b

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -114,3 +114,7 @@ ORDER BY c.written;
 -- name: SetCommentLastIndex :exec
 UPDATE comments SET last_index = NOW() WHERE idcomments = ?;
 
+
+-- name: GetAllCommentsForIndex :many
+SELECT idcomments, text FROM comments WHERE deleted_at IS NULL;
+

--- a/internal/db/queries-comments.sql.go
+++ b/internal/db/queries-comments.sql.go
@@ -89,6 +89,38 @@ func (q *Queries) GetAllCommentsByUser(ctx context.Context, usersIdusers int32) 
 	return items, nil
 }
 
+const getAllCommentsForIndex = `-- name: GetAllCommentsForIndex :many
+SELECT idcomments, text FROM comments WHERE deleted_at IS NULL
+`
+
+type GetAllCommentsForIndexRow struct {
+	Idcomments int32
+	Text       sql.NullString
+}
+
+func (q *Queries) GetAllCommentsForIndex(ctx context.Context) ([]*GetAllCommentsForIndexRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllCommentsForIndex)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetAllCommentsForIndexRow
+	for rows.Next() {
+		var i GetAllCommentsForIndexRow
+		if err := rows.Scan(&i.Idcomments, &i.Text); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getCommentById = `-- name: GetCommentById :one
 SELECT c.idcomments, c.forumthread_id, c.users_idusers, c.language_idlanguage, c.written, c.text, c.deleted_at, c.last_index
 FROM comments c

--- a/internal/db/queries-imagebbs.sql
+++ b/internal/db/queries-imagebbs.sql
@@ -192,3 +192,7 @@ LIMIT 1;
 -- name: SetImagePostLastIndex :exec
 UPDATE imagepost SET last_index = NOW() WHERE idimagepost = ?;
 
+
+-- name: GetAllImagePostsForIndex :many
+SELECT idimagepost, description FROM imagepost WHERE deleted_at IS NULL;
+

--- a/internal/db/queries-imagebbs.sql.go
+++ b/internal/db/queries-imagebbs.sql.go
@@ -545,6 +545,38 @@ func (q *Queries) GetAllImagePostsByIdWithAuthorUsernameAndThreadCommentCountFor
 	return &i, err
 }
 
+const getAllImagePostsForIndex = `-- name: GetAllImagePostsForIndex :many
+SELECT idimagepost, description FROM imagepost WHERE deleted_at IS NULL
+`
+
+type GetAllImagePostsForIndexRow struct {
+	Idimagepost int32
+	Description sql.NullString
+}
+
+func (q *Queries) GetAllImagePostsForIndex(ctx context.Context) ([]*GetAllImagePostsForIndexRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllImagePostsForIndex)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetAllImagePostsForIndexRow
+	for rows.Next() {
+		var i GetAllImagePostsForIndexRow
+		if err := rows.Scan(&i.Idimagepost, &i.Description); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getImageBoardById = `-- name: GetImageBoardById :one
 SELECT idimageboard, imageboard_idimageboard, title, description, approval_required FROM imageboard WHERE idimageboard = ?
 `

--- a/internal/db/queries-linker.sql
+++ b/internal/db/queries-linker.sql
@@ -317,3 +317,7 @@ WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercate
   )
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?;
+
+-- name: GetAllLinkersForIndex :many
+SELECT idlinker, title, description FROM linker WHERE deleted_at IS NULL;
+

--- a/internal/db/queries-linker.sql.go
+++ b/internal/db/queries-linker.sql.go
@@ -724,6 +724,39 @@ func (q *Queries) GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails(ctx co
 	return items, nil
 }
 
+const getAllLinkersForIndex = `-- name: GetAllLinkersForIndex :many
+SELECT idlinker, title, description FROM linker WHERE deleted_at IS NULL
+`
+
+type GetAllLinkersForIndexRow struct {
+	Idlinker    int32
+	Title       sql.NullString
+	Description sql.NullString
+}
+
+func (q *Queries) GetAllLinkersForIndex(ctx context.Context) ([]*GetAllLinkersForIndexRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllLinkersForIndex)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetAllLinkersForIndexRow
+	for rows.Next() {
+		var i GetAllLinkersForIndexRow
+		if err := rows.Scan(&i.Idlinker, &i.Title, &i.Description); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getLinkerCategoriesWithCount = `-- name: GetLinkerCategoriesWithCount :many
 SELECT c.idlinkerCategory, c.title, c.sortorder, COUNT(l.idlinker) AS linkcount
 FROM linker_category c

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -123,3 +123,7 @@ LIMIT ? OFFSET ?;
 -- name: SetSiteNewsLastIndex :exec
 UPDATE site_news SET last_index = NOW() WHERE idsiteNews = ?;
 
+
+-- name: GetAllSiteNewsForIndex :many
+SELECT idsiteNews, news FROM site_news WHERE deleted_at IS NULL;
+

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -53,6 +53,38 @@ func (q *Queries) DeactivateNewsPost(ctx context.Context, idsitenews int32) erro
 	return err
 }
 
+const getAllSiteNewsForIndex = `-- name: GetAllSiteNewsForIndex :many
+SELECT idsiteNews, news FROM site_news WHERE deleted_at IS NULL
+`
+
+type GetAllSiteNewsForIndexRow struct {
+	Idsitenews int32
+	News       sql.NullString
+}
+
+func (q *Queries) GetAllSiteNewsForIndex(ctx context.Context) ([]*GetAllSiteNewsForIndexRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllSiteNewsForIndex)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetAllSiteNewsForIndexRow
+	for rows.Next() {
+		var i GetAllSiteNewsForIndexRow
+		if err := rows.Scan(&i.Idsitenews, &i.News); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getForumThreadIdByNewsPostId = `-- name: GetForumThreadIdByNewsPostId :one
 SELECT s.forumthread_id, u.idusers
 FROM site_news s

--- a/internal/db/queries-search.sql
+++ b/internal/db/queries-search.sql
@@ -6,12 +6,12 @@ FROM searchwordlist;
 -- name: WordListWithCounts :many
 -- Show each search word with total usage counts across all search tables.
 SELECT swl.word,
-       (SELECT COUNT(*) FROM comments_search cs WHERE cs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM site_news_search ns WHERE ns.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM blogs_search bs WHERE bs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM linker_search ls WHERE ls.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM writing_search ws WHERE ws.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM imagepost_search ips WHERE ips.searchwordlist_idsearchwordlist=swl.idsearchwordlist) AS count
+       (SELECT IFNULL(SUM(cs.word_count),0) FROM comments_search cs WHERE cs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ns.word_count),0) FROM site_news_search ns WHERE ns.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(bs.word_count),0) FROM blogs_search bs WHERE bs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ls.word_count),0) FROM linker_search ls WHERE ls.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ws.word_count),0) FROM writing_search ws WHERE ws.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ips.word_count),0) FROM imagepost_search ips WHERE ips.searchwordlist_idsearchwordlist=swl.idsearchwordlist) AS count
 FROM searchwordlist swl
 ORDER BY swl.word
 LIMIT ? OFFSET ?;
@@ -27,102 +27,42 @@ WHERE word LIKE CONCAT(sqlc.arg(prefix), '%');
 
 -- name: WordListWithCountsByPrefix :many
 SELECT swl.word,
-       (SELECT COUNT(*) FROM comments_search cs WHERE cs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM site_news_search ns WHERE ns.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM blogs_search bs WHERE bs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM linker_search ls WHERE ls.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM writing_search ws WHERE ws.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM imagepost_search ips WHERE ips.searchwordlist_idsearchwordlist=swl.idsearchwordlist) AS count
+       (SELECT IFNULL(SUM(cs.word_count),0) FROM comments_search cs WHERE cs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ns.word_count),0) FROM site_news_search ns WHERE ns.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(bs.word_count),0) FROM blogs_search bs WHERE bs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ls.word_count),0) FROM linker_search ls WHERE ls.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ws.word_count),0) FROM writing_search ws WHERE ws.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ips.word_count),0) FROM imagepost_search ips WHERE ips.searchwordlist_idsearchwordlist=swl.idsearchwordlist) AS count
 FROM searchwordlist swl
 WHERE swl.word LIKE CONCAT(sqlc.arg(prefix), '%')
 ORDER BY swl.word
 LIMIT ? OFFSET ?;
 
--- name: RemakeCommentsSearch :exec
--- This query selects data from the "comments" table and populates the "comments_search" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "comments_search" using the "comment_id".
-INSERT INTO comments_search (text, comment_id)
-SELECT text, idcomments
-FROM comments;
 
--- name: RemakeNewsSearch :exec
--- This query selects data from the "site_news" table and populates the "site_news_search" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "site_news_search" using the "site_news_id".
-INSERT INTO site_news_search (text, site_news_id)
-SELECT news, idsiteNews
-FROM site_news;
 
--- name: RemakeBlogSearch :exec
--- This query selects data from the "blogs" table and populates the "blogs_search" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "blogs_search" using the "blog_id".
-INSERT INTO blogs_search (text, blog_id)
-SELECT blog, idblogs
-FROM blogs;
 
--- name: RemakeWritingSearch :exec
--- This query selects data from the "writing" table and populates the "writing_search" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "writing_search" using the "writing_id".
-INSERT INTO writing_search (text, writing_id)
-SELECT CONCAT(title, ' ', abstract, ' ', writing), idwriting
-FROM writing;
 
--- name: RemakeLinkerSearch :exec
--- This query selects data from the "linker" table and populates the "linker_search" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "linker_search" using the "linker_id".
-INSERT INTO linker_search (text, linker_id)
-SELECT CONCAT(title, ' ', description), idlinker
-FROM linker;
 
--- name: RemakeCommentsSearchInsert :exec
--- This query selects data from the "comments" table and populates the "comments_search" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "comments_search" using the "comment_id".
-INSERT INTO comments_search (text, comment_id)
-SELECT text, idcomments
-FROM comments;
 
 -- name: DeleteCommentsSearch :exec
 -- This query deletes all data from the "comments_search" table.
 DELETE FROM comments_search;
 
--- name: RemakeNewsSearchInsert :exec
--- This query selects data from the "site_news" table and populates the "site_news_search" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "site_news_search" using the "site_news_id".
-INSERT INTO site_news_search (text, site_news_id)
-SELECT news, idsiteNews
-FROM site_news;
 
 -- name: DeleteSiteNewsSearch :exec
 -- This query deletes all data from the "site_news_search" table.
 DELETE FROM site_news_search;
 
--- name: RemakeBlogsSearchInsert :exec
--- This query selects data from the "blogs" table and populates the "blogs_search" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "blogs_search" using the "blog_id".
-INSERT INTO blogs_search (text, blog_id)
-SELECT blog, idblogs
-FROM blogs;
 
 -- name: DeleteBlogsSearch :exec
 -- This query deletes all data from the "blogs_search" table.
 DELETE FROM blogs_search;
 
--- name: RemakeWritingSearchInsert :exec
--- This query selects data from the "writing" table and populates the "writing_search" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "writing_search" using the "writing_id".
-INSERT INTO writing_search (text, writing_id)
-SELECT CONCAT(title, ' ', abstract, ' ', writing), idwriting
-FROM writing;
 
 -- name: DeleteWritingSearch :exec
 -- This query deletes all data from the "writing_search" table.
 DELETE FROM writing_search;
 
--- name: RemakeLinkerSearchInsert :exec
--- This query selects data from the "linker" table and populates the "linker_search" table with the specified columns.
--- Then, it iterates over the "queue" linked list to add each text and ID pair to the "linker_search" using the "linker_id".
-INSERT INTO linker_search (text, linker_id)
-SELECT CONCAT(title, ' ', description), idlinker
-FROM linker;
 
 -- name: DeleteLinkerSearch :exec
 -- This query deletes all data from the "linker_search" table.
@@ -138,9 +78,10 @@ INSERT IGNORE INTO searchwordlist (word)
 VALUES (lcase(sqlc.arg(word)));
 
 -- name: AddToForumCommentSearch :exec
-INSERT IGNORE INTO comments_search
-(comment_id, searchwordlist_idsearchwordlist)
-VALUES (?, ?);
+INSERT INTO comments_search
+(comment_id, searchwordlist_idsearchwordlist, word_count)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE word_count=VALUES(word_count);
 
 -- name: CommentsSearchFirstNotInRestrictedTopic :many
 SELECT DISTINCT cs.comment_id
@@ -187,14 +128,28 @@ AND fth.forumtopic_idforumtopic IN (sqlc.slice('ftids'))
 ;
 
 -- name: AddToForumWritingSearch :exec
-INSERT IGNORE INTO writing_search
-(writing_id, searchwordlist_idsearchwordlist)
-VALUES (?, ?);
+INSERT INTO writing_search
+(writing_id, searchwordlist_idsearchwordlist, word_count)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE word_count=VALUES(word_count);
 
 -- name: AddToLinkerSearch :exec
-INSERT IGNORE INTO linker_search
-(linker_id, searchwordlist_idsearchwordlist)
-VALUES (?, ?);
+INSERT INTO linker_search
+(linker_id, searchwordlist_idsearchwordlist, word_count)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE word_count=VALUES(word_count);
+-- name: AddToBlogsSearch :exec
+INSERT INTO blogs_search
+(blog_id, searchwordlist_idsearchwordlist, word_count)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE word_count=VALUES(word_count);
+
+-- name: AddToSiteNewsSearch :exec
+INSERT INTO site_news_search
+(site_news_id, searchwordlist_idsearchwordlist, word_count)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE word_count=VALUES(word_count);
+
 
 
 -- name: WritingSearchDelete :exec
@@ -248,17 +203,14 @@ AND cs.linker_id IN (sqlc.slice('ids'))
 ;
 
 -- name: AddToImagePostSearch :exec
-INSERT IGNORE INTO imagepost_search
-(image_post_id, searchwordlist_idsearchwordlist)
-VALUES (?, ?);
+INSERT INTO imagepost_search
+(image_post_id, searchwordlist_idsearchwordlist, word_count)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE word_count=VALUES(word_count);
 
 -- name: DeleteImagePostSearch :exec
 DELETE FROM imagepost_search;
 
--- name: RemakeImagePostSearchInsert :exec
-INSERT INTO imagepost_search (text, image_post_id)
-SELECT description, idimagepost
-FROM imagepost;
 
 -- name: ImagePostSearchFirst :many
 SELECT DISTINCT cs.image_post_id

--- a/internal/db/queries-search.sql.go
+++ b/internal/db/queries-search.sql.go
@@ -11,67 +11,111 @@ import (
 	"strings"
 )
 
+const addToBlogsSearch = `-- name: AddToBlogsSearch :exec
+INSERT INTO blogs_search
+(blog_id, searchwordlist_idsearchwordlist, word_count)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE word_count=VALUES(word_count)
+`
+
+type AddToBlogsSearchParams struct {
+	BlogID                         int32
+	SearchwordlistIdsearchwordlist int32
+	WordCount                      int32
+}
+
+func (q *Queries) AddToBlogsSearch(ctx context.Context, arg AddToBlogsSearchParams) error {
+	_, err := q.db.ExecContext(ctx, addToBlogsSearch, arg.BlogID, arg.SearchwordlistIdsearchwordlist, arg.WordCount)
+	return err
+}
+
 const addToForumCommentSearch = `-- name: AddToForumCommentSearch :exec
-INSERT IGNORE INTO comments_search
-(comment_id, searchwordlist_idsearchwordlist)
-VALUES (?, ?)
+INSERT INTO comments_search
+(comment_id, searchwordlist_idsearchwordlist, word_count)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE word_count=VALUES(word_count)
 `
 
 type AddToForumCommentSearchParams struct {
 	CommentID                      int32
 	SearchwordlistIdsearchwordlist int32
+	WordCount                      int32
 }
 
 func (q *Queries) AddToForumCommentSearch(ctx context.Context, arg AddToForumCommentSearchParams) error {
-	_, err := q.db.ExecContext(ctx, addToForumCommentSearch, arg.CommentID, arg.SearchwordlistIdsearchwordlist)
+	_, err := q.db.ExecContext(ctx, addToForumCommentSearch, arg.CommentID, arg.SearchwordlistIdsearchwordlist, arg.WordCount)
 	return err
 }
 
 const addToForumWritingSearch = `-- name: AddToForumWritingSearch :exec
-INSERT IGNORE INTO writing_search
-(writing_id, searchwordlist_idsearchwordlist)
-VALUES (?, ?)
+INSERT INTO writing_search
+(writing_id, searchwordlist_idsearchwordlist, word_count)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE word_count=VALUES(word_count)
 `
 
 type AddToForumWritingSearchParams struct {
 	WritingID                      int32
 	SearchwordlistIdsearchwordlist int32
+	WordCount                      int32
 }
 
 func (q *Queries) AddToForumWritingSearch(ctx context.Context, arg AddToForumWritingSearchParams) error {
-	_, err := q.db.ExecContext(ctx, addToForumWritingSearch, arg.WritingID, arg.SearchwordlistIdsearchwordlist)
+	_, err := q.db.ExecContext(ctx, addToForumWritingSearch, arg.WritingID, arg.SearchwordlistIdsearchwordlist, arg.WordCount)
 	return err
 }
 
 const addToImagePostSearch = `-- name: AddToImagePostSearch :exec
-INSERT IGNORE INTO imagepost_search
-(image_post_id, searchwordlist_idsearchwordlist)
-VALUES (?, ?)
+INSERT INTO imagepost_search
+(image_post_id, searchwordlist_idsearchwordlist, word_count)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE word_count=VALUES(word_count)
 `
 
 type AddToImagePostSearchParams struct {
 	ImagePostID                    int32
 	SearchwordlistIdsearchwordlist int32
+	WordCount                      int32
 }
 
 func (q *Queries) AddToImagePostSearch(ctx context.Context, arg AddToImagePostSearchParams) error {
-	_, err := q.db.ExecContext(ctx, addToImagePostSearch, arg.ImagePostID, arg.SearchwordlistIdsearchwordlist)
+	_, err := q.db.ExecContext(ctx, addToImagePostSearch, arg.ImagePostID, arg.SearchwordlistIdsearchwordlist, arg.WordCount)
 	return err
 }
 
 const addToLinkerSearch = `-- name: AddToLinkerSearch :exec
-INSERT IGNORE INTO linker_search
-(linker_id, searchwordlist_idsearchwordlist)
-VALUES (?, ?)
+INSERT INTO linker_search
+(linker_id, searchwordlist_idsearchwordlist, word_count)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE word_count=VALUES(word_count)
 `
 
 type AddToLinkerSearchParams struct {
 	LinkerID                       int32
 	SearchwordlistIdsearchwordlist int32
+	WordCount                      int32
 }
 
 func (q *Queries) AddToLinkerSearch(ctx context.Context, arg AddToLinkerSearchParams) error {
-	_, err := q.db.ExecContext(ctx, addToLinkerSearch, arg.LinkerID, arg.SearchwordlistIdsearchwordlist)
+	_, err := q.db.ExecContext(ctx, addToLinkerSearch, arg.LinkerID, arg.SearchwordlistIdsearchwordlist, arg.WordCount)
+	return err
+}
+
+const addToSiteNewsSearch = `-- name: AddToSiteNewsSearch :exec
+INSERT INTO site_news_search
+(site_news_id, searchwordlist_idsearchwordlist, word_count)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE word_count=VALUES(word_count)
+`
+
+type AddToSiteNewsSearchParams struct {
+	SiteNewsID                     int32
+	SearchwordlistIdsearchwordlist int32
+	WordCount                      int32
+}
+
+func (q *Queries) AddToSiteNewsSearch(ctx context.Context, arg AddToSiteNewsSearchParams) error {
+	_, err := q.db.ExecContext(ctx, addToSiteNewsSearch, arg.SiteNewsID, arg.SearchwordlistIdsearchwordlist, arg.WordCount)
 	return err
 }
 
@@ -561,147 +605,6 @@ func (q *Queries) LinkerSearchNext(ctx context.Context, arg LinkerSearchNextPara
 	return items, nil
 }
 
-const remakeBlogSearch = `-- name: RemakeBlogSearch :exec
-INSERT INTO blogs_search (text, blog_id)
-SELECT blog, idblogs
-FROM blogs
-`
-
-// This query selects data from the "blogs" table and populates the "blogs_search" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "blogs_search" using the "blog_id".
-func (q *Queries) RemakeBlogSearch(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, remakeBlogSearch)
-	return err
-}
-
-const remakeBlogsSearchInsert = `-- name: RemakeBlogsSearchInsert :exec
-INSERT INTO blogs_search (text, blog_id)
-SELECT blog, idblogs
-FROM blogs
-`
-
-// This query selects data from the "blogs" table and populates the "blogs_search" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "blogs_search" using the "blog_id".
-func (q *Queries) RemakeBlogsSearchInsert(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, remakeBlogsSearchInsert)
-	return err
-}
-
-const remakeCommentsSearch = `-- name: RemakeCommentsSearch :exec
-INSERT INTO comments_search (text, comment_id)
-SELECT text, idcomments
-FROM comments
-`
-
-// This query selects data from the "comments" table and populates the "comments_search" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "comments_search" using the "comment_id".
-func (q *Queries) RemakeCommentsSearch(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, remakeCommentsSearch)
-	return err
-}
-
-const remakeCommentsSearchInsert = `-- name: RemakeCommentsSearchInsert :exec
-INSERT INTO comments_search (text, comment_id)
-SELECT text, idcomments
-FROM comments
-`
-
-// This query selects data from the "comments" table and populates the "comments_search" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "comments_search" using the "comment_id".
-func (q *Queries) RemakeCommentsSearchInsert(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, remakeCommentsSearchInsert)
-	return err
-}
-
-const remakeImagePostSearchInsert = `-- name: RemakeImagePostSearchInsert :exec
-INSERT INTO imagepost_search (text, image_post_id)
-SELECT description, idimagepost
-FROM imagepost
-`
-
-func (q *Queries) RemakeImagePostSearchInsert(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, remakeImagePostSearchInsert)
-	return err
-}
-
-const remakeLinkerSearch = `-- name: RemakeLinkerSearch :exec
-INSERT INTO linker_search (text, linker_id)
-SELECT CONCAT(title, ' ', description), idlinker
-FROM linker
-`
-
-// This query selects data from the "linker" table and populates the "linker_search" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "linker_search" using the "linker_id".
-func (q *Queries) RemakeLinkerSearch(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, remakeLinkerSearch)
-	return err
-}
-
-const remakeLinkerSearchInsert = `-- name: RemakeLinkerSearchInsert :exec
-INSERT INTO linker_search (text, linker_id)
-SELECT CONCAT(title, ' ', description), idlinker
-FROM linker
-`
-
-// This query selects data from the "linker" table and populates the "linker_search" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "linker_search" using the "linker_id".
-func (q *Queries) RemakeLinkerSearchInsert(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, remakeLinkerSearchInsert)
-	return err
-}
-
-const remakeNewsSearch = `-- name: RemakeNewsSearch :exec
-INSERT INTO site_news_search (text, site_news_id)
-SELECT news, idsiteNews
-FROM site_news
-`
-
-// This query selects data from the "site_news" table and populates the "site_news_search" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "site_news_search" using the "site_news_id".
-func (q *Queries) RemakeNewsSearch(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, remakeNewsSearch)
-	return err
-}
-
-const remakeNewsSearchInsert = `-- name: RemakeNewsSearchInsert :exec
-INSERT INTO site_news_search (text, site_news_id)
-SELECT news, idsiteNews
-FROM site_news
-`
-
-// This query selects data from the "site_news" table and populates the "site_news_search" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "site_news_search" using the "site_news_id".
-func (q *Queries) RemakeNewsSearchInsert(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, remakeNewsSearchInsert)
-	return err
-}
-
-const remakeWritingSearch = `-- name: RemakeWritingSearch :exec
-INSERT INTO writing_search (text, writing_id)
-SELECT CONCAT(title, ' ', abstract, ' ', writing), idwriting
-FROM writing
-`
-
-// This query selects data from the "writing" table and populates the "writing_search" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "writing_search" using the "writing_id".
-func (q *Queries) RemakeWritingSearch(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, remakeWritingSearch)
-	return err
-}
-
-const remakeWritingSearchInsert = `-- name: RemakeWritingSearchInsert :exec
-INSERT INTO writing_search (text, writing_id)
-SELECT CONCAT(title, ' ', abstract, ' ', writing), idwriting
-FROM writing
-`
-
-// This query selects data from the "writing" table and populates the "writing_search" table with the specified columns.
-// Then, it iterates over the "queue" linked list to add each text and ID pair to the "writing_search" using the "writing_id".
-func (q *Queries) RemakeWritingSearchInsert(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, remakeWritingSearchInsert)
-	return err
-}
-
 const siteNewsSearchFirst = `-- name: SiteNewsSearchFirst :many
 SELECT DISTINCT cs.site_news_id
 FROM site_news_search cs
@@ -781,12 +684,12 @@ func (q *Queries) SiteNewsSearchNext(ctx context.Context, arg SiteNewsSearchNext
 
 const wordListWithCounts = `-- name: WordListWithCounts :many
 SELECT swl.word,
-       (SELECT COUNT(*) FROM comments_search cs WHERE cs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM site_news_search ns WHERE ns.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM blogs_search bs WHERE bs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM linker_search ls WHERE ls.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM writing_search ws WHERE ws.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM imagepost_search ips WHERE ips.searchwordlist_idsearchwordlist=swl.idsearchwordlist) AS count
+       (SELECT IFNULL(SUM(cs.word_count),0) FROM comments_search cs WHERE cs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ns.word_count),0) FROM site_news_search ns WHERE ns.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(bs.word_count),0) FROM blogs_search bs WHERE bs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ls.word_count),0) FROM linker_search ls WHERE ls.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ws.word_count),0) FROM writing_search ws WHERE ws.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ips.word_count),0) FROM imagepost_search ips WHERE ips.searchwordlist_idsearchwordlist=swl.idsearchwordlist) AS count
 FROM searchwordlist swl
 ORDER BY swl.word
 LIMIT ? OFFSET ?
@@ -828,12 +731,12 @@ func (q *Queries) WordListWithCounts(ctx context.Context, arg WordListWithCounts
 
 const wordListWithCountsByPrefix = `-- name: WordListWithCountsByPrefix :many
 SELECT swl.word,
-       (SELECT COUNT(*) FROM comments_search cs WHERE cs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM site_news_search ns WHERE ns.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM blogs_search bs WHERE bs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM linker_search ls WHERE ls.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM writing_search ws WHERE ws.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
-       + (SELECT COUNT(*) FROM imagepost_search ips WHERE ips.searchwordlist_idsearchwordlist=swl.idsearchwordlist) AS count
+       (SELECT IFNULL(SUM(cs.word_count),0) FROM comments_search cs WHERE cs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ns.word_count),0) FROM site_news_search ns WHERE ns.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(bs.word_count),0) FROM blogs_search bs WHERE bs.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ls.word_count),0) FROM linker_search ls WHERE ls.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ws.word_count),0) FROM writing_search ws WHERE ws.searchwordlist_idsearchwordlist=swl.idsearchwordlist)
+       + (SELECT IFNULL(SUM(ips.word_count),0) FROM imagepost_search ips WHERE ips.searchwordlist_idsearchwordlist=swl.idsearchwordlist) AS count
 FROM searchwordlist swl
 WHERE swl.word LIKE CONCAT(?, '%')
 ORDER BY swl.word

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -280,3 +280,7 @@ LIMIT ? OFFSET ?;
 -- name: SetWritingLastIndex :exec
 UPDATE writing SET last_index = NOW() WHERE idwriting = ?;
 
+
+-- name: GetAllWritingsForIndex :many
+SELECT idwriting, title, abstract, writing FROM writing WHERE deleted_at IS NULL;
+

--- a/migrations/0048.sql
+++ b/migrations/0048.sql
@@ -1,0 +1,10 @@
+-- Add word_count columns to search tables
+ALTER TABLE comments_search ADD COLUMN word_count INT NOT NULL DEFAULT 1;
+ALTER TABLE site_news_search ADD COLUMN word_count INT NOT NULL DEFAULT 1;
+ALTER TABLE blogs_search ADD COLUMN word_count INT NOT NULL DEFAULT 1;
+ALTER TABLE linker_search ADD COLUMN word_count INT NOT NULL DEFAULT 1;
+ALTER TABLE writing_search ADD COLUMN word_count INT NOT NULL DEFAULT 1;
+ALTER TABLE imagepost_search ADD COLUMN word_count INT NOT NULL DEFAULT 1;
+
+-- Update schema version
+UPDATE schema_version SET version = 48 WHERE version = 47;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -16,6 +16,7 @@ CREATE TABLE `blogs` (
 CREATE TABLE `blogs_search` (
   `blog_id` int(10) NOT NULL DEFAULT 0,
   `searchwordlist_idsearchwordlist` int(10) NOT NULL DEFAULT 0,
+  `word_count` int(10) NOT NULL DEFAULT 1,
   PRIMARY KEY (`blog_id`,`searchwordlist_idsearchwordlist`),
   KEY `blogs_has_searchwordlist_FKIndex1` (`blog_id`),
   KEY `blogs_has_searchwordlist_FKIndex2` (`searchwordlist_idsearchwordlist`)
@@ -47,6 +48,7 @@ CREATE TABLE `comments` (
 CREATE TABLE `comments_search` (
   `searchwordlist_idsearchwordlist` int(10) NOT NULL DEFAULT 0,
   `comment_id` int(10) NOT NULL DEFAULT 0,
+  `word_count` int(10) NOT NULL DEFAULT 1,
   PRIMARY KEY (`searchwordlist_idsearchwordlist`,`comment_id`),
   KEY `searchwordlist_has_comments_FKIndex1` (`searchwordlist_idsearchwordlist`),
   KEY `searchwordlist_has_comments_FKIndex2` (`comment_id`)
@@ -140,6 +142,7 @@ CREATE TABLE `imagepost` (
 CREATE TABLE `imagepost_search` (
   `image_post_id` int(10) NOT NULL DEFAULT 0,
   `searchwordlist_idsearchwordlist` int(10) NOT NULL DEFAULT 0,
+  `word_count` int(10) NOT NULL DEFAULT 1,
   PRIMARY KEY (`image_post_id`,`searchwordlist_idsearchwordlist`),
   KEY `imagepostSearch_FKIndex1` (`image_post_id`),
   KEY `imagepostSearch_FKIndex2` (`searchwordlist_idsearchwordlist`)
@@ -195,6 +198,7 @@ CREATE TABLE `linker_queue` (
 CREATE TABLE `linker_search` (
   `searchwordlist_idsearchwordlist` int(10) NOT NULL DEFAULT 0,
   `linker_id` int(10) NOT NULL DEFAULT 0,
+  `word_count` int(10) NOT NULL DEFAULT 1,
   PRIMARY KEY (`searchwordlist_idsearchwordlist`,`linker_id`),
   KEY `searchwordlist_has_linker_FKIndex1` (`searchwordlist_idsearchwordlist`),
   KEY `searchwordlist_has_linker_FKIndex2` (`linker_id`)
@@ -278,6 +282,7 @@ CREATE TABLE `site_news` (
 CREATE TABLE `site_news_search` (
   `site_news_id` int(10) NOT NULL DEFAULT 0,
   `searchwordlist_idsearchwordlist` int(10) NOT NULL DEFAULT 0,
+  `word_count` int(10) NOT NULL DEFAULT 1,
   PRIMARY KEY (`site_news_id`,`searchwordlist_idsearchwordlist`),
   KEY `siteNews_has_searchwordlist_FKIndex1` (`site_news_id`),
   KEY `siteNews_has_searchwordlist_FKIndex2` (`searchwordlist_idsearchwordlist`)
@@ -357,6 +362,7 @@ CREATE TABLE `writing_category` (
 CREATE TABLE `writing_search` (
   `searchwordlist_idsearchwordlist` int(10) NOT NULL DEFAULT 0,
   `writing_id` int(10) NOT NULL DEFAULT 0,
+  `word_count` int(10) NOT NULL DEFAULT 1,
   PRIMARY KEY (`searchwordlist_idsearchwordlist`,`writing_id`),
   KEY `searchwordlist_has_writing_FKIndex1` (`searchwordlist_idsearchwordlist`),
   KEY `searchwordlist_has_writing_FKIndex2` (`writing_id`)

--- a/workers/searchworker/insert.go
+++ b/workers/searchworker/insert.go
@@ -7,13 +7,13 @@ import (
 )
 
 // InsertFunc performs an insert operation for a single search word.
-type InsertFunc func(ctx context.Context, wordID int64) error
+type InsertFunc func(ctx context.Context, wordID int64, count int32) error
 
 // InsertWords executes insertFn for each word ID. It redirects on error and
 // returns true when a redirect has been issued.
-func InsertWords(w http.ResponseWriter, r *http.Request, wordIDs []int64, insertFn InsertFunc) bool {
-	for _, wid := range wordIDs {
-		if err := insertFn(r.Context(), wid); err != nil {
+func InsertWords(w http.ResponseWriter, r *http.Request, words []WordCount, insertFn InsertFunc) bool {
+	for _, wc := range words {
+		if err := insertFn(r.Context(), wc.ID, wc.Count); err != nil {
 			log.Printf("Error inserting search word: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 			return true

--- a/workers/searchworker/tokenize_test.go
+++ b/workers/searchworker/tokenize_test.go
@@ -130,6 +130,9 @@ func TestSearchWordIdsFromText(t *testing.T) {
 	if db.word != "hello" && db.word != "world" {
 		t.Fatalf("word %s", db.word)
 	}
+	if ids[0].Count == 0 || ids[1].Count == 0 {
+		t.Fatalf("counts=%v", ids)
+	}
 }
 
 func TestSearchWordIdsFromTextError(t *testing.T) {


### PR DESCRIPTION
## Summary
- add helper for indexing text into search tables
- rebuild search index tasks using Go instead of faulty SQL
- add queries for retrieving all searchable text and insertion helpers
- add word count column and update indexing logic

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68818cfa551c832fabcd4a57c52e21cb