### PR TITLE
Add admin access verification

### DIFF
--- a/config/maps_runtime.go
+++ b/config/maps_runtime.go
@@ -12,13 +12,13 @@ func DefaultMap() map[string]string {
 	cfg := GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
 	m := make(map[string]string)
 	for _, o := range StringOptions {
-		m[o.Env] = *o.Target(&cfg)
+		m[o.Env] = *o.Target(cfg)
 	}
 	for _, o := range IntOptions {
-		m[o.Env] = strconv.Itoa(*o.Target(&cfg))
+		m[o.Env] = strconv.Itoa(*o.Target(cfg))
 	}
 	for _, o := range BoolOptions {
-		m[o.Env] = strconv.FormatBool(*o.Target(&cfg))
+		m[o.Env] = strconv.FormatBool(*o.Target(cfg))
 	}
 	return m
 }

--- a/handlers/access.go
+++ b/handlers/access.go
@@ -1,0 +1,19 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/arran4/goa4web/core/common"
+)
+
+// VerifyAccess wraps h and denies the request if the caller lacks any of
+// the provided roles.
+func VerifyAccess(h http.HandlerFunc, roles ...string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !common.Allowed(r, roles...) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		h(w, r)
+	}
+}

--- a/handlers/access_test.go
+++ b/handlers/access_test.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+)
+
+func TestVerifyAccess(t *testing.T) {
+	h := VerifyAccess(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}, "administrator")
+
+	req := httptest.NewRequest("GET", "/", nil)
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd.SetRoles([]string{"anonymous"})
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected %d got %d", http.StatusForbidden, rr.Code)
+	}
+
+	cd.SetRoles([]string{"administrator"})
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+	rr = httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected %d got %d", http.StatusOK, rr.Code)
+	}
+}

--- a/handlers/admin/reload_shutdown_test.go
+++ b/handlers/admin/reload_shutdown_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -49,6 +51,26 @@ func TestAdminReloadRoute_Unauthorized(t *testing.T) {
 	}
 }
 
+func TestAdminReloadRoute_Authorized(t *testing.T) {
+	r := mux.NewRouter()
+	ar := r.PathPrefix("/admin").Subrouter()
+	cfg := config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
+	RegisterRoutes(ar, cfg)
+
+	req := httptest.NewRequest("POST", "/admin/reload", nil)
+	cd := common.NewCoreData(req.Context(), nil, cfg)
+	cd.SetRoles([]string{"administrator"})
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected %d got %d", http.StatusOK, rr.Code)
+	}
+}
+
 func TestAdminShutdownRoute_Unauthorized(t *testing.T) {
 	r := mux.NewRouter()
 	ar := r.PathPrefix("/admin").Subrouter()
@@ -66,6 +88,34 @@ func TestAdminShutdownRoute_Unauthorized(t *testing.T) {
 
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected %d got %d", http.StatusNotFound, rr.Code)
+	}
+}
+
+type stubServer struct{}
+
+func (stubServer) Shutdown(context.Context) error { return nil }
+
+func TestAdminShutdownRoute_Authorized(t *testing.T) {
+	Srv = &stubServer{}
+	r := mux.NewRouter()
+	ar := r.PathPrefix("/admin").Subrouter()
+	cfg := config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
+	RegisterRoutes(ar, cfg)
+
+	form := url.Values{}
+	form.Set("task", string(TaskServerShutdown))
+	req := httptest.NewRequest("POST", "/admin/shutdown", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	cd := common.NewCoreData(req.Context(), nil, cfg)
+	cd.SetRoles([]string{"administrator"})
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected %d got %d", http.StatusOK, rr.Code)
 	}
 }
 

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -101,11 +101,14 @@ func RegisterRoutes(ar *mux.Router, _ config.RuntimeConfig) {
 	// writings admin
 	writings.RegisterAdminRoutes(ar)
 
-	// TODO ensure requires administrator to run. Even from CLI.
-	ar.HandleFunc("/reload", AdminReloadConfigPage).
+	// Verify administrator access within the handlers so direct CLI calls
+	// cannot bypass the permission checks.
+	ar.HandleFunc("/reload",
+		handlers.VerifyAccess(AdminReloadConfigPage, "administrator")).
 		Methods("POST").
 		MatcherFunc(handlers.RequiredAccess("administrator"))
-	ar.HandleFunc("/shutdown", handlers.TaskHandler(serverShutdownTask)).
+	ar.HandleFunc("/shutdown",
+		handlers.VerifyAccess(handlers.TaskHandler(serverShutdownTask), "administrator")).
 		Methods("POST").
 		MatcherFunc(handlers.RequiredAccess("administrator")).
 		MatcherFunc(serverShutdownTask.Matcher())


### PR DESCRIPTION
## Summary
- enforce admin checks within reload and shutdown routes
- add VerifyAccess helper
- test authorized access for reload and shutdown
- cover new helper with unit tests

## Testing
- `go mod tidy`
- `go vet ./...` *(fails: type checking errors)*
- `golangci-lint run ./...` *(fails: type checking errors)*
- `go test ./...` *(fails to build packages)*

------
https://chatgpt.com/codex/tasks/task_e_68846ad161e4832f9fa2b2b43d8322a6