### PR TITLE
Improve admin search tasks feedback

### DIFF
--- a/core/templates/email/searchRebuildBlogEmail.gohtml
+++ b/core/templates/email/searchRebuildBlogEmail.gohtml
@@ -1,0 +1,1 @@
+<p>Blog search index rebuild completed.</p>

--- a/core/templates/email/searchRebuildBlogEmail.gotxt
+++ b/core/templates/email/searchRebuildBlogEmail.gotxt
@@ -1,0 +1,1 @@
+Blog search index rebuild completed.

--- a/core/templates/email/searchRebuildBlogEmailSubject.gotxt
+++ b/core/templates/email/searchRebuildBlogEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Blog search rebuilt

--- a/core/templates/email/searchRebuildCommentsEmail.gohtml
+++ b/core/templates/email/searchRebuildCommentsEmail.gohtml
@@ -1,0 +1,1 @@
+<p>Comments search index rebuild completed.</p>

--- a/core/templates/email/searchRebuildCommentsEmail.gotxt
+++ b/core/templates/email/searchRebuildCommentsEmail.gotxt
@@ -1,0 +1,1 @@
+Comments search index rebuild completed.

--- a/core/templates/email/searchRebuildCommentsEmailSubject.gotxt
+++ b/core/templates/email/searchRebuildCommentsEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Comments search rebuilt

--- a/core/templates/email/searchRebuildImageEmail.gohtml
+++ b/core/templates/email/searchRebuildImageEmail.gohtml
@@ -1,0 +1,1 @@
+<p>Image search index rebuild completed.</p>

--- a/core/templates/email/searchRebuildImageEmail.gotxt
+++ b/core/templates/email/searchRebuildImageEmail.gotxt
@@ -1,0 +1,1 @@
+Image search index rebuild completed.

--- a/core/templates/email/searchRebuildImageEmailSubject.gotxt
+++ b/core/templates/email/searchRebuildImageEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Image search rebuilt

--- a/core/templates/email/searchRebuildLinkerEmail.gohtml
+++ b/core/templates/email/searchRebuildLinkerEmail.gohtml
@@ -1,0 +1,1 @@
+<p>Linker search index rebuild completed.</p>

--- a/core/templates/email/searchRebuildLinkerEmail.gotxt
+++ b/core/templates/email/searchRebuildLinkerEmail.gotxt
@@ -1,0 +1,1 @@
+Linker search index rebuild completed.

--- a/core/templates/email/searchRebuildLinkerEmailSubject.gotxt
+++ b/core/templates/email/searchRebuildLinkerEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Linker search rebuilt

--- a/core/templates/email/searchRebuildNewsEmail.gohtml
+++ b/core/templates/email/searchRebuildNewsEmail.gohtml
@@ -1,0 +1,1 @@
+<p>News search index rebuild completed.</p>

--- a/core/templates/email/searchRebuildNewsEmail.gotxt
+++ b/core/templates/email/searchRebuildNewsEmail.gotxt
@@ -1,0 +1,1 @@
+News search index rebuild completed.

--- a/core/templates/email/searchRebuildNewsEmailSubject.gotxt
+++ b/core/templates/email/searchRebuildNewsEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] News search rebuilt

--- a/core/templates/email/searchRebuildWritingEmail.gohtml
+++ b/core/templates/email/searchRebuildWritingEmail.gohtml
@@ -1,0 +1,1 @@
+<p>Writing search index rebuild completed.</p>

--- a/core/templates/email/searchRebuildWritingEmail.gotxt
+++ b/core/templates/email/searchRebuildWritingEmail.gotxt
@@ -1,0 +1,1 @@
+Writing search index rebuild completed.

--- a/core/templates/email/searchRebuildWritingEmailSubject.gotxt
+++ b/core/templates/email/searchRebuildWritingEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Writing search rebuilt

--- a/core/templates/notifications/search_rebuild_blog.gotxt
+++ b/core/templates/notifications/search_rebuild_blog.gotxt
@@ -1,0 +1,1 @@
+Blog search index rebuild completed.

