### PR TITLE
Enhance admin user forum page

### DIFF
--- a/core/templates/site/admin/userForumPage.gohtml
+++ b/core/templates/site/admin/userForumPage.gohtml
@@ -1,12 +1,14 @@
 {{ template "head" $ }}
 <h2>Forum threads by {{ .User.Username.String }}</h2>
 <table border="1">
-    <tr><th>ID</th><th>Topic</th><th>Comments</th><th>Link</th></tr>
+    <tr><th>ID</th><th>Topic</th><th>Category</th><th>Comments</th><th>Last Addition</th><th>View</th></tr>
     {{- range .Threads }}
     <tr>
-        <td>{{ .Idforumthread }}</td>
-        <td>{{ .ForumtopicIdforumtopic }}</td>
-        <td>{{ .Comments }}</td>
+        <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic }}/thread/{{ .Idforumthread }}">{{ .Idforumthread }}</a></td>
+        <td><a href="/admin/forum/topic/{{ .ForumtopicIdforumtopic }}/edit">{{ .TopicTitle.String }}</a></td>
+        <td>{{ if .CategoryID.Valid }}<a href="/admin/forum/category/{{ .CategoryID.Int32 }}/grants">{{ .CategoryTitle.String }}</a>{{ end }}</td>
+        <td>{{ .Comments.Int32 }}</td>
+        <td>{{ .Lastaddition.Time }}</td>
         <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic }}/thread/{{ .Idforumthread }}">View</a></td>
     </tr>
     {{- end }}

--- a/handlers/admin/adminUserForumPage.go
+++ b/handlers/admin/adminUserForumPage.go
@@ -23,7 +23,7 @@ func adminUserForumPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.GetThreadsStartedByUser(r.Context(), int32(id))
+	rows, err := queries.GetThreadsStartedByUserWithTopic(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -32,7 +32,7 @@ func adminUserForumPage(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		*common.CoreData
 		User    *db.User
-		Threads []*db.Forumthread
+		Threads []*db.GetThreadsStartedByUserWithTopicRow
 	}{
 		CoreData: cd,
 		User:     &db.User{Idusers: user.Idusers, Username: user.Username},

--- a/internal/db/queries-threads.sql
+++ b/internal/db/queries-threads.sql
@@ -91,3 +91,12 @@ FROM forumthread th
 JOIN comments c ON th.firstpost = c.idcomments
 WHERE c.users_idusers = ?
 ORDER BY th.lastaddition DESC;
+
+-- name: GetThreadsStartedByUserWithTopic :many
+SELECT th.*, t.title AS topic_title, fc.idforumcategory AS category_id, fc.title AS category_title
+FROM forumthread th
+JOIN comments c ON th.firstpost = c.idcomments
+LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic = t.idforumtopic
+LEFT JOIN forumcategory fc ON t.forumcategory_idforumcategory = fc.idforumcategory
+WHERE c.users_idusers = ?
+ORDER BY th.lastaddition DESC;


### PR DESCRIPTION
## Summary
- query forum threads started by a user along with topic and category info
- link to topic and category admin pages in the admin user forum table
- show last addition date and handle nullable comments properly

## Testing
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68889ae0fe8c832f884678d10dd03be2