### PR TITLE
Fix header title

### DIFF
--- a/core/templates/site/header.gohtml
+++ b/core/templates/site/header.gohtml
@@ -9,7 +9,9 @@
             {{ end }}
         {{ end }}
     </div>
-    <div class="navbar-center"><strong>{{cd.Title}}</strong></div>
+    <div class="navbar-center"><strong>
+        {{- if cd.PageTitle }}{{ cd.PageTitle }} - {{ end -}}{{ cd.Title }}
+    </strong></div>
     <div class="navbar-right user-links">
         {{ if cd.UserID }}
             {{ with $u := cd.CurrentUserLoaded }}{{ if $u }}<span class="username">{{ $u.Username.String }}</span>{{ end }}{{ end }}


### PR DESCRIPTION
## Summary
- show the same text in the navbar as in the page title

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688896654cc0832f850f384d8a24c132