### PR TITLE
Update admin links retrieval

### DIFF
--- a/handlers/admin/adminHandler.go
+++ b/handlers/admin/adminHandler.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
-	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 func AdminPage(w http.ResponseWriter, r *http.Request) {
@@ -29,9 +28,10 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 		Stats      Stats
 	}
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
-		CoreData:   r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		AdminLinks: nav.AdminLinks(),
+		CoreData:   cd,
+		AdminLinks: cd.NavReg.AdminLinks(),
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	ctx := r.Context()


### PR DESCRIPTION
## Summary
- use the CoreData navigation registry directly

## Testing
- `go vet ./...` *(fails: cannot use config.RuntimeConfig as *config.RuntimeConfig)*
- `golangci-lint run ./...`
- `go test ./...` *(fails to build handlers/imagebbs and others)*

------
https://chatgpt.com/codex/tasks/task_e_6884a11bdbc8832f9650f7413465d334