### PR TITLE
Inject runtime config into CoreData

### DIFF
--- a/cmd/goa4web/news_list.go
+++ b/cmd/goa4web/news_list.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
@@ -36,7 +37,7 @@ func (c *newsListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	cd := common.NewCoreData(ctx, queries)
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	posts, err := cd.LatestNewsList(int32(c.Offset), int32(c.Limit))
 	if err != nil {
 		return fmt.Errorf("list news: %w", err)

--- a/cmd/goa4web/writing_list.go
+++ b/cmd/goa4web/writing_list.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
@@ -68,7 +69,7 @@ func (c *writingListCmd) Run() error {
 		}
 		return nil
 	}
-	cd := common.NewCoreData(ctx, queries)
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	rows, err := cd.LatestWritings(common.WithWritingsOffset(int32(c.Offset)), common.WithWritingsLimit(int32(c.Limit)))
 	if err != nil {
 		return fmt.Errorf("list writings: %w", err)

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -37,7 +37,7 @@ func TestCoreDataLatestNewsLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries)
+       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -71,7 +71,7 @@ func TestWritingCategoriesLazy(t *testing.T) {
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "category", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries)
+cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 
@@ -102,7 +102,7 @@ func TestAnnouncementForNewsCaching(t *testing.T) {
 	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnRows(annRows)
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries)
+       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 
 	if _, err := cd.AnnouncementForNews(1); err != nil {
 		t.Fatalf("AnnouncementForNews: %v", err)
@@ -128,7 +128,7 @@ func TestAnnouncementForNewsError(t *testing.T) {
 	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnError(sql.ErrConnDone)
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries)
+       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 
 	if _, err := cd.AnnouncementForNews(1); !errors.Is(err, sql.ErrConnDone) {
 		t.Fatalf("AnnouncementForNews error=%v", err)
@@ -167,7 +167,7 @@ func TestPublicWritingsLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries)
+       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -211,7 +211,7 @@ func TestCoreDataLatestWritingsLazy(t *testing.T) {
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "article", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries)
+       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 
@@ -247,7 +247,7 @@ func TestBloggersLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries)
+       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	req = req.WithContext(ctx)
 
@@ -283,7 +283,7 @@ func TestWritersLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries)
+       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	req = req.WithContext(ctx)
 

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
@@ -64,7 +65,7 @@ func TestLatestNewsRespectsPermissions(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries)
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -28,7 +28,7 @@ func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 	config.AppRuntimeConfig.EmailProvider = ""
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
-	cd := common.NewCoreData(req.Context(), nil, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)))
+	cd := common.NewCoreData(req.Context(), nil, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)), common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -59,7 +59,7 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
 	q := db.New(sqldb)
-	cd := common.NewCoreData(req.Context(), q, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)))
+	cd := common.NewCoreData(req.Context(), q, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)), common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/admin/reload_shutdown_test.go
+++ b/handlers/admin/reload_shutdown_test.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 )
 
 func TestAdminReloadConfigPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
