### PR TITLE
Fix admin role toggle button

### DIFF
--- a/core/templates/site/admin/rolesPage.gohtml
+++ b/core/templates/site/admin/rolesPage.gohtml
@@ -13,10 +13,12 @@
                 <input type="hidden" name="id" value="{{ .ID }}">
                 {{ if .PublicProfileAllowedAt.Valid }}
                     <input type="hidden" name="enable" value="0">
-                    <input type="submit" name="task" value="Disable">
+                    <input type="hidden" name="task" value="Toggle role public profile">
+                    <input type="submit" value="Disable">
                 {{ else }}
                     <input type="hidden" name="enable" value="1">
-                    <input type="submit" name="task" value="Enable">
+                    <input type="hidden" name="task" value="Toggle role public profile">
+                    <input type="submit" value="Enable">
                 {{ end }}
             </form>
         </td>


### PR DESCRIPTION
## Summary
- ensure admin roles public profile button sends the correct task value

## Testing
- `go mod tidy`
- `gofmt -w handlers/admin/adminRolesPage.go handlers/admin/routes.go handlers/admin/role_public_profile_task.go handlers/admin/tasks.go internal/tasks/task_event.go internal/tasks/matchers.go`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6888968e64bc832f9c2e0fe949fa86c7