### PR TITLE
Improve admin user profile page

### DIFF
--- a/core/templates/site/admin/userProfile.gohtml
+++ b/core/templates/site/admin/userProfile.gohtml
@@ -1,12 +1,54 @@
 {{ template "head" $ }}
 <h2>User {{ .User.Username.String }} (ID {{ .User.Idusers }})</h2>
-<p><a href="/admin/user/{{.User.Idusers}}/permissions">Permissions</a></p>
+<p>
+    <a href="/admin/user/{{.User.Idusers}}/permissions">Permissions</a>
+    {{- if .User.PublicProfileEnabledAt.Valid }} |
+    <a href="/user/profile/{{ .User.Username.String }}">Public Profile</a>{{- end }}
+    {{- if and .Stats (gt .Stats.Blogs 0) }} |
+    <a href="/blogs/blogger/{{ .User.Username.String }}">Blogs</a>{{- end }}
+    {{- if and .Stats (gt .Stats.Writings 0) }} |
+    <a href="/writings/writer/{{ .User.Username.String }}">Writings</a>{{- end }}
+</p>
 <table border="1">
 <tr><th>Email</th><th>Verified</th><th>Priority</th></tr>
 {{ range .Emails }}
 <tr><td>{{ .Email }}</td><td>{{ if .VerifiedAt.Valid }}{{ .VerifiedAt.Time }}{{ else }}no{{ end }}</td><td>{{ .NotificationPriority }}</td></tr>
 {{ end }}
 </table>
+{{ if .Roles }}
+<h3>Groups</h3>
+<ul>
+    {{- range .Roles }}
+    <li>{{ .Name }}</li>
+    {{- end }}
+</ul>
+{{ end }}
+{{ if .Stats }}
+<h3>Stats</h3>
+<ul>
+    <li>Blogs: {{ .Stats.Blogs }}</li>
+    <li>News: {{ .Stats.News }}</li>
+    <li>Comments: {{ .Stats.Comments }}</li>
+    <li>Images: {{ .Stats.Images }}</li>
+    <li>Links: {{ .Stats.Links }}</li>
+    <li>Writings: {{ .Stats.Writings }}</li>
+    <li>Bookmark entries: {{ .BookmarkSize }}</li>
+</ul>
+{{ end }}
+{{ if .Grants }}
+<h3>Direct Grants</h3>
+<table border="1">
+    <tr><th>Section</th><th>Item</th><th>Action</th><th>Extra</th></tr>
+    {{- range .Grants }}
+    <tr>
+        <td>{{ .Section }}</td>
+        <td>{{ .Item.String }}{{ if .ItemID.Valid }} ({{ .ItemID.Int32 }}){{ end }}</td>
+        <td>{{ .Action }}</td>
+        <td>{{ .Extra.String }}</td>
+    </tr>
+    {{- end }}
+</table>
+{{ end }}
 <h3>Admin Comments</h3>
 <form method="post" action="/admin/user/{{.User.Idusers}}/comment">
     {{ csrfField }}

--- a/handlers/admin/adminUserProfilePage.go
+++ b/handlers/admin/adminUserProfilePage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"database/sql"
 	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"strconv"
@@ -24,16 +25,35 @@ func adminUserProfilePage(w http.ResponseWriter, r *http.Request) {
 	}
 	emails, _ := queries.GetUserEmailsByUserID(r.Context(), int32(id))
 	comments, _ := queries.ListAdminUserComments(r.Context(), int32(id))
+	roles, _ := queries.GetPermissionsByUserID(r.Context(), int32(id))
+	stats, _ := queries.UserPostCountsByID(r.Context(), int32(id))
+	bm, _ := queries.GetBookmarksForUser(r.Context(), int32(id))
+	var bmSize int
+	if bm != nil {
+		list := strings.TrimSpace(bm.List.String)
+		if list != "" {
+			bmSize = len(strings.Split(list, "\n"))
+		}
+	}
+	grants, _ := queries.ListGrantsByUserID(r.Context(), sql.NullInt32{Int32: int32(id), Valid: true})
 	data := struct {
 		*common.CoreData
-		User     *db.User
-		Emails   []*db.UserEmail
-		Comments []*db.AdminUserComment
+		User         *db.User
+		Emails       []*db.UserEmail
+		Comments     []*db.AdminUserComment
+		Roles        []*db.GetPermissionsByUserIDRow
+		Stats        *db.UserPostCountsByIDRow
+		BookmarkSize int
+		Grants       []*db.Grant
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		User:     &db.User{Idusers: user.Idusers, Username: user.Username},
-		Emails:   emails,
-		Comments: comments,
+		CoreData:     r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		User:         &db.User{Idusers: user.Idusers, Username: user.Username},
+		Emails:       emails,
+		Comments:     comments,
+		Roles:        roles,
+		Stats:        stats,
+		BookmarkSize: bmSize,
+		Grants:       grants,
 	}
 	handlers.TemplateHandler(w, r, "userProfile.gohtml", data)
 }

