### PR TITLE
Add Failed emails link on admin sent page

### DIFF
--- a/core/templates/site/admin/emailSentPage.gohtml
+++ b/core/templates/site/admin/emailSentPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-[<a href="/admin">Admin:</a> <a href="/admin/email/sent">(This page/Refresh)</a> | <a href="/admin/email/queue">Queue</a>]<br />
+[<a href="/admin">Admin:</a> <a href="/admin/email/sent">(This page/Refresh)</a> | <a href="/admin/email/queue">Queue</a> | <a href="/admin/email/failed">Failed</a>]<br />
 <form method="post">
     {{ csrfField }}
 <table border="1">


### PR DESCRIPTION
## Summary
- include a link to the failed emails page on the Sent Emails admin template

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: expectations remain in TestAdminCategoryGrantsPage)*

------
https://chatgpt.com/codex/tasks/task_e_6886260e1f04832f9b5fb660d111fe81