### PR TITLE
Auto enable admin mode on admin pages

### DIFF
--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -236,6 +236,9 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 			cd.Title = "Arran's Site"
 			cd.FeedsEnabled = s.Config.FeedsEnabled
 			cd.AdminMode = r.URL.Query().Get("mode") == "admin"
+			if strings.HasPrefix(r.URL.Path, "/admin") && cd.HasRole("administrator") {
+				cd.AdminMode = true
+			}
 			if uid != 0 && s.Config.NotificationsEnabled {
 				cd.NotificationCount = int32(cd.UnreadNotificationCount())
 			}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -110,6 +110,9 @@ func CoreAdderMiddlewareWithDB(db *sql.DB, cfg *config.RuntimeConfig, verbosity 
 			cd.Title = "Arran's Site"
 			cd.FeedsEnabled = cfg.FeedsEnabled
 			cd.AdminMode = r.URL.Query().Get("mode") == "admin"
+			if strings.HasPrefix(r.URL.Path, "/admin") && cd.HasRole("administrator") {
+				cd.AdminMode = true
+			}
 			if uid != 0 && cfg.NotificationsEnabled {
 				cd.NotificationCount = int32(cd.UnreadNotificationCount())
 			}


### PR DESCRIPTION
## Summary
- ensure admin mode is automatically on when visiting `/admin`
- same check in middleware as in server setup

## Testing
- `go test ./...`
- `golangci-lint run ./...`

------
https://chatgpt.com/codex/tasks/task_e_6885d4312960832f84ef86207a9a2992