### PR TITLE
Add admin edit page for Linker

### DIFF
--- a/core/templates/site/admin/userLinkerPage.gohtml
+++ b/core/templates/site/admin/userLinkerPage.gohtml
@@ -1,13 +1,14 @@
 {{ template "head" $ }}
 <h2>Links by {{ .User.Username.String }}</h2>
 <table border="1">
-    <tr><th>ID</th><th>Date</th><th>Title</th><th>Link</th></tr>
+    <tr><th>ID</th><th>Date</th><th>Title</th><th>URL</th><th>View</th></tr>
     {{- range .Links }}
     <tr>
-        <td>{{ .Idlinker }}</td>
-        <td>{{ .Listed }}</td>
-        <td>{{ .Title }}</td>
-        <td><a href="/linker/link/{{ .Idlinker }}">View</a></td>
+        <td><a href="/admin/linker/link/{{ .Idlinker }}">{{ .Idlinker }}</a></td>
+        <td>{{ if .Listed.Valid }}{{ .Listed.Time }}{{ end }}</td>
+        <td>{{ if .Title.Valid }}{{ .Title.String }}{{ end }}</td>
+        <td>{{ if .Url.Valid }}<a href="{{ .Url.String }}" target="_blank">{{ .Url.String }}</a>{{ end }}</td>
+        <td><a href="/linker/show/{{ .Idlinker }}">View</a></td>
     </tr>
     {{- end }}
 </table>

--- a/core/templates/site/linker/adminLinkPage.gohtml
+++ b/core/templates/site/linker/adminLinkPage.gohtml
@@ -1,0 +1,11 @@
+{{ template "head" $ }}
+    <form method="post" action="">
+        {{ csrfField }}
+        <label>Title <input name="title" value="{{ .Link.Title.String }}"></label><br>
+        <label>URL <input name="URL" value="{{ .Link.Url.String }}"></label><br>
+        <label>Description:<br><textarea name="desc" cols="40" rows="20">{{ .Link.Description.String }}</textarea></label><br>
+        {{ template "categoryCombobox" $ }}
+        {{ template "languageCombobox" $ }}
+        <input type="submit" name="task" value="Update">
+    </form>
+{{ template "tail" $ }}

--- a/handlers/linker/linkerAdminLinkPage.go
+++ b/handlers/linker/linkerAdminLinkPage.go
@@ -1,0 +1,92 @@
+package linker
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/gorilla/mux"
+)
+
+// adminLinkPage displays the edit form for a linker item.
+func adminLinkPage(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id, _ := strconv.Atoi(vars["link"])
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+
+	link, err := queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(r.Context(), int32(id))
+	if err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			http.NotFound(w, r)
+		default:
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	cats, _ := queries.GetAllLinkerCategories(r.Context())
+	langs, _ := cd.Languages()
+
+	cd.PageTitle = fmt.Sprintf("Edit Link %d", id)
+	data := struct {
+		*common.CoreData
+		Link               *db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow
+		Categories         []*db.LinkerCategory
+		Languages          []*db.Language
+		Selected           int
+		SelectedLanguageId int
+	}{
+		CoreData:           cd,
+		Link:               link,
+		Categories:         cats,
+		Languages:          langs,
+		Selected:           int(link.LinkerCategoryID),
+		SelectedLanguageId: int(link.LanguageIdlanguage),
+	}
+
+	handlers.TemplateHandler(w, r, "adminLinkPage.gohtml", data)
+}
+
+// editLinkTask updates an existing linker item.
+type editLinkTask struct{ tasks.TaskString }
+
+var EditLinkTask = &editLinkTask{TaskString: TaskUpdate}
+
+var _ tasks.Task = (*editLinkTask)(nil)
+
+func (editLinkTask) Page(w http.ResponseWriter, r *http.Request) { adminLinkPage(w, r) }
+
+func (editLinkTask) Action(w http.ResponseWriter, r *http.Request) any {
+	vars := mux.Vars(r)
+	id, _ := strconv.Atoi(vars["link"])
+	title := r.PostFormValue("title")
+	URL := r.PostFormValue("URL")
+	desc := r.PostFormValue("desc")
+	cat, _ := strconv.Atoi(r.PostFormValue("category"))
+	lang, _ := strconv.Atoi(r.PostFormValue("language"))
+
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+
+	if err := queries.UpdateLinkerItem(r.Context(), db.UpdateLinkerItemParams{
+		Title:              sql.NullString{Valid: true, String: title},
+		Url:                sql.NullString{Valid: true, String: URL},
+		Description:        sql.NullString{Valid: true, String: desc},
+		LinkerCategoryID:   int32(cat),
+		LanguageIdlanguage: int32(lang),
+		Idlinker:           int32(id),
+	}); err != nil {
+		return fmt.Errorf("update linker item fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+
+	return handlers.RedirectHandler(fmt.Sprintf("/admin/linker/link/%d", id))
+}

--- a/handlers/linker/routes_admin.go
+++ b/handlers/linker/routes_admin.go
@@ -25,6 +25,9 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	lar.HandleFunc("/users/roles", handlers.TaskHandler(UserAllowTask)).Methods("POST").MatcherFunc(UserAllowTask.Matcher())
 	lar.HandleFunc("/users/roles", handlers.TaskHandler(UserDisallowTask)).Methods("POST").MatcherFunc(UserDisallowTask.Matcher())
 
+	lar.HandleFunc("/link/{link}", adminLinkPage).Methods("GET")
+	lar.HandleFunc("/link/{link}", handlers.TaskHandler(EditLinkTask)).Methods("POST").MatcherFunc(EditLinkTask.Matcher())
+
 	lar.HandleFunc("/category/{category}/grants", AdminCategoryGrantsPage).Methods("GET")
 	lar.HandleFunc("/category/{category}/grant", handlers.TaskHandler(categoryGrantCreateTask)).Methods("POST").MatcherFunc(categoryGrantCreateTask.Matcher())
 	lar.HandleFunc("/category/{category}/grant/delete", handlers.TaskHandler(categoryGrantDeleteTask)).Methods("POST").MatcherFunc(categoryGrantDeleteTask.Matcher())

--- a/handlers/linker/tasks_register.go
+++ b/handlers/linker/tasks_register.go
@@ -14,6 +14,7 @@ func RegisterTasks() []tasks.NamedTask {
 		ApproveTask,
 		BulkDeleteTask,
 		BulkApproveTask,
+		EditLinkTask,
 		UserAllowTask,
 		UserDisallowTask,
 		categoryGrantCreateTask,


### PR DESCRIPTION
## Summary
- update user linker table to handle nulls and show URL
- link to a new admin page for editing a link
- add admin link edit handler and template
- register edit task and route

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68889a7a781c832f962f36ca93b0a2eb