### PR TITLE
Add admin category detail pages with navigation

### DIFF
--- a/core/templates/site/admin/siteAdminCategoriesPage.gohtml
+++ b/core/templates/site/admin/siteAdminCategoriesPage.gohtml
@@ -26,16 +26,17 @@
     <tr>
         <form method="post" action="/admin/forum/category/{{ .Idforumcategory }}">
         {{ csrfField }}
-            <td><a id="fc{{ .Idforumcategory }}" href="/forum/category/{{ .Idforumcategory }}">{{ .Idforumcategory }}</a></td>
+            <td><a id="fc{{ .Idforumcategory }}" href="/admin/forum/category/{{ .Idforumcategory }}">{{ .Idforumcategory }}</a></td>
             <td>{{ $fcid := .ForumcategoryIdforumcategory }} <a href="#fc{{ $fcid }}">{{ $fcid }}</a> <select name="pcid" value="{{ .ForumcategoryIdforumcategory }}"><option value="0">None</option>{{ range $.ForumCategories }}<option value="{{.Idforumcategory}}" {{if eq $fcid .Idforumcategory}}selected{{end}}>{{.Title.String}}</option>{{ end }}</select></td>
             <td><input name="name" value="{{ .Title.String }}"></td>
             <td><textarea name="desc" rows="3" cols="60">{{ .Description.String }}</textarea></td>
             <td>{{ .Subcategorycount }}</td>
-            <td>{{ .Topiccount }}</td>
+            <td><a href="/admin/forum/category/{{ .Idforumcategory }}#topics">{{ .Topiccount }}</a></td>
             <td>
                 <input type="hidden" name="cid" value="{{ .Idforumcategory }}">
                 <input type="submit" name="task" value="Forum category change">
-                {{ if eq .Topiccount 0 }}<input type="submit" name="task" formaction="/admin/forum/category/delete" value="Delete Category">{{ end }}
+                {{ if eq .Topiccount 0 }}<input type="submit" name="task" formaction="/admin/forum/category/delete" value="Delete Category">{{ end }}<br>
+                <a href="/forum/category/{{ .Idforumcategory }}">View on site</a>
             </td>
         </form>
     </tr>
@@ -69,7 +70,7 @@
     <tr>
         <form method="post" action="/admin/writings/categories">
         {{ csrfField }}
-            <td><input type="hidden" name="wcid" value="{{ .Idwritingcategory }}"><a id="wc{{ .Idwritingcategory }}" href="/writings/category/{{ .Idwritingcategory }}">{{ .Idwritingcategory }}</a></td>
+            <td><input type="hidden" name="wcid" value="{{ .Idwritingcategory }}"><a id="wc{{ .Idwritingcategory }}" href="/admin/writings/category/{{ .Idwritingcategory }}">{{ .Idwritingcategory }}</a></td>
             <td>{{ $fcid := .WritingCategoryID }} <a href="#wc{{ $fcid }}">{{ $fcid }}</a> <select name="pcid" value="{{ .WritingCategoryID }}"><option value="0">None</option>{{ range $.WritingCategories }}<option value="{{.Idwritingcategory}}" {{if eq $fcid .Idwritingcategory}}selected{{end}}>{{.Title.String}}</option>{{ end }}</select></td>
             <td><input name="name" value="{{ .Title.String }}"></td>
             <td><textarea name="desc" rows="3" cols="60">{{ .Description.String }}</textarea></td>
@@ -77,6 +78,7 @@
                 <input type="hidden" name="cid" value="{{ .Idwritingcategory }}">
                 <input type="submit" name="task" value="writing category change">
                 <br><a href="/admin/writings/category/{{ .Idwritingcategory }}/permissions">Permissions</a>
+                <br><a href="/writings/category/{{ .Idwritingcategory }}">View on site</a>
             </td>
         </form>
     </tr>
@@ -106,7 +108,7 @@
     </tr>
     {{- range .LinkerCategories }}
     <tr>
