### PR TITLE
Add configurable log verbosity

### DIFF
--- a/cmd/goa4web/db_migrate.go
+++ b/cmd/goa4web/db_migrate.go
@@ -24,7 +24,7 @@ func openDB(cfg config.RuntimeConfig, reg *dbdrivers.Registry) (*sql.DB, error) 
 	if err != nil {
 		return nil, err
 	}
-	var connector driver.Connector = dbpkg.NewLoggingConnector(c)
+	var connector driver.Connector = dbpkg.NewLoggingConnector(c, cfg.DBLogVerbosity)
 	db := sql.OpenDB(connector)
 	if err := db.Ping(); err != nil {
 		db.Close()

--- a/config/env.go
+++ b/config/env.go
@@ -66,6 +66,8 @@ const (
 
 	// EnvDBLogVerbosity controls the verbosity level of database logging.
 	EnvDBLogVerbosity = "DB_LOG_VERBOSITY"
+	// EnvEmailLogVerbosity controls the verbosity level of email logging.
+	EnvEmailLogVerbosity = "EMAIL_LOG_VERBOSITY"
 	// EnvLogFlags selects which HTTP request logs are emitted.
 	EnvLogFlags = "LOG_FLAGS"
 	// EnvListen is the network address the HTTP server listens on.

--- a/config/options_runtime.go
+++ b/config/options_runtime.go
@@ -75,6 +75,7 @@ var StringOptions = []StringOption{
 // IntOptions lists the integer runtime options shared by flag parsing and configuration generation.
 var IntOptions = []IntOption{
 	{"db-log-verbosity", EnvDBLogVerbosity, "database logging verbosity", 0, "", func(c *RuntimeConfig) *int { return &c.DBLogVerbosity }},
+	{"email-log-verbosity", EnvEmailLogVerbosity, "email logging verbosity", 0, "", func(c *RuntimeConfig) *int { return &c.EmailLogVerbosity }},
 	{"log-flags", EnvLogFlags, "request logging flags", 0, "", func(c *RuntimeConfig) *int { return &c.LogFlags }},
 	{"page-size-min", EnvPageSizeMin, "minimum allowed page size", 0, "", func(c *RuntimeConfig) *int { return &c.PageSizeMin }},
 	{"page-size-max", EnvPageSizeMax, "maximum allowed page size", 0, "", func(c *RuntimeConfig) *int { return &c.PageSizeMax }},

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -12,10 +12,11 @@ const DefaultPageSize = 15
 // RuntimeConfig stores configuration values resolved from environment
 // variables, optional files and command line flags.
 type RuntimeConfig struct {
-	DBConn         string
-	DBDriver       string
-	DBLogVerbosity int
-	LogFlags       int
+	DBConn            string
+	DBDriver          string
+	DBLogVerbosity    int
+	EmailLogVerbosity int
+	LogFlags          int
 
 	HTTPListen   string
 	HTTPHostname string

--- a/config/runtime_with_options_test.go
+++ b/config/runtime_with_options_test.go
@@ -8,23 +8,26 @@ import (
 
 func TestGenerateRuntimeConfigWithInjectedOptions(t *testing.T) {
 	env := map[string]string{
-		config.EnvDBConn:         "env",
-		config.EnvDBLogVerbosity: "2",
+		config.EnvDBConn:            "env",
+		config.EnvDBLogVerbosity:    "2",
+		config.EnvEmailLogVerbosity: "1",
 	}
 
 	strOpt := config.StringOption{Name: "db-conn-alt", Env: config.EnvDBConn, Usage: "", ExtendedUsage: "", Target: func(c *config.RuntimeConfig) *string { return &c.DBConn }}
 	intOpt := config.IntOption{Name: "db-verb-alt", Env: config.EnvDBLogVerbosity, Usage: "", ExtendedUsage: "", Target: func(c *config.RuntimeConfig) *int { return &c.DBLogVerbosity }}
-	fs := config.NewRuntimeFlagSetWithOptions("test", []config.StringOption{strOpt}, []config.IntOption{intOpt})
-	_ = fs.Parse([]string{"--db-conn-alt=cli", "--db-verb-alt=5"})
+	intOpt2 := config.IntOption{Name: "email-verb-alt", Env: config.EnvEmailLogVerbosity, Usage: "", ExtendedUsage: "", Target: func(c *config.RuntimeConfig) *int { return &c.EmailLogVerbosity }}
+	fs := config.NewRuntimeFlagSetWithOptions("test", []config.StringOption{strOpt}, []config.IntOption{intOpt, intOpt2})
+	_ = fs.Parse([]string{"--db-conn-alt=cli", "--db-verb-alt=5", "--email-verb-alt=4"})
 
 	vals := map[string]string{
-		config.EnvDBConn:         "file",
-		config.EnvDBLogVerbosity: "3",
+		config.EnvDBConn:            "file",
+		config.EnvDBLogVerbosity:    "3",
+		config.EnvEmailLogVerbosity: "2",
 	}
 
-	cfg := config.GenerateRuntimeConfigWithOptions(fs, vals, func(k string) string { return env[k] }, []config.StringOption{strOpt}, []config.IntOption{intOpt})
+	cfg := config.GenerateRuntimeConfigWithOptions(fs, vals, func(k string) string { return env[k] }, []config.StringOption{strOpt}, []config.IntOption{intOpt, intOpt2})
 
-	if cfg.DBConn != "cli" || cfg.DBLogVerbosity != 5 {
+	if cfg.DBConn != "cli" || cfg.DBLogVerbosity != 5 || cfg.EmailLogVerbosity != 4 {
 		t.Fatalf("merged %#v", cfg)
 	}
 }

--- a/internal/app/dbstart/automigrate.go
+++ b/internal/app/dbstart/automigrate.go
@@ -34,7 +34,7 @@ func applyMigrations(ctx context.Context, cfg config.RuntimeConfig, reg *dbdrive
 	if err != nil {
 		return err
 	}
-	var connector driver.Connector = dbpkg.NewLoggingConnector(c)
+	var connector driver.Connector = dbpkg.NewLoggingConnector(c, cfg.DBLogVerbosity)
 	db := sql.OpenDB(connector)
 	defer db.Close()
 	if err := db.PingContext(ctx); err != nil {

--- a/internal/db/db_logging.go
+++ b/internal/db/db_logging.go
@@ -10,17 +10,17 @@ import (
 
 type loggingConnector struct {
 	driver.Connector
+	verbosity int
 }
 
 // LogVerbosity controls the verbosity of database connection logging.
 // 0 disables logging, 1 logs connection lifecycle, 2 logs all queries.
-var LogVerbosity int
 
 // NewLoggingConnector wraps the provided connector with logging if verbosity is
 // greater than zero.
-func NewLoggingConnector(base driver.Connector) driver.Connector {
-	if LogVerbosity > 0 {
-		return loggingConnector{base}
+func NewLoggingConnector(base driver.Connector, verbosity int) driver.Connector {
+	if verbosity > 0 {
+		return loggingConnector{Connector: base, verbosity: verbosity}
 	}
 	return base
 }
@@ -28,16 +28,16 @@ func NewLoggingConnector(base driver.Connector) driver.Connector {
 func (lc loggingConnector) Connect(ctx context.Context) (driver.Conn, error) {
 	conn, err := lc.Connector.Connect(ctx)
 	if err != nil {
-		if LogVerbosity > 0 {
+		if lc.verbosity > 0 {
 			log.Printf("DB connect error: %v", err)
 		}
 		return nil, err
 	}
 	id := ksuid.New()
-	if LogVerbosity > 0 {
+	if lc.verbosity > 0 {
 		log.Printf("db connection %s opened", id.String())
 	}
-	return &loggingConn{id: id, Conn: conn}, nil
+	return &loggingConn{id: id, Conn: conn, verbosity: lc.verbosity}, nil
 }
 
 func (lc loggingConnector) Driver() driver.Driver {
@@ -45,34 +45,35 @@ func (lc loggingConnector) Driver() driver.Driver {
 }
 
 type loggingConn struct {
-	id ksuid.KSUID
+	id        ksuid.KSUID
+	verbosity int
 	driver.Conn
 }
 
 func (lc *loggingConn) Prepare(query string) (driver.Stmt, error) {
-	if LogVerbosity >= 2 {
+	if lc.verbosity >= 2 {
 		log.Printf("conn %s Prepare: %s", lc.id, query)
 	}
 	stmt, err := lc.Conn.Prepare(query)
-	if err != nil && LogVerbosity > 0 {
+	if err != nil && lc.verbosity > 0 {
 		log.Printf("conn %s Prepare error: %v", lc.id, err)
 	}
 	return stmt, err
 }
 
 func (lc *loggingConn) Close() error {
-	if LogVerbosity > 0 {
+	if lc.verbosity > 0 {
 		log.Printf("conn %s closed", lc.id)
 	}
 	return lc.Conn.Close()
 }
 
 func (lc *loggingConn) Begin() (driver.Tx, error) {
-	if LogVerbosity >= 2 {
+	if lc.verbosity >= 2 {
 		log.Printf("conn %s Begin", lc.id)
 	}
 	tx, err := lc.Conn.Begin()
-	if err != nil && LogVerbosity > 0 {
+	if err != nil && lc.verbosity > 0 {
 		log.Printf("conn %s Begin error: %v", lc.id, err)
 	}
 	return tx, err
@@ -80,11 +81,11 @@ func (lc *loggingConn) Begin() (driver.Tx, error) {
 
 func (lc *loggingConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
 	if pc, ok := lc.Conn.(driver.ConnPrepareContext); ok {
-		if LogVerbosity >= 2 {
+		if lc.verbosity >= 2 {
 			log.Printf("conn %s PrepareContext: %s", lc.id, query)
 		}
 		stmt, err := pc.PrepareContext(ctx, query)
-		if err != nil && LogVerbosity > 0 {
+		if err != nil && lc.verbosity > 0 {
 			log.Printf("conn %s PrepareContext error: %v", lc.id, err)
 		}
 		return stmt, err
@@ -94,11 +95,11 @@ func (lc *loggingConn) PrepareContext(ctx context.Context, query string) (driver
 
 func (lc *loggingConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	if ec, ok := lc.Conn.(driver.ExecerContext); ok {
-		if LogVerbosity >= 2 {
+		if lc.verbosity >= 2 {
 			log.Printf("conn %s ExecContext: %s", lc.id, query)
 		}
 		res, err := ec.ExecContext(ctx, query, args)
-		if err != nil && LogVerbosity > 0 {
+		if err != nil && lc.verbosity > 0 {
 			log.Printf("conn %s ExecContext error: %v", lc.id, err)
 		}
 		return res, err
@@ -108,11 +109,11 @@ func (lc *loggingConn) ExecContext(ctx context.Context, query string, args []dri
 
 func (lc *loggingConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	if qc, ok := lc.Conn.(driver.QueryerContext); ok {
-		if LogVerbosity >= 2 {
+		if lc.verbosity >= 2 {
 			log.Printf("conn %s QueryContext: %s", lc.id, query)
 		}
 		rows, err := qc.QueryContext(ctx, query, args)
-		if err != nil && LogVerbosity > 0 {
+		if err != nil && lc.verbosity > 0 {
 			log.Printf("conn %s QueryContext error: %v", lc.id, err)
 		}
 		return rows, err
@@ -122,11 +123,11 @@ func (lc *loggingConn) QueryContext(ctx context.Context, query string, args []dr
 
 func (lc *loggingConn) Ping(ctx context.Context) error {
 	if p, ok := lc.Conn.(driver.Pinger); ok {
-		if LogVerbosity >= 2 {
+		if lc.verbosity >= 2 {
 			log.Printf("conn %s Ping", lc.id)
 		}
 		err := p.Ping(ctx)
-		if err != nil && LogVerbosity > 0 {
+		if err != nil && lc.verbosity > 0 {
 			log.Printf("conn %s Ping error: %v", lc.id, err)
 		}
 		return err
@@ -136,11 +137,11 @@ func (lc *loggingConn) Ping(ctx context.Context) error {
 
 func (lc *loggingConn) ResetSession(ctx context.Context) error {
 	if rs, ok := lc.Conn.(driver.SessionResetter); ok {
-		if LogVerbosity >= 2 {
+		if lc.verbosity >= 2 {
 			log.Printf("conn %s ResetSession", lc.id)
 		}
 		err := rs.ResetSession(ctx)
-		if err != nil && LogVerbosity > 0 {
+		if err != nil && lc.verbosity > 0 {
 			log.Printf("conn %s ResetSession error: %v", lc.id, err)
 		}
 		return err

--- a/internal/email/log/log.go
+++ b/internal/email/log/log.go
@@ -10,14 +10,20 @@ import (
 )
 
 // Provider just logs emails for development purposes.
-type Provider struct{}
+type Provider struct{ Verbosity int }
 
-func (Provider) Send(ctx context.Context, to mail.Address, rawEmailMessage []byte) error {
-	log.Printf("sending mail to %s\n%s", to.String(), rawEmailMessage)
+func (p Provider) Send(ctx context.Context, to mail.Address, rawEmailMessage []byte) error {
+	if p.Verbosity >= email.LogLevelBody {
+		log.Printf("sending mail to %s\n%s", to.String(), rawEmailMessage)
+	} else if p.Verbosity >= email.LogLevelSummary {
+		log.Printf("sending mail to %s", to.String())
+	}
 	return nil
 }
 
-func providerFromConfig(config.RuntimeConfig) email.Provider { return Provider{} }
+func providerFromConfig(cfg config.RuntimeConfig) email.Provider {
+	return Provider{Verbosity: cfg.EmailLogVerbosity}
+}
 
 // Register registers the log provider factory.
 func Register(r *email.Registry) { r.RegisterProvider("log", providerFromConfig) }

--- a/internal/email/logging.go
+++ b/internal/email/logging.go
@@ -9,4 +9,4 @@ const (
 
 // LogVerbosity controls the amount of logging performed by email providers.
 // Set to LogLevelSummary to log basic info or LogLevelBody for verbose output.
-var LogVerbosity = LogLevelSummary
+// The effective level is determined by RuntimeConfig.


### PR DESCRIPTION
## Summary
- add `EmailLogVerbosity` to runtime config
- add env var and CLI option for email log verbosity
- refactor DB logging connector to accept verbosity parameter
- honour email logging verbosity for the log provider
- update tests for new option

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6883295a6b60832fae597383985555dc