--- a/handlers/writings/writingsAdminCategoryGrantsPage_test.go
+++ b/handlers/writings/writingsAdminCategoryGrantsPage_test.go
@@ -25,9 +25,9 @@ func TestAdminCategoryGrantsPage(t *testing.T) {
 
 	queries := db.New(sqlDB)
 
-	rolesRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin"}).
-		AddRow(1, "user", true, false)
-	mock.ExpectQuery("SELECT id, name, can_login, is_admin FROM roles ORDER BY id").WillReturnRows(rolesRows)
+	rolesRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).
+		AddRow(1, "user", true, false, nil)
+	mock.ExpectQuery("SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id").WillReturnRows(rolesRows)
 
 	grantsRows := sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}).
 		AddRow(1, nil, nil, nil, nil, "writing", "category", "allow", 1, nil, "see", nil, true)

--- a/internal/db/queries-permissions.sql
+++ b/internal/db/queries-permissions.sql
@@ -98,6 +98,9 @@ DELETE FROM grants WHERE id = ?;
 -- name: ListGrants :many
 SELECT * FROM grants ORDER BY id;
 
+-- name: ListGrantsByUserID :many
+SELECT * FROM grants WHERE user_id = ? ORDER BY id;
+
 -- name: UserHasRole :one
 SELECT 1
 FROM user_roles ur

--- a/internal/db/queries-stats.sql
+++ b/internal/db/queries-stats.sql
@@ -50,6 +50,22 @@ LEFT JOIN writing w ON w.users_idusers = u.idusers
 GROUP BY u.idusers
 ORDER BY u.username;
 
+-- name: UserPostCountsByID :one
+SELECT COUNT(DISTINCT b.idblogs) AS blogs,
+       COUNT(DISTINCT n.idsiteNews) AS news,
+       COUNT(DISTINCT c.idcomments) AS comments,
+       COUNT(DISTINCT i.idimagepost) AS images,
+       COUNT(DISTINCT l.idlinker) AS links,
+       COUNT(DISTINCT w.idwriting) AS writings
+FROM users u
+LEFT JOIN blogs b ON b.users_idusers = u.idusers
+LEFT JOIN site_news n ON n.users_idusers = u.idusers
+LEFT JOIN comments c ON c.users_idusers = u.idusers
+LEFT JOIN imagepost i ON i.users_idusers = u.idusers
+LEFT JOIN linker l ON l.users_idusers = u.idusers
+LEFT JOIN writing w ON w.users_idusers = u.idusers
+WHERE u.idusers = ?;
+
 -- name: GetTemplateOverride :one
 SELECT body FROM template_overrides WHERE name = ?;
 

--- a/internal/db/queries-stats.sql.go
+++ b/internal/db/queries-stats.sql.go
@@ -328,6 +328,46 @@ func (q *Queries) UserPostCounts(ctx context.Context) ([]*UserPostCountsRow, err
 	return items, nil
 }
 
+const userPostCountsByID = `-- name: UserPostCountsByID :one
+SELECT COUNT(DISTINCT b.idblogs) AS blogs,
+       COUNT(DISTINCT n.idsiteNews) AS news,
+       COUNT(DISTINCT c.idcomments) AS comments,
+       COUNT(DISTINCT i.idimagepost) AS images,
+       COUNT(DISTINCT l.idlinker) AS links,
+       COUNT(DISTINCT w.idwriting) AS writings
+FROM users u
+LEFT JOIN blogs b ON b.users_idusers = u.idusers
+LEFT JOIN site_news n ON n.users_idusers = u.idusers
+LEFT JOIN comments c ON c.users_idusers = u.idusers
+LEFT JOIN imagepost i ON i.users_idusers = u.idusers
+LEFT JOIN linker l ON l.users_idusers = u.idusers
+LEFT JOIN writing w ON w.users_idusers = u.idusers
+WHERE u.idusers = ?
+`
+
+type UserPostCountsByIDRow struct {
+	Blogs    int64
+	News     int64
+	Comments int64
+	Images   int64
+	Links    int64
+	Writings int64
+}
+
+func (q *Queries) UserPostCountsByID(ctx context.Context, idusers int32) (*UserPostCountsByIDRow, error) {
+	row := q.db.QueryRowContext(ctx, userPostCountsByID, idusers)
+	var i UserPostCountsByIDRow
+	err := row.Scan(
+		&i.Blogs,
+		&i.News,
+		&i.Comments,
+		&i.Images,
+		&i.Links,
+		&i.Writings,
+	)
+	return &i, err
+}
+
 const writingCategoryCounts = `-- name: WritingCategoryCounts :many
 SELECT wc.title, COUNT(w.idwriting) AS count
 FROM writing_category wc


### PR DESCRIPTION
## Summary
- show more data on admin user profile page: role list, bookmark size, direct grants and post counts
- link to public profile, blogs, and writings when available
- add queries for stats and direct grants
- fix a test expecting old roles query

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688627ac923c832f94045630af4437c3