### PR TITLE
Fix email field references in user role templates

### DIFF
--- a/core/templates/site/admin/usersPermissionsPage.gohtml
+++ b/core/templates/site/admin/usersPermissionsPage.gohtml
@@ -16,7 +16,7 @@
         <tr data-id="{{.IduserRoles}}">
             <td>{{.IduserRoles}}</td>
             <td class="username">{{.Username.String}}</td>
-            <td class="email">{{.Email.String}}</td>
+            <td class="email">{{.Email}}</td>
             <td class="role">{{.Role}}</td>
             <td><button class="edit-btn" data-id="{{.IduserRoles}}">Edit</button></td>
             <td><button class="delete-btn" data-id="{{.IduserRoles}}">Delete</button></td>

--- a/core/templates/site/blogs/userPermissionsPage.gohtml
+++ b/core/templates/site/blogs/userPermissionsPage.gohtml
@@ -25,7 +25,7 @@ Filter by role:
             <td><input type="checkbox" name="permid" value="{{.IduserRoles}}"></td>
             <td>{{.IduserRoles}}</td>
             <td>{{.Username.String}}</td>
-            <td>{{.Email.String}}</td>
+            <td>{{.Email}}</td>
             <td>{{.Role}}</td>
         </tr>
         {{end}}

--- a/core/templates/site/news/adminUserRolesPage.gohtml
+++ b/core/templates/site/news/adminUserRolesPage.gohtml
@@ -12,7 +12,7 @@
                 <tr>
                     <td>{{ .IduserRoles }}</td>
                     <td>{{ .Username.String }}</td>
-                    <td>{{ .Email.String }}</td>
+                    <td>{{ .Email }}</td>
                     <td>{{ .Role }}</td>
                     <td>
                         <form method="post">

--- a/core/templates/site/news/userPermissionsPage.gohtml
+++ b/core/templates/site/news/userPermissionsPage.gohtml
@@ -11,7 +11,7 @@
                                 <tr>
                                         <td>{{.IduserRoles}}</td>
                                         <td>{{.Username.String}}</td>
-                                        <td>{{.Email.String}}</td>
+                                        <td>{{.Email}}</td>
                                         <td>{{.Role}}</td>
                                         <td>
                                                 <form method="post">

--- a/core/templates/site/writings/adminUserRolesPage.gohtml
+++ b/core/templates/site/writings/adminUserRolesPage.gohtml
@@ -11,7 +11,7 @@
         <tr>
             <td>{{ .IduserRoles }}</td>
             <td>{{ .Username.String }}</td>
-            <td>{{ .Email.String }}</td>
+            <td>{{ .Email }}</td>
             <td>{{ .Role }}</td>
             <td>
                 <form method="post">


### PR DESCRIPTION
## Summary
- correct email references from `.Email.String` to `.Email` in admin user role templates

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885d4691b90832f8af04a6b1f6a546c