### PR TITLE
refactor handlers to use runtime config from CoreData

### DIFF
--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -15,7 +15,6 @@ import (
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/tasks"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -113,7 +112,7 @@ func BlogAddPage(w http.ResponseWriter, r *http.Request) {
 
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
 		Mode:               "Add",
 	}
 

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -14,7 +14,6 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/tasks"
 
-	"github.com/arran4/goa4web/config"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
 
@@ -84,7 +83,7 @@ func BlogEditPage(w http.ResponseWriter, r *http.Request) {
 
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
 		Mode:               "Edit",
 	}
 

--- a/handlers/blogs/blogsBlogPage.go
+++ b/handlers/blogs/blogsBlogPage.go
@@ -15,7 +15,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/gorilla/mux"
@@ -57,7 +56,7 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:           cd,
 		Offset:             offset,
 		IsReplyable:        true,
-		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
 		EditUrl:            fmt.Sprintf("/blogs/blog/%d/edit", blogId),
 	}
 

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/gorilla/mux"
@@ -60,7 +59,7 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:           cd,
 		Offset:             offset,
 		IsReplyable:        true,
-		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
 		EditUrl:            fmt.Sprintf("/blogs/blog/%d/edit", blogId),
 	}
 

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
@@ -47,7 +46,7 @@ func (AskTask) Page(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage),
+		SelectedLanguageId: cd.PreferredLanguageID(cd.Config.DefaultLanguage),
 	}
 
 	languageRows, err := cd.Languages()

--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -69,13 +69,12 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	}
 	defer dbconn.Close()
 
-	origCfg := config.AppRuntimeConfig
-	config.AppRuntimeConfig.EmailEnabled = true
-	config.AppRuntimeConfig.AdminNotify = true
-	config.AppRuntimeConfig.AdminEmails = "a@test"
-	config.AppRuntimeConfig.EmailFrom = "from@example.com"
-	config.AppRuntimeConfig.NotificationsEnabled = true
-	t.Cleanup(func() { config.AppRuntimeConfig = origCfg })
+	cfg := config.AppRuntimeConfig
+	cfg.EmailEnabled = true
+	cfg.AdminNotify = true
+	cfg.AdminEmails = "a@test"
+	cfg.EmailFrom = "from@example.com"
+	cfg.NotificationsEnabled = true
 
 	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO faq (question, users_idusers, language_idlanguage) VALUES (?, ?, ?)")).
 		WithArgs(sql.NullString{String: "hi", Valid: true}, int32(1), int32(1)).
@@ -98,7 +97,7 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	bus := eventbus.NewBus()
 	q := db.New(dbconn)
 	evt := &eventbus.TaskEvent{Path: "/faq/ask", Task: tasks.TaskString(TaskAsk), UserID: 1}
-	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.AppRuntimeConfig))
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(cfg))
 	cd.UserID = 1
 	cd.SetEvent(evt)
 

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -20,7 +20,6 @@ import (
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/tasks"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 )
@@ -93,7 +92,7 @@ func (CreateThreadTask) Page(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
 	}
 
 	languageRows, err := cd.Languages()

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -15,7 +15,6 @@ import (
 	blogs "github.com/arran4/goa4web/handlers/blogs"
 	"github.com/arran4/goa4web/internal/db"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 )
 
@@ -52,7 +51,7 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:           cd,
 		Offset:             offset,
 		IsReplyable:        true,
-		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
 	}
 
 	languageRows, err := cd.Languages()

--- a/handlers/images/routes.go
+++ b/handlers/images/routes.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	imagesign "github.com/arran4/goa4web/internal/images"
 	router "github.com/arran4/goa4web/internal/router"
@@ -54,8 +55,10 @@ func serveImage(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cfg := cd.Config
 	sub1, sub2 := id[:2], id[2:4]
-	full := filepath.Join(config.AppRuntimeConfig.ImageUploadDir, sub1, sub2, id)
+	full := filepath.Join(cfg.ImageUploadDir, sub1, sub2, id)
 	http.ServeFile(w, r, full)
 }
 
