### PR TITLE
Add writing category admin page

### DIFF
--- a/core/templates/site/admin/siteAdminCategoriesPage.gohtml
+++ b/core/templates/site/admin/siteAdminCategoriesPage.gohtml
@@ -69,7 +69,7 @@
     <tr>
         <form method="post" action="/admin/writings/categories">
         {{ csrfField }}
-            <td><input type="hidden" name="wcid" value="{{ .Idwritingcategory }}"><a id="wc{{ .Idwritingcategory }}" href="/writings/category/{{ .Idwritingcategory }}">{{ .Idwritingcategory }}</a></td>
+            <td><input type="hidden" name="wcid" value="{{ .Idwritingcategory }}"><a id="wc{{ .Idwritingcategory }}" href="/admin/writings/category/{{ .Idwritingcategory }}">{{ .Idwritingcategory }}</a></td>
             <td>{{ $fcid := .WritingCategoryID }} <a href="#wc{{ $fcid }}">{{ $fcid }}</a> <select name="pcid" value="{{ .WritingCategoryID }}"><option value="0">None</option>{{ range $.WritingCategories }}<option value="{{.Idwritingcategory}}" {{if eq $fcid .Idwritingcategory}}selected{{end}}>{{.Title.String}}</option>{{ end }}</select></td>
             <td><input name="name" value="{{ .Title.String }}"></td>
             <td><textarea name="desc" rows="3" cols="60">{{ .Description.String }}</textarea></td>
@@ -77,6 +77,7 @@
                 <input type="hidden" name="cid" value="{{ .Idwritingcategory }}">
                 <input type="submit" name="task" value="writing category change">
                 <br><a href="/admin/writings/category/{{ .Idwritingcategory }}/permissions">Permissions</a>
+                <br><a href="/writings/category/{{ .Idwritingcategory }}">View</a>
             </td>
         </form>
     </tr>

--- a/core/templates/site/writings/writingsAdminCategoriesPage.gohtml
+++ b/core/templates/site/writings/writingsAdminCategoriesPage.gohtml
@@ -11,7 +11,7 @@
             <tr>
                 <form method="post" action="/admin/writings/categories">
         {{ csrfField }}
-                    <td><input type="hidden" name="wcid" value="{{ .Idwritingcategory }}"><a id="wc{{ .Idwritingcategory }}" href="/writings/category/{{ .Idwritingcategory }}">{{ .Idwritingcategory }}</a>
+                    <td><input type="hidden" name="wcid" value="{{ .Idwritingcategory }}"><a id="wc{{ .Idwritingcategory }}" href="/admin/writings/category/{{ .Idwritingcategory }}">{{ .Idwritingcategory }}</a>
                     <td>{{ $fcid := .WritingCategoryID }} <a href="#wc{{ $fcid }}">{{ $fcid }}</a> <select name="pcid" value="{{ .WritingCategoryID }}"><option value="0">None</option>{{ range $.Categories }}<option value="{{.Idwritingcategory}}" {{if eq $fcid .Idwritingcategory}}selected{{end}}>{{.Title.String}}</option>  {{ end }}</select>
                     <td><input name="name" value="{{ .Title.String }}">
                     <td><textarea name="desc">{{ .Description.String }}</textarea>
@@ -19,6 +19,7 @@
                         <input type="hidden" name="cid" value="{{ .Idwritingcategory }}">
                         <input type="submit" name="task" value="writing category change">
                         <br><a href="/admin/writings/category/{{ .Idwritingcategory }}/permissions">Permissions</a>
+                        <br><a href="/writings/category/{{ .Idwritingcategory }}">View</a>
                     </td>
                 </form>
             </tr>

--- a/core/templates/site/writings/writingsAdminCategoryPage.gohtml
+++ b/core/templates/site/writings/writingsAdminCategoryPage.gohtml
@@ -1,0 +1,30 @@
+{{ template "head" $ }}
+<form method="post" action="/admin/writings/categories">
+    {{ csrfField }}
+    <input type="hidden" name="cid" value="{{ .Category.Idwritingcategory }}">
+    <table border="1">
+        <tr><th>ID</th><td>{{ .Category.Idwritingcategory }}</td></tr>
+        <tr>
+            <th>Parent ID</th>
+            <td>{{ $pid := .Category.WritingCategoryID }}
+                <a href="/admin/writings/category/{{ $pid }}">{{ $pid }}</a>
+                <select name="pcid" value="{{ $pid }}">
+                    <option value="0">None</option>
+                    {{- range .Categories }}
+                        <option value="{{ .Idwritingcategory }}" {{ if eq $pid .Idwritingcategory }}selected{{ end }}>{{ .Title.String }}</option>
+                    {{- end }}
+                </select>
+            </td>
+        </tr>
+        <tr><th>Title</th><td><input name="name" value="{{ .Category.Title.String }}"></td></tr>
+        <tr><th>Description</th><td><textarea name="desc">{{ .Category.Description.String }}</textarea></td></tr>
+        <tr>
+            <td colspan="2">
+                <input type="submit" name="task" value="writing category change">
+                <a href="/admin/writings/category/{{ .Category.Idwritingcategory }}/permissions">Permissions</a>
+                <a href="/writings/category/{{ .Category.Idwritingcategory }}">View</a>
+            </td>
+        </tr>
+    </table>
+</form>
+{{ template "tail" $ }}

