### PR TITLE
Pass runtime config through feeds and helpers

### DIFF
--- a/handlers/admin/resend_queue_task.go
+++ b/handlers/admin/resend_queue_task.go
@@ -9,7 +9,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/tasks"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
@@ -27,7 +26,8 @@ var _ tasks.AuditableTask = (*ResendQueueTask)(nil)
 
 func (ResendQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	provider := email.ProviderFromConfig(config.AppRuntimeConfig)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	provider := email.ProviderFromConfig(cd.Config)
 	if err := r.ParseForm(); err != nil {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
@@ -59,7 +59,7 @@ func (ResendQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	for _, e := range emails {
-		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, config.AppRuntimeConfig, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
+		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, cd.Config, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
 		if err != nil {
 			return fmt.Errorf("resolve address fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -238,10 +238,11 @@ func FeedGen(r *http.Request, queries *db.Queries, uid int, username string) (*f
 		}
 	}
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	for _, row := range rows {
 		u := r.URL
 		u.Query().Set("show", fmt.Sprintf("%d", row.Idblogs))
-		conv := a4code2html.New(imagesign.MapURL)
+		conv := a4code2html.New(imagesign.Mapper(cd.Config))
 		conv.CodeType = a4code2html.CTTagStrip
 		conv.SetInput(row.Blog.String)
 		out, _ := io.ReadAll(conv.Process())

--- a/handlers/forum/forumFeed.go
+++ b/handlers/forum/forumFeed.go
@@ -32,7 +32,8 @@ func TopicFeed(r *http.Request, title string, topicID int, rows []*db.GetForumTh
 			continue
 		}
 		text := row.Firstposttext.String
-		conv := a4code2html.New(imagesign.MapURL)
+		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		conv := a4code2html.New(imagesign.Mapper(cd.Config))
 		conv.CodeType = a4code2html.CTTagStrip
 		conv.SetInput(text)
 		out, _ := io.ReadAll(conv.Process())

--- a/handlers/forum/forumFeed_test.go
+++ b/handlers/forum/forumFeed_test.go
@@ -1,11 +1,15 @@
 package forum
 
 import (
+	"context"
 	"database/sql"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/db"
 )
 
@@ -19,6 +23,8 @@ func TestForumTopicFeed(t *testing.T) {
 		},
 	}
 	r := httptest.NewRequest("GET", "http://example.com/forum/topic/1.rss", nil)
+	ctx := context.WithValue(r.Context(), consts.KeyCoreData, &common.CoreData{Config: config.RuntimeConfig{}})
+	r = r.WithContext(ctx)
 	feed := TopicFeed(r, "Test", 1, rows)
 	if len(feed.Items) != 1 {
 		t.Fatalf("expected 1 item got %d", len(feed.Items))

--- a/handlers/imagebbs/imagebbsFeed.go
+++ b/handlers/imagebbs/imagebbsFeed.go
@@ -38,7 +38,8 @@ func imagebbsFeed(r *http.Request, title string, boardID int, rows []*db.GetAllI
 			continue
 		}
 		desc := row.Description.String
-		conv := a4code2html.New(imagesign.MapURL)
+		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		conv := a4code2html.New(imagesign.Mapper(cd.Config))
 		conv.CodeType = a4code2html.CTTagStrip
 		conv.SetInput(desc)
 		out, _ := io.ReadAll(conv.Process())

--- a/handlers/imagebbs/imagebbsFeed_test.go
+++ b/handlers/imagebbs/imagebbsFeed_test.go
@@ -1,11 +1,16 @@
 package imagebbs
 
 import (
+	"context"
 	"database/sql"
-	"github.com/arran4/goa4web/internal/db"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
 )
 
 func TestImagebbsFeed(t *testing.T) {
@@ -19,6 +24,8 @@ func TestImagebbsFeed(t *testing.T) {
 		},
 	}
 	r := httptest.NewRequest("GET", "http://example.com/imagebbs/board/1.rss", nil)
+	ctx := context.WithValue(r.Context(), consts.KeyCoreData, &common.CoreData{Config: config.RuntimeConfig{}})
+	r = r.WithContext(ctx)
 	feed := imagebbsFeed(r, "Test", 1, rows)
 	if len(feed.Items) != 1 {
 		t.Fatalf("expected 1 item got %d", len(feed.Items))

--- a/handlers/linker/linkerFeed.go
+++ b/handlers/linker/linkerFeed.go
@@ -30,7 +30,8 @@ func linkerFeed(r *http.Request, rows []*db.GetAllLinkerItemsByCategoryIdWitherP
 		}
 		desc := ""
 		if row.Description.Valid {
-			conv := a4code2html.New(imagesign.MapURL)
+			cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+			conv := a4code2html.New(imagesign.Mapper(cd.Config))
 			conv.CodeType = a4code2html.CTTagStrip
 			conv.SetInput(row.Description.String)
 			out, _ := io.ReadAll(conv.Process())

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -28,6 +28,8 @@ func TestLinkerFeed(t *testing.T) {
 		},
 	}
 	r := httptest.NewRequest("GET", "http://example.com/linker/rss", nil)
+	ctx := context.WithValue(r.Context(), consts.KeyCoreData, &common.CoreData{Config: config.RuntimeConfig{}})
+	r = r.WithContext(ctx)
 	feed := linkerFeed(r, rows)
 	if len(feed.Items) != 1 {
 		t.Fatalf("expected 1 item got %d", len(feed.Items))

--- a/handlers/news/newsRssPage.go
+++ b/handlers/news/newsRssPage.go
@@ -37,7 +37,7 @@ func NewsRssPage(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		text := row.News.String
-		conv := a4code2html.New(imagesign.MapURL)
+		conv := a4code2html.New(imagesign.Mapper(cd.Config))
 		conv.CodeType = a4code2html.CTTagStrip
 		conv.SetInput(text)
 		out, _ := io.ReadAll(conv.Process())

--- a/handlers/writings/writingsFeed.go
+++ b/handlers/writings/writingsFeed.go
@@ -34,7 +34,7 @@ func feedGen(r *http.Request, cd *common.CoreData) (*feeds.Feed, error) {
 		if desc == "" {
 			desc = row.Writing.String
 		}
-		conv := a4code2html.New(imagesign.MapURL)
+		conv := a4code2html.New(imagesign.Mapper(cd.Config))
 		conv.CodeType = a4code2html.CTTagStrip
 		conv.SetInput(desc)
 		out, _ := io.ReadAll(conv.Process())

--- a/internal/dlq/email/email.go
+++ b/internal/dlq/email/email.go
@@ -20,6 +20,21 @@ type DLQ struct {
 	Config   config.RuntimeConfig
 }
 
+// Option configures a DLQ instance.
+type Option func(*DLQ)
+
+// WithConfig sets the runtime configuration.
+func WithConfig(cfg config.RuntimeConfig) Option { return func(d *DLQ) { d.Config = cfg } }
+
+// New constructs a DLQ with the provided options.
+func New(opts ...Option) DLQ {
+	d := DLQ{}
+	for _, o := range opts {
+		o(&d)
+	}
+	return d
+}
+
 // Record emails the message to the configured recipients.
 func (e DLQ) Record(ctx context.Context, message string) error {
 	if e.Provider == nil {

--- a/internal/email/emaildefaults/email_test.go
+++ b/internal/email/emaildefaults/email_test.go
@@ -98,9 +98,7 @@ func TestInsertPendingEmail(t *testing.T) {
 }
 
 func TestEmailQueueWorker(t *testing.T) {
-	origCfg := config.AppRuntimeConfig
-	config.AppRuntimeConfig.EmailEnabled = true
-	t.Cleanup(func() { config.AppRuntimeConfig = origCfg })
+	cfg := config.RuntimeConfig{EmailEnabled: true}
 
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -116,7 +114,7 @@ func TestEmailQueueWorker(t *testing.T) {
 	mock.ExpectExec("UPDATE pending_emails SET sent_at").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	rec := &mockemail.Provider{}
-	if !emailqueue.ProcessPendingEmail(context.Background(), q, rec, nil, config.AppRuntimeConfig) {
+	if !emailqueue.ProcessPendingEmail(context.Background(), q, rec, nil, cfg) {
 		t.Fatal("no email processed")
 	}
 
@@ -135,9 +133,7 @@ func (errProvider) Send(context.Context, mail.Address, []byte) error {
 }
 
 func TestProcessPendingEmailDLQ(t *testing.T) {
-	origCfg := config.AppRuntimeConfig
-	config.AppRuntimeConfig.EmailEnabled = true
-	t.Cleanup(func() { config.AppRuntimeConfig = origCfg })
+	cfg := config.RuntimeConfig{EmailEnabled: true}
 
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -156,7 +152,7 @@ func TestProcessPendingEmailDLQ(t *testing.T) {
 
 	p := errProvider{}
 	dlqRec := &mockdlq.Provider{}
-	if !emailqueue.ProcessPendingEmail(context.Background(), q, p, dlqRec, config.AppRuntimeConfig) {
+	if !emailqueue.ProcessPendingEmail(context.Background(), q, p, dlqRec, cfg) {
 		t.Fatal("no email processed")
 	}
 

--- a/internal/images/sign.go
+++ b/internal/images/sign.go
@@ -73,7 +73,7 @@ func SignedRef(ref string) string {
 }
 
 // MapURL converts image references to signed HTTP URLs.
-func MapURL(tag, val string) string {
+func MapURL(tag, val string, cfg config.RuntimeConfig) string {
 	if tag != "img" {
 		return val
 	}
@@ -81,10 +81,15 @@ func MapURL(tag, val string) string {
 	case strings.HasPrefix(val, "uploading:"):
 		return val
 	case strings.HasPrefix(val, "image:") || strings.HasPrefix(val, "img:"):
-		return SignedURL(val, config.AppRuntimeConfig)
+		return SignedURL(val, cfg)
 	case strings.HasPrefix(val, "cache:"):
-		return SignedCacheURL(strings.TrimPrefix(val, "cache:"), config.AppRuntimeConfig)
+		return SignedCacheURL(strings.TrimPrefix(val, "cache:"), cfg)
 	default:
 		return val
 	}
+}
+
+// Mapper returns an image URL mapper closure using cfg.
+func Mapper(cfg config.RuntimeConfig) func(string, string) string {
+	return func(tag, val string) string { return MapURL(tag, val, cfg) }
 }

--- a/internal/images/sign_test.go
+++ b/internal/images/sign_test.go
@@ -1,10 +1,14 @@
 package images
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+)
 
 func TestMapURLUploading(t *testing.T) {
 	SetSigningKey("k")
-	got := MapURL("img", "uploading:abc")
+	got := MapURL("img", "uploading:abc", config.RuntimeConfig{})
 	if got != "uploading:abc" {
 		t.Fatalf("expected placeholder unchanged, got %s", got)
 	}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -91,7 +91,7 @@ func CoreAdderMiddlewareWithDB(db *sql.DB, cfg config.RuntimeConfig, verbosity i
 			}
 			provider := emailReg.ProviderFromConfig(cfg)
 			cd := common.NewCoreData(r.Context(), queries,
-				common.WithImageURLMapper(imagesign.MapURL),
+				common.WithImageURLMapper(imagesign.Mapper(cfg)),
 				common.WithSession(session),
 				common.WithEmailProvider(provider),
 				common.WithAbsoluteURLBase(base),


### PR DESCRIPTION
## Summary
- add Mapper helper to images for signed URLs
- wire runtime config into middleware and feed handlers
- update DLQ email provider with config option
- update tests to construct runtime configs

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6883086c61a8832fb665f1abcad1a5de