### PR TITLE
Switch pagination helpers to CoreData

### DIFF
--- a/handlers/admin/adminAuditLogPage.go
+++ b/handlers/admin/adminAuditLogPage.go
@@ -34,11 +34,12 @@ func AdminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 		PageSize int
 	}
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		User:     r.URL.Query().Get("user"),
 		Action:   r.URL.Query().Get("action"),
-		PageSize: handlers.GetPageSize(r),
+		PageSize: cd.PageSize(),
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))

--- a/handlers/admin/adminSentEmailsPage.go
+++ b/handlers/admin/adminSentEmailsPage.go
@@ -28,11 +28,12 @@ func AdminSentEmailsPage(w http.ResponseWriter, r *http.Request) {
 		PageSize int
 	}
 
-	pageSize := handlers.GetPageSize(r)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	pageSize := cd.PageSize()
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		PageSize: pageSize,
 	}
 

--- a/handlers/blogs/bloggerListPage.go
+++ b/handlers/blogs/bloggerListPage.go
@@ -28,15 +28,16 @@ func BloggerListPage(w http.ResponseWriter, r *http.Request) {
 		PageSize int
 	}
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Search:   r.URL.Query().Get("search"),
-		PageSize: handlers.GetPageSize(r),
+		PageSize: cd.PageSize(),
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
-	pageSize := handlers.GetPageSize(r)
+	pageSize := cd.PageSize()
 	rows, err := data.CoreData.Bloggers(r)
 	if err != nil {
 		switch {

--- a/handlers/linker/linkerAdminQueuePage.go
+++ b/handlers/linker/linkerAdminQueuePage.go
@@ -31,8 +31,9 @@ func AdminQueuePage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Search:   r.URL.Query().Get("search"),
 		User:     r.URL.Query().Get("user"),
 		Category: r.URL.Query().Get("category"),
@@ -71,7 +72,7 @@ func AdminQueuePage(w http.ResponseWriter, r *http.Request) {
 		filtered = append(filtered, &QueueRow{q, FetchPageTitle(r.Context(), q.Url.String)})
 	}
 
-	pageSize := handlers.GetPageSize(r)
+	pageSize := cd.PageSize()
 	if data.Offset < 0 {
 		data.Offset = 0
 	}

--- a/handlers/user/admin_users.go
+++ b/handlers/user/admin_users.go
@@ -38,12 +38,13 @@ func adminUsersPage(w http.ResponseWriter, r *http.Request) {
 		Comments map[int32]*db.AdminUserComment
 	}
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Search:   r.URL.Query().Get("search"),
 		Role:     r.URL.Query().Get("role"),
 		Status:   r.URL.Query().Get("status"),
-		PageSize: handlers.GetPageSize(r),
+		PageSize: cd.PageSize(),
 		Comments: map[int32]*db.AdminUserComment{},
 	}
 

--- a/handlers/writings/writingsWriterListPage.go
+++ b/handlers/writings/writingsWriterListPage.go
@@ -30,13 +30,13 @@ func WriterListPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
 		Search:     r.URL.Query().Get("search"),
-		PageSize:   handlers.GetPageSize(r),
+		PageSize:   cd.PageSize(),
 		CategoryId: 0,
 	}
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
-	pageSize := handlers.GetPageSize(r)
+	pageSize := cd.PageSize()
 	rows, err := cd.Writers(r)
 	if err != nil {
 		switch {


### PR DESCRIPTION
## Summary
- use `cd.PageSize()` instead of `handlers.GetPageSize`
- update page size retrieval in blogger, linker queue, writers list, admin users, audit log, and sent emails handlers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot use &cfg as *RuntimeConfig)*
- `golangci-lint run ./...` *(fails: typecheck issues)*
- `go test ./...` *(fails to build various packages)*

------
https://chatgpt.com/codex/tasks/task_e_68846cf07b90832fb511198f51863f4e