### PR TITLE
Fix admin user permission page

### DIFF
--- a/core/templates/site/admin/userPermissionsPage.gohtml
+++ b/core/templates/site/admin/userPermissionsPage.gohtml
@@ -1,0 +1,97 @@
+{{ template "head" $ }}
+[<a href="/admin">Admin:</a> <a href="/admin/user/{{.User.Idusers}}">Profile</a>: <a href="/admin/user/{{.User.Idusers}}/permissions">(This page/Refresh)</a>]<br />
+<table border="1" class="perm-table">
+    <thead>
+        <tr>
+            <th class="sortable">ID</th>
+            <th class="sortable">Role</th>
+            <th>Edit</th>
+            <th>Delete</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{- range .Rows}}
+        <tr data-id="{{.IduserRoles}}">
+            <td>{{.IduserRoles}}</td>
+            <td class="role">{{.Name}}</td>
+            <td><button class="edit-btn" data-id="{{.IduserRoles}}">Edit</button></td>
+            <td><button class="delete-btn" data-id="{{.IduserRoles}}">Delete</button></td>
+        </tr>
+        {{- end}}
+    </tbody>
+</table>
+<h3>Add Permission</h3>
+<form id="add-permission-form">
+    <input type="hidden" name="username" value="{{.User.Username.String}}">
+    Role:
+    <select name="role">
+        {{- range $.Roles }}<option value="{{.Name}}">{{.Name}}</option>{{- end }}
+    </select>
+    <button type="submit">Add</button>
+</form>
+<template id="roleOptions">
+    {{- range $.Roles }}<option value="{{.Name}}">{{.Name}}</option>{{- end }}
+</template>
+<script>
+(function(){
+    function post(data){
+        return fetch('/admin/user/{{.User.Idusers}}/permissions', {
+            method:'POST',
+            body:data,
+            headers:{'X-CSRF-Token': '{{ csrfToken }}'}
+        });
+    }
+    document.querySelectorAll('.delete-btn').forEach(function(btn){
+        btn.addEventListener('click', function(e){
+            e.preventDefault();
+            var data = new URLSearchParams();
+            data.set('task','User Disallow');
+            data.set('permid',btn.dataset.id);
+            post(data).then(function(){ location.reload(); });
+        });
+    });
+    document.querySelectorAll('.edit-btn').forEach(function(btn){
+        btn.addEventListener('click', function(e){
+            e.preventDefault();
+            var tr = btn.closest('tr');
+            var roleCell = tr.querySelector('.role');
+            var curRole = roleCell.textContent.trim();
+            roleCell.innerHTML = document.getElementById('roleOptions').innerHTML;
+            roleCell.querySelector('select').value = curRole;
+            btn.textContent = 'Save';
+            btn.addEventListener('click', function(ev){
+                ev.preventDefault();
+                var data = new URLSearchParams();
+                data.set('task','Update permission');
+                data.set('permid',btn.dataset.id);
+                data.set('role',roleCell.querySelector('select').value);
+                post(data).then(function(){ location.reload(); });
+            }, {once:true});
+        }, {once:true});
+    });
+    document.getElementById('add-permission-form').addEventListener('submit', function(e){
+        e.preventDefault();
+        var data = new URLSearchParams(new FormData(e.target));
+        data.set('task','User Allow');
+        post(data).then(function(){ location.reload(); });
+    });
+    document.querySelectorAll('.perm-table th.sortable').forEach(function(th){
+        th.addEventListener('click', function(){
+            var table = th.closest('table');
+            var tbody = table.querySelector('tbody');
+            var rows = Array.from(tbody.querySelectorAll('tr'));
+            var idx = Array.from(th.parentNode.children).indexOf(th);
+            var asc = th.dataset.asc === 'true';
+            rows.sort(function(a,b){
+                var av = a.children[idx].textContent.trim();
+                var bv = b.children[idx].textContent.trim();
+                if(av === bv) return 0;
+                return (av > bv ? 1 : -1) * (asc ? 1 : -1);
+            });
+            th.dataset.asc = !asc;
+            rows.forEach(function(r){ tbody.appendChild(r); });
+        });
+    });
+})();
+</script>
+{{ template "tail" $ }}

