### PR TITLE
Fix Add Permission Form

### DIFF
--- a/core/templates/site/admin/userPermissionsPage.gohtml
+++ b/core/templates/site/admin/userPermissionsPage.gohtml
@@ -21,7 +21,7 @@
     </tbody>
 </table>
 <h3>Add Permission</h3>
-<form id="add-permission-form">
+<form id="add-permission-form" action="/admin/user/{{.User.Idusers}}/permissions" method="POST">
     <input type="hidden" name="username" value="{{.User.Username.String}}">
     Role:
     <select name="role">


### PR DESCRIPTION
## Summary
- send Add Permission form data via POST even without JavaScript

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68889f3f0780832faca8aa9845864b76