### PR TITLE
refactor registries

### DIFF
--- a/cmd/goa4web/config_as.go
+++ b/cmd/goa4web/config_as.go
@@ -46,7 +46,7 @@ func (c *configAsCmd) asEnvFile() error {
 	}
 	sort.Strings(keys)
 	usage := config.UsageMap()
-	ext := config.ExtendedUsageMap()
+	ext := config.ExtendedUsageMap(c.rootCmd.dbReg)
 	ex := config.ExamplesMap()
 	for _, k := range keys {
 		u := usage[k]
@@ -85,7 +85,7 @@ func (c *configAsCmd) asEnv() error {
 	}
 	sort.Strings(keys)
 	usage := config.UsageMap()
-	ext := config.ExtendedUsageMap()
+	ext := config.ExtendedUsageMap(c.rootCmd.dbReg)
 	ex := config.ExamplesMap()
 	for _, k := range keys {
 		u := usage[k]

--- a/cmd/goa4web/config_options.go
+++ b/cmd/goa4web/config_options.go
@@ -39,7 +39,7 @@ type option struct {
 func (c *configOptionsCmd) Run() error {
 	def := defaultMap()
 	usage := config.UsageMap()
-	ext := config.ExtendedUsageMap()
+	ext := config.ExtendedUsageMap(c.rootCmd.dbReg)
 	names := config.NameMap()
 	keys := make([]string, 0, len(def))
 	for k := range def {

--- a/cmd/goa4web/db_backup.go
+++ b/cmd/goa4web/db_backup.go
@@ -3,8 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-
-	"github.com/arran4/goa4web/internal/dbdrivers"
 )
 
 // dbBackupCmd implements "db backup".
@@ -31,7 +29,7 @@ func (c *dbBackupCmd) Run() error {
 	}
 	cfg := c.rootCmd.cfg
 	c.rootCmd.Verbosef("creating backup using %s", cfg.DBDriver)
-	if err := dbdrivers.Backup(cfg.DBDriver, cfg.DBConn, c.File); err != nil {
+	if err := c.rootCmd.dbReg.Backup(cfg.DBDriver, cfg.DBConn, c.File); err != nil {
 		return err
 	}
 	c.rootCmd.Infof("database backup written to %s", c.File)

--- a/cmd/goa4web/db_migrate.go
+++ b/cmd/goa4web/db_migrate.go
@@ -15,12 +15,12 @@ import (
 )
 
 // openDB establishes a database connection without verifying the schema version.
-func openDB(cfg config.RuntimeConfig) (*sql.DB, error) {
+func openDB(cfg config.RuntimeConfig, reg *dbdrivers.Registry) (*sql.DB, error) {
 	conn := cfg.DBConn
 	if conn == "" {
 		return nil, fmt.Errorf("connection string required")
 	}
-	c, err := dbdrivers.Connector(cfg.DBDriver, conn)
+	c, err := reg.Connector(cfg.DBDriver, conn)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func parseDbMigrateCmd(parent *dbCmd, args []string) (*dbMigrateCmd, error) {
 
 func (c *dbMigrateCmd) Run() error {
 	c.rootCmd.Verbosef("connecting to database using %s", c.rootCmd.cfg.DBConn)
-	db, err := openDB(c.rootCmd.cfg)
+	db, err := openDB(c.rootCmd.cfg, c.rootCmd.dbReg)
 	if err != nil {
 		return fmt.Errorf("open db: %w", err)
 	}

--- a/cmd/goa4web/db_restore.go
+++ b/cmd/goa4web/db_restore.go
@@ -3,8 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-
-	"github.com/arran4/goa4web/internal/dbdrivers"
 )
 
 // dbRestoreCmd implements "db restore".
@@ -31,7 +29,7 @@ func (c *dbRestoreCmd) Run() error {
 	}
 	cfg := c.rootCmd.cfg
 	c.rootCmd.Verbosef("restoring from %s", c.File)
-	if err := dbdrivers.Restore(cfg.DBDriver, cfg.DBConn, c.File); err != nil {
+	if err := c.rootCmd.dbReg.Restore(cfg.DBDriver, cfg.DBConn, c.File); err != nil {
 		return err
 	}
 	c.rootCmd.Infof("database restored from %s", c.File)

--- a/cmd/goa4web/db_seed.go
+++ b/cmd/goa4web/db_seed.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"github.com/arran4/goa4web/internal/dbdrivers"
 )
 
 // dbSeedCmd implements "db seed".
@@ -36,7 +34,7 @@ func (c *dbSeedCmd) Run() error {
 	if conn == "" {
 		return fmt.Errorf("connection string required")
 	}
-	connector, err := dbdrivers.Connector(cfg.DBDriver, conn)
+	connector, err := c.rootCmd.dbReg.Connector(cfg.DBDriver, conn)
 	if err != nil {
 		return err
 	}

--- a/cmd/goa4web/dbinit.go
+++ b/cmd/goa4web/dbinit.go
@@ -1,9 +1,8 @@
 package main
 
 import (
+	"github.com/arran4/goa4web/internal/dbdrivers"
 	dbdefaults "github.com/arran4/goa4web/internal/dbdrivers/dbdefaults"
 )
 
-func init() {
-	dbdefaults.Register()
-}
+func init() { dbdefaults.Register(dbdrivers.NewRegistry()) }

--- a/cmd/goa4web/email_queue_resend.go
+++ b/cmd/goa4web/email_queue_resend.go
@@ -7,6 +7,7 @@ import (
 
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
+	emaildefaults "github.com/arran4/goa4web/internal/email/emaildefaults"
 	"github.com/arran4/goa4web/workers/emailqueue"
 )
 
@@ -42,7 +43,9 @@ func (c *emailQueueResendCmd) Run() error {
 	if err != nil {
 		return fmt.Errorf("get email: %w", err)
 	}
-	provider := email.ProviderFromConfig(c.rootCmd.cfg)
+	reg := email.NewRegistry()
+	emaildefaults.Register(reg)
+	provider := reg.ProviderFromConfig(c.rootCmd.cfg)
 	if provider != nil {
 		addr, err := emailqueue.ResolveQueuedEmailAddress(ctx, queries, &dbpkg.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
 		if err != nil {

--- a/cmd/goa4web/emailinit.go
+++ b/cmd/goa4web/emailinit.go
@@ -1,5 +1,0 @@
-package main
-
-import emaildefaults "github.com/arran4/goa4web/internal/email/emaildefaults"
-
-func init() { emaildefaults.Register() }

--- a/cmd/goa4web/notifications_tasks.go
+++ b/cmd/goa4web/notifications_tasks.go
@@ -39,7 +39,7 @@ func (c *notificationsTasksCmd) Run() error {
 	tw := table.NewWriter()
 	tw.SetOutputMirror(c.fs.Output())
 	tw.AppendHeader(table.Row{"Task", "Self Email", "Self Internal", "Subscribed Email", "Subscribed Internal", "Admin Email", "Admin Internal"})
-	for _, info := range taskTemplateInfos() {
+	for _, info := range taskTemplateInfos(c.notificationsCmd.rootCmd.tasksReg) {
 		tw.AppendRow(table.Row{
 			info.Task,
 			strings.Join(info.SelfEmail, ","),

--- a/cmd/goa4web/notifications_tasks_data.go
+++ b/cmd/goa4web/notifications_tasks_data.go
@@ -18,10 +18,10 @@ type taskTemplateInfo struct {
 	AdminInternal string
 }
 
-func taskTemplateInfos() []taskTemplateInfo {
-	reg := tasks.Registered()
-	infos := make([]taskTemplateInfo, 0, len(reg))
-	for _, t := range reg {
+func taskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
+	tasks := reg.Registered()
+	infos := make([]taskTemplateInfo, 0, len(tasks))
+	for _, t := range tasks {
 		info := taskTemplateInfo{Task: t.Name()}
 		if tp, ok := t.(notif.SelfNotificationTemplateProvider); ok {
 			if et := tp.SelfEmailTemplate(); et != nil {

--- a/config/maps_runtime.go
+++ b/config/maps_runtime.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"strconv"
+
+	"github.com/arran4/goa4web/internal/dbdrivers"
 )
 
 // DefaultMap returns a map of environment variable names to their
@@ -108,25 +110,25 @@ func NameMapWithOptions(sopts []StringOption, iopts []IntOption, bopts []BoolOpt
 
 // ExtendedUsageMap returns extended usage text indexed by environment variable name.
 // Errors while rendering the usage templates are ignored.
-func ExtendedUsageMap() map[string]string {
+func ExtendedUsageMap(reg *dbdrivers.Registry) map[string]string {
 	m := make(map[string]string)
 	for _, o := range StringOptions {
 		if o.ExtendedUsage != "" {
-			if txt, err := ExtendedUsage(o.ExtendedUsage); err == nil {
+			if txt, err := ExtendedUsage(o.ExtendedUsage, reg); err == nil {
 				m[o.Env] = txt
 			}
 		}
 	}
 	for _, o := range IntOptions {
 		if o.ExtendedUsage != "" {
-			if txt, err := ExtendedUsage(o.ExtendedUsage); err == nil {
+			if txt, err := ExtendedUsage(o.ExtendedUsage, reg); err == nil {
 				m[o.Env] = txt
 			}
 		}
 	}
 	for _, o := range BoolOptions {
 		if o.ExtendedUsage != "" {
-			if txt, err := ExtendedUsage(o.ExtendedUsage); err == nil {
+			if txt, err := ExtendedUsage(o.ExtendedUsage, reg); err == nil {
 				m[o.Env] = txt
 			}
 		}

--- a/config/templates_runtime.go
+++ b/config/templates_runtime.go
@@ -12,7 +12,7 @@ import (
 var tmplFS embed.FS
 
 // ExtendedUsage renders the named template with data from dbdrivers.Registry.
-func ExtendedUsage(name string) (string, error) {
+func ExtendedUsage(name string, reg *dbdrivers.Registry) (string, error) {
 	b, err := tmplFS.ReadFile("templates/" + name)
 	if err != nil {
 		return "", err
@@ -22,7 +22,7 @@ func ExtendedUsage(name string) (string, error) {
 		return "", err
 	}
 	var buf bytes.Buffer
-	if err := t.Execute(&buf, dbdrivers.Registry); err != nil {
+	if err := t.Execute(&buf, reg); err != nil {
 		return "", err
 	}
 	return buf.String(), nil

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -18,17 +18,24 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
+	emaildefaults "github.com/arran4/goa4web/internal/email/emaildefaults"
 	logProv "github.com/arran4/goa4web/internal/email/log"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
 
-func init() { logProv.Register() }
+var emailReg *email.Registry
+
+func init() {
+	emailReg = email.NewRegistry()
+	logProv.Register(emailReg)
+	emaildefaults.Register(emailReg)
+}
 
 func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 	config.AppRuntimeConfig.EmailProvider = ""
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
-	cd := common.NewCoreData(req.Context(), nil, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)))
+	cd := common.NewCoreData(req.Context(), nil, common.WithEmailProvider(emailReg.ProviderFromConfig(config.AppRuntimeConfig)))
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -59,7 +66,7 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
 	q := db.New(sqldb)
-	cd := common.NewCoreData(req.Context(), q, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)))
+	cd := common.NewCoreData(req.Context(), q, common.WithEmailProvider(emailReg.ProviderFromConfig(config.AppRuntimeConfig)))
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/admin/resend_queue_task.go
+++ b/handlers/admin/resend_queue_task.go
@@ -13,6 +13,7 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
+	emaildefaults "github.com/arran4/goa4web/internal/email/emaildefaults"
 	"github.com/arran4/goa4web/workers/emailqueue"
 )
 
@@ -27,7 +28,9 @@ var _ tasks.AuditableTask = (*ResendQueueTask)(nil)
 
 func (ResendQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	provider := email.ProviderFromConfig(config.AppRuntimeConfig)
+	reg := email.NewRegistry()
+	emaildefaults.Register(reg)
+	provider := reg.ProviderFromConfig(config.AppRuntimeConfig)
 	if err := r.ParseForm(); err != nil {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/admin/test_template_task.go
+++ b/handlers/admin/test_template_task.go
@@ -14,6 +14,7 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
+	emaildefaults "github.com/arran4/goa4web/internal/email/emaildefaults"
 	"github.com/arran4/goa4web/internal/tasks"
 
 	"github.com/arran4/goa4web/config"
@@ -31,7 +32,9 @@ var _ tasks.Task = (*TestTemplateTask)(nil)
 var _ tasks.AuditableTask = (*TestTemplateTask)(nil)
 
 func (TestTemplateTask) Action(w http.ResponseWriter, r *http.Request) any {
-	if email.ProviderFromConfig(config.AppRuntimeConfig) == nil {
+	reg := email.NewRegistry()
+	emaildefaults.Register(reg)
+	if reg.ProviderFromConfig(config.AppRuntimeConfig) == nil {
 		return fmt.Errorf("mail not configured %w", handlers.ErrRedirectOnSamePageHandler(userhandlers.ErrMailNotConfigured))
 	}
 

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -85,7 +85,7 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 	// Wait for the worker goroutine to exit before verifying expectations.
 	time.Sleep(50 * time.Millisecond)
 	err = nil
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 50; i++ {
 		err = mock.ExpectationsWereMet()
 		if err == nil {
 			break

--- a/handlers/taskhandler.go
+++ b/handlers/taskhandler.go
@@ -13,9 +13,6 @@ import (
 // TaskHandler wraps t.Action to record the task on the request event and handle the
 // returned result
 func TaskHandler(t tasks.Task) func(http.ResponseWriter, *http.Request) {
-	if nt, ok := t.(tasks.NamedTask); ok {
-		tasks.Register(nt)
-	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		if v := r.Context().Value(consts.KeyCoreData).(*common.CoreData); v != nil {
 			v.SetEventTask(t)

--- a/internal/app/dbstart/automigrate.go
+++ b/internal/app/dbstart/automigrate.go
@@ -25,12 +25,12 @@ func autoMigrateEnabled() bool {
 }
 
 // applyMigrations connects to the database and executes SQL migrations.
-func applyMigrations(ctx context.Context, cfg config.RuntimeConfig) error {
+func applyMigrations(ctx context.Context, cfg config.RuntimeConfig, reg *dbdrivers.Registry) error {
 	conn := cfg.DBConn
 	if conn == "" {
 		return fmt.Errorf("connection string required")
 	}
-	c, err := dbdrivers.Connector(cfg.DBDriver, conn)
+	c, err := reg.Connector(cfg.DBDriver, conn)
 	if err != nil {
 		return err
 	}
@@ -45,12 +45,12 @@ func applyMigrations(ctx context.Context, cfg config.RuntimeConfig) error {
 }
 
 // MaybeAutoMigrate runs migrations when enabled via AUTO_MIGRATE.
-func MaybeAutoMigrate(cfg config.RuntimeConfig) error {
+func MaybeAutoMigrate(cfg config.RuntimeConfig, reg *dbdrivers.Registry) error {
 	if !autoMigrateEnabled() {
 		return nil
 	}
 	ctx := context.Background()
-	if err := applyMigrations(ctx, cfg); err != nil {
+	if err := applyMigrations(ctx, cfg, reg); err != nil {
 		return fmt.Errorf("auto-migrate: %w", err)
 	}
 	return nil

--- a/internal/app/startup.go
+++ b/internal/app/startup.go
@@ -8,15 +8,19 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/internal/dbdrivers"
+	dbdefaults "github.com/arran4/goa4web/internal/dbdrivers/dbdefaults"
 	"github.com/arran4/goa4web/internal/upload"
 )
 
 // PerformChecks checks DB connectivity and the upload provider.
 func PerformChecks(cfg config.RuntimeConfig) error {
-	if err := dbstart2.MaybeAutoMigrate(cfg); err != nil {
+	reg := dbdrivers.NewRegistry()
+	dbdefaults.Register(reg)
+	if err := dbstart2.MaybeAutoMigrate(cfg, reg); err != nil {
 		return err
 	}
-	if ue := dbstart2.InitDB(cfg); ue != nil {
+	if ue := dbstart2.InitDB(cfg, reg); ue != nil {
 		return fmt.Errorf("%s: %w", ue.ErrorMessage, ue.Err)
 	}
 	if ue := CheckUploadTarget(cfg); ue != nil {

--- a/internal/dbdrivers/dbdefaults/allstable.go
+++ b/internal/dbdrivers/dbdefaults/allstable.go
@@ -1,14 +1,15 @@
 package dbdefaults
 
 import (
+	"github.com/arran4/goa4web/internal/dbdrivers"
 	"github.com/arran4/goa4web/internal/dbdrivers/mysql"
 	"github.com/arran4/goa4web/internal/dbdrivers/postgres"
 	"github.com/arran4/goa4web/internal/dbdrivers/sqlite"
 )
 
 // Register registers all stable database connectors.
-func Register() {
-	mysql.Register()
-	postgres.Register()
-	sqlite.Register()
+func Register(r *dbdrivers.Registry) {
+	mysql.Register(r)
+	postgres.Register(r)
+	sqlite.Register(r)
 }

--- a/internal/dbdrivers/dbdefaults/drivers_test.go
+++ b/internal/dbdrivers/dbdefaults/drivers_test.go
@@ -15,16 +15,18 @@ func (testConnector) Connect(context.Context) (driver.Conn, error) { return nil,
 func (testConnector) Driver() driver.Driver                        { return nil }
 
 func TestConnectorUnknown(t *testing.T) {
-	dbdefaults.Register()
-	if _, err := dbdrivers.Connector("unknown-driver", ""); err == nil {
+	reg := dbdrivers.NewRegistry()
+	dbdefaults.Register(reg)
+	if _, err := reg.Connector("unknown-driver", ""); err == nil {
 		t.Fatalf("expected error for unknown driver")
 	}
 }
 
 func TestRegistryNames(t *testing.T) {
-	dbdefaults.Register()
+	reg := dbdrivers.NewRegistry()
+	dbdefaults.Register(reg)
 	want := []string{"mysql", "postgres"}
-	names := dbdrivers.Names()
+	names := reg.Names()
 	for _, n := range want {
 		found := false
 		for _, rn := range names {
@@ -48,11 +50,9 @@ func (testDriver) Backup(string, string) error                    { return nil }
 func (testDriver) Restore(string, string) error                   { return nil }
 
 func TestConnectorRegistered(t *testing.T) {
-	orig := dbdrivers.Registry
-	t.Cleanup(func() { dbdrivers.Registry = orig })
-
-	dbdrivers.RegisterDriver(testDriver{})
-	c, err := dbdrivers.Connector("test", "")
+	reg := dbdrivers.NewRegistry()
+	reg.RegisterDriver(testDriver{})
+	c, err := reg.Connector("test", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/dbdrivers/mysql/driver.go
+++ b/internal/dbdrivers/mysql/driver.go
@@ -83,4 +83,4 @@ func (Driver) Restore(dsn, file string) error {
 }
 
 // Register registers the MySQL driver.
-func Register() { dbdrivers.RegisterDriver(Driver{}) }
+func Register(r *dbdrivers.Registry) { r.RegisterDriver(Driver{}) }

--- a/internal/dbdrivers/postgres/driver.go
+++ b/internal/dbdrivers/postgres/driver.go
@@ -66,4 +66,4 @@ func (Driver) Restore(dsn, file string) error {
 }
 
 // Register registers the PostgreSQL driver.
-func Register() { dbdrivers.RegisterDriver(Driver{}) }
+func Register(r *dbdrivers.Registry) { r.RegisterDriver(Driver{}) }

--- a/internal/dbdrivers/registry.go
+++ b/internal/dbdrivers/registry.go
@@ -17,31 +17,34 @@ type DBDriver interface {
 	Restore(dsn, file string) error
 }
 
-// Registry lists the built-in database drivers.
-var (
-	regMu    sync.RWMutex
-	Registry []DBDriver
-)
+// Registry maintains registered database drivers.
+type Registry struct {
+	mu      sync.RWMutex
+	drivers []DBDriver
+}
+
+// NewRegistry returns an empty driver registry.
+func NewRegistry() *Registry { return &Registry{} }
 
 // RegisterDriver adds d to the Registry.
-func RegisterDriver(d DBDriver) {
-	regMu.Lock()
-	defer regMu.Unlock()
-	for _, r := range Registry {
-		if r.Name() == d.Name() {
+func (r *Registry) RegisterDriver(d DBDriver) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, exist := range r.drivers {
+		if exist.Name() == d.Name() {
 			log.Printf("dbdrivers: driver %s already registered", d.Name())
 			return
 		}
 	}
-	Registry = append(Registry, d)
+	r.drivers = append(r.drivers, d)
 }
 
 // Connector returns a driver.Connector for the driver with the given name and
 // DSN. It searches the Registry for a matching driver.
-func Connector(name, dsn string) (driver.Connector, error) {
-	regMu.RLock()
-	drivers := append([]DBDriver(nil), Registry...)
-	regMu.RUnlock()
+func (r *Registry) Connector(name, dsn string) (driver.Connector, error) {
+	r.mu.RLock()
+	drivers := append([]DBDriver(nil), r.drivers...)
+	r.mu.RUnlock()
 	for _, d := range drivers {
 		if d.Name() == name {
 			return d.OpenConnector(dsn)
@@ -51,10 +54,10 @@ func Connector(name, dsn string) (driver.Connector, error) {
 }
 
 // Driver looks up a registered driver by name.
-func Driver(name string) (DBDriver, error) {
-	regMu.RLock()
-	drivers := append([]DBDriver(nil), Registry...)
-	regMu.RUnlock()
+func (r *Registry) Driver(name string) (DBDriver, error) {
+	r.mu.RLock()
+	drivers := append([]DBDriver(nil), r.drivers...)
+	r.mu.RUnlock()
 	for _, d := range drivers {
 		if d.Name() == name {
 			return d, nil
@@ -64,8 +67,8 @@ func Driver(name string) (DBDriver, error) {
 }
 
 // Backup invokes the driver's Backup method.
-func Backup(name, dsn, file string) error {
-	d, err := Driver(name)
+func (r *Registry) Backup(name, dsn, file string) error {
+	d, err := r.Driver(name)
 	if err != nil {
 		return err
 	}
@@ -73,8 +76,8 @@ func Backup(name, dsn, file string) error {
 }
 
 // Restore invokes the driver's Restore method.
-func Restore(name, dsn, file string) error {
-	d, err := Driver(name)
+func (r *Registry) Restore(name, dsn, file string) error {
+	d, err := r.Driver(name)
 	if err != nil {
 		return err
 	}
@@ -82,10 +85,10 @@ func Restore(name, dsn, file string) error {
 }
 
 // Names returns the names of all registered drivers.
-func Names() []string {
-	regMu.RLock()
-	drivers := append([]DBDriver(nil), Registry...)
-	regMu.RUnlock()
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	drivers := append([]DBDriver(nil), r.drivers...)
+	r.mu.RUnlock()
 	m := map[string]struct{}{}
 	for _, d := range drivers {
 		m[d.Name()] = struct{}{}

--- a/internal/dbdrivers/sqlite/driver.go
+++ b/internal/dbdrivers/sqlite/driver.go
@@ -85,4 +85,4 @@ func (Driver) Restore(dsn, file string) error {
 }
 
 // Register registers the SQLite driver.
-func Register() { dbdrivers.RegisterDriver(Driver{}) }
+func Register(r *dbdrivers.Registry) { r.RegisterDriver(Driver{}) }

--- a/internal/dbdrivers/sqlite/driver_nocgodeps.go
+++ b/internal/dbdrivers/sqlite/driver_nocgodeps.go
@@ -2,9 +2,12 @@
 
 package sqlite
 
-import "log"
+import (
+	"github.com/arran4/goa4web/internal/dbdrivers"
+	"log"
+)
 
 // Register logs that SQLite is disabled for quick tests.
-func Register() {
+func Register(r *dbdrivers.Registry) {
 	log.Println("sqlite: driver disabled for quick tests")
 }

--- a/internal/dlq/db/db.go
+++ b/internal/dlq/db/db.go
@@ -21,8 +21,8 @@ func (d DLQ) Record(ctx context.Context, message string) error {
 }
 
 // Register registers the database provider.
-func Register() {
-	dlq.RegisterProvider("db", func(_ config.RuntimeConfig, q *dbpkg.Queries) dlq.DLQ {
+func Register(r *dlq.Registry) {
+	r.RegisterProvider("db", func(_ config.RuntimeConfig, q *dbpkg.Queries) dlq.DLQ {
 		return DLQ{Queries: q}
 	})
 }

--- a/internal/dlq/dir/dir.go
+++ b/internal/dlq/dir/dir.go
@@ -30,8 +30,8 @@ func (d *DLQ) Record(_ context.Context, message string) error {
 }
 
 // Register registers the directory provider.
-func Register() {
-	dlq.RegisterProvider("dir", func(cfg config.RuntimeConfig, _ *dbpkg.Queries) dlq.DLQ {
+func Register(r *dlq.Registry) {
+	r.RegisterProvider("dir", func(cfg config.RuntimeConfig, _ *dbpkg.Queries) dlq.DLQ {
 		return &DLQ{Dir: cfg.DLQFile}
 	})
 }

--- a/internal/dlq/dlq.go
+++ b/internal/dlq/dlq.go
@@ -22,10 +22,8 @@ func (LogDLQ) Record(_ context.Context, message string) error {
 }
 
 // RegisterLogDLQ registers the log provider.
-func RegisterLogDLQ() {
-	RegisterProvider("log", func(config.RuntimeConfig, *dbpkg.Queries) DLQ {
+func RegisterLogDLQ(r *Registry) {
+	r.RegisterProvider("log", func(config.RuntimeConfig, *dbpkg.Queries) DLQ {
 		return LogDLQ{}
 	})
 }
-
-func init() { RegisterLogDLQ() }

--- a/internal/dlq/dlq_test.go
+++ b/internal/dlq/dlq_test.go
@@ -11,28 +11,34 @@ import (
 	dlqdefaults "github.com/arran4/goa4web/internal/dlq/dlqdefaults"
 	emaildlq "github.com/arran4/goa4web/internal/dlq/email"
 	filedlq "github.com/arran4/goa4web/internal/dlq/file"
+	email "github.com/arran4/goa4web/internal/email"
+	emaildefaults "github.com/arran4/goa4web/internal/email/emaildefaults"
 )
 
 func TestProviderFromConfigRegistry(t *testing.T) {
-	dlqdefaults.Register()
+	emailReg := email.NewRegistry()
+	emaildefaults.Register(emailReg)
+	reg := dlq.NewRegistry()
+	dlq.RegisterLogDLQ(reg)
+	dlqdefaults.Register(reg, emailReg)
 
 	cfg := config.RuntimeConfig{DLQProvider: "file", DLQFile: "p"}
-	if _, ok := dlq.ProviderFromConfig(cfg, nil).(*filedlq.DLQ); !ok {
+	if _, ok := reg.ProviderFromConfig(cfg, nil).(*filedlq.DLQ); !ok {
 		t.Fatalf("expected *file.DLQ")
 	}
 
 	cfg = config.RuntimeConfig{DLQProvider: "dir", DLQFile: "d"}
-	if _, ok := dlq.ProviderFromConfig(cfg, nil).(*dirdlq.DLQ); !ok {
+	if _, ok := reg.ProviderFromConfig(cfg, nil).(*dirdlq.DLQ); !ok {
 		t.Fatalf("expected *dir.DLQ")
 	}
 
 	cfg = config.RuntimeConfig{DLQProvider: "db"}
-	if _, ok := dlq.ProviderFromConfig(cfg, (&dbpkg.Queries{})).(dbdlq.DLQ); !ok {
+	if _, ok := reg.ProviderFromConfig(cfg, (&dbpkg.Queries{})).(dbdlq.DLQ); !ok {
 		t.Fatalf("expected db.DLQ")
 	}
 
 	cfg = config.RuntimeConfig{DLQProvider: "email"}
-	p := dlq.ProviderFromConfig(cfg, nil)
+	p := reg.ProviderFromConfig(cfg, nil)
 	if _, ok := p.(emaildlq.DLQ); !ok {
 		if _, ok := p.(dlq.LogDLQ); !ok {
 			t.Fatalf("unexpected type %T", p)
@@ -40,20 +46,22 @@ func TestProviderFromConfigRegistry(t *testing.T) {
 	}
 
 	cfg = config.RuntimeConfig{DLQProvider: "db,log"}
-	if _, ok := dlq.ProviderFromConfig(cfg, (&dbpkg.Queries{})).(dlq.MultiDLQ); !ok {
+	if _, ok := reg.ProviderFromConfig(cfg, (&dbpkg.Queries{})).(dlq.MultiDLQ); !ok {
 		t.Fatalf("expected MultiDLQ")
 	}
 }
 
 func TestRegisterProviderCustom(t *testing.T) {
 	called := false
-	dlq.RegisterProvider("custom", func(cfg config.RuntimeConfig, q *dbpkg.Queries) dlq.DLQ {
+	reg := dlq.NewRegistry()
+	dlq.RegisterLogDLQ(reg)
+	reg.RegisterProvider("custom", func(cfg config.RuntimeConfig, q *dbpkg.Queries) dlq.DLQ {
 		called = true
 		return dlq.LogDLQ{}
 	})
 
 	cfg := config.RuntimeConfig{DLQProvider: "custom"}
-	if _, ok := dlq.ProviderFromConfig(cfg, nil).(dlq.LogDLQ); !ok || !called {
+	if _, ok := reg.ProviderFromConfig(cfg, nil).(dlq.LogDLQ); !ok || !called {
 		t.Fatalf("custom provider not used")
 	}
 }

--- a/internal/dlq/dlqdefaults/defaults.go
+++ b/internal/dlq/dlqdefaults/defaults.go
@@ -1,16 +1,18 @@
 package dlqdefaults
 
 import (
+	dlqpkg "github.com/arran4/goa4web/internal/dlq"
 	"github.com/arran4/goa4web/internal/dlq/db"
 	"github.com/arran4/goa4web/internal/dlq/dir"
 	"github.com/arran4/goa4web/internal/dlq/email"
 	"github.com/arran4/goa4web/internal/dlq/file"
+	emailpkg "github.com/arran4/goa4web/internal/email"
 )
 
 // Register registers all stable DLQ providers.
-func Register() {
-	file.Register()
-	dir.Register()
-	db.Register()
-	email.Register()
+func Register(d *dlqpkg.Registry, e *emailpkg.Registry) {
+	file.Register(d)
+	dir.Register(d)
+	db.Register(d)
+	email.Register(d, e)
 }

--- a/internal/dlq/email/email.go
+++ b/internal/dlq/email/email.go
@@ -42,9 +42,9 @@ func (e DLQ) Record(ctx context.Context, message string) error {
 }
 
 // Register registers the email provider.
-func Register() {
-	dlq.RegisterProvider("email", func(cfg config.RuntimeConfig, q *dbpkg.Queries) dlq.DLQ {
-		p := email.ProviderFromConfig(cfg)
+func Register(d *dlq.Registry, e *email.Registry) {
+	d.RegisterProvider("email", func(cfg config.RuntimeConfig, q *dbpkg.Queries) dlq.DLQ {
+		p := e.ProviderFromConfig(cfg)
 		if p == nil {
 			return dlq.LogDLQ{}
 		}

--- a/internal/dlq/file/file.go
+++ b/internal/dlq/file/file.go
@@ -43,8 +43,8 @@ func (f *DLQ) Record(_ context.Context, message string) error {
 }
 
 // Register registers the file provider.
-func Register() {
-	dlq.RegisterProvider("file", func(cfg config.RuntimeConfig, _ *dbpkg.Queries) dlq.DLQ {
+func Register(r *dlq.Registry) {
+	r.RegisterProvider("file", func(cfg config.RuntimeConfig, _ *dbpkg.Queries) dlq.DLQ {
 		return &DLQ{Path: cfg.DLQFile}
 	})
 }

--- a/internal/dlq/mock/mock.go
+++ b/internal/dlq/mock/mock.go
@@ -31,4 +31,4 @@ func providerFromConfig(_ config.RuntimeConfig, _ *dbpkg.Queries) dlq.DLQ {
 }
 
 // Register registers the mock provider factory.
-func Register() { dlq.RegisterProvider("mock", providerFromConfig) }
+func Register(r *dlq.Registry) { r.RegisterProvider("mock", providerFromConfig) }

--- a/internal/dlq/provider_factory.go
+++ b/internal/dlq/provider_factory.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ProviderFromConfig returns a DLQ implementation configured from cfg.
-func ProviderFromConfig(cfg config.RuntimeConfig, q *dbpkg.Queries) DLQ {
+func (r *Registry) ProviderFromConfig(cfg config.RuntimeConfig, q *dbpkg.Queries) DLQ {
 	names := strings.Split(cfg.DLQProvider, ",")
 	var qs []DLQ
 	for _, name := range names {
@@ -17,7 +17,7 @@ func ProviderFromConfig(cfg config.RuntimeConfig, q *dbpkg.Queries) DLQ {
 		if n == "" {
 			continue
 		}
-		if f := lookupProvider(n); f != nil {
+		if f := r.lookupProvider(n); f != nil {
 			qs = append(qs, f(cfg, q))
 		} else {
 			if n != "log" {

--- a/internal/email/email_sendgrid_test.go
+++ b/internal/email/email_sendgrid_test.go
@@ -7,15 +7,19 @@ import (
 	"testing"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/internal/email"
 	sendgridProv "github.com/arran4/goa4web/internal/email/sendgrid"
 )
 
+var reg *email.Registry
+
 func init() {
-	sendgridProv.Register()
+	reg = email.NewRegistry()
+	sendgridProv.Register(reg)
 }
 
 func TestSendGridProviderFromConfig(t *testing.T) {
-	p := ProviderFromConfig(config.RuntimeConfig{EmailProvider: "sendgrid", EmailSendGridKey: "k", EmailFrom: "from@example.com"})
+	p := reg.ProviderFromConfig(config.RuntimeConfig{EmailProvider: "sendgrid", EmailSendGridKey: "k", EmailFrom: "from@example.com"})
 	if _, ok := p.(sendgridProv.Provider); !ok {
 		t.Fatalf("expected SendGridProvider, got %#v", p)
 	}

--- a/internal/email/emaildefaults/builtin.go
+++ b/internal/email/emaildefaults/builtin.go
@@ -1,6 +1,7 @@
 package emaildefaults
 
 import (
+	emailpkg "github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/internal/email/jmap"
 	"github.com/arran4/goa4web/internal/email/local"
 	"github.com/arran4/goa4web/internal/email/log"
@@ -9,10 +10,10 @@ import (
 )
 
 // Register registers all stable email providers.
-func Register() {
-	smtp.Register()
-	ses.Register()
-	jmap.Register()
-	local.Register()
-	log.Register()
+func Register(r *emailpkg.Registry) {
+	smtp.Register(r)
+	ses.Register(r)
+	jmap.Register(r)
+	local.Register(r)
+	log.Register(r)
 }

--- a/internal/email/jmap/jmap.go
+++ b/internal/email/jmap/jmap.go
@@ -126,4 +126,4 @@ func providerFromConfig(cfg config.RuntimeConfig) email.Provider {
 }
 
 // Register registers the JMAP provider.
-func Register() { email.RegisterProvider("jmap", providerFromConfig) }
+func Register(r *email.Registry) { r.RegisterProvider("jmap", providerFromConfig) }

--- a/internal/email/local/local.go
+++ b/internal/email/local/local.go
@@ -22,4 +22,4 @@ func (Provider) Send(ctx context.Context, to mail.Address, rawEmailMessage []byt
 func providerFromConfig(config.RuntimeConfig) email.Provider { return Provider{} }
 
 // Register registers the local provider factory.
-func Register() { email.RegisterProvider("local", providerFromConfig) }
+func Register(r *email.Registry) { r.RegisterProvider("local", providerFromConfig) }

--- a/internal/email/log/log.go
+++ b/internal/email/log/log.go
@@ -20,4 +20,4 @@ func (Provider) Send(ctx context.Context, to mail.Address, rawEmailMessage []byt
 func providerFromConfig(config.RuntimeConfig) email.Provider { return Provider{} }
 
 // Register registers the log provider factory.
-func Register() { email.RegisterProvider("log", providerFromConfig) }
+func Register(r *email.Registry) { r.RegisterProvider("log", providerFromConfig) }

--- a/internal/email/mock/mock.go
+++ b/internal/email/mock/mock.go
@@ -69,4 +69,4 @@ func (p *Provider) Send(_ context.Context, to mail.Address, rawEmailMessage []by
 func providerFromConfig(config.RuntimeConfig) email.Provider { return &Provider{} }
 
 // Register registers the mock provider factory.
-func Register() { email.RegisterProvider("mock", providerFromConfig) }
+func Register(r *email.Registry) { r.RegisterProvider("mock", providerFromConfig) }

--- a/internal/email/provider_factory.go
+++ b/internal/email/provider_factory.go
@@ -8,10 +8,10 @@ import (
 )
 
 // ProviderFromConfig returns an email provider configured from cfg.
-func ProviderFromConfig(cfg config.RuntimeConfig) Provider {
+func (r *Registry) ProviderFromConfig(cfg config.RuntimeConfig) Provider {
 	mode := strings.ToLower(cfg.EmailProvider)
 
-	if f := providerFactory(mode); f != nil {
+	if f := r.providerFactory(mode); f != nil {
 		return f(cfg)
 	}
 

--- a/internal/email/registry.go
+++ b/internal/email/registry.go
@@ -8,26 +8,32 @@ import (
 	"github.com/arran4/goa4web/config"
 )
 
-var (
-	regMu            sync.RWMutex
-	providerRegistry = map[string]func(config.RuntimeConfig) Provider{}
-)
+// Registry stores registered email providers.
+type Registry struct {
+	mu        sync.RWMutex
+	providers map[string]func(config.RuntimeConfig) Provider
+}
 
-// RegisterProvider registers a factory for name.
-func RegisterProvider(name string, factory func(config.RuntimeConfig) Provider) {
+// NewRegistry returns an initialised email provider registry.
+func NewRegistry() *Registry {
+	return &Registry{providers: map[string]func(config.RuntimeConfig) Provider{}}
+}
+
+// RegisterProvider registers factory under name.
+func (r *Registry) RegisterProvider(name string, factory func(config.RuntimeConfig) Provider) {
 	n := strings.ToLower(name)
-	regMu.Lock()
-	defer regMu.Unlock()
-	if _, ok := providerRegistry[n]; ok {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.providers[n]; ok {
 		log.Printf("email: provider %s already registered", n)
 	}
-	providerRegistry[n] = factory
+	r.providers[n] = factory
 }
 
 // providerFactory looks up the factory for name.
-func providerFactory(name string) func(config.RuntimeConfig) Provider {
-	regMu.RLock()
-	f := providerRegistry[strings.ToLower(name)]
-	regMu.RUnlock()
+func (r *Registry) providerFactory(name string) func(config.RuntimeConfig) Provider {
+	r.mu.RLock()
+	f := r.providers[strings.ToLower(name)]
+	r.mu.RUnlock()
 	return f
 }

--- a/internal/email/sendgrid/sendgrid.go
+++ b/internal/email/sendgrid/sendgrid.go
@@ -89,8 +89,8 @@ func providerFromConfig(key string, from string) email.Provider {
 }
 
 // Register registers the SendGrid provider factory.
-func Register() {
-	email.RegisterProvider("sendgrid", func(cfg config.RuntimeConfig) email.Provider {
+func Register(r *email.Registry) {
+	r.RegisterProvider("sendgrid", func(cfg config.RuntimeConfig) email.Provider {
 		return providerFromConfig(cfg.EmailSendGridKey, cfg.EmailFrom)
 	})
 }

--- a/internal/email/ses/ses.go
+++ b/internal/email/ses/ses.go
@@ -54,4 +54,4 @@ func providerFromConfig(cfg config.RuntimeConfig) email.Provider {
 }
 
 // Register registers the SES provider factory.
-func Register() { email.RegisterProvider("ses", providerFromConfig) }
+func Register(r *email.Registry) { r.RegisterProvider("ses", providerFromConfig) }

--- a/internal/email/ses/ses_stub.go
+++ b/internal/email/ses/ses_stub.go
@@ -13,4 +13,4 @@ const Built = false
 func providerFromConfig(config.RuntimeConfig) email.Provider { return nil }
 
 // Register is a no-op when the ses build tag is not present.
-func Register() { email.RegisterProvider("ses", providerFromConfig) }
+func Register(r *email.Registry) { r.RegisterProvider("ses", providerFromConfig) }

--- a/internal/email/smtp/smtp.go
+++ b/internal/email/smtp/smtp.go
@@ -155,4 +155,4 @@ func providerFromConfig(cfg config.RuntimeConfig) email.Provider {
 }
 
 // Register registers the SMTP provider factory.
-func Register() { email.RegisterProvider("smtp", providerFromConfig) }
+func Register(r *email.Registry) { r.RegisterProvider("smtp", providerFromConfig) }

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -18,6 +18,7 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
+	emaildefaults "github.com/arran4/goa4web/internal/email/emaildefaults"
 	imagesign "github.com/arran4/goa4web/internal/images"
 	nav "github.com/arran4/goa4web/internal/navigation"
 	"github.com/gorilla/sessions"
@@ -87,10 +88,12 @@ func CoreAdderMiddlewareWithDB(db *sql.DB) func(http.Handler) http.Handler {
 			if config.AppRuntimeConfig.HTTPHostname != "" {
 				base = strings.TrimRight(config.AppRuntimeConfig.HTTPHostname, "/")
 			}
+			emailReg := email.NewRegistry()
+			emaildefaults.Register(emailReg)
 			cd := common.NewCoreData(r.Context(), queries,
 				common.WithImageURLMapper(imagesign.MapURL),
 				common.WithSession(session),
-				common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)),
+				common.WithEmailProvider(emailReg.ProviderFromConfig(config.AppRuntimeConfig)),
 				common.WithAbsoluteURLBase(base))
 			cd.UserID = uid
 			_ = cd.UserRoles()

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -12,6 +12,7 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
+	emaildefaults "github.com/arran4/goa4web/internal/email/emaildefaults"
 	htemplate "html/template"
 )
 
@@ -41,7 +42,9 @@ func WithEmailProvider(p email.Provider) Option { return func(n *Notifier) { n.E
 func WithConfig(cfg config.RuntimeConfig) Option {
 	return func(n *Notifier) {
 		if n.EmailProvider == nil {
-			n.EmailProvider = email.ProviderFromConfig(cfg)
+			reg := email.NewRegistry()
+			emaildefaults.Register(reg)
+			n.EmailProvider = reg.ProviderFromConfig(cfg)
 		}
 	}
 }

--- a/internal/tasks/registry.go
+++ b/internal/tasks/registry.go
@@ -7,27 +7,31 @@ type NamedTask interface {
 	Name() string
 }
 
-var (
-	regMu    sync.Mutex
-	registry []NamedTask
-)
+// Registry stores registered tasks.
+type Registry struct {
+	mu    sync.Mutex
+	tasks []NamedTask
+}
+
+// NewRegistry returns an initialised task registry.
+func NewRegistry() *Registry { return &Registry{} }
 
 // Register adds t to the registry. Duplicate names are ignored.
-func Register(t NamedTask) {
-	regMu.Lock()
-	defer regMu.Unlock()
-	for _, r := range registry {
-		if r.Name() == t.Name() {
+func (r *Registry) Register(t NamedTask) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, existing := range r.tasks {
+		if existing.Name() == t.Name() {
 			return
 		}
 	}
-	registry = append(registry, t)
+	r.tasks = append(r.tasks, t)
 }
 
 // Registered returns a copy of the registered tasks slice.
-func Registered() []NamedTask {
-	regMu.Lock()
-	tasks := append([]NamedTask(nil), registry...)
-	regMu.Unlock()
+func (r *Registry) Registered() []NamedTask {
+	r.mu.Lock()
+	tasks := append([]NamedTask(nil), r.tasks...)
+	r.mu.Unlock()
 	return tasks
 }

--- a/specs/dbdrivers.md
+++ b/specs/dbdrivers.md
@@ -21,15 +21,15 @@ type DBDriver interface {
 
 ## Registration
 
-Drivers must be registered before they can be used. The registry is a simple in-memory slice protected by a mutex. Drivers call `dbdrivers.RegisterDriver` from an init or setup function:
+Drivers must be registered before they can be used. Applications create a `dbdrivers.Registry` and register drivers with the `RegisterDriver` method:
 
 ```go
-func Register() { dbdrivers.RegisterDriver(Driver{}) }
+func Register(r *dbdrivers.Registry) { r.RegisterDriver(Driver{}) }
 ```
 
 The `dbdefaults` package registers all stable drivers by calling the `Register` function of each built-in driver. Application code can also register custom drivers.
 
-`dbdrivers.Connector`, `dbdrivers.Backup` and `dbdrivers.Restore` look up the requested driver in the registry.
+The registry provides `Connector`, `Backup` and `Restore` methods that look up the requested driver by name.
 
 ## Built-in drivers
 


### PR DESCRIPTION
## Summary
- introduce instance-based registry for tasks and db drivers
- update db driver initialization and related commands
- adjust config functions to accept registries

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestLinkerApproveAddsToSearch)*

------
https://chatgpt.com/codex/tasks/task_e_688186a44a00832f85237ac22eea629a