### PR TITLE
Fix page title handling

### DIFF
--- a/handlers/blogs/bloggerListPage.go
+++ b/handlers/blogs/bloggerListPage.go
@@ -29,7 +29,7 @@ func BloggerListPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	handlers.SetPageTitle(r, "Bloggers")
+	cd.PageTitle = "Bloggers"
 	data := Data{
 		CoreData: cd,
 		Search:   r.URL.Query().Get("search"),

--- a/handlers/blogs/bloggerPostsPage.go
+++ b/handlers/blogs/bloggerPostsPage.go
@@ -35,7 +35,8 @@ func BloggerPostsPage(w http.ResponseWriter, r *http.Request) {
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	vars := mux.Vars(r)
 	username := vars["username"]
-	handlers.SetPageTitlef(r, "Posts by %s", username)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = fmt.Sprintf("Posts by %s", username)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -99,7 +99,7 @@ func (AddBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 func BlogAddPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	handlers.SetPageTitle(r, "Add Blog")
+	cd.PageTitle = "Add Blog"
 	if !(cd.HasRole("content writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -70,7 +70,7 @@ func (EditBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 func BlogEditPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	handlers.SetPageTitle(r, "Edit Blog")
+	cd.PageTitle = "Edit Blog"
 	if !(cd.HasRole("content writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return

--- a/handlers/blogs/blogsBlogPage.go
+++ b/handlers/blogs/blogsBlogPage.go
@@ -79,9 +79,9 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err == nil {
 		if blog.Username.Valid {
-			handlers.SetPageTitlef(r, "Blog by %s", blog.Username.String)
+			cd.PageTitle = fmt.Sprintf("Blog by %s", blog.Username.String)
 		} else {
-			handlers.SetPageTitlef(r, "Blog %d", blog.Idblogs)
+			cd.PageTitle = fmt.Sprintf("Blog %d", blog.Idblogs)
 		}
 	}
 	if err != nil {

--- a/handlers/blogs/blogsBloggersBloggerPage.go
+++ b/handlers/blogs/blogsBloggersBloggerPage.go
@@ -20,7 +20,7 @@ func BloggersBloggerPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
-	handlers.SetPageTitle(r, "Bloggers")
+	data.CoreData.PageTitle = "Bloggers"
 
 	cd := data.CoreData
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -81,7 +81,7 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 		ID:            int32(blogId),
 	})
 	if err == nil {
-		handlers.SetPageTitlef(r, "Blog %d Comments", blog.Idblogs)
+		cd.PageTitle = fmt.Sprintf("Blog %d Comments", blog.Idblogs)
 	}
 	if err != nil {
 		switch {

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -45,7 +45,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	handlers.SetPageTitle(r, "Blogs")
+	cd.PageTitle = "Blogs"
 	queries := cd.Queries()
 	rows, err := queries.GetBlogEntriesForUserDescendingLanguages(r.Context(), db.GetBlogEntriesForUserDescendingLanguagesParams{
 		UsersIdusers:  int32(userId),

--- a/handlers/blogs/blogsUserPermissionsPage.go
+++ b/handlers/blogs/blogsUserPermissionsPage.go
@@ -19,7 +19,7 @@ import (
 
 func GetPermissionsByUserIdAndSectionBlogsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	handlers.SetPageTitle(r, "Blog Permissions")
+	cd.PageTitle = "Blog Permissions"
 	if !(cd.HasRole("content writer") || cd.HasRole("administrator")) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return


### PR DESCRIPTION
## Summary
- set page titles directly in blog handlers
- remove use of `SetPageTitle` wrappers

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6887048770a4832f93b1e6fcf8d9150d