-        <td><a id="lc{{ .Idlinkercategory }}" href="/linker/category/{{ .Idlinkercategory }}">{{ .Idlinkercategory }}</a></td>
+        <td><a id="lc{{ .Idlinkercategory }}" href="/admin/linker/category/{{ .Idlinkercategory }}">{{ .Idlinkercategory }}</a></td>
         <td>
             <form method="post" action="/admin/linker/categories">
         {{ csrfField }}
@@ -118,7 +120,8 @@
         <td>
             <input type="submit" name="task" value="Update">
             <input type="submit" name="task" value="Rename Category">
-            {{ if eq .Linkcount 0 }}<input type="submit" name="task" value="Delete Category">{{ end }}
+            {{ if eq .Linkcount 0 }}<input type="submit" name="task" value="Delete Category">{{ end }}<br>
+            <a href="/linker/category/{{ .Idlinkercategory }}">View on site</a>
             </form>
         </td>
     </tr>

--- a/core/templates/site/forum/forumAdminCategoryPage.gohtml
+++ b/core/templates/site/forum/forumAdminCategoryPage.gohtml
@@ -1,0 +1,25 @@
+{{ template "head" $ }}
+<h2>Forum Category {{ .Category.Idforumcategory }} - {{ .Category.Title.String }}</h2>
+<p>{{ .Category.Description.String }}</p>
+<h3 id="topics">Topics</h3>
+<table border="1">
+    <tr>
+        <th>ID</th>
+        <th>Title</th>
+        <th>Description</th>
+        <th>Threads</th>
+        <th>Posts</th>
+        <th>View</th>
+    </tr>
+    {{ range .Topics }}
+    <tr>
+        <td>{{ .Idforumtopic }}</td>
+        <td>{{ .Title.String }}</td>
+        <td>{{ .Description.String }}</td>
+        <td>{{ .Threads.Int32 }}</td>
+        <td>{{ .Comments.Int32 }}</td>
+        <td><a href="/forum/topic/{{ .Idforumtopic }}">View</a></td>
+    </tr>
+    {{ end }}
+</table>
+{{ template "tail" $ }}

--- a/core/templates/site/linker/linkerAdminCategoryPage.gohtml
+++ b/core/templates/site/linker/linkerAdminCategoryPage.gohtml
@@ -1,0 +1,21 @@
+{{ template "head" $ }}
+<h2>Linker Category {{ .Category.Idlinkercategory }} - {{ .Category.Title.String }}</h2>
+<p>Order: {{ .Category.Position }}</p>
+<h3 id="links">Links</h3>
+<table border="1">
+    <tr>
+        <th>ID</th>
+        <th>Title</th>
+        <th>URL</th>
+        <th>Poster</th>
+    </tr>
+    {{ range .Links }}
+    <tr>
+        <td>{{ .Idlinker }}</td>
+        <td>{{ .Title.String }}</td>
+        <td><a href="{{ .Url.String }}">{{ .Url.String }}</a></td>
+        <td>{{ .Posterusername.String }}</td>
+    </tr>
+    {{ end }}
+</table>
+{{ template "tail" $ }}

--- a/core/templates/site/writings/writingsAdminCategoryPage.gohtml
+++ b/core/templates/site/writings/writingsAdminCategoryPage.gohtml
@@ -1,0 +1,23 @@
+{{ template "head" $ }}
+<h2>Writing Category {{ .Category.Idwritingcategory }} - {{ .Category.Title.String }}</h2>
+<p>{{ .Category.Description.String }}</p>
+<h3 id="writings">Writings</h3>
+<table border="1">
+    <tr>
+        <th>ID</th>
+        <th>Title</th>
+        <th>Author</th>
+        <th>Published</th>
+        <th>View</th>
+    </tr>
+    {{ range .Writings }}
+    <tr>
+        <td>{{ .Idwriting }}</td>
+        <td>{{ .Title.String }}</td>
+        <td>{{ .Username.String }}</td>
+        <td>{{ .Published.Time }}</td>
+        <td><a href="/writings/{{ .Idwriting }}">View</a></td>
+    </tr>
+    {{ end }}
+</table>
+{{ template "tail" $ }}

