### PR TITLE
Add session name runtime option

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -72,6 +72,8 @@ const (
 	EnvListen = "LISTEN"
 	// EnvHostname is the base URL advertised by the HTTP server.
 	EnvHostname = "HOSTNAME"
+	// EnvSessionName sets the cookie name used for session data.
+	EnvSessionName = "SESSION_NAME"
 
 	// EnvSessionSecret is the secret used to encrypt session cookies.
 	EnvSessionSecret = "SESSION_SECRET"

--- a/config/options_runtime.go
+++ b/config/options_runtime.go
@@ -62,6 +62,7 @@ var StringOptions = []StringOption{
 	{"image-cache-dir", EnvImageCacheDir, "directory for cached thumbnails when using the local provider", "", nil, "", func(c *RuntimeConfig) *string { return &c.ImageCacheDir }},
 	{"dlq-provider", EnvDLQProvider, "dead letter queue provider", "", nil, "", func(c *RuntimeConfig) *string { return &c.DLQProvider }},
 	{"dlq-file", EnvDLQFile, "dead letter queue file path", "", nil, "", func(c *RuntimeConfig) *string { return &c.DLQFile }},
+	{"session-name", EnvSessionName, "session cookie name", "my-session", nil, "", func(c *RuntimeConfig) *string { return &c.SessionName }},
 	{"admin-emails", EnvAdminEmails, "administrator email addresses", "", nil, "", func(c *RuntimeConfig) *string { return &c.AdminEmails }},
 	{"session-secret", EnvSessionSecret, "session secret key", "", nil, "", func(c *RuntimeConfig) *string { return &c.SessionSecret }},
 	{"session-secret-file", EnvSessionSecretFile, "path to session secret file", "", nil, "", func(c *RuntimeConfig) *string { return &c.SessionSecretFile }},

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -77,6 +77,9 @@ type RuntimeConfig struct {
 	DLQProvider string
 	DLQFile     string
 
+	// SessionName specifies the cookie name used for session data.
+	SessionName string
+
 	// SessionSecret holds the session secret used to encrypt cookies.
 	SessionSecret string
 	// SessionSecretFile specifies the path to the session secret file.
@@ -235,6 +238,9 @@ func normalizeRuntimeConfig(cfg *RuntimeConfig) {
 	}
 	if cfg.HTTPHostname == "" {
 		cfg.HTTPHostname = "http://localhost:8080"
+	}
+	if cfg.SessionName == "" {
+		cfg.SessionName = "my-session"
 	}
 	if cfg.PageSizeMin == 0 {
 		cfg.PageSizeMin = 5

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -34,9 +34,8 @@ import (
 var ConfigFile string
 
 var (
-	sessionName = "my-session"
-	store       *sessions.CookieStore
-	srv         *server.Server
+	store *sessions.CookieStore
+	srv   *server.Server
 
 	version = "dev"
 )
@@ -52,7 +51,7 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 	adminhandlers.StartTime = time.Now()
 	store = sessions.NewCookieStore([]byte(sessionSecret))
 	core.Store = store
-	core.SessionName = sessionName
+	core.SessionName = cfg.SessionName
 	store.Options = &sessions.Options{
 		Path:     "/",
 		HttpOnly: true,


### PR DESCRIPTION
## Summary
- add `SESSION_NAME` env var constant
- make runtime configuration store session cookie name
- set `core.SessionName` from configuration

## Testing
- `go mod tidy`
- `gofmt -w $(git ls-files '*.go')`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688231b47458832f844f8172923d671a