### PR TITLE
Remove redundant HasAdminRole flags

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -41,7 +41,6 @@ type NewsPost struct {
 	ShowEdit     bool
 	Editing      bool
 	Announcement *db.SiteAnnouncement
-	IsAdmin      bool
 }
 
 type CoreData struct {
@@ -573,7 +572,6 @@ func (cd *CoreData) fetchLatestNews(offset, limit int32, replyID int) ([]*NewsPo
 			ShowEdit:     cd.HasGrant("news", "post", "edit", row.Idsitenews) && (cd.AdminMode || cd.UserID != 0),
 			Editing:      replyID == int(row.Idsitenews),
 			Announcement: ann,
-			IsAdmin:      cd.HasRole("administrator") && cd.AdminMode,
 		})
 	}
 	return posts, nil
@@ -924,10 +922,10 @@ func (cd *CoreData) LinkerCategoryCounts() ([]*db.GetLinkerCategoryLinkCountsRow
 	})
 }
 
-func (cd *CoreData) IsAdmin() bool {
+func (cd *CoreData) HasAdminRole() bool {
 	return cd.HasRole("administrator") && cd.AdminMode
 }
 
-func (cd *CoreData) IsWriter() bool {
-	return cd.HasRole("content writer") || cd.IsAdmin()
+func (cd *CoreData) HasContentWriterRole() bool {
+	return cd.HasRole("content writer") || cd.HasAdminRole()
 }

--- a/core/templates/site/listAbstracts.gohtml
+++ b/core/templates/site/listAbstracts.gohtml
@@ -1,5 +1,5 @@
 {{ define "listAbstracts" }}
-    {{ if $.IsWriter }}
+    {{ if $.HasContentWriterRole }}
         [<a href="/writings/category/{{ .CategoryId }}/add">Write writing here.</a>]<br>
     {{ end }}
     {{ if .Abstracts }}

--- a/core/templates/site/listWritingCategories.gohtml
+++ b/core/templates/site/listWritingCategories.gohtml
@@ -8,7 +8,7 @@
             {{ $title := .Title.String }}
             {{ $description := .Description.String }}
             {{ $id := .Idwritingcategory }}
-            {{ if and cd.IsAdmin (eq $.EditingCategoryId $id) }}
+            {{ if and cd.HasAdminRole (eq $.EditingCategoryId $id) }}
                 <tr>
                     <th><a href="/admin/writings/categories?category={{ $id }}">{{ $title }}</a></th>
                     <td>{{ $description }}</td>
@@ -31,12 +31,12 @@
                 </tr>
             {{ else }}
                 <tr>
-                    <th><a href="/writings/category/{{ $id }}">{{ $title }}</a>{{ if cd.IsAdmin }} [<a href="?edit={{ $id }}">Edit</a>]{{ end }}</th>
+                    <th><a href="/writings/category/{{ $id }}">{{ $title }}</a>{{ if cd.HasAdminRole }} [<a href="?edit={{ $id }}">Edit</a>]{{ end }}</th>
                     <td>{{ $description }}</td>
                 </tr>
             {{ end }}
         {{ end }}
-        {{ if cd.IsAdmin }}
+        {{ if cd.HasAdminRole }}
             <tr>
                 <td>
                     <form method="post">

--- a/core/templates/site/news/post.gohtml
+++ b/core/templates/site/news/post.gohtml
@@ -14,7 +14,7 @@
             {{ if .ShowEdit }}
                 [<a href="/news/news/{{ .Idsitenews }}/edit">EDIT</a>]
             {{ end }}
-            {{ if cd.IsAdmin }}
+            {{ if cd.HasAdminRole }}
                 [<a href="/admin/announcements?news_id={{ .Idsitenews }}">
                     {{ if and .Announcement (eq .Announcement.Active true) }}
                         MANAGE ANNOUNCEMENT

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -44,7 +44,6 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		ShowEdit     bool
 		Editing      bool
 		Announcement *db.SiteAnnouncement
-		IsAdmin      bool
 	}
 	type Data struct {
 		*common.CoreData
@@ -192,7 +191,6 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		ShowEdit:     canEditNewsPost(data.CoreData, post.Idsitenews),
 		Editing:      editingId == int(post.Idsitenews),
 		Announcement: ann,
-		IsAdmin:      data.CoreData.HasRole("administrator") && data.CoreData.AdminMode,
 	}
 
 	handlers.TemplateHandler(w, r, "postPage.gohtml", data)

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -75,8 +75,7 @@ func TestPageTemplatesRender(t *testing.T) {
 			Categories        []*db.WritingCategory
 			WritingCategoryID int32
 			CategoryId        int32
-			IsAdmin           bool
-		}{&common.CoreData{}, nil, 0, 0, false}},
+		}{&common.CoreData{}, nil, 0, 0}},
 		{"linkerCategoryPage", struct {
 			*common.CoreData
 			Offset      int
@@ -88,15 +87,14 @@ func TestPageTemplatesRender(t *testing.T) {
 		}{&common.CoreData{}, 0, false, 0, 0, 0, nil}},
 		{"writingsCategoryPage", struct {
 			*common.CoreData
-			Categories          []*db.WritingCategory
-			CategoryBreadcrumbs []*db.WritingCategory
-			EditingCategoryId   int32
-			CategoryId          int32
-			WritingCategoryID   int32
-			IsAdmin             bool
-			IsWriter            bool
-			Abstracts           []*db.GetPublicWritingsInCategoryRow
-		}{&common.CoreData{}, nil, nil, 0, 0, 0, false, false, nil}},
+			Categories           []*db.WritingCategory
+			CategoryBreadcrumbs  []*db.WritingCategory
+			EditingCategoryId    int32
+			CategoryId           int32
+			WritingCategoryID    int32
+			HasContentWriterRole bool
+			Abstracts            []*db.GetPublicWritingsInCategoryRow
+		}{&common.CoreData{}, nil, nil, 0, 0, 0, false, nil}},
 		{"searchPage", struct {
 			*common.CoreData
 			SearchWords string

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -47,7 +47,6 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		Thread              *db.GetThreadLastPosterAndPermsRow
 		Comments            []*CommentPlus
 		IsReplyable         bool
-		IsAdmin             bool
 		Categories          []*db.WritingCategory
 		CategoryId          int32
 		Offset              int32

--- a/handlers/writings/writingsCategoriesPage.go
+++ b/handlers/writings/writingsCategoriesPage.go
@@ -19,18 +19,18 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 		Categories          []*db.WritingCategory
 		CategoryBreadcrumbs []*db.WritingCategory
 		EditingCategoryId   int32
-		IsAdmin             bool
-		IsWriter            bool
-		Abstracts           []*db.GetPublicWritingsInCategoryForUserRow
-		WritingCategoryID   int32
+		// HasContentWriterRole shows if the viewer can write content.
+		HasContentWriterRole bool
+		Abstracts            []*db.GetPublicWritingsInCategoryForUserRow
+		WritingCategoryID    int32
 	}
 
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
 
-	data.IsAdmin = data.CoreData.HasRole("administrator") && data.CoreData.AdminMode
-	data.IsWriter = data.CoreData.HasRole("content writer") || data.IsAdmin
+	data.HasContentWriterRole = data.CoreData.HasContentWriterRole()
+
 	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
 	data.EditingCategoryId = int32(editID)
 	data.WritingCategoryID = 0

--- a/handlers/writings/writingsCategoryPage.go
+++ b/handlers/writings/writingsCategoryPage.go
@@ -24,17 +24,17 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 		EditingCategoryId   int32
 		CategoryId          int32
 		WritingCategoryID   int32
-		IsAdmin             bool
-		IsWriter            bool
-		Abstracts           []*db.GetPublicWritingsInCategoryForUserRow
+		// HasContentWriterRole shows if the viewer can write content.
+		HasContentWriterRole bool
+		Abstracts            []*db.GetPublicWritingsInCategoryForUserRow
 	}
 
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
 