-	cd := common.NewCoreData(req.Context(), nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -29,7 +30,7 @@ func TestAdminReloadConfigPage_Unauthorized(t *testing.T) {
 
 func TestAdminShutdownPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
-	cd := common.NewCoreData(req.Context(), nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -48,7 +49,7 @@ func TestAdminReloadRoute_Unauthorized(t *testing.T) {
 	RegisterRoutes(ar)
 
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
-	cd := common.NewCoreData(req.Context(), nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -67,7 +68,7 @@ func TestAdminShutdownRoute_Unauthorized(t *testing.T) {
 	RegisterRoutes(ar)
 
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
-	cd := common.NewCoreData(req.Context(), nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/auth/forgotPassword_event_test.go
+++ b/handlers/auth/forgotPassword_event_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -30,7 +31,7 @@ func TestForgotPasswordEventData(t *testing.T) {
 	mock.ExpectExec("INSERT INTO pending_passwords").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
-	cd := common.NewCoreData(context.Background(), q, common.WithEvent(evt))
+	cd := common.NewCoreData(context.Background(), q, common.WithEvent(evt), common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 
 	form := url.Values{"username": {"u"}, "password": {"pw"}}

--- a/handlers/auth/forgotPassword_limit_test.go
+++ b/handlers/auth/forgotPassword_limit_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -33,7 +34,7 @@ func TestForgotPasswordRateLimit(t *testing.T) {
 	form := url.Values{"username": {"u"}, "password": {"pw"}}
 	req := httptest.NewRequest(http.MethodPost, "/forgot", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	cd := common.NewCoreData(context.Background(), q)
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -66,7 +67,7 @@ func TestForgotPasswordReplaceOld(t *testing.T) {
 	form := url.Values{"username": {"u"}, "password": {"pw"}}
 	req := httptest.NewRequest(http.MethodPost, "/forgot", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	cd := common.NewCoreData(context.Background(), q)
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/handlers/auth/forgotPassword_no_email_test.go
+++ b/handlers/auth/forgotPassword_no_email_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -24,7 +25,7 @@ func TestForgotPasswordNoEmail(t *testing.T) {
 	q := dbpkg.New(db)
 	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "", "u"))
 
-	cd := common.NewCoreData(context.Background(), q)
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 
 	form := url.Values{"username": {"u"}, "password": {"pw"}}
@@ -54,7 +55,7 @@ func TestEmailAssociationRequestTask(t *testing.T) {
 	mock.ExpectExec("INSERT INTO admin_request_comments").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO admin_user_comments").WillReturnResult(sqlmock.NewResult(1, 1))
 
-	cd := common.NewCoreData(context.Background(), q)
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 
 	form := url.Values{"username": {"u"}, "email": {"a@test.com"}, "reason": {"help"}}

--- a/handlers/auth/loginPage_test.go
+++ b/handlers/auth/loginPage_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
@@ -34,7 +35,7 @@ func TestLoginAction_NoSuchUser(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = "1.2.3.4:1111"
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries)
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -72,7 +73,7 @@ func TestLoginAction_InvalidPassword(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = "1.2.3.4:1111"
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries)
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -97,7 +98,7 @@ func TestLoginPageHiddenFields(t *testing.T) {
 	q := dbpkg.New(db)
 
 	req := httptest.NewRequest(http.MethodGet, "/login?code=abc&back=%2Ffoo&method=POST&data=x", nil)
-	cd := common.NewCoreData(context.Background(), q)
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -140,7 +141,7 @@ func TestLoginAction_PendingResetPrompt(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = "1.2.3.4:1111"
 
-	cd := common.NewCoreData(req.Context(), q)
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/blogs/blogsBloggersBloggerPage_test.go
+++ b/handlers/blogs/blogsBloggersBloggerPage_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 )
@@ -27,7 +28,7 @@ func TestBloggersBloggerPage(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/blogs/bloggers/blogger", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q)
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.AppRuntimeConfig))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/handlers/blogs/blogsCommentPage_replyable_test.go
+++ b/handlers/blogs/blogsCommentPage_replyable_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 
+	"github.com/arran4/goa4web/config"
+
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
@@ -30,7 +32,7 @@ func setupCommentRequest(t *testing.T, queries *db.Queries, store *sessions.Cook
 		req.AddCookie(c)
 	}
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess))
+	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), common.WithConfig(config.AppRuntimeConfig))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	return req, sess

--- a/handlers/blogs/blogsIndexPermissions_test.go
+++ b/handlers/blogs/blogsIndexPermissions_test.go
@@ -4,13 +4,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 )
 
 func TestCustomBlogIndexRoles(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs", nil)
 
-	cd := common.NewCoreData(req.Context(), nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"administrator"})
 	cd.AdminMode = true
 	CustomBlogIndex(cd, req)
@@ -21,7 +22,7 @@ func TestCustomBlogIndexRoles(t *testing.T) {
 		t.Errorf("admin should see write blog")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil)
+	cd = common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"content writer"})
 	CustomBlogIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "User Permissions") {
@@ -31,7 +32,7 @@ func TestCustomBlogIndexRoles(t *testing.T) {
 		t.Errorf("content writer should see write blog")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil)
+	cd = common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"anonymous"})
 	CustomBlogIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "User Permissions") || common.ContainsItem(cd.CustomIndexItems, "Write blog") {

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 
+	"github.com/arran4/goa4web/config"
+
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
@@ -52,7 +54,7 @@ func TestBlogsBloggerPostsPage(t *testing.T) {
 	}
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess))
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithConfig(config.AppRuntimeConfig))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -100,7 +102,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "http://example.com/blogs/rss?rss=bob", nil)
 	q := db.New(sqldb)
