### PR TITLE
Fix template init log message

### DIFF
--- a/core/templates/embedded.go
+++ b/core/templates/embedded.go
@@ -31,7 +31,7 @@ var (
 )
 
 func init() {
-	log.Printf("Embedded Templatee Mode")
+	log.Printf("Embedded Template Mode")
 }
 
 func GetCompiledSiteTemplates(funcs htemplate.FuncMap) *htemplate.Template {


### PR DESCRIPTION
## Summary
- correct typo in embedded templates init log

## Testing
- `go mod tidy`
- `go fmt ./core/templates`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot use &cfg as *RuntimeConfig)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: build failures)*

------
https://chatgpt.com/codex/tasks/task_e_68846ac700ec832fb53bd40154190296