### PR TITLE
Remove global tasks registry

### DIFF
--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -42,7 +42,6 @@ var version = "dev"
 func registerTasks(reg *tasks.Registry) {
 	register := func(ts []tasks.NamedTask) {
 		for _, t := range ts {
-			tasks.Register(t)
 			reg.Register(t)
 		}
 	}

--- a/cmd/goa4web/serve.go
+++ b/cmd/goa4web/serve.go
@@ -61,6 +61,7 @@ func (c *serveCmd) Run() error {
 		app.WithDBRegistry(c.rootCmd.dbReg),
 		app.WithEmailRegistry(c.rootCmd.emailReg),
 		app.WithDLQRegistry(c.rootCmd.dlqReg),
+		app.WithTasksRegistry(c.rootCmd.tasksReg),
 		app.WithAPISecret(apiKey),
 	)
 	if err != nil {

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -72,6 +72,7 @@ type CoreData struct {
 	NotificationCount int32
 	Config            config.RuntimeConfig
 	ImageSigner       *imagesign.Signer
+	TasksReg          *tasks.Registry
 	a4codeMapper      func(tag, val string) string
 
 	session        *sessions.Session
@@ -189,6 +190,11 @@ func WithImageSigner(s *imagesign.Signer) CoreOption {
 			cd.a4codeMapper = s.MapURL
 		}
 	}
+}
+
+// WithTasksRegistry registers the task registry on CoreData.
+func WithTasksRegistry(r *tasks.Registry) CoreOption {
+	return func(cd *CoreData) { cd.TasksReg = r }
 }
 
 // NewCoreData creates a CoreData with context and queries applied.

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -25,10 +25,10 @@ type taskTemplateInfo struct {
 	AdminInternal string
 }
 
-func gatherTaskTemplateInfos() []taskTemplateInfo {
-	reg := tasks.Registered()
-	infos := make([]taskTemplateInfo, 0, len(reg))
-	for _, t := range reg {
+func gatherTaskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
+	tasksSlice := reg.Registered()
+	infos := make([]taskTemplateInfo, 0, len(tasksSlice))
+	for _, t := range tasksSlice {
 		info := taskTemplateInfo{Task: t.Name()}
 		if tp, ok := t.(notif.SelfNotificationTemplateProvider); ok {
 			if et := tp.SelfEmailTemplate(); et != nil {
@@ -89,7 +89,7 @@ func AdminEmailTemplatePage(w http.ResponseWriter, r *http.Request) {
 		data := struct {
 			*common.CoreData
 			Infos []taskTemplateInfo
-		}{cd, gatherTaskTemplateInfos()}
+		}{cd, gatherTaskTemplateInfos(cd.TasksReg)}
 		handlers.TemplateHandler(w, r, "emailTemplateListPage.gohtml", data)
 		return
 	}

--- a/handlers/admin/adminServerStatsPage.go
+++ b/handlers/admin/adminServerStatsPage.go
@@ -12,7 +12,6 @@ import (
 	"github.com/arran4/goa4web/internal/dbdrivers"
 	"github.com/arran4/goa4web/internal/dlq"
 	"github.com/arran4/goa4web/internal/email"
-	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/arran4/goa4web/internal/upload"
 )
 
@@ -44,8 +43,9 @@ func AdminServerStatsPage(w http.ResponseWriter, r *http.Request) {
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Stats: Stats{
 			Goroutines: runtime.NumGoroutine(),
 			Alloc:      mem.Alloc,
@@ -59,7 +59,7 @@ func AdminServerStatsPage(w http.ResponseWriter, r *http.Request) {
 		Config: config.AppRuntimeConfig,
 	}
 
-	for _, t := range tasks.Registered() {
+	for _, t := range cd.TasksReg.Registered() {
 		data.Registries.Tasks = append(data.Registries.Tasks, t.Name())
 	}
 	data.Registries.DBDrivers = dbdrivers.Names()

--- a/handlers/taskhandler.go
+++ b/handlers/taskhandler.go
@@ -13,9 +13,6 @@ import (
 // TaskHandler wraps t.Action to record the task on the request event and handle the
 // returned result
 func TaskHandler(t tasks.Task) func(http.ResponseWriter, *http.Request) {
-	if nt, ok := t.(tasks.NamedTask); ok {
-		tasks.Register(nt)
-	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		if v := r.Context().Value(consts.KeyCoreData).(*common.CoreData); v != nil {
 			v.SetEventTask(t)

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -24,6 +24,7 @@ import (
 	middleware "github.com/arran4/goa4web/internal/middleware"
 	csrfmw "github.com/arran4/goa4web/internal/middleware/csrf"
 	routerpkg "github.com/arran4/goa4web/internal/router"
+	"github.com/arran4/goa4web/internal/tasks"
 	websocket "github.com/arran4/goa4web/internal/websocket"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
@@ -51,6 +52,7 @@ type serverOptions struct {
 	DBReg           *dbdrivers.Registry
 	EmailReg        *email.Registry
 	DLQReg          *dlq.Registry
+	TasksReg        *tasks.Registry
 	Bus             *eventbus.Bus
 	Store           *sessions.CookieStore
 	DB              *sql.DB
@@ -84,6 +86,11 @@ func WithEmailRegistry(r *email.Registry) ServerOption {
 // WithDLQRegistry sets the dead letter queue provider registry.
 func WithDLQRegistry(r *dlq.Registry) ServerOption {
 	return func(o *serverOptions) { o.DLQReg = r }
+}
+
+// WithTasksRegistry sets the task registry.
+func WithTasksRegistry(r *tasks.Registry) ServerOption {
+	return func(o *serverOptions) { o.TasksReg = r }
 }
 
 // WithBus uses the provided event bus instead of creating a new one.
@@ -173,6 +180,7 @@ func NewServer(ctx context.Context, cfg config.RuntimeConfig, opts ...ServerOpti
 	adminhandlers.Srv = srv
 	adminhandlers.DBPool = dbPool
 	adminhandlers.UpdateConfigKeyFunc = config.UpdateConfigKey
+	srv.TasksReg = o.TasksReg
 
 	emailProvider := o.EmailReg.ProviderFromConfig(cfg)
 	if cfg.EmailEnabled && cfg.EmailProvider != "" && cfg.EmailFrom == "" {

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -23,6 +23,7 @@ import (
 	imagesign "github.com/arran4/goa4web/internal/images"
 	"github.com/arran4/goa4web/internal/middleware"
 	nav "github.com/arran4/goa4web/internal/navigation"
+	"github.com/arran4/goa4web/internal/tasks"
 )
 
 // Server bundles the application's configuration, router and runtime dependencies.
@@ -34,6 +35,7 @@ type Server struct {
 	Bus         *eventbus.Bus
 	EmailReg    *email.Registry
 	ImageSigner *imagesign.Signer
+	TasksReg    *tasks.Registry
 
 	WorkerCancel context.CancelFunc
 
@@ -169,7 +171,8 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 				common.WithEmailProvider(provider),
 				common.WithAbsoluteURLBase(base),
 				common.WithConfig(s.Config),
-				common.WithSessionManager(sm))
+				common.WithSessionManager(sm),
+				common.WithTasksRegistry(s.TasksReg))
 			cd.UserID = uid
 			_ = cd.UserRoles()
 

--- a/internal/tasks/registry.go
+++ b/internal/tasks/registry.go
@@ -16,14 +16,6 @@ type Registry struct {
 // NewRegistry returns an empty Registry.
 func NewRegistry() *Registry { return &Registry{} }
 
-// Register adds t to the DefaultRegistry. Duplicate names are ignored.
-func Register(t NamedTask) { DefaultRegistry.Register(t) }
-
-// Registered returns a copy of the registered tasks slice.
-func Registered() []NamedTask {
-	return DefaultRegistry.Registered()
-}
-
 // Register adds t to the Registry. Duplicate names are ignored.
 func (r *Registry) Register(t NamedTask) {
 	r.mu.Lock()
@@ -43,6 +35,3 @@ func (r *Registry) Registered() []NamedTask {
 	r.mu.Unlock()
 	return tasks
 }
-
-// DefaultRegistry holds the package default tasks.
-var DefaultRegistry = NewRegistry()


### PR DESCRIPTION
## Summary
- plumb the tasks registry into `CoreData` and `Server`
- update admin handlers to read the registry from `CoreData`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688350098f7c832f9c32e62822b6ab82