### PR TITLE
Enhance migration guidelines

### DIFF
--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -5,6 +5,7 @@ const (
 	Alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 	// ExpectedSchemaVersion defines the required database schema version.
+	// Bump this when adding a new migration.
 	ExpectedSchemaVersion = 48
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.

--- a/migrations/embed.go
+++ b/migrations/embed.go
@@ -2,7 +2,9 @@ package migrations
 
 import "embed"
 
-// FS contains the database migration SQL scripts.
+// FS contains the database migration SQL scripts. Each new migration must
+// update the `schema_version` table and bump
+// handlers.ExpectedSchemaVersion.
 //
 //go:embed *.sql
 var FS embed.FS

--- a/readme.md
+++ b/readme.md
@@ -330,6 +330,7 @@ Database schema changes are stored in the `migrations/` directory. Run
 `goa4web db migrate` to apply all pending scripts using your configured
 database connection. Set `AUTO_MIGRATE=true` to perform this step
 automatically when the server starts.
+Every new migration must conclude with an `UPDATE schema_version` statement, and the `ExpectedSchemaVersion` constant in `handlers/constants.go` should be incremented.
 
 When upgrading from v0.0.1 the script `migrations/0002.sql` must be applied.
 This can be done manually using the `mysql` client:


### PR DESCRIPTION
## Summary
- clarify migration versioning in developer docs
- note bumping `ExpectedSchemaVersion` in constants
- remind developers inside migration embed comment

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot use &cfg as *RuntimeConfig)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_68846aaebc54832faeaf771958e6880c