### PR TITLE
Fix cd usage in imagebbs handlers

### DIFF
--- a/handlers/imagebbs/imagebbsAdminFilesPage.go
+++ b/handlers/imagebbs/imagebbsAdminFilesPage.go
@@ -12,11 +12,10 @@ import (
 	"github.com/arran4/goa4web/core/common"
 
 	"github.com/arran4/goa4web/handlers"
-
-	"github.com/arran4/goa4web/config"
 )
 
 func AdminFilesPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	type Entry struct {
 		Name  string
 		Path  string

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -99,6 +99,7 @@ func BoardPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	text := r.PostFormValue("text")
 
 	vars := mux.Vars(r)

--- a/handlers/imagebbs/routes.go
+++ b/handlers/imagebbs/routes.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
 	router "github.com/arran4/goa4web/internal/router"
@@ -14,6 +17,7 @@ import (
 
 // RegisterRoutes attaches the public image board endpoints to r.
 func RegisterRoutes(r *mux.Router, _ config.RuntimeConfig) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	nav.RegisterIndexLink("ImageBBS", "/imagebbs", SectionWeight)
 	nav.RegisterAdminControlCenter("ImageBBS", "/admin/imagebbs", SectionWeight)
 	r.HandleFunc("/imagebbs.rss", RssPage).Methods("GET")


### PR DESCRIPTION
## Summary
- capture CoreData from request context in imagebbs admin files page
- capture CoreData from request context in upload image handler
- register routes with CoreData for config use

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot use &cfg as *RuntimeConfig)*
- `golangci-lint run ./...` *(fails: cannot use &cfg as *RuntimeConfig)*
- `go test ./...` *(fails: cannot use &cfg as *RuntimeConfig)*

------
https://chatgpt.com/codex/tasks/task_e_68846cf29048832fac50246dae9205c1