### PR TITLE
Allow router modules to access config

### DIFF
--- a/handlers/admin/reload_shutdown_test.go
+++ b/handlers/admin/reload_shutdown_test.go
@@ -31,7 +31,7 @@ func TestAdminReloadConfigPage_Unauthorized(t *testing.T) {
 func TestAdminReloadRoute_Unauthorized(t *testing.T) {
 	r := mux.NewRouter()
 	ar := r.PathPrefix("/admin").Subrouter()
-	RegisterRoutes(ar)
+	RegisterRoutes(ar, config.AppRuntimeConfig)
 
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
 	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
@@ -50,7 +50,7 @@ func TestAdminReloadRoute_Unauthorized(t *testing.T) {
 func TestAdminShutdownRoute_Unauthorized(t *testing.T) {
 	r := mux.NewRouter()
 	ar := r.PathPrefix("/admin").Subrouter()
-	RegisterRoutes(ar)
+	RegisterRoutes(ar, config.AppRuntimeConfig)
 
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
 	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -4,6 +4,8 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/config"
+
 	blogs "github.com/arran4/goa4web/handlers/blogs"
 	faq "github.com/arran4/goa4web/handlers/faq"
 	forum "github.com/arran4/goa4web/handlers/forum"
@@ -20,7 +22,7 @@ import (
 
 // RegisterRoutes attaches the admin endpoints to ar. The router is expected to
 // already have any required authentication middleware applied.
-func RegisterRoutes(ar *mux.Router) {
+func RegisterRoutes(ar *mux.Router, _ config.RuntimeConfig) {
 	nav.RegisterAdminControlCenter("Categories", "/admin/categories", 20)
 	nav.RegisterAdminControlCenter("Notifications", "/admin/notifications", 90)
 	nav.RegisterAdminControlCenter("Queued Emails", "/admin/email/queue", 110)
@@ -115,10 +117,10 @@ func RegisterRoutes(ar *mux.Router) {
 
 // Register registers the admin router module.
 func Register(reg *router.Registry) {
-	reg.RegisterModule("admin", []string{"faq", "forum", "imagebbs", "languages", "linker", "news", "search", "user", "writings", "blogs"}, func(r *mux.Router) {
+	reg.RegisterModule("admin", []string{"faq", "forum", "imagebbs", "languages", "linker", "news", "search", "user", "writings", "blogs"}, func(r *mux.Router, cfg config.RuntimeConfig) {
 		ar := r.PathPrefix("/admin").Subrouter()
 		ar.Use(router.AdminCheckerMiddleware)
 		ar.Use(handlers.IndexMiddleware(CustomIndex))
-		RegisterRoutes(ar)
+		RegisterRoutes(ar, cfg)
 	})
 }

--- a/handlers/auth/routes.go
+++ b/handlers/auth/routes.go
@@ -5,11 +5,12 @@ import (
 	. "github.com/arran4/gorillamuxlogic"
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/config"
 	router "github.com/arran4/goa4web/internal/router"
 )
 
 // RegisterRoutes attaches the login and registration endpoints to r.
-func RegisterRoutes(r *mux.Router) {
+func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
 	rr := r.PathPrefix("/register").Subrouter()
 	rr.Use(handlers.IndexMiddleware(CustomIndex))
 	rr.HandleFunc("", registerTask.Page).Methods("GET").MatcherFunc(Not(handlers.RequiresAnAccount()))

--- a/handlers/blogs/routes.go
+++ b/handlers/blogs/routes.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
 	router "github.com/arran4/goa4web/internal/router"
 
@@ -12,7 +13,7 @@ import (
 )
 
 // RegisterRoutes attaches the public blog endpoints to r.
-func RegisterRoutes(r *mux.Router) {
+func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
 	nav.RegisterIndexLink("Blogs", "/blogs", SectionWeight)
 	nav.RegisterAdminControlCenter("Blogs", "/admin/blogs/user/permissions", SectionWeight)
 	br := r.PathPrefix("/blogs").Subrouter()

--- a/handlers/bookmarks/routes.go
+++ b/handlers/bookmarks/routes.go
@@ -3,6 +3,7 @@ package bookmarks
 import (
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/router"
 
@@ -10,7 +11,7 @@ import (
 )
 
 // RegisterRoutes attaches the bookmarks endpoints to r.
-func RegisterRoutes(r *mux.Router) {
+func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
 	nav.RegisterIndexLink("Bookmarks", "/bookmarks", SectionWeight)
 	br := r.PathPrefix("/bookmarks").Subrouter()
 	br.Use(handlers.IndexMiddleware(bookmarksCustomIndex))

--- a/handlers/faq/routes.go
+++ b/handlers/faq/routes.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
 	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
@@ -16,7 +17,7 @@ func noTask() mux.MatcherFunc {
 }
 
 // RegisterRoutes attaches the public FAQ endpoints to the router.
-func RegisterRoutes(r *mux.Router) {
+func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
 	nav.RegisterIndexLink("FAQ", "/faq", SectionWeight)
 	nav.RegisterAdminControlCenter("FAQ", "/admin/faq/categories", SectionWeight)
 	faqr := r.PathPrefix("/faq").Subrouter()

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
 	router "github.com/arran4/goa4web/internal/router"
 
@@ -12,7 +13,7 @@ import (
 )
 
 // RegisterRoutes attaches the public forum endpoints to r.
-func RegisterRoutes(r *mux.Router) {
+func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
 	nav.RegisterIndexLink("Forum", "/forum", SectionWeight)
 	nav.RegisterAdminControlCenter("Forum", "/admin/forum", SectionWeight)
 	fr := r.PathPrefix("/forum").Subrouter()

--- a/handlers/imagebbs/routes.go
+++ b/handlers/imagebbs/routes.go
@@ -13,7 +13,7 @@ import (
 )
 
 // RegisterRoutes attaches the public image board endpoints to r.
-func RegisterRoutes(r *mux.Router) {
+func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
 	nav.RegisterIndexLink("ImageBBS", "/imagebbs", SectionWeight)
 	nav.RegisterAdminControlCenter("ImageBBS", "/admin/imagebbs", SectionWeight)
 	r.HandleFunc("/imagebbs.rss", RssPage).Methods("GET")

--- a/handlers/images/routes.go
+++ b/handlers/images/routes.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -37,7 +38,7 @@ func verifyMiddleware(prefix string) mux.MiddlewareFunc {
 }
 
 // RegisterRoutes attaches the image endpoints to r.
-func RegisterRoutes(r *mux.Router) {
+func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
 	ir := r.PathPrefix("/images").Subrouter()
 	ir.Use(handlers.IndexMiddleware(CustomIndex))
 	ir.HandleFunc("/upload/image", handlers.TaskHandler(uploadImageTask)).

--- a/handlers/languages/routes.go
+++ b/handlers/languages/routes.go
@@ -4,6 +4,7 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/config"
 	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
 )
@@ -20,7 +21,7 @@ func RegisterAdminRoutes(ar *mux.Router) {
 
 // Register registers the languages router module.
 func Register(reg *router.Registry) {
-	reg.RegisterModule("languages", nil, func(r *mux.Router) {
+	reg.RegisterModule("languages", nil, func(r *mux.Router, cfg config.RuntimeConfig) {
 		ar := r.PathPrefix("/admin").Subrouter()
 		ar.Use(router.AdminCheckerMiddleware)
 		RegisterAdminRoutes(ar)

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/config"
 	nav "github.com/arran4/goa4web/internal/navigation"
 	"github.com/arran4/goa4web/internal/router"
 )
@@ -14,7 +15,7 @@ import (
 var legacyRedirectsEnabled = true
 
 // RegisterRoutes attaches the public linker endpoints to r.
-func RegisterRoutes(r *mux.Router) {
+func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
 	nav.RegisterIndexLink("Linker", "/linker", SectionWeight)
 	nav.RegisterAdminControlCenter("Linker", "/admin/linker/categories", SectionWeight)
 	lr := r.PathPrefix("/linker").Subrouter()

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/router"
@@ -37,7 +38,7 @@ func runTemplate(name string) http.HandlerFunc {
 }
 
 // RegisterRoutes attaches the public news endpoints to r.
-func RegisterRoutes(r *mux.Router) {
+func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
 	nav.RegisterIndexLink("News", "/", SectionWeight)
 	nav.RegisterAdminControlCenter("News", "/admin/news/users/roles", SectionWeight)
 	r.Use(handlers.IndexMiddleware(CustomNewsIndex))

--- a/handlers/search/routes.go
+++ b/handlers/search/routes.go
@@ -4,12 +4,13 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/config"
 	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
 )
 
 // RegisterRoutes attaches the search endpoints to r.
-func RegisterRoutes(r *mux.Router) {
+func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
 	nav.RegisterIndexLink("Search", "/search", SectionWeight)
 	nav.RegisterAdminControlCenter("Search", "/admin/search", SectionWeight)
 	sr := r.PathPrefix("/search").Subrouter()

--- a/handlers/user/routes.go
+++ b/handlers/user/routes.go
@@ -4,12 +4,13 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
 	router "github.com/arran4/goa4web/internal/router"
 )
 
 // RegisterRoutes attaches user account endpoints to the router.
-func RegisterRoutes(r *mux.Router) {
+func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
 	ur := r.PathPrefix("/usr").Subrouter()
 	ur.Use(handlers.IndexMiddleware(CustomIndex))
 	ur.HandleFunc("", userPage).Methods(http.MethodGet)

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gorilla/mux"
 	"net/http"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
 	router "github.com/arran4/goa4web/internal/router"
 
@@ -14,7 +15,7 @@ import (
 var legacyRedirectsEnabled = true
 
 // RegisterRoutes attaches the public writings endpoints to r.
-func RegisterRoutes(r *mux.Router) {
+func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
 	nav.RegisterIndexLink("Writings", "/writings", SectionWeight)
 	nav.RegisterAdminControlCenter("Writings", "/admin/writings/categories", SectionWeight)
 	wr := r.PathPrefix("/writings").Subrouter()

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -166,7 +166,7 @@ func NewServer(ctx context.Context, cfg config.RuntimeConfig, opts ...ServerOpti
 	wsMod := websocket.NewModule(bus)
 	wsMod.Register(reg)
 	r := mux.NewRouter()
-	routerpkg.RegisterRoutes(r, reg)
+	routerpkg.RegisterRoutes(r, reg, cfg)
 
 	navReg := nav.NewRegistry()
 	srv := server.New(
@@ -178,7 +178,7 @@ func NewServer(ctx context.Context, cfg config.RuntimeConfig, opts ...ServerOpti
 		server.WithDLQRegistry(o.DLQReg),
 	)
 	nav.SetDefaultRegistry(navReg) // TODO make it work like the others.
-  // TODO the following should be New.WIth* arguments above - merge conflict issue perhaps resolve.
+	// TODO the following should be New.WIth* arguments above - merge conflict issue perhaps resolve.
 	srv.Bus = bus
 	srv.EmailReg = o.EmailReg
 	srv.ImageSigner = imgSigner

--- a/internal/dlq/dlqdefaults/defaults.go
+++ b/internal/dlq/dlqdefaults/defaults.go
@@ -11,11 +11,10 @@ import (
 
 // Register registers all stable DLQ providers.
 func Register(r *dlqpkg.Registry, er *emailpkg.Registry) {
-  // TODO refactor this out it's incorrectly being used 
+	// TODO refactor this out it's incorrectly being used
 	file.Register(r)
 	dir.Register(r)
 	db.Register(r)
 	email.Register(r, er)
-	email.Register(r)
 	dlqpkg.RegisterLogDLQ(r)
 }

--- a/internal/router/registry.go
+++ b/internal/router/registry.go
@@ -4,13 +4,15 @@ import (
 	"sync"
 
 	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/config"
 )
 
 // Module represents a router module and its setup function.
 type Module struct {
 	Name  string
 	Deps  []string
-	Setup func(*mux.Router)
+	Setup func(*mux.Router, config.RuntimeConfig)
 	once  sync.Once
 }
 
@@ -25,7 +27,7 @@ func NewRegistry() *Registry { return &Registry{modules: map[string]*Module{}} }
 
 // RegisterModule registers a router module with optional dependencies. A module
 // is stored only on the first call.
-func (reg *Registry) RegisterModule(name string, deps []string, setup func(*mux.Router)) {
+func (reg *Registry) RegisterModule(name string, deps []string, setup func(*mux.Router, config.RuntimeConfig)) {
 	reg.mu.Lock()
 	defer reg.mu.Unlock()
 	if _, ok := reg.modules[name]; ok {
@@ -36,7 +38,7 @@ func (reg *Registry) RegisterModule(name string, deps []string, setup func(*mux.
 
 // InitModules initialises all registered modules by resolving their
 // dependencies and invoking their Setup function once.
-func (reg *Registry) InitModules(r *mux.Router) {
+func (reg *Registry) InitModules(r *mux.Router, cfg config.RuntimeConfig) {
 	reg.mu.Lock()
 	defer reg.mu.Unlock()
 
@@ -67,6 +69,6 @@ func (reg *Registry) InitModules(r *mux.Router) {
 		if m.Setup == nil {
 			continue
 		}
-		m.once.Do(func() { m.Setup(r) })
+		m.once.Do(func() { m.Setup(r, cfg) })
 	}
 }

--- a/internal/router/registry_test.go
+++ b/internal/router/registry_test.go
@@ -5,16 +5,18 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/config"
 )
 
 func TestInitModulesOnce(t *testing.T) {
 	reg := NewRegistry()
 	r := mux.NewRouter()
 	count := 0
-	reg.RegisterModule("a", nil, func(*mux.Router) { count++ })
+	reg.RegisterModule("a", nil, func(*mux.Router, config.RuntimeConfig) { count++ })
 
-	reg.InitModules(r)
-	reg.InitModules(r)
+	reg.InitModules(r, config.RuntimeConfig{})
+	reg.InitModules(r, config.RuntimeConfig{})
 
 	if count != 1 {
 		t.Fatalf("expected setup to run once, got %d", count)
@@ -26,11 +28,11 @@ func TestInitModulesDependencyOrder(t *testing.T) {
 	r := mux.NewRouter()
 	order := []string{}
 
-	reg.RegisterModule("a", nil, func(*mux.Router) { order = append(order, "a") })
-	reg.RegisterModule("b", []string{"a"}, func(*mux.Router) { order = append(order, "b") })
-	reg.RegisterModule("c", []string{"b"}, func(*mux.Router) { order = append(order, "c") })
+	reg.RegisterModule("a", nil, func(*mux.Router, config.RuntimeConfig) { order = append(order, "a") })
+	reg.RegisterModule("b", []string{"a"}, func(*mux.Router, config.RuntimeConfig) { order = append(order, "b") })
+	reg.RegisterModule("c", []string{"b"}, func(*mux.Router, config.RuntimeConfig) { order = append(order, "c") })
 
-	reg.InitModules(r)
+	reg.InitModules(r, config.RuntimeConfig{})
 
 	want := []string{"a", "b", "c"}
 	if diff := cmp.Diff(want, order); diff != "" {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -7,16 +7,17 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 )
 
 // RegisterRoutes sets up all application routes on r.
-func RegisterRoutes(r *mux.Router, reg *Registry) {
+func RegisterRoutes(r *mux.Router, reg *Registry, cfg config.RuntimeConfig) {
 	r.HandleFunc("/main.css", handlers.MainCSS).Methods("GET")
 	r.HandleFunc("/favicon.svg", handlers.Favicon).Methods("GET")
 
-	reg.InitModules(r)
+	reg.InitModules(r, cfg)
 
 }
 


### PR DESCRIPTION
## Summary
- pass `RuntimeConfig` through router Registry
- update all module Register functions to accept the config
- adapt router initialisation
- fix dlqdefaults registration

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: TestLoginAction_SignedExternalBackURL)*

------
https://chatgpt.com/codex/tasks/task_e_68844460bbec832f81bc6c29984d1016