### PR TITLE
Fix admin writing category permissions route

### DIFF
--- a/core/templates/site/writings/writingsAdminCategoryGrantsPage.gohtml
+++ b/core/templates/site/writings/writingsAdminCategoryGrantsPage.gohtml
@@ -1,0 +1,46 @@
+{{ template "head" $ }}
+<h3>Category {{ .CategoryID }} Grants</h3>
+<table border="1">
+    <tr>
+        <th>ID</th>
+        <th>User</th>
+        <th>Role</th>
+        <th>Action</th>
+        <th>Delete?</th>
+    </tr>
+    {{- range .Grants }}
+    <tr>
+        <td>{{ .ID }}</td>
+        <td>{{ if .Username.Valid }}{{ .Username.String }}{{ end }}</td>
+        <td>{{ if .RoleName.Valid }}{{ .RoleName.String }}{{ end }}</td>
+        <td>{{ .Action }}</td>
+        <td>
+            <form method="post" action="/admin/writings/category/{{ $.CategoryID }}/grant/delete">
+        {{ csrfField }}
+                <input type="hidden" name="grantid" value="{{ .ID }}">
+                <input type="submit" name="task" value="Delete grant">
+            </form>
+        </td>
+    </tr>
+    {{- end }}
+    <tr>
+        <form method="post" action="/admin/writings/category/{{ $.CategoryID }}/grant">
+        {{ csrfField }}
+            <td>NEW</td>
+            <td><input name="username"></td>
+            <td>
+                <select name="role">
+                    <option value="">None</option>
+                    {{- range $.Roles }}<option value="{{ .Name }}">{{ .Name }}</option>{{- end }}
+                </select>
+            </td>
+            <td>
+                {{- range $.Actions }}
+                <label><input type="checkbox" name="action" value="{{ . }}">{{ . }}</label>
+                {{- end }}
+            </td>
+            <td><input type="submit" name="task" value="Create grant"></td>
+        </form>
+    </tr>
+</table>
+{{ template "tail" $ }}

