### PR TITLE
Use server options for runtime dependencies

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -176,14 +176,13 @@ func NewServer(ctx context.Context, cfg config.RuntimeConfig, opts ...ServerOpti
 		server.WithRouterRegistry(reg),
 		server.WithNavRegistry(navReg),
 		server.WithDLQRegistry(o.DLQReg),
+		server.WithBus(bus),
+		server.WithEmailRegistry(o.EmailReg),
+		server.WithImageSigner(imgSigner),
+		server.WithDBRegistry(o.DBReg),
+		server.WithWebsocket(wsMod),
 	)
-	nav.SetDefaultRegistry(navReg) // TODO make it work like the others.
-  // TODO the following should be New.WIth* arguments above - merge conflict issue perhaps resolve.
-	srv.Bus = bus
-	srv.EmailReg = o.EmailReg
-	srv.ImageSigner = imgSigner
-	srv.DBReg = o.DBReg
-	srv.Websocket = wsMod
+	nav.SetDefaultRegistry(navReg)
 
 	taskEventMW := middleware.NewTaskEventMiddleware(bus)
 	handler := middleware.NewMiddlewareChain(

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -25,8 +25,8 @@ import (
 	imagesign "github.com/arran4/goa4web/internal/images"
 	"github.com/arran4/goa4web/internal/middleware"
 	nav "github.com/arran4/goa4web/internal/navigation"
-	"github.com/arran4/goa4web/internal/tasks"
 	router "github.com/arran4/goa4web/internal/router"
+	"github.com/arran4/goa4web/internal/tasks"
 	websocket "github.com/arran4/goa4web/internal/websocket"
 )
 
@@ -126,6 +126,23 @@ func WithNavRegistry(n *nav.Registry) Option { return func(s *Server) { s.Nav = 
 // WithDLQRegistry sets the dead letter queue registry.
 func WithDLQRegistry(r *dlq.Registry) Option { return func(s *Server) { s.DLQReg = r } }
 
+// WithBus sets the event bus used by the server.
+func WithBus(b *eventbus.Bus) Option { return func(s *Server) { s.Bus = b } }
+
+// WithEmailRegistry sets the email provider registry.
+func WithEmailRegistry(r *email.Registry) Option { return func(s *Server) { s.EmailReg = r } }
+
+// WithImageSigner sets the image signer.
+func WithImageSigner(signer *imagesign.Signer) Option {
+	return func(s *Server) { s.ImageSigner = signer }
+}
+
+// WithDBRegistry sets the database driver registry.
+func WithDBRegistry(r *dbdrivers.Registry) Option { return func(s *Server) { s.DBReg = r } }
+
+// WithWebsocket sets the websocket module.
+func WithWebsocket(w *websocket.Module) Option { return func(s *Server) { s.Websocket = w } }
+
 // New returns a Server configured using the supplied options.
 func New(opts ...Option) *Server {
 	s := &Server{}
@@ -206,7 +223,7 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 				common.WithSessionManager(sm),
 				common.WithTasksRegistry(s.TasksReg),
 				common.WithDBRegistry(s.DBReg),
-      )
+			)
 			cd.UserID = uid
 			_ = cd.UserRoles()
 


### PR DESCRIPTION
## Summary
- extend server.New option API with Bus, EmailRegistry, ImageSigner, DBRegistry and Websocket setters
- construct the server with these options in `internal/app/run.go`
- remove outdated TODO comments

## Testing
- `go mod tidy`
- `go vet ./...` *(fails: build issues in websocket and dlqdefaults)*
- `golangci-lint run ./...` *(fails: typecheck errors in websocket and dlqdefaults)*
- `go test ./...` *(fails: build errors in websocket and dlqdefaults)*

------
https://chatgpt.com/codex/tasks/task_e_6884445a5e20832f913f44adcbec2e72