--- a/core/templates/notifications/search_rebuild_comments.gotxt
+++ b/core/templates/notifications/search_rebuild_comments.gotxt
@@ -1,0 +1,1 @@
+Comments search index rebuild completed.

--- a/core/templates/notifications/search_rebuild_image.gotxt
+++ b/core/templates/notifications/search_rebuild_image.gotxt
@@ -1,0 +1,1 @@
+Image search index rebuild completed.

--- a/core/templates/notifications/search_rebuild_linker.gotxt
+++ b/core/templates/notifications/search_rebuild_linker.gotxt
@@ -1,0 +1,1 @@
+Linker search index rebuild completed.

--- a/core/templates/notifications/search_rebuild_news.gotxt
+++ b/core/templates/notifications/search_rebuild_news.gotxt
@@ -1,0 +1,1 @@
+News search index rebuild completed.

--- a/core/templates/notifications/search_rebuild_writing.gotxt
+++ b/core/templates/notifications/search_rebuild_writing.gotxt
@@ -1,0 +1,1 @@
+Writing search index rebuild completed.

--- a/handlers/search/remakeBlogFinishedTask.go
+++ b/handlers/search/remakeBlogFinishedTask.go
@@ -1,0 +1,37 @@
+package search
+
+import (
+	"net/http"
+
+	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// RemakeBlogFinishedTask notifies when the blog index rebuild completes.
+type RemakeBlogFinishedTask struct{ tasks.TaskString }
+
+var remakeBlogFinishedTask = &RemakeBlogFinishedTask{TaskString: TaskRemakeBlogSearchComplete}
+
+var _ tasks.Task = (*RemakeBlogFinishedTask)(nil)
+var _ notif.AdminEmailTemplateProvider = (*RemakeBlogFinishedTask)(nil)
+var _ notif.SelfNotificationTemplateProvider = (*RemakeBlogFinishedTask)(nil)
+
+func (RemakeBlogFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
+
+func (RemakeBlogFinishedTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("searchRebuildBlogEmail")
+}
+
+func (RemakeBlogFinishedTask) AdminInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_blog")
+	return &s
+}
+
+func (RemakeBlogFinishedTask) SelfEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("searchRebuildBlogEmail")
+}
+
+func (RemakeBlogFinishedTask) SelfInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_blog")
+	return &s
+}

--- a/handlers/search/remakeBlogTask.go
+++ b/handlers/search/remakeBlogTask.go
@@ -2,15 +2,13 @@ package search
 
 import (
 	"context"
-	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"strings"
 
 	"github.com/arran4/goa4web/core/common"
-
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
+	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -19,48 +17,47 @@ type RemakeBlogTask struct{ tasks.TaskString }
 
 var remakeBlogTask = &RemakeBlogTask{TaskString: TaskRemakeBlogSearch}
 var _ tasks.Task = (*RemakeBlogTask)(nil)
+var _ tasks.BackgroundTasker = (*RemakeBlogTask)(nil)
 
 func (RemakeBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := struct {
 		*common.CoreData
-		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
+		Messages: []string{"work queued"},
 		Back:     "/admin/search",
 	}
-	ctx := r.Context()
-	if err := queries.DeleteBlogsSearch(ctx); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("DeleteBlogsSearch: %w", err).Error())
-	}
+	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+}
 
