### PR TITLE
Fix websocket script path

### DIFF
--- a/internal/websocket/notifications.go
+++ b/internal/websocket/notifications.go
@@ -205,7 +205,7 @@ func (h *NotificationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 func (m *Module) registerRoutes(r *mux.Router, cfg *config.RuntimeConfig, _ *navigation.Registry) {
 	h := NewNotificationsHandler(m.Bus, cfg)
 	r.Handle("/ws/notifications", h).Methods(http.MethodGet)
-	r.HandleFunc("/notifications.js", NotificationsJS).Methods(http.MethodGet)
+	r.HandleFunc("/websocket/notifications.js", NotificationsJS).Methods(http.MethodGet)
 }
 
 // Register registers the websocket router module.


### PR DESCRIPTION
## Summary
- serve notifications.js under `/websocket/` to match templates
- test route for notifications.js

## Testing
- `go test ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_6888a0310538832fb958125fe9d56085