### PR TITLE
Improve forum thread admin controls

### DIFF
--- a/core/templates/site/forum/adminThreadPage.gohtml
+++ b/core/templates/site/forum/adminThreadPage.gohtml
@@ -1,0 +1,14 @@
+{{ template "head" $ }}
+<h2>Forum thread {{ .Thread.Idforumthread }}</h2>
+<table border="1">
+    <tr><th>ID<th>Posts<th>Last Addition<th>View public</tr>
+    <tr>
+        <td>{{ .Thread.Idforumthread }}</td>
+        <td>{{ .Thread.Comments.Int32 }}</td>
+        <td>{{ .Thread.Lastaddition.Time }}</td>
+        <td><a href="/forum/topic/{{ .Thread.ForumtopicIdforumtopic }}/thread/{{ .Thread.Idforumthread }}">View</a></td>
+    </tr>
+</table>
+<p><a href="/admin/forum/thread/{{ .Thread.Idforumthread }}/delete">Delete thread</a></p>
+<p><a href="/admin/forum/conversations">Back</a></p>
+{{ template "tail" $ }}

--- a/core/templates/site/forum/adminThreadsPage.gohtml
+++ b/core/templates/site/forum/adminThreadsPage.gohtml
@@ -3,20 +3,13 @@
     {{ $grp := index $.Groups $tid }}
     <h2>{{ $grp.TopicTitle }}</h2>
     <table border="1">
-        <tr><th>ID<th>Posts<th>Last Addition<th>View<th>Delete</tr>
+        <tr><th>ID<th>Posts<th>Last Addition<th>View public</tr>
         {{ range $grp.Threads }}
             <tr>
-                <td>{{ .Idforumthread }}</td>
+                <td><a href="/admin/forum/thread/{{ .Idforumthread }}">{{ .Idforumthread }}</a></td>
                 <td>{{ .Comments.Int32 }}</td>
                 <td>{{ .Lastaddition.Time }}</td>
                 <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic }}/thread/{{ .Idforumthread }}">View</a></td>
-                <td>
-                    <form method="post" action="/admin/forum/thread/{{ .Idforumthread }}/delete" style="display:inline">
-        {{ csrfField }}
-                        <input type="hidden" name="topic" value="{{ .ForumtopicIdforumtopic }}">
-                        <input type="submit" name="task" value="Forum thread delete">
-                    </form>
-                </td>
             </tr>
         {{ end }}
     </table>

--- a/handlers/forum/forumAdminThreadsPage.go
+++ b/handlers/forum/forumAdminThreadsPage.go
@@ -1,11 +1,13 @@
 package forum
 
 import (
+	"database/sql"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
@@ -59,15 +61,74 @@ func AdminThreadDeletePage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	topicID, err := strconv.Atoi(r.PostFormValue("topic"))
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	topicID, err := queries.GetForumTopicIdByThreadId(r.Context(), int32(threadID))
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	if err := ThreadDelete(r.Context(), queries, int32(threadID), int32(topicID)); err != nil {
+	if err := ThreadDelete(r.Context(), queries, int32(threadID), topicID); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
 	http.Redirect(w, r, "/admin/forum/conversations", http.StatusTemporaryRedirect)
+}
+
+func AdminThreadDeleteConfirmPage(w http.ResponseWriter, r *http.Request) {
+	threadID, err := strconv.Atoi(mux.Vars(r)["thread"])
+	if err != nil {
+		http.Redirect(w, r, "/admin/forum/conversations?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Confirm forum thread delete"
+	data := struct {
+		*common.CoreData
+		Message      string
+		ConfirmLabel string
+		Back         string
+	}{
+		CoreData:     cd,
+		Message:      "Are you sure you want to delete forum thread " + strconv.Itoa(threadID) + "?",
+		ConfirmLabel: "Confirm delete",
+		Back:         "/admin/forum/thread/" + strconv.Itoa(threadID),
+	}
+	handlers.TemplateHandler(w, r, "confirmPage.gohtml", data)
+}
+
+func AdminThreadPage(w http.ResponseWriter, r *http.Request) {
+	threadID, err := strconv.Atoi(mux.Vars(r)["thread"])
+	if err != nil {
+		http.Redirect(w, r, "/admin/forum/conversations?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+
+	session, _ := core.GetSession(r)
+	var uid int32
+	if session != nil {
+		uid, _ = session.Values["UID"].(int32)
+	}
+
+	threadRow, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
+		ViewerID:      uid,
+		ThreadID:      int32(threadID),
+		ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0},
+	})
+	if err != nil {
+		http.Redirect(w, r, "/admin/forum/conversations?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+
+	cd.PageTitle = "Forum Admin Thread"
+	data := struct {
+		*common.CoreData
+		Thread *db.GetThreadLastPosterAndPermsRow
+	}{
+		CoreData: cd,
+		Thread:   threadRow,
+	}
+
+	handlers.TemplateHandler(w, r, "adminThreadPage.gohtml", data)
 }

--- a/handlers/forum/routes_admin.go
+++ b/handlers/forum/routes_admin.go
@@ -23,6 +23,8 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	far.HandleFunc("/topics", AdminTopicsPage).Methods("GET")
 	far.HandleFunc("/topics", handlers.TaskDoneAutoRefreshPage).Methods("POST")
 	far.HandleFunc("/conversations", AdminThreadsPage).Methods("GET")
+	far.HandleFunc("/thread/{thread}", AdminThreadPage).Methods("GET")
+	far.HandleFunc("/thread/{thread}/delete", AdminThreadDeleteConfirmPage).Methods("GET")
 	far.HandleFunc("/users", AdminUsersRedirect).Methods("GET")
 	far.HandleFunc("/user/{id}/levels", AdminUserLevelsRedirect).Methods("GET")
 	far.HandleFunc("/thread/{thread}/delete", AdminThreadDeletePage).Methods("POST").MatcherFunc(threadDeleteTask.Matcher())


### PR DESCRIPTION
## Summary
- add detailed admin thread page
- move delete action behind confirmation
- remove inline delete from conversation list
- wire up routes for admin thread view and confirm delete

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68889970e5e8832f920eeb595542c3f6