### PR TITLE
Remove duplicate csrf helper

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -26,8 +26,6 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 		"cd":        func() *CoreData { return cd },
 		"now":       func() time.Time { return time.Now() },
 		"csrfField": func() template.HTML { return csrf.TemplateField(r) },
-		// TODO merge
-		"csrf":      func() string { return csrf.Token(r) },
 		"csrfToken": func() string { return csrf.Token(r) },
 		"version":   func() string { return goa4web.Version },
 		"a4code2html": func(s string) template.HTML {

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -38,6 +38,18 @@ func TestTemplateFuncsLeft(t *testing.T) {
 	}
 }
 
+func TestTemplateFuncsCSRFToken(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	cd := &common.CoreData{}
+	funcs := cd.Funcs(r)
+	if _, ok := funcs["csrfToken"]; !ok {
+		t.Errorf("csrfToken func missing")
+	}
+	if _, ok := funcs["csrf"]; ok {
+		t.Errorf("csrf func should not be present")
+	}
+}
+
 func TestLatestNewsRespectsPermissions(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/core/templates/site/admin/notificationsPage.gohtml
+++ b/core/templates/site/admin/notificationsPage.gohtml
@@ -83,7 +83,7 @@
         link.addEventListener('click', e => {
             e.preventDefault();
             const data = new URLSearchParams();
-            data.set('gorilla.csrf.Token', '{{ csrf }}');
+            data.set('gorilla.csrf.Token', '{{ csrfToken }}');
             data.set('task', 'Toggle read');
             data.set('id', link.dataset.id);
             fetch('/admin/notifications', {method: 'POST', body: data}).then(() => { location.reload(); });


### PR DESCRIPTION
## Summary
- remove old `csrf` func and keep a single `csrfToken` helper
- update templates to use the renamed helper
- test for new helper presence

## Testing
- `go mod tidy`
- `go vet ./...` *(fails: cannot use &cfg as *RuntimeConfig)*
- `go test ./...` *(fails to build due to same issue)*
- `golangci-lint run ./...` *(fails to build due to same issue)*

------
https://chatgpt.com/codex/tasks/task_e_68846aea698c832f86bcf7935bebb802