### PR TITLE
Fix local upload path escaping

### DIFF
--- a/internal/upload/local/local.go
+++ b/internal/upload/local/local.go
@@ -52,7 +52,11 @@ func (p Provider) safePath(name string) (string, error) {
 	if !fs.ValidPath(name) || filepath.IsAbs(name) {
 		return "", fmt.Errorf("invalid path")
 	}
-	return filepath.Join(p.Dir, filepath.Clean(name)), nil
+	path := filepath.Join(p.Dir, filepath.Clean(name))
+	if rel, err := filepath.Rel(p.Dir, path); err != nil || strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("invalid path")
+	}
+	return path, nil
 }
 
 func providerFromConfig(cfg config.RuntimeConfig) upload.Provider {

--- a/internal/upload/local/local_test.go
+++ b/internal/upload/local/local_test.go
@@ -132,6 +132,14 @@ func TestWriteRejectsAbs(t *testing.T) {
 	}
 }
 
+func TestWriteRejectsCleanEscape(t *testing.T) {
+	mfs := newMemFS()
+	p := Provider{Dir: "/cache", FS: mfs}
+	if err := p.Write(context.Background(), "..\\evil", []byte("x")); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
 func TestReadRejectsTraversal(t *testing.T) {
 	mfs := newMemFS()
 	_ = mfs.WriteFile("/cache/good", []byte("data"), 0o644)
@@ -146,6 +154,15 @@ func TestReadRejectsAbs(t *testing.T) {
 	_ = mfs.WriteFile("/cache/good", []byte("data"), 0o644)
 	p := Provider{Dir: "/cache", FS: mfs}
 	if _, err := p.Read(context.Background(), "/abs"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestReadRejectsCleanEscape(t *testing.T) {
+	mfs := newMemFS()
+	_ = mfs.WriteFile("/cache/good", []byte("data"), 0o644)
+	p := Provider{Dir: "/cache", FS: mfs}
+	if _, err := p.Read(context.Background(), "..\\good"); err == nil {
 		t.Fatalf("expected error")
 	}
 }


### PR DESCRIPTION
## Summary
- guard against filesystem escapes in local upload provider
- check for traversal after `filepath.Clean`
- add tests for malicious backslash paths

## Testing
- `go vet ./...` *(fails: cannot use m.registerRoutes)*
- `golangci-lint run ./...` *(fails: typecheck issues)*
- `go mod tidy`
- `go test ./...` *(fails: build failed for various packages)*

------
https://chatgpt.com/codex/tasks/task_e_688444cbb240832f98d5e591ef8b1487