### PR TITLE
Implement admin password reset via email

### DIFF
--- a/core/templates/email/adminPasswordResetEmail.gohtml
+++ b/core/templates/email/adminPasswordResetEmail.gohtml
@@ -1,0 +1,4 @@
+<p>Hi {{.Item.Username}},</p>
+<p>An administrator has reset your password.</p>
+<p>Your new password is <b>{{.Item.Password}}</b>.</p>
+<p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminPasswordResetEmail.gotxt
+++ b/core/templates/email/adminPasswordResetEmail.gotxt
@@ -1,0 +1,5 @@
+Hi {{.Item.Username}},
+An administrator has reset your password.
+Your new password is {{.Item.Password}}.
+
+Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminPasswordResetEmailSubject.gotxt
+++ b/core/templates/email/adminPasswordResetEmailSubject.gotxt
@@ -1,0 +1,1 @@
+[{{.SubjectPrefix}}] Password reset by administrator

--- a/core/templates/notifications/admin_password_reset.gotxt
+++ b/core/templates/notifications/admin_password_reset.gotxt
@@ -1,0 +1,1 @@
+Administrator reset your password via {{.Path}}

--- a/core/templates/site/admin/userResetPasswordConfirmPage.gohtml
+++ b/core/templates/site/admin/userResetPasswordConfirmPage.gohtml
@@ -1,0 +1,8 @@
+{{ template "head" $ }}
+<p>Are you sure you want to reset the password for user {{ .User.Username.String }}?</p>
+<form method="post">
+    {{ csrfField }}
+    <input type="submit" value="Reset password">
+</form>
+<p><a href="{{ .Back }}">Cancel</a></p>
+{{ template "tail" $ }}

--- a/core/templates/site/admin/usersPage.gohtml
+++ b/core/templates/site/admin/usersPage.gohtml
@@ -41,11 +41,7 @@
                         <input type="hidden" name="uid" value="{{.Idusers}}">
                         <input type="submit" value="Disable account">
                     </form>
-                    <form style="display:inline-block;margin:0 4px" method="post" action="/admin/users/reset">
-                        {{ csrfField }}
-                        <input type="hidden" name="uid" value="{{.Idusers}}">
-                        <input type="submit" value="Reset password">
-                    </form>
+                    <a style="display:inline-block;margin:0 4px" href="/admin/user/{{.Idusers}}/reset">Reset password</a>
                     <a style="display:inline-block;margin:0 4px" href="/user/profile/{{.Username.String}}">Profile</a>
                     <a style="display:inline-block;margin:0 4px" href="/admin/user/{{.Idusers}}">Profile</a>
                     <a style="display:inline-block;margin:0 4px" href="/admin/user/{{.Idusers}}/permissions">Permissions</a>

