### PR TITLE
Move auth links to header

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -18,6 +18,19 @@ body {
         background-color: #FFF6E0;
 }
 
+.navbar-left,
+.navbar-right {
+        flex: 1;
+}
+
+.navbar-center {
+        flex: 1;
+        text-align: center;
+        font-weight: bold;
+        font-family: tahoma, arial, helvetica, sans-serif;
+        color: #800000;
+}
+
 .layout {
         display: flex;
         flex: 1;

--- a/core/templates/site/header.gohtml
+++ b/core/templates/site/header.gohtml
@@ -1,12 +1,23 @@
 {{define "header"}}
 <header class="navbar">
-    <div class="title"><strong>{{cd.Title}}</strong></div>
-    <div class="user-links">
+    <div class="navbar-left">
+        {{ if cd.HasRole "administrator" }}
+            {{ if cd.AdminMode }}
+                <a href="{{ addmode "/admin" }}">Admin Dashboard</a>
+                <a href="?">Disable admin mode</a>
+            {{ else }}
+                <a href="?mode=admin">Enable admin mode</a>
+            {{ end }}
+        {{ end }}
+    </div>
+    <div class="navbar-center"><strong>{{cd.Title}}</strong></div>
+    <div class="navbar-right user-links">
         {{ if cd.UserID }}
             {{ with $u := cd.CurrentUserLoaded }}{{ if $u }}<span class="username">{{ $u.Username.String }}</span>{{ end }}{{ end }}
             <a href="/usr/logout">Logout</a>
         {{ else }}
             <a href="/login">Login</a>
+            <a href="/register">Register</a>
         {{ end }}
     </div>
 </header>

--- a/core/templates/site/userPanel.gohtml
+++ b/core/templates/site/userPanel.gohtml
@@ -4,9 +4,6 @@
         <a href="/usr">Preferences</a><br>
         <a href="/usr/notifications" id="notif-index">Notifications{{ if gt cd.NotificationCount 0 }} ({{ cd.NotificationCount }}){{ end }}</a><br>
         <a href="/usr/logout">Logout</a><br>
-    {{ else }}
-        <a href="/register">Register</a><br>
-        <a href="/login">Login</a><br>
     {{ end }}
     <hr>
 {{ end }}


### PR DESCRIPTION
## Summary
- update header with login, register, username, and admin mode controls
- remove login/register from sidebar user panel
- center site title and adjust header layout styles

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885d3404e2c832fb1af6e2e0bff02b4