### PR TITLE
Add helper for default DLQ registry

### DIFF
--- a/internal/dlq/dlqdefaults/defaults.go
+++ b/internal/dlq/dlqdefaults/defaults.go
@@ -18,3 +18,10 @@ func Register(r *dlqpkg.Registry, er *emailpkg.Registry) {
 	email.Register(r, er)
 	dlqpkg.RegisterLogDLQ(r)
 }
+
+// NewRegistry returns a Registry with stable providers registered.
+func NewRegistry(er *emailpkg.Registry) *dlqpkg.Registry {
+	r := dlqpkg.NewRegistry()
+	Register(r, er)
+	return r
+}

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -101,7 +101,7 @@ func TestSecurityHeadersMiddlewareForwardedProto(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
-  }
+	}
 }
 
 func TestSecurityHeadersMiddleware(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `NewRegistry` helper to dlqdefaults for initializing a registry with the stable providers
- run gofmt on tests

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot use &cfg as *RuntimeConfig)*
- `golangci-lint run ./...` *(fails: cannot use &cfg as *RuntimeConfig)*

------
https://chatgpt.com/codex/tasks/task_e_68846c6118a0832f90f27d324ae06738