### PR TITLE
Fix redirect after forum grant delete

### DIFF
--- a/handlers/forum/category_grant_delete_task.go
+++ b/handlers/forum/category_grant_delete_task.go
@@ -10,6 +10,7 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/gorilla/mux"
 )
 
 // CategoryGrantDeleteTask removes a grant from a forum category.
@@ -20,7 +21,13 @@ var categoryGrantDeleteTask = &CategoryGrantDeleteTask{TaskString: TaskCategoryG
 var _ tasks.Task = (*CategoryGrantDeleteTask)(nil)
 
 func (CategoryGrantDeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	vars := mux.Vars(r)
+	categoryID, err := strconv.Atoi(vars["category"])
+	if err != nil {
+		return fmt.Errorf("category id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
 	grantID, err := strconv.Atoi(r.PostFormValue("grantid"))
 	if err != nil {
 		return fmt.Errorf("grant id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
@@ -29,5 +36,5 @@ func (CategoryGrantDeleteTask) Action(w http.ResponseWriter, r *http.Request) an
 		log.Printf("DeleteGrant: %v", err)
 		return fmt.Errorf("delete grant %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	return nil
+	return handlers.RefreshDirectHandler{TargetURL: fmt.Sprintf("/admin/forum/category/%d/grants", categoryID)}
 }


### PR DESCRIPTION
## Summary
- ensure topic and category grant deletes redirect back to the grants list

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688898a67428832f983f8d790481a1f9