### PR TITLE
Enhance admin blogs view

### DIFF
--- a/core/templates/site/admin/userBlogsPage.gohtml
+++ b/core/templates/site/admin/userBlogsPage.gohtml
@@ -1,12 +1,14 @@
 {{ template "head" $ }}
-<h2>Blogs by {{ .User.Username.String }}</h2>
+<h2>Blogs by <a href="/admin/user/{{ .User.Idusers }}">{{ .User.Username.String }}</a></h2>
 <table border="1">
-    <tr><th>ID</th><th>Date</th><th>Comments</th><th>Link</th></tr>
+    <tr><th>ID</th><th>Date</th><th>Comments</th><th>Language</th><th>Snippet</th><th>Link</th></tr>
     {{- range .Blogs }}
     <tr>
-        <td>{{ .Idblogs }}</td>
+        <td><a href="/admin/blogs/blog/{{ .Idblogs }}">{{ .Idblogs }}</a></td>
         <td>{{ .Written }}</td>
         <td>{{ .Comments }}</td>
+        <td>{{ .LanguageIdlanguage }}</td>
+        <td>{{ left 40 (firstline (a4code2string .Blog.String)) }}</td>
         <td><a href="/blogs/blog/{{ .Idblogs }}">View</a></td>
     </tr>
     {{- end }}

--- a/handlers/blogs/routes_admin.go
+++ b/handlers/blogs/routes_admin.go
@@ -13,4 +13,5 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	br.HandleFunc("/users/roles", UsersPermissionsDisallowPage).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(userDisallowTask.Matcher())
 	br.HandleFunc("/users/roles", UsersPermissionsBulkAllowPage).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(usersAllowTask.Matcher())
 	br.HandleFunc("/users/roles", UsersPermissionsBulkDisallowPage).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(usersDisallowTask.Matcher())
+	br.HandleFunc("/blog/{blog}", BlogPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 }


### PR DESCRIPTION
## Summary
- link username on admin's blog list to the profile
- expose language and a snippet of each blog entry
- make blog entry IDs link to a new admin-accessible blog page

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68889b4c3888832f8e6eeff857283c85