### PR TITLE
Enhance admin file browsing

### DIFF
--- a/core/templates/site/imagebbs/adminFilesPage.gohtml
+++ b/core/templates/site/imagebbs/adminFilesPage.gohtml
@@ -2,12 +2,13 @@
 <h2>Uploaded Files - {{ .Path }}</h2>
 {{ if .Parent }}<a href="/admin/imagebbs/files?path={{ .Parent }}">Parent</a><br>{{ end }}
 <table border="1">
-<tr><th>Name<th>Size<th>Type</tr>
+<tr><th>Name<th>Size<th>Type<th>User<th>Board<th>Posted<th>Preview</tr>
 {{ range .Entries }}
 <tr>
 <td>{{ if .IsDir }}<a href="/admin/imagebbs/files?path={{ .Path }}">{{ .Name }}/</a>{{ else }}{{ .Name }}{{ end }}</td>
 <td>{{ .Size }}</td>
 <td>{{ if .IsDir }}dir{{ else }}file{{ end }}</td>
+{{ if .IsDir }}<td colspan="4"></td>{{ else }}<td>{{ .Username }}</td><td>{{ .Board }}</td><td>{{ .Posted }}</td><td>{{ if .URL }}<a href="{{ .URL }}">view</a>{{ end }}</td>{{ end }}
 </tr>
 {{ end }}
 </table>

--- a/internal/db/queries-imagebbs.sql
+++ b/internal/db/queries-imagebbs.sql
@@ -196,3 +196,12 @@ UPDATE imagepost SET last_index = NOW() WHERE idimagepost = ?;
 -- name: GetAllImagePostsForIndex :many
 SELECT idimagepost, description FROM imagepost WHERE deleted_at IS NULL;
 
+-- name: GetImagePostInfoByPath :one
+SELECT i.idimagepost, i.imageboard_idimageboard, i.users_idusers, i.posted, u.username, b.title
+FROM imagepost i
+LEFT JOIN users u ON i.users_idusers = u.idusers
+LEFT JOIN imageboard b ON i.imageboard_idimageboard = b.idimageboard
+WHERE i.fullimage = ? OR i.thumbnail = ?
+LIMIT 1;
+
+

--- a/internal/db/queries-imagebbs.sql.go
+++ b/internal/db/queries-imagebbs.sql.go
@@ -594,6 +594,43 @@ func (q *Queries) GetImageBoardById(ctx context.Context, idimageboard int32) (*I
 	return &i, err
 }
 
+const getImagePostInfoByPath = `-- name: GetImagePostInfoByPath :one
+SELECT i.idimagepost, i.imageboard_idimageboard, i.users_idusers, i.posted, u.username, b.title
+FROM imagepost i
+LEFT JOIN users u ON i.users_idusers = u.idusers
+LEFT JOIN imageboard b ON i.imageboard_idimageboard = b.idimageboard
+WHERE i.fullimage = ? OR i.thumbnail = ?
+LIMIT 1
+`
+
+type GetImagePostInfoByPathParams struct {
+	Fullimage sql.NullString
+	Thumbnail sql.NullString
+}
+
+type GetImagePostInfoByPathRow struct {
+	Idimagepost            int32
+	ImageboardIdimageboard int32
+	UsersIdusers           int32
+	Posted                 sql.NullTime
+	Username               sql.NullString
+	Title                  sql.NullString
+}
+
+func (q *Queries) GetImagePostInfoByPath(ctx context.Context, arg GetImagePostInfoByPathParams) (*GetImagePostInfoByPathRow, error) {
+	row := q.db.QueryRowContext(ctx, getImagePostInfoByPath, arg.Fullimage, arg.Thumbnail)
+	var i GetImagePostInfoByPathRow
+	err := row.Scan(
+		&i.Idimagepost,
+		&i.ImageboardIdimageboard,
+		&i.UsersIdusers,
+		&i.Posted,
+		&i.Username,
+		&i.Title,
+	)
+	return &i, err
+}
+
 const getImagePostsByUserDescending = `-- name: GetImagePostsByUserDescending :many
 SELECT i.idimagepost, i.forumthread_id, i.users_idusers, i.imageboard_idimageboard, i.posted, i.description, i.thumbnail, i.fullimage, i.file_size, i.approved, i.deleted_at, i.last_index, u.username, th.comments
 FROM imagepost i

--- a/internal/images/sign_test.go
+++ b/internal/images/sign_test.go
@@ -1,7 +1,11 @@
 package images
 
 import (
+	"net/url"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/arran4/goa4web/config"
 )
@@ -11,5 +15,28 @@ func TestMapURLUploading(t *testing.T) {
 	got := signer.MapURL("img", "uploading:abc")
 	if got != "uploading:abc" {
 		t.Fatalf("expected placeholder unchanged, got %s", got)
+	}
+}
+
+func TestSignedURLTTL(t *testing.T) {
+	cfg := &config.RuntimeConfig{HTTPHostname: "http://example.com"}
+	signer := NewSigner(cfg, "k")
+	ttl := 2 * time.Hour
+	surl := signer.SignedURLTTL("img123.jpg", ttl)
+	if !strings.Contains(surl, "ts=") || !strings.Contains(surl, "sig=") {
+		t.Fatalf("missing signature params in %s", surl)
+	}
+	u, err := url.Parse(surl)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	ts := u.Query().Get("ts")
+	sig := u.Query().Get("sig")
+	if !signer.Verify("image:"+"img123.jpg", ts, sig) {
+		t.Fatalf("signature did not verify")
+	}
+	exp, _ := strconv.ParseInt(ts, 10, 64)
+	if exp < time.Now().Add(ttl-time.Minute).Unix() || exp > time.Now().Add(ttl+time.Minute).Unix() {
+		t.Fatalf("expiry not roughly ttl: %d", exp)
 	}
 }

--- a/specs/images.md
+++ b/specs/images.md
@@ -8,10 +8,11 @@ The signing key comes from the `IMAGE_SIGN_SECRET` setting (or the file referenc
 
 Functions in `pkg/images/sign.go` produce signed URLs:
 
-- `SignedURL` returns a URL for an uploaded image.
+- `SignedURL` returns a URL for an uploaded image using the default 24 hour expiration.
 - `SignedCacheURL` does the same for cache entries.
+- `SignedURLTTL` and `SignedCacheURLTTL` accept a custom `time.Duration` specifying how long the link should remain valid.
 
-Each helper appends `ts` and `sig` query parameters to the host configured in `HTTPHostname`. The signature uses HMAC‑SHA256 and expires after 24 hours.
+All helpers append `ts` and `sig` query parameters to the host configured in `HTTPHostname`. Signatures use HMAC‑SHA256 and expire after the supplied duration.
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- extend `images.Signer` with TTL-based signing helpers
- expose signed links in admin file browser
- show uploader, board and date for each image
- document new TTL signing options
- add SQL query and handler support for retrieving image info

## Testing
- `go vet ./...`
- `go mod tidy`
- `go test ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_68889ce7a7c0832fbd7ae4fb7d45e02e