### PR TITLE
Replace NewRuntimeConfig usages

### DIFF
--- a/config/maps_runtime.go
+++ b/config/maps_runtime.go
@@ -12,13 +12,13 @@ func DefaultMap() map[string]string {
 	cfg := GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
 	m := make(map[string]string)
 	for _, o := range StringOptions {
-		m[o.Env] = *o.Target(&cfg)
+		m[o.Env] = *o.Target(cfg)
 	}
 	for _, o := range IntOptions {
-		m[o.Env] = strconv.Itoa(*o.Target(&cfg))
+		m[o.Env] = strconv.Itoa(*o.Target(cfg))
 	}
 	for _, o := range BoolOptions {
-		m[o.Env] = strconv.FormatBool(*o.Target(&cfg))
+		m[o.Env] = strconv.FormatBool(*o.Target(cfg))
 	}
 	return m
 }

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -37,7 +37,7 @@ func TestCoreDataLatestNewsLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -71,7 +71,7 @@ func TestWritingCategoriesLazy(t *testing.T) {
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "category", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 
@@ -102,7 +102,7 @@ func TestAnnouncementForNewsCaching(t *testing.T) {
 	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnRows(annRows)
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 
 	if _, err := cd.AnnouncementForNews(1); err != nil {
 		t.Fatalf("AnnouncementForNews: %v", err)
@@ -128,7 +128,7 @@ func TestAnnouncementForNewsError(t *testing.T) {
 	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnError(sql.ErrConnDone)
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 
 	if _, err := cd.AnnouncementForNews(1); !errors.Is(err, sql.ErrConnDone) {
 		t.Fatalf("AnnouncementForNews error=%v", err)
@@ -167,7 +167,7 @@ func TestPublicWritingsLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -211,7 +211,7 @@ func TestCoreDataLatestWritingsLazy(t *testing.T) {
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "article", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -65,7 +65,7 @@ func TestLatestNewsRespectsPermissions(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)

--- a/handlers/admin/reload_shutdown_test.go
+++ b/handlers/admin/reload_shutdown_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAdminReloadConfigPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/admin/server_shutdown_task_test.go
+++ b/handlers/admin/server_shutdown_task_test.go
@@ -19,7 +19,7 @@ func TestServerShutdownTask_EventPublished(t *testing.T) {
 	Srv = &serverpkg.Server{Bus: bus}
 	ch := bus.Subscribe(eventbus.TaskMessageType)
 
-	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 

--- a/handlers/auth/forgotPassword_event_test.go
+++ b/handlers/auth/forgotPassword_event_test.go
@@ -31,7 +31,7 @@ func TestForgotPasswordEventData(t *testing.T) {
 	mock.ExpectExec("INSERT INTO pending_passwords").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
-	cd := common.NewCoreData(context.Background(), q, common.WithEvent(evt), config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, common.WithEvent(evt), config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 
 	form := url.Values{"username": {"u"}, "password": {"pw"}}

--- a/handlers/auth/forgotPassword_limit_test.go
+++ b/handlers/auth/forgotPassword_limit_test.go
@@ -34,7 +34,7 @@ func TestForgotPasswordRateLimit(t *testing.T) {
 	form := url.Values{"username": {"u"}, "password": {"pw"}}
 	req := httptest.NewRequest(http.MethodPost, "/forgot", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -67,7 +67,7 @@ func TestForgotPasswordReplaceOld(t *testing.T) {
 	form := url.Values{"username": {"u"}, "password": {"pw"}}
 	req := httptest.NewRequest(http.MethodPost, "/forgot", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/handlers/auth/forgotPassword_no_email_test.go
+++ b/handlers/auth/forgotPassword_no_email_test.go
@@ -25,7 +25,7 @@ func TestForgotPasswordNoEmail(t *testing.T) {
 	q := dbpkg.New(db)
 	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "", "u"))
 
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 
 	form := url.Values{"username": {"u"}, "password": {"pw"}}
@@ -55,7 +55,7 @@ func TestEmailAssociationRequestTask(t *testing.T) {
 	mock.ExpectExec("INSERT INTO admin_request_comments").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO admin_user_comments").WillReturnResult(sqlmock.NewResult(1, 1))
 
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 
 	form := url.Values{"username": {"u"}, "email": {"a@test.com"}, "reason": {"help"}}

--- a/handlers/auth/loginPage_test.go
+++ b/handlers/auth/loginPage_test.go
@@ -49,7 +49,7 @@ func TestLoginAction_NoSuchUser(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = "1.2.3.4:1111"
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -87,7 +87,7 @@ func TestLoginAction_InvalidPassword(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = "1.2.3.4:1111"
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -112,7 +112,7 @@ func TestLoginPageHiddenFields(t *testing.T) {
 	q := dbpkg.New(db)
 
 	req := httptest.NewRequest(http.MethodGet, "/login?code=abc&back=%2Ffoo&method=POST&data=x", nil)
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -158,7 +158,7 @@ func TestLoginAction_PendingResetPrompt(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = "1.2.3.4:1111"
 
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -211,7 +211,7 @@ func TestSanitizeBackURLSigned(t *testing.T) {
 	req.Host = "example.com"
 	cfg := config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
 	signer := imagesign.NewSigner(cfg, "k")
-	cd := common.NewCoreData(req.Context(), dbpkg.New(nil), config.NewRuntimeConfig(), common.WithImageSigner(signer))
+	cd := common.NewCoreData(req.Context(), dbpkg.New(nil), config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }), common.WithImageSigner(signer))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	ts := time.Now().Add(time.Hour).Unix()
@@ -232,7 +232,7 @@ func TestLoginPageInvalidBackURL(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/login?back=https://evil.com/x", nil)
 	req.Host = "example.com"
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -257,7 +257,7 @@ func TestLoginPageSignedBackURL(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/login?back="+url.QueryEscape(raw)+"&back_ts="+fmt.Sprint(ts)+"&back_sig="+sig, nil)
 	req.Host = "example.com"
 	signer := imagesign.NewSigner(cfg, "k")
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithImageSigner(signer))
+	cd := common.NewCoreData(req.Context(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }), common.WithImageSigner(signer))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -296,7 +296,7 @@ func TestLoginAction_ExternalBackURLIgnored(t *testing.T) {
 	req.RemoteAddr = "1.2.3.4:1111"
 	req.Host = "example.com"
 
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -345,7 +345,7 @@ func TestLoginAction_SignedExternalBackURL(t *testing.T) {
 	req.RemoteAddr = "1.2.3.4:1111"
 	req.Host = "example.com"
 
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithImageSigner(signer))
+	cd := common.NewCoreData(req.Context(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }), common.WithImageSigner(signer))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/blogs/blogsBloggersBloggerPage_test.go
+++ b/handlers/blogs/blogsBloggersBloggerPage_test.go
@@ -28,7 +28,7 @@ func TestBloggersBloggerPage(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/blogs/bloggers/blogger", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/handlers/blogs/blogsCommentPage_replyable_test.go
+++ b/handlers/blogs/blogsCommentPage_replyable_test.go
@@ -32,7 +32,7 @@ func setupCommentRequest(t *testing.T, queries *db.Queries, store *sessions.Cook
 		req.AddCookie(c)
 	}
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	return req, sess

--- a/handlers/blogs/blogsIndexPermissions_test.go
+++ b/handlers/blogs/blogsIndexPermissions_test.go
@@ -11,7 +11,7 @@ import (
 func TestCustomBlogIndexRoles(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs", nil)
 
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"administrator"})
 	cd.AdminMode = true
 	CustomBlogIndex(cd, req)
@@ -22,7 +22,7 @@ func TestCustomBlogIndexRoles(t *testing.T) {
 		t.Errorf("admin should see write blog")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd = common.NewCoreData(req.Context(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"content writer"})
 	CustomBlogIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "User Permissions") {
@@ -32,7 +32,7 @@ func TestCustomBlogIndexRoles(t *testing.T) {
 		t.Errorf("content writer should see write blog")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd = common.NewCoreData(req.Context(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"anonymous"})
 	CustomBlogIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "User Permissions") || common.ContainsItem(cd.CustomIndexItems, "Write blog") {

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -54,7 +54,7 @@ func TestBlogsBloggerPostsPage(t *testing.T) {
 	}
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -102,7 +102,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "http://example.com/blogs/rss?rss=bob", nil)
 	q := db.New(sqldb)
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -127,7 +127,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 
 func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -140,7 +140,7 @@ func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
 
 func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/1/edit", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -153,7 +153,7 @@ func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 
 func TestGetPermissionsByUserIdAndSectionBlogsPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin/blogs/user/permissions", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/bookmarks/mine_test.go
+++ b/handlers/bookmarks/mine_test.go
@@ -96,7 +96,7 @@ func TestMinePage_NoBookmarks(t *testing.T) {
 	}
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/faq/page_test.go
+++ b/handlers/faq/page_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCustomFAQIndexRoles(t *testing.T) {
-	cd := common.NewCoreData(nil, nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(nil, nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"administrator"})
 	cd.AdminMode = true
 	CustomFAQIndex(cd, nil)
@@ -16,7 +16,7 @@ func TestCustomFAQIndexRoles(t *testing.T) {
 		t.Errorf("admin should see question controls")
 	}
 
-	cd = common.NewCoreData(nil, nil, config.NewRuntimeConfig())
+	cd = common.NewCoreData(nil, nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"anonymous"})
 	CustomFAQIndex(cd, nil)
 	if common.ContainsItem(cd.CustomIndexItems, "Question Qontrols") {

--- a/handlers/forum/forumIndexPermissions_test.go
+++ b/handlers/forum/forumIndexPermissions_test.go
@@ -23,7 +23,7 @@ func TestCustomForumIndexWriteReply(t *testing.T) {
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "reply", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -49,7 +49,7 @@ func TestCustomForumIndexWriteReplyDenied(t *testing.T) {
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "reply", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -75,7 +75,7 @@ func TestCustomForumIndexCreateThread(t *testing.T) {
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -101,7 +101,7 @@ func TestCustomForumIndexCreateThreadDenied(t *testing.T) {
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -127,7 +127,7 @@ func TestCustomForumIndexSubscribeLink(t *testing.T) {
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 
 	mock.ExpectQuery("SELECT id, pattern, method FROM subscriptions").
@@ -154,7 +154,7 @@ func TestCustomForumIndexUnsubscribeLink(t *testing.T) {
 	defer sqldb.Close()
 	q := dbpkg.New(sqldb)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 
 	pattern := topicSubscriptionPattern(2)

--- a/handlers/forum/matchers_test.go
+++ b/handlers/forum/matchers_test.go
@@ -45,7 +45,7 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
 	q := db.New(sqldb)
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -96,7 +96,7 @@ func TestRequireThreadAndTopicFalse(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
 	q := db.New(sqldb)
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -133,7 +133,7 @@ func TestRequireThreadAndTopicError(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
 	q := db.New(sqldb)
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -75,7 +75,7 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/admin/queue?qid=1", nil)
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
-	cd := common.NewCoreData(req.Context(), queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetEvent(evt)
 	cd.SetEventTask(ApproveTask)
 	ctxreq := context.WithValue(req.Context(), consts.KeyCoreData, cd)

--- a/handlers/matchers_test.go
+++ b/handlers/matchers_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestRequiredAccessAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	cd.SetRoles([]string{"content writer"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
@@ -27,7 +27,7 @@ func TestRequiredAccessAllowed(t *testing.T) {
 
 func TestRequiredAccessDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)

--- a/handlers/news/newsIndexPermissions_test.go
+++ b/handlers/news/newsIndexPermissions_test.go
@@ -13,7 +13,7 @@ import (
 func TestCustomNewsIndexRoles(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"administrator"})
 	cd.AdminMode = true
 	CustomNewsIndex(cd, req)
@@ -31,7 +31,7 @@ func TestCustomNewsIndexRoles(t *testing.T) {
 	defer db.Close()
 	q := dbpkg.New(db)
 	ctx := req.Context()
-	cd = common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd = common.NewCoreData(ctx, q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"content writer", "administrator"})
 	CustomNewsIndex(cd, req.WithContext(ctx))
 	if common.ContainsItem(cd.CustomIndexItems, "User Permissions") {
@@ -41,7 +41,7 @@ func TestCustomNewsIndexRoles(t *testing.T) {
 		t.Errorf("content writer should see add news")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd = common.NewCoreData(req.Context(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"anonymous"})
 	CustomNewsIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "User Permissions") || common.ContainsItem(cd.CustomIndexItems, "Add News") {

--- a/handlers/user/addEmailTask_invalid_test.go
+++ b/handlers/user/addEmailTask_invalid_test.go
@@ -38,7 +38,7 @@ func TestAddEmailTaskInvalid(t *testing.T) {
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)

--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -31,7 +31,7 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cd := common.NewCoreData(r.Context(), queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(r.Context(), queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = int32(uid)
 
 	user, err := cd.CurrentUser()

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -62,7 +62,7 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 	form.Set("task", string(TaskUserAllow))
 	req := httptest.NewRequest("POST", "/admin/users/permissions", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	cd := common.NewCoreData(req.Context(), queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	evt := &eventbus.TaskEvent{}
 	cd.SetEvent(evt)
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)

--- a/handlers/user/userEmailPage_event_test.go
+++ b/handlers/user/userEmailPage_event_test.go
@@ -45,7 +45,7 @@ func TestAddEmailTaskEventData(t *testing.T) {
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -88,7 +88,7 @@ func TestVerifyRemovesDuplicates(t *testing.T) {
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 
 	rows := sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).
@@ -151,7 +151,7 @@ func TestResendVerificationEmailTaskEventData(t *testing.T) {
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), common.WithEvent(evt), config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	req = req.WithContext(ctx)

--- a/handlers/user/userEmailVerify_test.go
+++ b/handlers/user/userEmailVerify_test.go
@@ -39,7 +39,7 @@ func TestUserEmailVerifyCodePage_Invalid(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	req := httptest.NewRequest(http.MethodGet, "/usr/email/verify?code="+code, nil).WithContext(ctx)
@@ -75,7 +75,7 @@ func TestUserEmailVerifyCodePage_Success(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithSession(sess), config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	form := url.Values{"code": {code}}

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -116,7 +116,7 @@ func TestUserEmailPage_ShowError(t *testing.T) {
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("GET", "/usr/email?error=missing", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -141,7 +141,7 @@ func TestUserEmailPage_NoUnverified(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/usr/email", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -167,7 +167,7 @@ func TestUserEmailPage_NoVerified(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/usr/email", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -266,7 +266,7 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithSession(sess), config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/writings/matchers_test.go
+++ b/handlers/writings/matchers_test.go
@@ -37,7 +37,7 @@ func TestRequireWritingAuthorArticleVar(t *testing.T) {
 	sess, _ := store.Get(req, core.SessionName)
 	sess.Values["UID"] = int32(1)
 
-	cd := common.NewCoreData(req.Context(), q, common.WithSession(sess), config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, common.WithSession(sess), config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"content writer"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/writings/writingsAdminCategoriesPage_test.go
+++ b/handlers/writings/writingsAdminCategoriesPage_test.go
@@ -29,7 +29,7 @@ func TestWritingsAdminCategoriesPage(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/admin/writings/categories", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/handlers/writings/writingsArticlePage_test.go
+++ b/handlers/writings/writingsArticlePage_test.go
@@ -52,7 +52,7 @@ func TestArticleReplyActionPage_UsesArticleParam(t *testing.T) {
 	}
 
 	q := db.New(dbconn)
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/writings/writingsWriterListPage_test.go
+++ b/handlers/writings/writingsWriterListPage_test.go
@@ -26,7 +26,7 @@ func TestWriterListPage_List(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/writings/writers", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -56,7 +56,7 @@ func TestWriterListPage_Search(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/writings/writers?search=bob", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -77,7 +77,7 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 	session := &sessions.Session{ID: "sessid"}
 	req := httptest.NewRequest("GET", "/", nil)
 	q := dbpkg.New(db)
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	ctx := context.WithValue(req.Context(), core.ContextValues("session"), session)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/internal/router/roles_test.go
+++ b/internal/router/roles_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"administrator"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -39,7 +39,7 @@ func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 
 func TestRoleCheckerMiddlewareDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, config.GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" }))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)


### PR DESCRIPTION
## Summary
- replace deprecated `NewRuntimeConfig` helper with `GenerateRuntimeConfig`
- update production code and tests accordingly
- fix pointer usage in `config/maps_runtime.go`

## Testing
- `go vet ./...` *(fails: cannot build packages)*
- `golangci-lint run ./...` *(fails: cannot build packages)*
- `go test ./...` *(fails: undefined references)*

------
https://chatgpt.com/codex/tasks/task_e_68846cb5d63c832f9f9f7f0b6eee1e4e