### PR TITLE
Remove CSRF helper followup

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -104,7 +104,7 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 		taskEventMW.Middleware,
 		middleware.SecurityHeadersMiddleware,
 	).Wrap(r)
-	if csrfmw.CSRFEnabled() {
+	if cfg.CSRFEnabled {
 		handler = csrfmw.NewCSRFMiddleware(sessionSecret, cfg.HTTPHostname, version)(handler)
 	}
 

--- a/internal/middleware/csrf/csrf.go
+++ b/internal/middleware/csrf/csrf.go
@@ -5,16 +5,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/gorilla/csrf"
 )
-
-// CSRFEnabled reports if CSRF protection should be active.
-// CSRFEnabled reports if CSRF protection should be active according to the
-// runtime configuration.
-func CSRFEnabled() bool {
-	return config.AppRuntimeConfig.CSRFEnabled
-}
 
 // NewCSRFMiddleware returns middleware enforcing CSRF protection using the
 // provided session secret and HTTP configuration.

--- a/internal/middleware/csrf/csrf_test.go
+++ b/internal/middleware/csrf/csrf_test.go
@@ -120,12 +120,10 @@ func TestCSRFDisabled(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}).Methods("POST")
 
-	orig := config.AppRuntimeConfig
-	config.AppRuntimeConfig.CSRFEnabled = false
-	t.Cleanup(func() { config.AppRuntimeConfig = orig })
+	cfg := config.RuntimeConfig{CSRFEnabled: false}
 
 	var handler http.Handler = r
-	if CSRFEnabled() {
+	if cfg.CSRFEnabled {
 		key := sha256.Sum256([]byte("testsecret"))
 		handler = csrf.Protect(key[:], csrf.Secure(false))(handler)
 	}


### PR DESCRIPTION
## Summary
- check the passed config instead of the global AppRuntimeConfig
- update CSRF tests to use a local config value

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688312bac054832f8516bb3ddbd19811