### PR TITLE
Refactor news admin user roles

### DIFF
--- a/core/templates/site/news/adminUserRolesPage.gohtml
+++ b/core/templates/site/news/adminUserRolesPage.gohtml
@@ -1,47 +1,44 @@
 {{ template "head" $ }}
-    <table border="1">
-        <tr>
-            <th>ID</th>
-            <th>User</th>
-            <th>Email</th>
-            <th>Role</th>
-            <th>Delete?</th>
-        </tr>
-        {{- if .UserLevels }}
-            {{- range .UserLevels }}
-                <tr>
-                    <td>{{ .IduserRoles }}</td>
-                    <td>{{ .Username.String }}</td>
-                    <td>{{ .Email }}</td>
-                    <td>{{ .Role }}</td>
-                    <td>
-                        <form method="post">
+<table border="1">
+    <tr>
+        <th>ID</th>
+        <th>User</th>
+        <th>Email</th>
+        <th>Roles</th>
+        <th>Actions</th>
+    </tr>
+    {{- range .Users }}
+    <tr>
+        <td>{{ .ID }}</td>
+        <td>{{ .Username.String }}</td>
+        <td>{{ .Email }}</td>
+        <td>
+            {{- if .Roles }}
+            <ul>
+                {{- range .Roles }}
+                <li>{{ .Name }}
+                    <form method="post" style="display:inline">
         {{ csrfField }}
-                            <input type="hidden" name="permid" value="{{ .IduserRoles }}">
-                            <input type="submit" name="task" value="remove">
-                        </form>
-                    </td>
-                </tr>
-            {{- end }}
-        {{- else }}
-            <tr><td colspan="5">No results</td></tr>
-        {{- end }}
-        <tr>
+                        <input type="hidden" name="permid" value="{{ .PermID }}">
+                        <button type="submit" name="task" value="remove">Remove Role</button>
+                    </form>
+                </li>
+                {{- end }}
+            </ul>
+            {{- else }}None{{- end }}
+        </td>
+        <td>
             <form method="post">
         {{ csrfField }}
-                <td>NEW</td>
-                <td><input name="username"></td>
-                <td>?</td>
-                <td>
-                    <select name="role">
-                        {{- range $.Roles }}<option value="{{.Name}}">{{.Name}}</option>{{- end }}
-                    </select>
-                </td>
-                <td>
-                    <input type="submit" name="task" value="allow">
-                </td>
+                <input type="hidden" name="username" value="{{ .Username.String }}">
+                <select name="role">
+                    {{- range $.Roles }}<option value="{{.Name}}">{{.Name}}</option>{{- end }}
+                </select>
+                <button type="submit" name="task" value="allow">Add Role</button>
             </form>
-        </tr>
-    </table>
-    <p>Permissions should be valid only.</p>
+        </td>
+    </tr>
+    {{- end }}
+</table>
+<p>Permissions should be valid only.</p>
 {{ template "tail" $ }}

--- a/handlers/news/newsAdminUserLevelsPage.go
+++ b/handlers/news/newsAdminUserLevelsPage.go
@@ -3,20 +3,31 @@ package news
 import (
 	"database/sql"
 	"errors"
-	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
+	"sort"
 
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 )
 
 func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
+	type RoleInfo struct {
+		PermID int32
+		Name   string
+	}
+	type UserInfo struct {
+		ID       int32
+		Username sql.NullString
+		Email    string
+		Roles    []RoleInfo
+	}
 	type Data struct {
 		*common.CoreData
-		UserLevels []*db.GetUserRolesRow
-		Roles      []*db.Role
+		Users []UserInfo
+		Roles []*db.Role
 	}
 
 	data := Data{
@@ -24,21 +35,43 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.CoreData.PageTitle = "News Roles"
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := data.CoreData.Queries()
 	if roles, err := data.AllRoles(); err == nil {
 		data.Roles = roles
 	}
-	rows, err := queries.GetUserRoles(r.Context())
-	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-		default:
-			log.Printf("getUsersPermissions Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
+
+	users, err := queries.AllUsers(r.Context())
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		log.Printf("AllUsers Error: %s", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
 	}
-	data.UserLevels = rows
+	userMap := make(map[int32]*UserInfo)
+	for _, u := range users {
+		userMap[u.Idusers] = &UserInfo{ID: u.Idusers, Username: u.Username, Email: u.Email}
+	}
+
+	rows, err := queries.GetUserRoles(r.Context())
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		log.Printf("getUsersPermissions Error: %s", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	for _, row := range rows {
+		u, ok := userMap[row.UsersIdusers]
+		if !ok {
+			u = &UserInfo{ID: row.UsersIdusers, Username: row.Username, Email: row.Email}
+			userMap[row.UsersIdusers] = u
+		}
+		u.Roles = append(u.Roles, RoleInfo{PermID: row.IduserRoles, Name: row.Role})
+	}
+
+	for _, u := range userMap {
+		data.Users = append(data.Users, *u)
+	}
+	sort.Slice(data.Users, func(i, j int) bool {
+		return data.Users[i].Username.String < data.Users[j].Username.String
+	})
 
 	handlers.TemplateHandler(w, r, "adminUserRolesPage.gohtml", data)
 }


### PR DESCRIPTION
## Summary
- group user roles per user and show them in news admin page
- rename delete column to Actions and update labels

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6888953dfc24832f9e311f0ae4b8b444