### PR TITLE
Update readme with default port note

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ The default build embeds templates and `main.css` so the resulting binary is sel
 
 ## Running
 
-Run the compiled binary and open <http://localhost:8080> in your browser:
+Run the compiled binary and open <http://localhost:8080> in your browser. By default the server listens on port 8080; change this with the `--listen` flag or `LISTEN` environment variable:
 ```bash
 ./goa4web
 ```


### PR DESCRIPTION
## Summary
- note default port when starting goa4web

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6888242aef84832f8a1a0b229993f5f8