### PR TITLE
Fix websocket Register function

### DIFF
--- a/internal/websocket/notifications.go
+++ b/internal/websocket/notifications.go
@@ -201,7 +201,8 @@ func (h *NotificationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 }
 
 // RegisterRoutes attaches the websocket handler to r.
-func (m *Module) registerRoutes(r *mux.Router) {
+func (m *Module) registerRoutes(r *mux.Router, cfg config.RuntimeConfig) {
+	m.Config = cfg
 	h := NewNotificationsHandler(m.Bus, m.Config)
 	r.Handle("/ws/notifications", h).Methods(http.MethodGet)
 	r.HandleFunc("/notifications.js", NotificationsJS).Methods(http.MethodGet)
@@ -209,7 +210,5 @@ func (m *Module) registerRoutes(r *mux.Router) {
 
 // Register registers the websocket router module.
 func (m *Module) Register(reg *routerpkg.Registry) {
-	reg.RegisterModule("websocket", nil, func(r *mux.Router) {
-		m.registerRoutes(r, cfg)
-	})
+	reg.RegisterModule("websocket", nil, m.registerRoutes)
 }


### PR DESCRIPTION
## Summary
- refactor websocket module registration to avoid closure and set runtime config via method parameter

## Testing
- `go vet ./...` *(fails: cannot use &cfg as *RuntimeConfig)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails to build multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_68846cf622a8832fa9f56cedba3628d7