### PR TITLE
Fix pending user approval template error

### DIFF
--- a/handlers/user/admin_pending.go
+++ b/handlers/user/admin_pending.go
@@ -37,8 +37,9 @@ func adminPendingUsersApprove(w http.ResponseWriter, r *http.Request) {
 	fmt.Sscanf(uid, "%d", &id)
 	data := struct {
 		*common.CoreData
-		Errors []string
-		Back   string
+		Errors   []string
+		Messages []string
+		Back     string
 	}{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/admin/users/pending",
@@ -48,6 +49,8 @@ func adminPendingUsersApprove(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{UsersIdusers: id, Name: "user"}); err != nil {
 			data.Errors = append(data.Errors, fmt.Errorf("add role: %w", err).Error())
+		} else {
+			data.Messages = append(data.Messages, "User approved")
 		}
 
 	}
@@ -62,8 +65,9 @@ func adminPendingUsersReject(w http.ResponseWriter, r *http.Request) {
 	fmt.Sscanf(uid, "%d", &id)
 	data := struct {
 		*common.CoreData
-		Errors []string
-		Back   string
+		Errors   []string
+		Messages []string
+		Back     string
 	}{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/admin/users/pending",
@@ -73,6 +77,8 @@ func adminPendingUsersReject(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{UsersIdusers: id, Name: "rejected"}); err != nil {
 			data.Errors = append(data.Errors, fmt.Errorf("add role:%w", err).Error())
+		} else {
+			data.Messages = append(data.Messages, "User rejected")
 		}
 		if reason != "" {
 			if err := queries.InsertAdminUserComment(r.Context(), db.InsertAdminUserCommentParams{UsersIdusers: id, Comment: reason}); err != nil {


### PR DESCRIPTION
## Summary
- ensure `adminPendingUsersApprove` and `adminPendingUsersReject` supply a `Messages` slice when rendering `runTaskPage.gohtml`
- display outcome messages when approving or rejecting users

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: TestAdminCategoryGrantsPage)*

------
https://chatgpt.com/codex/tasks/task_e_688623274bcc832f8b7193f4abbd1c38