### PR TITLE
Improve server stats page formatting

### DIFF
--- a/core/templates/site/admin/serverStatsPage.gohtml
+++ b/core/templates/site/admin/serverStatsPage.gohtml
@@ -18,7 +18,10 @@
     <li>DLQ Providers: {{ range $i, $d := .Registries.DLQProviders }}{{ if $i }}, {{ end }}{{ $d }}{{ end }}</li>
     <li>Email Providers: {{ range $i, $e := .Registries.EmailProviders }}{{ if $i }}, {{ end }}{{ $e }}{{ end }}</li>
     <li>Upload Providers: {{ range $i, $u := .Registries.UploadProviders }}{{ if $i }}, {{ end }}{{ $u }}{{ end }}</li>
+    <li>Router Modules: {{ range $i, $m := .Registries.RouterModules }}{{ if $i }}, {{ end }}{{ $m }}{{ end }}</li>
 </ul>
 <h3>Current Configuration</h3>
-<pre>{{ printf "%+v" .Config }}</pre>
+<pre>{{ .ConfigEnv }}</pre>
+<h3>Configuration JSON</h3>
+<pre>{{ .ConfigJSON }}</pre>
 {{ template "tail" $ }}

--- a/internal/router/registry.go
+++ b/internal/router/registry.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"sort"
 	"sync"
 
 	"github.com/gorilla/mux"
@@ -72,4 +73,16 @@ func (reg *Registry) InitModules(r *mux.Router, cfg *config.RuntimeConfig, navRe
 		}
 		m.once.Do(func() { m.Setup(r, cfg, navReg) })
 	}
+}
+
+// Names returns the names of registered modules in sorted order.
+func (reg *Registry) Names() []string {
+	reg.mu.Lock()
+	names := make([]string, 0, len(reg.modules))
+	for n := range reg.modules {
+		names = append(names, n)
+	}
+	reg.mu.Unlock()
+	sort.Strings(names)
+	return names
 }

--- a/internal/router/registry_test.go
+++ b/internal/router/registry_test.go
@@ -44,3 +44,13 @@ func TestInitModulesDependencyOrder(t *testing.T) {
 		t.Fatalf("order mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestRegistryNames(t *testing.T) {
+	reg := NewRegistry()
+	reg.RegisterModule("b", nil, nil)
+	reg.RegisterModule("a", nil, nil)
+	want := []string{"a", "b"}
+	if diff := cmp.Diff(want, reg.Names()); diff != "" {
+		t.Fatalf("names mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
## Summary
- add router registry name listing
- show config values in env-file format
- prettify config JSON on admin stats page
- list router modules

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885d711c534832fb2519802edef2f04