### PR TITLE
Introduce SessionManager

### DIFF
--- a/core/session_test.go
+++ b/core/session_test.go
@@ -18,19 +18,16 @@ var (
 
 func TestSessionMiddlewareBadSession(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("test"))
-	core.Store = store
-	core.SessionName = sessionName
+	sm := &core.SessionManager{Name: sessionName, Store: store}
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if _, err := core.GetSession(r); err != nil {
-			core.SessionErrorRedirect(w, r, err)
+		if _, err := sm.GetSession(r); err != nil {
+			sm.SessionErrorRedirect(w, r, err)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
 	})
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(&http.Cookie{Name: sessionName, Value: "bad"})
-	ctx := req.Context()
-	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 	if rr.Code != http.StatusFound {
@@ -44,12 +41,11 @@ func TestSessionMiddlewareBadSession(t *testing.T) {
 
 func TestGetSessionOrFailBadSession(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("test"))
-	core.Store = store
-	core.SessionName = sessionName
+	sm := &core.SessionManager{Name: sessionName, Store: store}
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(&http.Cookie{Name: sessionName, Value: "bad"})
 	rr := httptest.NewRecorder()
-	sess, ok := core.GetSessionOrFail(rr, req)
+	sess, ok := sm.GetSessionOrFail(rr, req)
 	if ok {
 		t.Fatalf("expected failure, got session %v", sess)
 	}

--- a/handlers/auth/login_task.go
+++ b/handlers/auth/login_task.go
@@ -14,7 +14,6 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/tasks"
@@ -39,7 +38,8 @@ func (LoginTask) Page(w http.ResponseWriter, r *http.Request) {
 // Action processes the submitted login form.
 func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if config.AppRuntimeConfig.LogFlags&config.LogFlagAuth != 0 {
-		sess, _ := core.GetSession(r)
+		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		sess, _ := cd.GetSession(r)
 		log.Printf("login attempt for %s session=%s", r.PostFormValue("username"), sess.ID)
 	}
 
@@ -68,7 +68,8 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 				_ = queries.MarkPasswordResetVerified(r.Context(), reset.ID)
 				_ = queries.InsertPassword(r.Context(), db.InsertPasswordParams{UsersIdusers: reset.UserID, Passwd: reset.Passwd, PasswdAlgorithm: sql.NullString{String: reset.PasswdAlgorithm, Valid: true}})
 			} else {
-				session, ok := core.GetSessionOrFail(w, r)
+				cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+				session, ok := cd.GetSessionOrFail(w, r)
 				if !ok {
 					return handlers.SessionFetchFail{}
 				}
@@ -104,7 +105,8 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/auth/verify_password_task.go
+++ b/handlers/auth/verify_password_task.go
@@ -11,7 +11,6 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/tasks"
@@ -30,7 +29,8 @@ var _ tasks.Task = (*VerifyPasswordTask)(nil)
 
 // Action verifies a password reset code and logs the user in.
 func (VerifyPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/blogs/bloggerPostsPage.go
+++ b/handlers/blogs/bloggerPostsPage.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/arran4/goa4web/handlers"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 )
 
@@ -35,13 +34,14 @@ func BloggerPostsPage(w http.ResponseWriter, r *http.Request) {
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	vars := mux.Vars(r)
 	username := vars["username"]
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 
 	bu, err := queries.GetUserByUsername(r.Context(), sql.NullString{
 		String: username,

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/arran4/goa4web/internal/tasks"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
 
@@ -66,8 +65,9 @@ func (AddBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("languageId parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/blogs/blogsBlogPage.go
+++ b/handlers/blogs/blogsBlogPage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/gorilla/mux"
 )
@@ -68,7 +67,7 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers"
@@ -80,7 +79,8 @@ func (ReplyBlogTask) IndexData(data map[string]any) []searchworker.IndexEventDat
 var _ searchworker.IndexedTask = ReplyBlogTask{}
 
 func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/blogs/blogsCommentEditReplyTask.go
+++ b/handlers/blogs/blogsCommentEditReplyTask.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -42,11 +41,12 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	text := r.PostFormValue("replytext")
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	vars := mux.Vars(r)
 	blogId, _ := strconv.Atoi(vars["blog"])
 	commentId, _ := strconv.Atoi(vars["comment"])
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -17,7 +17,6 @@ import (
 	"github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/gorilla/mux"
 )
@@ -71,7 +70,7 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -19,7 +19,6 @@ import (
 	"github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/a4code/a4code2html"
-	"github.com/arran4/goa4web/core"
 	imagesign "github.com/arran4/goa4web/internal/images"
 	"github.com/gorilla/feeds"
 )
@@ -39,13 +38,14 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	buid := r.URL.Query().Get("uid")
 	userId, _ := strconv.Atoi(buid)
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 	rows, err := queries.GetBlogEntriesForUserDescendingLanguages(r.Context(), db.GetBlogEntriesForUserDescendingLanguagesParams{
 		UsersIdusers:  int32(userId),
 		ViewerIdusers: uid,

--- a/handlers/blogs/matchers.go
+++ b/handlers/blogs/matchers.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 )
@@ -25,8 +24,9 @@ func RequireBlogAuthor(next http.Handler) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-		session, err := core.GetSession(r)
+		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		queries := cd.Queries()
+		session, err := cd.GetSession(r)
 		if err != nil {
 			http.NotFound(w, r)
 			return
@@ -47,7 +47,7 @@ func RequireBlogAuthor(next http.Handler) http.Handler {
 			}
 			return
 		}
-		cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		cd = r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 		if cd != nil && cd.HasRole("administrator") {
 			ctx := context.WithValue(r.Context(), consts.KeyBlogEntry, row)
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/handlers/bookmarks/createTask.go
+++ b/handlers/bookmarks/createTask.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -23,8 +22,9 @@ var _ tasks.Task = (*CreateTask)(nil)
 
 func (CreateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/bookmarks/mine.go
+++ b/handlers/bookmarks/mine.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 )
@@ -77,12 +76,12 @@ func MinePage(w http.ResponseWriter, r *http.Request) {
 		HasBookmarks bool
 	}
 
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
 	_ = session
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	bookmarks, err := cd.Bookmarks()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("error getBookmarksForUser: %s", err)

--- a/handlers/bookmarks/page.go
+++ b/handlers/bookmarks/page.go
@@ -4,7 +4,6 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 )
@@ -14,15 +13,14 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		*common.CoreData
 	}
 
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-	}
+	data := Data{CoreData: cd}
 
 	if uid == 0 {
 		handlers.TemplateHandler(w, r, "infoPage.gohtml", data)

--- a/handlers/bookmarks/saveTask.go
+++ b/handlers/bookmarks/saveTask.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
@@ -34,12 +33,12 @@ func (SaveTask) Page(w http.ResponseWriter, r *http.Request) {
 		CoreData:        r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		BookmarkContent: "Category: Example 1\nhttp://www.google.com.au Google\nColumn\nCategory: Example 2\nhttp://www.google.com.au Google\nhttp://www.google.com.au Google\n",
 	}
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
 	_ = session
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	bookmarks, err := cd.Bookmarks()
 	if err != nil {
 		switch {
@@ -59,8 +58,9 @@ func (SaveTask) Page(w http.ResponseWriter, r *http.Request) {
 
 func (SaveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
@@ -69,8 +68,9 @@ func (AskTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("languageId parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
@@ -87,7 +87,7 @@ func (AskTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("faq fetch fail: %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd = r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	evt := cd.Event()
 	evt.Path = "/admin/faq"
 	if evt.Data == nil {

--- a/handlers/faq/create_question_task.go
+++ b/handlers/faq/create_question_task.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -31,8 +30,9 @@ func (CreateQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("category parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/forum/comments/matchers.go
+++ b/handlers/forum/comments/matchers.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 )
@@ -23,8 +22,9 @@ func RequireCommentAuthor(next http.Handler) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-		session, err := core.GetSession(r)
+		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		queries := cd.Queries()
+		session, err := cd.GetSession(r)
 		if err != nil {
 			http.NotFound(w, r)
 			return
@@ -42,7 +42,6 @@ func RequireCommentAuthor(next http.Handler) http.Handler {
 			return
 		}
 
-		cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 		if row.UsersIdusers != uid && (cd == nil || !cd.HasRole("administrator")) {
 			http.NotFound(w, r)
 			return

--- a/handlers/forum/forumFeed.go
+++ b/handlers/forum/forumFeed.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/arran4/goa4web/a4code/a4code2html"
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 	imagesign "github.com/arran4/goa4web/internal/images"
@@ -60,7 +59,7 @@ func TopicFeed(r *http.Request, title string, topicID int, rows []*db.GetForumTh
 }
 
 func TopicRssPage(w http.ResponseWriter, r *http.Request) {
-	if _, ok := core.GetSessionOrFail(w, r); !ok {
+	if _, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r); !ok {
 		return
 	}
 	vars := mux.Vars(r)
@@ -91,7 +90,7 @@ func TopicRssPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func TopicAtomPage(w http.ResponseWriter, r *http.Request) {
-	if _, ok := core.GetSessionOrFail(w, r); !ok {
+	if _, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r); !ok {
 		return
 	}
 	vars := mux.Vars(r)

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 )
 
@@ -30,7 +29,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -21,7 +21,6 @@ import (
 	"github.com/arran4/goa4web/internal/tasks"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 )
 
@@ -115,7 +114,7 @@ func (CreateThreadTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("topic id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 )
 
 func ThreadPage(w http.ResponseWriter, r *http.Request) {
@@ -65,7 +64,7 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 	threadRow := r.Context().Value(consts.KeyThread).(*db.GetThreadLastPosterAndPermsRow)
 	topicRow := r.Context().Value(consts.KeyTopic).(*db.GetForumTopicByIdForUserRow)
 
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/handlers/forum/forumTopicPage.go
+++ b/handlers/forum/forumTopicPage.go
@@ -12,7 +12,6 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 )
 
@@ -30,7 +29,7 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 		CopyDataToSubCategories func(rootCategory *ForumcategoryPlus) *Data
 	}
 
-	if _, ok := core.GetSessionOrFail(w, r); !ok {
+	if _, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r); !ok {
 		return
 	}
 	vars := mux.Vars(r)

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
@@ -75,7 +74,7 @@ func (ReplyTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string, erro
 }
 
 func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/forum/matchers.go
+++ b/handlers/forum/matchers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/internal/db"
 )
 
@@ -33,9 +32,10 @@ func RequireThreadAndTopic(next http.Handler) http.Handler {
 			return
 		}
 
-		queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		queries := cd.Queries()
 
-		session, _ := core.GetSession(r)
+		session, _ := cd.GetSession(r)
 		var uid int32
 		if session != nil {
 			uid, _ = session.Values["UID"].(int32)

--- a/handlers/forum/subscribe_topic_task.go
+++ b/handlers/forum/subscribe_topic_task.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -24,7 +23,7 @@ var subscribeTopicTaskAction = &subscribeTopicTask{TaskString: TaskSubscribeToTo
 var _ tasks.Task = (*subscribeTopicTask)(nil)
 
 func (subscribeTopicTask) Action(w http.ResponseWriter, r *http.Request) any {
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/forum/unsubscribe_topic_task.go
+++ b/handlers/forum/unsubscribe_topic_task.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -24,7 +23,7 @@ var unsubscribeTopicTaskAction = &unsubscribeTopicTask{TaskString: TaskUnsubscri
 var _ tasks.Task = (*unsubscribeTopicTask)(nil)
 
 func (unsubscribeTopicTask) Action(w http.ResponseWriter, r *http.Request) any {
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -25,7 +25,6 @@ import (
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/arran4/goa4web/workers/searchworker"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
 	imagesign "github.com/arran4/goa4web/internal/images"
 	"github.com/gorilla/mux"
@@ -104,7 +103,8 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	vars := mux.Vars(r)
 	bid, _ := strconv.Atoi(vars["boardno"])
 
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -19,7 +19,6 @@ import (
 	"github.com/arran4/goa4web/workers/postcountworker"
 	"github.com/arran4/goa4web/workers/searchworker"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/gorilla/mux"
 )
@@ -88,7 +87,8 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bid, _ := strconv.Atoi(vars["boardno"])
 	thid, _ := strconv.Atoi(vars["thread"])
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -197,7 +197,8 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/linker/edit_reply_task.go
+++ b/handlers/linker/edit_reply_task.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -39,7 +38,7 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	linkId, _ := strconv.Atoi(vars["link"])
 	commentId, _ := strconv.Atoi(vars["comment"])
 
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -17,7 +17,6 @@ import (
 	"github.com/arran4/goa4web/internal/tasks"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 )
 
 func AdminAddPage(w http.ResponseWriter, r *http.Request) {
@@ -72,7 +71,7 @@ var _ notif.AdminEmailTemplateProvider = (*addTask)(nil)
 func (addTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return nil
 	}

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/arran4/goa4web/config"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/gorilla/mux"
 )
@@ -67,7 +66,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 	if lid, err := strconv.Atoi(vars["link"]); err == nil {
 		linkId = lid
 	}
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -198,7 +197,7 @@ func (replyTask) IndexData(data map[string]any) []searchworker.IndexEventData {
 var _ searchworker.IndexedTask = replyTask{}
 
 func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/arran4/goa4web/config"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 )
 
@@ -69,7 +68,7 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/arran4/goa4web/internal/tasks"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 )
 
 func SuggestPage(w http.ResponseWriter, r *http.Request) {
@@ -71,7 +70,7 @@ func (SuggestTask) Page(w http.ResponseWriter, r *http.Request) { SuggestPage(w,
 func (SuggestTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return nil
 	}

--- a/handlers/matchers.go
+++ b/handlers/matchers.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 )
 
 // RequiredAccess ensures the requestor has one of the provided roles.
@@ -19,7 +19,8 @@ func RequiredAccess(accessLevels ...string) mux.MatcherFunc {
 // RequiresAnAccount checks that the requester has a valid user session.
 func RequiresAnAccount() mux.MatcherFunc {
 	return func(request *http.Request, match *mux.RouteMatch) bool {
-		session, err := core.GetSession(request)
+		cd := request.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		session, err := cd.GetSession(request)
 		if err != nil {
 			return false
 		}

--- a/handlers/news/announcement_add_task.go
+++ b/handlers/news/announcement_add_task.go
@@ -24,8 +24,8 @@ var announcementAddTask = &AnnouncementAddTask{TaskString: TaskAdd}
 var _ tasks.Task = (*AnnouncementAddTask)(nil)
 
 func (AnnouncementAddTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
 

--- a/handlers/news/announcement_delete_task.go
+++ b/handlers/news/announcement_delete_task.go
@@ -24,8 +24,8 @@ var announcementDeleteTask = &AnnouncementDeleteTask{TaskString: TaskDelete}
 var _ tasks.Task = (*AnnouncementDeleteTask)(nil)
 
 func (AnnouncementDeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
 

--- a/handlers/news/edit_reply_task.go
+++ b/handlers/news/edit_reply_task.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -42,12 +41,13 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	text := r.PostFormValue("replytext")
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	vars := mux.Vars(r)
 	postId, _ := strconv.Atoi(vars["post"])
 	commentId, _ := strconv.Atoi(vars["comment"])
 
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/news/matchers.go
+++ b/handlers/news/matchers.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 
 	"github.com/gorilla/mux"
-
-	"github.com/arran4/goa4web/core"
 )
 
 // RequireNewsPostAuthor ensures the requester authored the news post referenced in the URL.
@@ -21,8 +19,9 @@ func RequireNewsPostAuthor(next http.Handler) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-		session, err := core.GetSession(r)
+		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		queries := cd.Queries()
+		session, err := cd.GetSession(r)
 		if err != nil {
 			http.NotFound(w, r)
 			return

--- a/handlers/news/newsAdminUserLevelsPage.go
+++ b/handlers/news/newsAdminUserLevelsPage.go
@@ -19,11 +19,10 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 		Roles      []*db.Role
 	}
 
-	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-	}
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	data := Data{CoreData: cd}
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 	if roles, err := data.AllRoles(); err == nil {
 		data.Roles = roles
 	}

--- a/handlers/news/newsEditPostTask.go
+++ b/handlers/news/newsEditPostTask.go
@@ -42,11 +42,10 @@ func (EditTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("languageId parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	vars := mux.Vars(r)
 	postId, _ := strconv.Atoi(vars["post"])
-
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if !cd.HasGrant("news", "post", "edit", int32(postId)) {
 		r.URL.RawQuery = "error=" + url.QueryEscape("Forbidden")
 		handlers.TaskErrorAcknowledgementPage(w, r)

--- a/handlers/news/newsNewPostTask.go
+++ b/handlers/news/newsNewPostTask.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -69,8 +68,9 @@ func (NewPostTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("languageId parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/arran4/goa4web/a4code"
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers"
@@ -60,8 +59,8 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		ReplyText          string
 	}
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	data := Data{
 		CoreData:           cd,
 		IsReplying:         r.URL.Query().Has("comment"),
@@ -70,7 +69,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 	}
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/handlers/news/newsPostPage_test.go
+++ b/handlers/news/newsPostPage_test.go
@@ -27,8 +27,7 @@ func TestNewsPostNewActionPage_InvalidForms(t *testing.T) {
 	defer dbconn.Close()
 
 	store := sessions.NewCookieStore([]byte("test"))
-	core.Store = store
-	core.SessionName = "test-session"
+	sm := &core.SessionManager{Name: "test-session", Store: store}
 
 	cases := []url.Values{
 		{"text": {"hi"}},
@@ -38,14 +37,14 @@ func TestNewsPostNewActionPage_InvalidForms(t *testing.T) {
 	for _, form := range cases {
 		req := httptest.NewRequest("POST", "/news", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		sess, _ := store.Get(req, core.SessionName)
+		sess, _ := store.Get(req, sm.Name)
 		sess.Values["UID"] = int32(1)
 		w := httptest.NewRecorder()
 		sess.Save(req, w)
 		for _, c := range w.Result().Cookies() {
 			req.AddCookie(c)
 		}
-		ctx := req.Context()
+		ctx := context.WithValue(req.Context(), core.ContextValues("sessionManager"), sm)
 		ctx = context.WithValue(ctx, consts.KeyCoreData, &common.CoreData{})
 		req = req.WithContext(ctx)
 
@@ -71,8 +70,7 @@ func TestNewsPostEditActionPage_InvalidForms(t *testing.T) {
 	defer dbconn.Close()
 
 	store := sessions.NewCookieStore([]byte("test"))
-	core.Store = store
-	core.SessionName = "test-session"
+	sm := &core.SessionManager{Name: "test-session", Store: store}
 
 	cases := []url.Values{
 		{"text": {"hi"}},
@@ -83,14 +81,14 @@ func TestNewsPostEditActionPage_InvalidForms(t *testing.T) {
 		req := httptest.NewRequest("POST", "/news/1", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req = mux.SetURLVars(req, map[string]string{"post": "1"})
-		sess, _ := store.Get(req, core.SessionName)
+		sess, _ := store.Get(req, sm.Name)
 		sess.Values["UID"] = int32(1)
 		w := httptest.NewRecorder()
 		sess.Save(req, w)
 		for _, c := range w.Result().Cookies() {
 			req.AddCookie(c)
 		}
-		ctx := req.Context()
+		ctx := context.WithValue(req.Context(), core.ContextValues("sessionManager"), sm)
 		ctx = context.WithValue(ctx, consts.KeyCoreData, &common.CoreData{})
 		req = req.WithContext(ctx)
 

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
@@ -75,7 +74,8 @@ func (ReplyTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string, erro
 }
 
 func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
@@ -93,8 +93,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	if !cd.HasGrant("news", "post", "reply", int32(pid)) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return nil

--- a/handlers/news/newsUserPermissionsPage.go
+++ b/handlers/news/newsUserPermissionsPage.go
@@ -24,11 +24,9 @@ func NewsUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 		Roles []*db.Role
 	}
 
-	data := Data{
-		CoreData: cd,
-	}
+	data := Data{CoreData: cd}
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 	if roles, err := cd.AllRoles(); err == nil {
 		data.Roles = roles
 	}

--- a/handlers/news/searchResultNewsActionPage.go
+++ b/handlers/news/searchResultNewsActionPage.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/arran4/goa4web/core/common"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/workers/searchworker"
@@ -26,11 +25,10 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 		EmptyWords         bool
 	}
 
-	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	data := Data{CoreData: cd}
+	queries := cd.Queries()
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/handlers/news/user_allow_task.go
+++ b/handlers/news/user_allow_task.go
@@ -31,7 +31,8 @@ func (UserAllowTask) AdminInternalNotificationTemplate() *string {
 }
 
 func (UserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	username := r.PostFormValue("username")
 	role := r.PostFormValue("role")
 	data := struct {
@@ -40,7 +41,7 @@ func (UserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Back:     "/news",
 	}
 	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {

--- a/handlers/news/user_disallow_task.go
+++ b/handlers/news/user_disallow_task.go
@@ -30,7 +30,8 @@ func (UserDisallowTask) AdminInternalNotificationTemplate() *string {
 }
 
 func (UserDisallowTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	permid := r.PostFormValue("permid")
 	data := struct {
 		*common.CoreData
@@ -38,7 +39,7 @@ func (UserDisallowTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Back:     "/news",
 	}
 	if permidi, err := strconv.Atoi(permid); err != nil {

--- a/handlers/search/searchResultBlogsActionPage.go
+++ b/handlers/search/searchResultBlogsActionPage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/workers/searchworker"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -37,7 +36,7 @@ func (SearchBlogsTask) Action(w http.ResponseWriter, r *http.Request) any {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/search/searchResultForumActionPage.go
+++ b/handlers/search/searchResultForumActionPage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/workers/searchworker"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -34,7 +33,7 @@ func (SearchForumTask) Action(w http.ResponseWriter, r *http.Request) any {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/search/searchResultLinkerActionPage.go
+++ b/handlers/search/searchResultLinkerActionPage.go
@@ -14,7 +14,6 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/workers/searchworker"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -39,7 +38,7 @@ func (SearchLinkerTask) Action(w http.ResponseWriter, r *http.Request) any {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/search/searchResultWritingsActionPage.go
+++ b/handlers/search/searchResultWritingsActionPage.go
@@ -14,7 +14,6 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 	searchutil "github.com/arran4/goa4web/workers/searchworker"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -38,7 +37,7 @@ func (SearchWritingsTask) Action(w http.ResponseWriter, r *http.Request) any {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/user/deleteEmailTask.go
+++ b/handlers/user/deleteEmailTask.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -21,7 +20,8 @@ var deleteEmailTask = &DeleteEmailTask{TaskString: tasks.TaskString(TaskDelete)}
 var _ tasks.Task = (*DeleteEmailTask)(nil)
 
 func (DeleteEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
@@ -30,7 +30,7 @@ func (DeleteEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	id, _ := strconv.Atoi(r.FormValue("id"))
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 	ue, err := queries.GetUserEmailByID(r.Context(), int32(id))
 	if err == nil && ue.UserID == uid {
 		if err := queries.DeleteUserEmail(r.Context(), int32(id)); err != nil {

--- a/handlers/user/deleteSubscriptionTask.go
+++ b/handlers/user/deleteSubscriptionTask.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -22,7 +21,8 @@ var deleteTask = &DeleteTask{TaskString: tasks.TaskString(TaskDelete)}
 var _ tasks.Task = (*DeleteTask)(nil)
 
 func (DeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
@@ -31,7 +31,7 @@ func (DeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	idStr := r.PostFormValue("id")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 	if idStr == "" {
 		return handlers.RefreshDirectHandler{TargetURL: "/usr/subscriptions?error=missing id"}
 	}

--- a/handlers/user/saveAllTask.go
+++ b/handlers/user/saveAllTask.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -25,13 +24,13 @@ func (SaveAllTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 
 	if err := updateLanguageSelections(r, cd, queries, uid); err != nil {
 		log.Printf("Save languages Error: %s", err)

--- a/handlers/user/saveEmailTask.go
+++ b/handlers/user/saveEmailTask.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -23,7 +22,8 @@ var saveEmailTask = &SaveEmailTask{TaskString: tasks.TaskString(TaskSaveAll)}
 var _ tasks.Task = (*SaveEmailTask)(nil)
 
 func (SaveEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
@@ -36,8 +36,7 @@ func (SaveEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 
 	updates := r.PostFormValue("emailupdates") != ""
 	auto := r.PostFormValue("autosubscribe") != ""

--- a/handlers/user/saveLanguageTask.go
+++ b/handlers/user/saveLanguageTask.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -25,12 +24,13 @@ func (SaveLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 
 	if err := updateDefaultLanguage(r, queries, uid); err != nil {
 		log.Printf("Save language Error: %s", err)

--- a/handlers/user/saveLanguagesTask.go
+++ b/handlers/user/saveLanguagesTask.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -25,13 +24,13 @@ func (SaveLanguagesTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 
 	if err := updateLanguageSelections(r, cd, queries, uid); err != nil {
 		log.Printf("Save languages Error: %s", err)

--- a/handlers/user/updateSubscriptionsTask.go
+++ b/handlers/user/updateSubscriptionsTask.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -21,7 +20,8 @@ var updateSubscriptionsTask = &UpdateSubscriptionsTask{TaskString: tasks.TaskStr
 var _ tasks.Task = (*UpdateSubscriptionsTask)(nil)
 
 func (UpdateSubscriptionsTask) Action(w http.ResponseWriter, r *http.Request) any {
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
@@ -29,7 +29,7 @@ func (UpdateSubscriptionsTask) Action(w http.ResponseWriter, r *http.Request) an
 	if err := r.ParseForm(); err != nil {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 	existing, err := queries.ListSubscriptionsByUser(r.Context(), uid)
 	if err != nil {
 		log.Printf("list subs: %v", err)

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/middleware"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/internal/db"
 )
 
@@ -64,7 +63,8 @@ func userEmailPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func userEmailVerifyCodePage(w http.ResponseWriter, r *http.Request) {
-	session, err := core.GetSession(r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, err := cd.GetSession(r)
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/user/userEmailVerify_test.go
+++ b/handlers/user/userEmailVerify_test.go
@@ -31,14 +31,16 @@ func TestUserEmailVerifyCodePage_Invalid(t *testing.T) {
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(sql.NullString{String: code, Valid: true}).WillReturnRows(rows)
 
 	store := sessions.NewCookieStore([]byte("test"))
-	sess := sessions.NewSession(store, "test")
+	sm := &core.SessionManager{Name: "test", Store: store}
+	sess := sessions.NewSession(store, sm.Name)
 	sess.Values = map[interface{}]interface{}{"UID": int32(2)}
-	core.Store = store
-	core.SessionName = "test"
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess))
+	ctx = context.WithValue(ctx, core.ContextValues("sessionManager"), sm)
+	cd := common.NewCoreData(ctx, q,
+		common.WithSession(sess),
+		common.WithSessionManager(sm))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	req := httptest.NewRequest(http.MethodGet, "/usr/email/verify?code="+code, nil).WithContext(ctx)
@@ -67,14 +69,16 @@ func TestUserEmailVerifyCodePage_Success(t *testing.T) {
 	mock.ExpectExec("UPDATE user_emails").WithArgs(sqlmock.AnyArg(), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	store := sessions.NewCookieStore([]byte("test"))
-	sess := sessions.NewSession(store, "test")
+	sm := &core.SessionManager{Name: "test", Store: store}
+	sess := sessions.NewSession(store, sm.Name)
 	sess.Values = map[interface{}]interface{}{"UID": int32(1)}
-	core.Store = store
-	core.SessionName = "test"
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess))
+	ctx = context.WithValue(ctx, core.ContextValues("sessionManager"), sm)
+	cd := common.NewCoreData(ctx, q,
+		common.WithSession(sess),
+		common.WithSessionManager(sm))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	form := url.Values{"code": {code}}

--- a/handlers/user/userGalleryPage.go
+++ b/handlers/user/userGalleryPage.go
@@ -12,7 +12,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	imagesign "github.com/arran4/goa4web/internal/images"
@@ -25,12 +24,13 @@ type galleryImage struct {
 }
 
 func userGalleryPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 
 	pageStr := r.URL.Query().Get("p")
 	page, _ := strconv.Atoi(pageStr)
@@ -38,7 +38,7 @@ func userGalleryPage(w http.ResponseWriter, r *http.Request) {
 		page = 1
 	}
 
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd = r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	size := config.AppRuntimeConfig.PageSizeDefault
 	if pref, _ := cd.Preference(); pref != nil {
 		size = int(pref.PageSize)

--- a/handlers/user/userLogoutPage.go
+++ b/handlers/user/userLogoutPage.go
@@ -8,14 +8,13 @@ import (
 	"github.com/arran4/goa4web/core/common"
 
 	"github.com/arran4/goa4web/handlers"
-
-	"github.com/arran4/goa4web/core"
 )
 
 func userLogoutPage(w http.ResponseWriter, r *http.Request) {
-	session, err := core.GetSession(r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, err := cd.GetSession(r)
 	if err != nil {
-		core.SessionError(w, r, err)
+		cd.SessionError(w, r, err)
 	}
 	uid, _ := session.Values["UID"].(int32)
 	log.Printf("logout request session=%s uid=%d", session.ID, uid)

--- a/handlers/user/userNotificationsPage.go
+++ b/handlers/user/userNotificationsPage.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/arran4/goa4web/handlers"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -26,7 +25,7 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -64,7 +63,7 @@ func (DismissTask) Action(w http.ResponseWriter, r *http.Request) any {
 		http.NotFound(w, r)
 		return nil
 	}
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
@@ -93,7 +92,7 @@ func notificationsRssPage(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -114,7 +113,7 @@ func notificationsRssPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func userNotificationEmailActionPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/handlers/user/userPage.go
+++ b/handlers/user/userPage.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/middleware"
-
-	"github.com/arran4/goa4web/core"
 )
 
 func userPage(w http.ResponseWriter, r *http.Request) {
@@ -22,7 +20,7 @@ func userPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if data.CoreData.UserID == 0 {
-		session, err := core.GetSession(r)
+		session, err := data.CoreData.GetSession(r)
 		if err != nil {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return

--- a/handlers/user/userPagingPage.go
+++ b/handlers/user/userPagingPage.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/arran4/goa4web/handlers"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/config"
@@ -50,7 +49,8 @@ func (PagingSaveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err := r.ParseForm(); err != nil {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
@@ -62,8 +62,7 @@ func (PagingSaveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if size > config.AppRuntimeConfig.PageSizeMax {
 		size = config.AppRuntimeConfig.PageSizeMax
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 
 	pref, err := cd.Preference()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/handlers/user/userSubscriptionsPage.go
+++ b/handlers/user/userSubscriptionsPage.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/arran4/goa4web/handlers"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/internal/db"
 )
 
@@ -27,12 +26,13 @@ var userSubscriptionOptions = []subscriptionOption{
 }
 
 func userSubscriptionsPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 	rows, err := queries.ListSubscriptionsByUser(r.Context(), uid)
 	if err != nil {
 		log.Printf("list subs: %v", err)

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -185,10 +185,7 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 
 	queries := dbpkg.New(db)
 	store = sessions.NewCookieStore([]byte("test"))
-	core.Store = store
-	core.SessionName = sessionName
-	core.Store = store
-	core.SessionName = sessionName
+	sm := &core.SessionManager{Name: sessionName, Store: store}
 
 	form := url.Values{}
 	form.Set("dothis", "Save all")
@@ -198,7 +195,7 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 	req := httptest.NewRequest("POST", "/usr/lang", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	sess, _ := store.Get(req, sessionName)
+	sess, _ := store.Get(req, sm.Name)
 	sess.Values["UID"] = int32(1)
 	w := httptest.NewRecorder()
 	sess.Save(req, w)
@@ -207,8 +204,11 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 	}
 	rr := httptest.NewRecorder()
 
+	cd := common.NewCoreData(req.Context(), queries,
+		common.WithSession(sess),
+		common.WithSessionManager(sm))
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess))
+	ctx = context.WithValue(ctx, core.ContextValues("sessionManager"), sm)
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -239,6 +239,7 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 
 	queries := dbpkg.New(db)
 	store = sessions.NewCookieStore([]byte("test"))
+	sm := &core.SessionManager{Name: sessionName, Store: store}
 
 	form := url.Values{}
 	form.Set("dothis", "Save languages")
@@ -247,7 +248,7 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 	req := httptest.NewRequest("POST", "/usr/lang", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	sess, _ := store.Get(req, sessionName)
+	sess, _ := store.Get(req, sm.Name)
 	sess.Values["UID"] = int32(1)
 	w := httptest.NewRecorder()
 	sess.Save(req, w)
@@ -256,8 +257,11 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 	}
 	rr := httptest.NewRecorder()
 
+	cd := common.NewCoreData(req.Context(), queries,
+		common.WithSession(sess),
+		common.WithSessionManager(sm))
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess))
+	ctx = context.WithValue(ctx, core.ContextValues("sessionManager"), sm)
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -287,8 +291,7 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	queries := dbpkg.New(db)
 	config.AppRuntimeConfig.PageSizeDefault = 15
 	store = sessions.NewCookieStore([]byte("test"))
-	core.Store = store
-	core.SessionName = sessionName
+	sm := &core.SessionManager{Name: sessionName, Store: store}
 
 	form := url.Values{}
 	form.Set("dothis", "Save language")
@@ -297,7 +300,7 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	req := httptest.NewRequest("POST", "/usr/lang", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	sess, _ := store.Get(req, sessionName)
+	sess, _ := store.Get(req, sm.Name)
 	sess.Values["UID"] = int32(1)
 	w := httptest.NewRecorder()
 	sess.Save(req, w)
@@ -306,8 +309,11 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	}
 	rr := httptest.NewRecorder()
 
+	cd := common.NewCoreData(req.Context(), queries,
+		common.WithSession(sess),
+		common.WithSessionManager(sm))
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess))
+	ctx = context.WithValue(ctx, core.ContextValues("sessionManager"), sm)
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/writings/edit_reply_task.go
+++ b/handlers/writings/edit_reply_task.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -34,7 +33,8 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	text := r.PostFormValue("replytext")
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	vars := mux.Vars(r)
 	articleID, err := strconv.Atoi(vars["article"])
 	if err != nil {
@@ -45,7 +45,7 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("comment id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}

--- a/handlers/writings/matchers.go
+++ b/handlers/writings/matchers.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/internal/db"
 )
 
@@ -30,8 +29,9 @@ func RequireWritingAuthor(next http.Handler) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-		session, err := core.GetSession(r)
+		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		queries := cd.Queries()
+		session, err := cd.GetSession(r)
 		if err != nil {
 			http.NotFound(w, r)
 			return
@@ -49,7 +49,7 @@ func RequireWritingAuthor(next http.Handler) http.Handler {
 			return
 		}
 
-		cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		cd = r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 		if cd != nil && cd.HasRole("administrator") {
 			ctx := context.WithValue(r.Context(), consts.KeyWriting, row)
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/core/templates"
@@ -67,7 +66,8 @@ func (ReplyTask) AutoSubscribePath(evt eventbus.TaskEvent) (string, string, erro
 }
 
 func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
@@ -78,7 +78,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("article id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 	uid, _ := session.Values["UID"].(int32)
 
 	post, err := queries.GetWritingByIdForUserDescendingByPublishedDate(r.Context(), db.GetWritingByIdForUserDescendingByPublishedDateParams{

--- a/handlers/writings/submit_writing_task.go
+++ b/handlers/writings/submit_writing_task.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -37,7 +36,8 @@ func (SubmitWritingTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("category id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
@@ -55,7 +55,7 @@ func (SubmitWritingTask) Action(w http.ResponseWriter, r *http.Request) any {
 	body := r.PostFormValue("body")
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 
 	articleID, err := queries.InsertWriting(r.Context(), db.InsertWritingParams{
 		WritingCategoryID:  int32(categoryID),

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -14,7 +14,6 @@ import (
 	"github.com/arran4/goa4web/workers/searchworker"
 	"strings"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 )
 
@@ -40,7 +39,8 @@ func ArticleAddPage(w http.ResponseWriter, r *http.Request) {
 func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	categoryId, _ := strconv.Atoi(vars["category"])
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -52,7 +52,7 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 	body := r.PostFormValue("body")
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 
 	articleId, err := queries.InsertWriting(r.Context(), db.InsertWritingParams{
 		WritingCategoryID:  int32(categoryId),

--- a/handlers/writings/writingsArticleCommentEditPage.go
+++ b/handlers/writings/writingsArticleCommentEditPage.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/workers/postcountworker"
@@ -26,12 +25,13 @@ func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	text := r.PostFormValue("replytext")
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	vars := mux.Vars(r)
 	articleId, _ := strconv.Atoi(vars["article"])
 	commentId, _ := strconv.Atoi(vars["comment"])
 
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 )
 
 func ArticleEditPage(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +36,7 @@ func ArticleEditPage(w http.ResponseWriter, r *http.Request) {
 	// article ID is validated by the RequireWritingAuthor middleware, so we
 	// no longer need to parse it here.
 
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -18,7 +18,6 @@ import (
 	"github.com/arran4/goa4web/workers/searchworker"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/gorilla/mux"
 	"golang.org/x/exp/slices"
@@ -56,7 +55,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 	data := Data{
 		CoreData:           cd,
 		CanReply:           cd.UserID != 0,
@@ -68,13 +67,13 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	articleId, _ := strconv.Atoi(vars["article"])
 
-	session, ok := core.GetSessionOrFail(w, r)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
 	data.UserId = uid
-	queries = r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries = cd.Queries()
 
 	writing, err := queries.GetWritingByIdForUserDescendingByPublishedDate(r.Context(), db.GetWritingByIdForUserDescendingByPublishedDateParams{
 		ViewerID:      uid,
@@ -263,7 +262,8 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
-	session, ok := core.GetSessionOrFail(w, r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	session, ok := cd.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
@@ -281,7 +281,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 	uid, _ := session.Values["UID"].(int32)
 
 	post, err := queries.GetWritingByIdForUserDescendingByPublishedDate(r.Context(), db.GetWritingByIdForUserDescendingByPublishedDateParams{

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -12,14 +12,16 @@ import (
 	"time"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
 )
 
 // Server bundles the application's configuration, router and runtime dependencies.
 type Server struct {
-	Config config.RuntimeConfig
-	Router http.Handler
-	Store  *sessions.CookieStore
-	DB     *sql.DB
+	Config         config.RuntimeConfig
+	Router         http.Handler
+	Store          *sessions.CookieStore
+	DB             *sql.DB
+	SessionManager *core.SessionManager
 
 	addr       string
 	httpServer *http.Server
@@ -56,12 +58,13 @@ func (s *Server) Shutdown(ctx context.Context) error {
 }
 
 // New returns a Server with the supplied dependencies.
-func New(handler http.Handler, store *sessions.CookieStore, db *sql.DB, cfg config.RuntimeConfig) *Server {
+func New(handler http.Handler, store *sessions.CookieStore, sm *core.SessionManager, db *sql.DB, cfg config.RuntimeConfig) *Server {
 	return &Server{
-		Config: cfg,
-		Router: handler,
-		Store:  store,
-		DB:     db,
+		Config:         cfg,
+		Router:         handler,
+		Store:          store,
+		SessionManager: sm,
+		DB:             db,
 	}
 }
 

--- a/internal/middleware/csrf/csrf_test.go
+++ b/internal/middleware/csrf/csrf_test.go
@@ -24,8 +24,7 @@ var (
 
 func TestCSRFLoginFlow(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("testsecret"))
-	core.Store = store
-	core.SessionName = sessionName
+	_ = &core.SessionManager{Name: sessionName, Store: store}
 	key := sha256.Sum256([]byte("testsecret"))
 
 	r := mux.NewRouter()
@@ -68,8 +67,7 @@ func TestCSRFLoginFlow(t *testing.T) {
 
 func TestCSRFMismatchedReferer(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("testsecret"))
-	core.Store = store
-	core.SessionName = sessionName
+	_ = &core.SessionManager{Name: sessionName, Store: store}
 	key := sha256.Sum256([]byte("testsecret"))
 
 	r := mux.NewRouter()
@@ -112,8 +110,7 @@ func TestCSRFMismatchedReferer(t *testing.T) {
 
 func TestCSRFDisabled(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("testsecret"))
-	core.Store = store
-	core.SessionName = sessionName
+	_ = &core.SessionManager{Name: sessionName, Store: store}
 
 	r := mux.NewRouter()
 	r.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/websocket/notifications.go
+++ b/internal/websocket/notifications.go
@@ -54,9 +54,10 @@ func NewNotificationsHandler(bus *eventbus.Bus) *NotificationsHandler {
 // ServeHTTP upgrades the connection and streams events as JSON.
 
 func (h *NotificationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	sess, err := core.GetSession(r)
+	cd := r.Context().Value(coreconsts.KeyCoreData).(*corecommon.CoreData)
+	sess, err := cd.GetSession(r)
 	if err != nil {
-		core.SessionError(w, r, err)
+		cd.SessionError(w, r, err)
 		http.Error(w, "invalid session", http.StatusUnauthorized)
 		return
 	}


### PR DESCRIPTION
## Summary
- remove global default session manager
- store session manager on request context
- expose helpers via CoreData
- refactor handlers and tests to use CoreData directly
- fix variable naming to prefer `cd` when accessing CoreData

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688186770e98832faa0907c7ef51c5b9