### PR TITLE
Add resend/retry options for sent emails

### DIFF
--- a/core/templates/site/admin/emailSentPage.gohtml
+++ b/core/templates/site/admin/emailSentPage.gohtml
@@ -1,16 +1,23 @@
 {{ template "head" $ }}
 [<a href="/admin">Admin:</a> <a href="/admin/email/sent">(This page/Refresh)</a> | <a href="/admin/email/queue">Queue</a>]<br />
+<form method="post">
+    {{ csrfField }}
 <table border="1">
-<tr><th>ID</th><th>To</th><th>Subject</th><th>Sent</th></tr>
+<tr><th>Select</th><th>ID</th><th>To</th><th>Subject</th><th>Retries</th><th>Outcome</th></tr>
 {{- range .Emails }}
 <tr>
+    <td><input type="checkbox" name="id" value="{{ .ID }}"></td>
     <td>{{ .ID }}</td>
     <td>{{ .Email }}</td>
     <td>{{ .Subject }}</td>
-    <td>{{ if .SentAt.Valid }}{{ .SentAt.Time }}{{ end }}</td>
+    <td>{{ .ErrorCount }}</td>
+    <td>{{ if .SentAt.Valid }}Sent {{ .SentAt.Time }}{{ else }}Unknown{{ end }}</td>
 </tr>
 {{- end }}
 </table>
+<input type="submit" name="task" value="Resend">
+<input type="submit" name="task" value="Retry">
+</form>
 {{if $.PrevLink}}<a href="{{$.PrevLink}}">Previous {{$.PageSize}}</a>{{end}}
 {{if $.NextLink}}<a href="{{$.NextLink}}">Next {{$.PageSize}}</a>{{end}}
 {{ template "tail" $ }}

--- a/handlers/admin/resend_sent_task.go
+++ b/handlers/admin/resend_sent_task.go
@@ -1,0 +1,65 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/arran4/goa4web/workers/emailqueue"
+)
+
+// ResendSentEmailTask re-sends already delivered emails immediately.
+type ResendSentEmailTask struct{ tasks.TaskString }
+
+var resendSentEmailTask = &ResendSentEmailTask{TaskString: TaskResend}
+
+// ensure ResendSentEmailTask satisfies the tasks.Task interface
+var _ tasks.Task = (*ResendSentEmailTask)(nil)
+var _ tasks.AuditableTask = (*ResendSentEmailTask)(nil)
+
+func (ResendSentEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	provider := cd.EmailProvider()
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	for _, idStr := range r.Form["id"] {
+		id, _ := strconv.Atoi(idStr)
+		e, err := queries.GetPendingEmailByID(r.Context(), int32(id))
+		if err != nil {
+			return fmt.Errorf("get email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, cd.Config, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
+		if err != nil {
+			return fmt.Errorf("resolve address fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		if provider != nil {
+			if err := provider.Send(r.Context(), addr, []byte(e.Body)); err != nil {
+				return fmt.Errorf("send email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+			}
+		}
+		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+			if evt := cd.Event(); evt != nil {
+				if evt.Data == nil {
+					evt.Data = map[string]any{}
+				}
+				evt.Data["SentEmailID"] = appendID(evt.Data["SentEmailID"], id)
+			}
+		}
+	}
+	return nil
+}
+
+// AuditRecord summarises sent emails being resent.
+func (ResendSentEmailTask) AuditRecord(data map[string]any) string {
+	if ids, ok := data["SentEmailID"].(string); ok {
+		return "resent sent emails " + ids
+	}
+	return "resent sent emails"
+}

--- a/handlers/admin/retry_sent_task.go
+++ b/handlers/admin/retry_sent_task.go
@@ -1,0 +1,55 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// RetrySentEmailTask queues a previously sent email for delivery again.
+type RetrySentEmailTask struct{ tasks.TaskString }
+
+var retrySentEmailTask = &RetrySentEmailTask{TaskString: TaskRetry}
+
+var _ tasks.Task = (*RetrySentEmailTask)(nil)
+var _ tasks.AuditableTask = (*RetrySentEmailTask)(nil)
+
+func (RetrySentEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	for _, idStr := range r.Form["id"] {
+		id, _ := strconv.Atoi(idStr)
+		e, err := queries.GetPendingEmailByID(r.Context(), int32(id))
+		if err != nil {
+			return fmt.Errorf("get email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		if err := queries.InsertPendingEmail(r.Context(), db.InsertPendingEmailParams{ToUserID: e.ToUserID, Body: e.Body, DirectEmail: e.DirectEmail}); err != nil {
+			return fmt.Errorf("queue email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+			if evt := cd.Event(); evt != nil {
+				if evt.Data == nil {
+					evt.Data = map[string]any{}
+				}
+				evt.Data["RetryEmailID"] = appendID(evt.Data["RetryEmailID"], id)
+			}
+		}
+	}
+	return nil
+}
+
+func (RetrySentEmailTask) AuditRecord(data map[string]any) string {
+	if ids, ok := data["RetryEmailID"].(string); ok {
+		return "retried sent emails " + ids
+	}
+	return "retried sent emails"
+}

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -40,6 +40,8 @@ func (h *Handlers) RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navRe
 	ar.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")
 	ar.HandleFunc("/email/queue", AdminEmailQueuePage).Methods("GET")
 	ar.HandleFunc("/email/sent", AdminSentEmailsPage).Methods("GET")
+	ar.HandleFunc("/email/sent", handlers.TaskHandler(resendSentEmailTask)).Methods("POST").MatcherFunc(resendSentEmailTask.Matcher())
+	ar.HandleFunc("/email/sent", handlers.TaskHandler(retrySentEmailTask)).Methods("POST").MatcherFunc(retrySentEmailTask.Matcher())
 	ar.HandleFunc("/email/queue", handlers.TaskHandler(resendQueueTask)).Methods("POST").MatcherFunc(resendQueueTask.Matcher())
 	ar.HandleFunc("/email/queue", handlers.TaskHandler(deleteQueueTask)).Methods("POST").MatcherFunc(deleteQueueTask.Matcher())
 	ar.HandleFunc("/email/template", AdminEmailTemplatePage).Methods("GET")

--- a/handlers/admin/tasks.go
+++ b/handlers/admin/tasks.go
@@ -197,6 +197,9 @@ const (
 	// TaskResend attempts to send queued emails immediately.
 	TaskResend tasks.TaskString = "Resend"
 
+	// TaskRetry queues a previously sent email for another attempt.
+	TaskRetry tasks.TaskString = "Retry"
+
 	// TaskDismiss marks a notification as read.
 	TaskDismiss tasks.TaskString = "Dismiss"
 

--- a/handlers/admin/tasks_register.go
+++ b/handlers/admin/tasks_register.go
@@ -9,6 +9,8 @@ func (h *Handlers) RegisterTasks() []tasks.NamedTask {
 		deleteAnnouncementTask,
 		resendQueueTask,
 		deleteQueueTask,
+		resendSentEmailTask,
+		retrySentEmailTask,
 		saveTemplateTask,
 		deleteTemplateTask,
 		testTemplateTask,


### PR DESCRIPTION
## Summary
- support resending previously delivered emails
- allow retrying sent mail by requeuing
- expose new POST routes and register tasks
- update sent emails table to display retry counts

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885d6267100832fb5000b66b2de1f86