### PR TITLE
Update README email config intro

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,7 +162,7 @@ When using SQLite you must compile the binary with the `sqlite` build tag.
 
 ## Email Provider Configuration
 
-Email notifications can be sent via several backends. Set `EMAIL_PROVIDER` to select one of the following modes:
+The application supports multiple email backends. Choose one by setting `EMAIL_PROVIDER`:
 
 - `ses` (default): Amazon SES. Requires valid AWS credentials and `AWS_REGION`.
   The provider is built only when the `ses` build tag is enabled.


### PR DESCRIPTION
## Summary
- clarify that SES isn't required when selecting an email provider

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run --timeout=5m`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688823d2c530832faf968a5c5ce9fb59