### PR TITLE
Refactor image signing helper

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -18,6 +18,7 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
+	images "github.com/arran4/goa4web/internal/images"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -57,6 +58,7 @@ type CoreData struct {
 	AdminMode         bool
 	NotificationCount int32
 	a4codeMapper      func(tag, val string) string
+	signer            *images.ImageSigner
 
 	session *sessions.Session
 
@@ -110,6 +112,16 @@ func WithImageURLMapper(fn func(tag, val string) string) CoreOption {
 	return func(cd *CoreData) { cd.a4codeMapper = fn }
 }
 
+// WithImageSigner attaches an ImageSigner to the CoreData and sets the image URL mapper.
+func WithImageSigner(s *images.ImageSigner) CoreOption {
+	return func(cd *CoreData) {
+		cd.signer = s
+		if s != nil {
+			cd.a4codeMapper = s.MapURL
+		}
+	}
+}
+
 // WithSession stores the gorilla session on the CoreData object.
 func WithSession(s *sessions.Session) CoreOption {
 	return func(cd *CoreData) { cd.session = s }
@@ -147,6 +159,9 @@ func (cd *CoreData) ImageURLMapper(tag, val string) string {
 	}
 	return val
 }
+
+// ImageSigner returns the signer associated with this request, if any.
+func (cd *CoreData) ImageSigner() *images.ImageSigner { return cd.signer }
 
 // EmailProvider lazily returns the configured email provider.
 // WithEmailProvider sets the email provider used by CoreData.

--- a/handlers/forum/forumFeed_test.go
+++ b/handlers/forum/forumFeed_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/arran4/goa4web/internal/db"
+	images "github.com/arran4/goa4web/internal/images"
 )
 
 func TestForumTopicFeed(t *testing.T) {
@@ -19,7 +20,7 @@ func TestForumTopicFeed(t *testing.T) {
 		},
 	}
 	r := httptest.NewRequest("GET", "http://example.com/forum/topic/1.rss", nil)
-	feed := TopicFeed(r, "Test", 1, rows)
+	feed := TopicFeed(r, "Test", 1, rows, images.NewSigner("k"))
 	if len(feed.Items) != 1 {
 		t.Fatalf("expected 1 item got %d", len(feed.Items))
 	}

--- a/handlers/imagebbs/imagebbsFeed_test.go
+++ b/handlers/imagebbs/imagebbsFeed_test.go
@@ -3,6 +3,7 @@ package imagebbs
 import (
 	"database/sql"
 	"github.com/arran4/goa4web/internal/db"
+	images "github.com/arran4/goa4web/internal/images"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -19,7 +20,7 @@ func TestImagebbsFeed(t *testing.T) {
 		},
 	}
 	r := httptest.NewRequest("GET", "http://example.com/imagebbs/board/1.rss", nil)
-	feed := imagebbsFeed(r, "Test", 1, rows)
+	feed := imagebbsFeed(r, "Test", 1, rows, images.NewSigner("k"))
 	if len(feed.Items) != 1 {
 		t.Fatalf("expected 1 item got %d", len(feed.Items))
 	}

--- a/handlers/images/routes.go
+++ b/handlers/images/routes.go
@@ -10,9 +10,10 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	imagesign "github.com/arran4/goa4web/internal/images"
-	router "github.com/arran4/goa4web/internal/router"
+	"github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/internal/upload"
 )
 
@@ -26,7 +27,8 @@ func verifyMiddleware(prefix string) mux.MiddlewareFunc {
 			if prefix != "" {
 				data = prefix + id
 			}
-			if !imagesign.Verify(data, ts, sig) {
+			cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+			if cd == nil || cd.ImageSigner() == nil || !cd.ImageSigner().Verify(data, ts, sig) {
 				http.Error(w, "forbidden", http.StatusForbidden)
 				return
 			}

--- a/handlers/images/upload_task.go
+++ b/handlers/images/upload_task.go
@@ -125,6 +125,10 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("create uploaded image %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	signed := imagesign.SignedRef("image:" + fname)
+	cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	signed := ""
+	if cd != nil && cd.ImageSigner() != nil {
+		signed = cd.ImageSigner().SignedRef("image:" + fname)
+	}
 	return handlers.TextByteWriter([]byte(signed))
 }

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
+	images "github.com/arran4/goa4web/internal/images"
 	"github.com/arran4/goa4web/workers/searchworker"
 )
 
@@ -27,7 +28,7 @@ func TestLinkerFeed(t *testing.T) {
 		},
 	}
 	r := httptest.NewRequest("GET", "http://example.com/linker/rss", nil)
-	feed := linkerFeed(r, rows)
+	feed := linkerFeed(r, rows, images.NewSigner("k"))
 	if len(feed.Items) != 1 {
 		t.Fatalf("expected 1 item got %d", len(feed.Items))
 	}

