### PR TITLE
Isolate middleware role tests

### DIFF
--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -101,7 +101,7 @@ func TestSecurityHeadersMiddlewareForwardedProto(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
-  }
+	}
 }
 
 func TestSecurityHeadersMiddleware(t *testing.T) {


### PR DESCRIPTION
## Summary
- avoid global state in TestCoreAdderMiddleware*
- run gofmt on security_test.go

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot use &cfg as *RuntimeConfig)*
- `golangci-lint run ./...` *(fails: typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_68846c737264832f9d4187263b3e1dd8