### PR TITLE
Merge user and role columns on grant pages

### DIFF
--- a/core/templates/site/forum/adminCategoryGrantsPage.gohtml
+++ b/core/templates/site/forum/adminCategoryGrantsPage.gohtml
@@ -3,16 +3,18 @@
 <table border="1">
     <tr>
         <th>ID</th>
-        <th>User</th>
-        <th>Role</th>
+        <th>User / Role</th>
         <th>Action</th>
         <th>Delete?</th>
     </tr>
     {{- range .Grants }}
     <tr>
         <td>{{ .ID }}</td>
-        <td>{{ if .Username.Valid }}{{ .Username.String }}{{ end }}</td>
-        <td>{{ if .RoleName.Valid }}{{ .RoleName.String }}{{ end }}</td>
+        <td>
+            {{- if .Username.Valid }}User: {{ .Username.String }}{{ end -}}
+            {{- if and .Username.Valid .RoleName.Valid }}<br>{{ end -}}
+            {{- if .RoleName.Valid }}Role: {{ .RoleName.String }}{{ end -}}
+        </td>
         <td>{{ .Action }}</td>
         <td>
             <form method="post" action="/forum/admin/category/{{ $.CategoryID }}/grant/delete">
@@ -27,8 +29,8 @@
         <form method="post" action="/forum/admin/category/{{ $.CategoryID }}/grant">
         {{ csrfField }}
             <td>NEW</td>
-            <td><input name="username"></td>
             <td>
+                <input name="username" placeholder="username"><br>
                 <select name="role">
                     <option value="">None</option>
                     {{- range $.Roles }}<option value="{{ .Name }}">{{ .Name }}</option>{{- end }}

--- a/core/templates/site/forum/adminTopicGrantsPage.gohtml
+++ b/core/templates/site/forum/adminTopicGrantsPage.gohtml
@@ -3,16 +3,18 @@
 <table border="1">
     <tr>
         <th>ID</th>
-        <th>User</th>
-        <th>Role</th>
+        <th>User / Role</th>
         <th>Action</th>
         <th>Delete?</th>
     </tr>
     {{- range .Grants }}
     <tr>
         <td>{{ .ID }}</td>
-        <td>{{ if .Username.Valid }}{{ .Username.String }}{{ end }}</td>
-        <td>{{ if .RoleName.Valid }}{{ .RoleName.String }}{{ end }}</td>
+        <td>
+            {{- if .Username.Valid }}User: {{ .Username.String }}{{ end -}}
+            {{- if and .Username.Valid .RoleName.Valid }}<br>{{ end -}}
+            {{- if .RoleName.Valid }}Role: {{ .RoleName.String }}{{ end -}}
+        </td>
         <td>{{ .Action }}</td>
         <td>
             <form method="post" action="/admin/forum/topic/{{ $.TopicID }}/grant/delete">
@@ -27,8 +29,8 @@
         <form method="post" action="/admin/forum/topic/{{ $.TopicID }}/grant">
         {{ csrfField }}
             <td>NEW</td>
-            <td><input name="username"></td>
             <td>
+                <input name="username" placeholder="username"><br>
                 <select name="role">
                     <option value="">None</option>
                     {{- range $.Roles }}<option value="{{ .Name }}">{{ .Name }}</option>{{- end }}

--- a/core/templates/site/linker/adminCategoryGrantsPage.gohtml
+++ b/core/templates/site/linker/adminCategoryGrantsPage.gohtml
@@ -3,16 +3,18 @@
 <table border="1">
     <tr>
         <th>ID</th>
-        <th>User</th>
-        <th>Role</th>
+        <th>User / Role</th>
         <th>Action</th>
         <th>Delete?</th>
     </tr>
     {{- range .Grants }}
     <tr>
         <td>{{ .ID }}</td>
-        <td>{{ if .Username.Valid }}{{ .Username.String }}{{ end }}</td>
-        <td>{{ if .RoleName.Valid }}{{ .RoleName.String }}{{ end }}</td>
+        <td>
+            {{- if .Username.Valid }}User: {{ .Username.String }}{{ end -}}
+            {{- if and .Username.Valid .RoleName.Valid }}<br>{{ end -}}
+            {{- if .RoleName.Valid }}Role: {{ .RoleName.String }}{{ end -}}
+        </td>
         <td>{{ .Action }}</td>
         <td>
             <form method="post" action="/linker/admin/category/{{ $.CategoryID }}/grant/delete">
