### PR TITLE
Use short hash for config example PRs

### DIFF
--- a/.github/workflows/config-examples-update.yml
+++ b/.github/workflows/config-examples-update.yml
@@ -25,6 +25,9 @@ jobs:
         run: |
           if [[ -n $(git status --porcelain examples/config.env examples/config.json) ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            # Use a short hash to keep branch names concise
+            hash=$(sha1sum examples/config.env examples/config.json | sha1sum | cut -d" " -f1 | cut -c1-8)
+            echo "branch_suffix=$hash" >> "$GITHUB_ENV"
           fi
       - name: Create Pull Request
         if: steps.diff.outputs.changed == 'true'
@@ -32,7 +35,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore(config): update generated examples'
-          branch: config-examples-${{ github.run_id }}
+          branch: config-examples-${{ env.branch_suffix }}
           base: ${{ github.ref_name }}
           title: 'Update generated config examples'
           body: |


### PR DESCRIPTION
## Summary
- update `config-examples-update` workflow to shorten branch hash

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: undefined `navigation`)*
- `golangci-lint run ./...` *(fails: undefined `navigation`)*
- `go test ./...` *(fails to build)*

------
https://chatgpt.com/codex/tasks/task_e_6883542a76a0832faedea4109a770249