### PR TITLE
Add disk and memory stats to admin page

### DIFF
--- a/core/templates/site/admin/serverStatsPage.gohtml
+++ b/core/templates/site/admin/serverStatsPage.gohtml
@@ -9,6 +9,10 @@
     <tr><td>Heap Alloc</td><td>{{ .Stats.HeapAlloc }}</td></tr>
     <tr><td>Heap Sys</td><td>{{ .Stats.HeapSys }}</td></tr>
     <tr><td>GC Count</td><td>{{ .Stats.NumGC }}</td></tr>
+    <tr><td>CPU Cores</td><td>{{ .Stats.NumCPU }}</td></tr>
+    <tr><td>Architecture</td><td>{{ .Stats.Arch }}</td></tr>
+    <tr><td>Disk Free</td><td>{{ .Stats.DiskFree }}</td></tr>
+    <tr><td>RAM Free</td><td>{{ .Stats.RAMFree }}</td></tr>
 </table>
 <p>Uptime: {{ .Uptime }}</p>
 <h3>Registered Components</h3>

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/jedib0t/go-pretty/v6 v6.6.7
 	golang.org/x/image v0.29.0
+	golang.org/x/sys v0.34.0
 )
 
 require (
@@ -37,7 +38,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/sendgrid/rest v2.6.9+incompatible // indirect
-	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )


### PR DESCRIPTION
## Summary
- expose disk free, ram free and CPU details on the `/admin/stats` page
- add `golang.org/x/sys` as a dependency

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68889e6cb1a4832fa55bff6da32323a9