### PR TITLE
Rename FAQ section to Help

### DIFF
--- a/handlers/faq/routes.go
+++ b/handlers/faq/routes.go
@@ -18,10 +18,10 @@ func noTask() mux.MatcherFunc {
 
 // RegisterRoutes attaches the public FAQ endpoints to the router.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
-	navReg.RegisterIndexLink("FAQ", "/faq", SectionWeight)
-	navReg.RegisterAdminControlCenter("FAQ Questions", "/admin/faq/questions", SectionWeight)
-	navReg.RegisterAdminControlCenter("FAQ Answers", "/admin/faq/answer", SectionWeight+1)
-	navReg.RegisterAdminControlCenter("FAQ Categories", "/admin/faq/categories", SectionWeight+2)
+	navReg.RegisterIndexLink("Help", "/faq", SectionWeight)
+	navReg.RegisterAdminControlCenter("Help Questions", "/admin/faq/questions", SectionWeight)
+	navReg.RegisterAdminControlCenter("Help Answers", "/admin/faq/answer", SectionWeight+1)
+	navReg.RegisterAdminControlCenter("Help Categories", "/admin/faq/categories", SectionWeight+2)
 	faqr := r.PathPrefix("/faq").Subrouter()
 	faqr.Use(handlers.IndexMiddleware(CustomFAQIndex))
 	faqr.HandleFunc("", Page).Methods("GET", "POST")

--- a/handlers/faq/section.go
+++ b/handlers/faq/section.go
@@ -1,6 +1,6 @@
 package faq
 
 const (
-	// SectionWeight controls the order of the FAQ section in navigation.
+	// SectionWeight controls the order of the Help section in navigation.
 	SectionWeight = 20
 )

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ The code in this repository exposes all pages using the [Gorilla Mux](https://gi
 
 - **News** – publish posts and allow discussion in comment threads. Writers,
   moderators and administrators may edit posts.
-- **FAQ** – manage question and answer entries with administrative tools.
+- **Help** – manage question and answer entries with administrative tools.
 - **Blogs** – users can write blogs, comment on posts and subscribe to bloggers.
 - **Forum** – a traditional threaded forum with categories, topics and moderation tools.
 - **Linker** – a directory of community links with suggestion and approval queues.
@@ -104,7 +104,7 @@ Example weights:
 
 ```
 News        10
-FAQ         20
+Help        20
 Blogs       30
 Forum       40
 Linker      50


### PR DESCRIPTION
## Summary
- rename user-facing FAQ label to Help in the README
- rename navigation link and admin control centre labels to Help
- update section weight comment

## Testing
- `go mod tidy`
- `gofmt -w handlers/faq/routes.go handlers/faq/section.go`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6886221bd5a4832f99016927c6aa62ab