### PR TITLE
Hash and verify reset codes

### DIFF
--- a/handlers/auth/forgot_password_task.go
+++ b/handlers/auth/forgot_password_task.go
@@ -82,7 +82,8 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("rand %w", err)
 	}
 	code := hex.EncodeToString(buf[:])
-	if err := queries.CreatePasswordReset(r.Context(), db.CreatePasswordResetParams{UserID: row.Idusers, Passwd: hash, PasswdAlgorithm: alg, VerificationCode: code}); err != nil {
+	hashed := HashResetCode(code)
+	if err := queries.CreatePasswordReset(r.Context(), db.CreatePasswordResetParams{UserID: row.Idusers, Passwd: hash, PasswdAlgorithm: alg, VerificationCode: hashed}); err != nil {
 		log.Printf("create reset: %v", err)
 		return fmt.Errorf("create reset %w", err)
 	}

--- a/handlers/auth/login_task.go
+++ b/handlers/auth/login_task.go
@@ -75,7 +75,7 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 		reset, err := queries.GetPasswordResetByUser(r.Context(), db.GetPasswordResetByUserParams{UserID: row.Idusers, CreatedAt: expiry})
 		code := r.FormValue("code")
 		if err == nil && VerifyPassword(password, reset.Passwd, reset.PasswdAlgorithm) {
-			if code != "" && code == reset.VerificationCode {
+			if code != "" && HashResetCode(code) == reset.VerificationCode {
 				_ = queries.MarkPasswordResetVerified(r.Context(), reset.ID)
 				_ = queries.InsertPassword(r.Context(), db.InsertPasswordParams{UsersIdusers: reset.UserID, Passwd: reset.Passwd, PasswdAlgorithm: sql.NullString{String: reset.PasswdAlgorithm, Valid: true}})
 			} else {

--- a/handlers/auth/password.go
+++ b/handlers/auth/password.go
@@ -55,3 +55,11 @@ func VerifyPassword(pw, storedHash, alg string) bool {
 		return false
 	}
 }
+
+// HashResetCode returns the SHA-256 hash of a password reset code in
+// hexadecimal form. The hash is used when storing and comparing reset
+// verification codes in the database.
+func HashResetCode(code string) string {
+	sum := sha256.Sum256([]byte(code))
+	return hex.EncodeToString(sum[:])
+}

--- a/handlers/auth/verify_password_task.go
+++ b/handlers/auth/verify_password_task.go
@@ -40,9 +40,10 @@ func (VerifyPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	id := int32(id64)
 	code := r.FormValue("code")
+	hashed := HashResetCode(code)
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	expiry := time.Now().Add(-time.Duration(config.AppRuntimeConfig.PasswordResetExpiryHours) * time.Hour)
-	reset, err := queries.GetPasswordResetByCode(r.Context(), db.GetPasswordResetByCodeParams{VerificationCode: code, CreatedAt: expiry})
+	reset, err := queries.GetPasswordResetByCode(r.Context(), db.GetPasswordResetByCodeParams{VerificationCode: hashed, CreatedAt: expiry})
 	if err != nil || reset.ID != id {
 		return handlers.ErrRedirectOnSamePageHandler(errors.New("invalid code"))
 	}

--- a/handlers/auth/verify_password_task_test.go
+++ b/handlers/auth/verify_password_task_test.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+func TestVerifyPasswordUsesHashedCode(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := dbpkg.New(db)
+
+	hashed := HashResetCode("abc")
+	now := time.Now()
+
+	rows := sqlmock.NewRows([]string{"id", "user_id", "passwd", "passwd_algorithm", "verification_code", "created_at", "verified_at"}).
+		AddRow(1, 2, "hash", "alg", hashed, now, nil)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, passwd")).
+		WithArgs(hashed, sqlmock.AnyArg()).
+		WillReturnRows(rows)
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE pending_passwords SET verified_at = NOW() WHERE id = ?")).
+		WithArgs(int32(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO passwords")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.AppRuntimeConfig))
+	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
+
+	form := url.Values{"id": {"1"}, "code": {"abc"}}
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handlers.TaskHandler(verifyPasswordTask)(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- hash password reset codes before saving them
- look up resets using hashed codes
- test new hashing behaviour

## Testing
- `go vet ./...` *(fails: not enough arguments in call to email.Register)*
- `golangci-lint run ./...` *(fails: could not import github.com/arran4/goa4web/internal/websocket)*
- `go test ./...` *(fails: build errors in cmd/goa4web and internal packages)*

------
https://chatgpt.com/codex/tasks/task_e_688444a71518832fae7640a632008849