### PR TITLE
Fix runTaskPage template error

### DIFF
--- a/handlers/admin/adminPageSizePage.go
+++ b/handlers/admin/adminPageSizePage.go
@@ -29,6 +29,7 @@ func AdminPageSizePage(w http.ResponseWriter, r *http.Request) {
 
 		data := struct {
 			*common.CoreData
+			Errors   []string
 			Messages []string
 			Back     string
 		}{

--- a/handlers/search/remakeBlogTask.go
+++ b/handlers/search/remakeBlogTask.go
@@ -24,6 +24,7 @@ func (RemakeBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := struct {
 		*common.CoreData
+		Errors   []string
 		Messages []string
 		Back     string
 	}{

--- a/handlers/search/remakeCommentsTask.go
+++ b/handlers/search/remakeCommentsTask.go
@@ -24,6 +24,7 @@ func (RemakeCommentsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := struct {
 		*common.CoreData
+		Errors   []string
 		Messages []string
 		Back     string
 	}{

--- a/handlers/search/remakeImageTask.go
+++ b/handlers/search/remakeImageTask.go
@@ -24,6 +24,7 @@ func (RemakeImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := struct {
 		*common.CoreData
+		Errors   []string
 		Messages []string
 		Back     string
 	}{

--- a/handlers/search/remakeLinkerTask.go
+++ b/handlers/search/remakeLinkerTask.go
@@ -24,6 +24,7 @@ func (RemakeLinkerTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := struct {
 		*common.CoreData
+		Errors   []string
 		Messages []string
 		Back     string
 	}{

--- a/handlers/search/remakeNewsTask.go
+++ b/handlers/search/remakeNewsTask.go
@@ -24,6 +24,7 @@ func (RemakeNewsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := struct {
 		*common.CoreData
+		Errors   []string
 		Messages []string
 		Back     string
 	}{

--- a/handlers/search/remakeWritingTask.go
+++ b/handlers/search/remakeWritingTask.go
@@ -24,6 +24,7 @@ func (RemakeWritingTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	data := struct {
 		*common.CoreData
+		Errors   []string
 		Messages []string
 		Back     string
 	}{


### PR DESCRIPTION
## Summary
- add missing Errors field to search rebuild tasks
- include Errors field in admin page size update feedback

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`
- `go mod tidy`

------
https://chatgpt.com/codex/tasks/task_e_68889cfe0348832fa56a4f060fc53a98