### PR TITLE
Fix redirectBackPageHandler for GET

### DIFF
--- a/handlers/auth/loginPage.go
+++ b/handlers/auth/loginPage.go
@@ -25,6 +25,14 @@ type redirectBackPageHandler struct {
 }
 
 func (h redirectBackPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.Method == "" || h.Method == http.MethodGet {
+		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		rdh := handlers.RefreshDirectHandler{TargetURL: h.BackURL}
+		cd.AutoRefresh = rdh.Content()
+		handlers.TemplateHandler(w, r, "taskDoneAutoRefreshPage.gohtml", rdh)
+		return
+	}
+
 	type Data struct {
 		*common.CoreData
 		BackURL string
@@ -37,7 +45,6 @@ func (h redirectBackPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		Method:   h.Method,
 		Values:   h.Values,
 	}
-	// TODO consider using RefreshDirect if the target method is "GET" or ""
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if err := cd.ExecuteSiteTemplate(w, r, "redirectBackPage.gohtml", data); err != nil {
 		log.Printf("Template Error: %s", err)

--- a/handlers/auth/loginPage_test.go
+++ b/handlers/auth/loginPage_test.go
@@ -400,3 +400,52 @@ func TestLoginAction_Throttle(t *testing.T) {
 		t.Fatalf("body=%q", rr.Body.String())
 	}
 }
+
+func TestRedirectBackPageHandler(t *testing.T) {
+	db, _, _ := sqlmock.New()
+	defer db.Close()
+	q := dbpkg.New(db)
+
+	cases := map[string]string{"empty": "", "get": http.MethodGet}
+	for name, method := range cases {
+		t.Run(name, func(t *testing.T) {
+			cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+			req = req.WithContext(ctx)
+			rr := httptest.NewRecorder()
+
+			h := redirectBackPageHandler{BackURL: "/back", Method: method, Values: url.Values{"a": {"b"}}}
+			h.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status=%d", rr.Code)
+			}
+			if cd.AutoRefresh == "" || !strings.Contains(cd.AutoRefresh, "url=/back") {
+				t.Fatalf("auto refresh=%q", cd.AutoRefresh)
+			}
+			if strings.Contains(rr.Body.String(), "<form") {
+				t.Fatalf("unexpected form: %q", rr.Body.String())
+			}
+		})
+	}
+
+	t.Run("post", func(t *testing.T) {
+		cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+		req = req.WithContext(ctx)
+		rr := httptest.NewRecorder()
+
+		h := redirectBackPageHandler{BackURL: "/back", Method: http.MethodPost, Values: url.Values{"a": {"b"}}}
+		h.ServeHTTP(rr, req)
+
+		if cd.AutoRefresh != "" {
+			t.Fatalf("unexpected refresh: %q", cd.AutoRefresh)
+		}
+		body := rr.Body.String()
+		if !strings.Contains(body, "<form") || !strings.Contains(body, "action=\"/back\"") {
+			t.Fatalf("missing form: %q", body)
+		}
+	})
+}

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -101,7 +101,7 @@ func TestSecurityHeadersMiddlewareForwardedProto(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
-  }
+	}
 }
 
 func TestSecurityHeadersMiddleware(t *testing.T) {


### PR DESCRIPTION
## Summary
- refresh via meta when redirectBackPageHandler is invoked with GET or empty method
- test redirectBackPageHandler for both refresh and form rendering
- gofmt whitespace cleanup in security_test.go

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot use &cfg as *RuntimeConfig)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: many build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68846acc889c832f8d9e2b01a1db93a5