### PR TITLE
Expose DLQ RegisterDefaults helper

### DIFF
--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -29,7 +29,7 @@ import (
 	"github.com/arran4/goa4web/internal/dbdrivers"
 	dbdefaults "github.com/arran4/goa4web/internal/dbdrivers/dbdefaults"
 	dlq "github.com/arran4/goa4web/internal/dlq"
-	dlqreg "github.com/arran4/goa4web/internal/dlq/dlqdefaults"
+	dlqdefaults "github.com/arran4/goa4web/internal/dlq/dlqdefaults"
 	email "github.com/arran4/goa4web/internal/email"
 	emaildefaults "github.com/arran4/goa4web/internal/email/emaildefaults"
 
@@ -142,8 +142,7 @@ func parseRoot(args []string) (*rootCmd, error) {
 	registerTasks(r.tasksReg)
 	registerModules(r.routerReg)
 	emaildefaults.Register(r.emailReg)
-	dlqreg.Register(r.dlqReg, r.emailReg)
-	dlq.RegisterLogDLQ(r.dlqReg)
+	dlqdefaults.RegisterDefaults(r.dlqReg, r.emailReg)
 	dbdefaults.Register(r.dbReg)
 
 	early := newFlagSet(args[0])

--- a/config/maps_runtime.go
+++ b/config/maps_runtime.go
@@ -12,13 +12,13 @@ func DefaultMap() map[string]string {
 	cfg := GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
 	m := make(map[string]string)
 	for _, o := range StringOptions {
-		m[o.Env] = *o.Target(&cfg)
+		m[o.Env] = *o.Target(cfg)
 	}
 	for _, o := range IntOptions {
-		m[o.Env] = strconv.Itoa(*o.Target(&cfg))
+		m[o.Env] = strconv.Itoa(*o.Target(cfg))
 	}
 	for _, o := range BoolOptions {
-		m[o.Env] = strconv.FormatBool(*o.Target(&cfg))
+		m[o.Env] = strconv.FormatBool(*o.Target(cfg))
 	}
 	return m
 }

--- a/internal/dlq/dlq_test.go
+++ b/internal/dlq/dlq_test.go
@@ -17,7 +17,7 @@ import (
 func TestProviderFromConfigRegistry(t *testing.T) {
 	reg := dlq.NewRegistry()
 	emailReg := emailpkg.NewRegistry()
-	dlqdefaults.Register(reg, emailReg)
+	dlqdefaults.RegisterDefaults(reg, emailReg)
 
 	cfg := config.RuntimeConfig{DLQProvider: "file", DLQFile: "p"}
 	if _, ok := reg.ProviderFromConfig(cfg, nil).(*filedlq.DLQ); !ok {

--- a/internal/dlq/dlqdefaults/defaults.go
+++ b/internal/dlq/dlqdefaults/defaults.go
@@ -9,9 +9,8 @@ import (
 	emailpkg "github.com/arran4/goa4web/internal/email"
 )
 
-// Register registers all stable DLQ providers.
-func Register(r *dlqpkg.Registry, er *emailpkg.Registry) {
-	// TODO refactor this out it's incorrectly being used
+// RegisterDefaults registers all stable DLQ providers.
+func RegisterDefaults(r *dlqpkg.Registry, er *emailpkg.Registry) {
 	file.Register(r)
 	dir.Register(r)
 	db.Register(r)

--- a/specs/dlq.md
+++ b/specs/dlq.md
@@ -16,7 +16,7 @@ Providers implement `Record` to persist messages for later inspection.
 
 ## Default Providers
 
-The `internal/dlq/dlqdefaults` package registers the stable implementations:
+The `dlqdefaults.RegisterDefaults` function registers the stable implementations:
 
 - **log** – writes messages to the application log.
 - **file** – appends messages to a single log file specified by `DLQ_FILE`. Each entry begins with an RFC3339 timestamp.


### PR DESCRIPTION
## Summary
- simplify registering DLQ providers by exposing `RegisterDefaults`
- fix pointer usage in `DefaultMap`
- update main program, docs and tests for new API

## Testing
- `go vet ./...` *(fails: cannot build handlers and other packages)*
- `go test ./...` *(fails: build errors in multiple packages)*
- `golangci-lint run ./...` *(fails: build errors in multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_68846ae4bd84832fa1cf3d8c9a600955