@@ -65,9 +68,11 @@ func serveCache(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cfg := cd.Config
 	sub1, sub2 := id[:2], id[2:4]
 	key := path.Join(sub1, sub2, id)
-	if p := upload.CacheProviderFromConfig(config.AppRuntimeConfig); p != nil {
+	if p := upload.CacheProviderFromConfig(cfg); p != nil {
 		data, err := p.Read(r.Context(), key)
 		if err != nil {
 			http.NotFound(w, r)
@@ -76,7 +81,7 @@ func serveCache(w http.ResponseWriter, r *http.Request) {
 		http.ServeContent(w, r, id, time.Now(), bytes.NewReader(data))
 		return
 	}
-	full := filepath.Join(config.AppRuntimeConfig.ImageCacheDir, sub1, sub2, id)
+	full := filepath.Join(cfg.ImageCacheDir, sub1, sub2, id)
 	http.ServeFile(w, r, full)
 }
 

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -16,7 +16,6 @@ import (
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 )
 
@@ -32,7 +31,7 @@ func AdminAddPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
 	}
 
 	categoryRows, err := queries.GetAllLinkerCategories(r.Context())

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -16,8 +16,6 @@ import (
 	"github.com/arran4/goa4web/workers/postcountworker"
 	"github.com/arran4/goa4web/workers/searchworker"
 
-	"github.com/arran4/goa4web/config"
-
 	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 )
@@ -59,7 +57,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		CanReply:           cd.UserID != 0,
 		CanEdit:            false,
 		Offset:             offset,
-		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
 	}
 	vars := mux.Vars(r)
 	linkId := 0

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -15,8 +15,6 @@ import (
 	"github.com/arran4/goa4web/workers/postcountworker"
 	"github.com/arran4/goa4web/workers/searchworker"
 
-	"github.com/arran4/goa4web/config"
-
 	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 )
@@ -35,7 +33,7 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData:           cd,
 		CanReply:           cd.UserID != 0,
-		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
 	}
 	vars := mux.Vars(r)
 	linkId, _ := strconv.Atoi(vars["link"])

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/arran4/goa4web/internal/tasks"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 )
 
@@ -31,7 +30,7 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
 	}
 
 	uid := data.CoreData.UserID

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/a4code"
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
@@ -62,7 +61,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		IsReplying:         r.URL.Query().Has("comment"),
 		IsReplyable:        true,
-		SelectedLanguageId: cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage),
+		SelectedLanguageId: cd.PreferredLanguageID(cd.Config.DefaultLanguage),
 	}
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])

