### PR TITLE
Standardize lazy cache operations

### DIFF
--- a/core/common/lazy.go
+++ b/core/common/lazy.go
@@ -1,6 +1,11 @@
 package common
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
+
+// TODO extract lazy system into a reusable library.
 
 // lazyValue manages on-demand loading of a value.
 type lazyValue[T any] struct {
@@ -30,4 +35,102 @@ func (l *lazyValue[T]) set(v T) {
 // peek returns the cached value and whether it has been loaded.
 func (l *lazyValue[T]) peek() (T, bool) {
 	return l.value, l.loaded
+}
+
+// lazyArgs holds the behaviour modifiers for lazy operations.
+type lazyArgs[T any] struct {
+	dontFetch    bool
+	refresh      bool
+	clear        bool
+	must         bool
+	mustCached   bool
+	setID        *int32
+	setValue     *T
+	defaultValue *T
+}
+
+// LazyOption configures lazy retrieval behaviour.
+type LazyOption[T any] func(*lazyArgs[T])
+
+// LazyDontFetch prevents data fetching when not already cached.
+func LazyDontFetch[T any]() LazyOption[T] { return func(a *lazyArgs[T]) { a.dontFetch = true } }
+
+// LazySet stores v in the cache for the referenced ID.
+func LazySet[T any](v T) LazyOption[T] { return func(a *lazyArgs[T]) { a.setValue = &v } }
+
+// LazySetID changes which ID is referenced by the operation.
+func LazySetID[T any](id int32) LazyOption[T] { return func(a *lazyArgs[T]) { a.setID = &id } }
+
+// LazyRefresh forces reloading the value by discarding the cached data.
+func LazyRefresh[T any]() LazyOption[T] { return func(a *lazyArgs[T]) { a.refresh = true } }
+
+// LazyClear removes any cached value for the referenced ID.
+func LazyClear[T any]() LazyOption[T] { return func(a *lazyArgs[T]) { a.clear = true } }
+
+// LazyMustBeCached errors if the value was not already cached.
+func LazyMustBeCached[T any]() LazyOption[T] { return func(a *lazyArgs[T]) { a.mustCached = true } }
+
+// LazyMust errors if fetching fails.
+func LazyMust[T any]() LazyOption[T] { return func(a *lazyArgs[T]) { a.must = true } }
+
+// LazyDefaultValue returns v when the lookup would otherwise yield nothing.
+func LazyDefaultValue[T any](v T) LazyOption[T] { return func(a *lazyArgs[T]) { a.defaultValue = &v } }
+
+func lazyMap[T any](m *map[int32]*lazyValue[T], id int32, fetch func(int32) (T, error), opts ...LazyOption[T]) (T, error) {
+	var zero T
+	args := &lazyArgs[T]{}
+	for _, opt := range opts {
+		opt(args)
+	}
+	if args.setID != nil {
+		id = *args.setID
+	}
+	if m == nil {
+		return zero, fmt.Errorf("lazy map pointer nil")
+	}
+	if *m == nil {
+		*m = make(map[int32]*lazyValue[T])
+	}
+	if args.clear {
+		delete(*m, id)
+		return zero, nil
+	}
+	lv, ok := (*m)[id]
+	if !ok || args.refresh {
+		lv = &lazyValue[T]{}
+		(*m)[id] = lv
+	}
+	if args.setValue != nil {
+		lv.set(*args.setValue)
+		return *args.setValue, nil
+	}
+	v, loaded := lv.peek()
+	if loaded {
+		return v, nil
+	}
+	if args.dontFetch {
+		if args.mustCached && !loaded {
+			return zero, fmt.Errorf("value not cached")
+		}
+		if args.defaultValue != nil {
+			lv.set(*args.defaultValue)
+			return *args.defaultValue, nil
+		}
+		return v, nil
+	}
+	if fetch == nil {
+		return zero, nil
+	}
+	v, err := lv.load(func() (T, error) { return fetch(id) })
+	if err != nil {
+		if args.defaultValue != nil && !args.must {
+			lv.set(*args.defaultValue)
+			return *args.defaultValue, nil
+		}
+		if args.must {
+			return v, fmt.Errorf("fetch error: %w", err)
+		}
+		return v, err
+	}
+	return v, nil
 }

--- a/handlers/blogs/matchers.go
+++ b/handlers/blogs/matchers.go
@@ -48,7 +48,7 @@ func RequireBlogAuthor(next http.Handler) http.Handler {
 		}
 		cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 		if cd != nil {
-			cd.CacheBlogEntry(int32(blogID), row)
+			cd.BlogEntryByID(int32(blogID), common.LazySet[*db.GetBlogEntryForUserByIdRow](row))
 			cd.SetCurrentBlog(int32(blogID))
 		}
 		if cd != nil && cd.HasRole("administrator") {

--- a/handlers/forum/comments/matchers.go
+++ b/handlers/forum/comments/matchers.go
@@ -1,28 +1,28 @@
 package comments
 
 import (
-	"database/sql"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
-	"strconv"
-
-	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/internal/db"
 )
 
 // RequireCommentAuthor ensures the requester authored the comment referenced in the URL.
 func RequireCommentAuthor(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		commentID, err := strconv.Atoi(mux.Vars(r)["comment"])
+		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		row, err := cd.CurrentComment(r)
 		if err != nil {
+			log.Printf("Error: %s", err)
 			http.NotFound(w, r)
 			return
 		}
-		queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+		if row == nil {
+			http.NotFound(w, r)
+			return
+		}
 		session, err := core.GetSession(r)
 		if err != nil {
 			http.NotFound(w, r)
@@ -30,25 +30,9 @@ func RequireCommentAuthor(next http.Handler) http.Handler {
 		}
 		uid, _ := session.Values["UID"].(int32)
 
-		row, err := queries.GetCommentByIdForUser(r.Context(), db.GetCommentByIdForUserParams{
-			ViewerID: uid,
-			ID:       int32(commentID),
-			UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
-		})
-		if err != nil {
-			log.Printf("Error: %s", err)
-			http.NotFound(w, r)
-			return
-		}
-
-		cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 		if row.UsersIdusers != uid && (cd == nil || !cd.HasRole("administrator")) {
 			http.NotFound(w, r)
 			return
-		}
-		if cd != nil {
-			cd.CacheComment(row.Idcomments, row)
-			cd.SetCurrentComment(row.Idcomments)
 		}
 		next.ServeHTTP(w, r)
 	})

--- a/handlers/news/matchers.go
+++ b/handlers/news/matchers.go
@@ -3,6 +3,7 @@ package news
 import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
 	"log"
 	"net/http"
 	"strconv"
@@ -41,7 +42,7 @@ func RequireNewsPostAuthor(next http.Handler) http.Handler {
 			return
 		}
 
-		cd.CacheNewsPost(int32(postID), row)
+		cd.NewsPostByID(int32(postID), common.LazySet[*db.GetForumThreadIdByNewsPostIdRow](row))
 		cd.SetCurrentNewsPost(int32(postID))
 		next.ServeHTTP(w, r)
 	})

--- a/handlers/writings/matchers.go
+++ b/handlers/writings/matchers.go
@@ -50,7 +50,7 @@ func RequireWritingAuthor(next http.Handler) http.Handler {
 
 		cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 		if cd != nil {
-			cd.CacheWriting(int32(writingID), row)
+			cd.WritingByID(int32(writingID), common.LazySet[*db.GetWritingByIdForUserDescendingByPublishedDateRow](row))
 			cd.SetCurrentWriting(int32(writingID))
 		}
 		if cd != nil && cd.HasAdminRole() {


### PR DESCRIPTION
## Summary
- introduce default value option and add TODO to extract lazy package
- auto-load comment IDs from request in `CurrentComment`
- drop `SetCurrentComment` usage in comment matcher

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68822f1be0fc832fa3b0ca4dadc02db6