### PR TITLE
Validate sendmail recipient

### DIFF
--- a/internal/email/local/local.go
+++ b/internal/email/local/local.go
@@ -3,8 +3,10 @@ package local
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/mail"
 	"os/exec"
+	"unicode"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/email"
@@ -14,7 +16,20 @@ import (
 type Provider struct{}
 
 func (Provider) Send(ctx context.Context, to mail.Address, rawEmailMessage []byte) error {
-	cmd := exec.CommandContext(ctx, "sendmail", to.Address)
+	addr := to.Address
+	if addr == "" {
+		return fmt.Errorf("recipient address empty")
+	}
+	for _, r := range addr {
+		if r == '\n' || r == '\r' || unicode.IsControl(r) {
+			return fmt.Errorf("invalid recipient address")
+		}
+	}
+	parsed, err := mail.ParseAddress(addr)
+	if err != nil || parsed.Address != addr {
+		return fmt.Errorf("invalid recipient address: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, "sendmail", addr)
 	cmd.Stdin = bytes.NewReader(rawEmailMessage)
 	return cmd.Run()
 }

--- a/internal/email/local/local_test.go
+++ b/internal/email/local/local_test.go
@@ -1,0 +1,21 @@
+package local
+
+import (
+	"context"
+	"net/mail"
+	"testing"
+)
+
+func TestProviderInvalidAddr(t *testing.T) {
+	p := Provider{}
+	cases := []string{
+		"foo@example.com\n",
+		"foo@example.com,bar@example.com",
+		"foo\x01@example.com",
+	}
+	for _, c := range cases {
+		if err := p.Send(context.Background(), mail.Address{Address: c}, nil); err == nil {
+			t.Errorf("expected error for %q", c)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- validate the recipient address in the local email provider before invoking `sendmail`
- add tests for invalid local provider addresses

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688329ac2474832f82a2f318dd938a1e