--- a/handlers/pagesize.go
+++ b/handlers/pagesize.go
@@ -13,12 +13,13 @@ func GetPageSize(r *http.Request) int {
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok && cd != nil {
 		return cd.PageSize()
 	}
-	size := config.AppRuntimeConfig.PageSizeDefault
-	if size < config.AppRuntimeConfig.PageSizeMin {
-		size = config.AppRuntimeConfig.PageSizeMin
+	cfg := config.AppRuntimeConfig
+	size := cfg.PageSizeDefault
+	if size < cfg.PageSizeMin {
+		size = cfg.PageSizeMin
 	}
-	if size > config.AppRuntimeConfig.PageSizeMax {
-		size = config.AppRuntimeConfig.PageSizeMax
+	if size > cfg.PageSizeMax {
+		size = cfg.PageSizeMax
 	}
 	return size
 }

--- a/handlers/pagesize_test.go
+++ b/handlers/pagesize_test.go
@@ -12,9 +12,6 @@ import (
 )
 
 func TestGetPageSize(t *testing.T) {
-	orig := config.AppRuntimeConfig
-	defer func() { config.AppRuntimeConfig = orig }()
-
 	tests := []struct {
 		name string
 		pref *db.Preference
@@ -28,11 +25,12 @@ func TestGetPageSize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config.AppRuntimeConfig.PageSizeMin = 5
-			config.AppRuntimeConfig.PageSizeMax = 50
-			config.AppRuntimeConfig.PageSizeDefault = 15
+			cfg := config.AppRuntimeConfig
+			cfg.PageSizeMin = 5
+			cfg.PageSizeMax = 50
+			cfg.PageSizeDefault = 15
 
-			cd := common.NewCoreData(context.Background(), nil, common.WithConfig(config.AppRuntimeConfig))
+			cd := common.NewCoreData(context.Background(), nil, common.WithConfig(cfg))
 			if tt.pref != nil {
 				common.WithPreference(tt.pref)(cd)
 			}

--- a/handlers/user/addEmailTask.go
+++ b/handlers/user/addEmailTask.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
@@ -59,11 +58,12 @@ func (AddEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("insert user email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	path := "/usr/email/verify?code=" + code
-	page := "http://" + r.Host + path
-	if config.AppRuntimeConfig.HTTPHostname != "" {
-		page = strings.TrimRight(config.AppRuntimeConfig.HTTPHostname, "/") + path
-	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cfg := cd.Config
+	page := "http://" + r.Host + path
+	if cfg.HTTPHostname != "" {
+		page = strings.TrimRight(cfg.HTTPHostname, "/") + path
+	}
 	evt := cd.Event()
 	evt.Data["page"] = page
 	evt.Data["email"] = emailAddr
@@ -99,11 +99,12 @@ func (AddEmailTask) Resend(w http.ResponseWriter, r *http.Request) any {
 		log.Printf("set verification code: %v", err)
 	}
 	path := "/usr/email/verify?code=" + code
-	page := "http://" + r.Host + path
-	if config.AppRuntimeConfig.HTTPHostname != "" {
-		page = strings.TrimRight(config.AppRuntimeConfig.HTTPHostname, "/") + path
-	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cfg := cd.Config
+	page := "http://" + r.Host + path
+	if cfg.HTTPHostname != "" {
+		page = strings.TrimRight(cfg.HTTPHostname, "/") + path
+	}
 	evt := cd.Event()
 	evt.Data["page"] = page
 	evt.Data["email"] = ue.Email

--- a/handlers/user/userGalleryPage.go
+++ b/handlers/user/userGalleryPage.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/arran4/goa4web/core/common"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
@@ -39,7 +38,7 @@ func userGalleryPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	size := config.AppRuntimeConfig.PageSizeDefault
+	size := cd.Config.PageSizeDefault
 	if pref, _ := cd.Preference(); pref != nil {
 		size = int(pref.PageSize)
 	}

--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -12,8 +12,6 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-
-	"github.com/arran4/goa4web/config"
 )
 
 func userLangPage(w http.ResponseWriter, r *http.Request) {
@@ -125,7 +123,7 @@ func updateDefaultLanguage(r *http.Request, queries *db.Queries, uid int32) erro
 		return queries.InsertPreference(r.Context(), db.InsertPreferenceParams{
 			LanguageIdlanguage: int32(langID),
 			UsersIdusers:       uid,
-			PageSize:           int32(config.AppRuntimeConfig.PageSizeDefault),
+			PageSize:           int32(cd.Config.PageSizeDefault),
 		})
 	}
 

--- a/handlers/user/userPagingPage.go
+++ b/handlers/user/userPagingPage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/internal/db"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -28,7 +27,7 @@ var _ tasks.Task = (*PagingSaveTask)(nil)
 func userPagingPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	pref, _ := cd.Preference()
-	size := config.AppRuntimeConfig.PageSizeDefault
+	size := cd.Config.PageSizeDefault
 	if pref != nil {
 		size = int(pref.PageSize)
 	}
@@ -40,8 +39,8 @@ func userPagingPage(w http.ResponseWriter, r *http.Request) {
 	}{
 		CoreData: cd,
 		Size:     size,
-		Min:      config.AppRuntimeConfig.PageSizeMin,
-		Max:      config.AppRuntimeConfig.PageSizeMax,
+		Min:      cd.Config.PageSizeMin,
+		Max:      cd.Config.PageSizeMax,
 	}
 	handlers.TemplateHandler(w, r, "pagingPage.gohtml", data)
 }
@@ -55,15 +54,15 @@ func (PagingSaveTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
-	size, _ := strconv.Atoi(r.FormValue("size"))
-	if size < config.AppRuntimeConfig.PageSizeMin {
-		size = config.AppRuntimeConfig.PageSizeMin
-	}
-	if size > config.AppRuntimeConfig.PageSizeMax {
-		size = config.AppRuntimeConfig.PageSizeMax
-	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	size, _ := strconv.Atoi(r.FormValue("size"))
+	if size < cd.Config.PageSizeMin {
+		size = cd.Config.PageSizeMin
+	}
+	if size > cd.Config.PageSizeMax {
+		size = cd.Config.PageSizeMax
+	}
+	queries := cd.Queries()
 
 	pref, err := cd.Preference()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -215,7 +215,9 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), common.WithConfig(config.AppRuntimeConfig))
+	cfg := config.AppRuntimeConfig
+	cfg.PageSizeDefault = 15
+	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), common.WithConfig(cfg))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -224,8 +226,7 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language")).WillReturnRows(rows)
 	mock.ExpectExec("INSERT INTO user_language").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectQuery("SELECT idpreferences").WithArgs(int32(1)).WillReturnError(sql.ErrNoRows)
-	config.AppRuntimeConfig.PageSizeDefault = 15
-	mock.ExpectExec("INSERT INTO preferences").WithArgs(int32(2), int32(1), int32(config.AppRuntimeConfig.PageSizeDefault)).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO preferences").WithArgs(int32(2), int32(1), int32(cfg.PageSizeDefault)).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	saveAllTask.Action(rr, req)
 

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -15,7 +15,6 @@ import (
 	"github.com/arran4/goa4web/workers/searchworker"
 	"strings"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 )
 
@@ -31,7 +30,7 @@ func ArticleEditPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
 		CoreData:           cd,
-		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
 	}
 
 	// article ID is validated by the RequireWritingAuthor middleware, so we

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -17,7 +17,6 @@ import (
 	"github.com/arran4/goa4web/workers/postcountworker"
 	"github.com/arran4/goa4web/workers/searchworker"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
 	"golang.org/x/exp/slices"
@@ -59,7 +58,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		CoreData:           cd,
 		CanReply:           cd.UserID != 0,
 		CanEdit:            false,
-		SelectedLanguageId: int(cd.PreferredLanguageID(config.AppRuntimeConfig.DefaultLanguage)),
+		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
 		IsReplyable:        true,
 	}
 


### PR DESCRIPTION
## Summary
- access runtime settings through `cd.Config` instead of the global `config.AppRuntimeConfig`
- adjust default language lookups
- update tests to pass configuration through `CoreData`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68822b5b3368832f81499b176bde39e6