### PR TITLE
Update page titles for auth and user sections

### DIFF
--- a/handlers/auth/forgot_password_task.go
+++ b/handlers/auth/forgot_password_task.go
@@ -57,6 +57,8 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 			RequestTask: string(TaskEmailAssociationRequest),
 		}
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+			cd.PageTitle = "Password Reset"
 			handlers.TemplateHandler(w, r, "forgotPasswordNoEmailPage.gohtml", data)
 		})
 	}
@@ -101,7 +103,8 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 		}
 	}
-	return handlers.TemplateWithDataHandler("forgotPasswordEmailSentPage.gohtml", r.Context().Value(consts.KeyCoreData))
+	cd.PageTitle = "Password Reset"
+	return handlers.TemplateWithDataHandler("forgotPasswordEmailSentPage.gohtml", cd)
 }
 
 func (ForgotPasswordTask) AuditRecord(data map[string]any) string {
@@ -141,5 +144,7 @@ func (f ForgotPasswordTask) SelfInternalNotificationTemplate() *string {
 func (ForgotPasswordTask) SelfEmailBroadcast() bool { return true }
 
 func (ForgotPasswordTask) Page(w http.ResponseWriter, r *http.Request) {
-	handlers.TemplateHandler(w, r, "forgotPasswordPage.gohtml", r.Context().Value(consts.KeyCoreData))
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Password Reset"
+	handlers.TemplateHandler(w, r, "forgotPasswordPage.gohtml", cd)
 }

--- a/handlers/auth/login_task.go
+++ b/handlers/auth/login_task.go
@@ -85,8 +85,10 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 					*common.CoreData
 					ID int32
 				}
+				cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+				cd.PageTitle = "Verify Password"
 				data := Data{
-					CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+					CoreData: cd,
 					ID:       reset.ID,
 				}
 				return handlers.TemplateWithDataHandler("passwordVerifyPage.gohtml", data)

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -31,7 +31,8 @@ var _ tasks.Task = (*RegisterTask)(nil)
 
 // RegisterPage renders the user registration form.
 func (RegisterTask) Page(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(consts.KeyCoreData)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Register"
 	handlers.TemplateHandler(w, r, "registerPage.gohtml", cd)
 }
 

--- a/handlers/user/publicProfilePage.go
+++ b/handlers/user/publicProfilePage.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"database/sql"
+	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -30,6 +31,7 @@ func userPublicProfilePage(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	cd.PageTitle = fmt.Sprintf("Profile for %s", u.Username.String)
 	data := struct {
 		*common.CoreData
 		User *db.User

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -31,7 +31,8 @@ func userEmailPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd.PageTitle = "Email Settings"
+	queries := cd.Queries()
 	user, _ := cd.CurrentUser()
 	pref, _ := cd.Preference()
 
@@ -45,7 +46,7 @@ func userEmailPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	data := Data{
-		CoreData:   r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData:   cd,
 		UserData:   user,
 		Verified:   verified,
 		Unverified: unverified,
@@ -64,6 +65,8 @@ func userEmailPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func userEmailVerifyCodePage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Verify Email"
 	session, err := core.GetSession(r)
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -108,7 +111,7 @@ func userEmailVerifyCodePage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if ue.VerifiedAt.Valid {
-		handlers.TemplateHandler(w, r, "user/emailVerifiedPage.gohtml", struct{ *common.CoreData }{r.Context().Value(consts.KeyCoreData).(*common.CoreData)})
+		handlers.TemplateHandler(w, r, "user/emailVerifiedPage.gohtml", struct{ *common.CoreData }{cd})
 		return
 	}
 
@@ -117,7 +120,7 @@ func userEmailVerifyCodePage(w http.ResponseWriter, r *http.Request) {
 		Code  string
 		Email string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Code:     code,
 		Email:    ue.Email,
 	}

--- a/handlers/user/userGalleryPage.go
+++ b/handlers/user/userGalleryPage.go
@@ -37,6 +37,7 @@ func userGalleryPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Gallery"
 	size := cd.Config.PageSizeDefault
 	if pref, _ := cd.Preference(); pref != nil {
 		size = int(pref.PageSize)

--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -29,7 +29,8 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd.PageTitle = "Languages"
+	queries := cd.Queries()
 
 	pref, err := cd.Preference()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/handlers/user/userLogoutPage.go
+++ b/handlers/user/userLogoutPage.go
@@ -13,6 +13,8 @@ import (
 )
 
 func userLogoutPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Logout"
 	session, err := core.GetSession(r)
 	if err != nil {
 		core.SessionError(w, r, err)
@@ -24,14 +26,14 @@ func userLogoutPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 	}
 
 	// session retrieved earlier
 	delete(session.Values, "UID")
 	delete(session.Values, "LoginTime")
 	delete(session.Values, "ExpiryTime")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 	if session.ID != "" {
 		if err := queries.DeleteSessionByID(r.Context(), session.ID); err != nil {
 			log.Printf("delete session: %v", err)

--- a/handlers/user/userNotificationsPage.go
+++ b/handlers/user/userNotificationsPage.go
@@ -23,6 +23,7 @@ var _ tasks.Task = (*DismissTask)(nil)
 
 func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Notifications"
 	if !cd.Config.NotificationsEnabled {
 		http.NotFound(w, r)
 		return
@@ -32,7 +33,7 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 	notifs, err := queries.GetUnreadNotifications(r.Context(), uid)
 	if err != nil {
 		log.Printf("get notifications: %v", err)
@@ -52,7 +53,7 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		Emails        []*db.UserEmail
 		MaxPriority   int32
 	}{
-		CoreData:      r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData:      cd,
 		Notifications: notifs,
 		Emails:        emails,
 		MaxPriority:   maxPr,

--- a/handlers/user/userPage.go
+++ b/handlers/user/userPage.go
@@ -17,8 +17,10 @@ func userPage(w http.ResponseWriter, r *http.Request) {
 		*common.CoreData
 	}
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "User Preferences"
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 	}
 
 	if data.CoreData.UserID == 0 {

--- a/handlers/user/userPagingPage.go
+++ b/handlers/user/userPagingPage.go
@@ -26,6 +26,7 @@ var _ tasks.Task = (*PagingSaveTask)(nil)
 
 func userPagingPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Pagination"
 	pref, _ := cd.Preference()
 	size := cd.Config.PageSizeDefault
 	if pref != nil {

--- a/handlers/user/userPublicSettingPage.go
+++ b/handlers/user/userPublicSettingPage.go
@@ -17,6 +17,7 @@ import (
 // userPublicProfileSettingPage allows users to enable or disable their public profile.
 func userPublicProfileSettingPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Public Profile"
 	if _, err := cd.Queries().UserHasPublicProfileRole(r.Context(), cd.UserID); err != nil {
 		http.NotFound(w, r)
 		return

--- a/handlers/user/userSubscriptionsPage.go
+++ b/handlers/user/userSubscriptionsPage.go
@@ -27,12 +27,14 @@ var userSubscriptionOptions = []subscriptionOption{
 }
 
 func userSubscriptionsPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Subscriptions"
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := cd.Queries()
 	rows, err := queries.ListSubscriptionsByUser(r.Context(), uid)
 	if err != nil {
 		log.Printf("list subs: %v", err)
@@ -51,7 +53,7 @@ func userSubscriptionsPage(w http.ResponseWriter, r *http.Request) {
 		SubMap  map[string]bool
 		Error   string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Subs:     rows,
 		Options:  userSubscriptionOptions,
 		SubMap:   subMap,


### PR DESCRIPTION
## Summary
- set `cd.PageTitle` within authentication handlers and user account pages
- show user context in public profile page titles

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688704873e44832fb96fe890714c8e0b