--- a/core/templates/site/admin/userProfile.gohtml
+++ b/core/templates/site/admin/userProfile.gohtml
@@ -1,5 +1,6 @@
 {{ template "head" $ }}
 <h2>User {{ .User.Username.String }} (ID {{ .User.Idusers }})</h2>
+<p><a href="/admin/user/{{.User.Idusers}}/permissions">Permissions</a></p>
 <table border="1">
 <tr><th>Email</th><th>Verified</th><th>Priority</th></tr>
 {{ range .Emails }}

--- a/core/templates/site/admin/usersPage.gohtml
+++ b/core/templates/site/admin/usersPage.gohtml
@@ -47,6 +47,7 @@
                         <input type="submit" value="Reset password">
                     </form>
                     <a style="display:inline-block;margin:0 4px" href="/admin/user/{{.Idusers}}">Profile</a>
+                    <a style="display:inline-block;margin:0 4px" href="/admin/user/{{.Idusers}}/permissions">Permissions</a>
                     <a style="display:inline-block;margin:0 4px" href="/admin/users/export?uid={{.Idusers}}">Export ZIP</a>
                 </td>
             </tr>

--- a/handlers/user/admin_permissions.go
+++ b/handlers/user/admin_permissions.go
@@ -6,16 +6,23 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"sort"
+	"strconv"
+
+	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 )
 
-func adminUsersPermissionsPage(w http.ResponseWriter, r *http.Request) {
+func adminUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
+	idStr := mux.Vars(r)["id"]
+	id, _ := strconv.Atoi(idStr)
+
 	type Data struct {
 		*common.CoreData
-		Rows  []*db.GetPermissionsWithUsersRow
+		User  *db.User
+		Rows  []*db.GetPermissionsByUserIDRow
 		Roles []*db.Role
 	}
 
@@ -23,24 +30,28 @@ func adminUsersPermissionsPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := data.Queries()
+
+	if u, err := queries.GetUserById(r.Context(), int32(id)); err == nil {
+		data.User = &db.User{Idusers: u.Idusers, Username: u.Username}
+	} else {
+		http.Error(w, "user not found", http.StatusNotFound)
+		return
+	}
+
 	if roles, err := data.AllRoles(); err == nil {
 		data.Roles = roles
 	}
 
-	rows, err := queries.GetPermissionsWithUsers(r.Context(), db.GetPermissionsWithUsersParams{Username: sql.NullString{}})
-	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-		default:
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
+	rows, err := queries.GetPermissionsByUserID(r.Context(), int32(id))
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
 	}
 	sort.Slice(rows, func(i, j int) bool {
-		return rows[i].Username.String < rows[j].Username.String
+		return rows[i].Name < rows[j].Name
 	})
 	data.Rows = rows
 
-	handlers.TemplateHandler(w, r, "usersPermissionsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "userPermissionsPage.gohtml", data)
 }

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -60,7 +60,7 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 	form.Set("username", "bob")
 	form.Set("role", "moderator")
 	form.Set("task", string(TaskUserAllow))
