### PR TITLE
Use PageTitle in image board handlers

### DIFF
--- a/handlers/imagebbs/imagebbsAdminBoardsPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardsPage.go
@@ -25,10 +25,11 @@ func AdminBoardsPage(w http.ResponseWriter, r *http.Request) {
 		Boards []*BoardRow
 	}
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Image Boards"
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 	}
-	handlers.SetPageTitle(r, "Image Boards")
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	boardRows, err := data.CoreData.ImageBoards()
 	if err != nil {

--- a/handlers/imagebbs/imagebbsAdminFilesPage.go
+++ b/handlers/imagebbs/imagebbsAdminFilesPage.go
@@ -16,7 +16,7 @@ import (
 
 func AdminFilesPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	handlers.SetPageTitle(r, "Image Files")
+	cd.PageTitle = "Image Files"
 	type Entry struct {
 		Name  string
 		Path  string

--- a/handlers/imagebbs/imagebbsAdminNewBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminNewBoardPage.go
@@ -39,10 +39,11 @@ func AdminNewBoardPage(w http.ResponseWriter, r *http.Request) {
 		*common.CoreData
 		Boards []*db.Imageboard
 	}
-	handlers.SetPageTitle(r, "New Image Board")
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "New Image Board"
 
 	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 	}
 	boardRows, err := data.CoreData.ImageBoards()
 	if err != nil {

--- a/handlers/imagebbs/imagebbsAdminPage.go
+++ b/handlers/imagebbs/imagebbsAdminPage.go
@@ -23,7 +23,7 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 	} else if err != sql.ErrNoRows {
 		log.Printf("imagebbsAdminPage stats: %v", err)
 	}
+	cd.PageTitle = "Image Board Admin"
 	data := Data{CoreData: cd, Stats: stats}
-	handlers.SetPageTitle(r, "Image Board Admin")
 	handlers.TemplateHandler(w, r, "imagebbsAdminPage", data)
 }

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -84,7 +84,7 @@ func BoardPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(boards) > 0 {
-		handlers.SetPageTitlef(r, "Board %s", boards[0].Title.String)
+		data.CoreData.PageTitle = fmt.Sprintf("Board %s", boards[0].Title.String)
 	}
 
 	data.Boards = boards

--- a/handlers/imagebbs/imagebbsPage.go
+++ b/handlers/imagebbs/imagebbsPage.go
@@ -19,7 +19,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	handlers.SetPageTitle(r, "Image Board")
+	cd.PageTitle = "Image Board"
 	data := Data{
 		CoreData:    cd,
 		IsSubBoard:  false,

--- a/handlers/imagebbs/imagebbsPosterPage.go
+++ b/handlers/imagebbs/imagebbsPosterPage.go
@@ -3,6 +3,7 @@ package imagebbs
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -27,9 +28,9 @@ func PosterPage(w http.ResponseWriter, r *http.Request) {
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	vars := mux.Vars(r)
 	username := vars["username"]
-	handlers.SetPageTitlef(r, "Images by %s", username)
-
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = fmt.Sprintf("Images by %s", username)
+	queries := cd.Queries()
 	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		switch {
@@ -42,7 +43,6 @@ func PosterPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	rows, err := queries.GetImagePostsByUserDescendingForUser(r.Context(), db.GetImagePostsByUserDescendingForUserParams{
 		ViewerID:     cd.UserID,
 		UserID:       u.Idusers,


### PR DESCRIPTION
## Summary
- replace `SetPageTitle` usage with direct `PageTitle` assignment
- format titles for boards, threads and posters

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6887048913d0832f87e43fd608f7bb26