--- a/handlers/forum/forumAdminCategoryPage.go
+++ b/handlers/forum/forumAdminCategoryPage.go
@@ -1,0 +1,45 @@
+package forum
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/gorilla/mux"
+)
+
+// AdminCategoryPage shows information about a single forum category and its topics.
+func AdminCategoryPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	cid, err := strconv.Atoi(mux.Vars(r)["category"])
+	if err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+	cat, err := queries.GetForumCategoryById(r.Context(), int32(cid))
+	if err != nil {
+		http.Error(w, "Category not found", http.StatusNotFound)
+		return
+	}
+	topics, err := queries.GetForumTopicsByCategoryId(r.Context(), int32(cid))
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	cd.PageTitle = fmt.Sprintf("Forum Category %d", cid)
+	data := struct {
+		*common.CoreData
+		Category *db.Forumcategory
+		Topics   []*db.Forumtopic
+	}{
+		CoreData: cd,
+		Category: cat,
+		Topics:   topics,
+	}
+	handlers.TemplateHandler(w, r, "forumAdminCategoryPage.gohtml", data)
+}

--- a/handlers/forum/routes_admin.go
+++ b/handlers/forum/routes_admin.go
@@ -16,6 +16,7 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	far.HandleFunc("/logs", AdminForumModeratorLogsPage).Methods("GET")
 	far.HandleFunc("/list", AdminForumWordListPage).Methods("GET")
 	far.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")
+	far.HandleFunc("/category/{category}", AdminCategoryPage).Methods("GET")
 	far.HandleFunc("/categories", handlers.TaskDoneAutoRefreshPage).Methods("POST")
 	far.HandleFunc("/category/{category}", AdminCategoryEditPage).Methods("POST").MatcherFunc(categoryChangeTask.Matcher())
 	far.HandleFunc("/category", AdminCategoryCreatePage).Methods("POST").MatcherFunc(categoryCreateTask.Matcher())

--- a/handlers/linker/linkerAdminCategoryPage.go
+++ b/handlers/linker/linkerAdminCategoryPage.go
@@ -1,0 +1,45 @@
+package linker
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/gorilla/mux"
+)
+
+// AdminCategoryPage shows a linker category with its links.
+func AdminCategoryPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	cid, err := strconv.Atoi(mux.Vars(r)["category"])
+	if err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+	cat, err := queries.GetLinkerCategoryById(r.Context(), int32(cid))
+	if err != nil {
+		http.Error(w, "Category not found", http.StatusNotFound)
+		return
+	}
+	links, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(cid)})
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	cd.PageTitle = fmt.Sprintf("Linker Category %d", cid)
+	data := struct {
+		*common.CoreData
+		Category *db.LinkerCategory
+		Links    []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow
+	}{
+		CoreData: cd,
+		Category: cat,
+		Links:    links,
+	}
+	handlers.TemplateHandler(w, r, "linkerAdminCategoryPage.gohtml", data)
+}

