### PR TITLE
Secure reload and shutdown admin routes

### DIFF
--- a/handlers/admin/reload_shutdown_test.go
+++ b/handlers/admin/reload_shutdown_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gorilla/mux"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 )
@@ -37,5 +39,43 @@ func TestAdminShutdownPage_Unauthorized(t *testing.T) {
 
 	if rr.Result().StatusCode != http.StatusForbidden {
 		t.Fatalf("expected %d got %d", http.StatusForbidden, rr.Result().StatusCode)
+	}
+}
+
+func TestAdminReloadRoute_Unauthorized(t *testing.T) {
+	r := mux.NewRouter()
+	ar := r.PathPrefix("/admin").Subrouter()
+	RegisterRoutes(ar)
+
+	req := httptest.NewRequest("POST", "/admin/reload", nil)
+	cd := common.NewCoreData(req.Context(), nil)
+	cd.SetRoles([]string{"anonymous"})
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected %d got %d", http.StatusNotFound, rr.Code)
+	}
+}
+
+func TestAdminShutdownRoute_Unauthorized(t *testing.T) {
+	r := mux.NewRouter()
+	ar := r.PathPrefix("/admin").Subrouter()
+	RegisterRoutes(ar)
+
+	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
+	cd := common.NewCoreData(req.Context(), nil)
+	cd.SetRoles([]string{"anonymous"})
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected %d got %d", http.StatusNotFound, rr.Code)
 	}
 }

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -99,8 +99,12 @@ func RegisterRoutes(ar *mux.Router) {
 	writings.RegisterAdminRoutes(ar)
 
 	// TODO ensure requires administrator to run. Even from CLI.
-	ar.HandleFunc("/reload", AdminReloadConfigPage).Methods("POST")
-	ar.HandleFunc("/shutdown", AdminShutdownPage).Methods("POST")
+	ar.HandleFunc("/reload", AdminReloadConfigPage).
+		Methods("POST").
+		MatcherFunc(handlers.RequiredAccess("administrator"))
+	ar.HandleFunc("/shutdown", AdminShutdownPage).
+		Methods("POST").
+		MatcherFunc(handlers.RequiredAccess("administrator"))
 }
 
 // Register registers the admin router module.


### PR DESCRIPTION
## Summary
- require the administrator role to access `/admin/reload` and `/admin/shutdown`
- test that the handler functions and routes block non-admin users

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6881bbef6630832fb28c62710e1f01f7