### PR TITLE
Enhance DLQ admin page

### DIFF
--- a/core/templates/site/admin/dlqPage.gohtml
+++ b/core/templates/site/admin/dlqPage.gohtml
@@ -1,5 +1,29 @@
 {{ template "head" $ }}
 [<a href="/admin">Admin:</a> <a href="/admin/dlq">(This page/Refresh)</a>]<br />
+Configured providers: {{ .Providers }}<br />
+
+{{- if .FileErrors }}
+<h2>File DLQ</h2>
+<table border="1">
+<tr><th>Time</th><th>Message</th></tr>
+{{- range .FileErrors }}
+<tr><td>{{ .Time }}</td><td>{{ .Message }}</td></tr>
+{{- end }}
+</table>
+{{- end }}
+
+{{- if .DirErrors }}
+<h2>Directory DLQ</h2>
+<table border="1">
+<tr><th>Name</th><th>Message</th></tr>
+{{- range .DirErrors }}
+<tr><td>{{ .Name }}</td><td>{{ .Message }}</td></tr>
+{{- end }}
+</table>
+{{- end }}
+
+{{- if .Errors }}
+<h2>Database DLQ</h2>
 <form method="post">
     {{ csrfField }}
 <table border="1">
@@ -17,4 +41,5 @@ Before: <input type="date" name="before">
 <input type="submit" name="task" value="Delete">
 <input type="submit" name="task" value="Purge">
 </form>
+{{- end }}
 {{ template "tail" $ }}

--- a/internal/dlq/dir/dir.go
+++ b/internal/dlq/dir/dir.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/arran4/goa4web/config"
 	dbpkg "github.com/arran4/goa4web/internal/db"
@@ -34,4 +36,34 @@ func Register(r *dlq.Registry) {
 	r.RegisterProvider("dir", func(cfg *config.RuntimeConfig, _ *dbpkg.Queries) dlq.DLQ {
 		return &DLQ{Dir: cfg.DLQFile}
 	})
+}
+
+// Record represents a DLQ message stored in a directory file.
+type Record struct {
+	Name    string
+	Message string
+}
+
+// List reads up to limit records from dir sorted by filename descending.
+func List(dir string, limit int) ([]Record, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() > entries[j].Name() })
+	var recs []Record
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		recs = append(recs, Record{Name: e.Name(), Message: strings.TrimSpace(string(data))})
+		if limit > 0 && len(recs) >= limit {
+			break
+		}
+	}
+	return recs, nil
 }


### PR DESCRIPTION
## Summary
- expose configured DLQ providers and list file/dir contents
- add helpers to read file and dir DLQ entries
- display new information on `/admin/dlq`

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885d6b77f04832fbab498c76f749a80