### PR TITLE
Add interface checks for remake tasks

### DIFF
--- a/config/maps_runtime.go
+++ b/config/maps_runtime.go
@@ -12,13 +12,13 @@ func DefaultMap() map[string]string {
 	cfg := GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
 	m := make(map[string]string)
 	for _, o := range StringOptions {
-		m[o.Env] = *o.Target(&cfg)
+		m[o.Env] = *o.Target(cfg)
 	}
 	for _, o := range IntOptions {
-		m[o.Env] = strconv.Itoa(*o.Target(&cfg))
+		m[o.Env] = strconv.Itoa(*o.Target(cfg))
 	}
 	for _, o := range BoolOptions {
-		m[o.Env] = strconv.FormatBool(*o.Target(&cfg))
+		m[o.Env] = strconv.FormatBool(*o.Target(cfg))
 	}
 	return m
 }

--- a/handlers/forum/remake_thread_stats_task.go
+++ b/handlers/forum/remake_thread_stats_task.go
@@ -6,3 +6,6 @@ import "github.com/arran4/goa4web/internal/tasks"
 type RemakeThreadStatsTask struct{ tasks.TaskString }
 
 var remakeThreadStatsTask = &RemakeThreadStatsTask{TaskString: TaskRemakeStatisticInformationOnForumthread}
+
+// ensure RemakeThreadStatsTask conforms to tasks.Task
+var _ tasks.Task = (*RemakeThreadStatsTask)(nil)

--- a/handlers/forum/remake_topic_stats_task.go
+++ b/handlers/forum/remake_topic_stats_task.go
@@ -6,3 +6,6 @@ import "github.com/arran4/goa4web/internal/tasks"
 type RemakeTopicStatsTask struct{ tasks.TaskString }
 
 var remakeTopicStatsTask = &RemakeTopicStatsTask{TaskString: TaskRemakeStatisticInformationOnForumtopic}
+
+// ensure RemakeTopicStatsTask conforms to tasks.Task
+var _ tasks.Task = (*RemakeTopicStatsTask)(nil)


### PR DESCRIPTION
## Summary
- assert `RemakeThreadStatsTask` and `RemakeTopicStatsTask` implement `tasks.Task`
- fix `DefaultMap` so it compiles when building config maps

## Testing
- `go vet ./...` *(fails: imported config unused and other compile errors)*
- `golangci-lint run` *(fails: typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_68846af4e3c8832f880a4f913683493a