### PR TITLE
Add test verifying unique site template names

### DIFF
--- a/core/templates/site_names_unique_test.go
+++ b/core/templates/site_names_unique_test.go
@@ -1,0 +1,39 @@
+package templates
+
+import (
+	"embed"
+	"html/template"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/arran4/goa4web/core/common"
+)
+
+//go:embed site/*.gohtml site/*/*.gohtml
+var uniqueTemplates embed.FS
+
+func TestSiteTemplateNamesUnique(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	cd := &common.CoreData{}
+	tmpl, err := template.New("").Funcs(cd.Funcs(r)).ParseFS(uniqueTemplates,
+		"site/*.gohtml", "site/*/*.gohtml")
+	if err != nil {
+		t.Fatalf("failed to parse templates: %v", err)
+	}
+
+	seen := map[string]string{}
+	for _, tt := range tmpl.Templates() {
+		name := tt.Name()
+		if name == "" {
+			continue
+		}
+		parseName := ""
+		if tt.Tree != nil {
+			parseName = tt.Tree.ParseName
+		}
+		if prev, ok := seen[name]; ok {
+			t.Fatalf("duplicate template name %q found in %s and %s", name, prev, parseName)
+		}
+		seen[name] = parseName
+	}
+}


### PR DESCRIPTION
## Summary
- validate all embedded site templates do not share names

## Testing
- `go test ./core/templates -run TestSiteTemplateNamesUnique -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6881bbf76dd8832f8de996be5f85fcda