### PR TITLE
Validate emails via mail.ParseAddress

### DIFF
--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -7,6 +7,7 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
+	"net/mail"
 	"strings"
 
 	"github.com/arran4/goa4web/internal/db"
@@ -45,7 +46,7 @@ func (RegisterTask) Action(w http.ResponseWriter, r *http.Request) any {
 	username := r.PostFormValue("username")
 	password := r.PostFormValue("password")
 	email := r.PostFormValue("email")
-	if !strings.Contains(email, "@") {
+	if _, err := mail.ParseAddress(email); err != nil {
 		return handlers.ErrRedirectOnSamePageHandler(errors.New("invalid email"))
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()

--- a/handlers/auth/registerPage_test.go
+++ b/handlers/auth/registerPage_test.go
@@ -20,7 +20,7 @@ func TestRegisterActionPageValidation(t *testing.T) {
 		{"no username", url.Values{"password": {"p"}, "email": {"e@example.com"}}},
 		{"no password", url.Values{"username": {"u"}, "email": {"e@example.com"}}},
 		{"no email", url.Values{"username": {"u"}, "password": {"p"}}},
-		{"invalid email", url.Values{"username": {"u"}, "password": {"p"}, "email": {"bad"}}},
+		{"invalid email", url.Values{"username": {"u"}, "password": {"p"}, "email": {"foo@bar..com"}}},
 	}
 	for _, c := range cases {
 		req := httptest.NewRequest("POST", "/register", strings.NewReader(c.form.Encode()))

--- a/handlers/user/addEmailTask.go
+++ b/handlers/user/addEmailTask.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/mail"
 	"strconv"
 	"strings"
 	"time"
@@ -42,6 +43,9 @@ func (AddEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
 	emailAddr := r.FormValue("new_email")
 	if emailAddr == "" {
 		return handlers.RefreshDirectHandler{TargetURL: "/usr/email"}
+	}
+	if _, err := mail.ParseAddress(emailAddr); err != nil {
+		return handlers.RefreshDirectHandler{TargetURL: "/usr/email?error=invalid+email"}
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	if ue, err := queries.GetUserEmailByEmail(r.Context(), emailAddr); err == nil && ue.VerifiedAt.Valid {

--- a/handlers/user/addEmailTask_invalid_test.go
+++ b/handlers/user/addEmailTask_invalid_test.go
@@ -1,0 +1,62 @@
+package user
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+)
+
+func TestAddEmailTaskInvalid(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := dbpkg.New(db)
+
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test"
+	sess, _ := store.Get(httptest.NewRequest(http.MethodGet, "http://example.com", nil), core.SessionName)
+	sess.Values["UID"] = int32(1)
+	w := httptest.NewRecorder()
+	_ = sess.Save(httptest.NewRequest(http.MethodGet, "http://example.com", nil), w)
+
+	evt := &eventbus.TaskEvent{Data: map[string]any{}}
+	ctx := context.Background()
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), common.WithConfig(config.AppRuntimeConfig))
+	cd.UserID = 1
+	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+
+	form := url.Values{"new_email": {"foo@bar..com"}}
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/usr/email", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	handlers.TaskHandler(addEmailTask)(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	if evt.Data != nil && len(evt.Data) != 0 {
+		t.Fatalf("unexpected event data: %+v", evt.Data)
+	}
+	if cd.AutoRefresh == "" || !strings.Contains(cd.AutoRefresh, "invalid+email") {
+		t.Fatalf("auto refresh=%q", cd.AutoRefresh)
+	}
+}


### PR DESCRIPTION
## Summary
- validate registration emails using `net/mail`
- validate AddEmailTask emails
- test invalid emails in registration and AddEmailTask

## Testing
- `go vet ./...` *(fails: not enough arguments in call to email.Register)*
- `golangci-lint run ./...` *(fails: could not import github.com/arran4/goa4web/internal/dlq/dlqdefaults)*
- `go test ./...` *(fails: not enough arguments in call to email.Register)*

------
https://chatgpt.com/codex/tasks/task_e_68844509ae7c832f9a13b74cbe6653cc