-	data.IsAdmin = data.CoreData.HasRole("administrator") && data.CoreData.AdminMode
-	data.IsWriter = data.CoreData.HasRole("content writer") || data.IsAdmin
+	data.HasContentWriterRole = data.CoreData.HasContentWriterRole()
+
 	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
 	data.EditingCategoryId = int32(editID)
 

--- a/handlers/writings/writingsPage.go
+++ b/handlers/writings/writingsPage.go
@@ -21,14 +21,12 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		EditingCategoryId int32
 		CategoryId        int32
 		WritingCategoryID int32
-		IsAdmin           bool
 	}
 
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
 
-	data.IsAdmin = data.CoreData.HasRole("administrator") && data.CoreData.AdminMode
 	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
 	data.EditingCategoryId = int32(editID)
 	data.CategoryId = 0

--- a/handlers/writings/writingsWriterListPage.go
+++ b/handlers/writings/writingsWriterListPage.go
@@ -24,7 +24,6 @@ func WriterListPage(w http.ResponseWriter, r *http.Request) {
 		NextLink            string
 		PrevLink            string
 		PageSize            int
-		IsAdmin             bool
 		CategoryBreadcrumbs []*db.WritingCategory
 		CategoryId          int32
 	}
@@ -33,7 +32,6 @@ func WriterListPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:   r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Search:     r.URL.Query().Get("search"),
 		PageSize:   handlers.GetPageSize(r),
-		IsAdmin:    false,
 		CategoryId: 0,
 	}
 


### PR DESCRIPTION
## Summary
- drop `HasAdminRole` fields from page data and NewsPost
- rely on `CoreData.HasAdminRole()` directly in templates and handlers
- update template render tests

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6881b3c4b74c832f9967e71cdf89b1c6