### PR TITLE
Fix runTaskPage struct mismatch

### DIFF
--- a/handlers/admin/adminRequestQueuePage.go
+++ b/handlers/admin/adminRequestQueuePage.go
@@ -93,16 +93,19 @@ func adminRequestAddCommentPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	data := struct {
 		*common.CoreData
-		Errors []string
-		Back   string
+		Errors   []string
+		Messages []string
+		Back     string
 	}{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     fmt.Sprintf("/admin/request/%d", id),
 	}
 	if comment == "" || id == 0 {
 		data.Errors = append(data.Errors, "invalid")
+	} else if err := queries.InsertAdminRequestComment(r.Context(), db.InsertAdminRequestCommentParams{RequestID: int32(id), Comment: comment}); err != nil {
+		data.Errors = append(data.Errors, err.Error())
 	} else {
-		_ = queries.InsertAdminRequestComment(r.Context(), db.InsertAdminRequestCommentParams{RequestID: int32(id), Comment: comment})
+		data.Messages = append(data.Messages, "comment added")
 	}
 	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
@@ -116,13 +119,33 @@ func handleRequestAction(w http.ResponseWriter, r *http.Request, status string) 
 		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
-	_ = queries.UpdateAdminRequestStatus(r.Context(), db.UpdateAdminRequestStatusParams{Status: status, ID: int32(id)})
-	auto := fmt.Sprintf("status changed to %s", status)
-	_ = queries.InsertAdminRequestComment(r.Context(), db.InsertAdminRequestCommentParams{RequestID: int32(id), Comment: auto})
-	if comment != "" {
-		_ = queries.InsertAdminRequestComment(r.Context(), db.InsertAdminRequestCommentParams{RequestID: int32(id), Comment: comment})
+	data := struct {
+		*common.CoreData
+		Errors   []string
+		Messages []string
+		Back     string
+	}{
+		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		Back:     "/admin/requests",
 	}
-	_ = queries.InsertAdminUserComment(r.Context(), db.InsertAdminUserCommentParams{UsersIdusers: req.UsersIdusers, Comment: auto})
+
+	if err := queries.UpdateAdminRequestStatus(r.Context(), db.UpdateAdminRequestStatusParams{Status: status, ID: int32(id)}); err != nil {
+		data.Errors = append(data.Errors, err.Error())
+	} else {
+		auto := fmt.Sprintf("status changed to %s", status)
+		data.Messages = append(data.Messages, auto)
+		if err := queries.InsertAdminRequestComment(r.Context(), db.InsertAdminRequestCommentParams{RequestID: int32(id), Comment: auto}); err != nil {
+			data.Errors = append(data.Errors, err.Error())
+		}
+		if comment != "" {
+			if err := queries.InsertAdminRequestComment(r.Context(), db.InsertAdminRequestCommentParams{RequestID: int32(id), Comment: comment}); err != nil {
+				data.Errors = append(data.Errors, err.Error())
+			}
+		}
+		if err := queries.InsertAdminUserComment(r.Context(), db.InsertAdminUserCommentParams{UsersIdusers: req.UsersIdusers, Comment: auto}); err != nil {
+			data.Errors = append(data.Errors, err.Error())
+		}
+	}
 
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 		if evt := cd.Event(); evt != nil {
@@ -132,13 +155,6 @@ func handleRequestAction(w http.ResponseWriter, r *http.Request, status string) 
 			evt.Data["RequestID"] = id
 			evt.Data["Status"] = status
 		}
-	}
-	data := struct {
-		*common.CoreData
-		Back string
-	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		Back:     "/admin/requests",
 	}
 	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/handlers/admin/adminUserProfilePage.go
+++ b/handlers/admin/adminUserProfilePage.go
@@ -43,8 +43,9 @@ func adminUserAddCommentPage(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(idStr)
 	data := struct {
 		*common.CoreData
-		Errors []string
-		Back   string
+		Errors   []string
+		Messages []string
+		Back     string
 	}{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/admin/user/" + idStr,
@@ -58,6 +59,8 @@ func adminUserAddCommentPage(w http.ResponseWriter, r *http.Request) {
 		queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 		if err := queries.InsertAdminUserComment(r.Context(), db.InsertAdminUserCommentParams{UsersIdusers: int32(id), Comment: comment}); err != nil {
 			data.Errors = append(data.Errors, err.Error())
+		} else {
+			data.Messages = append(data.Messages, "comment added")
 		}
 	}
 	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)

--- a/handlers/user/admin_pending.go
+++ b/handlers/user/admin_pending.go
@@ -37,8 +37,9 @@ func adminPendingUsersApprove(w http.ResponseWriter, r *http.Request) {
 	fmt.Sscanf(uid, "%d", &id)
 	data := struct {
 		*common.CoreData
-		Errors []string
-		Back   string
+		Errors   []string
+		Messages []string
+		Back     string
 	}{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/admin/users/pending",
@@ -48,6 +49,8 @@ func adminPendingUsersApprove(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{UsersIdusers: id, Name: "user"}); err != nil {
 			data.Errors = append(data.Errors, fmt.Errorf("add role: %w", err).Error())
+		} else {
+			data.Messages = append(data.Messages, "user approved")
 		}
 
 	}
@@ -62,8 +65,9 @@ func adminPendingUsersReject(w http.ResponseWriter, r *http.Request) {
 	fmt.Sscanf(uid, "%d", &id)
 	data := struct {
 		*common.CoreData
-		Errors []string
-		Back   string
+		Errors   []string
+		Messages []string
+		Back     string
 	}{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/admin/users/pending",
@@ -73,10 +77,14 @@ func adminPendingUsersReject(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{UsersIdusers: id, Name: "rejected"}); err != nil {
 			data.Errors = append(data.Errors, fmt.Errorf("add role:%w", err).Error())
+		} else {
+			data.Messages = append(data.Messages, "user rejected")
 		}
 		if reason != "" {
 			if err := queries.InsertAdminUserComment(r.Context(), db.InsertAdminUserCommentParams{UsersIdusers: id, Comment: reason}); err != nil {
 				log.Printf("insert admin user comment: %v", err)
+			} else {
+				data.Messages = append(data.Messages, "comment recorded")
 			}
 		}
 


### PR DESCRIPTION
## Summary
- add messages to comment actions and admin approvals
- return errors from admin request actions

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...` *(fails: TestAdminCategoryGrantsPage)*

------
https://chatgpt.com/codex/tasks/task_e_688627bfdbf8832fab89bfd347432076