### PR TITLE
inject runtime config into notifier

### DIFF
--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -158,8 +158,8 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username FROM users u JOIN user_emails ue ON ue.user_id = u.idusers WHERE ue.email = ? LIMIT 1")).WithArgs("b@test.com").WillReturnRows(rows2)
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 2, Valid: true}, sqlmock.AnyArg(), false).WillReturnResult(sqlmock.NewResult(1, 1))
 
-	rec := &recordAdminMail{}
-	n := notif.New(notif.WithQueries(q), notif.WithEmailProvider(rec))
+       rec := &recordAdminMail{}
+       n := notif.New(notif.WithQueries(q), notif.WithEmailProvider(rec), notif.WithConfig(config.AppRuntimeConfig))
 	n.NotifyAdmins(context.Background(), &notif.EmailTemplates{}, notif.EmailData{})
 	if len(rec.to) != 0 {
 		t.Fatalf("expected 0 direct mails, got %d", len(rec.to))
@@ -185,8 +185,8 @@ func TestNotifyAdminsDisabled(t *testing.T) {
 	origEmails := config.AppRuntimeConfig.AdminEmails
 	config.AppRuntimeConfig.AdminEmails = "a@test.com"
 	defer func() { config.AppRuntimeConfig.AdminEmails = origEmails }()
-	rec := &recordAdminMail{}
-	n := notif.New(notif.WithEmailProvider(rec))
+       rec := &recordAdminMail{}
+       n := notif.New(notif.WithEmailProvider(rec), notif.WithConfig(config.AppRuntimeConfig))
 	n.NotifyAdmins(context.Background(), &notif.EmailTemplates{}, notif.EmailData{})
 	if len(rec.to) != 0 {
 		t.Fatalf("expected 0 mails, got %d", len(rec.to))

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/dlq"
@@ -339,7 +338,7 @@ func (n *Notifier) handleAutoSubscribe(ctx context.Context, evt eventbus.TaskEve
 			return fmt.Errorf("auto subscribe path: %w", err)
 		}
 		pattern := buildPatterns(tasks.TaskString(task), path)[0]
-		if config.AppRuntimeConfig.NotificationsEnabled {
+		if n.cfg.NotificationsEnabled {
 			ensureSubscription(ctx, n.Queries, evt.UserID, pattern, "internal")
 		}
 		if email {

--- a/internal/notifications/bus_worker_test.go
+++ b/internal/notifications/bus_worker_test.go
@@ -138,7 +138,7 @@ func TestProcessEventDLQ(t *testing.T) {
 	defer db.Close()
 	q := dbpkg.New(db)
 	prov := &errProvider{}
-	n := New(WithQueries(q), WithEmailProvider(prov))
+	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(config.AppRuntimeConfig))
 	dlqRec := &recordDLQ{}
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/p", Task: TestTask{TaskString: TaskTest}, UserID: 1}, dlqRec); err != nil {
@@ -166,7 +166,7 @@ func TestProcessEventSubscribeSelf(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q))
+	n := New(WithQueries(q), WithConfig(config.AppRuntimeConfig))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/p", Task: TaskTest, UserID: 1}, nil); err != nil {
 		t.Fatalf("process: %v", err)
@@ -186,7 +186,7 @@ func TestProcessEventNoAutoSubscribe(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q))
+	n := New(WithQueries(q), WithConfig(config.AppRuntimeConfig))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/p", Task: TaskTest, UserID: 1}, nil); err != nil {
 		t.Fatalf("process: %v", err)
@@ -209,7 +209,7 @@ func TestProcessEventAdminNotify(t *testing.T) {
 	defer db.Close()
 	q := dbpkg.New(db)
 	prov := &busDummyProvider{}
-	n := New(WithQueries(q), WithEmailProvider(prov))
+	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(config.AppRuntimeConfig))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/admin/x", Task: TaskTest, UserID: 1}, nil); err != nil {
 		t.Fatalf("process: %v", err)
@@ -230,7 +230,7 @@ func TestProcessEventWritingSubscribers(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q))
+	n := New(WithQueries(q), WithConfig(config.AppRuntimeConfig))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/writings/article/1", Task: TaskTest, UserID: 2, Data: map[string]any{"target": Target{Type: "writing", ID: 1}}}, nil); err != nil {
 		t.Fatalf("process: %v", err)
@@ -265,7 +265,7 @@ func TestProcessEventTargetUsers(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q))
+	n := New(WithQueries(q), WithConfig(config.AppRuntimeConfig))
 
 	for _, id := range []int32{2, 3} {
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
@@ -307,7 +307,7 @@ func TestBusWorker(t *testing.T) {
 	q := dbpkg.New(db)
 
 	prov := &busDummyProvider{}
-	n := New(WithQueries(q), WithEmailProvider(prov))
+	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(config.AppRuntimeConfig))
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -350,7 +350,7 @@ func TestProcessEventAutoSubscribe(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q))
+	n := New(WithQueries(q), WithConfig(config.AppRuntimeConfig))
 
 	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies"}).
 		AddRow(1, 0, 1, nil, 0, true)

--- a/internal/notifications/email.go
+++ b/internal/notifications/email.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/internal/eventbus"
@@ -59,20 +58,20 @@ func (n *Notifier) RenderEmailFromTemplates(ctx context.Context, emailAddr strin
 	if emailAddr == "" {
 		return nil, fmt.Errorf("no email specified")
 	}
-	from := email.ParseAddress(config.AppRuntimeConfig.EmailFrom)
+	from := email.ParseAddress(n.cfg.EmailFrom)
 	to := email.ParseAddress(emailAddr)
 
-	subjectPrefix := config.AppRuntimeConfig.EmailSubjectPrefix
+	subjectPrefix := n.cfg.EmailSubjectPrefix
 	if subjectPrefix == "" {
 		subjectPrefix = "goa4web"
 	}
 
 	unsub := "/usr/subscriptions"
-	if config.AppRuntimeConfig.HTTPHostname != "" {
-		unsub = strings.TrimRight(config.AppRuntimeConfig.HTTPHostname, "/") + unsub
+	if n.cfg.HTTPHostname != "" {
+		unsub = strings.TrimRight(n.cfg.HTTPHostname, "/") + unsub
 	}
 
-	signOff := config.AppRuntimeConfig.EmailSignOff
+	signOff := n.cfg.EmailSignOff
 	htmlSignOff := html.EscapeString(signOff)
 	htmlSignOff = strings.ReplaceAll(htmlSignOff, "\n", "<br />")
 

--- a/internal/notifications/linker_queue_test.go
+++ b/internal/notifications/linker_queue_test.go
@@ -36,7 +36,7 @@ func TestLinkerQueueNotifierMessages(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"body"}).AddRow(""))
 
 	q := dbpkg.New(db)
-	n := New(WithQueries(q))
+	n := New(WithQueries(q), WithConfig(config.AppRuntimeConfig))
 	data := map[string]any{
 		"Title":     "Example",
 		"Username":  "bob",

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -71,7 +71,7 @@ func TestNotifierNotifyAdmins(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test", "a"))
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 1, Valid: true}, sqlmock.AnyArg(), false).WillReturnResult(sqlmock.NewResult(1, 1))
 	rec := &dummyProvider{}
-	n := New(WithQueries(q), WithEmailProvider(rec))
+	n := New(WithQueries(q), WithEmailProvider(rec), WithConfig(config.AppRuntimeConfig))
 	n.NotifyAdmins(context.Background(), &EmailTemplates{}, EmailData{})
 	if rec.to != "" {
 		t.Fatalf("expected no direct mail got %s", rec.to)
@@ -82,7 +82,7 @@ func TestNotifierNotifyAdmins(t *testing.T) {
 }
 
 func TestNotifierInitialization(t *testing.T) {
-	n := New()
+	n := New(WithConfig(config.AppRuntimeConfig))
 	if n.Queries != nil {
 		t.Fatalf("expected nil Queries")
 	}
@@ -92,7 +92,7 @@ func TestNotifierInitialization(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n = New(WithQueries(q))
+	n = New(WithQueries(q), WithConfig(config.AppRuntimeConfig))
 	if n.Queries != q {
 		t.Fatalf("queries not set via option")
 	}

--- a/internal/notifications/permission_tasks_test.go
+++ b/internal/notifications/permission_tasks_test.go
@@ -46,7 +46,7 @@ func TestProcessEventPermissionTasks(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := notif.New(notif.WithQueries(q))
+	n := notif.New(notif.WithQueries(q), notif.WithConfig(config.AppRuntimeConfig))
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/workers/workers.go
+++ b/workers/workers.go
@@ -46,6 +46,7 @@ func Start(ctx context.Context, db *sql.DB, provider email.Provider, dlqProvider
 			notifications.WithQueries(dbpkg.New(db)),
 			notifications.WithEmailProvider(provider),
 			notifications.WithBus(bus),
+			notifications.WithConfig(cfg),
 		)
 		n.NotificationPurgeWorker(ctx, time.Hour)
 	})
@@ -59,6 +60,7 @@ func Start(ctx context.Context, db *sql.DB, provider email.Provider, dlqProvider
 			notifications.WithQueries(dbpkg.New(db)),
 			notifications.WithEmailProvider(provider),
 			notifications.WithBus(bus),
+			notifications.WithConfig(cfg),
 		)
 		n.BusWorker(ctx, bus, dlqProvider)
 	})


### PR DESCRIPTION
## Summary
- remove notifier dependency on global runtime config
- pass runtime config through worker setup
- use configured address for DLQ email sender

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestLinkerApproveAddsToSearch)*

------
https://chatgpt.com/codex/tasks/task_e_6881da71ea90832faf2d0935d652dd3e