### PR TITLE
Use option for tasks registry

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -185,6 +185,7 @@ func NewServer(ctx context.Context, cfg *config.RuntimeConfig, opts ...ServerOpt
 		server.WithRouterRegistry(reg),
 		server.WithNavRegistry(navReg),
 		server.WithDLQRegistry(o.DLQReg),
+		server.WithTasksRegistry(o.TasksReg),
 		server.WithBus(bus),
 		server.WithEmailRegistry(o.EmailReg),
 		server.WithImageSigner(imgSigner),
@@ -211,7 +212,6 @@ func NewServer(ctx context.Context, cfg *config.RuntimeConfig, opts ...ServerOpt
 	adminhandlers.Srv = srv
 	adminhandlers.DBPool = dbPool
 	adminhandlers.UpdateConfigKeyFunc = config.UpdateConfigKey
-	srv.TasksReg = o.TasksReg
 
 	emailProvider := o.EmailReg.ProviderFromConfig(cfg)
 	if cfg.EmailEnabled && cfg.EmailProvider != "" && cfg.EmailFrom == "" {

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -143,6 +143,9 @@ func WithDBRegistry(r *dbdrivers.Registry) Option { return func(s *Server) { s.D
 // WithWebsocket sets the websocket module.
 func WithWebsocket(w *websocket.Module) Option { return func(s *Server) { s.Websocket = w } }
 
+// WithTasksRegistry sets the tasks registry used by the server.
+func WithTasksRegistry(r *tasks.Registry) Option { return func(s *Server) { s.TasksReg = r } }
+
 // New returns a Server configured using the supplied options.
 func New(opts ...Option) *Server {
 	s := &Server{}


### PR DESCRIPTION
## Summary
- add `WithTasksRegistry` option for the server
- pass `TasksRegistry` to `server.New`

## Testing
- `go vet ./...` *(fails: cannot use cfg as *config.RuntimeConfig in several packages)*
- `golangci-lint run ./...` *(fails: typechecking errors)*
- `go test ./...` *(fails to build: multiple packages report type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884a12f7d38832fa8beb85b1fb0fabd