### PR TITLE
Fix admin profile link text

### DIFF
--- a/core/templates/site/admin/userPermissionsPage.gohtml
+++ b/core/templates/site/admin/userPermissionsPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-[<a href="/admin">Admin:</a> <a href="/admin/user/{{.User.Idusers}}">Profile</a>: <a href="/admin/user/{{.User.Idusers}}/permissions">(This page/Refresh)</a>]<br />
+[<a href="/admin">Admin:</a> <a href="/admin/user/{{.User.Idusers}}">Admin profile</a>: <a href="/admin/user/{{.User.Idusers}}/permissions">(This page/Refresh)</a>]<br />
 <table border="1" class="perm-table">
     <thead>
         <tr>

--- a/core/templates/site/admin/usersPage.gohtml
+++ b/core/templates/site/admin/usersPage.gohtml
@@ -45,7 +45,7 @@
                     <a style="display:inline-block;margin:0 4px" href="/admin/user/{{.Idusers}}/disable">Disable account</a>
                     <a style="display:inline-block;margin:0 4px" href="/admin/user/{{.Idusers}}/reset">Reset password</a>
                     <a style="display:inline-block;margin:0 4px" href="/user/profile/{{.Username.String}}">Profile</a>
-                    <a style="display:inline-block;margin:0 4px" href="/admin/user/{{.Idusers}}">Profile</a>
+                    <a style="display:inline-block;margin:0 4px" href="/admin/user/{{.Idusers}}">Admin profile</a>
                     <a style="display:inline-block;margin:0 4px" href="/admin/user/{{.Idusers}}/permissions">Permissions</a>
                     <a style="display:inline-block;margin:0 4px" href="/admin/users/export?uid={{.Idusers}}">Export ZIP</a>
                 </td>


### PR DESCRIPTION
## Summary
- rename admin user page breadcrumbs to say "Admin profile"
- clarify label for admin profile link on the users list

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688899f4d64c832fb0003ca61f5ee875