### PR TITLE
Remove writing category creation from public pages

### DIFF
--- a/core/templates/site/listWritingCategories.gohtml
+++ b/core/templates/site/listWritingCategories.gohtml
@@ -8,50 +8,9 @@
             {{ $title := .Title.String }}
             {{ $description := .Description.String }}
             {{ $id := .Idwritingcategory }}
-            {{ if and cd.HasAdminRole (eq $.EditingCategoryId $id) }}
-                <tr>
-                    <th><a href="/admin/writings/categories?category={{ $id }}">{{ $title }}</a></th>
-                    <td>{{ $description }}</td>
-                </tr>
-                <tr>
-                    <td>
-                        <form method="post">
-        {{ csrfField }}
-                            <input name="name" value="{{ $title }}">
-                        </td>
-                        <td>
-                            <textarea name="desc">{{ $description }}</textarea>
-                        </td>
-                        <input type="hidden" name="wcid" value="{{ $id }}">
-                        <input type="hidden" name="pwcid" value="{{ .Idwritingcategory }}">
-                        <td>
-                            <input type="submit" name="task" value="Modify category">
-                        </form>
-                    </td>
-                </tr>
-            {{ else }}
-                <tr>
-                    <th><a href="/writings/category/{{ $id }}">{{ $title }}</a>{{ if cd.HasAdminRole }} [<a href="?edit={{ $id }}">Edit</a>]{{ end }}</th>
-                    <td>{{ $description }}</td>
-                </tr>
-            {{ end }}
-        {{ end }}
-        {{ if cd.HasAdminRole }}
             <tr>
-                <td>
-                    <form method="post">
-        {{ csrfField }}
-                        <input name="name" value="New">
-                    </td>
-                    <td>
-                        <textarea name="desc">New</textarea>
-                    </td>
-                    <input type="hidden" name="wcid" value="0">
-                    <input type="hidden" name="pwcid" value="{{ $.CategoryId }}">
-                    <td>
-                        <input type="submit" name="task" value="New category">
-                    </form>
-                </td>
+                <th><a href="/writings/category/{{ $id }}">{{ $title }}</a>{{ if cd.HasAdminRole }} [<a href="/admin/writings/categories?category={{ $id }}">Admin</a>]{{ end }}</th>
+                <td>{{ $description }}</td>
             </tr>
         {{ end }}
     </table><br>

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -89,11 +89,10 @@ func TestPageTemplatesRender(t *testing.T) {
 			*common.CoreData
 			Categories          []*db.WritingCategory
 			CategoryBreadcrumbs []*db.WritingCategory
-			EditingCategoryId   int32
 			CategoryId          int32
 			WritingCategoryID   int32
 			Abstracts           []*db.GetPublicWritingsInCategoryRow
-		}{&common.CoreData{}, nil, nil, 0, 0, 0, nil}},
+		}{&common.CoreData{}, nil, nil, 0, 0, nil}},
 		{"searchPage", struct {
 			*common.CoreData
 			SearchWords string

--- a/handlers/writings/writingsCategoriesPage.go
+++ b/handlers/writings/writingsCategoriesPage.go
@@ -6,7 +6,6 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
@@ -17,16 +16,12 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		Categories          []*db.WritingCategory
 		CategoryBreadcrumbs []*db.WritingCategory
-		EditingCategoryId   int32
 		Abstracts           []*db.GetPublicWritingsInCategoryForUserRow
 		WritingCategoryID   int32
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{}
-
-	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
-	data.EditingCategoryId = int32(editID)
 	data.WritingCategoryID = 0
 
 	categoryRows, err := cd.VisibleWritingCategories(cd.UserID)

--- a/handlers/writings/writingsCategoryPage.go
+++ b/handlers/writings/writingsCategoryPage.go
@@ -20,7 +20,6 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		Categories          []*db.WritingCategory
 		CategoryBreadcrumbs []*db.WritingCategory
-		EditingCategoryId   int32
 		CategoryId          int32
 		WritingCategoryID   int32
 		Abstracts           []*db.GetPublicWritingsInCategoryForUserRow
@@ -28,9 +27,6 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{}
-
-	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
-	data.EditingCategoryId = int32(editID)
 
 	vars := mux.Vars(r)
 	categoryId, _ := strconv.Atoi(vars["category"])

--- a/handlers/writings/writingsPage.go
+++ b/handlers/writings/writingsPage.go
@@ -17,15 +17,12 @@ var writingsPermissionsPageEnabled = true
 func Page(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		Categories        []*db.WritingCategory
-		EditingCategoryId int32
 		CategoryId        int32
 		WritingCategoryID int32
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{}
-	editID, _ := strconv.Atoi(r.URL.Query().Get("edit"))
-	data.EditingCategoryId = int32(editID)
 	data.CategoryId = 0
 	data.WritingCategoryID = data.CategoryId
 


### PR DESCRIPTION
## Summary
- drop editing and creation forms from listWritingCategories template
- simplify data structs for writings pages
- adjust template render tests

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885d3b53e10832faf181bdb52be400b