### PR TITLE
Refactor server init into configurable constructor

### DIFF
--- a/cmd/goa4web/serve.go
+++ b/cmd/goa4web/serve.go
@@ -55,7 +55,19 @@ func (c *serveCmd) Run() error {
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-  if err := app.RunWithConfig(ctx, cfg, secret, signKey, c.rootCmd.dbReg, c.rootCmd.emailReg, c.rootCmd.dlqReg, apiKey); err != nil {
+	srv, err := app.NewServer(ctx, cfg,
+		app.WithSessionSecret(secret),
+		app.WithImageSignSecret(signKey),
+		app.WithDBRegistry(c.rootCmd.dbReg),
+		app.WithEmailRegistry(c.rootCmd.emailReg),
+		app.WithDLQRegistry(c.rootCmd.dlqReg),
+		app.WithAPISecret(apiKey),
+	)
+	if err != nil {
+		return err
+	}
+	defer srv.Close()
+	if err := srv.RunContext(ctx); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Summary
- drop `ServerState` and embed runtime pieces into `server.Server`
- introduce `ServerOption` pattern for constructing the server with optional dependencies
- adjust `serve` command to use the new constructor

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68831cba8754832fa20d62f1d3810b13