### PR TITLE
Access notifications via runtime config

### DIFF
--- a/handlers/notifications.go
+++ b/handlers/notifications.go
@@ -1,9 +1,0 @@
-package handlers
-
-import "github.com/arran4/goa4web/config"
-
-// NotificationsEnabled reports whether the internal notification system should
-// run according to the runtime configuration.
-func NotificationsEnabled() bool {
-	return config.AppRuntimeConfig.NotificationsEnabled
-}

--- a/handlers/user/userNotificationsPage.go
+++ b/handlers/user/userNotificationsPage.go
@@ -22,7 +22,8 @@ var dismissTask = &DismissTask{TaskString: tasks.TaskString(TaskDismiss)}
 var _ tasks.Task = (*DismissTask)(nil)
 
 func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
-	if !handlers.NotificationsEnabled() {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if !cd.Config.NotificationsEnabled {
 		http.NotFound(w, r)
 		return
 	}
@@ -60,7 +61,8 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func (DismissTask) Action(w http.ResponseWriter, r *http.Request) any {
-	if !handlers.NotificationsEnabled() {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if !cd.Config.NotificationsEnabled {
 		http.NotFound(w, r)
 		return nil
 	}
@@ -89,7 +91,8 @@ func (DismissTask) Action(w http.ResponseWriter, r *http.Request) any {
 }
 
 func notificationsRssPage(w http.ResponseWriter, r *http.Request) {
-	if !handlers.NotificationsEnabled() {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if !cd.Config.NotificationsEnabled {
 		http.NotFound(w, r)
 		return
 	}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -106,7 +106,7 @@ func CoreAdderMiddlewareWithDB(db *sql.DB, cfg config.RuntimeConfig, verbosity i
 			cd.Title = "Arran's Site"
 			cd.FeedsEnabled = cfg.FeedsEnabled
 			cd.AdminMode = r.URL.Query().Get("mode") == "admin"
-			if uid != 0 && handlers.NotificationsEnabled() {
+			if uid != 0 && cfg.NotificationsEnabled {
 				cd.NotificationCount = int32(cd.UnreadNotificationCount())
 			}
 			ctx := context.WithValue(r.Context(), consts.KeyCoreData, cd)

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/arran4/goa4web/handlers"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/dlq"
 	"github.com/arran4/goa4web/internal/eventbus"
@@ -69,7 +68,7 @@ func (n *Notifier) BusWorker(ctx context.Context, bus *eventbus.Bus, q dlq.DLQ) 
 }
 
 func (n *Notifier) processEvent(ctx context.Context, evt eventbus.TaskEvent, q dlq.DLQ) error {
-	if !handlers.NotificationsEnabled() {
+	if !n.Config.NotificationsEnabled {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- reference runtime config from CoreData and Notifier
- check runtime config in middleware

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688312b90c38832fbb896f39b14769f4