### PR TITLE
Fix template mode typo

### DIFF
--- a/core/templates/embedded.go
+++ b/core/templates/embedded.go
@@ -31,7 +31,7 @@ var (
 )
 
 func init() {
-	log.Printf("Embedded Templatee Mode")
+	log.Printf("Embedded Template Mode")
 }
 
 func GetCompiledSiteTemplates(funcs htemplate.FuncMap) *htemplate.Template {


### PR DESCRIPTION
## Summary
- fix a typo in the embedded templates init log message

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot use &cfg as *RuntimeConfig ...)*
- `golangci-lint run ./...` *(fails: typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_68846aa109b4832fb5b9bc6518e34f35