### PR TITLE
Update page titles per handler

### DIFF
--- a/handlers/admin/adminCategoriesPage.go
+++ b/handlers/admin/adminCategoriesPage.go
@@ -21,11 +21,13 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 		LinkerCategories  []*db.GetLinkerCategoryLinkCountsRow
 	}
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Admin Categories")
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Section:  r.URL.Query().Get("section"),
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 
 	if data.Section == "" || data.Section == "forum" {
 		rows, err := queries.GetAllForumCategoriesWithSubcategoryCount(r.Context())

--- a/handlers/auth/loginPage.go
+++ b/handlers/auth/loginPage.go
@@ -64,8 +64,10 @@ func renderLoginForm(w http.ResponseWriter, r *http.Request, errMsg string) {
 		Method  string
 		Data    string
 	}
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Login")
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Error:    errMsg,
 		Code:     r.FormValue("code"),
 		Back:     r.Context().Value(consts.KeyCoreData).(*common.CoreData).SanitizeBackURL(r, r.FormValue("back")),

--- a/handlers/blogs/bloggerListPage.go
+++ b/handlers/blogs/bloggerListPage.go
@@ -29,6 +29,7 @@ func BloggerListPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Bloggers")
 	data := Data{
 		CoreData: cd,
 		Search:   r.URL.Query().Get("search"),

--- a/handlers/blogs/bloggerPostsPage.go
+++ b/handlers/blogs/bloggerPostsPage.go
@@ -35,6 +35,7 @@ func BloggerPostsPage(w http.ResponseWriter, r *http.Request) {
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	vars := mux.Vars(r)
 	username := vars["username"]
+	handlers.SetPageTitlef(r, "Posts by %s", username)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -99,6 +99,7 @@ func (AddBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 func BlogAddPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Add Blog")
 	if !(cd.HasRole("content writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -70,6 +70,7 @@ func (EditBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 func BlogEditPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Edit Blog")
 	if !(cd.HasRole("content writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return

--- a/handlers/blogs/blogsBlogPage.go
+++ b/handlers/blogs/blogsBlogPage.go
@@ -77,6 +77,13 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 		ViewerIdusers: uid,
 		ID:            int32(blogId),
 	})
+	if err == nil {
+		if blog.Username.Valid {
+			handlers.SetPageTitlef(r, "Blog by %s", blog.Username.String)
+		} else {
+			handlers.SetPageTitlef(r, "Blog %d", blog.Idblogs)
+		}
+	}
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/blogs/blogsBloggersBloggerPage.go
+++ b/handlers/blogs/blogsBloggersBloggerPage.go
@@ -20,6 +20,7 @@ func BloggersBloggerPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	handlers.SetPageTitle(r, "Bloggers")
 
 	cd := data.CoreData
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -80,6 +80,9 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 		ViewerIdusers: uid,
 		ID:            int32(blogId),
 	})
+	if err == nil {
+		handlers.SetPageTitlef(r, "Blog %d Comments", blog.Idblogs)
+	}
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -44,7 +44,9 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Blogs")
+	queries := cd.Queries()
 	rows, err := queries.GetBlogEntriesForUserDescendingLanguages(r.Context(), db.GetBlogEntriesForUserDescendingLanguagesParams{
 		UsersIdusers:  int32(userId),
 		ViewerIdusers: uid,

--- a/handlers/blogs/blogsUserPermissionsPage.go
+++ b/handlers/blogs/blogsUserPermissionsPage.go
@@ -20,6 +20,7 @@ import (
 
 func GetPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Blog Permissions")
 	if !(cd.HasRole("content writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return

--- a/handlers/bookmarks/mine.go
+++ b/handlers/bookmarks/mine.go
@@ -83,6 +83,7 @@ func MinePage(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = session
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "My Bookmarks")
 	bookmarks, err := cd.Bookmarks()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("error getBookmarksForUser: %s", err)

--- a/handlers/bookmarks/page.go
+++ b/handlers/bookmarks/page.go
@@ -23,6 +23,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	handlers.SetPageTitle(r, "Bookmarks")
 
 	if uid == 0 {
 		handlers.TemplateHandler(w, r, "infoPage.gohtml", data)

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -29,7 +29,9 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		Back                    bool
 	}
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Forum")
+	queries := cd.Queries()
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
@@ -38,7 +40,6 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	categoryId, _ := strconv.Atoi(vars["category"])
 
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := &Data{
 		CoreData: cd,
 		Admin:    cd.CanEditAny(),

--- a/handlers/imagebbs/imagebbsAdminBoardsPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardsPage.go
@@ -28,6 +28,7 @@ func AdminBoardsPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	handlers.SetPageTitle(r, "Image Boards")
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	boardRows, err := data.CoreData.ImageBoards()
 	if err != nil {

--- a/handlers/imagebbs/imagebbsAdminFilesPage.go
+++ b/handlers/imagebbs/imagebbsAdminFilesPage.go
@@ -16,6 +16,7 @@ import (
 
 func AdminFilesPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Image Files")
 	type Entry struct {
 		Name  string
 		Path  string

--- a/handlers/imagebbs/imagebbsAdminNewBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminNewBoardPage.go
@@ -39,6 +39,7 @@ func AdminNewBoardPage(w http.ResponseWriter, r *http.Request) {
 		*common.CoreData
 		Boards []*db.Imageboard
 	}
+	handlers.SetPageTitle(r, "New Image Board")
 
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),

--- a/handlers/imagebbs/imagebbsAdminPage.go
+++ b/handlers/imagebbs/imagebbsAdminPage.go
@@ -11,5 +11,6 @@ import (
 
 func AdminPage(w http.ResponseWriter, r *http.Request) {
 	data := struct{ *common.CoreData }{r.Context().Value(consts.KeyCoreData).(*common.CoreData)}
+	handlers.SetPageTitle(r, "Image Board Admin")
 	handlers.TemplateHandler(w, r, "imagebbsAdminPage", data)
 }

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -83,6 +83,10 @@ func BoardPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(boards) > 0 {
+		handlers.SetPageTitlef(r, "Board %s", boards[0].Title.String)
+	}
+
 	data.Boards = boards
 
 	posts, err := data.CoreData.ImageBoardPosts(int32(bid))

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -87,6 +87,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bid, _ := strconv.Atoi(vars["boardno"])
 	thid, _ := strconv.Atoi(vars["thread"])
+	handlers.SetPageTitlef(r, "Thread %d/%d", bid, thid)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/handlers/imagebbs/imagebbsPage.go
+++ b/handlers/imagebbs/imagebbsPage.go
@@ -18,8 +18,10 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		BoardNumber int
 	}
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Image Board")
 	data := Data{
-		CoreData:    r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData:    cd,
 		IsSubBoard:  false,
 		BoardNumber: 0,
 	}

--- a/handlers/imagebbs/imagebbsPosterPage.go
+++ b/handlers/imagebbs/imagebbsPosterPage.go
@@ -27,6 +27,7 @@ func PosterPage(w http.ResponseWriter, r *http.Request) {
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	vars := mux.Vars(r)
 	username := vars["username"]
+	handlers.SetPageTitlef(r, "Images by %s", username)
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -56,8 +56,9 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		ReplyText          string
 	}
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "News")
+	queries := cd.Queries()
 	data := Data{
 		IsReplying:         r.URL.Query().Has("comment"),
 		IsReplyable:        true,

--- a/handlers/page_title.go
+++ b/handlers/page_title.go
@@ -1,0 +1,21 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+)
+
+// SetPageTitle prepends prefix to the global site title.
+func SetPageTitle(r *http.Request, prefix string) {
+	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok && cd != nil {
+		cd.Title = prefix + " - " + cd.Title
+	}
+}
+
+// SetPageTitlef formats and prepends the prefix to the global site title.
+func SetPageTitlef(r *http.Request, format string, args ...any) {
+	SetPageTitle(r, fmt.Sprintf(format, args...))
+}

--- a/handlers/search/admin.go
+++ b/handlers/search/admin.go
@@ -32,6 +32,7 @@ func adminSearchPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	handlers.SetPageTitle(r, "Search Admin")
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	ctx := r.Context()

--- a/handlers/search/admin_wordlist.go
+++ b/handlers/search/admin_wordlist.go
@@ -38,6 +38,8 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 		CurrentLtr string
 	}
 
+	handlers.SetPageTitle(r, "Search Word List")
+
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}

--- a/handlers/search/searchPage.go
+++ b/handlers/search/searchPage.go
@@ -14,8 +14,10 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		SearchWords string
 	}
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Search")
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 	}
 
 	handlers.TemplateHandler(w, r, "searchPage", data)

--- a/handlers/writings/writingsAdminCategoriesPage.go
+++ b/handlers/writings/writingsAdminCategoriesPage.go
@@ -17,8 +17,10 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 		*common.CoreData
 		Categories []*db.WritingCategory
 	}
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Writing Categories")
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 	}
 
 	categoryRows, err := data.CoreData.WritingCategories()

--- a/handlers/writings/writingsAdminCategoryGrantsPage.go
+++ b/handlers/writings/writingsAdminCategoryGrantsPage.go
@@ -28,6 +28,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Category Grants")
 	queries := cd.Queries()
 	cid, err := strconv.Atoi(mux.Vars(r)["category"])
 	if err != nil {

--- a/handlers/writings/writingsAdminCategoryGrantsPage_test.go
+++ b/handlers/writings/writingsAdminCategoryGrantsPage_test.go
@@ -25,9 +25,9 @@ func TestAdminCategoryGrantsPage(t *testing.T) {
 
 	queries := db.New(sqlDB)
 
-	rolesRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin"}).
-		AddRow(1, "user", true, false)
-	mock.ExpectQuery("SELECT id, name, can_login, is_admin FROM roles ORDER BY id").WillReturnRows(rolesRows)
+	rolesRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).
+		AddRow(1, "user", true, false, nil)
+	mock.ExpectQuery("SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id").WillReturnRows(rolesRows)
 
 	grantsRows := sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}).
 		AddRow(1, nil, nil, nil, nil, "writing", "category", "allow", 1, nil, "see", nil, true)

--- a/handlers/writings/writingsAdminUserLevelsPage.go
+++ b/handlers/writings/writingsAdminUserLevelsPage.go
@@ -22,6 +22,7 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	handlers.SetPageTitle(r, "Writing Roles")
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	if roles, err := data.AllRoles(); err == nil {

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -23,6 +23,7 @@ func ArticleAddPage(w http.ResponseWriter, r *http.Request) {
 		*common.CoreData
 		Languages []*db.Language
 	}
+	handlers.SetPageTitle(r, "Add Article")
 
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -26,6 +26,7 @@ func ArticleEditPage(w http.ResponseWriter, r *http.Request) {
 		Writing            *db.GetWritingByIdForUserDescendingByPublishedDateRow
 		UserId             int32
 	}
+	handlers.SetPageTitle(r, "Edit Article")
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -53,6 +53,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Writing")
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	data := Data{
 		CoreData:           cd,
@@ -78,6 +79,13 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		Idwriting:     int32(articleId),
 		ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})
+	if err == nil {
+		if writing.Title.Valid {
+			handlers.SetPageTitlef(r, "Writing: %s", writing.Title.String)
+		} else {
+			handlers.SetPageTitlef(r, "Writing %d", writing.Idwriting)
+		}
+	}
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/writings/writingsCategoriesPage.go
+++ b/handlers/writings/writingsCategoriesPage.go
@@ -21,6 +21,7 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Writing Categories")
 	data := Data{}
 	data.WritingCategoryID = 0
 

--- a/handlers/writings/writingsCategoryPage.go
+++ b/handlers/writings/writingsCategoryPage.go
@@ -61,6 +61,11 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 			data.Categories = append(data.Categories, cat)
 		}
 	}
+	if cat, ok := categoryMap[data.CategoryId]; ok {
+		handlers.SetPageTitlef(r, "Category: %s", cat.Title.String)
+	} else {
+		handlers.SetPageTitlef(r, "Category %d", data.CategoryId)
+	}
 	for cid := data.CategoryId; len(data.CategoryBreadcrumbs) < len(categoryRows); {
 		cat, ok := categoryMap[cid]
 		if ok {

--- a/handlers/writings/writingsPage.go
+++ b/handlers/writings/writingsPage.go
@@ -22,6 +22,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Writings")
 	data := Data{}
 	data.CategoryId = 0
 	data.WritingCategoryID = data.CategoryId

--- a/handlers/writings/writingsUserPermissionsPage.go
+++ b/handlers/writings/writingsUserPermissionsPage.go
@@ -21,6 +21,7 @@ func UserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 		Rows  []*db.GetUserRolesRow
 		Roles []*db.Role
 	}
+	handlers.SetPageTitle(r, "Writing Permissions")
 
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),

--- a/handlers/writings/writingsWriterListPage.go
+++ b/handlers/writings/writingsWriterListPage.go
@@ -28,6 +28,7 @@ func WriterListPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	handlers.SetPageTitle(r, "Writers")
 	data := Data{
 		Search:     r.URL.Query().Get("search"),
 		PageSize:   cd.PageSize(),

--- a/handlers/writings/writingsWriterPage.go
+++ b/handlers/writings/writingsWriterPage.go
@@ -26,6 +26,7 @@ func WriterPage(w http.ResponseWriter, r *http.Request) {
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	vars := mux.Vars(r)
 	username := vars["username"]
+	handlers.SetPageTitlef(r, "Writer: %s", username)
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()


### PR DESCRIPTION
## Summary
- revert global title prefix change
- add `SetPageTitle` helper to set a prefix per request
- prefix titles in several pages
- update admin category grants test to expect `public_profile_allowed_at`
- implement formatted page titles across the rest of the site

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688622103f60832fa611e268c8995280