### PR TITLE
Add admin links for FAQ tasks

### DIFF
--- a/handlers/faq/routes.go
+++ b/handlers/faq/routes.go
@@ -19,7 +19,9 @@ func noTask() mux.MatcherFunc {
 // RegisterRoutes attaches the public FAQ endpoints to the router.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
 	navReg.RegisterIndexLink("FAQ", "/faq", SectionWeight)
-	navReg.RegisterAdminControlCenter("FAQ", "/admin/faq/categories", SectionWeight)
+	navReg.RegisterAdminControlCenter("FAQ Questions", "/admin/faq/questions", SectionWeight)
+	navReg.RegisterAdminControlCenter("FAQ Answers", "/admin/faq/answer", SectionWeight+1)
+	navReg.RegisterAdminControlCenter("FAQ Categories", "/admin/faq/categories", SectionWeight+2)
 	faqr := r.PathPrefix("/faq").Subrouter()
 	faqr.Use(handlers.IndexMiddleware(CustomFAQIndex))
 	faqr.HandleFunc("", Page).Methods("GET", "POST")


### PR DESCRIPTION
## Summary
- add admin FAQ links to show `FAQ Questions`, `FAQ Answers`, and `FAQ Categories`
- remove the old `Question Qontrols` wording

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885d4ac93a8832fa58e797072f8681b