### PR TITLE
Add create FAQ question page

### DIFF
--- a/core/templates/site/faq/adminQuestionEditPage.gohtml
+++ b/core/templates/site/faq/adminQuestionEditPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-<h4>Edit FAQ Entry</h4>
+<h4>{{ if eq .Faq.Idfaq 0 }}Create FAQ Entry{{ else }}Edit FAQ Entry{{ end }}</h4>
 <form method="post" action="/admin/faq/questions">
 {{ csrfField }}
 <textarea name="question" cols="80" rows="15">{{ .Faq.Question.String }}</textarea><br>
@@ -12,6 +12,10 @@
     {{- end }}
 </select><br>
 <input type="hidden" name="faq" value="{{ .Faq.Idfaq }}">
+{{ if eq .Faq.Idfaq 0 }}
+<input type="submit" name="task" value="Create">
+{{ else }}
 <input type="submit" name="task" value="Edit">
+{{ end }}
 </form>
 {{ template "tail" $ }}

--- a/core/templates/site/faq/adminQuestionPage.gohtml
+++ b/core/templates/site/faq/adminQuestionPage.gohtml
@@ -18,5 +18,5 @@
 </tr>
 {{- end }}
 </table>
-<p><a href="/admin/faq/question/0/edit">Create New Question</a></p>
+<p><a href="/admin/faq/question/create">Create New Question</a></p>
 {{ template "tail" $ }}

--- a/handlers/faq/admin_edit_question_page.go
+++ b/handlers/faq/admin_edit_question_page.go
@@ -60,3 +60,10 @@ func AdminEditQuestionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	handlers.TemplateHandler(w, r, "adminQuestionEditPage.gohtml", data)
 }
+
+// AdminCreateQuestionPage redirects to AdminEditQuestionPage with id zero to
+// display the form for creating a new FAQ entry.
+func AdminCreateQuestionPage(w http.ResponseWriter, r *http.Request) {
+	r = mux.SetURLVars(r, map[string]string{"id": "0"})
+	AdminEditQuestionPage(w, r)
+}

--- a/handlers/faq/routes.go
+++ b/handlers/faq/routes.go
@@ -44,6 +44,7 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	farq.HandleFunc("/questions", handlers.TaskHandler(editQuestionTask)).Methods("POST").MatcherFunc(editQuestionTask.Matcher())
 	farq.HandleFunc("/questions", handlers.TaskHandler(deleteQuestionTask)).Methods("POST").MatcherFunc(deleteQuestionTask.Matcher())
 	farq.HandleFunc("/questions", handlers.TaskHandler(createQuestionTask)).Methods("POST").MatcherFunc(createQuestionTask.Matcher())
+	farq.HandleFunc("/question/create", AdminCreateQuestionPage).Methods("GET")
 	farq.HandleFunc("/question/{id:[0-9]+}/edit", AdminEditQuestionPage).Methods("GET")
 	farq.HandleFunc("/revisions/{id:[0-9]+}", AdminRevisionHistoryPage).Methods("GET")
 }


### PR DESCRIPTION
## Summary
- allow creating FAQ questions using a dedicated route
- wire up new route in FAQ admin router
- show a `Create` link on the admin questions list
- adjust the edit/create form to show appropriate heading and button label

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688895825b6c832f959c4c01c49b3423