-	rows, err := queries.GetAllBlogsForIndex(ctx)
+func (RemakeBlogTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tasks.Task, error) {
+	if err := q.DeleteBlogsSearch(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := q.GetAllBlogsForIndex(ctx)
 	if err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("GetAllBlogsForIndex: %w", err).Error())
-	} else {
-		for _, row := range rows {
-			text := strings.TrimSpace(row.Blog.String)
-			if text == "" {
-				continue
-			}
-			err := indexText(ctx, queries, text, func(c context.Context, wid int64, count int32) error {
-				return queries.AddToBlogsSearch(c, db.AddToBlogsSearchParams{
-					BlogID:                         row.Idblogs,
-					SearchwordlistIdsearchwordlist: int32(wid),
-					WordCount:                      count,
-				})
+		return nil, err
+	}
+	for _, row := range rows {
+		text := strings.TrimSpace(row.Blog.String)
+		if text == "" {
+			continue
+		}
+		if err := indexText(ctx, q, text, func(c context.Context, wid int64, count int32) error {
+			return q.AddToBlogsSearch(c, dbpkg.AddToBlogsSearchParams{
+				BlogID:                         row.Idblogs,
+				SearchwordlistIdsearchwordlist: int32(wid),
+				WordCount:                      count,
 			})
-			if err != nil {
-				data.Errors = append(data.Errors, fmt.Errorf("index blog %d: %w", row.Idblogs, err).Error())
-				continue
-			}
-			if err := queries.SetBlogLastIndex(ctx, row.Idblogs); err != nil {
-				data.Errors = append(data.Errors, fmt.Errorf("SetBlogLastIndex %d: %w", row.Idblogs, err).Error())
-			}
+		}); err != nil {
+			return nil, err
+		}
+		if err := q.SetBlogLastIndex(ctx, row.Idblogs); err != nil {
+			return nil, err
 		}
 	}
-
-	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+	return remakeBlogFinishedTask, nil
 }

--- a/handlers/search/remakeCommentsFinishedTask.go
+++ b/handlers/search/remakeCommentsFinishedTask.go
@@ -1,0 +1,37 @@
+package search
+
+import (
+	"net/http"
+
+	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// RemakeCommentsFinishedTask notifies when the comment index rebuild completes.
+type RemakeCommentsFinishedTask struct{ tasks.TaskString }
+
+var remakeCommentsFinishedTask = &RemakeCommentsFinishedTask{TaskString: TaskRemakeCommentsSearchComplete}
+
+var _ tasks.Task = (*RemakeCommentsFinishedTask)(nil)
+var _ notif.AdminEmailTemplateProvider = (*RemakeCommentsFinishedTask)(nil)
+var _ notif.SelfNotificationTemplateProvider = (*RemakeCommentsFinishedTask)(nil)
+
+func (RemakeCommentsFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
+
+func (RemakeCommentsFinishedTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("searchRebuildCommentsEmail")
+}
+
+func (RemakeCommentsFinishedTask) AdminInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_comments")
+	return &s
+}
+
+func (RemakeCommentsFinishedTask) SelfEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("searchRebuildCommentsEmail")
+}
+
+func (RemakeCommentsFinishedTask) SelfInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_comments")
+	return &s
+}

--- a/handlers/search/remakeImageFinishedTask.go
+++ b/handlers/search/remakeImageFinishedTask.go
@@ -1,0 +1,37 @@
+package search
+
+import (
+	"net/http"
+
+	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// RemakeImageFinishedTask notifies when the image index rebuild completes.
+type RemakeImageFinishedTask struct{ tasks.TaskString }
+
+var remakeImageFinishedTask = &RemakeImageFinishedTask{TaskString: TaskRemakeImageSearchComplete}
+
+var _ tasks.Task = (*RemakeImageFinishedTask)(nil)
+var _ notif.AdminEmailTemplateProvider = (*RemakeImageFinishedTask)(nil)
+var _ notif.SelfNotificationTemplateProvider = (*RemakeImageFinishedTask)(nil)
+
+func (RemakeImageFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
+
+func (RemakeImageFinishedTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("searchRebuildImageEmail")
+}
+
+func (RemakeImageFinishedTask) AdminInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_image")
+	return &s
+}
+
+func (RemakeImageFinishedTask) SelfEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("searchRebuildImageEmail")
+}
+
+func (RemakeImageFinishedTask) SelfInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_image")
+	return &s
+}

--- a/handlers/search/remakeImageTask.go
+++ b/handlers/search/remakeImageTask.go
@@ -2,15 +2,13 @@ package search
 
 import (
 	"context"
-	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"strings"
 
 	"github.com/arran4/goa4web/core/common"
-
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
+	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -19,48 +17,47 @@ type RemakeImageTask struct{ tasks.TaskString }
 
 var remakeImageTask = &RemakeImageTask{TaskString: TaskRemakeImageSearch}
 var _ tasks.Task = (*RemakeImageTask)(nil)
+var _ tasks.BackgroundTasker = (*RemakeImageTask)(nil)
 
 func (RemakeImageTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := struct {
 		*common.CoreData
-		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
+		Messages: []string{"work queued"},
 		Back:     "/admin/search",
 	}
-	ctx := r.Context()
-	if err := queries.DeleteImagePostSearch(ctx); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("DeleteImagePostSearch: %w", err).Error())
-	}
+	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+}
 
