### PR TITLE
Remove duplicate admin mode toggle

### DIFF
--- a/core/templates/site/index.gohtml
+++ b/core/templates/site/index.gohtml
@@ -7,9 +7,6 @@
     {{ if cd.HasRole "administrator" }}
         {{ if cd.AdminMode }}
             <a href="{{ addmode "/admin" }}">Admin Dashboard</a><br>
-            <a href="?">Disable admin mode</a><br>
-        {{ else }}
-            <a href="?mode=admin">Enable admin mode</a><br>
         {{ end }}
     {{ end }}
 {{- end}}


### PR DESCRIPTION
## Summary
- remove `Enable admin mode` link from the index sidebar

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688893e5f998832fad1f00f6046cdcc4