### PR TITLE
Refresh titles for linker and bookmark pages

### DIFF
--- a/handlers/bookmarks/mine.go
+++ b/handlers/bookmarks/mine.go
@@ -83,7 +83,7 @@ func MinePage(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = session
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	handlers.SetPageTitle(r, "My Bookmarks")
+	cd.PageTitle = "My Bookmarks"
 	bookmarks, err := cd.Bookmarks()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("error getBookmarksForUser: %s", err)

--- a/handlers/bookmarks/page.go
+++ b/handlers/bookmarks/page.go
@@ -23,7 +23,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
-	handlers.SetPageTitle(r, "Bookmarks")
+	data.CoreData.PageTitle = "Bookmarks"
 
 	if uid == 0 {
 		handlers.TemplateHandler(w, r, "infoPage.gohtml", data)

--- a/handlers/bookmarks/routes.go
+++ b/handlers/bookmarks/routes.go
@@ -17,7 +17,7 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Regis
 	br.Use(handlers.IndexMiddleware(bookmarksCustomIndex))
 	br.HandleFunc("", Page).Methods("GET")
 	br.HandleFunc("/mine", MinePage).Methods("GET").MatcherFunc(handlers.RequiresAnAccount())
-	br.HandleFunc("/edit", saveTask.Page).Methods("GET").MatcherFunc(handlers.RequiresAnAccount())
+	br.HandleFunc("/edit", EditPage).Methods("GET").MatcherFunc(handlers.RequiresAnAccount())
 	br.HandleFunc("/edit", handlers.TaskHandler(saveTask)).Methods("POST").MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(saveTask.Matcher())
 	br.HandleFunc("/edit", handlers.TaskHandler(createTask)).Methods("POST").MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(createTask.Matcher())
 }

--- a/handlers/bookmarks/saveTask.go
+++ b/handlers/bookmarks/saveTask.go
@@ -23,7 +23,7 @@ var saveTask = &SaveTask{TaskString: TaskSave}
 // ensure SaveTask implements tasks.Task for routing
 var _ tasks.Task = (*SaveTask)(nil)
 
-func (SaveTask) Page(w http.ResponseWriter, r *http.Request) {
+func EditPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
 		BookmarkContent string
@@ -54,6 +54,7 @@ func (SaveTask) Page(w http.ResponseWriter, r *http.Request) {
 		data.Bid = bookmarks.Idbookmarks
 	}
 
+	cd.PageTitle = "Edit Bookmarks"
 	handlers.TemplateHandler(w, r, "editPage.gohtml", data)
 }
 

--- a/handlers/linker/cancel_edit_reply_task.go
+++ b/handlers/linker/cancel_edit_reply_task.go
@@ -1,16 +1,8 @@
 package linker
 
-import (
-	"net/http"
-
-	"github.com/arran4/goa4web/internal/tasks"
-)
+import "github.com/arran4/goa4web/internal/tasks"
 
 type cancelEditReplyTask struct{ tasks.TaskString }
 
 var commentEditActionCancel = &cancelEditReplyTask{TaskString: TaskCancel}
 var _ tasks.Task = (*cancelEditReplyTask)(nil)
-
-func (cancelEditReplyTask) Page(w http.ResponseWriter, r *http.Request) {
-	CommentEditActionCancelPage(w, r)
-}

--- a/handlers/linker/edit_reply_task.go
+++ b/handlers/linker/edit_reply_task.go
@@ -23,10 +23,6 @@ type EditReplyTask struct{ tasks.TaskString }
 var commentEditAction = &EditReplyTask{TaskString: TaskEditReply}
 var _ tasks.Task = (*EditReplyTask)(nil)
 
-func (t EditReplyTask) Page(w http.ResponseWriter, r *http.Request) {
-	t.Action(w, r)
-}
-
 func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	languageId, err := strconv.Atoi(r.PostFormValue("language"))
 	if err != nil {

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -29,6 +29,7 @@ func AdminAddPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Add Link"
 	data := Data{
 		CoreData:           cd,
 		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),

--- a/handlers/linker/linkerAdminCategoriesPage.go
+++ b/handlers/linker/linkerAdminCategoriesPage.go
@@ -21,6 +21,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	data.CoreData.PageTitle = "Link Categories"
 
 	categoryRows, err := data.LinkerCategoryCounts()
 	if err != nil {

--- a/handlers/linker/linkerAdminCategoryGrantsPage.go
+++ b/handlers/linker/linkerAdminCategoryGrantsPage.go
@@ -2,6 +2,7 @@ package linker
 
 import (
 	"database/sql"
+	"fmt"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -34,6 +35,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data := Data{CoreData: cd, CategoryID: int32(cid), Actions: []string{"see", "view"}}
+	cd.PageTitle = fmt.Sprintf("Category %d Grants", cid)
 	if roles, err := cd.AllRoles(); err == nil {
 		data.Roles = roles
 	}

--- a/handlers/linker/linkerAdminQueuePage.go
+++ b/handlers/linker/linkerAdminQueuePage.go
@@ -32,6 +32,7 @@ func AdminQueuePage(w http.ResponseWriter, r *http.Request) {
 
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Approval Queue"
 	data := Data{
 		CoreData: cd,
 		Search:   r.URL.Query().Get("search"),

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -32,6 +32,7 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Search:   r.URL.Query().Get("search"),
 	}
+	data.CoreData.PageTitle = "User Roles"
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	if roles, err := data.AllRoles(); err == nil {

--- a/handlers/linker/linkerCategoriesPage.go
+++ b/handlers/linker/linkerCategoriesPage.go
@@ -21,6 +21,7 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	data.CoreData.PageTitle = "Categories"
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 

--- a/handlers/linker/linkerCategoryPage.go
+++ b/handlers/linker/linkerCategoryPage.go
@@ -3,6 +3,7 @@ package linker
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -63,6 +64,12 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
+	}
+
+	if len(linkerPosts) > 0 && linkerPosts[0].CategoryTitle.Valid {
+		data.CoreData.PageTitle = fmt.Sprintf("Category: %s", linkerPosts[0].CategoryTitle.String)
+	} else {
+		data.CoreData.PageTitle = fmt.Sprintf("Category %d", data.CatId)
 	}
 
 	for _, row := range linkerPosts {

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -107,6 +107,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data.Link = link
+	data.CoreData.PageTitle = fmt.Sprintf("Link %d Comments", link.Idlinker)
 	data.CanEdit = cd.HasRole("administrator") || uid == link.UsersIdusers
 
 	commentRows, err := queries.GetCommentsByThreadIdForUser(r.Context(), db.GetCommentsByThreadIdForUserParams{
@@ -180,8 +181,6 @@ type replyTask struct{ tasks.TaskString }
 
 var replyTaskEvent = &replyTask{TaskString: TaskReply}
 var _ tasks.Task = (*replyTask)(nil)
-
-func (replyTask) Page(w http.ResponseWriter, r *http.Request) { CommentsPage(w, r) }
 
 func (replyTask) IndexType() string { return searchworker.TypeComment }
 

--- a/handlers/linker/linkerPage.go
+++ b/handlers/linker/linkerPage.go
@@ -32,6 +32,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	data := Data{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 	}
+	data.CoreData.PageTitle = "Links"
 
 	if off, err := strconv.Atoi(r.URL.Query().Get("offset")); err == nil {
 		data.Offset = off

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -62,6 +62,11 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data.Link = link
+	if link.Title.Valid {
+		cd.PageTitle = fmt.Sprintf("Link: %s", link.Title.String)
+	} else {
+		cd.PageTitle = fmt.Sprintf("Link %d", link.Idlinker)
+	}
 
 	handlers.TemplateHandler(w, r, "showPage.gohtml", data)
 }

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -28,6 +28,7 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Suggest Link"
 	data := Data{
 		CoreData:           cd,
 		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
@@ -64,8 +65,6 @@ type SuggestTask struct{ tasks.TaskString }
 
 var suggestTask = SuggestTask{TaskString: TaskSuggest}
 var _ tasks.Task = (*SuggestTask)(nil)
-
-func (SuggestTask) Page(w http.ResponseWriter, r *http.Request) { SuggestPage(w, r) }
 
 func (SuggestTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()

--- a/handlers/linker/linkerUserPage.go
+++ b/handlers/linker/linkerUserPage.go
@@ -3,6 +3,7 @@ package linker
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -56,6 +57,7 @@ func UserPage(w http.ResponseWriter, r *http.Request) {
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := Data{CoreData: cd, Username: username, HasOffset: offset != 0}
+	cd.PageTitle = fmt.Sprintf("Links by %s", username)
 	for _, row := range rows {
 		if !cd.HasGrant("linker", "link", "see", row.Idlinker) {
 			continue

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -28,12 +28,12 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Regis
 	lr.HandleFunc("/linker/{username}/", UserPage).Methods("GET")
 	lr.HandleFunc("/categories", CategoriesPage).Methods("GET")
 	lr.HandleFunc("/category/{category}", CategoryPage).Methods("GET")
-	lr.HandleFunc("/comments/{link}", replyTaskEvent.Page).Methods("GET")
+	lr.HandleFunc("/comments/{link}", CommentsPage).Methods("GET")
 	lr.HandleFunc("/comments/{link}", handlers.TaskHandler(replyTaskEvent)).Methods("POST").MatcherFunc(replyTaskEvent.Matcher())
-	lr.Handle("/comments/{link}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(commentEditAction.Page))).Methods("POST").MatcherFunc(commentEditAction.Matcher())
-	lr.Handle("/comments/{link}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(commentEditActionCancel.Page))).Methods("POST").MatcherFunc(commentEditActionCancel.Matcher())
-	lr.HandleFunc("/show/{link}", replyTaskEvent.Page).Methods("GET")
-	lr.HandleFunc("/suggest", suggestTask.Page).Methods("GET")
+	lr.Handle("/comments/{link}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(handlers.TaskHandler(commentEditAction)))).Methods("POST").MatcherFunc(commentEditAction.Matcher())
+	lr.Handle("/comments/{link}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(CommentEditActionCancelPage))).Methods("POST")
+	lr.HandleFunc("/show/{link}", ShowPage).Methods("GET")
+	lr.HandleFunc("/suggest", SuggestPage).Methods("GET")
 	lr.HandleFunc("/suggest", handlers.TaskHandler(suggestTask)).Methods("POST").MatcherFunc(suggestTask.Matcher())
 
 	if legacyRedirectsEnabled {


### PR DESCRIPTION
## Summary
- use `cd.PageTitle` for page titles in bookmarks and linker handlers
- remove obsolete Page wrapper methods
- set informative titles for admin and user pages
- route handlers directly to page functions
- fix comment cancel route

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68870489c02c832f8a780fbc406acf15