### PR TITLE
Link admin pending user list to profiles

### DIFF
--- a/core/templates/site/admin/pendingUsersPage.gohtml
+++ b/core/templates/site/admin/pendingUsersPage.gohtml
@@ -4,7 +4,7 @@
         <tr><th>ID</th><th>User</th><th>Email</th><th>Actions</th></tr>
         {{range .Rows}}
         <tr>
-            <td>{{.Idusers}}</td><td>{{.Username.String}}</td><td>{{.Email}}</td>
+            <td><a href="/admin/user/{{.Idusers}}">{{.Idusers}}</a></td><td>{{.Username.String}}</td><td>{{.Email}}</td>
             <td>
                 <form style="display:inline" method="post" action="/admin/users/pending/approve">
                     {{ csrfField }}<input type="hidden" name="uid" value="{{.Idusers}}">


### PR DESCRIPTION
## Summary
- link each ID in the admin pending users page to the admin user profile page

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go mod tidy`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6885d7b3d824832fb19026eecf8eb48a