### PR TITLE
Refactor DB driver access

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -21,6 +21,7 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/dbdrivers"
 	"github.com/arran4/goa4web/internal/eventbus"
 	imagesign "github.com/arran4/goa4web/internal/images"
 	"github.com/arran4/goa4web/internal/tasks"
@@ -125,6 +126,7 @@ type CoreData struct {
 	blogEntries              map[int32]*lazyValue[*db.GetBlogEntryForUserByIdRow]
 
 	absoluteURLBase lazyValue[string]
+	dbRegistry      *dbdrivers.Registry
 	// marks records which template sections have been rendered to avoid
 	// duplicate output when re-rendering after an error.
 	marks map[string]struct{}
@@ -189,6 +191,11 @@ func WithImageSigner(s *imagesign.Signer) CoreOption {
 			cd.a4codeMapper = s.MapURL
 		}
 	}
+}
+
+// WithDBRegistry sets the database driver registry for CoreData.
+func WithDBRegistry(r *dbdrivers.Registry) CoreOption {
+	return func(cd *CoreData) { cd.dbRegistry = r }
 }
 
 // NewCoreData creates a CoreData with context and queries applied.
@@ -338,6 +345,9 @@ func (cd *CoreData) Session() *sessions.Session { return cd.session }
 
 // SessionManager returns the configured session manager, if any.
 func (cd *CoreData) SessionManager() SessionManager { return cd.sessionManager }
+
+// DBRegistry returns the database driver registry associated with this request.
+func (cd *CoreData) DBRegistry() *dbdrivers.Registry { return cd.dbRegistry }
 
 // SetEvent stores evt on cd for handler access.
 func (cd *CoreData) SetEvent(evt *eventbus.TaskEvent) { cd.event = evt }

--- a/handlers/admin/adminServerStatsPage.go
+++ b/handlers/admin/adminServerStatsPage.go
@@ -9,7 +9,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/dbdrivers"
 	"github.com/arran4/goa4web/internal/dlq"
 	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/internal/tasks"
@@ -62,7 +61,9 @@ func AdminServerStatsPage(w http.ResponseWriter, r *http.Request) {
 	for _, t := range tasks.Registered() {
 		data.Registries.Tasks = append(data.Registries.Tasks, t.Name())
 	}
-	data.Registries.DBDrivers = dbdrivers.Names()
+	if reg := data.CoreData.DBRegistry(); reg != nil {
+		data.Registries.DBDrivers = reg.Names()
+	}
 	data.Registries.DLQProviders = dlq.ProviderNames()
 	data.Registries.EmailProviders = email.ProviderNames()
 	data.Registries.UploadProviders = upload.ProviderNames()

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -154,6 +154,7 @@ func NewServer(ctx context.Context, cfg config.RuntimeConfig, opts ...ServerOpti
 	srv.Bus = bus
 	srv.EmailReg = o.EmailReg
 	srv.ImageSigner = imgSigner
+	srv.DBReg = o.DBReg
 
 	taskEventMW := middleware.NewTaskEventMiddleware(bus)
 	handler := middleware.NewMiddlewareChain(

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/dbdrivers"
 	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/internal/eventbus"
 	imagesign "github.com/arran4/goa4web/internal/images"
@@ -34,6 +35,7 @@ type Server struct {
 	Bus         *eventbus.Bus
 	EmailReg    *email.Registry
 	ImageSigner *imagesign.Signer
+	DBReg       *dbdrivers.Registry
 
 	WorkerCancel context.CancelFunc
 
@@ -169,7 +171,8 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 				common.WithEmailProvider(provider),
 				common.WithAbsoluteURLBase(base),
 				common.WithConfig(s.Config),
-				common.WithSessionManager(sm))
+				common.WithSessionManager(sm),
+				common.WithDBRegistry(s.DBReg))
 			cd.UserID = uid
 			_ = cd.UserRoles()
 

--- a/internal/dbdrivers/registry.go
+++ b/internal/dbdrivers/registry.go
@@ -99,25 +99,5 @@ func (r *Registry) Names() []string {
 	return names
 }
 
-// DefaultRegistry holds the package default drivers.
-var DefaultRegistry = NewRegistry()
-
-// RegisterDriver adds d to the DefaultRegistry.
-func RegisterDriver(d DBDriver) { DefaultRegistry.RegisterDriver(d) }
-
-// Connector uses DefaultRegistry to create a connector.
-func Connector(name, dsn string) (driver.Connector, error) {
-	return DefaultRegistry.Connector(name, dsn)
-}
-
-// Driver uses DefaultRegistry to find a driver.
-func Driver(name string) (DBDriver, error) { return DefaultRegistry.Driver(name) }
-
-// Backup uses DefaultRegistry to backup a database.
-func Backup(name, dsn, file string) error { return DefaultRegistry.Backup(name, dsn, file) }
-
-// Restore uses DefaultRegistry to restore a database.
-func Restore(name, dsn, file string) error { return DefaultRegistry.Restore(name, dsn, file) }
-
-// Names lists drivers in the DefaultRegistry.
-func Names() []string { return DefaultRegistry.Names() }
+// Deprecated global registry helpers removed. Create a Registry with
+// NewRegistry and pass it where needed instead of relying on global state.

--- a/specs/db_drivers.md
+++ b/specs/db_drivers.md
@@ -6,7 +6,7 @@ The `internal/dbdrivers` package defines a small registry for database connector
 - **PostgreSQL** – relies on `github.com/lib/pq` for connections. Backups and restores call `pg_dump` and `psql` respectively.
 - **SQLite** – uses `github.com/mattn/go-sqlite3` when built with the `sqlite` build tag. The command line `sqlite3` tool handles dumps and loads.
 
-`dbdefaults.Register()` registers all stable drivers so `dbdrivers.Connector()` can look them up by name.
+`dbdefaults.Register()` registers all stable drivers on a `dbdrivers.Registry`. Applications pass this registry to functions that need to open database connections.
 
 Example connection strings are shown in `config/templates/db_conn.txt`:
 

--- a/specs/dbdrivers.md
+++ b/specs/dbdrivers.md
@@ -21,15 +21,13 @@ type DBDriver interface {
 
 ## Registration
 
-Drivers must be registered before they can be used. The registry is a simple in-memory slice protected by a mutex. Drivers call `dbdrivers.RegisterDriver` from an init or setup function:
+Drivers must be registered before they can be used. The registry is a simple in-memory slice protected by a mutex. Each driver exposes a `Register` function that accepts a `*dbdrivers.Registry`:
 
 ```go
-func Register() { dbdrivers.RegisterDriver(Driver{}) }
+func Register(r *dbdrivers.Registry) { r.RegisterDriver(Driver{}) }
 ```
 
-The `dbdefaults` package registers all stable drivers by calling the `Register` function of each built-in driver. Application code can also register custom drivers.
-
-`dbdrivers.Connector`, `dbdrivers.Backup` and `dbdrivers.Restore` look up the requested driver in the registry.
+The `dbdefaults` package registers all stable drivers by calling the `Register` function of each built-in driver. Application code can also register custom drivers. Use a `dbdrivers.Registry` instance to access drivers via its `Connector`, `Backup` and `Restore` methods.
 
 ## Built-in drivers
 


### PR DESCRIPTION
## Summary
- access DB driver registry via CoreData instead of a global
- store driver registry on server and pass it through middleware
- update admin stats page to read driver names from CoreData

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68834fdcce70832f88f63a3cb37f9942