### PR TITLE
Fix websocket upgrade when task middleware used

### DIFF
--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -1,8 +1,11 @@
 package middleware
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -21,6 +24,14 @@ import (
 type statusRecorder struct {
 	http.ResponseWriter
 	status int
+}
+
+// Hijack delegates to the underlying ResponseWriter when available.
+func (r *statusRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := r.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, fmt.Errorf("underlying ResponseWriter does not implement http.Hijacker")
 }
 
 // maxQueuedTaskEvents limits the number of task events stored while the event


### PR DESCRIPTION
## Summary
- ensure middleware statusRecorder implements http.Hijacker
- run `go fmt`, `go vet`, `golangci-lint`, `go test ./...`

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68899ef693cc832fa44fb7a01c286a92