### PR TITLE
Use request parameters for password verification

### DIFF
--- a/core/templates/site/passwordVerifyPage.gohtml
+++ b/core/templates/site/passwordVerifyPage.gohtml
@@ -1,6 +1,7 @@
 {{ template "head" $ }}
 <form method="post" action="/login/verify">
     {{ csrfField }}
+    <input type="hidden" name="id" value="{{ .ID }}">
     Code: <input name="code">
     <input type="submit" name="task" value="Password Verify">
 </form>

--- a/handlers/auth/login_task.go
+++ b/handlers/auth/login_task.go
@@ -68,15 +68,15 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 				_ = queries.MarkPasswordResetVerified(r.Context(), reset.ID)
 				_ = queries.InsertPassword(r.Context(), db.InsertPasswordParams{UsersIdusers: reset.UserID, Passwd: reset.Passwd, PasswdAlgorithm: sql.NullString{String: reset.PasswdAlgorithm, Valid: true}})
 			} else {
-				session, ok := core.GetSessionOrFail(w, r)
-				if !ok {
-					return handlers.SessionFetchFail{}
+				type Data struct {
+					*common.CoreData
+					ID int32
 				}
-				session.Values["PendingResetID"] = reset.ID
-				if err := session.Save(r, w); err != nil {
-					log.Printf("save session: %v", err)
+				data := Data{
+					CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+					ID:       reset.ID,
 				}
-				return handlers.TemplateWithDataHandler("passwordVerifyPage.gohtml", struct{}{})
+				return handlers.TemplateWithDataHandler("passwordVerifyPage.gohtml", data)
 			}
 		} else {
 			if err := queries.InsertLoginAttempt(r.Context(), db.InsertLoginAttemptParams{Username: username, IpAddress: strings.Split(r.RemoteAddr, ":")[0]}); err != nil {


### PR DESCRIPTION
## Summary
- remove session usage from password verification handler
- pass reset ID via hidden field from login task
- include reset ID input in the verify password template
- test pending reset login flow

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6881bbf54b58832facd4082272ae76c0