### PR TITLE
Fix missing forum reply and see grants

### DIFF
--- a/migrations/0039.mysql.sql
+++ b/migrations/0039.mysql.sql
@@ -17,6 +17,31 @@ FROM user_topic_permissions utp
 WHERE utp.role_id = 4
 ON DUPLICATE KEY UPDATE action=VALUES(action);
 
+-- Convert topic permissions to grants
+INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
+SELECT NOW(), tp.see_role_id, 'forum', 'topic', 'allow', tp.forumtopic_idforumtopic, 'see', 1
+FROM topic_permissions tp
+WHERE tp.see_role_id IS NOT NULL
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
+SELECT NOW(), tp.view_role_id, 'forum', 'topic', 'allow', tp.forumtopic_idforumtopic, 'view', 1
+FROM topic_permissions tp
+WHERE tp.view_role_id IS NOT NULL
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
+SELECT NOW(), tp.reply_role_id, 'forum', 'topic', 'allow', tp.forumtopic_idforumtopic, 'reply', 1
+FROM topic_permissions tp
+WHERE tp.reply_role_id IS NOT NULL
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
+SELECT NOW(), tp.newthread_role_id, 'forum', 'topic', 'allow', tp.forumtopic_idforumtopic, 'post', 1
+FROM topic_permissions tp
+WHERE tp.newthread_role_id IS NOT NULL
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
 -- Default grants for public topics
 INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
 SELECT NOW(), r.id, 'forum', 'topic', 'allow', t.idforumtopic, 'see', 1
@@ -38,7 +63,7 @@ INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, acti
 SELECT NOW(), r.id, 'forum', 'topic', 'allow', t.idforumtopic, 'reply', 1
 FROM forumtopic t
 CROSS JOIN roles r
-WHERE r.name = 'user'
+WHERE r.name IN ('user','content writer','moderator','administrator')
   AND NOT EXISTS (SELECT 1 FROM topic_permissions tp WHERE tp.forumtopic_idforumtopic = t.idforumtopic)
 ON DUPLICATE KEY UPDATE action=VALUES(action);
 
@@ -46,7 +71,7 @@ INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, acti
 SELECT NOW(), r.id, 'forum', 'topic', 'allow', t.idforumtopic, 'post', 1
 FROM forumtopic t
 CROSS JOIN roles r
-WHERE r.name = 'user'
+WHERE r.name IN ('user','content writer','moderator','administrator')
   AND NOT EXISTS (SELECT 1 FROM topic_permissions tp WHERE tp.forumtopic_idforumtopic = t.idforumtopic)
 ON DUPLICATE KEY UPDATE action=VALUES(action);
 

--- a/migrations/0039.postgres.sql
+++ b/migrations/0039.postgres.sql
@@ -17,6 +17,31 @@ FROM user_topic_permissions utp
 WHERE utp.role_id = 4
 ON DUPLICATE KEY UPDATE action=VALUES(action);
 
+-- Convert topic permissions to grants
+INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
+SELECT NOW(), tp.see_role_id, 'forum', 'topic', 'allow', tp.forumtopic_idforumtopic, 'see', 1
+FROM topic_permissions tp
+WHERE tp.see_role_id IS NOT NULL
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
+SELECT NOW(), tp.view_role_id, 'forum', 'topic', 'allow', tp.forumtopic_idforumtopic, 'view', 1
+FROM topic_permissions tp
+WHERE tp.view_role_id IS NOT NULL
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
+SELECT NOW(), tp.reply_role_id, 'forum', 'topic', 'allow', tp.forumtopic_idforumtopic, 'reply', 1
+FROM topic_permissions tp
+WHERE tp.reply_role_id IS NOT NULL
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
+SELECT NOW(), tp.newthread_role_id, 'forum', 'topic', 'allow', tp.forumtopic_idforumtopic, 'post', 1
+FROM topic_permissions tp
+WHERE tp.newthread_role_id IS NOT NULL
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
 -- Default grants for public topics
 INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
 SELECT NOW(), r.id, 'forum', 'topic', 'allow', t.idforumtopic, 'see', 1
