### PR TITLE
Add page title setter and migration stub

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -357,6 +357,11 @@ func (cd *CoreData) SetEventTask(t tasks.Task) {
 	}
 }
 
+// SetPageTitle updates the Title field used by templates.
+func (cd *CoreData) SetPageTitle(title string) {
+	cd.Title = title
+}
+
 // AbsoluteURL returns an absolute URL by combining the configured hostname or
 // the request host with path. The base value is cached per request.
 func (cd *CoreData) AbsoluteURL(path string) string {

--- a/handlers/set_page_title_task.go
+++ b/handlers/set_page_title_task.go
@@ -1,0 +1,15 @@
+package handlers
+
+import "github.com/arran4/goa4web/internal/tasks"
+
+// TaskMigratePageTitles updates handlers to use CoreData.SetPageTitle.
+const TaskMigratePageTitles tasks.TaskString = "Migrate page titles"
+
+// MigratePageTitlesTask is a placeholder task for migrating page titles to
+// CoreData. The action implementation will be added in the future.
+type MigratePageTitlesTask struct{ tasks.TaskString }
+
+var migratePageTitlesTask = &MigratePageTitlesTask{TaskString: TaskMigratePageTitles}
+
+// compile-time check ensuring MigratePageTitlesTask implements tasks.Task.
+var _ tasks.Task = (*MigratePageTitlesTask)(nil)


### PR DESCRIPTION
## Summary
- add `SetPageTitle` method to `CoreData`
- create `MigratePageTitlesTask` stub for moving to CoreData page titles

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6886df3bc930832f844048dc6c1fadfd