### PR TITLE
Pass runtime config via rootCmd

### DIFF
--- a/cmd/goa4web/images.go
+++ b/cmd/goa4web/images.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/upload"
 )
 
@@ -54,12 +53,12 @@ func (c *imagesCmd) runCache(args []string) error {
 	if err := usageIfHelp(c.fs, args); err != nil {
 		return err
 	}
-	dir := config.AppRuntimeConfig.ImageCacheDir
+	dir := c.rootCmd.cfg.ImageCacheDir
 	switch args[0] {
 	case "prune":
-		if cp := upload.CacheProviderFromConfig(config.AppRuntimeConfig); cp != nil {
+		if cp := upload.CacheProviderFromConfig(c.rootCmd.cfg); cp != nil {
 			if ccp, ok := cp.(upload.CacheProvider); ok {
-				return ccp.Cleanup(context.Background(), int64(config.AppRuntimeConfig.ImageCacheMaxBytes))
+				return ccp.Cleanup(context.Background(), int64(c.rootCmd.cfg.ImageCacheMaxBytes))
 			}
 		}
 		return nil

--- a/cmd/goa4web/news_list.go
+++ b/cmd/goa4web/news_list.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
@@ -37,7 +36,7 @@ func (c *newsListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(c.rootCmd.cfg))
 	posts, err := cd.LatestNewsList(int32(c.Offset), int32(c.Limit))
 	if err != nil {
 		return fmt.Errorf("list news: %w", err)

--- a/cmd/goa4web/writing_list.go
+++ b/cmd/goa4web/writing_list.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
@@ -69,7 +68,7 @@ func (c *writingListCmd) Run() error {
 		}
 		return nil
 	}
-	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.AppRuntimeConfig))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(c.rootCmd.cfg))
 	rows, err := cd.LatestWritings(common.WithWritingsOffset(int32(c.Offset)), common.WithWritingsLimit(int32(c.Limit)))
 	if err != nil {
 		return fmt.Errorf("list writings: %w", err)


### PR DESCRIPTION
## Summary
- use runtime config from `rootCmd` for subcommands
- drop unused config imports

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68823150ae64832f8e1825a0244ee46e