### PR TITLE
Use NavReg directly in admin handler

### DIFF
--- a/handlers/admin/adminHandler.go
+++ b/handlers/admin/adminHandler.go
@@ -29,9 +29,10 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 		Stats      Stats
 	}
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{
-		CoreData:   r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		AdminLinks: nav.AdminLinks(),
+		CoreData:   cd,
+		AdminLinks: cd.NavReg.AdminLinks(),
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	ctx := r.Context()


### PR DESCRIPTION
## Summary
- simplify usage of navigation registry in `adminHandler.go`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot use config.RuntimeConfig pointer)*
- `golangci-lint run` *(fails: typecheck errors)*
- `go test ./...` *(fails to build)*

------
https://chatgpt.com/codex/tasks/task_e_6884a129848c832fbac24a86f5b481e3