### PR TITLE
Add secrets helper

### DIFF
--- a/config/admin_api_secret.go
+++ b/config/admin_api_secret.go
@@ -1,36 +1,19 @@
 package config
 
 import (
-	"github.com/arran4/goa4web"
-	"os"
-	"path/filepath"
-
 	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/internal/secrets"
 )
 
-// TODO: build a small library for repeating secret helpers used across packages.
-
-const defaultAPISecretName = ".admin_api_secret"
+// adminAPISecretName is the filename used for storing the admin API secret.
+const adminAPISecretName = "admin_api_secret"
 
 // DefaultAdminAPISecretPath returns the default path for the admin API secret file based on the execution environment.
 func DefaultAdminAPISecretPath() string {
-	if goa4web.Version == "dev" {
-		return defaultAPISecretName
-	}
-	if os.Getenv(EnvDocker) != "" {
-		return "/var/lib/goa4web/admin_api_secret"
-	}
-	if os.Getenv("HOME") == "" && os.Getenv("XDG_CONFIG_HOME") == "" {
-		return "/var/lib/goa4web/admin_api_secret"
-	}
-	dir, err := os.UserConfigDir()
-	if err == nil && dir != "" {
-		return filepath.Join(dir, "goa4web", "admin_api_secret")
-	}
-	return defaultAPISecretName
+	return secrets.DefaultPath(adminAPISecretName, EnvDocker)
 }
 
 // LoadOrCreateAdminAPISecret works like LoadOrCreateSecret but defaults to DefaultAdminAPISecretPath.
 func LoadOrCreateAdminAPISecret(fs core.FileSystem, cliSecret, path string) (string, error) {
-	return LoadOrCreateSecret(fs, cliSecret, path, EnvAdminAPISecret, EnvAdminAPISecretFile)
+	return secrets.LoadOrCreate(fs, cliSecret, path, EnvAdminAPISecret, EnvAdminAPISecretFile, DefaultAdminAPISecretPath)
 }

--- a/config/maps_runtime.go
+++ b/config/maps_runtime.go
@@ -12,13 +12,13 @@ func DefaultMap() map[string]string {
 	cfg := GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
 	m := make(map[string]string)
 	for _, o := range StringOptions {
-		m[o.Env] = *o.Target(&cfg)
+		m[o.Env] = *o.Target(cfg)
 	}
 	for _, o := range IntOptions {
-		m[o.Env] = strconv.Itoa(*o.Target(&cfg))
+		m[o.Env] = strconv.Itoa(*o.Target(cfg))
 	}
 	for _, o := range BoolOptions {
-		m[o.Env] = strconv.FormatBool(*o.Target(&cfg))
+		m[o.Env] = strconv.FormatBool(*o.Target(cfg))
 	}
 	return m
 }

--- a/config/session_secret.go
+++ b/config/session_secret.go
@@ -1,79 +1,21 @@
 package config
 
 import (
-	"crypto/rand"
-	"encoding/hex"
-	"errors"
-	"github.com/arran4/goa4web"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/internal/secrets"
 )
 
-// defaultSecretName is used for local development when no other path is found.
-const defaultSecretName = ".session_secret"
+// sessionSecretName is the filename used for storing the session secret.
+const sessionSecretName = "session_secret"
 
 // DefaultSessionSecretPath returns the default path for the session secret file
 // based on the execution environment.
 func DefaultSessionSecretPath() string {
-	if goa4web.Version == "dev" {
-		return defaultSecretName
-	}
-	if os.Getenv(EnvDocker) != "" {
-		return "/var/lib/goa4web/session_secret"
-	}
-	if os.Getenv("HOME") == "" && os.Getenv("XDG_CONFIG_HOME") == "" {
-		return "/var/lib/goa4web/session_secret"
-	}
-	dir, err := os.UserConfigDir()
-	if err == nil && dir != "" {
-		return filepath.Join(dir, "goa4web", "session_secret")
-	}
-	return defaultSecretName
+	return secrets.DefaultPath(sessionSecretName, EnvDocker)
 }
 