@@ -27,8 +29,8 @@
         <form method="post" action="/linker/admin/category/{{ $.CategoryID }}/grant">
         {{ csrfField }}
             <td>NEW</td>
-            <td><input name="username"></td>
             <td>
+                <input name="username" placeholder="username"><br>
                 <select name="role">
                     <option value="">None</option>
                     {{- range $.Roles }}<option value="{{ .Name }}">{{ .Name }}</option>{{- end }}

--- a/core/templates/site/writings/adminCategoryGrantsPage.gohtml
+++ b/core/templates/site/writings/adminCategoryGrantsPage.gohtml
@@ -3,16 +3,18 @@
 <table border="1">
     <tr>
         <th>ID</th>
-        <th>User</th>
-        <th>Role</th>
+        <th>User / Role</th>
         <th>Action</th>
         <th>Delete?</th>
     </tr>
     {{- range .Grants }}
     <tr>
         <td>{{ .ID }}</td>
-        <td>{{ if .Username.Valid }}{{ .Username.String }}{{ end }}</td>
-        <td>{{ if .RoleName.Valid }}{{ .RoleName.String }}{{ end }}</td>
+        <td>
+            {{- if .Username.Valid }}User: {{ .Username.String }}{{ end -}}
+            {{- if and .Username.Valid .RoleName.Valid }}<br>{{ end -}}
+            {{- if .RoleName.Valid }}Role: {{ .RoleName.String }}{{ end -}}
+        </td>
         <td>{{ .Action }}</td>
         <td>
             <form method="post" action="/admin/writings/category/{{ $.CategoryID }}/permission/delete">
@@ -27,8 +29,8 @@
         <form method="post" action="/admin/writings/category/{{ $.CategoryID }}/permission">
         {{ csrfField }}
             <td>NEW</td>
-            <td><input name="username"></td>
             <td>
+                <input name="username" placeholder="username"><br>
                 <select name="role">
                     <option value="">None</option>
                     {{- range $.Roles }}<option value="{{ .Name }}">{{ .Name }}</option>{{- end }}

--- a/core/templates/site/writings/writingsAdminCategoryGrantsPage.gohtml
+++ b/core/templates/site/writings/writingsAdminCategoryGrantsPage.gohtml
@@ -3,16 +3,18 @@
 <table border="1">
     <tr>
         <th>ID</th>
-        <th>User</th>
-        <th>Role</th>
+        <th>User / Role</th>
         <th>Action</th>
         <th>Delete?</th>
     </tr>
     {{- range .Grants }}
     <tr>
         <td>{{ .ID }}</td>
-        <td>{{ if .Username.Valid }}{{ .Username.String }}{{ end }}</td>
-        <td>{{ if .RoleName.Valid }}{{ .RoleName.String }}{{ end }}</td>
+        <td>
+            {{- if .Username.Valid }}User: {{ .Username.String }}{{ end -}}
+            {{- if and .Username.Valid .RoleName.Valid }}<br>{{ end -}}
+            {{- if .RoleName.Valid }}Role: {{ .RoleName.String }}{{ end -}}
+        </td>
         <td>{{ .Action }}</td>
         <td>
             <form method="post" action="/admin/writings/category/{{ $.CategoryID }}/grant/delete">
@@ -27,8 +29,8 @@
         <form method="post" action="/admin/writings/category/{{ $.CategoryID }}/grant">
         {{ csrfField }}
             <td>NEW</td>
-            <td><input name="username"></td>
             <td>
+                <input name="username" placeholder="username"><br>
                 <select name="role">
                     <option value="">None</option>
                     {{- range $.Roles }}<option value="{{ .Name }}">{{ .Name }}</option>{{- end }}


### PR DESCRIPTION
## Summary
- merge user/role columns for topic and category grants
- show the assignee type in one column

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6888985b270c832fa1fa74138200b84e