### PR TITLE
Hash session ID in auth logs

### DIFF
--- a/handlers/auth/login_task.go
+++ b/handlers/auth/login_task.go
@@ -40,7 +40,7 @@ func (LoginTask) Page(w http.ResponseWriter, r *http.Request) {
 func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if config.AppRuntimeConfig.LogFlags&config.LogFlagAuth != 0 {
 		sess, _ := core.GetSession(r)
-		log.Printf("login attempt for %s session=%s", r.PostFormValue("username"), sess.ID)
+		log.Printf("login attempt for %s session=%s", r.PostFormValue("username"), handlers.HashSessionID(sess.ID))
 	}
 
 	username := r.PostFormValue("username")
@@ -119,7 +119,7 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if config.AppRuntimeConfig.LogFlags&config.LogFlagAuth != 0 {
-		log.Printf("login success uid=%d session=%s", row.Idusers, session.ID)
+		log.Printf("login success uid=%d session=%s", row.Idusers, handlers.HashSessionID(session.ID))
 	}
 
 	if backURL != "" {

--- a/handlers/logutils.go
+++ b/handlers/logutils.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"log"
+)
+
+var hashSecret []byte
+
+func init() {
+	hashSecret = make([]byte, 32)
+	if _, err := rand.Read(hashSecret); err != nil {
+		log.Printf("rand read: %v", err)
+	}
+}
+
+// HashSessionID returns a salted hash of a session ID for logging purposes.
+// The result is truncated for brevity while still being stable per instance.
+func HashSessionID(id string) string {
+	if id == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, hashSecret)
+	mac.Write([]byte(id))
+	sum := mac.Sum(nil)
+	return hex.EncodeToString(sum)[:12]
+}

--- a/handlers/logutils_test.go
+++ b/handlers/logutils_test.go
@@ -1,0 +1,22 @@
+package handlers
+
+import (
+	"testing"
+)
+
+func TestHashSessionID(t *testing.T) {
+	h1 := HashSessionID("abc123")
+	h2 := HashSessionID("abc123")
+	if h1 != h2 {
+		t.Fatalf("expected deterministic hash got %s and %s", h1, h2)
+	}
+	if len(h1) != 12 {
+		t.Fatalf("expected 12 char hash got %d", len(h1))
+	}
+	if h1 == "abc123" {
+		t.Fatalf("hash should not equal original")
+	}
+	if HashSessionID("") != "" {
+		t.Fatalf("expected empty result for empty ID")
+	}
+}

--- a/handlers/user/userLogoutPage.go
+++ b/handlers/user/userLogoutPage.go
@@ -18,7 +18,7 @@ func userLogoutPage(w http.ResponseWriter, r *http.Request) {
 		core.SessionError(w, r, err)
 	}
 	uid, _ := session.Values["UID"].(int32)
-	log.Printf("logout request session=%s uid=%d", session.ID, uid)
+	log.Printf("logout request session=%s uid=%d", handlers.HashSessionID(session.ID), uid)
 	type Data struct {
 		*common.CoreData
 	}
@@ -44,7 +44,7 @@ func userLogoutPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("logout success session=%s", session.ID)
+	log.Printf("logout success session=%s", handlers.HashSessionID(session.ID))
 
 	data.CoreData.UserID = 0
 


### PR DESCRIPTION
## Summary
- hash session IDs in logs using HMAC-SHA256 and a random per-instance secret
- update tests for deterministic hashing

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688329d3735c832f9c5b78f097921220