### PR TITLE
Remove KeyComment constant and use CoreData

### DIFF
--- a/core/consts/contextkeys.go
+++ b/core/consts/contextkeys.go
@@ -11,8 +11,6 @@ const (
 	KeyTopic ContextKey = "topic"
 	// KeyBlogEntry holds a fetched blog entry row.
 	KeyBlogEntry ContextKey = "blogEntry"
-	// KeyComment stores the current comment row.
-	KeyComment ContextKey = "comment"
 	// KeyNewsPost holds the news post row.
 	KeyNewsPost ContextKey = "newsPost"
 	// KeyWriting contains the writing row.

--- a/handlers/blogs/blogsCommentEditReplyTask.go
+++ b/handlers/blogs/blogsCommentEditReplyTask.go
@@ -52,7 +52,15 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	comment := r.Context().Value(consts.KeyComment).(*db.GetCommentByIdForUserRow)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	comment := cd.CurrentCommentLoaded()
+	if comment == nil {
+		var err error
+		comment, err = cd.CommentByID(int32(commentId))
+		if err != nil {
+			return fmt.Errorf("load comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+	}
 
 	thread, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		ViewerID:      uid,

--- a/handlers/forum/comments/matchers.go
+++ b/handlers/forum/comments/matchers.go
@@ -1,7 +1,6 @@
 package comments
 
 import (
-	"context"
 	"database/sql"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
@@ -47,7 +46,10 @@ func RequireCommentAuthor(next http.Handler) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		ctx := context.WithValue(r.Context(), consts.KeyComment, row)
-		next.ServeHTTP(w, r.WithContext(ctx))
+		if cd != nil {
+			cd.CacheComment(row.Idcomments, row)
+			cd.SetCurrentComment(row.Idcomments)
+		}
+		next.ServeHTTP(w, r)
 	})
 }

--- a/handlers/linker/edit_reply_task.go
+++ b/handlers/linker/edit_reply_task.go
@@ -45,7 +45,15 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	comment := r.Context().Value(consts.KeyComment).(*db.GetCommentByIdForUserRow)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	comment := cd.CurrentCommentLoaded()
+	if comment == nil {
+		var err error
+		comment, err = cd.CommentByID(int32(commentId))
+		if err != nil {
+			return fmt.Errorf("load comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+	}
 
 	thread, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		ViewerID:      uid,

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -90,7 +90,7 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 	// Wait for the worker goroutine to exit before verifying expectations.
 	time.Sleep(500 * time.Millisecond)
 	err = nil
-	for i := 0; i < 200; i++ {
+	for i := 0; i < 500; i++ {
 		err = mock.ExpectationsWereMet()
 		if err == nil {
 			break

--- a/handlers/news/edit_reply_task.go
+++ b/handlers/news/edit_reply_task.go
@@ -53,7 +53,15 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	comment := r.Context().Value(consts.KeyComment).(*db.GetCommentByIdForUserRow)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	comment := cd.CurrentCommentLoaded()
+	if comment == nil {
+		var err error
+		comment, err = cd.CommentByID(int32(commentId))
+		if err != nil {
+			return fmt.Errorf("load comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+	}
 
 	thread, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		ViewerID:      uid,

--- a/handlers/writings/edit_reply_task.go
+++ b/handlers/writings/edit_reply_task.go
@@ -51,7 +51,15 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	comment := r.Context().Value(consts.KeyComment).(*db.GetCommentByIdForUserRow)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	comment := cd.CurrentCommentLoaded()
+	if comment == nil {
+		var err error
+		comment, err = cd.CommentByID(int32(commentID))
+		if err != nil {
+			return fmt.Errorf("load comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+	}
 
 	thread, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		ViewerID:      uid,

--- a/handlers/writings/writingsArticleCommentEditPage.go
+++ b/handlers/writings/writingsArticleCommentEditPage.go
@@ -37,7 +37,16 @@ func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	comment := r.Context().Value(consts.KeyComment).(*db.GetCommentByIdForUserRow)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	comment := cd.CurrentCommentLoaded()
+	if comment == nil {
+		var err error
+		comment, err = cd.CommentByID(int32(commentId))
+		if err != nil {
+			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			return
+		}
+	}
 
 	thread, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
 		ViewerID:      uid,


### PR DESCRIPTION
## Summary
- remove the `KeyComment` context key
- cache comments inside `CoreData` and expose helper methods
- update comment author middleware to store the comment on `CoreData`
- switch handlers to use `CoreData` for comment access
- relax timing in linker test for stability

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68820d34c4a8832fbaab053b52b8f1f4