### PR TITLE
Fix websocket route comment

### DIFF
--- a/internal/websocket/notifications.go
+++ b/internal/websocket/notifications.go
@@ -200,7 +200,7 @@ func (h *NotificationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-// RegisterRoutes attaches the websocket handler to r.
+// registerRoutes attaches the websocket handler to r.
 func (m *Module) registerRoutes(r *mux.Router, cfg *config.RuntimeConfig) {
 	h := NewNotificationsHandler(m.Bus, cfg)
 	r.Handle("/ws/notifications", h).Methods(http.MethodGet)


### PR DESCRIPTION
## Summary
- update comment in `internal/websocket/notifications.go`

## Testing
- `go vet ./...` *(fails: cannot use config.RuntimeConfig as *config.RuntimeConfig)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go fmt ./...`
- `go test ./...` *(fails: cannot use config.RuntimeConfig as *config.RuntimeConfig)*

------
https://chatgpt.com/codex/tasks/task_e_6884a0eef1c8832fb71ac35ebae96664