### PR TITLE
Add permission check for FAQ ask page

### DIFF
--- a/handlers/faq/faqIndexPermissions_test.go
+++ b/handlers/faq/faqIndexPermissions_test.go
@@ -1,0 +1,62 @@
+package faq
+
+import (
+	"database/sql"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+func TestCustomFAQIndexAsk(t *testing.T) {
+	req := httptest.NewRequest("GET", "/faq", nil)
+
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+	q := dbpkg.New(sqldb)
+	ctx := req.Context()
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+
+	mock.ExpectQuery("SELECT 1 FROM grants").
+		WithArgs(sqlmock.AnyArg(), "faq", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	CustomFAQIndex(cd, req.WithContext(ctx))
+	if !common.ContainsItem(cd.CustomIndexItems, "Ask") {
+		t.Errorf("expected ask item")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestCustomFAQIndexAskDenied(t *testing.T) {
+	req := httptest.NewRequest("GET", "/faq", nil)
+
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqldb.Close()
+	q := dbpkg.New(sqldb)
+	ctx := req.Context()
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+
+	mock.ExpectQuery("SELECT 1 FROM grants").
+		WithArgs(sqlmock.AnyArg(), "faq", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnError(sql.ErrNoRows)
+
+	CustomFAQIndex(cd, req.WithContext(ctx))
+	if common.ContainsItem(cd.CustomIndexItems, "Ask") {
+		t.Errorf("unexpected ask item")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/handlers/faq/page.go
+++ b/handlers/faq/page.go
@@ -69,10 +69,12 @@ func Page(w http.ResponseWriter, r *http.Request) {
 func CustomFAQIndex(data *common.CoreData, r *http.Request) {
 	userHasAdmin := data.HasRole("administrator") && data.AdminMode
 	data.CustomIndexItems = []common.IndexItem{}
-	data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
-		Name: "Ask",
-		Link: "/faq/ask",
-	})
+	if data.HasGrant("faq", "question", "post", 0) {
+		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
+			Name: "Ask",
+			Link: "/faq/ask",
+		})
+	}
 	if userHasAdmin {
 		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
 			Name: "Question Qontrols",

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -155,6 +155,10 @@ Many queries now filter results directly in SQL using `viewer_id` together with 
 | `blogs` | `entry` | `post` | `viewer_id` | viewer role ID | grant requiring both user and role |
 | `blogs` | `entry` | `post` | `NULL` | viewer role ID | role-based grant |
 | `blogs` | `entry` | `post` | `NULL` | `NULL` | public grant for everyone |
+| `faq` | `question` | `post` | `viewer_id` | `NULL` | grant specific to that user |
+| `faq` | `question` | `post` | `viewer_id` | viewer role ID | grant requiring both user and role |
+| `faq` | `question` | `post` | `NULL` | viewer role ID | role-based grant |
+| `faq` | `question` | `post` | `NULL` | `NULL` | public grant for everyone |
 | `writing` | `article` | `see` or `view` | `viewer_id` | `NULL` | grant specific to that user |
 | `writing` | `article` | `see` or `view` | `viewer_id` | viewer role ID | grant requiring both user and role |
 | `writing` | `article` | `see` or `view` | `NULL` | viewer role ID | role-based grant |


### PR DESCRIPTION
## Summary
- require `faq` `question` `post` grant in ask handler
- hide Ask link unless user has appropriate grant
- document FAQ posting grants in permissions spec
- add tests for new grant behaviour

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68899bb96180832f9db3fe6cf40c07dc