### PR TITLE
Fix admin forum URL paths

### DIFF
--- a/core/templates/site/forum/adminCategoryGrantsPage.gohtml
+++ b/core/templates/site/forum/adminCategoryGrantsPage.gohtml
@@ -15,7 +15,7 @@
         <td>{{ if .RoleName.Valid }}{{ .RoleName.String }}{{ end }}</td>
         <td>{{ .Action }}</td>
         <td>
-            <form method="post" action="/forum/admin/category/{{ $.CategoryID }}/grant/delete">
+            <form method="post" action="/admin/forum/category/{{ $.CategoryID }}/grant/delete">
         {{ csrfField }}
                 <input type="hidden" name="grantid" value="{{ .ID }}">
                 <input type="submit" name="task" value="Delete grant">
@@ -24,7 +24,7 @@
     </tr>
     {{- end }}
     <tr>
-        <form method="post" action="/forum/admin/category/{{ $.CategoryID }}/grant">
+        <form method="post" action="/admin/forum/category/{{ $.CategoryID }}/grant">
         {{ csrfField }}
             <td>NEW</td>
             <td><input name="username"></td>

--- a/core/templates/site/forum/forumAdminCategoriesPage.gohtml
+++ b/core/templates/site/forum/forumAdminCategoriesPage.gohtml
@@ -25,7 +25,7 @@
                         {{ if eq .Topiccount 0 }}
                         <input type="submit" name="task" formaction="/admin/forum/category/delete" value="Delete Category">
                         {{ end }}<br>
-                        <a href="/forum/admin/category/{{ .Idforumcategory }}/grants">Permissions</a>
+                        <a href="/admin/forum/category/{{ .Idforumcategory }}/grants">Permissions</a>
                     </td>
                 </form>
             </tr>


### PR DESCRIPTION
## Summary
- correct admin forum permissions links to use `/admin/forum` prefix

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688897274cc8832fb357fa7c761d4403