### PR TITLE
Fix admin category links

### DIFF
--- a/core/templates/site/writings/writingsAdminCategoriesPage.gohtml
+++ b/core/templates/site/writings/writingsAdminCategoriesPage.gohtml
@@ -11,7 +11,7 @@
             <tr>
                 <form method="post" action="/admin/writings/categories">
         {{ csrfField }}
-                    <td><input type="hidden" name="wcid" value="{{ .Idwritingcategory }}"><a id="wc{{ .Idwritingcategory }}" href="/writings/category/{{ .Idwritingcategory }}">{{ .Idwritingcategory }}</a>
+                    <td><input type="hidden" name="wcid" value="{{ .Idwritingcategory }}"><a id="wc{{ .Idwritingcategory }}" href="/admin/writings/category/{{ .Idwritingcategory }}">{{ .Idwritingcategory }}</a>
                     <td>{{ $fcid := .WritingCategoryID }} <a href="#wc{{ $fcid }}">{{ $fcid }}</a> <select name="pcid" value="{{ .WritingCategoryID }}"><option value="0">None</option>{{ range $.Categories }}<option value="{{.Idwritingcategory}}" {{if eq $fcid .Idwritingcategory}}selected{{end}}>{{.Title.String}}</option>  {{ end }}</select>
                     <td><input name="name" value="{{ .Title.String }}">
                     <td><textarea name="desc">{{ .Description.String }}</textarea>
@@ -19,6 +19,7 @@
                         <input type="hidden" name="cid" value="{{ .Idwritingcategory }}">
                         <input type="submit" name="task" value="writing category change">
                         <br><a href="/admin/writings/category/{{ .Idwritingcategory }}/permissions">Permissions</a>
+                        <br><a href="/writings/category/{{ .Idwritingcategory }}">View</a>
                     </td>
                 </form>
             </tr>

--- a/handlers/writings/writing_category_change_task.go
+++ b/handlers/writings/writing_category_change_task.go
@@ -37,7 +37,7 @@ func (WritingCategoryChangeTask) Action(w http.ResponseWriter, r *http.Request) 
 	if loop, err := writingCategoryWouldLoop(r.Context(), queries, int32(cid), int32(parentID)); err != nil {
 		return fmt.Errorf("check writing category loop %w", handlers.ErrRedirectOnSamePageHandler(err))
 	} else if loop {
-		return common.UserError{ErrorMessage: "invalid parent category"}
+		return common.UserError{ErrorMessage: "invalid parent category: loop detected"}
 	}
 
 	if err := queries.UpdateWritingCategory(r.Context(), db.UpdateWritingCategoryParams{

--- a/handlers/writings/writing_category_change_task_test.go
+++ b/handlers/writings/writing_category_change_task_test.go
@@ -158,7 +158,7 @@ func TestWritingCategoryChangeTaskLoop(t *testing.T) {
 		t.Fatalf("expected error")
 	} else if ue, ok := v.(common.UserError); !ok {
 		t.Fatalf("expected user error got %T", v)
-	} else if ue.UserErrorMessage() != "invalid parent category" {
+	} else if ue.UserErrorMessage() != "invalid parent category: loop detected" {
 		t.Fatalf("unexpected error message %q", ue.UserErrorMessage())
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
## Summary
- update writing category admin page links
- show view links for categories
- improve loop detection user message
- update tests

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6888b64c52f4832fac81dadb112d4644