--- a/handlers/writings/routes_admin.go
+++ b/handlers/writings/routes_admin.go
@@ -15,6 +15,7 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	war.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")
 	war.HandleFunc("/categories", handlers.TaskHandler(writingCategoryChangeTask)).Methods("POST").MatcherFunc(writingCategoryChangeTask.Matcher())
 	war.HandleFunc("/categories", handlers.TaskHandler(writingCategoryCreateTask)).Methods("POST").MatcherFunc(writingCategoryCreateTask.Matcher())
+	war.HandleFunc("/category/{category}", AdminCategoryPage).Methods("GET")
 	war.HandleFunc("/category/{category}/permissions", AdminCategoryGrantsPage).Methods("GET")
 	war.HandleFunc("/category/{category}/permission", handlers.TaskHandler(writingCategoryGrantCreateTask)).Methods("POST").MatcherFunc(writingCategoryGrantCreateTask.Matcher())
 	war.HandleFunc("/category/{category}/permission/delete", handlers.TaskHandler(writingCategoryGrantDeleteTask)).Methods("POST").MatcherFunc(writingCategoryGrantDeleteTask.Matcher())

--- a/handlers/writings/writingsAdminCategoryPage.go
+++ b/handlers/writings/writingsAdminCategoryPage.go
@@ -1,0 +1,46 @@
+package writings
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/gorilla/mux"
+)
+
+func AdminCategoryPage(w http.ResponseWriter, r *http.Request) {
+	type Data struct {
+		*common.CoreData
+		Category   *db.WritingCategory
+		Categories []*db.WritingCategory
+	}
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	cid, err := strconv.Atoi(mux.Vars(r)["category"])
+	if err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+	cat, err := queries.GetWritingCategory(r.Context(), int32(cid))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, "Not Found", http.StatusNotFound)
+		} else {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+		return
+	}
+	cats, err := cd.WritingCategories()
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	cd.PageTitle = "Writing Category"
+	data := Data{CoreData: cd, Category: cat, Categories: cats}
+	handlers.TemplateHandler(w, r, "writingsAdminCategoryPage.gohtml", data)
+}

--- a/handlers/writings/writingsAdminCategoryPage_test.go
+++ b/handlers/writings/writingsAdminCategoryPage_test.go
@@ -1,0 +1,51 @@
+package writings
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/gorilla/mux"
+)
+
+func TestWritingsAdminCategoryPage(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	queries := db.New(sqlDB)
+
+	rowsCat := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
+		AddRow(1, 0, "a", "b")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idwritingcategory, writing_category_id, title, description FROM writing_category WHERE idwritingcategory = ?")).WithArgs(1).WillReturnRows(rowsCat)
+
+	rowsAll := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
+		AddRow(1, 0, "a", "b")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT wc.idwritingcategory, wc.writing_category_id, wc.title, wc.description\nFROM writing_category wc")).WillReturnRows(rowsAll)
+
+	req := httptest.NewRequest("GET", "/admin/writings/category/1", nil)
+	ctx := req.Context()
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	req = mux.SetURLVars(req, map[string]string{"category": "1"})
+	rr := httptest.NewRecorder()
+
+	AdminCategoryPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+}

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -150,6 +150,9 @@ UPDATE writing_category
 SET title = ?, description = ?, writing_category_id = ?
 WHERE idwritingCategory = ?;
 
+-- name: GetWritingCategory :one
+SELECT * FROM writing_category WHERE idwritingcategory = ?;
+
 -- name: GetAllWritingCategories :many
 SELECT *
 FROM writing_category

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -731,6 +731,22 @@ func (q *Queries) GetWritingByIdForUserDescendingByPublishedDate(ctx context.Con
 	return &i, err
 }
 
+const getWritingCategory = `-- name: GetWritingCategory :one
+SELECT idwritingcategory, writing_category_id, title, description FROM writing_category WHERE idwritingcategory = ?
+`
+
+func (q *Queries) GetWritingCategory(ctx context.Context, idwritingcategory int32) (*WritingCategory, error) {
+	row := q.db.QueryRowContext(ctx, getWritingCategory, idwritingcategory)
+	var i WritingCategory
+	err := row.Scan(
+		&i.Idwritingcategory,
+		&i.WritingCategoryID,
+		&i.Title,
+		&i.Description,
+	)
+	return &i, err
+}
+
 const getWritingsByIdsForUserDescendingByPublishedDate = `-- name: GetWritingsByIdsForUserDescendingByPublishedDate :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?


### PR DESCRIPTION
## Summary
- add GetWritingCategory query and generate code
- add AdminCategoryPage handler and template
- add GET route for single category admin page
- link ID column to admin page and add public view link
- test AdminCategoryPage

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68889dbc8900832fbbacd31e76e9d1c3