### PR TITLE
Set page titles on FAQ and utility handlers

### DIFF
--- a/handlers/auto_refresh.go
+++ b/handlers/auto_refresh.go
@@ -10,6 +10,7 @@ func TaskDoneAutoRefreshPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct{}
 	data := Data{}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Done"
 	cd.AutoRefresh = "1"
 	TemplateHandler(w, r, "taskDoneAutoRefreshPage.gohtml", data)
 }

--- a/handlers/error_acknowledgement.go
+++ b/handlers/error_acknowledgement.go
@@ -2,6 +2,9 @@ package handlers
 
 import (
 	"net/http"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 )
 
 // TaskErrorAcknowledgementPage renders a page displaying an error message.
@@ -9,6 +12,10 @@ func TaskErrorAcknowledgementPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		Error   string
 		BackURL string
+	}
+	cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd != nil {
+		cd.PageTitle = "Error"
 	}
 	data := Data{
 		Error:   r.URL.Query().Get("error"),

--- a/handlers/errorpage.go
+++ b/handlers/errorpage.go
@@ -13,6 +13,7 @@ func RenderErrorPage(w http.ResponseWriter, r *http.Request, err error) {
 	if cd == nil {
 		cd = &common.CoreData{}
 	}
+	cd.PageTitle = "Error"
 	data := struct {
 		*common.CoreData
 		Error   string

--- a/handlers/faq/admin_answer.go
+++ b/handlers/faq/admin_answer.go
@@ -21,6 +21,8 @@ func AdminAnswerPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	cd := data.CoreData
+	cd.PageTitle = "Unanswered Questions"
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 

--- a/handlers/faq/admin_categories.go
+++ b/handlers/faq/admin_categories.go
@@ -20,6 +20,8 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	cd := data.CoreData
+	cd.PageTitle = "FAQ Categories"
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 

--- a/handlers/faq/admin_edit_question_page.go
+++ b/handlers/faq/admin_edit_question_page.go
@@ -3,6 +3,7 @@ package faq
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -50,6 +51,12 @@ func AdminEditQuestionPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:   r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Faq:        faq,
 		Categories: cats,
+	}
+	cd := data.CoreData
+	if id != 0 {
+		cd.PageTitle = fmt.Sprintf("Edit FAQ %d", id)
+	} else {
+		cd.PageTitle = "New FAQ"
 	}
 	handlers.TemplateHandler(w, r, "adminQuestionEditPage.gohtml", data)
 }

--- a/handlers/faq/admin_question.go
+++ b/handlers/faq/admin_question.go
@@ -21,6 +21,8 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	cd := data.CoreData
+	cd.PageTitle = "FAQ Questions"
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 

--- a/handlers/faq/admin_revision_page.go
+++ b/handlers/faq/admin_revision_page.go
@@ -3,6 +3,7 @@ package faq
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -45,5 +46,7 @@ func AdminRevisionHistoryPage(w http.ResponseWriter, r *http.Request) {
 		Faq:       faq,
 		Revisions: revs,
 	}
+	cd := data.CoreData
+	cd.PageTitle = fmt.Sprintf("FAQ %d History", id)
 	handlers.TemplateHandler(w, r, "adminFaqRevisionPage.gohtml", data)
 }

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -44,6 +44,7 @@ func (AskTask) Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Ask a Question"
 	data := Data{
 		CoreData:           cd,
 		SelectedLanguageId: cd.PreferredLanguageID(cd.Config.DefaultLanguage),

--- a/handlers/faq/page.go
+++ b/handlers/faq/page.go
@@ -29,6 +29,8 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := Data{}
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "FAQ"
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 


### PR DESCRIPTION
## Summary
- use `cd.PageTitle` to add titles to FAQ handlers and error/utility pages
- format titles using `fmt.Sprintf` when they include variables

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6887048c14b0832f9d30fd322148e5eb