-// LoadOrCreateSecret returns a secret using the following priority:
-//  1. cliSecret if non-empty
-//  2. the environment variable named envSecret
-//  3. contents of the file at path. If path is empty it uses envSecretFile
-//     or DefaultSessionSecretPath().
-//
-// If the file does not exist, a new random secret is generated and saved.
+// LoadOrCreateSecret returns a secret using DefaultSessionSecretPath when no path
+// is provided.
 func LoadOrCreateSecret(fs core.FileSystem, cliSecret, path, envSecret, envSecretFile string) (string, error) {
-	if cliSecret != "" {
-		return cliSecret, nil
-	}
-
-	if env := os.Getenv(envSecret); env != "" {
-		return env, nil
-	}
-
-	if path == "" {
-		path = os.Getenv(envSecretFile)
-		if path == "" {
-			path = DefaultSessionSecretPath()
-		}
-	}
-
-	b, err := fs.ReadFile(path)
-	if err == nil {
-		secret := strings.TrimSpace(string(b))
-		if secret != "" {
-			return secret, nil
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return "", err
-	}
-
-	buf := make([]byte, 32)
-	if _, err := rand.Read(buf); err != nil {
-		return "", err
-	}
-	secret := hex.EncodeToString(buf)
-	if err := fs.WriteFile(path, []byte(secret), 0600); err != nil {
-		return "", err
-	}
-	return secret, nil
+	return secrets.LoadOrCreate(fs, cliSecret, path, envSecret, envSecretFile, DefaultSessionSecretPath)
 }

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -101,7 +101,7 @@ func TestSecurityHeadersMiddlewareForwardedProto(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
-  }
+	}
 }
 
 func TestSecurityHeadersMiddleware(t *testing.T) {

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -1,0 +1,72 @@
+package secrets
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/arran4/goa4web"
+	"github.com/arran4/goa4web/core"
+)
+
+// DefaultPath returns the default path for a secret file named name.
+// dockerEnv specifies the environment variable used to detect Docker builds.
+func DefaultPath(name, dockerEnv string) string {
+	devName := "." + name
+	if goa4web.Version == "dev" {
+		return devName
+	}
+	if os.Getenv(dockerEnv) != "" {
+		return filepath.Join("/var/lib/goa4web", name)
+	}
+	if os.Getenv("HOME") == "" && os.Getenv("XDG_CONFIG_HOME") == "" {
+		return filepath.Join("/var/lib/goa4web", name)
+	}
+	if dir, err := os.UserConfigDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "goa4web", name)
+	}
+	return devName
+}
+
+// LoadOrCreate returns a secret using the following priority:
+//  1. cliSecret if non-empty
+//  2. the environment variable named envSecret
+//  3. contents of the file at path. If path is empty it uses envSecretFile
+//     or defaultPath.
+//
+// If the file does not exist, a new random secret is generated and saved.
+func LoadOrCreate(fs core.FileSystem, cliSecret, path, envSecret, envSecretFile string, defaultPath func() string) (string, error) {
+	if cliSecret != "" {
+		return cliSecret, nil
+	}
+	if env := os.Getenv(envSecret); env != "" {
+		return env, nil
+	}
+	if path == "" {
+		path = os.Getenv(envSecretFile)
+		if path == "" {
+			path = defaultPath()
+		}
+	}
+	b, err := fs.ReadFile(path)
+	if err == nil {
+		secret := strings.TrimSpace(string(b))
+		if secret != "" {
+			return secret, nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	secret := hex.EncodeToString(buf)
+	if err := fs.WriteFile(path, []byte(secret), 0600); err != nil {
+		return "", err
+	}
+	return secret, nil
+}


### PR DESCRIPTION
## Summary
- create `internal/secrets` package for reusable secret helpers
- refactor `config/admin_api_secret.go` and `config/session_secret.go` to use it
- fix compile issue in `config/maps_runtime.go`
- gofmt cleanup in `internal/middleware/security_test.go`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot compile packages)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_68846acb404c832f8963dba74d2c365c