### PR TITLE
Remove news context key

### DIFF
--- a/core/consts/contextkeys.go
+++ b/core/consts/contextkeys.go
@@ -9,6 +9,4 @@ const (
 	KeyCoreData ContextKey = "coreData"
 	// KeyBlogEntry holds a fetched blog entry row.
 	KeyBlogEntry ContextKey = "blogEntry"
-	// KeyNewsPost holds the news post row.
-	KeyNewsPost ContextKey = "newsPost"
 )

--- a/handlers/news/matchers.go
+++ b/handlers/news/matchers.go
@@ -1,7 +1,6 @@
 package news
 
 import (
-	"context"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
@@ -21,7 +20,8 @@ func RequireNewsPostAuthor(next http.Handler) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		queries := cd.Queries()
 		session, err := core.GetSession(r)
 		if err != nil {
 			http.NotFound(w, r)
@@ -41,7 +41,8 @@ func RequireNewsPostAuthor(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx := context.WithValue(r.Context(), consts.KeyNewsPost, row)
-		next.ServeHTTP(w, r.WithContext(ctx))
+		cd.CacheNewsPost(int32(postID), row)
+		cd.SetCurrentNewsPost(int32(postID))
+		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
## Summary
- drop `KeyNewsPost` context constant
- cache news posts using `CoreData`
- update matcher to store current news post in `CoreData`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68822069d358832fbea9aa1fb176e04d