### PR TITLE
Refactor DB initialization to avoid global

### DIFF
--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -97,10 +97,11 @@ func (r *rootCmd) DB() (*sql.DB, error) {
 	if r.db != nil {
 		return r.db, nil
 	}
-	if ue := dbstart.InitDB(r.cfg, r.dbReg); ue != nil {
+	dbPool, ue := dbstart.InitDB(r.cfg, r.dbReg)
+	if ue != nil {
 		return nil, fmt.Errorf("init db: %w", ue.Err)
 	}
-	r.db = dbstart.GetDBPool()
+	r.db = dbPool
 	return r.db, nil
 }
 

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/arran4/goa4web/internal/app/dbstart"
 	"github.com/arran4/goa4web/internal/app/server"
 	"github.com/arran4/goa4web/workers"
 
@@ -60,11 +59,10 @@ func RunWithConfig(ctx context.Context, cfg config.RuntimeConfig, sessionSecret,
 		SameSite: http.SameSiteLaxMode,
 	}
 
-	if err := PerformChecks(cfg, dbReg); err != nil {
+	dbPool, err := PerformChecks(cfg, dbReg)
+	if err != nil {
 		return fmt.Errorf("startup checks: %w", err)
 	}
-
-	dbPool := dbstart.GetDBPool()
 	queries := dbpkg.New(dbPool)
 	if err := corelanguage.EnsureDefaultLanguage(context.Background(), queries, cfg.DefaultLanguage); err != nil {
 		return fmt.Errorf("ensure default language: %w", err)


### PR DESCRIPTION
## Summary
- stop exporting a global DBPool
- return the DB connection from InitDB and startup checks
- update RunWithConfig and rootCmd.DB to use returned DB

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688312c1a470832fa95ca137676f12de