### PR TITLE
Set page title on core data

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -69,11 +69,13 @@ type CoreData struct {
 	IndexItems       []IndexItem
 	CustomIndexItems []IndexItem
 	UserID           int32
-	Title            string
-	AutoRefresh      string
-	FeedsEnabled     bool
-	RSSFeedUrl       string
-	AtomFeedUrl      string
+	// PageTitle holds the title of the current page.
+	PageTitle    string
+	Title        string
+	AutoRefresh  string
+	FeedsEnabled bool
+	RSSFeedUrl   string
+	AtomFeedUrl  string
 	// AdminMode indicates whether admin-only UI elements should be displayed.
 	AdminMode         bool
 	NotificationCount int32

--- a/core/templates/site/head.gohtml
+++ b/core/templates/site/head.gohtml
@@ -5,7 +5,11 @@
 {{ end }}
     {{ if cd.Marked "head" }}
         <head>
+                {{ if cd.PageTitle }}
+                <title>{{cd.PageTitle}} - {{cd.Title}}</title>
+                {{ else }}
                 <title>{{cd.Title}}</title>
+                {{ end }}
                 {{template "headdata"}}
                <link rel="stylesheet" href="/main.css">
                <link rel="icon" href="/favicon.svg" type="image/svg+xml">

--- a/handlers/writings/writingsWriterListPage.go
+++ b/handlers/writings/writingsWriterListPage.go
@@ -28,6 +28,7 @@ func WriterListPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Writers"
 	data := Data{
 		Search:     r.URL.Query().Get("search"),
 		PageSize:   cd.PageSize(),


### PR DESCRIPTION
## Summary
- add `PageTitle` field to `CoreData`
- show page title in `head.gohtml`
- set writers list page title using the new field

## Testing
- `go mod tidy`
- `go fmt ./...` *(fails: expected statement, found ')')*
- `go vet ./...` *(fails with syntax errors)*
- `golangci-lint run ./...` *(fails with syntax errors)*
- `go test ./...` *(fails to build)*

------
https://chatgpt.com/codex/tasks/task_e_6886deeb5d88832f9359cafd321c024a