### PR TITLE
Add session SameSite configuration

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -83,6 +83,8 @@ const (
 	EnvSessionSecret = "SESSION_SECRET"
 	// EnvSessionSecretFile specifies the file containing the session secret.
 	EnvSessionSecretFile = "SESSION_SECRET_FILE"
+	// EnvSessionSameSite sets the cookie SameSite policy for session data.
+	EnvSessionSameSite = "SESSION_SAME_SITE"
 
 	// EnvDocker indicates the application is running inside a Docker container.
 	EnvDocker = "GOA4WEB_DOCKER"

--- a/config/options_runtime.go
+++ b/config/options_runtime.go
@@ -67,6 +67,7 @@ var StringOptions = []StringOption{
 	{"admin-emails", EnvAdminEmails, "administrator email addresses", "", nil, "", func(c *RuntimeConfig) *string { return &c.AdminEmails }},
 	{"session-secret", EnvSessionSecret, "session secret key", "", nil, "", func(c *RuntimeConfig) *string { return &c.SessionSecret }},
 	{"session-secret-file", EnvSessionSecretFile, "path to session secret file", "", nil, "", func(c *RuntimeConfig) *string { return &c.SessionSecretFile }},
+	{"session-same-site", EnvSessionSameSite, "session cookie SameSite policy", "strict", nil, "", func(c *RuntimeConfig) *string { return &c.SessionSameSite }},
 	{"image-sign-secret", EnvImageSignSecret, "image signing key", "", nil, "", func(c *RuntimeConfig) *string { return &c.ImageSignSecret }},
 	{"image-sign-secret-file", EnvImageSignSecretFile, "path to image signing key", "", nil, "", func(c *RuntimeConfig) *string { return &c.ImageSignSecretFile }},
 	{"admin-api-secret", EnvAdminAPISecret, "admin API signing key", "", nil, "", func(c *RuntimeConfig) *string { return &c.AdminAPISecret }},

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -93,6 +93,8 @@ type RuntimeConfig struct {
 	SessionSecret string
 	// SessionSecretFile specifies the path to the session secret file.
 	SessionSecretFile string
+	// SessionSameSite selects the cookie SameSite mode used for sessions.
+	SessionSameSite string
 	// ImageSignSecret is used to sign image URLs.
 	ImageSignSecret string
 	// ImageSignSecretFile specifies the path to the image signing key.
@@ -261,6 +263,9 @@ func normalizeRuntimeConfig(cfg *RuntimeConfig) {
 	}
 	if cfg.SessionName == "" {
 		cfg.SessionName = "my-session"
+	}
+	if cfg.SessionSameSite == "" {
+		cfg.SessionSameSite = "strict"
 	}
 	if cfg.PageSizeMin == 0 {
 		cfg.PageSizeMin = 5

--- a/examples/config.env
+++ b/examples/config.env
@@ -102,6 +102,8 @@ SESSION_NAME=my-session
 SESSION_SECRET=
 # path to session secret file (default: .session_secret)
 SESSION_SECRET_FILE=.session_secret
+# session cookie SameSite policy (default: strict)
+SESSION_SAME_SITE=strict
 # SMTP auth method (default: plain)
 SMTP_AUTH=plain
 # SMTP host (default: )

--- a/examples/config.json
+++ b/examples/config.json
@@ -51,6 +51,7 @@
   "SESSION_NAME": "my-session",
   "SESSION_SECRET": "",
   "SESSION_SECRET_FILE": ".session_secret",
+  "SESSION_SAME_SITE": "strict",
   "SMTP_AUTH": "plain",
   "SMTP_HOST": "",
   "SMTP_PASS": "",

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/arran4/goa4web/internal/app/server"
@@ -129,7 +130,16 @@ func NewServer(ctx context.Context, cfg config.RuntimeConfig, opts ...ServerOpti
 	}
 	core.Store = store
 	core.SessionName = cfg.SessionName
-	store.Options = &sessions.Options{Path: "/", HttpOnly: true, Secure: true, SameSite: http.SameSiteLaxMode}
+	sameSite := http.SameSiteStrictMode
+	switch strings.ToLower(cfg.SessionSameSite) {
+	case "lax":
+		sameSite = http.SameSiteLaxMode
+	case "none":
+		sameSite = http.SameSiteNoneMode
+	case "strict":
+		sameSite = http.SameSiteStrictMode
+	}
+	store.Options = &sessions.Options{Path: "/", HttpOnly: true, Secure: true, SameSite: sameSite}
 
 	dbPool := o.DB
 	if dbPool == nil {
@@ -178,7 +188,7 @@ func NewServer(ctx context.Context, cfg config.RuntimeConfig, opts ...ServerOpti
 		server.WithDLQRegistry(o.DLQReg),
 	)
 	nav.SetDefaultRegistry(navReg) // TODO make it work like the others.
-  // TODO the following should be New.WIth* arguments above - merge conflict issue perhaps resolve.
+	// TODO the following should be New.WIth* arguments above - merge conflict issue perhaps resolve.
 	srv.Bus = bus
 	srv.EmailReg = o.EmailReg
 	srv.ImageSigner = imgSigner

--- a/readme.md
+++ b/readme.md
@@ -259,6 +259,7 @@ environment variables listed below.
 | `HOSTNAME` | `--hostname` | No | `http://localhost:8080` | Base URL advertised by the HTTP server. |
 | `SESSION_SECRET` | `--session-secret` | No | generated | Secret used to encrypt session cookies. |
 | `SESSION_SECRET_FILE` | `--session-secret-file` | No | auto | File containing the session secret. |
+| `SESSION_SAME_SITE` | `--session-same-site` | No | `strict` | Cookie SameSite policy for sessions. |
 | `GOA4WEB_DOCKER` | n/a | No | - | Set when running inside Docker to adjust defaults. |
 | `SENDGRID_KEY` | `--sendgrid-key` | No | - | API key for the SendGrid email provider. |
 | `EMAIL_WORKER_INTERVAL` | `--email-worker-interval` | No | `60` | Minimum seconds between queued email sends. |


### PR DESCRIPTION
## Summary
- make session SameSite cookie policy configurable via `SESSION_SAME_SITE`
- default to `strict` in runtime config
- handle the setting in server startup
- document and provide example values

## Testing
- `go vet ./...` *(fails: not enough arguments in call to email.Register; cannot use m.registerRoutes in RegisterModule)*
- `golangci-lint run ./...`
- `go test ./...` *(fails: build errors and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688444d57be4832f8806f1a3a1a289ee