-	rows, err := queries.GetAllImagePostsForIndex(ctx)
+func (RemakeImageTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tasks.Task, error) {
+	if err := q.DeleteImagePostSearch(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := q.GetAllImagePostsForIndex(ctx)
 	if err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("GetAllImagePostsForIndex: %w", err).Error())
-	} else {
-		for _, row := range rows {
-			text := strings.TrimSpace(row.Description.String)
-			if text == "" {
-				continue
-			}
-			err := indexText(ctx, queries, text, func(c context.Context, wid int64, count int32) error {
-				return queries.AddToImagePostSearch(c, db.AddToImagePostSearchParams{
-					ImagePostID:                    row.Idimagepost,
-					SearchwordlistIdsearchwordlist: int32(wid),
-					WordCount:                      count,
-				})
+		return nil, err
+	}
+	for _, row := range rows {
+		text := strings.TrimSpace(row.Description.String)
+		if text == "" {
+			continue
+		}
+		if err := indexText(ctx, q, text, func(c context.Context, wid int64, count int32) error {
+			return q.AddToImagePostSearch(c, dbpkg.AddToImagePostSearchParams{
+				ImagePostID:                    row.Idimagepost,
+				SearchwordlistIdsearchwordlist: int32(wid),
+				WordCount:                      count,
 			})
-			if err != nil {
-				data.Errors = append(data.Errors, fmt.Errorf("index image %d: %w", row.Idimagepost, err).Error())
-				continue
-			}
-			if err := queries.SetImagePostLastIndex(ctx, row.Idimagepost); err != nil {
-				data.Errors = append(data.Errors, fmt.Errorf("SetImagePostLastIndex %d: %w", row.Idimagepost, err).Error())
-			}
+		}); err != nil {
+			return nil, err
+		}
+		if err := q.SetImagePostLastIndex(ctx, row.Idimagepost); err != nil {
+			return nil, err
 		}
 	}
-
-	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+	return remakeImageFinishedTask, nil
 }

--- a/handlers/search/remakeLinkerFinishedTask.go
+++ b/handlers/search/remakeLinkerFinishedTask.go
@@ -1,0 +1,37 @@
+package search
+
+import (
+	"net/http"
+
+	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// RemakeLinkerFinishedTask notifies when the linker index rebuild completes.
+type RemakeLinkerFinishedTask struct{ tasks.TaskString }
+
+var remakeLinkerFinishedTask = &RemakeLinkerFinishedTask{TaskString: TaskRemakeLinkerSearchComplete}
+
+var _ tasks.Task = (*RemakeLinkerFinishedTask)(nil)
+var _ notif.AdminEmailTemplateProvider = (*RemakeLinkerFinishedTask)(nil)
+var _ notif.SelfNotificationTemplateProvider = (*RemakeLinkerFinishedTask)(nil)
+
+func (RemakeLinkerFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
+
+func (RemakeLinkerFinishedTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("searchRebuildLinkerEmail")
+}
+
+func (RemakeLinkerFinishedTask) AdminInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_linker")
+	return &s
+}
+
+func (RemakeLinkerFinishedTask) SelfEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("searchRebuildLinkerEmail")
+}
+
+func (RemakeLinkerFinishedTask) SelfInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_linker")
+	return &s
+}

--- a/handlers/search/remakeLinkerTask.go
+++ b/handlers/search/remakeLinkerTask.go
@@ -2,15 +2,13 @@ package search
 
 import (
 	"context"
-	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"strings"
 
 	"github.com/arran4/goa4web/core/common"
-
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
+	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -19,48 +17,47 @@ type RemakeLinkerTask struct{ tasks.TaskString }
 
 var remakeLinkerTask = &RemakeLinkerTask{TaskString: TaskRemakeLinkerSearch}
 var _ tasks.Task = (*RemakeLinkerTask)(nil)
+var _ tasks.BackgroundTasker = (*RemakeLinkerTask)(nil)
 
 func (RemakeLinkerTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := struct {
 		*common.CoreData
-		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
+		Messages: []string{"work queued"},
 		Back:     "/admin/search",
 	}
-	ctx := r.Context()
-	if err := queries.DeleteLinkerSearch(ctx); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("DeleteLinkerSearch: %w", err).Error())
-	}
+	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+}
 
