### PR TITLE
Use RefreshDirectHandler for GET redirects

### DIFF
--- a/handlers/auth/loginPage.go
+++ b/handlers/auth/loginPage.go
@@ -25,6 +25,14 @@ type redirectBackPageHandler struct {
 }
 
 func (h redirectBackPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.Method == "" || h.Method == http.MethodGet {
+		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		rdh := handlers.RefreshDirectHandler{TargetURL: h.BackURL}
+		cd.AutoRefresh = rdh.Content()
+		handlers.TemplateHandler(w, r, "taskDoneAutoRefreshPage.gohtml", rdh)
+		return
+	}
+
 	type Data struct {
 		*common.CoreData
 		BackURL string
@@ -37,7 +45,6 @@ func (h redirectBackPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		Method:   h.Method,
 		Values:   h.Values,
 	}
-	// TODO consider using RefreshDirect if the target method is "GET" or ""
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if err := cd.ExecuteSiteTemplate(w, r, "redirectBackPage.gohtml", data); err != nil {
 		log.Printf("Template Error: %s", err)


### PR DESCRIPTION
## Summary
- use `RefreshDirectHandler` when redirecting back to a GET request
- test that the redirect handler sets meta refresh

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot use &cfg as *RuntimeConfig in maps_runtime.go)*
- `golangci-lint run` *(fails: typecheck errors)*
- `go test ./...` *(fails to build due to maps_runtime.go)*

------
https://chatgpt.com/codex/tasks/task_e_68846b0306fc832f9f9812a5dcf92604