-	cd := common.NewCoreData(req.Context(), q)
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -125,7 +127,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 
 func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -138,7 +140,7 @@ func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
 
 func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/1/edit", nil)
-	cd := common.NewCoreData(req.Context(), nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -151,7 +153,7 @@ func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 
 func TestGetPermissionsByUserIdAndSectionBlogsPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin/blogs/user/permissions", nil)
-	cd := common.NewCoreData(req.Context(), nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/bookmarks/mine_test.go
+++ b/handlers/bookmarks/mine_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/sessions"
 
+	"github.com/arran4/goa4web/config"
+
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
@@ -94,7 +96,7 @@ func TestMinePage_NoBookmarks(t *testing.T) {
 	}
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess))
+	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -98,7 +98,7 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	bus := eventbus.NewBus()
 	q := db.New(dbconn)
 	evt := &eventbus.TaskEvent{Path: "/faq/ask", Task: tasks.TaskString(TaskAsk), UserID: 1}
-	cd := common.NewCoreData(req.Context(), q)
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	cd.SetEvent(evt)
 

--- a/handlers/faq/page_test.go
+++ b/handlers/faq/page_test.go
@@ -3,11 +3,12 @@ package faq
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 )
 
 func TestCustomFAQIndexRoles(t *testing.T) {
-	cd := common.NewCoreData(nil, nil)
+	cd := common.NewCoreData(nil, nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"administrator"})
 	cd.AdminMode = true
 	CustomFAQIndex(cd, nil)
@@ -15,7 +16,7 @@ func TestCustomFAQIndexRoles(t *testing.T) {
 		t.Errorf("admin should see question controls")
 	}
 
-	cd = common.NewCoreData(nil, nil)
+	cd = common.NewCoreData(nil, nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"anonymous"})
 	CustomFAQIndex(cd, nil)
 	if common.ContainsItem(cd.CustomIndexItems, "Question Qontrols") {

--- a/handlers/forum/forumIndexPermissions_test.go
+++ b/handlers/forum/forumIndexPermissions_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/mux"
@@ -22,7 +23,7 @@ func TestCustomForumIndexWriteReply(t *testing.T) {
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q)
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.AppRuntimeConfig))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "reply", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -48,7 +49,7 @@ func TestCustomForumIndexWriteReplyDenied(t *testing.T) {
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q)
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.AppRuntimeConfig))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "reply", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -74,7 +75,7 @@ func TestCustomForumIndexCreateThread(t *testing.T) {
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q)
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.AppRuntimeConfig))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -100,7 +101,7 @@ func TestCustomForumIndexCreateThreadDenied(t *testing.T) {
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q)
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.AppRuntimeConfig))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -126,7 +127,7 @@ func TestCustomForumIndexSubscribeLink(t *testing.T) {
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q)
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 
 	mock.ExpectQuery("SELECT id, pattern, method FROM subscriptions").
@@ -153,7 +154,7 @@ func TestCustomForumIndexUnsubscribeLink(t *testing.T) {
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q)
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 
 	pattern := topicSubscriptionPattern(2)

--- a/handlers/forum/matchers_test.go
+++ b/handlers/forum/matchers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 )
@@ -37,7 +38,7 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
 	q := db.New(sqldb)
