### PR TITLE
Propagate runtime config to helpers

### DIFF
--- a/cmd/goa4web/config_test_cmd.go
+++ b/cmd/goa4web/config_test_cmd.go
@@ -101,7 +101,7 @@ func (c *configTestEmailCmd) Run() error {
 		q = dbpkg.New(db)
 	}
 	ctx := context.Background()
-	emails := config.GetAdminEmails(ctx, q)
+	emails := config.GetAdminEmails(ctx, q, c.rootCmd.cfg)
 	if len(emails) == 0 {
 		return fmt.Errorf("no administrator emails configured")
 	}

--- a/cmd/goa4web/email_queue_resend.go
+++ b/cmd/goa4web/email_queue_resend.go
@@ -43,7 +43,7 @@ func (c *emailQueueResendCmd) Run() error {
 	}
 	provider := c.rootCmd.emailReg.ProviderFromConfig(c.rootCmd.cfg)
 	if provider != nil {
-		addr, err := emailqueue.ResolveQueuedEmailAddress(ctx, queries, &dbpkg.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
+		addr, err := emailqueue.ResolveQueuedEmailAddress(ctx, queries, &dbpkg.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail}, c.rootCmd.cfg)
 		if err != nil {
 			return err
 		}

--- a/config/email.go
+++ b/config/email.go
@@ -19,8 +19,8 @@ import (
 // empty and a Queries value is supplied, the database is queried for
 // administrator accounts. GetAdminEmails returns a slice of administrator
 // addresses using this logic.
-func GetAdminEmails(ctx context.Context, q *db.Queries) []string {
-	env := AppRuntimeConfig.AdminEmails
+func GetAdminEmails(ctx context.Context, q *db.Queries, cfg RuntimeConfig) []string {
+	env := cfg.AdminEmails
 	if env == "" {
 		env = os.Getenv(EnvAdminEmails)
 	}
@@ -46,16 +46,4 @@ func GetAdminEmails(ctx context.Context, q *db.Queries) []string {
 		}
 	}
 	return emails
-}
-
-// AdminNotificationsEnabled reports whether administrator notification emails
-// should be sent based on the runtime configuration.
-func AdminNotificationsEnabled() bool {
-	return AppRuntimeConfig.AdminNotify
-}
-
-// EmailSendingEnabled reports if queued emails should be dispatched according
-// to the runtime configuration.
-func EmailSendingEnabled() bool {
-	return AppRuntimeConfig.EmailEnabled
 }

--- a/handlers/admin/resend_queue_task.go
+++ b/handlers/admin/resend_queue_task.go
@@ -59,7 +59,7 @@ func (ResendQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	for _, e := range emails {
-		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
+		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail}, config.AppRuntimeConfig)
 		if err != nil {
 			return fmt.Errorf("resolve address fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/user/userGalleryPage.go
+++ b/handlers/user/userGalleryPage.go
@@ -71,8 +71,8 @@ func userGalleryPage(w http.ResponseWriter, r *http.Request) {
 		id := strings.TrimSuffix(fname, ext)
 		thumb := id + "_thumb" + ext
 		imgs = append(imgs, galleryImage{
-			Thumb:  imagesign.SignedCacheURL(thumb),
-			Full:   imagesign.SignedURL("image:" + fname),
+			Thumb:  imagesign.SignedCacheURL(thumb, cd.Config),
+			Full:   imagesign.SignedURL("image:"+fname, cd.Config),
 			A4Code: "[img=image:" + fname + "]",
 		})
 	}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -115,7 +115,7 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 	adminhandlers.UpdateConfigKeyFunc = config.UpdateConfigKey
 
 	emailProvider := emailReg.ProviderFromConfig(cfg)
-	if config.EmailSendingEnabled() && cfg.EmailProvider != "" && cfg.EmailFrom == "" {
+	if cfg.EmailEnabled && cfg.EmailProvider != "" && cfg.EmailFrom == "" {
 		log.Printf("%s not set while EMAIL_PROVIDER=%s", config.EnvEmailFrom, cfg.EmailProvider)
 	}
 

--- a/internal/dlq/email/email.go
+++ b/internal/dlq/email/email.go
@@ -17,6 +17,7 @@ type DLQ struct {
 	Provider email.Provider
 	Queries  *dbpkg.Queries
 	From     mail.Address
+	Config   config.RuntimeConfig
 }
 
 // Record emails the message to the configured recipients.
@@ -28,7 +29,7 @@ func (e DLQ) Record(ctx context.Context, message string) error {
 	if fromAddr.Address == "" {
 		fromAddr = email.ParseAddress("")
 	}
-	for _, addrStr := range config.GetAdminEmails(ctx, e.Queries) {
+	for _, addrStr := range config.GetAdminEmails(ctx, e.Queries, e.Config) {
 		toAddr := mail.Address{Address: addrStr}
 		msg, err := email.BuildMessage(fromAddr, toAddr, "DLQ message", message, "")
 		if err != nil {
@@ -53,6 +54,6 @@ func Register(r *dlq.Registry) {
 		if f, err := mail.ParseAddress(cfg.EmailFrom); err == nil {
 			from = *f
 		}
-		return DLQ{Provider: p, Queries: q, From: from}
+		return DLQ{Provider: p, Queries: q, From: from, Config: cfg}
 	})
 }

--- a/internal/email/emaildefaults/email_test.go
+++ b/internal/email/emaildefaults/email_test.go
@@ -116,7 +116,7 @@ func TestEmailQueueWorker(t *testing.T) {
 	mock.ExpectExec("UPDATE pending_emails SET sent_at").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	rec := &mockemail.Provider{}
-	if !emailqueue.ProcessPendingEmail(context.Background(), q, rec, nil) {
+	if !emailqueue.ProcessPendingEmail(context.Background(), q, rec, nil, config.AppRuntimeConfig) {
 		t.Fatal("no email processed")
 	}
 
@@ -156,7 +156,7 @@ func TestProcessPendingEmailDLQ(t *testing.T) {
 
 	p := errProvider{}
 	dlqRec := &mockdlq.Provider{}
-	if !emailqueue.ProcessPendingEmail(context.Background(), q, p, dlqRec) {
+	if !emailqueue.ProcessPendingEmail(context.Background(), q, p, dlqRec, config.AppRuntimeConfig) {
 		t.Fatal("no email processed")
 	}
 

--- a/internal/images/sign.go
+++ b/internal/images/sign.go
@@ -26,16 +26,16 @@ func sign(data string) (int64, string) {
 }
 
 // SignedURL maps an image identifier to a signed URL.
-func SignedURL(id string) string {
+func SignedURL(id string, cfg config.RuntimeConfig) string {
 	id = strings.TrimPrefix(strings.TrimPrefix(id, "image:"), "img:")
-	host := strings.TrimSuffix(config.AppRuntimeConfig.HTTPHostname, "/")
+	host := strings.TrimSuffix(cfg.HTTPHostname, "/")
 	ts, sig := sign("image:" + id)
 	return fmt.Sprintf("%s/images/image/%s?ts=%d&sig=%s", host, id, ts, sig)
 }
 
 // SignedCacheURL maps a cache identifier to a signed URL.
-func SignedCacheURL(id string) string {
-	host := strings.TrimSuffix(config.AppRuntimeConfig.HTTPHostname, "/")
+func SignedCacheURL(id string, cfg config.RuntimeConfig) string {
+	host := strings.TrimSuffix(cfg.HTTPHostname, "/")
 	ts, sig := sign("cache:" + id)
 	return fmt.Sprintf("%s/images/cache/%s?ts=%d&sig=%s", host, id, ts, sig)
 }
@@ -81,9 +81,9 @@ func MapURL(tag, val string) string {
 	case strings.HasPrefix(val, "uploading:"):
 		return val
 	case strings.HasPrefix(val, "image:") || strings.HasPrefix(val, "img:"):
-		return SignedURL(val)
+		return SignedURL(val, config.AppRuntimeConfig)
 	case strings.HasPrefix(val, "cache:"):
-		return SignedCacheURL(strings.TrimPrefix(val, "cache:"))
+		return SignedCacheURL(strings.TrimPrefix(val, "cache:"), config.AppRuntimeConfig)
 	default:
 		return val
 	}

--- a/internal/notifications/dlq.go
+++ b/internal/notifications/dlq.go
@@ -8,14 +8,14 @@ import (
 	"log"
 )
 
-func dlqRecordAndNotify(ctx context.Context, q dlq.DLQ, n *Notifier, msg string) error {
+func (n *Notifier) dlqRecordAndNotify(ctx context.Context, q dlq.DLQ, msg string) error {
 	if q == nil {
 		return fmt.Errorf("no dlq provider")
 	}
 	if err := q.Record(ctx, msg); err != nil {
 		return err
 	}
-	if n.Queries == nil || !n.cfg.AdminNotify {
+	if n.Queries == nil || !n.Config.AdminNotify {
 		return nil
 	}
 	if dbq, ok := q.(db.DLQ); ok {

--- a/internal/notifications/email.go
+++ b/internal/notifications/email.go
@@ -58,20 +58,20 @@ func (n *Notifier) RenderEmailFromTemplates(ctx context.Context, emailAddr strin
 	if emailAddr == "" {
 		return nil, fmt.Errorf("no email specified")
 	}
-	from := email.ParseAddress(n.cfg.EmailFrom)
+	from := email.ParseAddress(n.Config.EmailFrom)
 	to := email.ParseAddress(emailAddr)
 
-	subjectPrefix := n.cfg.EmailSubjectPrefix
+	subjectPrefix := n.Config.EmailSubjectPrefix
 	if subjectPrefix == "" {
 		subjectPrefix = "goa4web"
 	}
 
 	unsub := "/usr/subscriptions"
-	if n.cfg.HTTPHostname != "" {
-		unsub = strings.TrimRight(n.cfg.HTTPHostname, "/") + unsub
+	if n.Config.HTTPHostname != "" {
+		unsub = strings.TrimRight(n.Config.HTTPHostname, "/") + unsub
 	}
 
-	signOff := n.cfg.EmailSignOff
+	signOff := n.Config.EmailSignOff
 	htmlSignOff := html.EscapeString(signOff)
 	htmlSignOff = strings.ReplaceAll(htmlSignOff, "\n", "<br />")
 

--- a/workers/emailqueue/email_queue.go
+++ b/workers/emailqueue/email_queue.go
@@ -18,7 +18,7 @@ import (
 // EmailQueueWorker sends pending emails ensuring a minimum delay between sends.
 // When a bus is provided the worker wakes up immediately when a new message is
 // queued by listening for EmailQueueEvent messages.
-func EmailQueueWorker(ctx context.Context, q *db.Queries, provider email.Provider, dlqProvider dlq.DLQ, bus *eventbus.Bus, delay time.Duration) {
+func EmailQueueWorker(ctx context.Context, q *db.Queries, provider email.Provider, dlqProvider dlq.DLQ, bus *eventbus.Bus, delay time.Duration, cfg config.RuntimeConfig) {
 	if q == nil || provider == nil {
 		log.Printf("email queue worker disabled: missing queue or provider")
 		return
@@ -28,7 +28,7 @@ func EmailQueueWorker(ctx context.Context, q *db.Queries, provider email.Provide
 		ch = bus.Subscribe(eventbus.EmailQueueMessageType)
 	}
 	for {
-		if ProcessPendingEmail(ctx, q, provider, dlqProvider) {
+		if ProcessPendingEmail(ctx, q, provider, dlqProvider, cfg) {
 			log.Printf("email queue worker: waiting %s", delay)
 		}
 		if ch == nil {
@@ -50,7 +50,7 @@ func EmailQueueWorker(ctx context.Context, q *db.Queries, provider email.Provide
 
 // adminBypassAddr extracts the recipient address from the email body and
 // returns it when it matches one of the configured administrator emails.
-func adminBypassAddr(ctx context.Context, q *db.Queries, body string) (mail.Address, bool) {
+func adminBypassAddr(ctx context.Context, q *db.Queries, body string, cfg config.RuntimeConfig) (mail.Address, bool) {
 	m, err := mail.ReadMessage(strings.NewReader(body))
 	if err != nil {
 		return mail.Address{}, false
@@ -59,7 +59,7 @@ func adminBypassAddr(ctx context.Context, q *db.Queries, body string) (mail.Addr
 	if err != nil {
 		return mail.Address{}, false
 	}
-	for _, a := range config.GetAdminEmails(ctx, q) {
+	for _, a := range config.GetAdminEmails(ctx, q, cfg) {
 		if strings.EqualFold(a, addr.Address) {
 			return *addr, true
 		}
@@ -67,8 +67,8 @@ func adminBypassAddr(ctx context.Context, q *db.Queries, body string) (mail.Addr
 	return mail.Address{}, false
 }
 
-func isAdminEmail(ctx context.Context, q *db.Queries, addr string) bool {
-	for _, a := range config.GetAdminEmails(ctx, q) {
+func isAdminEmail(ctx context.Context, q *db.Queries, addr string, cfg config.RuntimeConfig) bool {
+	for _, a := range config.GetAdminEmails(ctx, q, cfg) {
 		if strings.EqualFold(a, addr) {
 			return true
 		}
@@ -96,7 +96,7 @@ func hasVerificationRecord(ctx context.Context, q *db.Queries, addr string) bool
 // ResolveQueuedEmailAddress resolves the recipient for a queued email.
 // When the user record is missing or lacks a valid address the admin or direct
 // email logic is applied.
-func ResolveQueuedEmailAddress(ctx context.Context, q *db.Queries, e *db.FetchPendingEmailsRow) (mail.Address, error) {
+func ResolveQueuedEmailAddress(ctx context.Context, q *db.Queries, e *db.FetchPendingEmailsRow, cfg config.RuntimeConfig) (mail.Address, error) {
 	if e.ToUserID.Valid && e.ToUserID.Int32 != 0 {
 		user, err := q.GetUserById(ctx, e.ToUserID.Int32)
 		if err == nil && user.Email.Valid && user.Email.String != "" {
@@ -116,7 +116,7 @@ func ResolveQueuedEmailAddress(ctx context.Context, q *db.Queries, e *db.FetchPe
 		return mail.Address{}, fmt.Errorf("parse address: %v", err)
 	}
 
-	if isAdminEmail(ctx, q, addr.Address) {
+	if isAdminEmail(ctx, q, addr.Address, cfg) {
 		addr.Name = "Admin"
 		return *addr, nil
 	}
@@ -135,11 +135,11 @@ func ResolveQueuedEmailAddress(ctx context.Context, q *db.Queries, e *db.FetchPe
 }
 
 // ProcessPendingEmail sends a single queued email if available.
-func ProcessPendingEmail(ctx context.Context, q *db.Queries, provider email.Provider, dlqProvider dlq.DLQ) bool {
+func ProcessPendingEmail(ctx context.Context, q *db.Queries, provider email.Provider, dlqProvider dlq.DLQ, cfg config.RuntimeConfig) bool {
 	if q == nil || provider == nil {
 		return false
 	}
-	if !config.EmailSendingEnabled() {
+	if !cfg.EmailEnabled {
 		return false
 	}
 	if provider == nil {
@@ -155,7 +155,7 @@ func ProcessPendingEmail(ctx context.Context, q *db.Queries, provider email.Prov
 		return false
 	}
 	e := emails[0]
-	addr, err := ResolveQueuedEmailAddress(ctx, q, e)
+	addr, err := ResolveQueuedEmailAddress(ctx, q, e, cfg)
 	if err != nil {
 		log.Printf("ResolveQueuedEmailAddress: %v", err)
 		if err := q.IncrementEmailError(ctx, e.ID); err != nil {

--- a/workers/workers.go
+++ b/workers/workers.go
@@ -38,7 +38,7 @@ func safeGo(fn func()) {
 func Start(ctx context.Context, db *sql.DB, provider email.Provider, dlqProvider dlq.DLQ, cfg config.RuntimeConfig, bus *eventbus.Bus) {
 	log.Printf("Starting email worker")
 	safeGo(func() {
-		emailqueue.EmailQueueWorker(ctx, dbpkg.New(db), provider, dlqProvider, bus, time.Duration(cfg.EmailWorkerInterval)*time.Second)
+		emailqueue.EmailQueueWorker(ctx, dbpkg.New(db), provider, dlqProvider, bus, time.Duration(cfg.EmailWorkerInterval)*time.Second, cfg)
 	})
 	log.Printf("Starting notification purger worker")
 	safeGo(func() {


### PR DESCRIPTION
## Summary
- reintroduce runtime config parameters in image signing helpers
- read admin emails from config and remove global checks
- pass runtime config through Notifier and DLQ implementations
- update workers and handlers to supply configuration
- update tests for new function signatures

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6882cefc3598832fae0ea18be676a07e