### PR TITLE
Add admin board editing page

### DIFF
--- a/core/templates/site/imagebbs/adminBoardPage.gohtml
+++ b/core/templates/site/imagebbs/adminBoardPage.gohtml
@@ -1,0 +1,9 @@
+{{ template "head" $ }}
+<form method="post" action="/admin/imagebbs/board/{{ .Board.Idimageboard }}">
+    {{ csrfField }}
+    Name: <input name="name" value="{{ .Board.Title.String }}"><br>
+    Description: <textarea name="desc" cols="40" rows="5">{{ .Board.Description.String }}</textarea><br>
+    Parent Board: <select name="pbid" value="{{ .Board.ImageboardIdimageboard }}"><option value="0">None</option>{{ range .Boards }}<option value="{{ .Idimageboard }}" {{ if eq $.Board.ImageboardIdimageboard .Idimageboard }}selected{{ end }}>{{ .Title.String }}</option>{{ end }}</select><br>
+    <input type="submit" name="task" value="Modify board">
+</form>
+{{ template "tail" $ }}

--- a/core/templates/site/imagebbs/adminBoardsPage.gohtml
+++ b/core/templates/site/imagebbs/adminBoardsPage.gohtml
@@ -1,4 +1,5 @@
 {{ template "head" $ }}
+<a href="/admin/imagebbs/board">Create New Board</a><br>
                 <table border="1">
                         <tr>
                                 <th>ID
@@ -6,22 +7,23 @@
                                 <th>Description
                                 <th>Parent board
                                 <th>Threads
+                                <th>View
                                 <th>Visible
                                 <th>Options?
                         {{ range .Boards }}
                                 <tr>
                                         <form method="post" action="/admin/imagebbs/board/{{.Idimageboard}}">
         {{ csrfField }}
-                                                <td>{{ .Idimageboard }}
+                                                <td><a href="/admin/imagebbs/board/{{ .Idimageboard }}">{{ .Idimageboard }}</a>
                                                 <td><input name="name" value="{{ .Title.String }}">
                                                 <td><textarea name="desc">{{ .Description.String }}</textarea>
                                                 <td>{{ $pbid := .ImageboardIdimageboard }} {{ $pbid }} <select name="pbid" value="{{ .ImageboardIdimageboard }}"><option value="0">None</option>{{ range $.Boards }}<option value="{{.Idimageboard}}" {{if eq $pbid .Idimageboard}}selected{{end}}>{{.Title.String}}</option>{{ end }}</select>
                                                 <td>{{ .Threads }}
+                                                <td><a href="/imagebbs/board/{{ .Idimageboard }}">View</a>
                                                 <td>{{ if .Visible }}Yes{{ else }}No{{ end }}
                                                 <td>
                                                         <input type="hidden" name="bid" value="{{ .Idimageboard }}">
                                                         <input type="submit" name="task" value="Modify board">
-                                                        <input type="submit" name="task" value="Toggle NSFW">
                                                 </td>
                                         </form>
                                 </tr>

--- a/handlers/imagebbs/routes_admin.go
+++ b/handlers/imagebbs/routes_admin.go
@@ -13,6 +13,7 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	iar.HandleFunc("/boards", AdminBoardsPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 	iar.HandleFunc("/board", AdminNewBoardPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 	iar.HandleFunc("/board", handlers.TaskHandler(newBoardTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(newBoardTask.Matcher())
+	iar.HandleFunc("/board/{board}", AdminBoardPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 	iar.HandleFunc("/board/{board}", handlers.TaskHandler(modifyBoardTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(modifyBoardTask.Matcher())
 	iar.HandleFunc("/approve/{post}", handlers.TaskHandler(approvePostTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(approvePostTask.Matcher())
 	iar.HandleFunc("/files", AdminFilesPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))


### PR DESCRIPTION
## Summary
- allow editing a board from `/admin/imagebbs/board/{id}`
- link board IDs to their admin page
- add link to create new boards and view link
- remove non-working Toggle NSFW button

## Testing
- `go mod tidy`
- `gofmt -w handlers/imagebbs/imagebbsAdminBoardPage.go handlers/imagebbs/routes_admin.go`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68889c5b868c832fbedf9d424b25c68c