### PR TITLE
Improve DLQ admin page

### DIFF
--- a/core/templates/site/admin/dlqPage.gohtml
+++ b/core/templates/site/admin/dlqPage.gohtml
@@ -1,6 +1,9 @@
 {{ template "head" $ }}
 [<a href="/admin">Admin:</a> <a href="/admin/dlq">(This page/Refresh)</a>]<br />
 Configured providers: {{ .Providers }}<br />
+{{- if .FilePath }}File: {{ .FilePath }} ({{ .FileSize }} bytes{{- if .FileMod }}, updated {{ .FileMod }}{{- end }})<br />{{- end }}
+{{- if .DirPath }}Directory: {{ .DirPath }} ({{ .DirCount }} files{{- if .DirMod }}, updated {{ .DirMod }}{{- end }})<br />{{- end }}
+{{- if .DBCount }}Database entries: {{ .DBCount }}{{- if .DBLatest }} (latest {{ .DBLatest }}){{- end }}<br />{{- end }}
 
 {{- if .FileErrors }}
 <h2>File DLQ</h2>
@@ -10,6 +13,14 @@ Configured providers: {{ .Providers }}<br />
 <tr><td>{{ .Time }}</td><td>{{ .Message }}</td></tr>
 {{- end }}
 </table>
+{{- end }}
+{{- if .FileTail }}
+<h3>File Tail</h3>
+<pre>
+{{- range .FileTail }}
+{{ . }}
+{{- end }}
+</pre>
 {{- end }}
 {{- if .FileErr }}
 <p>Error reading file DLQ: {{ .FileErr }}</p>

--- a/internal/db/queries-dlq.sql
+++ b/internal/db/queries-dlq.sql
@@ -14,3 +14,6 @@ DELETE FROM dead_letters WHERE created_at < ?;
 
 -- name: CountDeadLetters :one
 SELECT COUNT(*) FROM dead_letters;
+
+-- name: LatestDeadLetter :one
+SELECT MAX(created_at) FROM dead_letters;

--- a/internal/db/queries-dlq.sql.go
+++ b/internal/db/queries-dlq.sql.go
@@ -39,6 +39,17 @@ func (q *Queries) InsertDeadLetter(ctx context.Context, message string) error {
 	return err
 }
 
+const latestDeadLetter = `-- name: LatestDeadLetter :one
+SELECT MAX(created_at) FROM dead_letters
+`
+
+func (q *Queries) LatestDeadLetter(ctx context.Context) (interface{}, error) {
+	row := q.db.QueryRowContext(ctx, latestDeadLetter)
+	var max interface{}
+	err := row.Scan(&max)
+	return max, err
+}
+
 const listDeadLetters = `-- name: ListDeadLetters :many
 SELECT id, message, created_at FROM dead_letters
 ORDER BY id DESC

--- a/internal/dlq/file/tail.go
+++ b/internal/dlq/file/tail.go
@@ -1,0 +1,22 @@
+package file
+
+import (
+	"os"
+	"strings"
+)
+
+// Tail returns the last n lines of the file at path.
+func Tail(path string, n int) ([]string, error) {
+	if n <= 0 {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if n < len(lines) {
+		lines = lines[len(lines)-n:]
+	}
+	return lines, nil
+}


### PR DESCRIPTION
## Summary
- extend DLQ admin page with file tail section
- display path, size and counts
- show last updated times for file, directory and database

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68899f8a91b4832f928f2e1b68d187bb