### PR TITLE
Fix runtime config pointer

### DIFF
--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -69,9 +69,11 @@ func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 		}
 		w.Header().Set("Content-Security-Policy", "default-src 'self'")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
-		var cfg config.RuntimeConfig
+		var cfg *config.RuntimeConfig
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 			cfg = cd.Config
+		} else {
+			cfg = &config.RuntimeConfig{}
 		}
 		hsts := cfg.HSTSHeaderValue
 		if hsts != "" {

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -101,7 +101,7 @@ func TestSecurityHeadersMiddlewareForwardedProto(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
-  }
+	}
 }
 
 func TestSecurityHeadersMiddleware(t *testing.T) {


### PR DESCRIPTION
## Summary
- adjust `SecurityHeadersMiddleware` to use a pointer to `RuntimeConfig`

## Testing
- `go mod tidy`
- `go fmt ./...`
- ❌ `go vet ./...` (fails: cannot use &cfg as *RuntimeConfig)
- ❌ `golangci-lint run ./...` (typecheck errors)
- ❌ `go test ./...` (build failed in config package)


------
https://chatgpt.com/codex/tasks/task_e_68846ce85388832fa12f1e1f7339a4aa