### PR TITLE
Validate image ID

### DIFF
--- a/handlers/images/routes_test.go
+++ b/handlers/images/routes_test.go
@@ -1,0 +1,54 @@
+package images
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestValidID(t *testing.T) {
+	tests := []struct {
+		id    string
+		valid bool
+	}{
+		{"abcd", true},
+		{"1234", true},
+		{"a1b2c3", true},
+		{"abc!", false},
+		{"..", false},
+		{"a/bc", false},
+	}
+	for _, tt := range tests {
+		if got := validID(tt.id); got != tt.valid {
+			t.Errorf("validID(%q) = %v want %v", tt.id, got, tt.valid)
+		}
+	}
+}
+
+func TestImageRouteInvalidID(t *testing.T) {
+	r := mux.NewRouter()
+	RegisterRoutes(r)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/images/image/abc!", nil)
+
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("want %d got %d", http.StatusNotFound, rr.Code)
+	}
+}
+
+func TestCacheRouteInvalidID(t *testing.T) {
+	r := mux.NewRouter()
+	RegisterRoutes(r)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/images/cache/abc!", nil)
+
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("want %d got %d", http.StatusNotFound, rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure IDs for images and cache routes only contain alphanumeric characters
- verify ID validity in a route matcher instead of the handlers
- update tests for invalid IDs

## Testing
- `go vet ./...` *(fails: not enough arguments in call to email.Register)*
- `golangci-lint run ./...` *(fails: could not import internal packages)*
- `go test ./...` *(fails: build errors in internal packages)*

------
https://chatgpt.com/codex/tasks/task_e_688444d8a120832fabe3c54cd5e8240d