### PR TITLE
Fix go vet issues

### DIFF
--- a/cmd/goa4web/config_as.go
+++ b/cmd/goa4web/config_as.go
@@ -30,7 +30,7 @@ func parseConfigAsCmd(parent *configCmd, name string, args []string) (*configAsC
 
 func defaultMap() map[string]string {
 	def := config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
-	m, _ := config.ToEnvMap(def, "")
+	m, _ := config.ToEnvMap(*def, "")
 	return m
 }
 

--- a/cmd/goa4web/config_reload.go
+++ b/cmd/goa4web/config_reload.go
@@ -33,7 +33,7 @@ func (c *configReloadCmd) Run() error {
 		return fmt.Errorf("load config file: %w", err)
 	}
 	c.rootCmd.Verbosef("reloading configuration")
-	admin.Srv.Config = config.GenerateRuntimeConfig(nil, cfgMap, os.Getenv)
+	admin.Srv.Config = *config.GenerateRuntimeConfig(nil, cfgMap, os.Getenv)
 	c.rootCmd.Infof("configuration reloaded")
 	return nil
 }

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -195,7 +195,7 @@ func parseRoot(args []string) (*rootCmd, error) {
 	}
 
 	r.ConfigFile = cfgPath
-	r.cfg = config.GenerateRuntimeConfig(r.fs, fileVals, os.Getenv)
+	r.cfg = *config.GenerateRuntimeConfig(r.fs, fileVals, os.Getenv)
 	return r, nil
 }
 

