### PR TITLE
Remove legacy thread context key

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -26,7 +26,7 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 		"cd":        func() *CoreData { return cd },
 		"now":       func() time.Time { return time.Now() },
 		"csrfField": func() template.HTML { return csrf.TemplateField(r) },
-    // TODO merge
+		// TODO merge
 		"csrf":      func() string { return csrf.Token(r) },
 		"csrfToken": func() string { return csrf.Token(r) },
 		"version":   func() string { return goa4web.Version },

--- a/core/consts/contextkeys.go
+++ b/core/consts/contextkeys.go
@@ -7,8 +7,6 @@ type ContextKey string
 const (
 	// KeyCoreData provides access to CoreData.
 	KeyCoreData ContextKey = "coreData"
-	// KeyThread holds the current thread information.
-	KeyThread ContextKey = "thread"
 	// KeyTopic holds the current topic information.
 	KeyTopic ContextKey = "topic"
 	// KeyBlogEntry holds a fetched blog entry row.

--- a/handlers/forum/comment_edit_action_cancel_task.go
+++ b/handlers/forum/comment_edit_action_cancel_task.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -18,8 +18,15 @@ var topicThreadCommentEditActionCancel = &topicThreadCommentEditActionCancelTask
 var _ tasks.Task = (*topicThreadCommentEditActionCancelTask)(nil)
 
 func (topicThreadCommentEditActionCancelTask) Action(w http.ResponseWriter, r *http.Request) any {
-	threadRow := r.Context().Value(consts.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
-	topicRow := r.Context().Value(consts.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	threadRow, err := cd.CurrentThread()
+	if err != nil || threadRow == nil {
+		return fmt.Errorf("thread fetch %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	topicRow, err := cd.CurrentTopic()
+	if err != nil || topicRow == nil {
+		return fmt.Errorf("topic fetch %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
 	endURL := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
 	return handlers.RedirectHandler(endURL)
 }

--- a/handlers/forum/comment_edit_action_task.go
+++ b/handlers/forum/comment_edit_action_task.go
@@ -29,9 +29,16 @@ func (topicThreadCommentEditActionTask) Action(w http.ResponseWriter, r *http.Re
 	}
 	text := r.PostFormValue("replytext")
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	threadRow := r.Context().Value(consts.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
-	topicRow := r.Context().Value(consts.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	threadRow, err := cd.CurrentThread()
+	if err != nil || threadRow == nil {
+		return fmt.Errorf("thread fetch %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	topicRow, err := cd.CurrentTopic()
+	if err != nil || topicRow == nil {
+		return fmt.Errorf("topic fetch %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
 	commentID, _ := strconv.Atoi(mux.Vars(r)["comment"])
 
 	if err = queries.UpdateComment(r.Context(), db.UpdateCommentParams{

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -61,9 +61,18 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data.Languages = languageRows
-
-	threadRow := r.Context().Value(consts.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
-	topicRow := r.Context().Value(consts.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+	threadRow, err := cd.CurrentThread()
+	if err != nil || threadRow == nil {
+		log.Printf("current thread: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	topicRow, err := cd.CurrentTopic()
+	if err != nil || topicRow == nil {
+		log.Printf("current topic: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
 
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {

--- a/handlers/forum/forumTopicThreadCommentEditPage.go
+++ b/handlers/forum/forumTopicThreadCommentEditPage.go
@@ -21,9 +21,18 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	text := r.PostFormValue("replytext")
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	threadRow := r.Context().Value(consts.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
-	topicRow := r.Context().Value(consts.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	threadRow, err := cd.CurrentThread()
+	if err != nil || threadRow == nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	topicRow, err := cd.CurrentTopic()
+	if err != nil || topicRow == nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
 	commentId, _ := strconv.Atoi(mux.Vars(r)["comment"])
 
 	err = queries.UpdateComment(r.Context(), db.UpdateCommentParams{
@@ -53,8 +62,17 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func TopicThreadCommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
-	threadRow := r.Context().Value(consts.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
-	topicRow := r.Context().Value(consts.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	threadRow, err := cd.CurrentThread()
+	if err != nil || threadRow == nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	topicRow, err := cd.CurrentTopic()
+	if err != nil || topicRow == nil {
+		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
 

--- a/handlers/forum/matchers.go
+++ b/handlers/forum/matchers.go
@@ -1,7 +1,6 @@
 package forum
 
 import (
-	"context"
 	"database/sql"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
@@ -33,7 +32,8 @@ func RequireThreadAndTopic(next http.Handler) http.Handler {
 			return
 		}
 
-		queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		queries := cd.Queries()
 
 		session, _ := core.GetSession(r)
 		var uid int32
@@ -74,9 +74,10 @@ func RequireThreadAndTopic(next http.Handler) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
+		cd.CacheForumThread(int32(threadID), threadRow)
+		cd.CacheForumTopic(threadRow.ForumtopicIdforumtopic, topicRow)
 
-		ctx := context.WithValue(r.Context(), consts.KeyThread, threadRow)
-		ctx = context.WithValue(ctx, consts.KeyTopic, topicRow)
-		next.ServeHTTP(w, r.WithContext(ctx))
+		cd.SetCurrentThreadAndTopic(int32(threadID), threadRow.ForumtopicIdforumtopic)
+		next.ServeHTTP(w, r)
 	})
 }

--- a/handlers/forum/matchers_test.go
+++ b/handlers/forum/matchers_test.go
@@ -45,7 +45,7 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		if r.Context().Value(consts.KeyThread) == nil || r.Context().Value(consts.KeyTopic) == nil {
+		if cd.CurrentThreadLoaded() == nil || cd.CurrentTopicLoaded() == nil {
 			t.Errorf("context values missing")
 		}
 		w.WriteHeader(http.StatusOK)

--- a/handlers/forum/topic_thread_reply_cancel_task.go
+++ b/handlers/forum/topic_thread_reply_cancel_task.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -18,8 +18,15 @@ var topicThreadReplyCancel = &topicThreadReplyCancelTask{TaskString: TaskCancel}
 var _ tasks.Task = (*topicThreadReplyCancelTask)(nil)
 
 func (topicThreadReplyCancelTask) Action(w http.ResponseWriter, r *http.Request) any {
-	threadRow := r.Context().Value(consts.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
-	topicRow := r.Context().Value(consts.KeyTopic).(*db.GetForumTopicByIdForUserRow)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	threadRow, err := cd.CurrentThread()
+	if err != nil || threadRow == nil {
+		return fmt.Errorf("thread fetch %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	topicRow, err := cd.CurrentTopic()
+	if err != nil || topicRow == nil {
+		return fmt.Errorf("topic fetch %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
 	endURL := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
 	return handlers.RedirectHandler(endURL)
 }


### PR DESCRIPTION
## Summary
- implement lazy thread retrieval in CoreData
- remove `handlers/forum/context.go`
- update forum middleware to cache thread & topic on CoreData
- update handlers to use `CurrentThread` and `CurrentTopic`
- adjust tests for new lazy fetching

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6881ca4ded5c832f8db7451503cdec04