### PR TITLE
Fix path traversal in local upload provider

### DIFF
--- a/internal/upload/local/local_test.go
+++ b/internal/upload/local/local_test.go
@@ -112,3 +112,40 @@ func TestCleanup(t *testing.T) {
 		t.Fatalf("b removed: %v", err)
 	}
 }
+
+func TestWriteRejectsTraversal(t *testing.T) {
+	mfs := newMemFS()
+	p := Provider{Dir: "/cache", FS: mfs}
+	if err := p.Write(context.Background(), "../evil", []byte("x")); err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, err := mfs.Stat("/bad"); err == nil {
+		t.Fatalf("file created")
+	}
+}
+
+func TestWriteRejectsAbs(t *testing.T) {
+	mfs := newMemFS()
+	p := Provider{Dir: "/cache", FS: mfs}
+	if err := p.Write(context.Background(), "/abs", []byte("x")); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestReadRejectsTraversal(t *testing.T) {
+	mfs := newMemFS()
+	_ = mfs.WriteFile("/cache/good", []byte("data"), 0o644)
+	p := Provider{Dir: "/cache", FS: mfs}
+	if _, err := p.Read(context.Background(), "../good"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestReadRejectsAbs(t *testing.T) {
+	mfs := newMemFS()
+	_ = mfs.WriteFile("/cache/good", []byte("data"), 0o644)
+	p := Provider{Dir: "/cache", FS: mfs}
+	if _, err := p.Read(context.Background(), "/abs"); err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- validate file names in local upload provider using fs.ValidPath
- extend tests for absolute paths

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688329a7d114832f96f6f54ab8f51d6c