### PR TITLE
Remove middleware globals

### DIFF
--- a/internal/app/dbstart/dbstart.go
+++ b/internal/app/dbstart/dbstart.go
@@ -15,7 +15,6 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/dbdrivers"
-	"github.com/arran4/goa4web/internal/middleware"
 )
 
 var (
@@ -65,7 +64,6 @@ func InitDB(cfg config.RuntimeConfig) *common.UserError {
 	if err := EnsureSchema(context.Background(), dbPool); err != nil {
 		return &common.UserError{Err: err, ErrorMessage: "failed to verify schema"}
 	}
-	middleware.SetDBPool(dbPool, dbLogVerbosity)
 	if dbLogVerbosity > 0 {
 		log.Printf("db pool stats after init: %+v", dbPool.Stats())
 	}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -86,7 +86,7 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 
 	handler := middleware.NewMiddlewareChain(
 		middleware.RecoverMiddleware,
-		middleware.CoreAdderMiddleware,
+		middleware.CoreAdderMiddlewareWithDB(dbPool, cfg.DBLogVerbosity),
 		middleware.RequestLoggerMiddleware,
 		middleware.TaskEventMiddleware,
 		middleware.SecurityHeadersMiddleware,

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -44,7 +44,7 @@ func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
 		cdOut, _ = r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	})
 
-	CoreAdderMiddlewareWithDB(db)(handler).ServeHTTP(httptest.NewRecorder(), req)
+	CoreAdderMiddlewareWithDB(db, 0)(handler).ServeHTTP(httptest.NewRecorder(), req)
 
 	want := []string{"anonymous", "user", "moderator"}
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {
@@ -81,7 +81,7 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 		cdOut, _ = r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	})
 
-	CoreAdderMiddlewareWithDB(db)(handler).ServeHTTP(httptest.NewRecorder(), req)
+	CoreAdderMiddlewareWithDB(db, 0)(handler).ServeHTTP(httptest.NewRecorder(), req)
 
 	want := []string{"anonymous"}
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {


### PR DESCRIPTION
## Summary
- drop DBPool and dbLogVerbosity from middleware
- wire the database handle and log verbosity into CoreAdderMiddleware
- adjust the server startup to pass these values
- update related tests

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68818683ba80832fb0c631fe3caf7c59