--- a/handlers/linker/routes_admin.go
+++ b/handlers/linker/routes_admin.go
@@ -9,6 +9,7 @@ import (
 func RegisterAdminRoutes(ar *mux.Router) {
 	lar := ar.PathPrefix("/linker").Subrouter()
 	lar.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")
+	lar.HandleFunc("/category/{category}", AdminCategoryPage).Methods("GET")
 	lar.HandleFunc("/categories", handlers.TaskHandler(UpdateCategoryTask)).Methods("POST").MatcherFunc(UpdateCategoryTask.Matcher())
 	lar.HandleFunc("/categories", handlers.TaskHandler(RenameCategoryTask)).Methods("POST").MatcherFunc(RenameCategoryTask.Matcher())
 	lar.HandleFunc("/categories", handlers.TaskHandler(DeleteCategoryTask)).Methods("POST").MatcherFunc(DeleteCategoryTask.Matcher())

--- a/handlers/writings/routes_admin.go
+++ b/handlers/writings/routes_admin.go
@@ -13,6 +13,7 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	war.HandleFunc("/users/roles", handlers.TaskHandler(userAllowTask)).Methods("POST").MatcherFunc(userAllowTask.Matcher())
 	war.HandleFunc("/users/roles", handlers.TaskHandler(userDisallowTask)).Methods("POST").MatcherFunc(userDisallowTask.Matcher())
 	war.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")
+	war.HandleFunc("/category/{category}", AdminCategoryPage).Methods("GET")
 	war.HandleFunc("/categories", handlers.TaskHandler(writingCategoryChangeTask)).Methods("POST").MatcherFunc(writingCategoryChangeTask.Matcher())
 	war.HandleFunc("/categories", handlers.TaskHandler(writingCategoryCreateTask)).Methods("POST").MatcherFunc(writingCategoryCreateTask.Matcher())
 	war.HandleFunc("/category/{category}/permissions", AdminCategoryGrantsPage).Methods("GET")

--- a/handlers/writings/writingsAdminCategoryPage.go
+++ b/handlers/writings/writingsAdminCategoryPage.go
@@ -1,0 +1,45 @@
+package writings
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/gorilla/mux"
+)
+
+// AdminCategoryPage shows a single writing category and its writings.
+func AdminCategoryPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	cid, err := strconv.Atoi(mux.Vars(r)["category"])
+	if err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+	cat, err := queries.GetWritingCategoryById(r.Context(), int32(cid))
+	if err != nil {
+		http.Error(w, "Category not found", http.StatusNotFound)
+		return
+	}
+	writings, err := queries.GetWritingsByCategoryId(r.Context(), int32(cid))
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	cd.PageTitle = fmt.Sprintf("Writing Category %d", cid)
+	data := struct {
+		*common.CoreData
+		Category *db.WritingCategory
+		Writings []*db.GetWritingsByCategoryIdRow
+	}{
+		CoreData: cd,
+		Category: cat,
+		Writings: writings,
+	}
+	handlers.TemplateHandler(w, r, "writingsAdminCategoryPage.gohtml", data)
+}

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -199,3 +199,8 @@ FROM forumthread th
 LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic = t.idforumtopic
 ORDER BY t.idforumtopic, th.lastaddition DESC;
 
+-- name: GetForumCategoryById :one
+SELECT * FROM forumcategory WHERE idforumcategory = ?;
+
+-- name: GetForumTopicsByCategoryId :many
+SELECT * FROM forumtopic WHERE forumcategory_idforumcategory = ? ORDER BY lastaddition DESC;

--- a/internal/db/queries-linker.sql
+++ b/internal/db/queries-linker.sql
@@ -321,3 +321,5 @@ LIMIT ? OFFSET ?;
 -- name: GetAllLinkersForIndex :many
 SELECT idlinker, title, description FROM linker WHERE deleted_at IS NULL;
 
+-- name: GetLinkerCategoryById :one
+SELECT * FROM linker_category WHERE idlinkerCategory = ?;

--- a/internal/db/queries-linker.sql.go
+++ b/internal/db/queries-linker.sql.go
@@ -800,6 +800,22 @@ func (q *Queries) GetLinkerCategoriesWithCount(ctx context.Context) ([]*GetLinke
 	return items, nil
 }
 
