### PR TITLE
Fix duplicate language menu in admin

### DIFF
--- a/handlers/languages/routes.go
+++ b/handlers/languages/routes.go
@@ -4,7 +4,6 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/gorilla/mux"
 
-	"github.com/arran4/goa4web/config"
 	navpkg "github.com/arran4/goa4web/internal/navigation"
 	"github.com/arran4/goa4web/internal/router"
 )
@@ -21,9 +20,5 @@ func RegisterAdminRoutes(ar *mux.Router, navReg *navpkg.Registry) {
 
 // Register registers the languages router module.
 func Register(reg *router.Registry) {
-	reg.RegisterModule("languages", nil, func(r *mux.Router, cfg *config.RuntimeConfig, navReg *navpkg.Registry) {
-		ar := r.PathPrefix("/admin").Subrouter()
-		ar.Use(router.AdminCheckerMiddleware)
-		RegisterAdminRoutes(ar, navReg)
-	})
+	reg.RegisterModule("languages", nil, nil)
 }


### PR DESCRIPTION
## Summary
- reinstate `languages.RegisterAdminRoutes` call in admin router
- stop languages module from registering admin routes on initialization

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: TestAdminCategoryGrantsPage)*

------
https://chatgpt.com/codex/tasks/task_e_688624bf80fc832f95c0dc7720aa6869