### PR TITLE
Require password confirmation during reset verification

### DIFF
--- a/core/templates/site/passwordVerifyPage.gohtml
+++ b/core/templates/site/passwordVerifyPage.gohtml
@@ -2,7 +2,8 @@
 <form method="post" action="/login/verify">
     {{ csrfField }}
     <input type="hidden" name="id" value="{{ .ID }}">
-    Code: <input name="code">
+    Code: <input name="code"><br>
+    New Password: <input name="password" type="password"><br>
     <input type="submit" name="task" value="Password Verify">
 </form>
 {{ template "tail" $ }}

--- a/handlers/auth/verify_password_task_test.go
+++ b/handlers/auth/verify_password_task_test.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	dbpkg "github.com/arran4/goa4web/internal/db"
+)
+
+func TestVerifyPasswordAction_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := dbpkg.New(db)
+
+	pwHash, alg, _ := HashPassword("pw")
+	rows := sqlmock.NewRows([]string{"id", "user_id", "passwd", "passwd_algorithm", "verification_code", "created_at", "verified_at"}).
+		AddRow(1, 1, pwHash, alg, "code", time.Now(), nil)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, passwd")).WithArgs("code", sqlmock.AnyArg()).WillReturnRows(rows)
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE pending_passwords SET verified_at = NOW() WHERE id = ?")).WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO passwords (users_idusers, passwd, passwd_algorithm) VALUES (?, ?, ?)")).
+		WithArgs(int32(1), pwHash, sql.NullString{String: alg, Valid: true}).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
+	form := url.Values{"id": {"1"}, "code": {"code"}, "password": {"pw"}}
+	req := httptest.NewRequest(http.MethodPost, "/login/verify", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handlers.TaskHandler(verifyPasswordTask)(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestVerifyPasswordAction_InvalidPassword(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := dbpkg.New(db)
+
+	pwHash, alg, _ := HashPassword("pw")
+	rows := sqlmock.NewRows([]string{"id", "user_id", "passwd", "passwd_algorithm", "verification_code", "created_at", "verified_at"}).
+		AddRow(1, 1, pwHash, alg, "code", time.Now(), nil)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, passwd")).WithArgs("code", sqlmock.AnyArg()).WillReturnRows(rows)
+
+	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
+	form := url.Values{"id": {"1"}, "code": {"code"}, "password": {"wrong"}}
+	req := httptest.NewRequest(http.MethodPost, "/login/verify", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handlers.TaskHandler(verifyPasswordTask)(rr, req)
+
+	if rr.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- require the new password to be provided on the verification page
- verify the provided password when activating a reset
- test password verification behavior

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6889b0b89dc0832faaf7a1212239a0b8