-	rows, err := queries.GetAllLinkersForIndex(ctx)
+func (RemakeLinkerTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tasks.Task, error) {
+	if err := q.DeleteLinkerSearch(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := q.GetAllLinkersForIndex(ctx)
 	if err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("GetAllLinkersForIndex: %w", err).Error())
-	} else {
-		for _, row := range rows {
-			text := strings.TrimSpace(row.Title.String + " " + row.Description.String)
-			if text == "" {
-				continue
-			}
-			err := indexText(ctx, queries, text, func(c context.Context, wid int64, count int32) error {
-				return queries.AddToLinkerSearch(c, db.AddToLinkerSearchParams{
-					LinkerID:                       row.Idlinker,
-					SearchwordlistIdsearchwordlist: int32(wid),
-					WordCount:                      count,
-				})
+		return nil, err
+	}
+	for _, row := range rows {
+		text := strings.TrimSpace(row.Title.String + " " + row.Description.String)
+		if text == "" {
+			continue
+		}
+		if err := indexText(ctx, q, text, func(c context.Context, wid int64, count int32) error {
+			return q.AddToLinkerSearch(c, dbpkg.AddToLinkerSearchParams{
+				LinkerID:                       row.Idlinker,
+				SearchwordlistIdsearchwordlist: int32(wid),
+				WordCount:                      count,
 			})
-			if err != nil {
-				data.Errors = append(data.Errors, fmt.Errorf("index linker %d: %w", row.Idlinker, err).Error())
-				continue
-			}
-			if err := queries.SetLinkerLastIndex(ctx, row.Idlinker); err != nil {
-				data.Errors = append(data.Errors, fmt.Errorf("SetLinkerLastIndex %d: %w", row.Idlinker, err).Error())
-			}
+		}); err != nil {
+			return nil, err
+		}
+		if err := q.SetLinkerLastIndex(ctx, row.Idlinker); err != nil {
+			return nil, err
 		}
 	}
-
-	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+	return remakeLinkerFinishedTask, nil
 }

--- a/handlers/search/remakeNewsFinishedTask.go
+++ b/handlers/search/remakeNewsFinishedTask.go
@@ -1,0 +1,37 @@
+package search
+
+import (
+	"net/http"
+
+	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// RemakeNewsFinishedTask notifies when the news index rebuild completes.
+type RemakeNewsFinishedTask struct{ tasks.TaskString }
+
+var remakeNewsFinishedTask = &RemakeNewsFinishedTask{TaskString: TaskRemakeNewsSearchComplete}
+
+var _ tasks.Task = (*RemakeNewsFinishedTask)(nil)
+var _ notif.AdminEmailTemplateProvider = (*RemakeNewsFinishedTask)(nil)
+var _ notif.SelfNotificationTemplateProvider = (*RemakeNewsFinishedTask)(nil)
+
+func (RemakeNewsFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
+
+func (RemakeNewsFinishedTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("searchRebuildNewsEmail")
+}
+
+func (RemakeNewsFinishedTask) AdminInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_news")
+	return &s
+}
+
+func (RemakeNewsFinishedTask) SelfEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("searchRebuildNewsEmail")
+}
+
+func (RemakeNewsFinishedTask) SelfInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_news")
+	return &s
+}

--- a/handlers/search/remakeNewsTask.go
+++ b/handlers/search/remakeNewsTask.go
@@ -2,15 +2,13 @@ package search
 
 import (
 	"context"
-	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"strings"
 
 	"github.com/arran4/goa4web/core/common"
-
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
+	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -19,48 +17,47 @@ type RemakeNewsTask struct{ tasks.TaskString }
 
 var remakeNewsTask = &RemakeNewsTask{TaskString: TaskRemakeNewsSearch}
 var _ tasks.Task = (*RemakeNewsTask)(nil)
+var _ tasks.BackgroundTasker = (*RemakeNewsTask)(nil)
 
 func (RemakeNewsTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := struct {
 		*common.CoreData
-		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
+		Messages: []string{"work queued"},
 		Back:     "/admin/search",
 	}
-	ctx := r.Context()
-	if err := queries.DeleteSiteNewsSearch(ctx); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("DeleteSiteNewsSearch: %w", err).Error())
-	}
+	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+}
 
