### PR TITLE
Fix embedded template mode typo

### DIFF
--- a/core/templates/embedded.go
+++ b/core/templates/embedded.go
@@ -31,7 +31,7 @@ var (
 )
 
 func init() {
-	log.Printf("Embedded Templatee Mode")
+	log.Printf("Embedded Template Mode")
 }
 
 func GetCompiledSiteTemplates(funcs htemplate.FuncMap) *htemplate.Template {


### PR DESCRIPTION
## Summary
- fix log message typo in core/templates/embedded.go

## Testing
- `gofmt -w core/templates/embedded.go`
- `go vet core/templates/embedded.go`

------
https://chatgpt.com/codex/tasks/task_e_68846aba43e4832f903b45b22d353f94