--- a/handlers/admin/adminUserPasswordReset.go
+++ b/handlers/admin/adminUserPasswordReset.go
@@ -1,0 +1,126 @@
+package admin
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/handlers/auth"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// UserPasswordResetTask resets a user's password and notifies them.
+type UserPasswordResetTask struct{ tasks.TaskString }
+
+var userPasswordResetTask = &UserPasswordResetTask{TaskString: TaskUserResetPassword}
+
+var _ tasks.Task = (*UserPasswordResetTask)(nil)
+var _ tasks.AuditableTask = (*UserPasswordResetTask)(nil)
+var _ notif.TargetUsersNotificationProvider = (*UserPasswordResetTask)(nil)
+
+func (UserPasswordResetTask) Action(w http.ResponseWriter, r *http.Request) any {
+	idStr := mux.Vars(r)["id"]
+	id, _ := strconv.Atoi(idStr)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	data := struct {
+		*common.CoreData
+		Errors   []string
+		Messages []string
+		Back     string
+	}{
+		CoreData: cd,
+		Back:     "/admin/user/" + idStr,
+	}
+	userRow, err := queries.GetUserById(r.Context(), int32(id))
+	if err != nil {
+		data.Errors = append(data.Errors, "user not found")
+		return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+	}
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("rand: %w", err).Error())
+		return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+	}
+	newPass := hex.EncodeToString(buf[:])
+	hash, alg, err := auth.HashPassword(newPass)
+	if err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("hashPassword: %w", err).Error())
+		return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+	}
+	if err := queries.InsertPassword(r.Context(), db.InsertPasswordParams{UsersIdusers: int32(id), Passwd: hash, PasswdAlgorithm: sql.NullString{String: alg, Valid: true}}); err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("reset password: %w", err).Error())
+		return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+	}
+	if evt := cd.Event(); evt != nil {
+		if evt.Data == nil {
+			evt.Data = map[string]any{}
+		}
+		evt.Data["targetUserID"] = int32(id)
+		evt.Data["Username"] = userRow.Username.String
+		evt.Data["Password"] = newPass
+	}
+	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
+}
+
+func (UserPasswordResetTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
+	if id, ok := evt.Data["targetUserID"].(int32); ok {
+		return []int32{id}, nil
+	}
+	if id, ok := evt.Data["targetUserID"].(int); ok {
+		return []int32{int32(id)}, nil
+	}
+	return nil, fmt.Errorf("target user id not provided")
+}
+
+func (UserPasswordResetTask) TargetEmailTemplate() *notif.EmailTemplates {
+	return notif.NewEmailTemplates("adminPasswordResetEmail")
+}
+
+func (UserPasswordResetTask) TargetInternalNotificationTemplate() *string {
+	v := notif.NotificationTemplateFilenameGenerator("admin_password_reset")
+	return &v
+}
+
+func (UserPasswordResetTask) AuditRecord(data map[string]any) string {
+	if u, ok := data["Username"].(string); ok {
+		return "password reset for " + u
+	}
+	if id, ok := data["targetUserID"].(int32); ok {
+		return fmt.Sprintf("password reset for %d", id)
+	}
+	return "password reset"
+}
+
+func adminUserResetPasswordConfirmPage(w http.ResponseWriter, r *http.Request) {
+	idStr := mux.Vars(r)["id"]
+	id, _ := strconv.Atoi(idStr)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	userRow, err := queries.GetUserById(r.Context(), int32(id))
+	if err != nil {
+		http.Error(w, "user not found", http.StatusNotFound)
+		return
+	}
+	data := struct {
+		*common.CoreData
+		User *db.User
+		Back string
+	}{
+		CoreData: cd,
+		User:     &db.User{Idusers: userRow.Idusers, Username: userRow.Username},
+		Back:     "/admin/user/" + idStr,
+	}
+	handlers.TemplateHandler(w, r, "userResetPasswordConfirmPage.gohtml", data)
+}

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -68,6 +68,8 @@ func (h *Handlers) RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navRe
 	ar.HandleFunc("/user", adminUserListPage).Methods("GET")
 	ar.HandleFunc("/user/{id}", adminUserProfilePage).Methods("GET")
 	ar.HandleFunc("/user/{id}/comment", adminUserAddCommentPage).Methods("POST")
+	ar.HandleFunc("/user/{id}/reset", adminUserResetPasswordConfirmPage).Methods("GET")
+	ar.HandleFunc("/user/{id}/reset", handlers.TaskHandler(userPasswordResetTask)).Methods("POST").MatcherFunc(userPasswordResetTask.Matcher())
 	ar.HandleFunc("/announcements", AdminAnnouncementsPage).Methods("GET")
 	ar.HandleFunc("/announcements", handlers.TaskHandler(addAnnouncementTask)).Methods("POST").MatcherFunc(addAnnouncementTask.Matcher())
 	ar.HandleFunc("/announcements", handlers.TaskHandler(deleteAnnouncementTask)).Methods("POST").MatcherFunc(deleteAnnouncementTask.Matcher())

--- a/handlers/admin/tasks_register.go
+++ b/handlers/admin/tasks_register.go
@@ -29,6 +29,7 @@ func (h *Handlers) RegisterTasks() []tasks.NamedTask {
 		queryRequestTask,
 		newsUserAllow,
 		newsUserRemove,
+		userPasswordResetTask,
 		h.NewServerShutdownTask(),
 	}
 }


### PR DESCRIPTION
## Summary
- add admin password reset endpoint and task
- provide confirmation page
- create templates for administrator-initiated password reset email
- send internal notification to affected user
- update admin user list to link to new reset page

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: TestAdminCategoryGrantsPage)*

------
https://chatgpt.com/codex/tasks/task_e_68862761e828832fac98ae3bdb927866