### PR TITLE
Fix admin writing listing

### DIFF
--- a/handlers/admin/adminUserWritingsPage.go
+++ b/handlers/admin/adminUserWritingsPage.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"database/sql"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -24,11 +23,7 @@ func adminUserWritingsPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.GetAllWritingsByUser(r.Context(), db.GetAllWritingsByUserParams{
-		ViewerID:      int32(id),
-		AuthorID:      int32(id),
-		ViewerMatchID: sql.NullInt32{Int32: int32(id), Valid: true},
-	})
+	rows, err := queries.GetAllWritingsByUserAdmin(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -37,7 +32,7 @@ func adminUserWritingsPage(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		*common.CoreData
 		User     *db.User
-		Writings []*db.GetAllWritingsByUserRow
+		Writings []*db.GetAllWritingsByUserAdminRow
 	}{
 		CoreData: cd,
 		User:     &db.User{Idusers: user.Idusers, Username: user.Username},

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -212,6 +212,14 @@ WHERE w.users_idusers = sqlc.arg(author_id)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
 ORDER BY w.published DESC;
+
+-- name: GetAllWritingsByUserAdmin :many
+SELECT w.*, u.username,
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
+FROM writing w
+LEFT JOIN users u ON w.users_idusers = u.idusers
+WHERE w.users_idusers = ?
+ORDER BY w.published DESC;
 -- name: ListWritersForViewer :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)


### PR DESCRIPTION
## Summary
- provide unrestricted writings query for admins
- use the new query in admin user writings page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68889a3934e4832f97d6e58078eb045c