### PR TITLE
Improve DLQ file/dir error feedback

### DIFF
--- a/core/templates/site/admin/dlqPage.gohtml
+++ b/core/templates/site/admin/dlqPage.gohtml
@@ -11,6 +11,9 @@ Configured providers: {{ .Providers }}<br />
 {{- end }}
 </table>
 {{- end }}
+{{- if .FileErr }}
+<p>Error reading file DLQ: {{ .FileErr }}</p>
+{{- end }}
 
 {{- if .DirErrors }}
 <h2>Directory DLQ</h2>
@@ -20,6 +23,9 @@ Configured providers: {{ .Providers }}<br />
 <tr><td>{{ .Name }}</td><td>{{ .Message }}</td></tr>
 {{- end }}
 </table>
+{{- end }}
+{{- if .DirErr }}
+<p>Error reading directory DLQ: {{ .DirErr }}</p>
 {{- end }}
 
 {{- if .Errors }}

--- a/handlers/admin/adminDLQPage.go
+++ b/handlers/admin/adminDLQPage.go
@@ -36,7 +36,9 @@ func AdminDLQPage(w http.ResponseWriter, r *http.Request) {
 		*common.CoreData
 		Errors     []*db.DeadLetter
 		FileErrors []filedlq.Record
+		FileErr    string
 		DirErrors  []dirdlq.Record
+		DirErr     string
 		Providers  string
 	}{
 		CoreData:  cd,
@@ -61,12 +63,14 @@ func AdminDLQPage(w http.ResponseWriter, r *http.Request) {
 				data.FileErrors = recs
 			} else {
 				log.Printf("read dlq file: %v", err)
+				data.FileErr = err.Error()
 			}
 		case "dir":
 			if recs, err := dirdlq.List(cd.Config.DLQFile, 100); err == nil {
 				data.DirErrors = recs
 			} else {
 				log.Printf("read dlq dir: %v", err)
+				data.DirErr = err.Error()
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- show error details on the DLQ admin page when file or directory providers fail

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68889e34cd48832fa04075cf6aeb423a