-	cd := common.NewCoreData(req.Context(), q)
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -85,7 +86,7 @@ func TestRequireThreadAndTopicFalse(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
 	q := db.New(sqldb)
-	cd := common.NewCoreData(req.Context(), q)
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -122,7 +123,7 @@ func TestRequireThreadAndTopicError(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
 	q := db.New(sqldb)
-	cd := common.NewCoreData(req.Context(), q)
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
@@ -69,7 +70,7 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/admin/queue?qid=1", nil)
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
-	cd := common.NewCoreData(req.Context(), queries)
+	cd := common.NewCoreData(req.Context(), queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetEvent(evt)
 	cd.SetEventTask(ApproveTask)
 	ctxreq := context.WithValue(req.Context(), consts.KeyCoreData, cd)
@@ -84,7 +85,7 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 	bus.Shutdown(context.Background())
 	cancel()
 	// Wait for the worker goroutine to exit before verifying expectations.
-	time.Sleep(300 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	err = nil
 	for i := 0; i < 20; i++ {
 		err = mock.ExpectationsWereMet()

--- a/handlers/matchers_test.go
+++ b/handlers/matchers_test.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 )
 
 func TestRequiredAccessAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	cd.SetRoles([]string{"content writer"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
@@ -26,7 +27,7 @@ func TestRequiredAccessAllowed(t *testing.T) {
 
 func TestRequiredAccessDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)

--- a/handlers/news/newsIndexPermissions_test.go
+++ b/handlers/news/newsIndexPermissions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
@@ -12,7 +13,7 @@ import (
 func TestCustomNewsIndexRoles(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 
-	cd := common.NewCoreData(req.Context(), nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"administrator"})
 	cd.AdminMode = true
 	CustomNewsIndex(cd, req)
@@ -30,7 +31,7 @@ func TestCustomNewsIndexRoles(t *testing.T) {
 	defer db.Close()
 	q := dbpkg.New(db)
 	ctx := req.Context()
-	cd = common.NewCoreData(ctx, q)
+	cd = common.NewCoreData(ctx, q, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"content writer", "administrator"})
 	CustomNewsIndex(cd, req.WithContext(ctx))
 	if common.ContainsItem(cd.CustomIndexItems, "User Permissions") {
@@ -40,7 +41,7 @@ func TestCustomNewsIndexRoles(t *testing.T) {
 		t.Errorf("content writer should see add news")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil)
+	cd = common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"anonymous"})
 	CustomNewsIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "User Permissions") || common.ContainsItem(cd.CustomIndexItems, "Add News") {

--- a/handlers/pagesize_test.go
+++ b/handlers/pagesize_test.go
@@ -32,7 +32,7 @@ func TestGetPageSize(t *testing.T) {
 			config.AppRuntimeConfig.PageSizeMax = 50
 			config.AppRuntimeConfig.PageSizeDefault = 15
 
-			cd := common.NewCoreData(context.Background(), nil)
+			cd := common.NewCoreData(context.Background(), nil, common.WithConfig(config.AppRuntimeConfig))
 			if tt.pref != nil {
 				common.WithPreference(tt.pref)(cd)
 			}

--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 )
@@ -30,7 +31,7 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cd := common.NewCoreData(r.Context(), queries)
+	cd := common.NewCoreData(r.Context(), queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = int32(uid)
 
 	user, err := cd.CurrentUser()

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -61,7 +62,7 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 	form.Set("task", string(TaskUserAllow))
 	req := httptest.NewRequest("POST", "/admin/users/permissions", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	cd := common.NewCoreData(req.Context(), queries)
+	cd := common.NewCoreData(req.Context(), queries, common.WithConfig(config.AppRuntimeConfig))
 	evt := &eventbus.TaskEvent{}
 	cd.SetEvent(evt)
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)

--- a/handlers/user/userEmailPage_event_test.go
+++ b/handlers/user/userEmailPage_event_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
@@ -44,7 +45,7 @@ func TestAddEmailTaskEventData(t *testing.T) {
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt))
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -87,7 +88,7 @@ func TestVerifyRemovesDuplicates(t *testing.T) {
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt))
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 
 	rows := sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).
@@ -150,7 +151,7 @@ func TestResendVerificationEmailTaskEventData(t *testing.T) {
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt))
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), common.WithConfig(config.AppRuntimeConfig))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	req = req.WithContext(ctx)

--- a/handlers/user/userEmailVerify_test.go
+++ b/handlers/user/userEmailVerify_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/sessions"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
@@ -38,7 +39,7 @@ func TestUserEmailVerifyCodePage_Invalid(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess))
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithConfig(config.AppRuntimeConfig))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	req := httptest.NewRequest(http.MethodGet, "/usr/email/verify?code="+code, nil).WithContext(ctx)
@@ -74,7 +75,7 @@ func TestUserEmailVerifyCodePage_Success(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess))
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithConfig(config.AppRuntimeConfig))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	form := url.Values{"code": {code}}

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -56,7 +56,7 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)))
+	cd := common.NewCoreData(ctx, queries, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)), common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -87,7 +87,7 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)))
+	cd := common.NewCoreData(ctx, queries, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)), common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -108,7 +108,7 @@ func TestUserEmailPage_ShowError(t *testing.T) {
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("GET", "/usr/email?error=missing", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries)
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -133,7 +133,7 @@ func TestUserEmailPage_NoUnverified(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/usr/email", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries)
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -159,7 +159,7 @@ func TestUserEmailPage_NoVerified(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/usr/email", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries)
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -208,7 +208,7 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess))
+	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -257,7 +257,7 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess))
+	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -307,7 +307,7 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess))
+	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/writings/matchers_test.go
+++ b/handlers/writings/matchers_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 
+	"github.com/arran4/goa4web/config"
+
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
@@ -35,7 +37,7 @@ func TestRequireWritingAuthorArticleVar(t *testing.T) {
 	sess, _ := store.Get(req, core.SessionName)
 	sess.Values["UID"] = int32(1)
 
-	cd := common.NewCoreData(req.Context(), q, common.WithSession(sess))
+	cd := common.NewCoreData(req.Context(), q, common.WithSession(sess), common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"content writer"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/writings/writingsAdminCategoriesPage_test.go
+++ b/handlers/writings/writingsAdminCategoriesPage_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 )
@@ -28,7 +29,7 @@ func TestWritingsAdminCategoriesPage(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/admin/writings/categories", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries)
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/handlers/writings/writingsArticlePage_test.go
+++ b/handlers/writings/writingsArticlePage_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/arran4/goa4web/handlers"
 
+	"github.com/arran4/goa4web/config"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
@@ -50,7 +52,7 @@ func TestArticleReplyActionPage_UsesArticleParam(t *testing.T) {
 	}
 
 	q := db.New(dbconn)
-	cd := common.NewCoreData(req.Context(), q)
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/writings/writingsWriterListPage_test.go
+++ b/handlers/writings/writingsWriterListPage_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 )
@@ -25,7 +26,7 @@ func TestWriterListPage_List(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/writings/writers", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q)
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -55,7 +56,7 @@ func TestWriterListPage_Search(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/writings/writers?search=bob", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q)
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -93,7 +93,8 @@ func CoreAdderMiddlewareWithDB(db *sql.DB, verbosity int) func(http.Handler) htt
 				common.WithImageURLMapper(imagesign.MapURL),
 				common.WithSession(session),
 				common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)),
-				common.WithAbsoluteURLBase(base))
+				common.WithAbsoluteURLBase(base),
+				common.WithConfig(config.AppRuntimeConfig))
 			cd.UserID = uid
 			_ = cd.UserRoles()
 

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/google/go-cmp/cmp"
@@ -34,7 +35,7 @@ func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
 	session := &sessions.Session{ID: "sessid", Values: map[interface{}]interface{}{"UID": int32(1)}}
 	req := httptest.NewRequest("GET", "/", nil)
 	q := dbpkg.New(db)
-	cd := common.NewCoreData(req.Context(), q)
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(req.Context(), core.ContextValues("session"), session)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -71,7 +72,7 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 	session := &sessions.Session{ID: "sessid"}
 	req := httptest.NewRequest("GET", "/", nil)
 	q := dbpkg.New(db)
-	cd := common.NewCoreData(req.Context(), q)
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.AppRuntimeConfig))
 	ctx := context.WithValue(req.Context(), core.ContextValues("session"), session)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/internal/router/roles_test.go
+++ b/internal/router/roles_test.go
@@ -7,13 +7,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/middleware"
 )
 
 func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	cd := common.NewCoreData(req.Context(), nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"administrator"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -38,7 +39,7 @@ func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 
 func TestRoleCheckerMiddlewareDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	cd := common.NewCoreData(req.Context(), nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)


### PR DESCRIPTION
## Summary
- add `Config` field to `CoreData` and new `WithConfig` option
- apply default runtime config in `NewCoreData`
- base pagination on `cd.Config` instead of global settings
- pass `WithConfig` when constructing `CoreData`
- adjust flaky test wait

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6881c655d524832fbdfd5f0c1c3e8297