@@ -38,7 +63,7 @@ INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, acti
 SELECT NOW(), r.id, 'forum', 'topic', 'allow', t.idforumtopic, 'reply', 1
 FROM forumtopic t
 CROSS JOIN roles r
-WHERE r.name = 'user'
+WHERE r.name IN ('user','content writer','moderator','administrator')
   AND NOT EXISTS (SELECT 1 FROM topic_permissions tp WHERE tp.forumtopic_idforumtopic = t.idforumtopic)
 ON DUPLICATE KEY UPDATE action=VALUES(action);
 
@@ -46,7 +71,7 @@ INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, acti
 SELECT NOW(), r.id, 'forum', 'topic', 'allow', t.idforumtopic, 'post', 1
 FROM forumtopic t
 CROSS JOIN roles r
-WHERE r.name = 'user'
+WHERE r.name IN ('user','content writer','moderator','administrator')
   AND NOT EXISTS (SELECT 1 FROM topic_permissions tp WHERE tp.forumtopic_idforumtopic = t.idforumtopic)
 ON DUPLICATE KEY UPDATE action=VALUES(action);
 

--- a/migrations/0039.sqlite.sql
+++ b/migrations/0039.sqlite.sql
@@ -17,6 +17,31 @@ FROM user_topic_permissions utp
 WHERE utp.role_id = 4
 ON DUPLICATE KEY UPDATE action=VALUES(action);
 
+-- Convert topic permissions to grants
+INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
+SELECT NOW(), tp.see_role_id, 'forum', 'topic', 'allow', tp.forumtopic_idforumtopic, 'see', 1
+FROM topic_permissions tp
+WHERE tp.see_role_id IS NOT NULL
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
+SELECT NOW(), tp.view_role_id, 'forum', 'topic', 'allow', tp.forumtopic_idforumtopic, 'view', 1
+FROM topic_permissions tp
+WHERE tp.view_role_id IS NOT NULL
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
+SELECT NOW(), tp.reply_role_id, 'forum', 'topic', 'allow', tp.forumtopic_idforumtopic, 'reply', 1
+FROM topic_permissions tp
+WHERE tp.reply_role_id IS NOT NULL
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
+SELECT NOW(), tp.newthread_role_id, 'forum', 'topic', 'allow', tp.forumtopic_idforumtopic, 'post', 1
+FROM topic_permissions tp
+WHERE tp.newthread_role_id IS NOT NULL
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
 -- Default grants for public topics
 INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, action, active)
 SELECT NOW(), r.id, 'forum', 'topic', 'allow', t.idforumtopic, 'see', 1
@@ -38,7 +63,7 @@ INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, acti
 SELECT NOW(), r.id, 'forum', 'topic', 'allow', t.idforumtopic, 'reply', 1
 FROM forumtopic t
 CROSS JOIN roles r
-WHERE r.name = 'user'
+WHERE r.name IN ('user','content writer','moderator','administrator')
   AND NOT EXISTS (SELECT 1 FROM topic_permissions tp WHERE tp.forumtopic_idforumtopic = t.idforumtopic)
 ON DUPLICATE KEY UPDATE action=VALUES(action);
 
@@ -46,7 +71,7 @@ INSERT INTO grants (created_at, role_id, section, item, rule_type, item_id, acti
 SELECT NOW(), r.id, 'forum', 'topic', 'allow', t.idforumtopic, 'post', 1
 FROM forumtopic t
 CROSS JOIN roles r
-WHERE r.name = 'user'
+WHERE r.name IN ('user','content writer','moderator','administrator')
   AND NOT EXISTS (SELECT 1 FROM topic_permissions tp WHERE tp.forumtopic_idforumtopic = t.idforumtopic)
 ON DUPLICATE KEY UPDATE action=VALUES(action);
 


### PR DESCRIPTION
## Summary
- fix migration step to correctly backfill forum topic grants
- remove unused migration and reset schema expectation

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6888cdb329e4832fa6cf3a72bf345765