### PR TITLE
Add inlined CoreData middleware

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -150,10 +150,15 @@ func NewServer(ctx context.Context, cfg config.RuntimeConfig, opts ...ServerOpti
 	r := mux.NewRouter()
 	routerpkg.RegisterRoutes(r)
 
+	srv := server.New(nil, store, dbPool, cfg)
+	srv.Bus = bus
+	srv.EmailReg = o.EmailReg
+	srv.ImageSigner = imgSigner
+
 	taskEventMW := middleware.NewTaskEventMiddleware(bus)
 	handler := middleware.NewMiddlewareChain(
 		middleware.RecoverMiddleware,
-		middleware.CoreAdderMiddlewareWithDB(dbPool, cfg, cfg.DBLogVerbosity, o.EmailReg, imgSigner),
+		srv.CoreDataMiddleware(),
 		middleware.RequestLoggerMiddleware,
 		taskEventMW.Middleware,
 		middleware.SecurityHeadersMiddleware,
@@ -162,8 +167,7 @@ func NewServer(ctx context.Context, cfg config.RuntimeConfig, opts ...ServerOpti
 		handler = csrfmw.NewCSRFMiddleware(o.SessionSecret, cfg.HTTPHostname, version)(handler)
 	}
 
-	srv := server.New(handler, store, dbPool, cfg)
-	srv.Bus = bus
+	srv.Router = handler
 
 	adminhandlers.ConfigFile = ConfigFile
 	adminhandlers.Srv = srv

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -5,23 +5,35 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/gorilla/sessions"
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/gorilla/sessions"
+
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/internal/eventbus"
+	imagesign "github.com/arran4/goa4web/internal/images"
+	"github.com/arran4/goa4web/internal/middleware"
+	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 // Server bundles the application's configuration, router and runtime dependencies.
 type Server struct {
-	Config config.RuntimeConfig
-	Router http.Handler
-	Store  *sessions.CookieStore
-	DB     *sql.DB
-	Bus    *eventbus.Bus
+	Config      config.RuntimeConfig
+	Router      http.Handler
+	Store       *sessions.CookieStore
+	DB          *sql.DB
+	Bus         *eventbus.Bus
+	EmailReg    *email.Registry
+	ImageSigner *imagesign.Signer
 
 	WorkerCancel context.CancelFunc
 
@@ -86,6 +98,92 @@ func New(handler http.Handler, store *sessions.CookieStore, db *sql.DB, cfg conf
 		Router: handler,
 		Store:  store,
 		DB:     db,
+	}
+}
+
+// CoreDataMiddleware constructs the middleware responsible for populating
+// CoreData in the request context using the server's configured dependencies.
+func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			session, err := core.GetSession(r)
+			if err != nil {
+				core.SessionErrorRedirect(w, r, err)
+				return
+			}
+			var uid int32
+			if v, ok := session.Values["UID"].(int32); ok {
+				uid = v
+			}
+			if expi, ok := session.Values["ExpiryTime"]; ok {
+				var exp int64
+				switch t := expi.(type) {
+				case int64:
+					exp = t
+				case int:
+					exp = int64(t)
+				case float64:
+					exp = int64(t)
+				}
+				if exp != 0 && time.Now().Unix() > exp {
+					delete(session.Values, "UID")
+					delete(session.Values, "LoginTime")
+					delete(session.Values, "ExpiryTime")
+					middleware.RedirectToLogin(w, r, session)
+					return
+				}
+			}
+			if s.DB == nil {
+				ue := common.UserError{Err: fmt.Errorf("db not initialized"), ErrorMessage: "database unavailable"}
+				log.Printf("%s: %v", ue.ErrorMessage, ue.Err)
+				http.Error(w, ue.ErrorMessage, http.StatusInternalServerError)
+				return
+			}
+
+			queries := dbpkg.New(s.DB)
+			sm := queries
+			if s.Config.DBLogVerbosity > 0 {
+				log.Printf("db pool stats: %+v", s.DB.Stats())
+			}
+
+			if session.ID != "" {
+				if uid != 0 {
+					if err := queries.InsertSession(r.Context(), dbpkg.InsertSessionParams{SessionID: session.ID, UsersIdusers: uid}); err != nil {
+						log.Printf("insert session: %v", err)
+					}
+				} else {
+					if err := queries.DeleteSessionByID(r.Context(), session.ID); err != nil {
+						log.Printf("delete session: %v", err)
+					}
+				}
+			}
+
+			base := "http://" + r.Host
+			if s.Config.HTTPHostname != "" {
+				base = strings.TrimRight(s.Config.HTTPHostname, "/")
+			}
+			provider := s.EmailReg.ProviderFromConfig(s.Config)
+			cd := common.NewCoreData(r.Context(), queries,
+				common.WithImageSigner(s.ImageSigner),
+				common.WithSession(session),
+				common.WithEmailProvider(provider),
+				common.WithAbsoluteURLBase(base),
+				common.WithConfig(s.Config),
+				common.WithSessionManager(sm))
+			cd.UserID = uid
+			_ = cd.UserRoles()
+
+			idx := nav.IndexItems()
+			cd.IndexItems = idx
+			cd.Title = "Arran's Site"
+			cd.FeedsEnabled = s.Config.FeedsEnabled
+			cd.AdminMode = r.URL.Query().Get("mode") == "admin"
+			if uid != 0 && s.Config.NotificationsEnabled {
+				cd.NotificationCount = int32(cd.UnreadNotificationCount())
+			}
+			ctx := context.WithValue(r.Context(), consts.KeyCoreData, cd)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- inline `CoreDataMiddleware` logic inside `Server`
- keep storing `EmailReg` and `ImageSigner` on the server

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68832929f1e4832f864a5013a001c0c2