### PR TITLE
Fix header links

### DIFF
--- a/core/templates/site/header.gohtml
+++ b/core/templates/site/header.gohtml
@@ -3,7 +3,6 @@
     <div class="navbar-left">
         {{ if cd.HasRole "administrator" }}
             {{ if cd.AdminMode }}
-                <a href="{{ addmode "/admin" }}">Admin Dashboard</a>
                 <a href="?">Disable admin mode</a>
             {{ else }}
                 <a href="?mode=admin">Enable admin mode</a>


### PR DESCRIPTION
## Summary
- remove Admin Dashboard link from the page header so it only appears in the sidebar

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: TestAdminCategoryGrantsPage)*
- `go test -tags nosqlite ./...` *(fails: TestAdminCategoryGrantsPage)*

------
https://chatgpt.com/codex/tasks/task_e_688621ed3798832f9f297ee4c932f28e