### PR TITLE
Fix user edit template rendering

### DIFF
--- a/handlers/user/admin_users.go
+++ b/handlers/user/admin_users.go
@@ -174,13 +174,12 @@ func adminUserEditFormPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	user := &db.User{Idusers: urow.Idusers, Username: urow.Username}
 	data := struct {
 		*common.CoreData
-		User *db.User
+		User *db.GetUserByIdRow
 	}{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		User:     user,
+		User:     urow,
 	}
 	handlers.TemplateHandler(w, r, "userEditPage.gohtml", data)
 }


### PR DESCRIPTION
## Summary
- fix admin user edit page crash by passing GetUserByIdRow to the template

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68889f25332c832f935b99766f99eb10