### PR TITLE
Fix config dereference in upload providers

### DIFF
--- a/cmd/goa4web/images.go
+++ b/cmd/goa4web/images.go
@@ -56,7 +56,7 @@ func (c *imagesCmd) runCache(args []string) error {
 	dir := c.rootCmd.cfg.ImageCacheDir
 	switch args[0] {
 	case "prune":
-		if cp := upload.CacheProviderFromConfig(c.rootCmd.cfg); cp != nil {
+		if cp := upload.CacheProviderFromConfig(&c.rootCmd.cfg); cp != nil {
 			if ccp, ok := cp.(upload.CacheProvider); ok {
 				return ccp.Cleanup(context.Background(), int64(c.rootCmd.cfg.ImageCacheMaxBytes))
 			}

--- a/config/maps_runtime.go
+++ b/config/maps_runtime.go
@@ -12,13 +12,13 @@ func DefaultMap() map[string]string {
 	cfg := GenerateRuntimeConfig(nil, map[string]string{}, func(string) string { return "" })
 	m := make(map[string]string)
 	for _, o := range StringOptions {
-		m[o.Env] = *o.Target(&cfg)
+		m[o.Env] = *o.Target(cfg)
 	}
 	for _, o := range IntOptions {
-		m[o.Env] = strconv.Itoa(*o.Target(&cfg))
+		m[o.Env] = strconv.Itoa(*o.Target(cfg))
 	}
 	for _, o := range BoolOptions {
-		m[o.Env] = strconv.FormatBool(*o.Target(&cfg))
+		m[o.Env] = strconv.FormatBool(*o.Target(cfg))
 	}
 	return m
 }

--- a/internal/app/startup.go
+++ b/internal/app/startup.go
@@ -35,14 +35,14 @@ func CheckUploadTarget(cfg config.RuntimeConfig) *common.UserError {
 	if cfg.ImageUploadDir == "" {
 		return &common.UserError{Err: fmt.Errorf("dir empty"), ErrorMessage: "image upload directory not set"}
 	}
-	p := upload.ProviderFromConfig(cfg)
+	p := upload.ProviderFromConfig(&cfg)
 	if p == nil {
 		return &common.UserError{Err: fmt.Errorf("no provider"), ErrorMessage: "image upload directory invalid"}
 	}
 	if err := p.Check(context.Background()); err != nil {
 		return &common.UserError{Err: err, ErrorMessage: "image upload directory invalid"}
 	}
-	if cp := upload.CacheProviderFromConfig(cfg); cp != nil {
+	if cp := upload.CacheProviderFromConfig(&cfg); cp != nil {
 		if err := cp.Check(context.Background()); err != nil {
 			return &common.UserError{Err: err, ErrorMessage: "image cache directory invalid"}
 		}

--- a/internal/upload/local/local.go
+++ b/internal/upload/local/local.go
@@ -59,7 +59,7 @@ func (p Provider) safePath(name string) (string, error) {
 	return path, nil
 }
 
-func providerFromConfig(cfg config.RuntimeConfig) upload.Provider {
+func providerFromConfig(cfg *config.RuntimeConfig) upload.Provider {
 	return Provider{Dir: cfg.ImageUploadDir, FS: osFS{}}
 }
 

--- a/internal/upload/provider_factory.go
+++ b/internal/upload/provider_factory.go
@@ -5,7 +5,7 @@ import "strings"
 import "github.com/arran4/goa4web/config"
 
 // ProviderFromConfig returns a provider selected by cfg.ImageUploadProvider.
-func ProviderFromConfig(cfg config.RuntimeConfig) Provider {
+func ProviderFromConfig(cfg *config.RuntimeConfig) Provider {
 	name := strings.ToLower(cfg.ImageUploadProvider)
 	if f := providerFactory(name); f != nil {
 		return f(cfg)
@@ -14,10 +14,10 @@ func ProviderFromConfig(cfg config.RuntimeConfig) Provider {
 }
 
 // CacheProviderFromConfig returns a provider selected by cfg.ImageCacheProvider.
-func CacheProviderFromConfig(cfg config.RuntimeConfig) Provider {
-	c := cfg
+func CacheProviderFromConfig(cfg *config.RuntimeConfig) Provider {
+	c := *cfg
 	c.ImageUploadProvider = cfg.ImageCacheProvider
 	c.ImageUploadDir = cfg.ImageCacheDir
 	c.ImageUploadS3URL = cfg.ImageCacheS3URL
-	return ProviderFromConfig(c)
+	return ProviderFromConfig(&c)
 }

--- a/internal/upload/registry.go
+++ b/internal/upload/registry.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ProviderFactory creates an upload provider from cfg.
-type ProviderFactory func(config.RuntimeConfig) Provider
+type ProviderFactory func(*config.RuntimeConfig) Provider
 
 var (
 	regMu    sync.RWMutex

--- a/internal/upload/s3/s3.go
+++ b/internal/upload/s3/s3.go
@@ -43,11 +43,11 @@ type sessionFactory struct{}
 
 func (sessionFactory) New(region string) (api, error) { return newSessionClient(region) }
 
-func providerFromConfig(cfg config.RuntimeConfig) upload.Provider {
+func providerFromConfig(cfg *config.RuntimeConfig) upload.Provider {
 	return providerFromConfigWithFactory(cfg, sessionFactory{})
 }
 
-func providerFromConfigWithFactory(cfg config.RuntimeConfig, f ClientFactory) upload.Provider {
+func providerFromConfigWithFactory(cfg *config.RuntimeConfig, f ClientFactory) upload.Provider {
 	raw := cfg.ImageUploadS3URL
 	if raw == "" {
 		raw = cfg.ImageUploadDir

--- a/internal/upload/s3/s3_test.go
+++ b/internal/upload/s3/s3_test.go
@@ -53,7 +53,7 @@ func (m *mockClient) GetObject(*awsS3.GetObjectInput) (*awsS3.GetObjectOutput, e
 
 func TestProviderCheckSuccess(t *testing.T) {
 	mock := &mockClient{}
-	p := providerFromConfigWithFactory(config.RuntimeConfig{EmailAWSRegion: "us-east-1", ImageUploadS3URL: "s3://bucket/path"}, mockFactory{mock})
+	p := providerFromConfigWithFactory(&config.RuntimeConfig{EmailAWSRegion: "us-east-1", ImageUploadS3URL: "s3://bucket/path"}, mockFactory{mock})
 	if p == nil {
 		t.Fatal("nil provider")
 	}
@@ -67,7 +67,7 @@ func TestProviderCheckSuccess(t *testing.T) {
 
 func TestProviderCheckWriteError(t *testing.T) {
 	mock := &mockClient{putErr: fmt.Errorf("fail")}
-	p := providerFromConfigWithFactory(config.RuntimeConfig{ImageUploadS3URL: "s3://bucket/path"}, mockFactory{mock})
+	p := providerFromConfigWithFactory(&config.RuntimeConfig{ImageUploadS3URL: "s3://bucket/path"}, mockFactory{mock})
 	if err := p.Check(nil); err == nil {
 		t.Fatal("expected error")
 	}
@@ -75,7 +75,7 @@ func TestProviderCheckWriteError(t *testing.T) {
 
 func TestProviderRead(t *testing.T) {
 	mock := &mockClient{getData: []byte("hello")}
-	p := providerFromConfigWithFactory(config.RuntimeConfig{ImageUploadS3URL: "s3://bucket/path"}, mockFactory{mock})
+	p := providerFromConfigWithFactory(&config.RuntimeConfig{ImageUploadS3URL: "s3://bucket/path"}, mockFactory{mock})
 	if p == nil {
 		t.Fatal("nil provider")
 	}


### PR DESCRIPTION
## Summary
- use runtime config pointer directly for default map helpers
- dereference config values in image handlers before passing to upload providers
- pass runtime config to upload provider helpers

## Testing
- `go vet ./...` *(fails: cannot use common.WithImageSigner(signer) as *config.RuntimeConfig in argument to common.NewCoreData)*
- `golangci-lint run ./...` *(fails with typecheck errors from multiple packages)*
- `go test ./...` *(fails to compile handlers and middleware packages)*

------
https://chatgpt.com/codex/tasks/task_e_68846ced1e60832f9c67630c7b43a11b