### PR TITLE
Refactor navigation registry into struct

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -23,6 +23,7 @@ import (
 	imagesign "github.com/arran4/goa4web/internal/images"
 	middleware "github.com/arran4/goa4web/internal/middleware"
 	csrfmw "github.com/arran4/goa4web/internal/middleware/csrf"
+	nav "github.com/arran4/goa4web/internal/navigation"
 	routerpkg "github.com/arran4/goa4web/internal/router"
 	websocket "github.com/arran4/goa4web/internal/websocket"
 	"github.com/gorilla/mux"
@@ -162,7 +163,9 @@ func NewServer(ctx context.Context, cfg config.RuntimeConfig, opts ...ServerOpti
 		handler = csrfmw.NewCSRFMiddleware(o.SessionSecret, cfg.HTTPHostname, version)(handler)
 	}
 
-	srv := server.New(handler, store, dbPool, cfg)
+	navReg := nav.NewRegistry()
+	srv := server.New(handler, store, dbPool, cfg, navReg)
+	nav.SetDefaultRegistry(navReg)
 	srv.Bus = bus
 
 	adminhandlers.ConfigFile = ConfigFile

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/internal/navigation"
 )
 
 // Server bundles the application's configuration, router and runtime dependencies.
@@ -22,6 +23,7 @@ type Server struct {
 	Store  *sessions.CookieStore
 	DB     *sql.DB
 	Bus    *eventbus.Bus
+	Nav    *navigation.Registry
 
 	WorkerCancel context.CancelFunc
 
@@ -80,12 +82,13 @@ func (s *Server) Close() {
 }
 
 // New returns a Server with the supplied dependencies.
-func New(handler http.Handler, store *sessions.CookieStore, db *sql.DB, cfg config.RuntimeConfig) *Server {
+func New(handler http.Handler, store *sessions.CookieStore, db *sql.DB, cfg config.RuntimeConfig, nav *navigation.Registry) *Server {
 	return &Server{
 		Config: cfg,
 		Router: handler,
 		Store:  store,
 		DB:     db,
+		Nav:    nav,
 	}
 }
 

--- a/internal/navigation/registry.go
+++ b/internal/navigation/registry.go
@@ -13,25 +13,29 @@ type link struct {
 	weight int
 }
 
-var (
-	indexRegistry []link
-	adminRegistry []link
-)
+// Registry stores navigation entries for the public index and admin pages.
+type Registry struct {
+	index []link
+	admin []link
+}
+
+// NewRegistry returns an empty Registry.
+func NewRegistry() *Registry { return &Registry{} }
 
 // RegisterIndexLink registers an entry for the site's index navigation.
-func RegisterIndexLink(name, url string, weight int) {
-	indexRegistry = append(indexRegistry, link{name: name, link: url, weight: weight})
+func (r *Registry) RegisterIndexLink(name, url string, weight int) {
+	r.index = append(r.index, link{name: name, link: url, weight: weight})
 }
 
 // RegisterAdminControlCenter registers a link for the admin control center menu.
-func RegisterAdminControlCenter(name, url string, weight int) {
-	adminRegistry = append(adminRegistry, link{name: name, link: url, weight: weight})
+func (r *Registry) RegisterAdminControlCenter(name, url string, weight int) {
+	r.admin = append(r.admin, link{name: name, link: url, weight: weight})
 }
 
 // IndexItems returns navigation items sorted by weight.
-func IndexItems() []common.IndexItem {
-	entries := make([]link, len(indexRegistry))
-	copy(entries, indexRegistry)
+func (r *Registry) IndexItems() []common.IndexItem {
+	entries := make([]link, len(r.index))
+	copy(entries, r.index)
 	sort.Slice(entries, func(i, j int) bool { return entries[i].weight < entries[j].weight })
 	items := make([]common.IndexItem, 0, len(entries))
 	for _, e := range entries {
@@ -41,9 +45,9 @@ func IndexItems() []common.IndexItem {
 }
 
 // AdminLinks returns admin navigation items sorted by weight.
-func AdminLinks() []common.IndexItem {
-	entries := make([]link, len(adminRegistry))
-	copy(entries, adminRegistry)
+func (r *Registry) AdminLinks() []common.IndexItem {
+	entries := make([]link, len(r.admin))
+	copy(entries, r.admin)
 	sort.Slice(entries, func(i, j int) bool { return entries[i].weight < entries[j].weight })
 	items := make([]common.IndexItem, 0, len(entries))
 	for _, e := range entries {
@@ -51,3 +55,28 @@ func AdminLinks() []common.IndexItem {
 	}
 	return items
 }
+
+var defaultRegistry = NewRegistry()
+
+// SetDefaultRegistry sets the package level registry used by the helper functions.
+func SetDefaultRegistry(r *Registry) {
+	if r != nil {
+		defaultRegistry = r
+	}
+}
+
+// RegisterIndexLink registers an entry for the site's index navigation using the default registry.
+func RegisterIndexLink(name, url string, weight int) {
+	defaultRegistry.RegisterIndexLink(name, url, weight)
+}
+
+// RegisterAdminControlCenter registers a link for the admin control center menu using the default registry.
+func RegisterAdminControlCenter(name, url string, weight int) {
+	defaultRegistry.RegisterAdminControlCenter(name, url, weight)
+}
+
+// IndexItems returns navigation items sorted by weight from the default registry.
+func IndexItems() []common.IndexItem { return defaultRegistry.IndexItems() }
+
+// AdminLinks returns admin navigation items sorted by weight from the default registry.
+func AdminLinks() []common.IndexItem { return defaultRegistry.AdminLinks() }

--- a/internal/navigation/registry_test.go
+++ b/internal/navigation/registry_test.go
@@ -5,9 +5,8 @@ import (
 )
 
 func TestIndexItemsOrdering(t *testing.T) {
-	indexRegistry = nil
-	adminRegistry = nil
-	t.Cleanup(func() { indexRegistry = nil; adminRegistry = nil })
+	defaultRegistry = NewRegistry()
+	t.Cleanup(func() { defaultRegistry = NewRegistry() })
 
 	RegisterIndexLink("b", "/b", 20)
 	RegisterIndexLink("a", "/a", 10)
@@ -32,9 +31,8 @@ func TestIndexItemsOrdering(t *testing.T) {
 }
 
 func TestIndexItemsSkipEmpty(t *testing.T) {
-	indexRegistry = nil
-	adminRegistry = nil
-	t.Cleanup(func() { indexRegistry = nil; adminRegistry = nil })
+	defaultRegistry = NewRegistry()
+	t.Cleanup(func() { defaultRegistry = NewRegistry() })
 
 	RegisterAdminControlCenter("no", "/admin/no", 5)
 	items := IndexItems()

--- a/specs/navigation.md
+++ b/specs/navigation.md
@@ -4,7 +4,7 @@ This document summarises how site sections register menu items using the `naviga
 
 ## Package overview
 
-The `internal/navigation/registry.go` file defines a simple registry that collects links for the index page and the admin control centre. Links are represented by a struct containing the name, URL and an integer weight. Two package level slices hold registered entries for the public index and for the admin pages.
+The `internal/navigation/registry.go` file defines a simple registry that collects links for the index page and the admin control centre. Links are represented by a struct containing the name, URL and an integer weight. A `Registry` struct stores the registered entries for the public index and for the admin pages. A single instance of this struct is constructed when the server starts and attached to the server state.
 
 ```go
 // link represents a navigation item for either index or admin control center.
@@ -17,7 +17,7 @@ type link struct {
 
 ### RegisterIndexLink
 
-`RegisterIndexLink(name, url string, weight int)` appends an entry to the index registry. Each handler package calls this function in its `RegisterRoutes` setup to expose its public section in the menu.
+`RegisterIndexLink(name, url string, weight int)` appends an entry to the server's navigation registry. Each handler package calls this function in its `RegisterRoutes` setup to expose its public section in the menu.
 
 ### RegisterAdminControlCenter
 


### PR DESCRIPTION
## Summary
- store index and admin navigation links in a `Registry` struct
- attach the navigation registry to server state and use it via helper functions
- update tests and documentation for the new registry design

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688335cf2664832f939c9678a4347fb8