### PR TITLE
Track server start time in app state

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -70,6 +71,7 @@ type CoreData struct {
 	AdminMode         bool
 	NotificationCount int32
 	Config            config.RuntimeConfig
+	StartTime         time.Time // time the application started
 	a4codeMapper      func(tag, val string) string
 
 	session        *sessions.Session
@@ -177,6 +179,11 @@ func WithPreference(p *db.Preference) CoreOption {
 // WithConfig sets the runtime config for this CoreData.
 func WithConfig(cfg config.RuntimeConfig) CoreOption {
 	return func(cd *CoreData) { cd.Config = cfg }
+}
+
+// WithStartTime sets the server start time.
+func WithStartTime(t time.Time) CoreOption {
+	return func(cd *CoreData) { cd.StartTime = t }
 }
 
 // NewCoreData creates a CoreData with context and queries applied.

--- a/handlers/admin/adminServerStatsPage.go
+++ b/handlers/admin/adminServerStatsPage.go
@@ -44,8 +44,9 @@ func AdminServerStatsPage(w http.ResponseWriter, r *http.Request) {
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Stats: Stats{
 			Goroutines: runtime.NumGoroutine(),
 			Alloc:      mem.Alloc,
@@ -55,7 +56,7 @@ func AdminServerStatsPage(w http.ResponseWriter, r *http.Request) {
 			HeapSys:    mem.HeapSys,
 			NumGC:      mem.NumGC,
 		},
-		Uptime: time.Since(StartTime),
+		Uptime: time.Since(cd.StartTime),
 		Config: config.AppRuntimeConfig,
 	}
 

--- a/handlers/admin/vars.go
+++ b/handlers/admin/vars.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"database/sql"
-	"time"
 
 	"github.com/arran4/goa4web/internal/app/server"
 
@@ -24,6 +23,3 @@ var AdminAPISecret string
 // UpdateConfigKeyFunc is used to persist configuration changes. It should be
 // set by the main application on startup.
 var UpdateConfigKeyFunc func(fs core.FileSystem, path, key, value string) error
-
-// StartTime marks when the server began running.
-var StartTime time.Time

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -49,7 +49,7 @@ func init() {
 // session secret. The context controls the lifetime of the HTTP server.
 func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret, imageSignSecret string, dbReg *dbdrivers.Registry, emailReg *email.Registry, dlqReg *dlq.Registry, apiSecret string) error {
 	log.Printf("application version %s starting", version)
-	adminhandlers.StartTime = time.Now()
+	startTime := time.Now()
 	store = sessions.NewCookieStore([]byte(sessionSecret))
 	core.Store = store
 	core.SessionName = cfg.SessionName
@@ -99,7 +99,7 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 	taskEventMW := middleware.NewTaskEventMiddleware(bus)
 	handler := middleware.NewMiddlewareChain(
 		middleware.RecoverMiddleware,
-		middleware.CoreAdderMiddlewareWithDB(dbPool, cfg, cfg.DBLogVerbosity, emailReg),
+		middleware.CoreAdderMiddlewareWithDB(dbPool, cfg, cfg.DBLogVerbosity, emailReg, startTime),
 		middleware.RequestLoggerMiddleware,
 		taskEventMW.Middleware,
 		middleware.SecurityHeadersMiddleware,

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -31,7 +31,7 @@ func handleDie(w http.ResponseWriter, message string) {
 // CoreAdderMiddlewareWithDB populates request context with CoreData for
 // templates using the supplied database handle. The verbosity controls optional
 // logging of database pool statistics.
-func CoreAdderMiddlewareWithDB(db *sql.DB, cfg config.RuntimeConfig, verbosity int, emailReg *email.Registry) func(http.Handler) http.Handler {
+func CoreAdderMiddlewareWithDB(db *sql.DB, cfg config.RuntimeConfig, verbosity int, emailReg *email.Registry, startTime time.Time) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			session, err := core.GetSession(r)
@@ -97,6 +97,7 @@ func CoreAdderMiddlewareWithDB(db *sql.DB, cfg config.RuntimeConfig, verbosity i
 				common.WithEmailProvider(provider),
 				common.WithAbsoluteURLBase(base),
 				common.WithConfig(cfg),
+				common.WithStartTime(startTime),
 				common.WithSessionManager(sm))
 			cd.UserID = uid
 			_ = cd.UserRoles()

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/arran4/goa4web/internal/email"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/sessions"
+	"time"
 )
 
 func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
@@ -47,7 +48,7 @@ func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
 	})
 
 	reg := email.NewRegistry()
-	CoreAdderMiddlewareWithDB(db, config.AppRuntimeConfig, 0, reg)(handler).ServeHTTP(httptest.NewRecorder(), req)
+	CoreAdderMiddlewareWithDB(db, config.AppRuntimeConfig, 0, reg, time.Now())(handler).ServeHTTP(httptest.NewRecorder(), req)
 
 	want := []string{"anonymous", "user", "moderator"}
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {
@@ -85,7 +86,7 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 	})
 
 	reg := email.NewRegistry()
-	CoreAdderMiddlewareWithDB(db, config.AppRuntimeConfig, 0, reg)(handler).ServeHTTP(httptest.NewRecorder(), req)
+	CoreAdderMiddlewareWithDB(db, config.AppRuntimeConfig, 0, reg, time.Now())(handler).ServeHTTP(httptest.NewRecorder(), req)
 
 	want := []string{"anonymous"}
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {


### PR DESCRIPTION
## Summary
- add StartTime field to CoreData with helper option
- propagate StartTime from RunWithConfig through CoreAdderMiddleware
- compute uptime from the CoreData StartTime in the stats handler
- remove unused global state package

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68830f00795c832f8f9ae70b301ed7c2