### PR TITLE
Show message when no unanswered FAQs

### DIFF
--- a/core/templates/site/faq/adminAnswerPage.gohtml
+++ b/core/templates/site/faq/adminAnswerPage.gohtml
@@ -1,6 +1,7 @@
 {{ template "head" $ }}
     <font size="5">Section: Unanswered/Uncategorized Questions</font><br>
-    {{- range .Rows }}
+    {{- if .Rows }}
+        {{- range .Rows }}
         <form method="post" action="">
         {{ csrfField }}
             <table width="100%">
@@ -38,5 +39,8 @@
                 </tr>
             </table>
         </form><br>
+        {{- end }}
+    {{- else }}
+        <p>No unanswered questions.</p>
     {{- end }}
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- add a fallback message if the FAQ answer page has no items to display

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885d4c8fef0832faea400663381568c