### PR TITLE
Remove unused dbinit

### DIFF
--- a/cmd/goa4web/dbinit.go
+++ b/cmd/goa4web/dbinit.go
@@ -1,9 +1,0 @@
-package main
-
-import (
-	dbdefaults "github.com/arran4/goa4web/internal/dbdrivers/dbdefaults"
-)
-
-func init() {
-	dbdefaults.Register()
-}

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -37,7 +37,7 @@ func TestCoreDataLatestNewsLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -71,7 +71,7 @@ func TestWritingCategoriesLazy(t *testing.T) {
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "category", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	ctx := context.Background()
-cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 
@@ -102,7 +102,7 @@ func TestAnnouncementForNewsCaching(t *testing.T) {
 	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnRows(annRows)
 
 	ctx := context.Background()
-       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 
 	if _, err := cd.AnnouncementForNews(1); err != nil {
 		t.Fatalf("AnnouncementForNews: %v", err)
@@ -128,7 +128,7 @@ func TestAnnouncementForNewsError(t *testing.T) {
 	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnError(sql.ErrConnDone)
 
 	ctx := context.Background()
-       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 
 	if _, err := cd.AnnouncementForNews(1); !errors.Is(err, sql.ErrConnDone) {
 		t.Fatalf("AnnouncementForNews error=%v", err)
@@ -167,7 +167,7 @@ func TestPublicWritingsLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -211,7 +211,7 @@ func TestCoreDataLatestWritingsLazy(t *testing.T) {
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "article", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	ctx := context.Background()
-       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 
@@ -247,7 +247,7 @@ func TestBloggersLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	req = req.WithContext(ctx)
 
@@ -283,7 +283,7 @@ func TestWritersLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-       cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	req = req.WithContext(ctx)
 

--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -26,7 +26,7 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 		"cd":        func() *CoreData { return cd },
 		"now":       func() time.Time { return time.Now() },
 		"csrfField": func() template.HTML { return csrf.TemplateField(r) },
-    // TODO merge
+		// TODO merge
 		"csrf":      func() string { return csrf.Token(r) },
 		"csrfToken": func() string { return csrf.Token(r) },
 		"version":   func() string { return goa4web.Version },


### PR DESCRIPTION
## Summary
- delete obsolete dbinit.go used for registering default DB drivers
- run gofmt on CoreData tests and template helpers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: import cycle between templates and common)*
- `golangci-lint run`
- `go test ./...` *(fails in core/templates due to import cycle)*

------
https://chatgpt.com/codex/tasks/task_e_6881d523966c832f84c231e5a76ffd08