### PR TITLE
Rename role helpers and update templates

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -43,7 +43,6 @@ type NewsPost struct {
 	ShowEdit     bool
 	Editing      bool
 	Announcement *db.SiteAnnouncement
-	IsAdmin      bool
 }
 
 type CoreData struct {
@@ -675,7 +674,6 @@ func (cd *CoreData) fetchLatestNews(offset, limit int32, replyID int) ([]*NewsPo
 			ShowEdit:     cd.HasGrant("news", "post", "edit", row.Idsitenews) && (cd.AdminMode || cd.UserID != 0),
 			Editing:      replyID == int(row.Idsitenews),
 			Announcement: ann,
-			IsAdmin:      cd.HasRole("administrator") && cd.AdminMode,
 		})
 	}
 	return posts, nil
@@ -1048,12 +1046,12 @@ func (cd *CoreData) LinkerCategoryCounts() ([]*db.GetLinkerCategoryLinkCountsRow
 	})
 }
 
-func (cd *CoreData) IsAdmin() bool {
+func (cd *CoreData) HasAdminRole() bool {
 	return cd.HasRole("administrator") && cd.AdminMode
 }
 
-func (cd *CoreData) IsWriter() bool {
-	return cd.HasRole("content writer") || cd.IsAdmin()
+func (cd *CoreData) HasContentWriterRole() bool {
+	return cd.HasRole("content writer") || cd.HasAdminRole()
 }
 
 // ExecuteSiteTemplate renders the named site template using cd's helper

--- a/core/templates/site/listAbstracts.gohtml
+++ b/core/templates/site/listAbstracts.gohtml
@@ -1,5 +1,5 @@
 {{ define "listAbstracts" }}
-    {{ if cd.IsWriter }}
+    {{ if cd.HasContentWriterRole }}
         [<a href="/writings/category/{{ .CategoryId }}/add">Write writing here.</a>]<br>
     {{ end }}
     {{ if .Abstracts }}

--- a/core/templates/site/listWritingCategories.gohtml
+++ b/core/templates/site/listWritingCategories.gohtml
@@ -8,7 +8,7 @@
             {{ $title := .Title.String }}
             {{ $description := .Description.String }}
             {{ $id := .Idwritingcategory }}
-            {{ if and cd.IsAdmin (eq $.EditingCategoryId $id) }}
+            {{ if and cd.HasAdminRole (eq $.EditingCategoryId $id) }}
                 <tr>
                     <th><a href="/admin/writings/categories?category={{ $id }}">{{ $title }}</a></th>
                     <td>{{ $description }}</td>
@@ -31,12 +31,12 @@
                 </tr>
             {{ else }}
                 <tr>
-                    <th><a href="/writings/category/{{ $id }}">{{ $title }}</a>{{ if cd.IsAdmin }} [<a href="?edit={{ $id }}">Edit</a>]{{ end }}</th>
+                    <th><a href="/writings/category/{{ $id }}">{{ $title }}</a>{{ if cd.HasAdminRole }} [<a href="?edit={{ $id }}">Edit</a>]{{ end }}</th>
                     <td>{{ $description }}</td>
                 </tr>
             {{ end }}
         {{ end }}
-        {{ if cd.IsAdmin }}
+        {{ if cd.HasAdminRole }}
             <tr>
                 <td>
                     <form method="post">

--- a/core/templates/site/news/post.gohtml
+++ b/core/templates/site/news/post.gohtml
@@ -14,7 +14,7 @@
             {{ if .ShowEdit }}
                 [<a href="/news/news/{{ .Idsitenews }}/edit">EDIT</a>]
             {{ end }}
-            {{ if cd.IsAdmin }}
+            {{ if cd.HasAdminRole }}
                 [<a href="/admin/announcements?news_id={{ .Idsitenews }}">
                     {{ if and .Announcement (eq .Announcement.Active true) }}
                         MANAGE ANNOUNCEMENT


### PR DESCRIPTION
## Summary
- refactor `NewsPost` struct to drop `IsAdmin` field
- rename role helper functions to `HasAdminRole` and `HasContentWriterRole`
- update news and writings templates to use new helpers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: import cycle not allowed)*
- `golangci-lint run ./...`
- `go test ./...` *(fails: import cycle in templates package)*

------
https://chatgpt.com/codex/tasks/task_e_6881d780bafc832fa3a696ac43a085c5