### PR TITLE
Add missing direct and target templates

### DIFF
--- a/cmd/goa4web/notifications_tasks.go
+++ b/cmd/goa4web/notifications_tasks.go
@@ -38,12 +38,15 @@ func parseNotificationsTasksCmd(parent *notificationsCmd, args []string) (*notif
 func (c *notificationsTasksCmd) Run() error {
 	tw := table.NewWriter()
 	tw.SetOutputMirror(c.fs.Output())
-	tw.AppendHeader(table.Row{"Task", "Self Email", "Self Internal", "Subscribed Email", "Subscribed Internal", "Admin Email", "Admin Internal"})
+	tw.AppendHeader(table.Row{"Task", "Self Email", "Self Internal", "Direct Email", "Target Email", "Target Internal", "Subscribed Email", "Subscribed Internal", "Admin Email", "Admin Internal"})
 	for _, info := range taskTemplateInfos(c.notificationsCmd.rootCmd.tasksReg) {
 		tw.AppendRow(table.Row{
 			info.Task,
 			strings.Join(info.SelfEmail, ","),
 			info.SelfInternal,
+			strings.Join(info.DirectEmail, ","),
+			strings.Join(info.TargetEmail, ","),
+			info.TargetInternal,
 			strings.Join(info.SubEmail, ","),
 			info.SubInternal,
 			strings.Join(info.AdminEmail, ","),

--- a/cmd/goa4web/notifications_tasks_data.go
+++ b/cmd/goa4web/notifications_tasks_data.go
@@ -9,13 +9,16 @@ import (
 
 // taskTemplateInfo describes the template files used for a task.
 type taskTemplateInfo struct {
-	Task          string
-	SelfEmail     []string
-	SelfInternal  string
-	SubEmail      []string
-	SubInternal   string
-	AdminEmail    []string
-	AdminInternal string
+	Task           string
+	SelfEmail      []string
+	SelfInternal   string
+	DirectEmail    []string
+	SubEmail       []string
+	SubInternal    string
+	TargetEmail    []string
+	TargetInternal string
+	AdminEmail     []string
+	AdminInternal  string
 }
 
 func taskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
@@ -29,6 +32,11 @@ func taskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 			}
 			if nt := tp.SelfInternalNotificationTemplate(); nt != nil {
 				info.SelfInternal = *nt
+			}
+		}
+		if tp, ok := t.(notif.DirectEmailNotificationTemplateProvider); ok {
+			if et := tp.DirectEmailTemplate(); et != nil {
+				info.DirectEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 		}
 		if tp, ok := t.(notif.SubscribersNotificationTemplateProvider); ok {
@@ -45,6 +53,14 @@ func taskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 			}
 			if nt := tp.AdminInternalNotificationTemplate(); nt != nil {
 				info.AdminInternal = *nt
+			}
+		}
+		if tp, ok := t.(notif.TargetUsersNotificationProvider); ok {
+			if et := tp.TargetEmailTemplate(); et != nil {
+				info.TargetEmail = []string{et.Text, et.HTML, et.Subject}
+			}
+			if nt := tp.TargetInternalNotificationTemplate(); nt != nil {
+				info.TargetInternal = *nt
 			}
 		}
 		infos = append(infos, info)

--- a/core/templates/site/admin/emailTemplateListPage.gohtml
+++ b/core/templates/site/admin/emailTemplateListPage.gohtml
@@ -1,12 +1,15 @@
 {{ template "head" $ }}
 [<a href="/admin">Admin</a>]<br />
 <table border="1">
-<tr><th>Task</th><th>Self Email</th><th>Self Internal</th><th>Subscribed Email</th><th>Subscribed Internal</th><th>Admin Email</th><th>Admin Internal</th></tr>
+<tr><th>Task</th><th>Self Email</th><th>Self Internal</th><th>Direct Email</th><th>Target Email</th><th>Target Internal</th><th>Subscribed Email</th><th>Subscribed Internal</th><th>Admin Email</th><th>Admin Internal</th></tr>
 {{- range .Infos }}
 <tr>
     <td>{{ .Task }}</td>
     <td>{{ range $i, $t := .SelfEmail }}{{ if $i }}, {{ end }}<a href="/admin/email/template?name={{ $t }}">{{ $t }}</a>{{ end }}</td>
     <td>{{ if .SelfInternal }}<a href="/admin/email/template?name={{ .SelfInternal }}">{{ .SelfInternal }}</a>{{ end }}</td>
+    <td>{{ range $i, $t := .DirectEmail }}{{ if $i }}, {{ end }}<a href="/admin/email/template?name={{ $t }}">{{ $t }}</a>{{ end }}</td>
+    <td>{{ range $i, $t := .TargetEmail }}{{ if $i }}, {{ end }}<a href="/admin/email/template?name={{ $t }}">{{ $t }}</a>{{ end }}</td>
+    <td>{{ if .TargetInternal }}<a href="/admin/email/template?name={{ .TargetInternal }}">{{ .TargetInternal }}</a>{{ end }}</td>
     <td>{{ range $i, $t := .SubEmail }}{{ if $i }}, {{ end }}<a href="/admin/email/template?name={{ $t }}">{{ $t }}</a>{{ end }}</td>
     <td>{{ if .SubInternal }}<a href="/admin/email/template?name={{ .SubInternal }}">{{ .SubInternal }}</a>{{ end }}</td>
     <td>{{ range $i, $t := .AdminEmail }}{{ if $i }}, {{ end }}<a href="/admin/email/template?name={{ $t }}">{{ $t }}</a>{{ end }}</td>

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -16,13 +16,16 @@ import (
 )
 
 type taskTemplateInfo struct {
-	Task          string
-	SelfEmail     []string
-	SelfInternal  string
-	SubEmail      []string
-	SubInternal   string
-	AdminEmail    []string
-	AdminInternal string
+	Task           string
+	SelfEmail      []string
+	SelfInternal   string
+	DirectEmail    []string
+	SubEmail       []string
+	SubInternal    string
+	TargetEmail    []string
+	TargetInternal string
+	AdminEmail     []string
+	AdminInternal  string
 }
 
 func gatherTaskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
@@ -36,6 +39,11 @@ func gatherTaskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 			}
 			if nt := tp.SelfInternalNotificationTemplate(); nt != nil {
 				info.SelfInternal = *nt
+			}
+		}
+		if tp, ok := t.(notif.DirectEmailNotificationTemplateProvider); ok {
+			if et := tp.DirectEmailTemplate(); et != nil {
+				info.DirectEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 		}
 		if tp, ok := t.(notif.SubscribersNotificationTemplateProvider); ok {
@@ -52,6 +60,14 @@ func gatherTaskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 			}
 			if nt := tp.AdminInternalNotificationTemplate(); nt != nil {
 				info.AdminInternal = *nt
+			}
+		}
+		if tp, ok := t.(notif.TargetUsersNotificationProvider); ok {
+			if et := tp.TargetEmailTemplate(); et != nil {
+				info.TargetEmail = []string{et.Text, et.HTML, et.Subject}
+			}
+			if nt := tp.TargetInternalNotificationTemplate(); nt != nil {
+				info.TargetInternal = *nt
 			}
 		}
 		infos = append(infos, info)


### PR DESCRIPTION
## Summary
- display direct and target template info in the admin UI
- surface direct and target template info in CLI `notifications tasks`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885d6701124832f9211f9d03cf52af0