--- a/handlers/news/newsRssPage.go
+++ b/handlers/news/newsRssPage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gorilla/feeds"
 
 	"github.com/arran4/goa4web/a4code/a4code2html"
-	imagesign "github.com/arran4/goa4web/internal/images"
 )
 
 func NewsRssPage(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +36,11 @@ func NewsRssPage(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		text := row.News.String
-		conv := a4code2html.New(imagesign.MapURL)
+		mapper := func(tag, val string) string { return val }
+		if cd.ImageSigner() != nil {
+			mapper = cd.ImageSigner().MapURL
+		}
+		conv := a4code2html.New(mapper)
 		conv.CodeType = a4code2html.CTTagStrip
 		conv.SetInput(text)
 		out, _ := io.ReadAll(conv.Process())

--- a/handlers/user/userGalleryPage.go
+++ b/handlers/user/userGalleryPage.go
@@ -15,7 +15,6 @@ import (
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	imagesign "github.com/arran4/goa4web/internal/images"
 )
 
 type galleryImage struct {
@@ -71,11 +70,13 @@ func userGalleryPage(w http.ResponseWriter, r *http.Request) {
 		ext := filepath.Ext(fname)
 		id := strings.TrimSuffix(fname, ext)
 		thumb := id + "_thumb" + ext
-		imgs = append(imgs, galleryImage{
-			Thumb:  imagesign.SignedCacheURL(thumb),
-			Full:   imagesign.SignedURL("image:" + fname),
-			A4Code: "[img=image:" + fname + "]",
-		})
+		if cd.ImageSigner() != nil {
+			imgs = append(imgs, galleryImage{
+				Thumb:  cd.ImageSigner().SignedCacheURL(thumb),
+				Full:   cd.ImageSigner().SignedURL("image:" + fname),
+				A4Code: "[img=image:" + fname + "]",
+			})
+		}
 	}
 
 	base := "/usr/notifications/gallery"

--- a/handlers/writings/writingsFeed.go
+++ b/handlers/writings/writingsFeed.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/arran4/goa4web/a4code/a4code2html"
 	"github.com/arran4/goa4web/core/common"
-	imagesign "github.com/arran4/goa4web/internal/images"
 	"github.com/gorilla/feeds"
 )
 
@@ -34,7 +33,11 @@ func feedGen(r *http.Request, cd *common.CoreData) (*feeds.Feed, error) {
 		if desc == "" {
 			desc = row.Writing.String
 		}
-		conv := a4code2html.New(imagesign.MapURL)
+		mapper := func(tag, val string) string { return val }
+		if cd.ImageSigner() != nil {
+			mapper = cd.ImageSigner().MapURL
+		}
+		conv := a4code2html.New(mapper)
 		conv.CodeType = a4code2html.CTTagStrip
 		conv.SetInput(desc)
 		out, _ := io.ReadAll(conv.Process())

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -70,7 +70,7 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 		return fmt.Errorf("smtp fallback: %w", err)
 	}
 	config.AppRuntimeConfig = cfg
-	imagesign.SetSigningKey(imageSignSecret)
+	signer := imagesign.NewSigner(imageSignSecret)
 	email.SetDefaultFromName(cfg.EmailFrom)
 
 	if dbPool != nil {
@@ -86,7 +86,7 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 
 	handler := middleware.NewMiddlewareChain(
 		middleware.RecoverMiddleware,
-		middleware.CoreAdderMiddleware,
+		middleware.CoreAdderMiddleware(signer),
 		middleware.RequestLoggerMiddleware,
 		middleware.TaskEventMiddleware,
 		middleware.SecurityHeadersMiddleware,

--- a/internal/images/sign.go
+++ b/internal/images/sign.go
@@ -13,39 +13,40 @@ import (
 	"github.com/arran4/goa4web/config"
 )
 
-var signKey string
+// ImageSigner signs and verifies image URLs.
+type ImageSigner struct{ key []byte }
 
-// SetSigningKey stores the key used for signing URLs.
-func SetSigningKey(k string) { signKey = k }
+// NewSigner creates a new ImageSigner.
+func NewSigner(k string) *ImageSigner { return &ImageSigner{key: []byte(k)} }
 
-func sign(data string) (int64, string) {
+func (s *ImageSigner) sign(data string) (int64, string) {
 	expires := time.Now().Add(24 * time.Hour).Unix()
-	mac := hmac.New(sha256.New, []byte(signKey))
+	mac := hmac.New(sha256.New, s.key)
 	io.WriteString(mac, fmt.Sprintf("%s:%d", data, expires))
 	return expires, hex.EncodeToString(mac.Sum(nil))
 }
 
 // SignedURL maps an image identifier to a signed URL.
-func SignedURL(id string) string {
+func (s *ImageSigner) SignedURL(id string) string {
 	id = strings.TrimPrefix(strings.TrimPrefix(id, "image:"), "img:")
 	host := strings.TrimSuffix(config.AppRuntimeConfig.HTTPHostname, "/")
-	ts, sig := sign("image:" + id)
+	ts, sig := s.sign("image:" + id)
 	return fmt.Sprintf("%s/images/image/%s?ts=%d&sig=%s", host, id, ts, sig)
 }
 
 // SignedCacheURL maps a cache identifier to a signed URL.
-func SignedCacheURL(id string) string {
+func (s *ImageSigner) SignedCacheURL(id string) string {
 	host := strings.TrimSuffix(config.AppRuntimeConfig.HTTPHostname, "/")
-	ts, sig := sign("cache:" + id)
+	ts, sig := s.sign("cache:" + id)
 	return fmt.Sprintf("%s/images/cache/%s?ts=%d&sig=%s", host, id, ts, sig)
 }
 
-func Verify(data, tsStr, sig string) bool {
+func (s *ImageSigner) Verify(data, tsStr, sig string) bool {
 	exp, err := strconv.ParseInt(tsStr, 10, 64)
 	if err != nil || time.Now().Unix() > exp {
 		return false
 	}
-	mac := hmac.New(sha256.New, []byte(signKey))
+	mac := hmac.New(sha256.New, s.key)
 	io.WriteString(mac, fmt.Sprintf("%s:%d", data, exp))
 	want := hex.EncodeToString(mac.Sum(nil))
 	return hmac.Equal([]byte(want), []byte(sig))
@@ -53,7 +54,7 @@ func Verify(data, tsStr, sig string) bool {
 
 // SignedRef appends a signature to an image or cache reference.
 // The input should start with "image:", "img:", or "cache:".
-func SignedRef(ref string) string {
+func (s *ImageSigner) SignedRef(ref string) string {
 	var prefix, id string
 	switch {
 	case strings.HasPrefix(ref, "image:"):
@@ -68,12 +69,12 @@ func SignedRef(ref string) string {
 	default:
 		return ref
 	}
-	ts, sig := sign(prefix + id)
+	ts, sig := s.sign(prefix + id)
 	return fmt.Sprintf("%s%s?ts=%d&sig=%s", prefix, id, ts, sig)
 }
 
 // MapURL converts image references to signed HTTP URLs.
-func MapURL(tag, val string) string {
+func (s *ImageSigner) MapURL(tag, val string) string {
 	if tag != "img" {
 		return val
 	}
@@ -81,9 +82,9 @@ func MapURL(tag, val string) string {
 	case strings.HasPrefix(val, "uploading:"):
 		return val
 	case strings.HasPrefix(val, "image:") || strings.HasPrefix(val, "img:"):
-		return SignedURL(val)
+		return s.SignedURL(val)
 	case strings.HasPrefix(val, "cache:"):
-		return SignedCacheURL(strings.TrimPrefix(val, "cache:"))
+		return s.SignedCacheURL(strings.TrimPrefix(val, "cache:"))
 	default:
 		return val
 	}

--- a/internal/images/sign_test.go
+++ b/internal/images/sign_test.go
@@ -3,8 +3,8 @@ package images
 import "testing"
 
 func TestMapURLUploading(t *testing.T) {
-	SetSigningKey("k")
-	got := MapURL("img", "uploading:abc")
+	signer := NewSigner("k")
+	got := signer.MapURL("img", "uploading:abc")
 	if got != "uploading:abc" {
 		t.Fatalf("expected placeholder unchanged, got %s", got)
 	}

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/core/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
+	images "github.com/arran4/goa4web/internal/images"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/sessions"
 )
@@ -44,7 +45,7 @@ func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
 		cdOut, _ = r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	})
 
-	CoreAdderMiddlewareWithDB(db)(handler).ServeHTTP(httptest.NewRecorder(), req)
+	CoreAdderMiddlewareWithDB(db, images.NewSigner("k"))(handler).ServeHTTP(httptest.NewRecorder(), req)
 
 	want := []string{"anonymous", "user", "moderator"}
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {
@@ -81,7 +82,7 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 		cdOut, _ = r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	})
 
-	CoreAdderMiddlewareWithDB(db)(handler).ServeHTTP(httptest.NewRecorder(), req)
+	CoreAdderMiddlewareWithDB(db, images.NewSigner("k"))(handler).ServeHTTP(httptest.NewRecorder(), req)
 
 	want := []string{"anonymous"}
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {


### PR DESCRIPTION
## Summary
- wrap image signing logic in an `ImageSigner` struct
- inject signer via CoreData instead of package globals
- update handlers and middleware to use injected signer

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6881868b4850832fbaf6694d0961b46b