### PR TITLE
enforce admin role for shutdown task

### DIFF
--- a/handlers/admin/reload_shutdown_test.go
+++ b/handlers/admin/reload_shutdown_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 )
 
 func TestAdminReloadConfigPage_Unauthorized(t *testing.T) {
@@ -63,5 +64,44 @@ func TestAdminShutdownRoute_Unauthorized(t *testing.T) {
 
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected %d got %d", http.StatusNotFound, rr.Code)
+	}
+}
+
+func TestServerShutdownTask_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
+	cd.SetRoles([]string{"anonymous"})
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handlers.TaskHandler(serverShutdownTask)(rr, req)
+
+	if rr.Result().StatusCode != http.StatusForbidden {
+		t.Fatalf("expected %d got %d", http.StatusForbidden, rr.Result().StatusCode)
+	}
+}
+
+func TestServerShutdownMatcher_Denied(t *testing.T) {
+	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
+	cd.SetRoles([]string{"anonymous"})
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	if serverShutdownTask.Matcher()(req, &mux.RouteMatch{}) {
+		t.Fatal("expected matcher failure")
+	}
+}
+
+func TestServerShutdownMatcher_Allowed(t *testing.T) {
+	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
+	req.Form = make(map[string][]string)
+	req.Form.Set("task", string(TaskServerShutdown))
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.AppRuntimeConfig))
+	cd.SetRoles([]string{"administrator"})
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	if !serverShutdownTask.Matcher()(req, &mux.RouteMatch{}) {
+		t.Fatal("expected matcher success")
 	}
 }

--- a/handlers/admin/server_shutdown_task.go
+++ b/handlers/admin/server_shutdown_task.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/gorilla/mux"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -23,9 +25,23 @@ type ServerShutdownTask struct{ tasks.TaskString }
 var serverShutdownTask = &ServerShutdownTask{TaskString: TaskServerShutdown}
 
 var _ tasks.Task = (*ServerShutdownTask)(nil)
+var _ tasks.TaskMatcher = (*ServerShutdownTask)(nil)
+
+func (ServerShutdownTask) Matcher() mux.MatcherFunc {
+	taskM := tasks.HasTask(string(TaskServerShutdown))
+	adminM := handlers.RequiredAccess("administrator")
+	return func(r *http.Request, m *mux.RouteMatch) bool {
+		return taskM(r, m) && adminM(r, m)
+	}
+}
 
 func (ServerShutdownTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd == nil || !cd.HasRole("administrator") {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+		})
+	}
 	data := struct {
 		*common.CoreData
 		Errors   []string


### PR DESCRIPTION
## Summary
- ensure the server shutdown task uses a matcher requiring administrator access
- test matcher behavior for authorized and unauthorized requests

## Testing
- `go mod tidy`
- `go vet ./...` *(fails: not enough arguments in call to email.Register; cannot compile internal/websocket)*
- `golangci-lint run ./...` *(fails to build internal modules)*
- `go test ./...` *(fails to build internal modules)*

------
https://chatgpt.com/codex/tasks/task_e_68844418cd34832f97820852007bf802