### PR TITLE
Fix empty categories message in linker root

### DIFF
--- a/core/templates/site/showCategories.gohtml
+++ b/core/templates/site/showCategories.gohtml
@@ -1,8 +1,10 @@
 {{ define "getAllLinkerCategories" }}
-    Please select a category:<br>
-    <a href="/linker">All</a><br>
-    {{- range .Categories }}
-        <a href="/linker/category/{{ .Idlinkercategory }}">{{ .Title.String }}</a><br>
+    {{- if .Categories }}
+        Please select a category:<br>
+        <a href="/linker">All</a><br>
+        {{- range .Categories }}
+            <a href="/linker/category/{{ .Idlinkercategory }}">{{ .Title.String }}</a><br>
+        {{- end }}
+        <br>
     {{- end }}
-    <br>
 {{ end }}


### PR DESCRIPTION
## Summary
- hide the "Please select a category" prompt when no categories exist

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688894442d58832f918f575458eb1166