-	rows, err := queries.GetAllSiteNewsForIndex(ctx)
+func (RemakeNewsTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tasks.Task, error) {
+	if err := q.DeleteSiteNewsSearch(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := q.GetAllSiteNewsForIndex(ctx)
 	if err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("GetAllSiteNewsForIndex: %w", err).Error())
-	} else {
-		for _, row := range rows {
-			text := strings.TrimSpace(row.News.String)
-			if text == "" {
-				continue
-			}
-			err := indexText(ctx, queries, text, func(c context.Context, wid int64, count int32) error {
-				return queries.AddToSiteNewsSearch(c, db.AddToSiteNewsSearchParams{
-					SiteNewsID:                     row.Idsitenews,
-					SearchwordlistIdsearchwordlist: int32(wid),
-					WordCount:                      count,
-				})
+		return nil, err
+	}
+	for _, row := range rows {
+		text := strings.TrimSpace(row.News.String)
+		if text == "" {
+			continue
+		}
+		if err := indexText(ctx, q, text, func(c context.Context, wid int64, count int32) error {
+			return q.AddToSiteNewsSearch(c, dbpkg.AddToSiteNewsSearchParams{
+				SiteNewsID:                     row.Idsitenews,
+				SearchwordlistIdsearchwordlist: int32(wid),
+				WordCount:                      count,
 			})
-			if err != nil {
-				data.Errors = append(data.Errors, fmt.Errorf("index site news %d: %w", row.Idsitenews, err).Error())
-				continue
-			}
-			if err := queries.SetSiteNewsLastIndex(ctx, row.Idsitenews); err != nil {
-				data.Errors = append(data.Errors, fmt.Errorf("SetSiteNewsLastIndex %d: %w", row.Idsitenews, err).Error())
-			}
+		}); err != nil {
+			return nil, err
+		}
+		if err := q.SetSiteNewsLastIndex(ctx, row.Idsitenews); err != nil {
+			return nil, err
 		}
 	}
-
-	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+	return remakeNewsFinishedTask, nil
 }

--- a/handlers/search/remakeWritingFinishedTask.go
+++ b/handlers/search/remakeWritingFinishedTask.go
@@ -1,0 +1,37 @@
+package search
+
+import (
+	"net/http"
+
+	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// RemakeWritingFinishedTask notifies when the writing index rebuild completes.
+type RemakeWritingFinishedTask struct{ tasks.TaskString }
+
+var remakeWritingFinishedTask = &RemakeWritingFinishedTask{TaskString: TaskRemakeWritingSearchComplete}
+
+var _ tasks.Task = (*RemakeWritingFinishedTask)(nil)
+var _ notif.AdminEmailTemplateProvider = (*RemakeWritingFinishedTask)(nil)
+var _ notif.SelfNotificationTemplateProvider = (*RemakeWritingFinishedTask)(nil)
+
+func (RemakeWritingFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
+
+func (RemakeWritingFinishedTask) AdminEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("searchRebuildWritingEmail")
+}
+
+func (RemakeWritingFinishedTask) AdminInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_writing")
+	return &s
+}
+
+func (RemakeWritingFinishedTask) SelfEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("searchRebuildWritingEmail")
+}
+
+func (RemakeWritingFinishedTask) SelfInternalNotificationTemplate() *string {
+	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_writing")
+	return &s
+}

--- a/handlers/search/remakeWritingTask.go
+++ b/handlers/search/remakeWritingTask.go
@@ -2,15 +2,13 @@ package search
 
 import (
 	"context"
-	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"strings"
 
 	"github.com/arran4/goa4web/core/common"
-
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
+	dbpkg "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -19,48 +17,47 @@ type RemakeWritingTask struct{ tasks.TaskString }
 
 var remakeWritingTask = &RemakeWritingTask{TaskString: TaskRemakeWritingSearch}
 var _ tasks.Task = (*RemakeWritingTask)(nil)
+var _ tasks.BackgroundTasker = (*RemakeWritingTask)(nil)
 
 func (RemakeWritingTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := struct {
 		*common.CoreData
-		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
+		Messages: []string{"work queued"},
 		Back:     "/admin/search",
 	}
-	ctx := r.Context()
-	if err := queries.DeleteWritingSearch(ctx); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("DeleteWritingSearch: %w", err).Error())
-	}
+	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+}
 
