### PR TITLE
Add server option methods and update construction

### DIFF
--- a/cmd/goa4web/config_as.go
+++ b/cmd/goa4web/config_as.go
@@ -35,7 +35,7 @@ func defaultMap() map[string]string {
 }
 
 func (c *configAsCmd) asEnvFile() error {
-	current, err := config.ToEnvMap(&c.rootCmd.cfg, c.rootCmd.ConfigFile)
+	current, err := config.ToEnvMap(c.rootCmd.cfg, c.rootCmd.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("env map: %w", err)
 	}
@@ -74,7 +74,7 @@ func (c *configAsCmd) asEnvFile() error {
 }
 
 func (c *configAsCmd) asEnv() error {
-	current, err := config.ToEnvMap(&c.rootCmd.cfg, c.rootCmd.ConfigFile)
+	current, err := config.ToEnvMap(c.rootCmd.cfg, c.rootCmd.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("env map: %w", err)
 	}
@@ -113,7 +113,7 @@ func (c *configAsCmd) asEnv() error {
 }
 
 func (c *configAsCmd) asJSON() error {
-	m, err := config.ToEnvMap(&c.rootCmd.cfg, c.rootCmd.ConfigFile)
+	m, err := config.ToEnvMap(c.rootCmd.cfg, c.rootCmd.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("env map: %w", err)
 	}
@@ -126,7 +126,7 @@ func (c *configAsCmd) asJSON() error {
 }
 
 func (c *configAsCmd) asCLI() error {
-	current, err := config.ToEnvMap(&c.rootCmd.cfg, c.rootCmd.ConfigFile)
+	current, err := config.ToEnvMap(c.rootCmd.cfg, c.rootCmd.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("env map: %w", err)
 	}

--- a/cmd/goa4web/config_json_add.go
+++ b/cmd/goa4web/config_json_add.go
@@ -30,7 +30,7 @@ func (c *configJSONAddCmd) Run() error {
 	if c.File == "" {
 		return fmt.Errorf("file required")
 	}
-	values, err := config.ToEnvMap(&c.rootCmd.cfg, c.rootCmd.ConfigFile)
+	values, err := config.ToEnvMap(c.rootCmd.cfg, c.rootCmd.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}

--- a/cmd/goa4web/images.go
+++ b/cmd/goa4web/images.go
@@ -56,7 +56,7 @@ func (c *imagesCmd) runCache(args []string) error {
 	dir := c.rootCmd.cfg.ImageCacheDir
 	switch args[0] {
 	case "prune":
-		if cp := upload.CacheProviderFromConfig(&c.rootCmd.cfg); cp != nil {
+		if cp := upload.CacheProviderFromConfig(c.rootCmd.cfg); cp != nil {
 			if ccp, ok := cp.(upload.CacheProvider); ok {
 				return ccp.Cleanup(context.Background(), int64(c.rootCmd.cfg.ImageCacheMaxBytes))
 			}

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -194,7 +194,7 @@ func parseRoot(args []string) (*rootCmd, error) {
 	}
 
 	r.ConfigFile = cfgPath
-	r.cfg = *config.NewRuntimeConfig(
+	r.cfg = config.NewRuntimeConfig(
 		config.WithFlagSet(r.fs),
 		config.WithFileValues(fileVals),
 		config.WithGetenv(os.Getenv),

--- a/cmd/goa4web/news_list.go
+++ b/cmd/goa4web/news_list.go
@@ -36,7 +36,7 @@ func (c *newsListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	cd := common.NewCoreData(ctx, queries, &c.rootCmd.cfg)
+	cd := common.NewCoreData(ctx, queries, c.rootCmd.cfg)
 	posts, err := cd.LatestNewsList(int32(c.Offset), int32(c.Limit))
 	if err != nil {
 		return fmt.Errorf("list news: %w", err)

--- a/cmd/goa4web/writing_list.go
+++ b/cmd/goa4web/writing_list.go
@@ -68,7 +68,7 @@ func (c *writingListCmd) Run() error {
 		}
 		return nil
 	}
-	cd := common.NewCoreData(ctx, queries, &c.rootCmd.cfg)
+	cd := common.NewCoreData(ctx, queries, c.rootCmd.cfg)
 	rows, err := cd.LatestWritings(common.WithWritingsOffset(int32(c.Offset)), common.WithWritingsLimit(int32(c.Limit)))
 	if err != nil {
 		return fmt.Errorf("list writings: %w", err)

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -34,7 +34,7 @@ func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
 	reg := newEmailReg()
-	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithEmailProvider(reg.ProviderFromConfig(*cfg)))
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithEmailProvider(reg.ProviderFromConfig(cfg)))
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -67,7 +67,7 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
 	q := db.New(sqldb)
 	reg := newEmailReg()
-	cd := common.NewCoreData(req.Context(), q, cfg, common.WithEmailProvider(reg.ProviderFromConfig(*cfg)))
+	cd := common.NewCoreData(req.Context(), q, cfg, common.WithEmailProvider(reg.ProviderFromConfig(cfg)))
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -167,7 +167,7 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 2, Valid: true}, sqlmock.AnyArg(), false).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	rec := &recordAdminMail{}
-	n := notif.New(notif.WithQueries(q), notif.WithEmailProvider(rec), notif.WithConfig(*cfg))
+	n := notif.New(notif.WithQueries(q), notif.WithEmailProvider(rec), notif.WithConfig(cfg))
 	n.NotifyAdmins(context.Background(), &notif.EmailTemplates{}, notif.EmailData{})
 	if len(rec.to) != 0 {
 		t.Fatalf("expected 0 direct mails, got %d", len(rec.to))
@@ -189,7 +189,7 @@ func TestNotifyAdminsDisabled(t *testing.T) {
 	defer os.Unsetenv(config.EnvAdminNotify)
 	cfg.AdminEmails = "a@test.com"
 	rec := &recordAdminMail{}
-	n := notif.New(notif.WithEmailProvider(rec), notif.WithConfig(*cfg))
+	n := notif.New(notif.WithEmailProvider(rec), notif.WithConfig(cfg))
 	n.NotifyAdmins(context.Background(), &notif.EmailTemplates{}, notif.EmailData{})
 	if len(rec.to) != 0 {
 		t.Fatalf("expected 0 mails, got %d", len(rec.to))

--- a/handlers/admin/reload_shutdown_test.go
+++ b/handlers/admin/reload_shutdown_test.go
@@ -36,7 +36,7 @@ func TestAdminReloadRoute_Unauthorized(t *testing.T) {
 	r := mux.NewRouter()
 	ar := r.PathPrefix("/admin").Subrouter()
 	cfg := config.NewRuntimeConfig()
-	RegisterRoutes(ar, *cfg)
+	RegisterRoutes(ar, cfg)
 
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
 	cd := common.NewCoreData(req.Context(), nil, cfg)
@@ -56,7 +56,7 @@ func TestAdminReloadRoute_Authorized(t *testing.T) {
 	r := mux.NewRouter()
 	ar := r.PathPrefix("/admin").Subrouter()
 	cfg := config.NewRuntimeConfig()
-	RegisterRoutes(ar, *cfg)
+	RegisterRoutes(ar, cfg)
 
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
 	cd := common.NewCoreData(req.Context(), nil, cfg)
@@ -76,7 +76,7 @@ func TestAdminShutdownRoute_Unauthorized(t *testing.T) {
 	r := mux.NewRouter()
 	ar := r.PathPrefix("/admin").Subrouter()
 	cfg := config.NewRuntimeConfig()
-	RegisterRoutes(ar, *cfg)
+	RegisterRoutes(ar, cfg)
 
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
 	cd := common.NewCoreData(req.Context(), nil, cfg)
@@ -97,7 +97,7 @@ func TestAdminShutdownRoute_Authorized(t *testing.T) {
 	r := mux.NewRouter()
 	ar := r.PathPrefix("/admin").Subrouter()
 	cfg := config.NewRuntimeConfig()
-	RegisterRoutes(ar, *cfg)
+	RegisterRoutes(ar, cfg)
 
 	form := url.Values{}
 	form.Set("task", string(TaskServerShutdown))

--- a/handlers/admin/resend_queue_task.go
+++ b/handlers/admin/resend_queue_task.go
@@ -58,7 +58,7 @@ func (ResendQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	for _, e := range emails {
-		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, *cd.Config, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
+		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, cd.Config, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
 		if err != nil {
 			return fmt.Errorf("resolve address fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/auth/loginPage_test.go
+++ b/handlers/auth/loginPage_test.go
@@ -212,7 +212,7 @@ func TestSanitizeBackURLSigned(t *testing.T) {
 	req.Host = "example.com"
 	cfg := config.NewRuntimeConfig()
 	cfg.LoginAttemptThreshold = 10
-	signer := imagesign.NewSigner(*cfg, "k")
+	signer := imagesign.NewSigner(cfg, "k")
 	cd := common.NewCoreData(req.Context(), dbpkg.New(nil), config.NewRuntimeConfig(), common.WithImageSigner(signer))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -259,7 +259,7 @@ func TestLoginPageSignedBackURL(t *testing.T) {
 	sig := signBackURL("k", raw, ts)
 	req := httptest.NewRequest(http.MethodGet, "/login?back="+url.QueryEscape(raw)+"&back_ts="+fmt.Sprint(ts)+"&back_sig="+sig, nil)
 	req.Host = "example.com"
-	signer := imagesign.NewSigner(*cfg, "k")
+	signer := imagesign.NewSigner(cfg, "k")
 	cd := common.NewCoreData(req.Context(), q, cfg, common.WithImageSigner(signer))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -339,7 +339,7 @@ func TestLoginAction_SignedExternalBackURL(t *testing.T) {
 	raw := "https://example.org/ok"
 	ts := time.Now().Add(time.Hour).Unix()
 	sig := signBackURL("k", raw, ts)
-	signer := imagesign.NewSigner(*cfg, "k")
+	signer := imagesign.NewSigner(cfg, "k")
 	form := url.Values{"username": {"bob"}, "password": {"pw"}, "back": {raw}, "back_ts": {fmt.Sprint(ts)}, "back_sig": {sig}}
 	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/handlers/imagebbs/routes.go
+++ b/handlers/imagebbs/routes.go
@@ -13,7 +13,7 @@ import (
 )
 
 // RegisterRoutes attaches the public image board endpoints to r.
-func RegisterRoutes(r *mux.Router, cfg config.RuntimeConfig) {
+func RegisterRoutes(r *mux.Router, cfg *config.RuntimeConfig) {
 	nav.RegisterIndexLink("ImageBBS", "/imagebbs", SectionWeight)
 	nav.RegisterAdminControlCenter("ImageBBS", "/admin/imagebbs", SectionWeight)
 	r.HandleFunc("/imagebbs.rss", RssPage).Methods("GET")

--- a/handlers/images/routes_test.go
+++ b/handlers/images/routes_test.go
@@ -32,7 +32,7 @@ func TestValidID(t *testing.T) {
 func TestImageRouteInvalidID(t *testing.T) {
 	r := mux.NewRouter()
 	cfg := config.NewRuntimeConfig()
-	RegisterRoutes(r, *cfg)
+	RegisterRoutes(r, cfg)
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/images/image/abc!", nil)
 
@@ -46,7 +46,7 @@ func TestImageRouteInvalidID(t *testing.T) {
 func TestCacheRouteInvalidID(t *testing.T) {
 	r := mux.NewRouter()
 	cfg := config.NewRuntimeConfig()
-	RegisterRoutes(r, *cfg)
+	RegisterRoutes(r, cfg)
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/images/cache/abc!", nil)
 

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -62,7 +62,7 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := req.Context()
 	reg := newEmailReg()
-	cd := common.NewCoreData(ctx, queries, cfg, common.WithEmailProvider(reg.ProviderFromConfig(*cfg)))
+	cd := common.NewCoreData(ctx, queries, cfg, common.WithEmailProvider(reg.ProviderFromConfig(cfg)))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -95,7 +95,7 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := req.Context()
 	reg := newEmailReg()
-	cd := common.NewCoreData(ctx, queries, cfg, common.WithEmailProvider(reg.ProviderFromConfig(*cfg)))
+	cd := common.NewCoreData(ctx, queries, cfg, common.WithEmailProvider(reg.ProviderFromConfig(cfg)))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -160,7 +160,7 @@ func NewServer(ctx context.Context, cfg *config.RuntimeConfig, opts ...ServerOpt
 	if err := config.ApplySMTPFallbacks(cfg); err != nil {
 		return nil, fmt.Errorf("smtp fallback: %w", err)
 	}
-	imgSigner := imagesign.NewSigner(*cfg, o.ImageSignSecret)
+	imgSigner := imagesign.NewSigner(cfg, o.ImageSignSecret)
 	adminhandlers.AdminAPISecret = o.APISecret
 	email.SetDefaultFromName(cfg.EmailFrom)
 
@@ -190,6 +190,7 @@ func NewServer(ctx context.Context, cfg *config.RuntimeConfig, opts ...ServerOpt
 		server.WithImageSigner(imgSigner),
 		server.WithDBRegistry(o.DBReg),
 		server.WithWebsocket(wsMod),
+		server.WithTasksRegistry(o.TasksReg),
 	)
 	nav.SetDefaultRegistry(navReg)
 
@@ -211,7 +212,6 @@ func NewServer(ctx context.Context, cfg *config.RuntimeConfig, opts ...ServerOpt
 	adminhandlers.Srv = srv
 	adminhandlers.DBPool = dbPool
 	adminhandlers.UpdateConfigKeyFunc = config.UpdateConfigKey
-	srv.TasksReg = o.TasksReg
 
 	emailProvider := o.EmailReg.ProviderFromConfig(cfg)
 	if cfg.EmailEnabled && cfg.EmailProvider != "" && cfg.EmailFrom == "" {

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -143,6 +143,9 @@ func WithDBRegistry(r *dbdrivers.Registry) Option { return func(s *Server) { s.D
 // WithWebsocket sets the websocket module.
 func WithWebsocket(w *websocket.Module) Option { return func(s *Server) { s.Websocket = w } }
 
+// WithTasksRegistry sets the tasks registry used by the server.
+func WithTasksRegistry(r *tasks.Registry) Option { return func(s *Server) { s.TasksReg = r } }
+
 // New returns a Server configured using the supplied options.
 func New(opts ...Option) *Server {
 	s := &Server{}
@@ -213,7 +216,7 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 			if s.Config.HTTPHostname != "" {
 				base = strings.TrimRight(s.Config.HTTPHostname, "/")
 			}
-			provider := s.EmailReg.ProviderFromConfig(*s.Config)
+			provider := s.EmailReg.ProviderFromConfig(s.Config)
 			cd := common.NewCoreData(r.Context(), queries, s.Config,
 				common.WithImageSigner(s.ImageSigner),
 				common.WithSession(session),

--- a/internal/app/startup.go
+++ b/internal/app/startup.go
@@ -16,14 +16,14 @@ import (
 
 // PerformChecks checks DB connectivity and the upload provider.
 func PerformChecks(cfg *config.RuntimeConfig, reg *dbdrivers.Registry) (*sql.DB, error) {
-	if err := dbstart2.MaybeAutoMigrate(*cfg, reg); err != nil {
+	if err := dbstart2.MaybeAutoMigrate(cfg, reg); err != nil {
 		return nil, err
 	}
-	dbPool, ue := dbstart2.InitDB(*cfg, reg)
+	dbPool, ue := dbstart2.InitDB(cfg, reg)
 	if ue != nil {
 		return nil, fmt.Errorf("%s: %w", ue.ErrorMessage, ue.Err)
 	}
-	if ue := CheckUploadTarget(*cfg); ue != nil {
+	if ue := CheckUploadTarget(cfg); ue != nil {
 		dbPool.Close()
 		return nil, fmt.Errorf("%s: %w", ue.ErrorMessage, ue.Err)
 	}

--- a/internal/app/startup_test.go
+++ b/internal/app/startup_test.go
@@ -20,7 +20,7 @@ func (t testProvider) Read(ctx context.Context, name string) ([]byte, error)    
 func TestCheckUploadTargetOK(t *testing.T) {
 	intupload.RegisterProvider("testok", func(*config.RuntimeConfig) intupload.Provider { return testProvider{} })
 	cfg := config.RuntimeConfig{ImageUploadProvider: "testok", ImageUploadDir: "ignored", ImageCacheProvider: "testok", ImageCacheDir: "cache"}
-	if err := CheckUploadTarget(cfg); err != nil {
+	if err := CheckUploadTarget(&cfg); err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
 }
@@ -28,14 +28,14 @@ func TestCheckUploadTargetOK(t *testing.T) {
 func TestCheckUploadTargetFail(t *testing.T) {
 	intupload.RegisterProvider("testfail", func(*config.RuntimeConfig) intupload.Provider { return testProvider{checkErr: context.Canceled} })
 	cfg := config.RuntimeConfig{ImageUploadProvider: "testfail", ImageUploadDir: "ignored", ImageCacheProvider: "testfail", ImageCacheDir: "cache"}
-	if err := CheckUploadTarget(cfg); err == nil {
+	if err := CheckUploadTarget(&cfg); err == nil {
 		t.Fatalf("expected error")
 	}
 }
 
 func TestCheckUploadTargetNoProvider(t *testing.T) {
 	cfg := config.RuntimeConfig{ImageUploadProvider: "missing", ImageUploadDir: "dir", ImageCacheProvider: "missing", ImageCacheDir: "cache"}
-	if err := CheckUploadTarget(cfg); err == nil {
+	if err := CheckUploadTarget(&cfg); err == nil {
 		t.Fatalf("expected error")
 	}
 }

--- a/internal/dlq/dlq_test.go
+++ b/internal/dlq/dlq_test.go
@@ -20,22 +20,22 @@ func TestProviderFromConfigRegistry(t *testing.T) {
 	dlqdefaults.RegisterDefaults(reg, emailReg)
 
 	cfg := config.RuntimeConfig{DLQProvider: "file", DLQFile: "p"}
-	if _, ok := reg.ProviderFromConfig(cfg, nil).(*filedlq.DLQ); !ok {
+	if _, ok := reg.ProviderFromConfig(&cfg, nil).(*filedlq.DLQ); !ok {
 		t.Fatalf("expected *file.DLQ")
 	}
 
 	cfg = config.RuntimeConfig{DLQProvider: "dir", DLQFile: "d"}
-	if _, ok := reg.ProviderFromConfig(cfg, nil).(*dirdlq.DLQ); !ok {
+	if _, ok := reg.ProviderFromConfig(&cfg, nil).(*dirdlq.DLQ); !ok {
 		t.Fatalf("expected *dir.DLQ")
 	}
 
 	cfg = config.RuntimeConfig{DLQProvider: "db"}
-	if _, ok := reg.ProviderFromConfig(cfg, (&dbpkg.Queries{})).(dbdlq.DLQ); !ok {
+	if _, ok := reg.ProviderFromConfig(&cfg, (&dbpkg.Queries{})).(dbdlq.DLQ); !ok {
 		t.Fatalf("expected db.DLQ")
 	}
 
 	cfg = config.RuntimeConfig{DLQProvider: "email"}
-	p := reg.ProviderFromConfig(cfg, nil)
+	p := reg.ProviderFromConfig(&cfg, nil)
 	if _, ok := p.(emaildlq.DLQ); !ok {
 		if _, ok := p.(dlq.LogDLQ); !ok {
 			t.Fatalf("unexpected type %T", p)
@@ -43,7 +43,7 @@ func TestProviderFromConfigRegistry(t *testing.T) {
 	}
 
 	cfg = config.RuntimeConfig{DLQProvider: "db,log"}
-	if _, ok := reg.ProviderFromConfig(cfg, (&dbpkg.Queries{})).(dlq.MultiDLQ); !ok {
+	if _, ok := reg.ProviderFromConfig(&cfg, (&dbpkg.Queries{})).(dlq.MultiDLQ); !ok {
 		t.Fatalf("expected MultiDLQ")
 	}
 }
@@ -51,13 +51,13 @@ func TestProviderFromConfigRegistry(t *testing.T) {
 func TestRegisterProviderCustom(t *testing.T) {
 	reg := dlq.NewRegistry()
 	called := false
-	reg.RegisterProvider("custom", func(cfg config.RuntimeConfig, q *dbpkg.Queries) dlq.DLQ {
+	reg.RegisterProvider("custom", func(cfg *config.RuntimeConfig, q *dbpkg.Queries) dlq.DLQ {
 		called = true
 		return dlq.LogDLQ{}
 	})
 
 	cfg := config.RuntimeConfig{DLQProvider: "custom"}
-	if _, ok := reg.ProviderFromConfig(cfg, nil).(dlq.LogDLQ); !ok || !called {
+	if _, ok := reg.ProviderFromConfig(&cfg, nil).(dlq.LogDLQ); !ok || !called {
 		t.Fatalf("custom provider not used")
 	}
 }

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -93,7 +93,7 @@ func CoreAdderMiddlewareWithDB(db *sql.DB, cfg *config.RuntimeConfig, verbosity 
 			}
 			var provider email.Provider
 			if emailReg != nil && cfg != nil {
-				provider = emailReg.ProviderFromConfig(*cfg)
+				provider = emailReg.ProviderFromConfig(cfg)
 			}
 			cd := common.NewCoreData(r.Context(), queries, cfg,
 				common.WithImageSigner(signer),

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -52,7 +52,7 @@ func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
 	})
 
 	reg := email.NewRegistry()
-	signer := imagesign.NewSigner(*cfg, "k")
+	signer := imagesign.NewSigner(cfg, "k")
 	CoreAdderMiddlewareWithDB(db, cfg, 0, reg, signer, navReg)(handler).ServeHTTP(httptest.NewRecorder(), req)
 
 	want := []string{"anonymous", "user", "moderator"}
@@ -93,7 +93,7 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 	})
 
 	reg := email.NewRegistry()
-	signer := imagesign.NewSigner(*cfg, "k")
+	signer := imagesign.NewSigner(cfg, "k")
 	CoreAdderMiddlewareWithDB(db, cfg, 0, reg, signer, navReg)(handler).ServeHTTP(httptest.NewRecorder(), req)
 
 	want := []string{"anonymous"}

--- a/internal/notifications/bus_worker_test.go
+++ b/internal/notifications/bus_worker_test.go
@@ -138,7 +138,7 @@ func TestProcessEventDLQ(t *testing.T) {
 	defer db.Close()
 	q := dbpkg.New(db)
 	prov := &errProvider{}
-	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(*cfg))
+	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(cfg))
 	dlqRec := &recordDLQ{}
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/p", Task: TestTask{TaskString: TaskTest}, UserID: 1}, dlqRec); err != nil {
@@ -166,7 +166,7 @@ func TestProcessEventSubscribeSelf(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q), WithConfig(*cfg))
+	n := New(WithQueries(q), WithConfig(cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/p", Task: TaskTest, UserID: 1}, nil); err != nil {
 		t.Fatalf("process: %v", err)
@@ -186,7 +186,7 @@ func TestProcessEventNoAutoSubscribe(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q), WithConfig(*cfg))
+	n := New(WithQueries(q), WithConfig(cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/p", Task: TaskTest, UserID: 1}, nil); err != nil {
 		t.Fatalf("process: %v", err)
@@ -209,7 +209,7 @@ func TestProcessEventAdminNotify(t *testing.T) {
 	defer db.Close()
 	q := dbpkg.New(db)
 	prov := &busDummyProvider{}
-	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(*cfg))
+	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/admin/x", Task: TaskTest, UserID: 1}, nil); err != nil {
 		t.Fatalf("process: %v", err)
@@ -230,7 +230,7 @@ func TestProcessEventWritingSubscribers(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q), WithConfig(*cfg))
+	n := New(WithQueries(q), WithConfig(cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/writings/article/1", Task: TaskTest, UserID: 2, Data: map[string]any{"target": Target{Type: "writing", ID: 1}}}, nil); err != nil {
 		t.Fatalf("process: %v", err)
@@ -264,7 +264,7 @@ func TestProcessEventTargetUsers(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q), WithConfig(*cfg))
+	n := New(WithQueries(q), WithConfig(cfg))
 
 	for _, id := range []int32{2, 3} {
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
@@ -306,7 +306,7 @@ func TestBusWorker(t *testing.T) {
 	q := dbpkg.New(db)
 
 	prov := &busDummyProvider{}
-	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(*cfg))
+	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(cfg))
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -349,7 +349,7 @@ func TestProcessEventAutoSubscribe(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := New(WithQueries(q), WithConfig(*cfg))
+	n := New(WithQueries(q), WithConfig(cfg))
 
 	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies"}).
 		AddRow(1, 0, 1, nil, 0, true)

--- a/internal/notifications/linker_queue_test.go
+++ b/internal/notifications/linker_queue_test.go
@@ -35,7 +35,7 @@ func TestLinkerQueueNotifierMessages(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"body"}).AddRow(""))
 
 	q := dbpkg.New(db)
-	n := New(WithQueries(q), WithConfig(*cfg))
+	n := New(WithQueries(q), WithConfig(cfg))
 	data := map[string]any{
 		"Title":     "Example",
 		"Username":  "bob",

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -71,7 +71,7 @@ func TestNotifierNotifyAdmins(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test", "a"))
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 1, Valid: true}, sqlmock.AnyArg(), false).WillReturnResult(sqlmock.NewResult(1, 1))
 	rec := &dummyProvider{}
-	n := New(WithQueries(q), WithEmailProvider(rec), WithConfig(*cfg))
+	n := New(WithQueries(q), WithEmailProvider(rec), WithConfig(cfg))
 	n.NotifyAdmins(context.Background(), &EmailTemplates{}, EmailData{})
 	if rec.to != "" {
 		t.Fatalf("expected no direct mail got %s", rec.to)
@@ -83,7 +83,7 @@ func TestNotifierNotifyAdmins(t *testing.T) {
 
 func TestNotifierInitialization(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
-	n := New(WithConfig(*cfg))
+	n := New(WithConfig(cfg))
 	if n.Queries != nil {
 		t.Fatalf("expected nil Queries")
 	}
@@ -93,7 +93,7 @@ func TestNotifierInitialization(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n = New(WithQueries(q), WithConfig(*cfg))
+	n = New(WithQueries(q), WithConfig(cfg))
 	if n.Queries != q {
 		t.Fatalf("queries not set via option")
 	}

--- a/internal/notifications/permission_tasks_test.go
+++ b/internal/notifications/permission_tasks_test.go
@@ -45,7 +45,7 @@ func TestProcessEventPermissionTasks(t *testing.T) {
 	}
 	defer db.Close()
 	q := dbpkg.New(db)
-	n := notif.New(notif.WithQueries(q), notif.WithConfig(*cfg))
+	n := notif.New(notif.WithQueries(q), notif.WithConfig(cfg))
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/internal/websocket/notifications_test.go
+++ b/internal/websocket/notifications_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNotificationsHandlerCheckOriginConfig(t *testing.T) {
 	cfg := config.RuntimeConfig{HTTPHostname: "http://example.com"}
-	h := NewNotificationsHandler(nil, cfg)
+	h := NewNotificationsHandler(nil, &cfg)
 	req := httptest.NewRequest("GET", "http://example.com/ws/notifications", nil)
 	req.Header.Set("Origin", "http://example.com")
 	if !h.Upgrader.CheckOrigin(req) {
@@ -19,7 +19,7 @@ func TestNotificationsHandlerCheckOriginConfig(t *testing.T) {
 
 func TestNotificationsHandlerCheckOriginMultipleHosts(t *testing.T) {
 	cfg := config.RuntimeConfig{HTTPHostname: "http://example.com, http://other.com"}
-	h := NewNotificationsHandler(nil, cfg)
+	h := NewNotificationsHandler(nil, &cfg)
 	req := httptest.NewRequest("GET", "http://other.com/ws/notifications", nil)
 	req.Header.Set("Origin", "http://other.com")
 	if !h.Upgrader.CheckOrigin(req) {
@@ -29,7 +29,7 @@ func TestNotificationsHandlerCheckOriginMultipleHosts(t *testing.T) {
 
 func TestNotificationsHandlerCheckOriginHostHeader(t *testing.T) {
 	cfg := config.RuntimeConfig{HTTPHostname: "http://other.com"}
-	h := NewNotificationsHandler(nil, cfg)
+	h := NewNotificationsHandler(nil, &cfg)
 	req := httptest.NewRequest("GET", "http://host/ws/notifications", nil)
 	req.Host = "host"
 	req.Header.Set("Origin", "http://host")
@@ -40,7 +40,7 @@ func TestNotificationsHandlerCheckOriginHostHeader(t *testing.T) {
 
 func TestNotificationsHandlerCheckOriginDenied(t *testing.T) {
 	cfg := config.RuntimeConfig{HTTPHostname: "http://example.com"}
-	h := NewNotificationsHandler(nil, cfg)
+	h := NewNotificationsHandler(nil, &cfg)
 	req := httptest.NewRequest("GET", "http://example.com/ws/notifications", nil)
 	req.Header.Set("Origin", "http://bad.com")
 	if h.Upgrader.CheckOrigin(req) {


### PR DESCRIPTION
## Summary
- implement `WithTasksRegistry` and expose other option helpers on Server
- update server initialization in `run.go`
- fix pointer handling across CLI and tests
- clean up tests and middleware to use config pointers

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: TestVerifyAccess and others)*

------
https://chatgpt.com/codex/tasks/task_e_6884a11a4ce0832f8a36a2ac4bb8a6c7