-	req := httptest.NewRequest("POST", "/admin/users/permissions", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest("POST", "/admin/user/2/permissions", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	cd := common.NewCoreData(req.Context(), queries, config.NewRuntimeConfig())
 	evt := &eventbus.TaskEvent{}

--- a/handlers/user/permissionUpdateTask.go
+++ b/handlers/user/permissionUpdateTask.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/gorilla/mux"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -30,6 +32,11 @@ func (PermissionUpdateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	permid := r.PostFormValue("permid")
 	role := r.PostFormValue("role")
 
+	idStr := mux.Vars(r)["id"]
+	back := "/admin/users/permissions"
+	if idStr != "" {
+		back = "/admin/user/" + idStr + "/permissions"
+	}
 	data := struct {
 		*common.CoreData
 		Errors   []string
@@ -37,7 +44,7 @@ func (PermissionUpdateTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Back     string
 	}{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		Back:     "/admin/users/permissions",
+		Back:     back,
 	}
 
 	if id, err := strconv.Atoi(permid); err != nil {

--- a/handlers/user/permissionUserAllowTask.go
+++ b/handlers/user/permissionUserAllowTask.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gorilla/mux"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -36,6 +38,11 @@ func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) an
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	username := r.PostFormValue("username")
 	role := r.PostFormValue("role")
+	idStr := mux.Vars(r)["id"]
+	back := "/admin/users/permissions"
+	if idStr != "" {
+		back = "/admin/user/" + idStr + "/permissions"
+	}
 	data := struct {
 		*common.CoreData
 		Errors   []string
@@ -43,7 +50,7 @@ func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) an
 		Back     string
 	}{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		Back:     "/admin/users/permissions",
+		Back:     back,
 	}
 	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("GetUserByUsername: %w", err).Error())

--- a/handlers/user/permissionUserDisallowTask.go
+++ b/handlers/user/permissionUserDisallowTask.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/gorilla/mux"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -35,6 +37,11 @@ func (PermissionUserDisallowTask) AdminInternalNotificationTemplate() *string {
 func (PermissionUserDisallowTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	permid := r.PostFormValue("permid")
+	idStr := mux.Vars(r)["id"]
+	back := "/admin/users/permissions"
+	if idStr != "" {
+		back = "/admin/user/" + idStr + "/permissions"
+	}
 	data := struct {
 		*common.CoreData
 		Errors   []string
@@ -42,7 +49,7 @@ func (PermissionUserDisallowTask) Action(w http.ResponseWriter, r *http.Request)
 		Back     string
 	}{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		Back:     "/admin/users/permissions",
+		Back:     back,
 	}
 	if permidi, err := strconv.Atoi(permid); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("strconv.Atoi: %w", err).Error())

--- a/handlers/user/routes_admin.go
+++ b/handlers/user/routes_admin.go
@@ -9,7 +9,6 @@ import (
 
 // RegisterAdminRoutes attaches user admin endpoints to the router.
 func RegisterAdminRoutes(ar *mux.Router, navReg *navpkg.Registry) {
-	navReg.RegisterAdminControlCenter("User Permissions", "/admin/users/permissions", SectionWeight-10)
 	navReg.RegisterAdminControlCenter("Pending Users", "/admin/users/pending", SectionWeight-5)
 	navReg.RegisterAdminControlCenter("Users", "/admin/users", SectionWeight)
 	ar.HandleFunc("/users", adminUsersPage).Methods("GET")
@@ -20,8 +19,8 @@ func RegisterAdminRoutes(ar *mux.Router, navReg *navpkg.Registry) {
 	ar.HandleFunc("/sessions", adminSessionsPage).Methods("GET")
 	ar.HandleFunc("/sessions/delete", adminSessionsDeletePage).Methods("POST")
 	ar.HandleFunc("/login/attempts", adminLoginAttemptsPage).Methods("GET")
-	ar.HandleFunc("/users/permissions", adminUsersPermissionsPage).Methods("GET")
-	ar.HandleFunc("/users/permissions", handlers.TaskHandler(permissionUserAllowTask)).Methods("POST").MatcherFunc(permissionUserAllowTask.Matcher())
-	ar.HandleFunc("/users/permissions", handlers.TaskHandler(permissionUserDisallowTask)).Methods("POST").MatcherFunc(permissionUserDisallowTask.Matcher())
-	ar.HandleFunc("/users/permissions", handlers.TaskHandler(permissionUpdateTask)).Methods("POST").MatcherFunc(permissionUpdateTask.Matcher())
+	ar.HandleFunc("/user/{id}/permissions", adminUserPermissionsPage).Methods("GET")
+	ar.HandleFunc("/user/{id}/permissions", handlers.TaskHandler(permissionUserAllowTask)).Methods("POST").MatcherFunc(permissionUserAllowTask.Matcher())
+	ar.HandleFunc("/user/{id}/permissions", handlers.TaskHandler(permissionUserDisallowTask)).Methods("POST").MatcherFunc(permissionUserDisallowTask.Matcher())
+	ar.HandleFunc("/user/{id}/permissions", handlers.TaskHandler(permissionUpdateTask)).Methods("POST").MatcherFunc(permissionUpdateTask.Matcher())
 }


### PR DESCRIPTION
## Summary
- add admin user permissions page at `/admin/user/{id}/permissions`
- remove old unused dashboard entry
- link to permissions from user profile and listing
- adjust permission tasks to redirect back to the new page
- update tests

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go mod tidy`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885d78fdb4c832fb831137993347904