### PR TITLE
Inject nav registry into router modules

### DIFF
--- a/handlers/admin/reload_shutdown_test.go
+++ b/handlers/admin/reload_shutdown_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	serverpkg "github.com/arran4/goa4web/internal/app/server"
+	"github.com/arran4/goa4web/internal/navigation"
 )
 
 func TestAdminReloadConfigPage_Unauthorized(t *testing.T) {
@@ -36,7 +37,8 @@ func TestAdminReloadRoute_Unauthorized(t *testing.T) {
 	r := mux.NewRouter()
 	ar := r.PathPrefix("/admin").Subrouter()
 	cfg := config.NewRuntimeConfig()
-	RegisterRoutes(ar, cfg)
+	navReg := navigation.NewRegistry()
+	RegisterRoutes(ar, cfg, navReg)
 
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
 	cd := common.NewCoreData(req.Context(), nil, cfg)
@@ -56,7 +58,8 @@ func TestAdminReloadRoute_Authorized(t *testing.T) {
 	r := mux.NewRouter()
 	ar := r.PathPrefix("/admin").Subrouter()
 	cfg := config.NewRuntimeConfig()
-	RegisterRoutes(ar, cfg)
+	navReg := navigation.NewRegistry()
+	RegisterRoutes(ar, cfg, navReg)
 
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
 	cd := common.NewCoreData(req.Context(), nil, cfg)
@@ -76,7 +79,8 @@ func TestAdminShutdownRoute_Unauthorized(t *testing.T) {
 	r := mux.NewRouter()
 	ar := r.PathPrefix("/admin").Subrouter()
 	cfg := config.NewRuntimeConfig()
-	RegisterRoutes(ar, cfg)
+	navReg := navigation.NewRegistry()
+	RegisterRoutes(ar, cfg, navReg)
 
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
 	cd := common.NewCoreData(req.Context(), nil, cfg)
@@ -97,7 +101,8 @@ func TestAdminShutdownRoute_Authorized(t *testing.T) {
 	r := mux.NewRouter()
 	ar := r.PathPrefix("/admin").Subrouter()
 	cfg := config.NewRuntimeConfig()
-	RegisterRoutes(ar, cfg)
+	navReg := navigation.NewRegistry()
+	RegisterRoutes(ar, cfg, navReg)
 
 	form := url.Values{}
 	form.Set("task", string(TaskServerShutdown))

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -16,24 +16,24 @@ import (
 	search "github.com/arran4/goa4web/handlers/search"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
 	writings "github.com/arran4/goa4web/handlers/writings"
-	nav "github.com/arran4/goa4web/internal/navigation"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
 )
 
 // RegisterRoutes attaches the admin endpoints to ar. The router is expected to
 // already have any required authentication middleware applied.
-func RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig) {
-	nav.RegisterAdminControlCenter("Categories", "/admin/categories", 20)
-	nav.RegisterAdminControlCenter("Notifications", "/admin/notifications", 90)
-	nav.RegisterAdminControlCenter("Queued Emails", "/admin/email/queue", 110)
-	nav.RegisterAdminControlCenter("Sent Emails", "/admin/email/sent", 115)
-	nav.RegisterAdminControlCenter("Email Template", "/admin/email/template", 120)
-	nav.RegisterAdminControlCenter("Dead Letter Queue", "/admin/dlq", 130)
-	nav.RegisterAdminControlCenter("Server Stats", "/admin/stats", 140)
-	nav.RegisterAdminControlCenter("Requests", "/admin/requests", 145)
-	nav.RegisterAdminControlCenter("Site Settings", "/admin/settings", 150)
-	nav.RegisterAdminControlCenter("Pagination", "/admin/page-size", 152)
-	nav.RegisterAdminControlCenter("Usage Stats", "/admin/usage", 160)
+func RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
+	navReg.RegisterAdminControlCenter("Categories", "/admin/categories", 20)
+	navReg.RegisterAdminControlCenter("Notifications", "/admin/notifications", 90)
+	navReg.RegisterAdminControlCenter("Queued Emails", "/admin/email/queue", 110)
+	navReg.RegisterAdminControlCenter("Sent Emails", "/admin/email/sent", 115)
+	navReg.RegisterAdminControlCenter("Email Template", "/admin/email/template", 120)
+	navReg.RegisterAdminControlCenter("Dead Letter Queue", "/admin/dlq", 130)
+	navReg.RegisterAdminControlCenter("Server Stats", "/admin/stats", 140)
+	navReg.RegisterAdminControlCenter("Requests", "/admin/requests", 145)
+	navReg.RegisterAdminControlCenter("Site Settings", "/admin/settings", 150)
+	navReg.RegisterAdminControlCenter("Pagination", "/admin/page-size", 152)
+	navReg.RegisterAdminControlCenter("Usage Stats", "/admin/usage", 160)
 
 	ar.HandleFunc("", AdminPage).Methods("GET")
 	ar.HandleFunc("/", AdminPage).Methods("GET")
@@ -88,8 +88,8 @@ func RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig) {
 	// faq admin
 	faq.RegisterAdminRoutes(ar)
 	search.RegisterAdminRoutes(ar)
-	userhandlers.RegisterAdminRoutes(ar)
-	languages.RegisterAdminRoutes(ar)
+	userhandlers.RegisterAdminRoutes(ar, navReg)
+	languages.RegisterAdminRoutes(ar, navReg)
 	blogs.RegisterAdminRoutes(ar)
 
 	// news admin
@@ -120,10 +120,10 @@ func RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig) {
 
 // Register registers the admin router module.
 func Register(reg *router.Registry) {
-	reg.RegisterModule("admin", []string{"faq", "forum", "imagebbs", "languages", "linker", "news", "search", "user", "writings", "blogs"}, func(r *mux.Router, cfg *config.RuntimeConfig) {
+	reg.RegisterModule("admin", []string{"faq", "forum", "imagebbs", "languages", "linker", "news", "search", "user", "writings", "blogs"}, func(r *mux.Router, cfg *config.RuntimeConfig, navReg *navpkg.Registry) {
 		ar := r.PathPrefix("/admin").Subrouter()
 		ar.Use(router.AdminCheckerMiddleware)
 		ar.Use(handlers.IndexMiddleware(CustomIndex))
-		RegisterRoutes(ar, cfg)
+		RegisterRoutes(ar, cfg, navReg)
 	})
 }

--- a/handlers/auth/routes.go
+++ b/handlers/auth/routes.go
@@ -6,11 +6,12 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
+	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
 )
 
 // RegisterRoutes attaches the login and registration endpoints to r.
-func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) {
+func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, _ *nav.Registry) {
 	rr := r.PathPrefix("/register").Subrouter()
 	rr.Use(handlers.IndexMiddleware(CustomIndex))
 	rr.HandleFunc("", registerTask.Page).Methods("GET").MatcherFunc(Not(handlers.RequiresAnAccount()))

--- a/handlers/blogs/routes.go
+++ b/handlers/blogs/routes.go
@@ -9,13 +9,13 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	router "github.com/arran4/goa4web/internal/router"
 
-	nav "github.com/arran4/goa4web/internal/navigation"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
 )
 
 // RegisterRoutes attaches the public blog endpoints to r.
-func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) {
-	nav.RegisterIndexLink("Blogs", "/blogs", SectionWeight)
-	nav.RegisterAdminControlCenter("Blogs", "/admin/blogs/user/permissions", SectionWeight)
+func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
+	navReg.RegisterIndexLink("Blogs", "/blogs", SectionWeight)
+	navReg.RegisterAdminControlCenter("Blogs", "/admin/blogs/user/permissions", SectionWeight)
 	br := r.PathPrefix("/blogs").Subrouter()
 	br.Use(handlers.IndexMiddleware(CustomBlogIndex))
 	br.HandleFunc("/rss", RssPage).Methods("GET")

--- a/handlers/bookmarks/routes.go
+++ b/handlers/bookmarks/routes.go
@@ -7,12 +7,12 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/router"
 
-	nav "github.com/arran4/goa4web/internal/navigation"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
 )
 
 // RegisterRoutes attaches the bookmarks endpoints to r.
-func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) {
-	nav.RegisterIndexLink("Bookmarks", "/bookmarks", SectionWeight)
+func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
+	navReg.RegisterIndexLink("Bookmarks", "/bookmarks", SectionWeight)
 	br := r.PathPrefix("/bookmarks").Subrouter()
 	br.Use(handlers.IndexMiddleware(bookmarksCustomIndex))
 	br.HandleFunc("", Page).Methods("GET")

--- a/handlers/faq/routes.go
+++ b/handlers/faq/routes.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
-	nav "github.com/arran4/goa4web/internal/navigation"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
 )
 
@@ -17,9 +17,9 @@ func noTask() mux.MatcherFunc {
 }
 
 // RegisterRoutes attaches the public FAQ endpoints to the router.
-func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) {
-	nav.RegisterIndexLink("FAQ", "/faq", SectionWeight)
-	nav.RegisterAdminControlCenter("FAQ", "/admin/faq/categories", SectionWeight)
+func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
+	navReg.RegisterIndexLink("FAQ", "/faq", SectionWeight)
+	navReg.RegisterAdminControlCenter("FAQ", "/admin/faq/categories", SectionWeight)
 	faqr := r.PathPrefix("/faq").Subrouter()
 	faqr.Use(handlers.IndexMiddleware(CustomFAQIndex))
 	faqr.HandleFunc("", Page).Methods("GET", "POST")

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -9,13 +9,13 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	router "github.com/arran4/goa4web/internal/router"
 
-	nav "github.com/arran4/goa4web/internal/navigation"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
 )
 
 // RegisterRoutes attaches the public forum endpoints to r.
-func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) {
-	nav.RegisterIndexLink("Forum", "/forum", SectionWeight)
-	nav.RegisterAdminControlCenter("Forum", "/admin/forum", SectionWeight)
+func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
+	navReg.RegisterIndexLink("Forum", "/forum", SectionWeight)
+	navReg.RegisterAdminControlCenter("Forum", "/admin/forum", SectionWeight)
 	fr := r.PathPrefix("/forum").Subrouter()
 	fr.Use(handlers.IndexMiddleware(CustomForumIndex))
 	fr.HandleFunc("/topic/{topic}.rss", TopicRssPage).Methods("GET")

--- a/handlers/imagebbs/routes.go
+++ b/handlers/imagebbs/routes.go
@@ -9,13 +9,13 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	router "github.com/arran4/goa4web/internal/router"
 
-	nav "github.com/arran4/goa4web/internal/navigation"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
 )
 
 // RegisterRoutes attaches the public image board endpoints to r.
-func RegisterRoutes(r *mux.Router, cfg *config.RuntimeConfig) {
-	nav.RegisterIndexLink("ImageBBS", "/imagebbs", SectionWeight)
-	nav.RegisterAdminControlCenter("ImageBBS", "/admin/imagebbs", SectionWeight)
+func RegisterRoutes(r *mux.Router, cfg *config.RuntimeConfig, navReg *navpkg.Registry) {
+	navReg.RegisterIndexLink("ImageBBS", "/imagebbs", SectionWeight)
+	navReg.RegisterAdminControlCenter("ImageBBS", "/admin/imagebbs", SectionWeight)
 	r.HandleFunc("/imagebbs.rss", RssPage).Methods("GET")
 	ibr := r.PathPrefix("/imagebbs").Subrouter()
 	ibr.Use(handlers.IndexMiddleware(CustomImageBBSIndex))

--- a/handlers/images/routes.go
+++ b/handlers/images/routes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
+	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/internal/upload"
 )
@@ -61,7 +62,7 @@ func verifyMiddleware(prefix string) mux.MiddlewareFunc {
 }
 
 // RegisterRoutes attaches the image endpoints to r.
-func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) {
+func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, _ *nav.Registry) {
 	ir := r.PathPrefix("/images").Subrouter()
 	ir.Use(handlers.IndexMiddleware(CustomIndex))
 	ir.HandleFunc("/upload/image", handlers.TaskHandler(uploadImageTask)).

--- a/handlers/images/routes_test.go
+++ b/handlers/images/routes_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/internal/navigation"
 )
 
 func TestValidID(t *testing.T) {
@@ -32,7 +33,8 @@ func TestValidID(t *testing.T) {
 func TestImageRouteInvalidID(t *testing.T) {
 	r := mux.NewRouter()
 	cfg := config.NewRuntimeConfig()
-	RegisterRoutes(r, cfg)
+	navReg := navigation.NewRegistry()
+	RegisterRoutes(r, cfg, navReg)
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/images/image/abc!", nil)
 
@@ -46,7 +48,8 @@ func TestImageRouteInvalidID(t *testing.T) {
 func TestCacheRouteInvalidID(t *testing.T) {
 	r := mux.NewRouter()
 	cfg := config.NewRuntimeConfig()
-	RegisterRoutes(r, cfg)
+	navReg := navigation.NewRegistry()
+	RegisterRoutes(r, cfg, navReg)
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/images/cache/abc!", nil)
 

--- a/handlers/languages/routes.go
+++ b/handlers/languages/routes.go
@@ -5,13 +5,13 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
-	nav "github.com/arran4/goa4web/internal/navigation"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
 )
 
 // RegisterAdminRoutes attaches the admin language endpoints to the router.
-func RegisterAdminRoutes(ar *mux.Router) {
-	nav.RegisterAdminControlCenter("Languages", "/admin/languages", SectionWeight)
+func RegisterAdminRoutes(ar *mux.Router, navReg *navpkg.Registry) {
+	navReg.RegisterAdminControlCenter("Languages", "/admin/languages", SectionWeight)
 	ar.HandleFunc("/languages", adminLanguagesPage).Methods("GET")
 	ar.HandleFunc("/language", adminLanguageRedirect).Methods("GET")
 	ar.HandleFunc("/languages", handlers.TaskHandler(renameLanguageTask)).Methods("POST").MatcherFunc(renameLanguageTask.Matcher())
@@ -21,9 +21,9 @@ func RegisterAdminRoutes(ar *mux.Router) {
 
 // Register registers the languages router module.
 func Register(reg *router.Registry) {
-	reg.RegisterModule("languages", nil, func(r *mux.Router, cfg *config.RuntimeConfig) {
+	reg.RegisterModule("languages", nil, func(r *mux.Router, cfg *config.RuntimeConfig, navReg *navpkg.Registry) {
 		ar := r.PathPrefix("/admin").Subrouter()
 		ar.Use(router.AdminCheckerMiddleware)
-		RegisterAdminRoutes(ar)
+		RegisterAdminRoutes(ar, navReg)
 	})
 }

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -8,16 +8,16 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
-	nav "github.com/arran4/goa4web/internal/navigation"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
 	"github.com/arran4/goa4web/internal/router"
 )
 
 var legacyRedirectsEnabled = true
 
 // RegisterRoutes attaches the public linker endpoints to r.
-func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) {
-	nav.RegisterIndexLink("Linker", "/linker", SectionWeight)
-	nav.RegisterAdminControlCenter("Linker", "/admin/linker/categories", SectionWeight)
+func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
+	navReg.RegisterIndexLink("Linker", "/linker", SectionWeight)
+	navReg.RegisterAdminControlCenter("Linker", "/admin/linker/categories", SectionWeight)
 	lr := r.PathPrefix("/linker").Subrouter()
 	lr.Use(handlers.IndexMiddleware(CustomLinkerIndex))
 	lr.HandleFunc("/rss", RssPage).Methods("GET")

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -17,7 +17,7 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/router"
 
-	nav "github.com/arran4/goa4web/internal/navigation"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
 )
 
 var (
@@ -38,9 +38,9 @@ func runTemplate(name string) http.HandlerFunc {
 }
 
 // RegisterRoutes attaches the public news endpoints to r.
-func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) {
-	nav.RegisterIndexLink("News", "/", SectionWeight)
-	nav.RegisterAdminControlCenter("News", "/admin/news/users/roles", SectionWeight)
+func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
+	navReg.RegisterIndexLink("News", "/", SectionWeight)
+	navReg.RegisterAdminControlCenter("News", "/admin/news/users/roles", SectionWeight)
 	r.Use(handlers.IndexMiddleware(CustomNewsIndex))
 	r.HandleFunc("/", runTemplate("newsPage")).Methods("GET")
 	r.HandleFunc("/", handlers.TaskDoneAutoRefreshPage).Methods("POST")

--- a/handlers/search/routes.go
+++ b/handlers/search/routes.go
@@ -5,14 +5,14 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
-	nav "github.com/arran4/goa4web/internal/navigation"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
 )
 
 // RegisterRoutes attaches the search endpoints to r.
-func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) {
-	nav.RegisterIndexLink("Search", "/search", SectionWeight)
-	nav.RegisterAdminControlCenter("Search", "/admin/search", SectionWeight)
+func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
+	navReg.RegisterIndexLink("Search", "/search", SectionWeight)
+	navReg.RegisterAdminControlCenter("Search", "/admin/search", SectionWeight)
 	sr := r.PathPrefix("/search").Subrouter()
 	sr.Use(handlers.IndexMiddleware(CustomIndex))
 	sr.HandleFunc("", Page).Methods("GET")

--- a/handlers/user/routes.go
+++ b/handlers/user/routes.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
+	nav "github.com/arran4/goa4web/internal/navigation"
 	router "github.com/arran4/goa4web/internal/router"
 )
 
 // RegisterRoutes attaches user account endpoints to the router.
-func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) {
+func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, _ *nav.Registry) {
 	ur := r.PathPrefix("/usr").Subrouter()
 	ur.Use(handlers.IndexMiddleware(CustomIndex))
 	ur.HandleFunc("", userPage).Methods(http.MethodGet)

--- a/handlers/user/routes_admin.go
+++ b/handlers/user/routes_admin.go
@@ -4,14 +4,14 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/handlers"
-	nav "github.com/arran4/goa4web/internal/navigation"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
 )
 
 // RegisterAdminRoutes attaches user admin endpoints to the router.
-func RegisterAdminRoutes(ar *mux.Router) {
-	nav.RegisterAdminControlCenter("User Permissions", "/admin/users/permissions", SectionWeight-10)
-	nav.RegisterAdminControlCenter("Pending Users", "/admin/users/pending", SectionWeight-5)
-	nav.RegisterAdminControlCenter("Users", "/admin/users", SectionWeight)
+func RegisterAdminRoutes(ar *mux.Router, navReg *navpkg.Registry) {
+	navReg.RegisterAdminControlCenter("User Permissions", "/admin/users/permissions", SectionWeight-10)
+	navReg.RegisterAdminControlCenter("Pending Users", "/admin/users/pending", SectionWeight-5)
+	navReg.RegisterAdminControlCenter("Users", "/admin/users", SectionWeight)
 	ar.HandleFunc("/users", adminUsersPage).Methods("GET")
 	ar.HandleFunc("/users/pending", adminPendingUsersPage).Methods("GET")
 	ar.HandleFunc("/users/pending/approve", adminPendingUsersApprove).Methods("POST")

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -9,15 +9,15 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	router "github.com/arran4/goa4web/internal/router"
 
-	nav "github.com/arran4/goa4web/internal/navigation"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
 )
 
 var legacyRedirectsEnabled = true
 
 // RegisterRoutes attaches the public writings endpoints to r.
-func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) {
-	nav.RegisterIndexLink("Writings", "/writings", SectionWeight)
-	nav.RegisterAdminControlCenter("Writings", "/admin/writings/categories", SectionWeight)
+func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
+	navReg.RegisterIndexLink("Writings", "/writings", SectionWeight)
+	navReg.RegisterAdminControlCenter("Writings", "/admin/writings/categories", SectionWeight)
 	wr := r.PathPrefix("/writings").Subrouter()
 	wr.Use(handlers.IndexMiddleware(CustomWritingsIndex))
 	wr.HandleFunc("/rss", RssPage).Methods("GET")

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -175,9 +175,9 @@ func NewServer(ctx context.Context, cfg *config.RuntimeConfig, opts ...ServerOpt
 	wsMod := websocket.NewModule(bus, cfg)
 	wsMod.Register(reg)
 	r := mux.NewRouter()
-	routerpkg.RegisterRoutes(r, reg, cfg)
 
 	navReg := nav.NewRegistry()
+	routerpkg.RegisterRoutes(r, reg, cfg, navReg)
 	srv := server.New(
 		server.WithStore(store),
 		server.WithDB(dbPool),
@@ -191,7 +191,6 @@ func NewServer(ctx context.Context, cfg *config.RuntimeConfig, opts ...ServerOpt
 		server.WithDBRegistry(o.DBReg),
 		server.WithWebsocket(wsMod),
 	)
-	nav.SetDefaultRegistry(navReg)
 
 	taskEventMW := middleware.NewTaskEventMiddleware(bus)
 	handler := middleware.NewMiddlewareChain(

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -226,8 +226,9 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 			cd.UserID = uid
 			_ = cd.UserRoles()
 
-			idx := nav.IndexItems()
-			cd.IndexItems = idx
+			if s.Nav != nil {
+				cd.IndexItems = s.Nav.IndexItems()
+			}
 			cd.Title = "Arran's Site"
 			cd.FeedsEnabled = s.Config.FeedsEnabled
 			cd.AdminMode = r.URL.Query().Get("mode") == "admin"

--- a/internal/router/registry.go
+++ b/internal/router/registry.go
@@ -6,13 +6,14 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
+	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 // Module represents a router module and its setup function.
 type Module struct {
 	Name  string
 	Deps  []string
-	Setup func(*mux.Router, *config.RuntimeConfig)
+	Setup func(*mux.Router, *config.RuntimeConfig, *nav.Registry)
 	once  sync.Once
 }
 
@@ -27,7 +28,7 @@ func NewRegistry() *Registry { return &Registry{modules: map[string]*Module{}} }
 
 // RegisterModule registers a router module with optional dependencies. A module
 // is stored only on the first call.
-func (reg *Registry) RegisterModule(name string, deps []string, setup func(*mux.Router, *config.RuntimeConfig)) {
+func (reg *Registry) RegisterModule(name string, deps []string, setup func(*mux.Router, *config.RuntimeConfig, *nav.Registry)) {
 	reg.mu.Lock()
 	defer reg.mu.Unlock()
 	if _, ok := reg.modules[name]; ok {
@@ -38,7 +39,7 @@ func (reg *Registry) RegisterModule(name string, deps []string, setup func(*mux.
 
 // InitModules initialises all registered modules by resolving their
 // dependencies and invoking their Setup function once.
-func (reg *Registry) InitModules(r *mux.Router, cfg *config.RuntimeConfig) {
+func (reg *Registry) InitModules(r *mux.Router, cfg *config.RuntimeConfig, navReg *nav.Registry) {
 	reg.mu.Lock()
 	defer reg.mu.Unlock()
 
@@ -69,6 +70,6 @@ func (reg *Registry) InitModules(r *mux.Router, cfg *config.RuntimeConfig) {
 		if m.Setup == nil {
 			continue
 		}
-		m.once.Do(func() { m.Setup(r, cfg) })
+		m.once.Do(func() { m.Setup(r, cfg, navReg) })
 	}
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -10,14 +10,15 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
+	nav "github.com/arran4/goa4web/internal/navigation"
 )
 
 // RegisterRoutes sets up all application routes on r.
-func RegisterRoutes(r *mux.Router, reg *Registry, cfg *config.RuntimeConfig) {
+func RegisterRoutes(r *mux.Router, reg *Registry, cfg *config.RuntimeConfig, navReg *nav.Registry) {
 	r.HandleFunc("/main.css", handlers.MainCSS).Methods("GET")
 	r.HandleFunc("/favicon.svg", handlers.Favicon).Methods("GET")
 
-	reg.InitModules(r, cfg)
+	reg.InitModules(r, cfg, navReg)
 
 }
 

--- a/internal/websocket/notifications.go
+++ b/internal/websocket/notifications.go
@@ -17,6 +17,7 @@ import (
 	coreconsts "github.com/arran4/goa4web/core/consts"
 	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/internal/navigation"
 	routerpkg "github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -201,7 +202,7 @@ func (h *NotificationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 }
 
 // registerRoutes attaches the websocket handler to r.
-func (m *Module) registerRoutes(r *mux.Router, cfg *config.RuntimeConfig) {
+func (m *Module) registerRoutes(r *mux.Router, cfg *config.RuntimeConfig, _ *navigation.Registry) {
 	h := NewNotificationsHandler(m.Bus, cfg)
 	r.Handle("/ws/notifications", h).Methods(http.MethodGet)
 	r.HandleFunc("/notifications.js", NotificationsJS).Methods(http.MethodGet)


### PR DESCRIPTION
## Summary
- extend server options for injecting dependencies
- pass navigation registry into router modules and server
- adjust handlers and tests for new navigation injection

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6884c6308b38832fb14efad514debbd4