### PR TITLE
Fix admin forum landing page

### DIFF
--- a/handlers/forum/adminForumHandler.go
+++ b/handlers/forum/adminForumHandler.go
@@ -83,7 +83,7 @@ func AdminForumPage(w http.ResponseWriter, r *http.Request) {
 	categoryTree := NewCategoryTree(categoryRows, topicRows)
 	data.Categories = categoryTree.CategoryChildrenLookup[0]
 
-	handlers.TemplateHandler(w, r, "forumPage", data)
+	handlers.TemplateHandler(w, r, "forumAdminPage", data)
 }
 
 func AdminForumRemakeForumThreadPage(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- admin forum page should render `forumAdminPage` template

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: TestAdminCategoryGrantsPage)*

------
https://chatgpt.com/codex/tasks/task_e_688624938e10832fb44790e349954319