-	rows, err := queries.GetAllWritingsForIndex(ctx)
+func (RemakeWritingTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tasks.Task, error) {
+	if err := q.DeleteWritingSearch(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := q.GetAllWritingsForIndex(ctx)
 	if err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("GetAllWritingsForIndex: %w", err).Error())
-	} else {
-		for _, row := range rows {
-			text := strings.TrimSpace(row.Title.String + " " + row.Abstract.String + " " + row.Writing.String)
-			if text == "" {
-				continue
-			}
-			err := indexText(ctx, queries, text, func(c context.Context, wid int64, count int32) error {
-				return queries.AddToForumWritingSearch(c, db.AddToForumWritingSearchParams{
-					WritingID:                      row.Idwriting,
-					SearchwordlistIdsearchwordlist: int32(wid),
-					WordCount:                      count,
-				})
+		return nil, err
+	}
+	for _, row := range rows {
+		text := strings.TrimSpace(row.Title.String + " " + row.Abstract.String + " " + row.Writing.String)
+		if text == "" {
+			continue
+		}
+		if err := indexText(ctx, q, text, func(c context.Context, wid int64, count int32) error {
+			return q.AddToForumWritingSearch(c, dbpkg.AddToForumWritingSearchParams{
+				WritingID:                      row.Idwriting,
+				SearchwordlistIdsearchwordlist: int32(wid),
+				WordCount:                      count,
 			})
-			if err != nil {
-				data.Errors = append(data.Errors, fmt.Errorf("index writing %d: %w", row.Idwriting, err).Error())
-				continue
-			}
-			if err := queries.SetWritingLastIndex(ctx, row.Idwriting); err != nil {
-				data.Errors = append(data.Errors, fmt.Errorf("SetWritingLastIndex %d: %w", row.Idwriting, err).Error())
-			}
+		}); err != nil {
+			return nil, err
+		}
+		if err := q.SetWritingLastIndex(ctx, row.Idwriting); err != nil {
+			return nil, err
 		}
 	}
-
-	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+	return remakeWritingFinishedTask, nil
 }

--- a/handlers/search/tasks.go
+++ b/handlers/search/tasks.go
@@ -38,3 +38,18 @@ const (
 	// TaskRemakeImageSearch rebuilds the image search index.
 	TaskRemakeImageSearch tasks.TaskString = "Remake image search"
 )
+
+const (
+	// TaskRemakeCommentsSearchComplete notifies comment index rebuild completion.
+	TaskRemakeCommentsSearchComplete tasks.TaskString = "Remake comments search complete"
+	// TaskRemakeNewsSearchComplete notifies news index rebuild completion.
+	TaskRemakeNewsSearchComplete tasks.TaskString = "Remake news search complete"
+	// TaskRemakeBlogSearchComplete notifies blog index rebuild completion.
+	TaskRemakeBlogSearchComplete tasks.TaskString = "Remake blog search complete"
+	// TaskRemakeLinkerSearchComplete notifies linker index rebuild completion.
+	TaskRemakeLinkerSearchComplete tasks.TaskString = "Remake linker search complete"
+	// TaskRemakeWritingSearchComplete notifies writing index rebuild completion.
+	TaskRemakeWritingSearchComplete tasks.TaskString = "Remake writing search complete"
+	// TaskRemakeImageSearchComplete notifies image index rebuild completion.
+	TaskRemakeImageSearchComplete tasks.TaskString = "Remake image search complete"
+)

--- a/handlers/search/tasks_register.go
+++ b/handlers/search/tasks_register.go
@@ -16,5 +16,11 @@ func RegisterTasks() []tasks.NamedTask {
 		remakeLinkerTask,
 		remakeWritingTask,
 		remakeImageTask,
+		remakeCommentsFinishedTask,
+		remakeNewsFinishedTask,
+		remakeBlogFinishedTask,
+		remakeLinkerFinishedTask,
+		remakeWritingFinishedTask,
+		remakeImageFinishedTask,
 	}
 }

--- a/internal/tasks/background_tasker.go
+++ b/internal/tasks/background_tasker.go
@@ -1,0 +1,18 @@
+package tasks
+
+import (
+	"context"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+// BackgroundTasker is implemented by tasks that perform additional work
+// after the HTTP response has been sent. The method should execute the
+// background action and return a task published once the work is done.
+// Returning nil indicates no follow-up event.
+type BackgroundTasker interface {
+	BackgroundTask(ctx context.Context, q *dbpkg.Queries) (Task, error)
+}
+
+// PostResultAction is kept for backward compatibility.
+type PostResultAction = BackgroundTasker

--- a/workers/backgroundtaskworker/worker.go
+++ b/workers/backgroundtaskworker/worker.go
@@ -1,0 +1,52 @@
+package backgroundtaskworker
+
+import (
+	"context"
+	"log"
+	"time"
+
+	dbpkg "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// Worker listens for task events implementing tasks.BackgroundTasker.
+// The background method is executed and any returned task is published
+// back onto the bus when the work completes.
+func Worker(ctx context.Context, bus *eventbus.Bus, q *dbpkg.Queries) {
+	if bus == nil || q == nil {
+		return
+	}
+	ch := bus.Subscribe(eventbus.TaskMessageType)
+	for {
+		select {
+		case msg := <-ch:
+			evt, ok := msg.(eventbus.TaskEvent)
+			if !ok {
+				continue
+			}
+			if p, ok := evt.Task.(tasks.BackgroundTasker); ok {
+				evtCtx := context.WithoutCancel(ctx)
+				t, err := p.BackgroundTask(evtCtx, q)
+				if err != nil {
+					log.Printf("background task: %v", err)
+					continue
+				}
+				if t != nil {
+					nEvt := eventbus.TaskEvent{
+						Path:   evt.Path,
+						Task:   t,
+						UserID: evt.UserID,
+						Time:   time.Now(),
+						Data:   evt.Data,
+					}
+					if err := bus.Publish(nEvt); err != nil && err != eventbus.ErrBusClosed {
+						log.Printf("background publish: %v", err)
+					}
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/workers/workers.go
+++ b/workers/workers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/arran4/goa4web/internal/notifications"
 
 	"github.com/arran4/goa4web/workers/auditworker"
+	"github.com/arran4/goa4web/workers/backgroundtaskworker"
 	"github.com/arran4/goa4web/workers/emailqueue"
 	"github.com/arran4/goa4web/workers/logworker"
 	"github.com/arran4/goa4web/workers/postcountworker"
@@ -66,6 +67,8 @@ func Start(ctx context.Context, db *sql.DB, provider email.Provider, dlqProvider
 	})
 	log.Printf("Starting search index worker")
 	safeGo(func() { searchworker.Worker(ctx, bus, dbpkg.New(db)) })
+	log.Printf("Starting background task worker")
+	safeGo(func() { backgroundtaskworker.Worker(ctx, bus, dbpkg.New(db)) })
 	log.Printf("Starting post count worker")
 	safeGo(func() { postcountworker.Worker(ctx, bus, dbpkg.New(db)) })
 }


### PR DESCRIPTION
## Summary
- add post result action interface and worker
- rebuild search indexes asynchronously using new interface
- notify admins and the initiating user when rebuild completes
- inline rebuild implementations in tasks so the worker stays generic
- rename `ActualTask` to `FinishedTask` and rename background worker package
- rename post result action interface

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885d5a87bcc832fab1307342d694ea7