### PR TITLE
Add template-based CSRF token support

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -26,6 +26,7 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 		"cd":        func() *CoreData { return cd },
 		"now":       func() time.Time { return time.Now() },
 		"csrfField": func() template.HTML { return csrf.TemplateField(r) },
+		"csrfToken": func() string { return csrf.Token(r) },
 		"version":   func() string { return goa4web.Version },
 		"a4code2html": func(s string) template.HTML {
 			c := a4code2html.New(mapper)

--- a/core/templates/site/admin/usersPermissionsPage.gohtml
+++ b/core/templates/site/admin/usersPermissionsPage.gohtml
@@ -41,7 +41,11 @@
 <script>
 (function(){
     function post(data){
-        return fetch('/admin/users/permissions', {method:'POST', body:data});
+        return fetch('/admin/users/permissions', {
+            method:'POST',
+            body:data,
+            headers:{'X-CSRF-Token': '{{ csrfToken }}'}
+        });
     }
     document.querySelectorAll('.delete-btn').forEach(function(btn){
         btn.addEventListener('click', function(e){


### PR DESCRIPTION
## Summary
- expose `csrfToken` template function returning `gorilla/csrf` token
- remove dedicated `/csrf.js` asset and route
- inject CSRF header in permissions page post helper

## Testing
- `go vet ./...`
- `go mod tidy`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6881bbcf2ae4832f818c67d864c6829d