### PR TITLE
Fix NewCoreData usage in list commands

### DIFF
--- a/cmd/goa4web/news_list.go
+++ b/cmd/goa4web/news_list.go
@@ -36,7 +36,7 @@ func (c *newsListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	cd := common.NewCoreData(ctx, queries, common.WithConfig(c.rootCmd.cfg))
+	cd := common.NewCoreData(ctx, queries, &c.rootCmd.cfg)
 	posts, err := cd.LatestNewsList(int32(c.Offset), int32(c.Limit))
 	if err != nil {
 		return fmt.Errorf("list news: %w", err)

--- a/cmd/goa4web/writing_list.go
+++ b/cmd/goa4web/writing_list.go
@@ -68,7 +68,7 @@ func (c *writingListCmd) Run() error {
 		}
 		return nil
 	}
-	cd := common.NewCoreData(ctx, queries, common.WithConfig(c.rootCmd.cfg))
+	cd := common.NewCoreData(ctx, queries, &c.rootCmd.cfg)
 	rows, err := cd.LatestWritings(common.WithWritingsOffset(int32(c.Offset)), common.WithWritingsLimit(int32(c.Limit)))
 	if err != nil {
 		return fmt.Errorf("list writings: %w", err)

--- a/config/maps_runtime.go
+++ b/config/maps_runtime.go
@@ -12,13 +12,13 @@ func DefaultMap() map[string]string {
 	cfg := GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
 	m := make(map[string]string)
 	for _, o := range StringOptions {
-		m[o.Env] = *o.Target(&cfg)
+		m[o.Env] = *o.Target(cfg)
 	}
 	for _, o := range IntOptions {
-		m[o.Env] = strconv.Itoa(*o.Target(&cfg))
+		m[o.Env] = strconv.Itoa(*o.Target(cfg))
 	}
 	for _, o := range BoolOptions {
-		m[o.Env] = strconv.FormatBool(*o.Target(&cfg))
+		m[o.Env] = strconv.FormatBool(*o.Target(cfg))
 	}
 	return m
 }


### PR DESCRIPTION
## Summary
- pass runtime config directly to `common.NewCoreData`
- adjust `config/maps_runtime.go` to use pointer properly

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: not enough arguments for NewCoreData and other build issues)*
- `golangci-lint run ./...` *(fails: type checking errors)*
- `go test ./...` *(fails to build handlers and internal packages)*

------
https://chatgpt.com/codex/tasks/task_e_68846c80b438832fb5c1242002910f3f