### PR TITLE
Fix duplicate email registration

### DIFF
--- a/internal/dlq/dlqdefaults/defaults.go
+++ b/internal/dlq/dlqdefaults/defaults.go
@@ -11,11 +11,10 @@ import (
 
 // Register registers all stable DLQ providers.
 func Register(r *dlqpkg.Registry, er *emailpkg.Registry) {
-  // TODO refactor this out it's incorrectly being used 
+	// TODO refactor this out it's incorrectly being used
 	file.Register(r)
 	dir.Register(r)
 	db.Register(r)
 	email.Register(r, er)
-	email.Register(r)
 	dlqpkg.RegisterLogDLQ(r)
 }


### PR DESCRIPTION
## Summary
- remove duplicate `email.Register(r)` call from DLQ defaults

## Testing
- `go vet ./...` *(fails: cannot use m.registerRoutes as func(*mux.Router))*
- `golangci-lint run ./...` *(fails: typecheck issues in internal/websocket)*
- `go test ./...` *(fails to build some packages)*

------
https://chatgpt.com/codex/tasks/task_e_68844440367c832fa12205522c5b9951