### PR TITLE
Refactor registries to be instance-based

### DIFF
--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -39,10 +39,11 @@ import (
 
 var version = "dev"
 
-func init() {
+func registerTasks(reg *tasks.Registry) {
 	register := func(ts []tasks.NamedTask) {
 		for _, t := range ts {
 			tasks.Register(t)
+			reg.Register(t)
 		}
 	}
 	register(adminhandlers.RegisterTasks())
@@ -86,6 +87,7 @@ type rootCmd struct {
 	ConfigFile string
 	db         *sql.DB
 	Verbosity  int
+	tasksReg   *tasks.Registry
 	dbReg      *dbdrivers.Registry
 	emailReg   *email.Registry
 	dlqReg     *dlq.Registry
@@ -128,10 +130,12 @@ func (r *rootCmd) Verbosef(format string, args ...any) {
 
 func parseRoot(args []string) (*rootCmd, error) {
 	r := &rootCmd{
+		tasksReg: tasks.NewRegistry(),
 		dbReg:    dbdrivers.NewRegistry(),
 		emailReg: email.NewRegistry(),
 		dlqReg:   dlq.NewRegistry(),
 	}
+	registerTasks(r.tasksReg)
 	emaildefaults.Register(r.emailReg)
 	dlqreg.Register(r.dlqReg)
 	dbdefaults.Register(r.dbReg)

--- a/cmd/goa4web/notifications_tasks.go
+++ b/cmd/goa4web/notifications_tasks.go
@@ -39,7 +39,7 @@ func (c *notificationsTasksCmd) Run() error {
 	tw := table.NewWriter()
 	tw.SetOutputMirror(c.fs.Output())
 	tw.AppendHeader(table.Row{"Task", "Self Email", "Self Internal", "Subscribed Email", "Subscribed Internal", "Admin Email", "Admin Internal"})
-	for _, info := range taskTemplateInfos() {
+	for _, info := range taskTemplateInfos(c.notificationsCmd.rootCmd.tasksReg) {
 		tw.AppendRow(table.Row{
 			info.Task,
 			strings.Join(info.SelfEmail, ","),

--- a/cmd/goa4web/notifications_tasks_data.go
+++ b/cmd/goa4web/notifications_tasks_data.go
@@ -18,10 +18,10 @@ type taskTemplateInfo struct {
 	AdminInternal string
 }
 
-func taskTemplateInfos() []taskTemplateInfo {
-	reg := tasks.Registered()
-	infos := make([]taskTemplateInfo, 0, len(reg))
-	for _, t := range reg {
+func taskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
+	tasksSlice := reg.Registered()
+	infos := make([]taskTemplateInfo, 0, len(tasksSlice))
+	for _, t := range tasksSlice {
 		info := taskTemplateInfo{Task: t.Name()}
 		if tp, ok := t.(notif.SelfNotificationTemplateProvider); ok {
 			if et := tp.SelfEmailTemplate(); et != nil {

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -25,9 +25,11 @@ import (
 	"time"
 )
 
-func init() {
-	email.DefaultRegistry = email.NewRegistry()
-	logProv.Register(email.DefaultRegistry)
+func newEmailReg() *email.Registry {
+	r := email.NewRegistry()
+	logProv.Register(r)
+	email.DefaultRegistry = r
+	return r
 }
 
 var (
@@ -59,7 +61,8 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)), common.WithConfig(config.AppRuntimeConfig))
+	reg := newEmailReg()
+	cd := common.NewCoreData(ctx, queries, common.WithEmailProvider(reg.ProviderFromConfig(config.AppRuntimeConfig)), common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -90,7 +93,8 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithEmailProvider(email.ProviderFromConfig(config.AppRuntimeConfig)), common.WithConfig(config.AppRuntimeConfig))
+	reg := newEmailReg()
+	cd := common.NewCoreData(ctx, queries, common.WithEmailProvider(reg.ProviderFromConfig(config.AppRuntimeConfig)), common.WithConfig(config.AppRuntimeConfig))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -97,7 +97,7 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 	taskEventMW := middleware.NewTaskEventMiddleware(bus)
 	handler := middleware.NewMiddlewareChain(
 		middleware.RecoverMiddleware,
-		middleware.CoreAdderMiddlewareWithDB(dbPool, cfg, cfg.DBLogVerbosity),
+		middleware.CoreAdderMiddlewareWithDB(dbPool, cfg, cfg.DBLogVerbosity, emailReg),
 		middleware.RequestLoggerMiddleware,
 		taskEventMW.Middleware,
 		middleware.SecurityHeadersMiddleware,

--- a/internal/dlq/dlq.go
+++ b/internal/dlq/dlq.go
@@ -22,10 +22,10 @@ func (LogDLQ) Record(_ context.Context, message string) error {
 }
 
 // RegisterLogDLQ registers the log provider.
-func RegisterLogDLQ() {
-	RegisterProvider("log", func(config.RuntimeConfig, *dbpkg.Queries) DLQ {
+func RegisterLogDLQ(r *Registry) {
+	r.RegisterProvider("log", func(config.RuntimeConfig, *dbpkg.Queries) DLQ {
 		return LogDLQ{}
 	})
 }
 
-func init() { RegisterLogDLQ() }
+func init() { RegisterLogDLQ(DefaultRegistry) }

--- a/internal/dlq/dlq_test.go
+++ b/internal/dlq/dlq_test.go
@@ -14,26 +14,26 @@ import (
 )
 
 func TestProviderFromConfigRegistry(t *testing.T) {
-	dlq.DefaultRegistry = dlq.NewRegistry()
-	dlqdefaults.Register(dlq.DefaultRegistry)
+	reg := dlq.NewRegistry()
+	dlqdefaults.Register(reg)
 
 	cfg := config.RuntimeConfig{DLQProvider: "file", DLQFile: "p"}
-	if _, ok := dlq.ProviderFromConfig(cfg, nil).(*filedlq.DLQ); !ok {
+	if _, ok := reg.ProviderFromConfig(cfg, nil).(*filedlq.DLQ); !ok {
 		t.Fatalf("expected *file.DLQ")
 	}
 
 	cfg = config.RuntimeConfig{DLQProvider: "dir", DLQFile: "d"}
-	if _, ok := dlq.ProviderFromConfig(cfg, nil).(*dirdlq.DLQ); !ok {
+	if _, ok := reg.ProviderFromConfig(cfg, nil).(*dirdlq.DLQ); !ok {
 		t.Fatalf("expected *dir.DLQ")
 	}
 
 	cfg = config.RuntimeConfig{DLQProvider: "db"}
-	if _, ok := dlq.ProviderFromConfig(cfg, (&dbpkg.Queries{})).(dbdlq.DLQ); !ok {
+	if _, ok := reg.ProviderFromConfig(cfg, (&dbpkg.Queries{})).(dbdlq.DLQ); !ok {
 		t.Fatalf("expected db.DLQ")
 	}
 
 	cfg = config.RuntimeConfig{DLQProvider: "email"}
-	p := dlq.ProviderFromConfig(cfg, nil)
+	p := reg.ProviderFromConfig(cfg, nil)
 	if _, ok := p.(emaildlq.DLQ); !ok {
 		if _, ok := p.(dlq.LogDLQ); !ok {
 			t.Fatalf("unexpected type %T", p)
@@ -41,21 +41,21 @@ func TestProviderFromConfigRegistry(t *testing.T) {
 	}
 
 	cfg = config.RuntimeConfig{DLQProvider: "db,log"}
-	if _, ok := dlq.ProviderFromConfig(cfg, (&dbpkg.Queries{})).(dlq.MultiDLQ); !ok {
+	if _, ok := reg.ProviderFromConfig(cfg, (&dbpkg.Queries{})).(dlq.MultiDLQ); !ok {
 		t.Fatalf("expected MultiDLQ")
 	}
 }
 
 func TestRegisterProviderCustom(t *testing.T) {
-	dlq.DefaultRegistry = dlq.NewRegistry()
+	reg := dlq.NewRegistry()
 	called := false
-	dlq.RegisterProvider("custom", func(cfg config.RuntimeConfig, q *dbpkg.Queries) dlq.DLQ {
+	reg.RegisterProvider("custom", func(cfg config.RuntimeConfig, q *dbpkg.Queries) dlq.DLQ {
 		called = true
 		return dlq.LogDLQ{}
 	})
 
 	cfg := config.RuntimeConfig{DLQProvider: "custom"}
-	if _, ok := dlq.ProviderFromConfig(cfg, nil).(dlq.LogDLQ); !ok || !called {
+	if _, ok := reg.ProviderFromConfig(cfg, nil).(dlq.LogDLQ); !ok || !called {
 		t.Fatalf("custom provider not used")
 	}
 }

--- a/internal/email/email_sendgrid_test.go
+++ b/internal/email/email_sendgrid_test.go
@@ -7,16 +7,19 @@ import (
 	"testing"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/internal/email"
 	sendgridProv "github.com/arran4/goa4web/internal/email/sendgrid"
 )
 
-func init() {
-	email.DefaultRegistry = email.NewRegistry()
-	sendgridProv.Register(email.DefaultRegistry)
+func newRegistry() *email.Registry {
+	r := email.NewRegistry()
+	sendgridProv.Register(r)
+	return r
 }
 
 func TestSendGridProviderFromConfig(t *testing.T) {
-	p := ProviderFromConfig(config.RuntimeConfig{EmailProvider: "sendgrid", EmailSendGridKey: "k", EmailFrom: "from@example.com"})
+	reg := newRegistry()
+	p := reg.ProviderFromConfig(config.RuntimeConfig{EmailProvider: "sendgrid", EmailSendGridKey: "k", EmailFrom: "from@example.com"})
 	if _, ok := p.(sendgridProv.Provider); !ok {
 		t.Fatalf("expected SendGridProvider, got %#v", p)
 	}

--- a/internal/email/emaildefaults/email_ses_test.go
+++ b/internal/email/emaildefaults/email_ses_test.go
@@ -11,13 +11,15 @@ import (
 	sesProv "github.com/arran4/goa4web/internal/email/ses"
 )
 
-func init() {
-	email.DefaultRegistry = email.NewRegistry()
-	sesProv.Register(email.DefaultRegistry)
+func newRegistry() *email.Registry {
+	r := email.NewRegistry()
+	sesProv.Register(r)
+	return r
 }
 
 func TestGetEmailProviderSESNoCreds(t *testing.T) {
-	if p := email.ProviderFromConfig(config.RuntimeConfig{EmailProvider: "ses", EmailAWSRegion: "us-east-1"}); p != nil {
+	reg := newRegistry()
+	if p := reg.ProviderFromConfig(config.RuntimeConfig{EmailProvider: "ses", EmailAWSRegion: "us-east-1"}); p != nil {
 		t.Errorf("expected nil provider, got %#v", p)
 	}
 }

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -31,7 +31,7 @@ func handleDie(w http.ResponseWriter, message string) {
 // CoreAdderMiddlewareWithDB populates request context with CoreData for
 // templates using the supplied database handle. The verbosity controls optional
 // logging of database pool statistics.
-func CoreAdderMiddlewareWithDB(db *sql.DB, cfg config.RuntimeConfig, verbosity int) func(http.Handler) http.Handler {
+func CoreAdderMiddlewareWithDB(db *sql.DB, cfg config.RuntimeConfig, verbosity int, emailReg *email.Registry) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			session, err := core.GetSession(r)
@@ -89,10 +89,11 @@ func CoreAdderMiddlewareWithDB(db *sql.DB, cfg config.RuntimeConfig, verbosity i
 			if cfg.HTTPHostname != "" {
 				base = strings.TrimRight(cfg.HTTPHostname, "/")
 			}
+			provider := emailReg.ProviderFromConfig(cfg)
 			cd := common.NewCoreData(r.Context(), queries,
 				common.WithImageURLMapper(imagesign.MapURL),
 				common.WithSession(session),
-				common.WithEmailProvider(email.ProviderFromConfig(cfg)),
+				common.WithEmailProvider(provider),
 				common.WithAbsoluteURLBase(base),
 				common.WithConfig(cfg))
 			cd.UserID = uid

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/email"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/sessions"
 )
@@ -45,7 +46,8 @@ func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
 		cdOut, _ = r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	})
 
-	CoreAdderMiddlewareWithDB(db, config.AppRuntimeConfig, 0)(handler).ServeHTTP(httptest.NewRecorder(), req)
+	reg := email.NewRegistry()
+	CoreAdderMiddlewareWithDB(db, config.AppRuntimeConfig, 0, reg)(handler).ServeHTTP(httptest.NewRecorder(), req)
 
 	want := []string{"anonymous", "user", "moderator"}
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {
@@ -82,7 +84,8 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 		cdOut, _ = r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	})
 
-	CoreAdderMiddlewareWithDB(db, config.AppRuntimeConfig, 0)(handler).ServeHTTP(httptest.NewRecorder(), req)
+	reg := email.NewRegistry()
+	CoreAdderMiddlewareWithDB(db, config.AppRuntimeConfig, 0, reg)(handler).ServeHTTP(httptest.NewRecorder(), req)
 
 	want := []string{"anonymous"}
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {


### PR DESCRIPTION
## Summary
- refactor task registry into struct with `Register` and `Registered` methods
- register tasks per-instance when parsing root command
- update middleware to accept an email registry and provide provider lookups
- wire new registries into startup
- adapt DLQ log registration to accept registry
- update tests to use fresh registries

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688212e80eb8832f9184325230512021