### PR TITLE
Remove unused forum context key

### DIFF
--- a/core/consts/contextkeys.go
+++ b/core/consts/contextkeys.go
@@ -7,8 +7,6 @@ type ContextKey string
 const (
 	// KeyCoreData provides access to CoreData.
 	KeyCoreData ContextKey = "coreData"
-	// KeyTopic holds the current topic information.
-	KeyTopic ContextKey = "topic"
 	// KeyBlogEntry holds a fetched blog entry row.
 	KeyBlogEntry ContextKey = "blogEntry"
 	// KeyComment stores the current comment row.

--- a/handlers/forum/matchers_test.go
+++ b/handlers/forum/matchers_test.go
@@ -35,6 +35,13 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "title", "description", "threads", "comments", "lastaddition", "LastPosterUsername",
 		}).AddRow(1, 0, 0, sql.NullString{}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullTime{}, sql.NullString{}))
 
+	// handler will trigger another load
+	mock.ExpectQuery("SELECT th.idforumthread").
+		WithArgs(int32(0), int32(2), sql.NullInt32{Int32: 0, Valid: false}).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername",
+		}).AddRow(2, 0, 0, 1, sql.NullInt32{}, sql.NullTime{}, sql.NullBool{}, sql.NullString{}))
+
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
 	q := db.New(sqldb)
@@ -46,8 +53,11 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		if cd.CurrentThreadLoaded() == nil || cd.CurrentTopicLoaded() == nil {
-			t.Errorf("context values missing")
+		if _, err := cd.CurrentThread(); err != nil {
+			t.Errorf("CurrentThread: %v", err)
+		}
+		if _, err := cd.CurrentTopic(); err != nil {
+			t.Errorf("CurrentTopic: %v", err)
 		}
 		w.WriteHeader(http.StatusOK)
 	})


### PR DESCRIPTION
## Summary
- delete unused `KeyTopic` constant
- stop caching thread row in middleware
- update forum matcher tests accordingly

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6881dab2808c832f9228768281d85a25