--- a/handlers/writings/category_grant_create_task.go
+++ b/handlers/writings/category_grant_create_task.go
@@ -1,0 +1,84 @@
+package writings
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/gorilla/mux"
+)
+
+// CategoryGrantCreateTask creates a new grant for a writing category.
+type CategoryGrantCreateTask struct{ tasks.TaskString }
+
+var categoryGrantCreateTask = &CategoryGrantCreateTask{TaskString: TaskCategoryGrantCreate}
+
+var _ tasks.Task = (*CategoryGrantCreateTask)(nil)
+
+func (CategoryGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	vars := mux.Vars(r)
+	categoryID, err := strconv.Atoi(vars["category"])
+	if err != nil {
+		return fmt.Errorf("category id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	username := r.PostFormValue("username")
+	role := r.PostFormValue("role")
+	actions := r.Form["action"]
+	if len(actions) == 0 {
+		actions = []string{"see"}
+	}
+	var uid sql.NullInt32
+	if username != "" {
+		u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
+		if err != nil {
+			log.Printf("GetUserByUsername: %v", err)
+			return fmt.Errorf("get user by username %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		uid = sql.NullInt32{Int32: u.Idusers, Valid: true}
+	}
+	var rid sql.NullInt32
+	if role != "" {
+		roles, err := queries.ListRoles(r.Context())
+		if err != nil {
+			log.Printf("ListRoles: %v", err)
+			return fmt.Errorf("list roles %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		for _, ro := range roles {
+			if ro.Name == role {
+				rid = sql.NullInt32{Int32: ro.ID, Valid: true}
+				break
+			}
+		}
+	}
+	for _, action := range actions {
+		if action == "" {
+			action = "see"
+		}
+		if _, err = queries.CreateGrant(r.Context(), db.CreateGrantParams{
+			UserID:   uid,
+			RoleID:   rid,
+			Section:  "writing",
+			Item:     sql.NullString{String: "category", Valid: true},
+			RuleType: "allow",
+			ItemID:   sql.NullInt32{Int32: int32(categoryID), Valid: true},
+			ItemRule: sql.NullString{},
+			Action:   action,
+			Extra:    sql.NullString{},
+		}); err != nil {
+			log.Printf("CreateGrant: %v", err)
+			return fmt.Errorf("create grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+	}
+	return nil
+}

--- a/handlers/writings/category_grant_delete_task.go
+++ b/handlers/writings/category_grant_delete_task.go
@@ -1,0 +1,33 @@
+package writings
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// CategoryGrantDeleteTask removes a grant from a writing category.
+type CategoryGrantDeleteTask struct{ tasks.TaskString }
+
+var categoryGrantDeleteTask = &CategoryGrantDeleteTask{TaskString: TaskCategoryGrantDelete}
+
+var _ tasks.Task = (*CategoryGrantDeleteTask)(nil)
+
+func (CategoryGrantDeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	grantID, err := strconv.Atoi(r.PostFormValue("grantid"))
+	if err != nil {
+		return fmt.Errorf("grant id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	if err := queries.DeleteGrant(r.Context(), int32(grantID)); err != nil {
+		log.Printf("DeleteGrant: %v", err)
+		return fmt.Errorf("delete grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	return nil
+}

--- a/handlers/writings/routes_admin.go
+++ b/handlers/writings/routes_admin.go
@@ -18,4 +18,7 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	war.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")
 	war.HandleFunc("/categories", handlers.TaskHandler(writingCategoryChangeTask)).Methods("POST").MatcherFunc(writingCategoryChangeTask.Matcher())
 	war.HandleFunc("/categories", handlers.TaskHandler(writingCategoryCreateTask)).Methods("POST").MatcherFunc(writingCategoryCreateTask.Matcher())
+	war.HandleFunc("/category/{category}/permissions", AdminCategoryGrantsPage).Methods("GET")
+	war.HandleFunc("/category/{category}/grant", handlers.TaskHandler(categoryGrantCreateTask)).Methods("POST").MatcherFunc(categoryGrantCreateTask.Matcher())
+	war.HandleFunc("/category/{category}/grant/delete", handlers.TaskHandler(categoryGrantDeleteTask)).Methods("POST").MatcherFunc(categoryGrantDeleteTask.Matcher())
 }

--- a/handlers/writings/tasks.go
+++ b/handlers/writings/tasks.go
@@ -30,4 +30,10 @@ const (
 
 	// TaskWritingCategoryCreate creates a new writing category.
 	TaskWritingCategoryCreate = "writing category create"
+
+	// TaskCategoryGrantCreate adds a new grant to a writing category.
+	TaskCategoryGrantCreate tasks.TaskString = "Create grant"
+
+	// TaskCategoryGrantDelete removes an existing grant from a writing category.
+	TaskCategoryGrantDelete tasks.TaskString = "Delete grant"
 )

--- a/handlers/writings/tasks_register.go
+++ b/handlers/writings/tasks_register.go
@@ -14,5 +14,7 @@ func RegisterTasks() []tasks.NamedTask {
 		userDisallowTask,
 		writingCategoryChangeTask,
 		writingCategoryCreateTask,
+		categoryGrantCreateTask,
+		categoryGrantDeleteTask,
 	}
 }

--- a/handlers/writings/writingsAdminCategoryGrantsPage.go
+++ b/handlers/writings/writingsAdminCategoryGrantsPage.go
@@ -1,0 +1,70 @@
+package writings
+
+import (
+	"database/sql"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/gorilla/mux"
+	"log"
+	"net/http"
+	"strconv"
+)
+
+// AdminCategoryGrantsPage shows grants for a writing category.
+func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
+	type GrantInfo struct {
+		*db.Grant
+		Username sql.NullString
+		RoleName sql.NullString
+	}
+	type Data struct {
+		*common.CoreData
+		CategoryID int32
+		Grants     []GrantInfo
+		Roles      []*db.Role
+		Actions    []string
+	}
+
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	cid, err := strconv.Atoi(mux.Vars(r)["category"])
+	if err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	data := Data{CoreData: cd, CategoryID: int32(cid), Actions: []string{"see", "view", "post", "edit"}}
+	if roles, err := cd.AllRoles(); err == nil {
+		data.Roles = roles
+	}
+
+	grants, err := queries.ListGrants(r.Context())
+	if err != nil {
+		log.Printf("ListGrants: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	for _, g := range grants {
+		if g.Section == "writing" && g.Item.Valid && g.Item.String == "category" && g.ItemID.Valid && g.ItemID.Int32 == int32(cid) {
+			gi := GrantInfo{Grant: g}
+			if g.UserID.Valid {
+				if u, err := queries.GetUserById(r.Context(), g.UserID.Int32); err == nil {
+					gi.Username = sql.NullString{String: u.Username.String, Valid: true}
+				}
+			}
+			if g.RoleID.Valid && data.Roles != nil {
+				for _, r := range data.Roles {
+					if r.ID == g.RoleID.Int32 {
+						gi.RoleName = sql.NullString{String: r.Name, Valid: true}
+						break
+					}
+				}
+			}
+			data.Grants = append(data.Grants, gi)
+		}
+	}
+
+	handlers.TemplateHandler(w, r, "writingsAdminCategoryGrantsPage.gohtml", data)
+}

--- a/handlers/writings/writingsAdminCategoryGrantsPage_test.go
+++ b/handlers/writings/writingsAdminCategoryGrantsPage_test.go
@@ -1,0 +1,52 @@
+package writings
+
+import (
+	"context"
+	"github.com/arran4/goa4web/core/consts"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestAdminCategoryGrantsPage(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	queries := db.New(sqlDB)
+
+	rolesRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin"}).
+		AddRow(1, "user", true, false)
+	mock.ExpectQuery("SELECT id, name, can_login, is_admin FROM roles ORDER BY id").WillReturnRows(rolesRows)
+
+	grantsRows := sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}).
+		AddRow(1, nil, nil, nil, nil, "writing", "category", "allow", 1, nil, "see", nil, true)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants ORDER BY id")).WillReturnRows(grantsRows)
+
+	req := httptest.NewRequest("GET", "/admin/writings/category/1/permissions", nil)
+	ctx := req.Context()
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	req = mux.SetURLVars(req, map[string]string{"category": "1"})
+	rr := httptest.NewRecorder()
+
+	AdminCategoryGrantsPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+}

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -166,6 +166,14 @@ Many queries now filter results directly in SQL using `viewer_id` together with 
 | `writing` | `article` | `edit` | `viewer_id` | viewer role ID | grant requiring both user and role |
 | `writing` | `article` | `edit` | `NULL` | viewer role ID | role-based grant |
 | `writing` | `article` | `edit` | `NULL` | `NULL` | public grant for everyone |
+| `writing` | `category` | `see` | `viewer_id` | `NULL` | grant specific to that user |
+| `writing` | `category` | `see` | `viewer_id` | viewer role ID | grant requiring both user and role |
+| `writing` | `category` | `see` | `NULL` | viewer role ID | role-based grant |
+| `writing` | `category` | `see` | `NULL` | `NULL` | public grant for everyone |
+| `writing` | `category` | `view` | `viewer_id` | `NULL` | grant specific to that user |
+| `writing` | `category` | `view` | `viewer_id` | viewer role ID | grant requiring both user and role |
+| `writing` | `category` | `view` | `NULL` | viewer role ID | role-based grant |
+| `writing` | `category` | `view` | `NULL` | `NULL` | public grant for everyone |
 | `imagebbs` | `board` | `see` or `view` | `viewer_id` | `NULL` | grant specific to that user |
 | `imagebbs` | `board` | `see` or `view` | `viewer_id` | viewer role ID | grant requiring both user and role |
 | `imagebbs` | `board` | `see` or `view` | `NULL` | viewer role ID | role-based grant |


### PR DESCRIPTION
## Summary
- add missing admin page for writing category permissions
- support creating and deleting grants on categories
- document writing category grants in permissions spec
- test admin category grants page

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885d4fb4070832f9b7de4d508a4c2d3