+const getLinkerCategoryById = `-- name: GetLinkerCategoryById :one
+SELECT idlinkercategory, position, title, sortorder FROM linker_category WHERE idlinkerCategory = ?
+`
+
+func (q *Queries) GetLinkerCategoryById(ctx context.Context, idlinkercategory int32) (*LinkerCategory, error) {
+	row := q.db.QueryRowContext(ctx, getLinkerCategoryById, idlinkercategory)
+	var i LinkerCategory
+	err := row.Scan(
+		&i.Idlinkercategory,
+		&i.Position,
+		&i.Title,
+		&i.Sortorder,
+	)
+	return &i, err
+}
+
 const getLinkerCategoryLinkCounts = `-- name: GetLinkerCategoryLinkCounts :many
 SELECT c.idlinkerCategory, c.title, c.position, COUNT(l.idlinker) as LinkCount
 FROM linker_category c

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -284,3 +284,12 @@ UPDATE writing SET last_index = NOW() WHERE idwriting = ?;
 -- name: GetAllWritingsForIndex :many
 SELECT idwriting, title, abstract, writing FROM writing WHERE deleted_at IS NULL;
 
+-- name: GetWritingCategoryById :one
+SELECT * FROM writing_category WHERE idwritingCategory = ?;
+
+-- name: GetWritingsByCategoryId :many
+SELECT w.*, u.username
+FROM writing w
+LEFT JOIN users u ON w.users_idusers = u.idusers
+WHERE w.writing_category_id = ?
+ORDER BY w.published DESC;

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -731,6 +731,83 @@ func (q *Queries) GetWritingByIdForUserDescendingByPublishedDate(ctx context.Con
 	return &i, err
 }
 
+const getWritingCategoryById = `-- name: GetWritingCategoryById :one
+SELECT idwritingcategory, writing_category_id, title, description FROM writing_category WHERE idwritingCategory = ?
+`
+
+func (q *Queries) GetWritingCategoryById(ctx context.Context, idwritingcategory int32) (*WritingCategory, error) {
+	row := q.db.QueryRowContext(ctx, getWritingCategoryById, idwritingcategory)
+	var i WritingCategory
+	err := row.Scan(
+		&i.Idwritingcategory,
+		&i.WritingCategoryID,
+		&i.Title,
+		&i.Description,
+	)
+	return &i, err
+}
+
+const getWritingsByCategoryId = `-- name: GetWritingsByCategoryId :many
+SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username
+FROM writing w
+LEFT JOIN users u ON w.users_idusers = u.idusers
+WHERE w.writing_category_id = ?
+ORDER BY w.published DESC
+`
+
+type GetWritingsByCategoryIdRow struct {
+	Idwriting          int32
+	UsersIdusers       int32
+	ForumthreadID      int32
+	LanguageIdlanguage int32
+	WritingCategoryID  int32
+	Title              sql.NullString
+	Published          sql.NullTime
+	Writing            sql.NullString
+	Abstract           sql.NullString
+	Private            sql.NullBool
+	DeletedAt          sql.NullTime
+	LastIndex          sql.NullTime
+	Username           sql.NullString
+}
+
+func (q *Queries) GetWritingsByCategoryId(ctx context.Context, writingCategoryID int32) ([]*GetWritingsByCategoryIdRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWritingsByCategoryId, writingCategoryID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetWritingsByCategoryIdRow
+	for rows.Next() {
+		var i GetWritingsByCategoryIdRow
+		if err := rows.Scan(
+			&i.Idwriting,
+			&i.UsersIdusers,
+			&i.ForumthreadID,
+			&i.LanguageIdlanguage,
+			&i.WritingCategoryID,
+			&i.Title,
+			&i.Published,
+			&i.Writing,
+			&i.Abstract,
+			&i.Private,
+			&i.DeletedAt,
+			&i.LastIndex,
+			&i.Username,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getWritingsByIdsForUserDescendingByPublishedDate = `-- name: GetWritingsByIdsForUserDescendingByPublishedDate :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?


### PR DESCRIPTION
## Summary
- add forum, writing, and linker admin category pages
- link category IDs in admin listing to new admin pages
- link topic counts to forum category topics section
- add 'view on site' links in options
- expose new SQL queries for fetching categories and items

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68889621b740832f96bc328dc1620194