### PR TITLE
Attach taskbus queue to middleware struct

### DIFF
--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -105,7 +105,8 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
-	handler := middleware.TaskEventMiddlewareWithBus(bus)(http.HandlerFunc(handlers.TaskHandler(askTask)))
+	mw := middleware.NewTaskEventMiddleware(bus)
+	handler := mw.Middleware(http.HandlerFunc(handlers.TaskHandler(askTask)))
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -67,7 +67,8 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
-	handler := middleware.TaskEventMiddlewareWithBus(bus)(http.HandlerFunc(handlers.TaskHandler(permissionUserAllowTask)))
+	mw := middleware.NewTaskEventMiddleware(bus)
+	handler := mw.Middleware(http.HandlerFunc(handlers.TaskHandler(permissionUserAllowTask)))
 	handler.ServeHTTP(rr, req)
 
 	select {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -93,11 +93,12 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 	r := mux.NewRouter()
 	routerpkg.RegisterRoutes(r)
 
+	taskEventMW := middleware.NewTaskEventMiddleware(bus)
 	handler := middleware.NewMiddlewareChain(
 		middleware.RecoverMiddleware,
 		middleware.CoreAdderMiddleware,
 		middleware.RequestLoggerMiddleware,
-		middleware.TaskEventMiddlewareWithBus(bus),
+		taskEventMW.Middleware,
 		middleware.SecurityHeadersMiddleware,
 	).Wrap(r)
 	if csrfmw.CSRFEnabled() {

--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -2,12 +2,13 @@ package middleware
 
 import (
 	"context"
-	"github.com/arran4/goa4web/internal/tasks"
 	"log"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/arran4/goa4web/internal/tasks"
 
 	"github.com/arran4/goa4web/core/common"
 	coreconsts "github.com/arran4/goa4web/core/consts"
@@ -83,48 +84,81 @@ func (q *eventQueue) flush(ctx context.Context) {
 	}
 }
 
-var taskQueue = newEventQueue(maxQueuedTaskEvents, nil)
+// TaskEventMiddleware provides middleware for publishing task events.
+type TaskEventMiddleware struct {
+	bus   *eventbus.Bus
+	queue *eventQueue
+}
+
+// NewTaskEventMiddleware creates a middleware instance using the provided bus.
+func NewTaskEventMiddleware(bus *eventbus.Bus) *TaskEventMiddleware {
+	if bus == nil {
+		panic("TaskEventMiddleware requires a bus")
+	}
+	return &TaskEventMiddleware{
+		bus:   bus,
+		queue: newEventQueue(maxQueuedTaskEvents, bus),
+	}
+}
 
 func (r *statusRecorder) WriteHeader(code int) {
 	r.status = code
 	r.ResponseWriter.WriteHeader(code)
 }
 
-func TaskEventMiddlewareWithBus(bus *eventbus.Bus) func(http.Handler) http.Handler {
-	if bus == nil {
-		panic("TaskEventMiddleware requires a bus")
-	}
-	taskQueue.bus = bus
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			task := r.PostFormValue("task")
-			cd, ok := r.Context().Value(coreconsts.KeyCoreData).(*common.CoreData)
-			if !ok || cd == nil {
-				log.Panicf("TaskEventMiddleware: missing CoreData for %s", r.URL.Path)
-			}
-			uid := cd.UserID
-			admin := strings.Contains(r.URL.Path, "/admin")
-			_ = admin
-			evt := &eventbus.TaskEvent{
-				Path:   r.URL.Path,
-				Task:   tasks.TaskString("MISSING"),
-				UserID: uid,
-				Time:   time.Now(),
-				Data:   map[string]any{},
-			}
-			cd.SetEvent(evt)
-			sr := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
-			next.ServeHTTP(sr, r)
-			if task != "" && sr.status < http.StatusBadRequest {
-				if err := bus.Publish(*evt); err != nil {
-					if err == eventbus.ErrBusClosed {
-						taskQueue.enqueue(*evt)
-					} else {
-						log.Printf("publish task event: %v", err)
-					}
+// Middleware returns a http.Handler middleware that records task events.
+func (m *TaskEventMiddleware) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		task := r.PostFormValue("task")
+		cd, ok := r.Context().Value(coreconsts.KeyCoreData).(*common.CoreData)
+		if !ok || cd == nil {
+			log.Panicf("TaskEventMiddleware: missing CoreData for %s", r.URL.Path)
+		}
+		uid := cd.UserID
+		admin := strings.Contains(r.URL.Path, "/admin")
+		_ = admin
+		evt := &eventbus.TaskEvent{
+			Path:   r.URL.Path,
+			Task:   tasks.TaskString("MISSING"),
+			UserID: uid,
+			Time:   time.Now(),
+			Data:   map[string]any{},
+		}
+		cd.SetEvent(evt)
+		sr := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(sr, r)
+		if task != "" && sr.status < http.StatusBadRequest {
+			if err := m.bus.Publish(*evt); err != nil {
+				if err == eventbus.ErrBusClosed {
+					m.queue.enqueue(*evt)
+				} else {
+					log.Printf("publish task event: %v", err)
 				}
 			}
-			taskQueue.flush(r.Context())
-		})
-	}
+		}
+		m.queue.flush(r.Context())
+	})
+}
+
+// Events returns a copy of the currently queued events.
+func (m *TaskEventMiddleware) Events() []eventbus.TaskEvent {
+	m.queue.mu.Lock()
+	defer m.queue.mu.Unlock()
+	return append([]eventbus.TaskEvent(nil), m.queue.events...)
+}
+
+// Flush publishes any queued events to the underlying bus.
+func (m *TaskEventMiddleware) Flush(ctx context.Context) {
+	m.queue.flush(ctx)
+}
+
+// SetBus updates the bus used for publishing and flushing events.
+func (m *TaskEventMiddleware) SetBus(bus *eventbus.Bus) {
+	m.bus = bus
+	m.queue.bus = bus
+}
+
+// TaskEventMiddlewareWithBus wraps NewTaskEventMiddleware for backward compatibility.
+func TaskEventMiddlewareWithBus(bus *eventbus.Bus) func(http.Handler) http.Handler {
+	return NewTaskEventMiddleware(bus).Middleware
 }


### PR DESCRIPTION
## Summary
- encapsulate task event queue in a `TaskEventMiddleware` struct
- create `taskEventMW` during app setup and register its middleware
- update tests to use the new middleware struct

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6881b551e3fc832fbb8e29c6ad200835