### PR TITLE
Use error page when resetting missing user

### DIFF
--- a/handlers/admin/adminUserPasswordReset.go
+++ b/handlers/admin/adminUserPasswordReset.go
@@ -111,7 +111,7 @@ func adminUserResetPasswordConfirmPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	userRow, err := queries.GetUserById(r.Context(), int32(id))
 	if err != nil {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	data := struct {


### PR DESCRIPTION
## Summary
- use `RenderErrorPage` for admin user password reset confirmation

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6888acfb0824832f8df100d5dd1858a0