### PR TITLE
Refactor titles in news and search handlers

### DIFF
--- a/handlers/news/newsAdminUserLevelsPage.go
+++ b/handlers/news/newsAdminUserLevelsPage.go
@@ -22,6 +22,7 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	data.CoreData.PageTitle = "News Roles"
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	if roles, err := data.AllRoles(); err == nil {

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -57,7 +57,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	handlers.SetPageTitle(r, "News")
+	cd.PageTitle = "News"
 	queries := cd.Queries()
 	data := Data{
 		IsReplying:         r.URL.Query().Has("comment"),

--- a/handlers/news/searchResultNewsActionPage.go
+++ b/handlers/news/searchResultNewsActionPage.go
@@ -29,6 +29,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	data.CoreData.PageTitle = "News Search Results"
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {

--- a/handlers/search/admin.go
+++ b/handlers/search/admin.go
@@ -32,7 +32,7 @@ func adminSearchPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
-	handlers.SetPageTitle(r, "Search Admin")
+	data.CoreData.PageTitle = "Search Admin"
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	ctx := r.Context()

--- a/handlers/search/admin_wordlist.go
+++ b/handlers/search/admin_wordlist.go
@@ -38,11 +38,10 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 		CurrentLtr string
 	}
 
-	handlers.SetPageTitle(r, "Search Word List")
-
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	data.CoreData.PageTitle = "Search Word List"
 
 	letters := make([]string, len(handlers.Alphabet))
 	for i, c := range handlers.Alphabet {

--- a/handlers/search/searchPage.go
+++ b/handlers/search/searchPage.go
@@ -15,7 +15,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	handlers.SetPageTitle(r, "Search")
+	cd.PageTitle = "Search"
 	data := Data{
 		CoreData: cd,
 	}


### PR DESCRIPTION
## Summary
- set `cd.PageTitle` directly in news and search handlers
- remove obsolete `SetPageTitle` calls

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6887048b88d8832f8f04e5bc4f65041d