--- a/cmd/goa4web/news_list.go
+++ b/cmd/goa4web/news_list.go
@@ -36,7 +36,7 @@ func (c *newsListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	cd := common.NewCoreData(ctx, queries, common.WithConfig(c.rootCmd.cfg))
+	cd := common.NewCoreData(ctx, queries, &c.rootCmd.cfg)
 	posts, err := cd.LatestNewsList(int32(c.Offset), int32(c.Limit))
 	if err != nil {
 		return fmt.Errorf("list news: %w", err)

--- a/cmd/goa4web/serve.go
+++ b/cmd/goa4web/serve.go
@@ -55,7 +55,7 @@ func (c *serveCmd) Run() error {
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	srv, err := app.NewServer(ctx, cfg,
+	srv, err := app.NewServer(ctx, *cfg,
 		app.WithSessionSecret(secret),
 		app.WithImageSignSecret(signKey),
 		app.WithDBRegistry(c.rootCmd.dbReg),

--- a/cmd/goa4web/writing_list.go
+++ b/cmd/goa4web/writing_list.go
@@ -68,7 +68,7 @@ func (c *writingListCmd) Run() error {
 		}
 		return nil
 	}
-	cd := common.NewCoreData(ctx, queries, common.WithConfig(c.rootCmd.cfg))
+	cd := common.NewCoreData(ctx, queries, &c.rootCmd.cfg)
 	rows, err := cd.LatestWritings(common.WithWritingsOffset(int32(c.Offset)), common.WithWritingsLimit(int32(c.Limit)))
 	if err != nil {
 		return fmt.Errorf("list writings: %w", err)

--- a/config/maps_runtime.go
+++ b/config/maps_runtime.go
@@ -12,13 +12,13 @@ func DefaultMap() map[string]string {
 	cfg := GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
 	m := make(map[string]string)
 	for _, o := range StringOptions {
-		m[o.Env] = *o.Target(&cfg)
+		m[o.Env] = *o.Target(cfg)
 	}
 	for _, o := range IntOptions {
-		m[o.Env] = strconv.Itoa(*o.Target(&cfg))
+		m[o.Env] = strconv.Itoa(*o.Target(cfg))
 	}
 	for _, o := range BoolOptions {
-		m[o.Env] = strconv.FormatBool(*o.Target(&cfg))
+		m[o.Env] = strconv.FormatBool(*o.Target(cfg))
 	}
 	return m
 }

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -240,6 +240,13 @@ func GenerateRuntimeConfig(fs *flag.FlagSet, fileVals map[string]string, getenv 
 	return generateRuntimeConfig(fs, fileVals, getenv, nil, nil, nil)
 }
 
+// NewRuntimeConfig returns the runtime configuration using OS environment values.
+// It is a convenience wrapper around GenerateRuntimeConfig for tests and
+// commands that only rely on environment variables.
+func NewRuntimeConfig() *RuntimeConfig {
+	return GenerateRuntimeConfig(nil, map[string]string{}, os.Getenv)
+}
+
 // GenerateRuntimeConfigWithOptions is like GenerateRuntimeConfig but also considers
 // the supplied option slices.
 func GenerateRuntimeConfigWithOptions(fs *flag.FlagSet, fileVals map[string]string, getenv func(string) string, sopts []StringOption, iopts []IntOption) *RuntimeConfig {

--- a/config/runtime_envmap_test.go
+++ b/config/runtime_envmap_test.go
@@ -10,7 +10,7 @@ import (
 // runtime options plus special config values.
 func TestToEnvMapIncludesAllKeys(t *testing.T) {
 	cfg := config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
-	m, err := config.ToEnvMap(cfg, "")
+	m, err := config.ToEnvMap(*cfg, "")
 	if err != nil {
 		t.Fatalf("ToEnvMap: %v", err)
 	}

--- a/core/common/coredata_allroles_test.go
+++ b/core/common/coredata_allroles_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 )
 
@@ -21,7 +22,7 @@ func TestAllRolesLazy(t *testing.T) {
 
 	mock.ExpectQuery("SELECT id, name, can_login, is_admin FROM roles ORDER BY id").WillReturnRows(rows)
 
-	cd := NewCoreData(context.Background(), dbpkg.New(db))
+	cd := NewCoreData(context.Background(), dbpkg.New(db), config.NewRuntimeConfig())
 
 	if _, err := cd.AllRoles(); err != nil {
 		t.Fatalf("AllRoles: %v", err)

--- a/handlers/admin/adminReloadConfigPage.go
+++ b/handlers/admin/adminReloadConfigPage.go
@@ -36,7 +36,7 @@ func AdminReloadConfigPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil && !errors.Is(err, config.ErrConfigFileNotFound) {
 		log.Printf("load config file: %v", err)
 	}
-	Srv.Config = config.GenerateRuntimeConfig(nil, cfgMap, os.Getenv)
+	Srv.Config = *config.GenerateRuntimeConfig(nil, cfgMap, os.Getenv)
 	if err := corelanguage.ValidateDefaultLanguage(r.Context(), db.New(DBPool), Srv.Config.DefaultLanguage); err != nil {
 		data.Errors = append(data.Errors, err.Error())
 	}

--- a/handlers/admin/adminServerStatsPage.go
+++ b/handlers/admin/adminServerStatsPage.go
@@ -53,7 +53,7 @@ func AdminServerStatsPage(w http.ResponseWriter, r *http.Request) {
 			NumGC:      mem.NumGC,
 		},
 		Uptime: time.Since(StartTime),
-		Config: cd.Config,
+		Config: *cd.Config,
 	}
 
 	for _, t := range cd.TasksReg.Registered() {

--- a/handlers/admin/adminSiteSettingsPage.go
+++ b/handlers/admin/adminSiteSettingsPage.go
@@ -17,7 +17,7 @@ func AdminSiteSettingsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.FeedsEnabled = cd.Config.FeedsEnabled
 
-	values := config.ValuesMap(cd.Config)
+	values := config.ValuesMap(*cd.Config)
 	defaults := config.DefaultMap()
 	usages := config.UsageMap()
 	examples := config.ExamplesMap()

--- a/handlers/admin/adminUsageStatsPage.go
+++ b/handlers/admin/adminUsageStatsPage.go
@@ -10,8 +10,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-
-	"github.com/arran4/goa4web/config"
 )
 
 func AdminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
@@ -29,7 +27,8 @@ func AdminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 		StartYear         int
 	}
 	data := Data{CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData)}
-	queries := data.Queries()
+	cd := data.CoreData
+	queries := cd.Queries()
 
 	var wg sync.WaitGroup
 	wg.Add(8)

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -34,7 +34,7 @@ func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
 	reg := newEmailReg()
-	cd := common.NewCoreData(req.Context(), nil, common.WithEmailProvider(reg.ProviderFromConfig(cfg)), cfg)
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithEmailProvider(reg.ProviderFromConfig(*cfg)))
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -67,7 +67,7 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
 	q := db.New(sqldb)
 	reg := newEmailReg()
-	cd := common.NewCoreData(req.Context(), q, common.WithEmailProvider(reg.ProviderFromConfig(cfg)), cfg)
+	cd := common.NewCoreData(req.Context(), q, cfg, common.WithEmailProvider(reg.ProviderFromConfig(*cfg)))
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -149,7 +149,7 @@ func TestNotifyAdminsEnv(t *testing.T) {
 
 	os.Setenv(config.EnvAdminEmails, "a@test.com,b@test.com")
 	defer os.Unsetenv(config.EnvAdminEmails)
-	cfg := config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
+	cfg = config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
 	origEmails := cfg.AdminEmails
 	cfg.AdminEmails = "a@test.com,b@test.com"
 	defer func() { cfg.AdminEmails = origEmails }()
@@ -167,7 +167,7 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 2, Valid: true}, sqlmock.AnyArg(), false).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	rec := &recordAdminMail{}
-	n := notif.New(notif.WithQueries(q), notif.WithEmailProvider(rec), notif.WithConfig(cfg))
+	n := notif.New(notif.WithQueries(q), notif.WithEmailProvider(rec), notif.WithConfig(*cfg))
 	n.NotifyAdmins(context.Background(), &notif.EmailTemplates{}, notif.EmailData{})
 	if len(rec.to) != 0 {
 		t.Fatalf("expected 0 direct mails, got %d", len(rec.to))
@@ -187,10 +187,9 @@ func TestNotifyAdminsDisabled(t *testing.T) {
 	cfg.AdminEmails = "a@test.com"
 	defer os.Unsetenv(config.EnvAdminEmails)
 	defer os.Unsetenv(config.EnvAdminNotify)
-	origEmails := cfg.AdminEmails
 	cfg.AdminEmails = "a@test.com"
 	rec := &recordAdminMail{}
-	n := notif.New(notif.WithEmailProvider(rec), notif.WithConfig(cfg))
+	n := notif.New(notif.WithEmailProvider(rec), notif.WithConfig(*cfg))
 	n.NotifyAdmins(context.Background(), &notif.EmailTemplates{}, notif.EmailData{})
 	if len(rec.to) != 0 {
 		t.Fatalf("expected 0 mails, got %d", len(rec.to))

--- a/handlers/admin/reload_shutdown_test.go
+++ b/handlers/admin/reload_shutdown_test.go
@@ -33,7 +33,7 @@ func TestAdminReloadRoute_Unauthorized(t *testing.T) {
 	r := mux.NewRouter()
 	ar := r.PathPrefix("/admin").Subrouter()
 	cfg := config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
-	RegisterRoutes(ar, cfg)
+	RegisterRoutes(ar, *cfg)
 
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
 	cd := common.NewCoreData(req.Context(), nil, cfg)
@@ -53,7 +53,7 @@ func TestAdminShutdownRoute_Unauthorized(t *testing.T) {
 	r := mux.NewRouter()
 	ar := r.PathPrefix("/admin").Subrouter()
 	cfg := config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
-	RegisterRoutes(ar, cfg)
+	RegisterRoutes(ar, *cfg)
 
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
 	cd := common.NewCoreData(req.Context(), nil, cfg)

--- a/handlers/admin/resend_queue_task.go
+++ b/handlers/admin/resend_queue_task.go
@@ -9,7 +9,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/tasks"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/workers/emailqueue"
@@ -59,7 +58,7 @@ func (ResendQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	for _, e := range emails {
-		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, cd.Config, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
+		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, *cd.Config, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
 		if err != nil {
 			return fmt.Errorf("resolve address fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/admin/test_template_task.go
+++ b/handlers/admin/test_template_task.go
@@ -16,11 +16,9 @@ import (
 	"github.com/arran4/goa4web/internal/email"
 	"github.com/arran4/goa4web/internal/tasks"
 
-	notif "github.com/arran4/goa4web/internal/notifications"
-
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
+	notif "github.com/arran4/goa4web/internal/notifications"
 )
 
 // TestTemplateTask queues an email using the template for preview.

--- a/handlers/auth/forgotPassword_event_test.go
+++ b/handlers/auth/forgotPassword_event_test.go
@@ -31,7 +31,7 @@ func TestForgotPasswordEventData(t *testing.T) {
 	mock.ExpectExec("INSERT INTO pending_passwords").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
-	cd := common.NewCoreData(context.Background(), q, common.WithEvent(evt), config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig(), common.WithEvent(evt))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 
 	form := url.Values{"username": {"u"}, "password": {"pw"}}

--- a/handlers/auth/forgot_password_task.go
+++ b/handlers/auth/forgot_password_task.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -40,7 +39,8 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	username := r.PostFormValue("username")
 	pw := r.PostFormValue("password")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	row, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		return fmt.Errorf("user not found %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/auth/login_task.go
+++ b/handlers/auth/login_task.go
@@ -38,6 +38,7 @@ func (LoginTask) Page(w http.ResponseWriter, r *http.Request) {
 
 // Action processes the submitted login form.
 func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if cd.Config.LogFlags&config.LogFlagAuth != 0 {
 		sess, _ := core.GetSession(r)
 		log.Printf("login attempt for %s session=%s", r.PostFormValue("username"), handlers.HashSessionID(sess.ID))
@@ -46,7 +47,6 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 	username := r.PostFormValue("username")
 	password := r.PostFormValue("password")
 
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
 
 	cfg := cd.Config

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -37,6 +37,7 @@ func (RegisterTask) Page(w http.ResponseWriter, r *http.Request) {
 
 // RegisterActionPage handles user creation from the registration form.
 func (RegisterTask) Action(w http.ResponseWriter, r *http.Request) any {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if cd.Config.LogFlags&config.LogFlagAuth != 0 {
 		log.Printf("registration attempt %s", r.PostFormValue("username"))
 	}
@@ -49,7 +50,7 @@ func (RegisterTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if _, err := mail.ParseAddress(email); err != nil {
 		return handlers.ErrRedirectOnSamePageHandler(errors.New("invalid email"))
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 
 	if _, err := queries.UserByUsername(r.Context(), sql.NullString{
 		String: username,

--- a/handlers/auth/verify_password_task.go
+++ b/handlers/auth/verify_password_task.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/arran4/goa4web/internal/db"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/tasks"
@@ -40,7 +39,8 @@ func (VerifyPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	id := int32(id64)
 	code := r.FormValue("code")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	expiry := time.Now().Add(-time.Duration(cd.Config.PasswordResetExpiryHours) * time.Hour)
 	reset, err := queries.GetPasswordResetByCode(r.Context(), db.GetPasswordResetByCodeParams{VerificationCode: code, CreatedAt: expiry})
 	if err != nil || reset.ID != id {

--- a/handlers/blogs/blogsCommentPage_replyable_test.go
+++ b/handlers/blogs/blogsCommentPage_replyable_test.go
@@ -32,7 +32,7 @@ func setupCommentRequest(t *testing.T, queries *db.Queries, store *sessions.Cook
 		req.AddCookie(c)
 	}
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithSession(sess))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	return req, sess

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -54,7 +54,7 @@ func TestBlogsBloggerPostsPage(t *testing.T) {
 	}
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/bookmarks/mine_test.go
+++ b/handlers/bookmarks/mine_test.go
@@ -96,7 +96,7 @@ func TestMinePage_NoBookmarks(t *testing.T) {
 	}
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithSession(sess))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -98,7 +98,7 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 	bus := eventbus.NewBus()
 	q := db.New(dbconn)
 	evt := &eventbus.TaskEvent{Path: "/faq/ask", Task: tasks.TaskString(TaskAsk), UserID: 1}
-	cd := common.NewCoreData(req.Context(), q, common.WithConfig(cfg))
+	cd := common.NewCoreData(req.Context(), q, cfg)
 	cd.UserID = 1
 	cd.SetEvent(evt)
 

--- a/handlers/imagebbs/imagebbsAdminFilesPage.go
+++ b/handlers/imagebbs/imagebbsAdminFilesPage.go
@@ -12,8 +12,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 
 	"github.com/arran4/goa4web/handlers"
-
-	"github.com/arran4/goa4web/config"
 )
 
 func AdminFilesPage(w http.ResponseWriter, r *http.Request) {
@@ -30,6 +28,7 @@ func AdminFilesPage(w http.ResponseWriter, r *http.Request) {
 		Entries []Entry
 	}
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	base := cd.Config.ImageUploadDir
 	reqPath := r.URL.Query().Get("path")
 	cleaned := filepath.Clean("/" + reqPath)

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -31,7 +31,6 @@ import (
 	"github.com/gorilla/mux"
 	"golang.org/x/image/draw"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/upload"
 )
 
@@ -110,7 +109,8 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 
 	board, err := queries.GetImageBoardById(r.Context(), int32(bid))
 	if err != nil {
@@ -144,7 +144,7 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("decode image error %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	fname := shaHex + ext
-	if p := upload.ProviderFromConfig(cd.Config); p != nil {
+	if p := upload.ProviderFromConfig(*cd.Config); p != nil {
 		if err := p.Write(r.Context(), path.Join(sub1, sub2, fname), data); err != nil {
 			return fmt.Errorf("upload write fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/imagebbs/routes.go
+++ b/handlers/imagebbs/routes.go
@@ -13,13 +13,13 @@ import (
 )
 
 // RegisterRoutes attaches the public image board endpoints to r.
-func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
+func RegisterRoutes(r *mux.Router, cfg config.RuntimeConfig) {
 	nav.RegisterIndexLink("ImageBBS", "/imagebbs", SectionWeight)
 	nav.RegisterAdminControlCenter("ImageBBS", "/admin/imagebbs", SectionWeight)
 	r.HandleFunc("/imagebbs.rss", RssPage).Methods("GET")
 	ibr := r.PathPrefix("/imagebbs").Subrouter()
 	ibr.Use(handlers.IndexMiddleware(CustomImageBBSIndex))
-	ibr.PathPrefix("/images/").Handler(http.StripPrefix("/imagebbs/images/", http.FileServer(http.Dir(cd.Config.ImageUploadDir))))
+	ibr.PathPrefix("/images/").Handler(http.StripPrefix("/imagebbs/images/", http.FileServer(http.Dir(cfg.ImageUploadDir))))
 	ibr.HandleFunc("/board/{boardno:[0-9]+}.rss", BoardRssPage).Methods("GET")
 	r.HandleFunc("/imagebbs.atom", AtomPage).Methods("GET")
 	ibr.HandleFunc("/board/{boardno:[0-9]+}.atom", BoardAtomPage).Methods("GET")

--- a/handlers/images/routes.go
+++ b/handlers/images/routes.go
@@ -92,7 +92,7 @@ func serveCache(w http.ResponseWriter, r *http.Request) {
 	cfg := cd.Config
 	sub1, sub2 := id[:2], id[2:4]
 	key := path.Join(sub1, sub2, id)
-	if p := upload.CacheProviderFromConfig(cfg); p != nil {
+	if p := upload.CacheProviderFromConfig(*cfg); p != nil {
 		data, err := p.Read(r.Context(), key)
 		if err != nil {
 			http.NotFound(w, r)

--- a/handlers/images/routes_test.go
+++ b/handlers/images/routes_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/config"
 )
 
 func TestValidID(t *testing.T) {
@@ -29,7 +31,8 @@ func TestValidID(t *testing.T) {
 
 func TestImageRouteInvalidID(t *testing.T) {
 	r := mux.NewRouter()
-	RegisterRoutes(r)
+	cfg := config.NewRuntimeConfig()
+	RegisterRoutes(r, *cfg)
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/images/image/abc!", nil)
 
@@ -42,7 +45,8 @@ func TestImageRouteInvalidID(t *testing.T) {
 
 func TestCacheRouteInvalidID(t *testing.T) {
 	r := mux.NewRouter()
-	RegisterRoutes(r)
+	cfg := config.NewRuntimeConfig()
+	RegisterRoutes(r, *cfg)
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/images/cache/abc!", nil)
 

--- a/handlers/images/upload_task.go
+++ b/handlers/images/upload_task.go
@@ -66,7 +66,7 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	ext := strings.ToLower(filepath.Ext(header.Filename))
 	sub1, sub2 := id[:2], id[2:4]
 	fname := id + ext
-	if p := upload.ProviderFromConfig(cfg); p != nil {
+	if p := upload.ProviderFromConfig(*cfg); p != nil {
 		if err := p.Write(r.Context(), path.Join(sub1, sub2, fname), data); err != nil {
 			log.Printf("upload write: %v", err)
 			return fmt.Errorf("upload write %w", handlers.ErrRedirectOnSamePageHandler(err))
@@ -97,7 +97,7 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err := enc(&tbuf, thumb); err != nil {
 		return fmt.Errorf("thumb encode %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if cp := upload.CacheProviderFromConfig(cfg); cp != nil {
+	if cp := upload.CacheProviderFromConfig(*cfg); cp != nil {
 		if err := cp.Write(r.Context(), path.Join(sub1, sub2, thumbName), tbuf.Bytes()); err != nil {
 			log.Printf("cache write: %v", err)
 			return fmt.Errorf("cache write %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/pagesize.go
+++ b/handlers/pagesize.go
@@ -1,0 +1,17 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+)
+
+// GetPageSize returns the preferred page size from the request context.
+func GetPageSize(r *http.Request) int {
+	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+		return cd.PageSize()
+	}
+	return config.DefaultPageSize
+}

--- a/handlers/user/addEmailTask_invalid_test.go
+++ b/handlers/user/addEmailTask_invalid_test.go
@@ -38,7 +38,7 @@ func TestAddEmailTaskInvalid(t *testing.T) {
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess), common.WithEvent(evt))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)

--- a/handlers/user/userEmailPage_event_test.go
+++ b/handlers/user/userEmailPage_event_test.go
@@ -45,7 +45,7 @@ func TestAddEmailTaskEventData(t *testing.T) {
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess), common.WithEvent(evt))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -88,7 +88,7 @@ func TestVerifyRemovesDuplicates(t *testing.T) {
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess), common.WithEvent(evt))
 	cd.UserID = 1
 
 	rows := sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).
@@ -151,7 +151,7 @@ func TestResendVerificationEmailTaskEventData(t *testing.T) {
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess), common.WithEvent(evt))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	req = req.WithContext(ctx)

--- a/handlers/user/userEmailVerify_test.go
+++ b/handlers/user/userEmailVerify_test.go
@@ -39,7 +39,7 @@ func TestUserEmailVerifyCodePage_Invalid(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	req := httptest.NewRequest(http.MethodGet, "/usr/email/verify?code="+code, nil).WithContext(ctx)
@@ -75,7 +75,7 @@ func TestUserEmailVerifyCodePage_Success(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	form := url.Values{"code": {code}}

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -62,7 +62,7 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := req.Context()
 	reg := newEmailReg()
-	cd := common.NewCoreData(ctx, queries, common.WithEmailProvider(reg.ProviderFromConfig(cfg)), cfg)
+	cd := common.NewCoreData(ctx, queries, cfg, common.WithEmailProvider(reg.ProviderFromConfig(*cfg)))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -95,7 +95,7 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := req.Context()
 	reg := newEmailReg()
-	cd := common.NewCoreData(ctx, queries, common.WithEmailProvider(reg.ProviderFromConfig(cfg)), cfg)
+	cd := common.NewCoreData(ctx, queries, cfg, common.WithEmailProvider(reg.ProviderFromConfig(*cfg)))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -218,7 +218,7 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 	ctx := req.Context()
 	cfg := config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
 	cfg.PageSizeDefault = 15
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), common.WithConfig(cfg))
+	cd := common.NewCoreData(ctx, queries, cfg, common.WithSession(sess))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -266,7 +266,7 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithSession(sess))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -294,7 +294,6 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	defer db.Close()
 
 	queries := dbpkg.New(db)
-	cfg.PageSizeDefault = 15
 	store = sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = sessionName
@@ -315,9 +314,10 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	}
 	rr := httptest.NewRecorder()
 	cfg := config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
+	cfg.PageSizeDefault = 15
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), cfg)
+	cd := common.NewCoreData(ctx, queries, cfg, common.WithSession(sess))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/writings/matchers_test.go
+++ b/handlers/writings/matchers_test.go
@@ -37,7 +37,7 @@ func TestRequireWritingAuthorArticleVar(t *testing.T) {
 	sess, _ := store.Get(req, core.SessionName)
 	sess.Values["UID"] = int32(1)
 
-	cd := common.NewCoreData(req.Context(), q, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithSession(sess))
 	cd.SetRoles([]string{"content writer"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -214,12 +214,11 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 				base = strings.TrimRight(s.Config.HTTPHostname, "/")
 			}
 			provider := s.EmailReg.ProviderFromConfig(s.Config)
-			cd := common.NewCoreData(r.Context(), queries,
+			cd := common.NewCoreData(r.Context(), queries, &s.Config,
 				common.WithImageSigner(s.ImageSigner),
 				common.WithSession(session),
 				common.WithEmailProvider(provider),
 				common.WithAbsoluteURLBase(base),
-				common.WithConfig(s.Config),
 				common.WithSessionManager(sm),
 				common.WithTasksRegistry(s.TasksReg),
 				common.WithDBRegistry(s.DBReg),

--- a/internal/email/emaildefaults/email_test.go
+++ b/internal/email/emaildefaults/email_test.go
@@ -115,7 +115,7 @@ func TestEmailQueueWorker(t *testing.T) {
 	mock.ExpectExec("UPDATE pending_emails SET sent_at").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	rec := &mockemail.Provider{}
-	if !emailqueue.ProcessPendingEmail(context.Background(), q, rec, nil, cfg) {
+	if !emailqueue.ProcessPendingEmail(context.Background(), q, rec, nil, *cfg) {
 		t.Fatal("no email processed")
 	}
 
@@ -154,7 +154,7 @@ func TestProcessPendingEmailDLQ(t *testing.T) {
 
 	p := errProvider{}
 	dlqRec := &mockdlq.Provider{}
-	if !emailqueue.ProcessPendingEmail(context.Background(), q, p, dlqRec, cfg) {
+	if !emailqueue.ProcessPendingEmail(context.Background(), q, p, dlqRec, *cfg) {
 		t.Fatal("no email processed")
 	}
 

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -91,12 +91,11 @@ func CoreAdderMiddlewareWithDB(db *sql.DB, cfg config.RuntimeConfig, verbosity i
 				base = strings.TrimRight(cfg.HTTPHostname, "/")
 			}
 			provider := emailReg.ProviderFromConfig(cfg)
-			cd := common.NewCoreData(r.Context(), queries,
+			cd := common.NewCoreData(r.Context(), queries, &cfg,
 				common.WithImageSigner(signer),
 				common.WithSession(session),
 				common.WithEmailProvider(provider),
 				common.WithAbsoluteURLBase(base),
-				common.WithConfig(cfg),
 				common.WithSessionManager(sm))
 			cd.UserID = uid
 			_ = cd.UserRoles()

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -49,8 +49,8 @@ func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
 	})
 
 	reg := email.NewRegistry()
-	signer := imagesign.NewSigner(cfg, "k")
-	CoreAdderMiddlewareWithDB(db, cfg, 0, reg, signer)(handler).ServeHTTP(httptest.NewRecorder(), req)
+	signer := imagesign.NewSigner(*cfg, "k")
+	CoreAdderMiddlewareWithDB(db, *cfg, 0, reg, signer)(handler).ServeHTTP(httptest.NewRecorder(), req)
 
 	want := []string{"anonymous", "user", "moderator"}
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {
@@ -77,7 +77,8 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 	session := &sessions.Session{ID: "sessid"}
 	req := httptest.NewRequest("GET", "/", nil)
 	q := dbpkg.New(db)
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cfg := config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
+	cd := common.NewCoreData(req.Context(), q, cfg)
 	ctx := context.WithValue(req.Context(), core.ContextValues("session"), session)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -88,8 +89,8 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 	})
 
 	reg := email.NewRegistry()
-	signer := imagesign.NewSigner(cfg, "k")
-	CoreAdderMiddlewareWithDB(db, cfg, 0, reg, signer)(handler).ServeHTTP(httptest.NewRecorder(), req)
+	signer := imagesign.NewSigner(*cfg, "k")
+	CoreAdderMiddlewareWithDB(db, *cfg, 0, reg, signer)(handler).ServeHTTP(httptest.NewRecorder(), req)
 
 	want := []string{"anonymous"}
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -71,7 +71,7 @@ func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		var cfg config.RuntimeConfig
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-			cfg = cd.Config
+			cfg = *cd.Config
 		}
 		hsts := cfg.HSTSHeaderValue
 		if hsts != "" {

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -25,7 +25,7 @@ func newCoreData(t *testing.T, cfg config.RuntimeConfig) (*common.CoreData, sqlm
 	if cfg.HSTSHeaderValue == "" {
 		cfg.HSTSHeaderValue = "max-age=63072000; includeSubDomains"
 	}
-	cd := common.NewCoreData(context.Background(), queries, common.WithConfig(cfg))
+	cd := common.NewCoreData(context.Background(), queries, &cfg)
 	return cd, mock, cleanup
 }
 
@@ -101,7 +101,7 @@ func TestSecurityHeadersMiddlewareForwardedProto(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
-  }
+	}
 }
 
 func TestSecurityHeadersMiddleware(t *testing.T) {

--- a/internal/notifications/bus_worker_test.go
+++ b/internal/notifications/bus_worker_test.go
@@ -138,7 +138,7 @@ func TestProcessEventDLQ(t *testing.T) {
 	defer db.Close()
 	q := dbpkg.New(db)
 	prov := &errProvider{}
-	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(cfg))
+	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(*cfg))
 	dlqRec := &recordDLQ{}
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/p", Task: TestTask{TaskString: TaskTest}, UserID: 1}, dlqRec); err != nil {
@@ -166,7 +166,7 @@ func TestProcessEventSubscribeSelf(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q), WithConfig(cfg))
+	n := New(WithQueries(q), WithConfig(*cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/p", Task: TaskTest, UserID: 1}, nil); err != nil {
 		t.Fatalf("process: %v", err)
@@ -186,7 +186,7 @@ func TestProcessEventNoAutoSubscribe(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q), WithConfig(cfg))
+	n := New(WithQueries(q), WithConfig(*cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/p", Task: TaskTest, UserID: 1}, nil); err != nil {
 		t.Fatalf("process: %v", err)
@@ -209,7 +209,7 @@ func TestProcessEventAdminNotify(t *testing.T) {
 	defer db.Close()
 	q := dbpkg.New(db)
 	prov := &busDummyProvider{}
-	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(cfg))
+	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(*cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/admin/x", Task: TaskTest, UserID: 1}, nil); err != nil {
 		t.Fatalf("process: %v", err)
@@ -230,7 +230,7 @@ func TestProcessEventWritingSubscribers(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q), WithConfig(cfg))
+	n := New(WithQueries(q), WithConfig(*cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/writings/article/1", Task: TaskTest, UserID: 2, Data: map[string]any{"target": Target{Type: "writing", ID: 1}}}, nil); err != nil {
 		t.Fatalf("process: %v", err)
@@ -264,7 +264,7 @@ func TestProcessEventTargetUsers(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q), WithConfig(cfg))
+	n := New(WithQueries(q), WithConfig(*cfg))
 
 	for _, id := range []int32{2, 3} {
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
@@ -306,7 +306,7 @@ func TestBusWorker(t *testing.T) {
 	q := dbpkg.New(db)
 
 	prov := &busDummyProvider{}
-	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(cfg))
+	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(*cfg))
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -349,7 +349,7 @@ func TestProcessEventAutoSubscribe(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q), WithConfig(cfg))
+	n := New(WithQueries(q), WithConfig(*cfg))
 
 	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies"}).
 		AddRow(1, 0, 1, nil, 0, true)

--- a/internal/notifications/linker_queue_test.go
+++ b/internal/notifications/linker_queue_test.go
@@ -14,7 +14,6 @@ func TestLinkerQueueNotifierMessages(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
 	cfg.EmailFrom = "from@example.com"
-	t.Cleanup(func() { cfg = cfg })
 	ntName := NotificationTemplateFilenameGenerator("linker_approved")
 
 	db, mock, err := sqlmock.New()
@@ -36,7 +35,7 @@ func TestLinkerQueueNotifierMessages(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"body"}).AddRow(""))
 
 	q := dbpkg.New(db)
-	n := New(WithQueries(q), WithConfig(cfg))
+	n := New(WithQueries(q), WithConfig(*cfg))
 	data := map[string]any{
 		"Title":     "Example",
 		"Username":  "bob",

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -71,7 +71,7 @@ func TestNotifierNotifyAdmins(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test", "a"))
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 1, Valid: true}, sqlmock.AnyArg(), false).WillReturnResult(sqlmock.NewResult(1, 1))
 	rec := &dummyProvider{}
-	n := New(WithQueries(q), WithEmailProvider(rec), WithConfig(cfg))
+	n := New(WithQueries(q), WithEmailProvider(rec), WithConfig(*cfg))
 	n.NotifyAdmins(context.Background(), &EmailTemplates{}, EmailData{})
 	if rec.to != "" {
 		t.Fatalf("expected no direct mail got %s", rec.to)
@@ -82,7 +82,8 @@ func TestNotifierNotifyAdmins(t *testing.T) {
 }
 
 func TestNotifierInitialization(t *testing.T) {
-	n := New(WithConfig(cfg))
+	cfg := config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
+	n := New(WithConfig(*cfg))
 	if n.Queries != nil {
 		t.Fatalf("expected nil Queries")
 	}
@@ -92,7 +93,7 @@ func TestNotifierInitialization(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n = New(WithQueries(q), WithConfig(cfg))
+	n = New(WithQueries(q), WithConfig(*cfg))
 	if n.Queries != q {
 		t.Fatalf("queries not set via option")
 	}

--- a/internal/notifications/permission_tasks_test.go
+++ b/internal/notifications/permission_tasks_test.go
@@ -45,7 +45,7 @@ func TestProcessEventPermissionTasks(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := notif.New(notif.WithQueries(q), notif.WithConfig(cfg))
+	n := notif.New(notif.WithQueries(q), notif.WithConfig(*cfg))
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/internal/websocket/notifications.go
+++ b/internal/websocket/notifications.go
@@ -201,15 +201,13 @@ func (h *NotificationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 }
 
 // RegisterRoutes attaches the websocket handler to r.
-func (m *Module) registerRoutes(r *mux.Router) {
-	h := NewNotificationsHandler(m.Bus, m.Config)
+func (m *Module) registerRoutes(r *mux.Router, cfg config.RuntimeConfig) {
+	h := NewNotificationsHandler(m.Bus, cfg)
 	r.Handle("/ws/notifications", h).Methods(http.MethodGet)
 	r.HandleFunc("/notifications.js", NotificationsJS).Methods(http.MethodGet)
 }
 
 // Register registers the websocket router module.
 func (m *Module) Register(reg *routerpkg.Registry) {
-	reg.RegisterModule("websocket", nil, func(r *mux.Router) {
-		m.registerRoutes(r, cfg)
-	})
+	reg.RegisterModule("websocket", nil, m.registerRoutes)
 }


### PR DESCRIPTION
## Summary
- remove pointer indirection bugs in config maps
- add GetPageSize helper
- add NewRuntimeConfig for convenience
- adjust middleware to pass config pointer
- fix type mismatches across tests and commands

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: TestServerShutdownMatcher_Allowed, TestServerShutdownTask_EventPublished, TestLoginAction_SignedExternalBackURL, TestRegisterActionPageValidation)*

------
https://chatgpt.com/codex/tasks/task_e_68845ff2d21c832faa6103eb5df2309b