### PR TITLE
Add admin news management

### DIFF
--- a/core/templates/site/news/adminNewsDeleteConfirmPage.gohtml
+++ b/core/templates/site/news/adminNewsDeleteConfirmPage.gohtml
@@ -1,0 +1,9 @@
+{{ template "head" $ }}
+<p>Are you sure you want to delete news post {{ .PostID }}?</p>
+<form method="post">
+    {{ csrfField }}
+    <input type="hidden" name="task" value="Delete">
+    <input type="submit" value="{{ .ConfirmLabel }}">
+</form>
+<a href="{{ .Back }}">Cancel</a>
+{{ template "tail" $ }}

--- a/core/templates/site/news/adminNewsEditPage.gohtml
+++ b/core/templates/site/news/adminNewsEditPage.gohtml
@@ -1,0 +1,10 @@
+{{ template "head" $ }}
+<form method="post">
+    {{ csrfField }}
+    <input type="hidden" name="task" value="Edit">
+    <textarea name="text" cols=40 rows=20>{{ .Post.News.String }}</textarea><br>
+    {{ template "languageCombobox" $ }}
+    <input type="submit" value="Save">
+</form>
+<p><a href="/admin/news/{{ .Post.Idsitenews }}">Cancel</a></p>
+{{ template "tail" $ }}

--- a/core/templates/site/news/adminNewsListPage.gohtml
+++ b/core/templates/site/news/adminNewsListPage.gohtml
@@ -1,0 +1,14 @@
+{{ template "head" $ }}
+<table border="1">
+    <tr><th>ID<th>Date<th>Writer<th>Comments<th>View</tr>
+    {{ range .Posts }}
+        <tr>
+            <td><a href="/admin/news/{{ .Idsitenews }}">{{ .Idsitenews }}</a></td>
+            <td><a href="/admin/news/{{ .Idsitenews }}">{{ .Occurred.Time }}</a></td>
+            <td>{{ if .Writerid.Valid }}<a href="/admin/user/{{ .Writerid.Int32 }}">{{ .Writername.String }}</a>{{ else }}{{ .Writername.String }}{{ end }}</td>
+            <td><a href="/admin/news/{{ .Idsitenews }}#comments">{{ .Comments.Int32 }}</a></td>
+            <td><a href="/news/news/{{ .Idsitenews }}">Public</a></td>
+        </tr>
+    {{ end }}
+</table>
+{{ template "tail" $ }}

--- a/core/templates/site/news/adminNewsPostPage.gohtml
+++ b/core/templates/site/news/adminNewsPostPage.gohtml
@@ -1,0 +1,15 @@
+{{ template "head" $ }}
+<h2>News post {{ .Post.Idsitenews }}</h2>
+<p>{{ .Post.News.String | a4code2html }}</p>
+<p>Writer: {{ if .Post.Writerid.Valid }}<a href="/admin/user/{{ .Post.Writerid.Int32 }}">{{ .Post.Writername.String }}</a>{{ else }}{{ .Post.Writername.String }}{{ end }}</p>
+<p>Occurred: {{ .Post.Occurred.Time }}</p>
+<p>Comments: {{ .Post.Comments.Int32 }}</p>
+<p><a href="/news/news/{{ .Post.Idsitenews }}">View public</a></p>
+{{ if .TopicID }}<p><a href="/forum/topic/{{ .TopicID }}/thread/{{ .Post.ForumthreadID }}">View forum thread</a></p>{{ end }}
+<p><a href="/admin/news/{{ .Post.Idsitenews }}/edit">Edit</a></p>
+<p><a href="/admin/news/{{ .Post.Idsitenews }}/delete">Delete</a></p>
+<a id="comments"></a>
+{{ if .Comments }}<hr><font size=4>Comments:</font>{{ end }}
+{{ template "threadComments" $ }}
+<p><a href="/admin/news">Back</a></p>
+{{ template "tail" $ }}

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -113,6 +113,7 @@ func (h *Handlers) RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navRe
 	blogs.RegisterAdminRoutes(ar)
 
 	// news admin
+	news.RegisterAdminRoutes(ar)
 	nar := ar.PathPrefix("/news").Subrouter()
 	nar.HandleFunc("/users/roles", news.AdminUserRolesPage).Methods("GET")
 	nar.HandleFunc("/users/roles", handlers.TaskHandler(newsUserAllow)).Methods("POST").MatcherFunc(newsUserAllow.Matcher())

--- a/handlers/news/admin_pages.go
+++ b/handlers/news/admin_pages.go
@@ -1,0 +1,180 @@
+package news
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func AdminNewsPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "News Admin"
+
+	posts, err := cd.LatestNewsList(0, 50)
+	if err != nil {
+		log.Printf("LatestNewsList: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	data := struct {
+		*common.CoreData
+		Posts []*common.NewsPost
+	}{
+		CoreData: cd,
+		Posts:    posts,
+	}
+	handlers.TemplateHandler(w, r, "adminNewsListPage.gohtml", data)
+}
+
+type CommentPlus struct {
+	*db.GetCommentsByThreadIdForUserRow
+	ShowReply          bool
+	EditUrl            string
+	Editing            bool
+	Offset             int
+	Languages          []*db.Language
+	SelectedLanguageId int32
+	EditSaveUrl        string
+}
+
+func AdminNewsPostPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	pid, err := strconv.Atoi(mux.Vars(r)["post"])
+	if err != nil {
+		http.Redirect(w, r, "/admin/news", http.StatusTemporaryRedirect)
+		return
+	}
+	post, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(r.Context(), db.GetNewsPostByIdWithWriterIdAndThreadCommentCountParams{
+		ViewerID: cd.UserID,
+		ID:       int32(pid),
+		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+	})
+	if err != nil {
+		http.Redirect(w, r, "/admin/news?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	topicID, err := queries.GetForumTopicIdByThreadId(r.Context(), post.ForumthreadID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		log.Printf("GetForumTopicIdByThreadId: %v", err)
+	}
+
+	commentRows, err := queries.GetCommentsByThreadIdForUser(r.Context(), db.GetCommentsByThreadIdForUserParams{
+		ViewerID: cd.UserID,
+		ThreadID: int32(post.ForumthreadID),
+		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+	})
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		log.Printf("GetCommentsByThreadIdForUser: %v", err)
+	}
+	var comments []*CommentPlus
+	for i, row := range commentRows {
+		comments = append(comments, &CommentPlus{
+			GetCommentsByThreadIdForUserRow: row,
+			ShowReply:                       false,
+			EditUrl:                         "",
+			EditSaveUrl:                     "",
+			Editing:                         false,
+			Offset:                          i,
+		})
+	}
+	threadRow, err := queries.GetThreadLastPosterAndPerms(r.Context(), db.GetThreadLastPosterAndPermsParams{
+		ViewerID:      cd.UserID,
+		ThreadID:      int32(post.ForumthreadID),
+		ViewerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+	})
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		log.Printf("GetThreadLastPosterAndPerms: %v", err)
+	}
+
+	cd.PageTitle = fmt.Sprintf("News Post %d", pid)
+	data := struct {
+		*common.CoreData
+		Post     *db.GetNewsPostByIdWithWriterIdAndThreadCommentCountRow
+		TopicID  int32
+		Thread   *db.GetThreadLastPosterAndPermsRow
+		Comments []*CommentPlus
+	}{
+		CoreData: cd,
+		Post:     post,
+		TopicID:  topicID,
+		Thread:   threadRow,
+		Comments: comments,
+	}
+	handlers.TemplateHandler(w, r, "adminNewsPostPage.gohtml", data)
+}
+
+func adminNewsEditFormPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	pid, err := strconv.Atoi(mux.Vars(r)["post"])
+	if err != nil {
+		http.Redirect(w, r, "/admin/news", http.StatusTemporaryRedirect)
+		return
+	}
+	post, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(r.Context(), db.GetNewsPostByIdWithWriterIdAndThreadCommentCountParams{
+		ViewerID: cd.UserID,
+		ID:       int32(pid),
+		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+	})
+	if err != nil {
+		http.Redirect(w, r, "/admin/news?error="+err.Error(), http.StatusTemporaryRedirect)
+		return
+	}
+	langs, err := cd.Languages()
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	cd.PageTitle = "Edit News"
+	data := struct {
+		*common.CoreData
+		Languages          []*db.Language
+		Post               *db.GetNewsPostByIdWithWriterIdAndThreadCommentCountRow
+		SelectedLanguageId int
+	}{
+		CoreData:           cd,
+		Languages:          langs,
+		Post:               post,
+		SelectedLanguageId: int(post.LanguageIdlanguage),
+	}
+	handlers.TemplateHandler(w, r, "adminNewsEditPage.gohtml", data)
+}
+
+func AdminNewsDeleteConfirmPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	pid, err := strconv.Atoi(mux.Vars(r)["post"])
+	if err != nil {
+		http.Redirect(w, r, "/admin/news", http.StatusTemporaryRedirect)
+		return
+	}
+	cd.PageTitle = "Confirm news delete"
+	data := struct {
+		*common.CoreData
+		PostID       int
+		ConfirmLabel string
+		Back         string
+	}{
+		CoreData:     cd,
+		PostID:       pid,
+		ConfirmLabel: "Confirm delete",
+		Back:         fmt.Sprintf("/admin/news/%d", pid),
+	}
+	handlers.TemplateHandler(w, r, "adminNewsDeleteConfirmPage.gohtml", data)
+}
+
+// NewsDelete deactivates a news post.
+func NewsDelete(ctx context.Context, q *db.Queries, postID int32) error {
+	return q.DeactivateNewsPost(ctx, postID)
+}

--- a/handlers/news/newsDeleteTask.go
+++ b/handlers/news/newsDeleteTask.go
@@ -1,0 +1,41 @@
+package news
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// DeleteNewsPostTask removes a news post.
+type DeleteNewsPostTask struct{ tasks.TaskString }
+
+var deleteNewsPostTask = &DeleteNewsPostTask{TaskString: TaskDelete}
+
+var _ tasks.Task = (*DeleteNewsPostTask)(nil)
+
+func (DeleteNewsPostTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	pid, err := strconv.Atoi(mux.Vars(r)["post"])
+	if err != nil {
+		return fmt.Errorf("post id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	if err := NewsDelete(r.Context(), queries, int32(pid)); err != nil {
+		return fmt.Errorf("delete news post fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+		if evt := cd.Event(); evt != nil {
+			if evt.Data == nil {
+				evt.Data = map[string]any{}
+			}
+			evt.Data["NewsPostID"] = pid
+		}
+	}
+	return nil
+}

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -42,7 +42,7 @@ func runTemplate(name string) http.HandlerFunc {
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
 	log.Printf("News: Registering Routes")
 	navReg.RegisterIndexLink("News", "/", SectionWeight)
-	navReg.RegisterAdminControlCenter("News", "News", "/admin/news/users/roles", SectionWeight)
+	navReg.RegisterAdminControlCenter("News", "News", "/admin/news", SectionWeight)
 	r.Use(handlers.IndexMiddleware(CustomNewsIndex))
 	r.HandleFunc("/", runTemplate("newsPage")).Methods("GET")
 	r.HandleFunc("/", handlers.TaskDoneAutoRefreshPage).Methods("POST")

--- a/handlers/news/routes_admin.go
+++ b/handlers/news/routes_admin.go
@@ -1,0 +1,17 @@
+package news
+
+import (
+	"github.com/arran4/goa4web/handlers"
+	"github.com/gorilla/mux"
+)
+
+// RegisterAdminRoutes attaches news admin endpoints to ar.
+func RegisterAdminRoutes(ar *mux.Router) {
+	nr := ar.PathPrefix("/news").Subrouter()
+	nr.HandleFunc("", AdminNewsPage).Methods("GET")
+	nr.HandleFunc("/{post}", AdminNewsPostPage).Methods("GET")
+	nr.HandleFunc("/{post}/edit", adminNewsEditFormPage).Methods("GET")
+	nr.HandleFunc("/{post}/edit", handlers.TaskHandler(editTask)).Methods("POST").MatcherFunc(editTask.Matcher())
+	nr.HandleFunc("/{post}/delete", AdminNewsDeleteConfirmPage).Methods("GET")
+	nr.HandleFunc("/{post}/delete", handlers.TaskHandler(deleteNewsPostTask)).Methods("POST").MatcherFunc(deleteNewsPostTask.Matcher())
+}

--- a/handlers/news/tasks_register.go
+++ b/handlers/news/tasks_register.go
@@ -11,6 +11,7 @@ func RegisterTasks() []tasks.NamedTask {
 		cancelTask,
 		replyTask,
 		editTask,
+		deleteNewsPostTask,
 		newPostTask,
 	}
 }


### PR DESCRIPTION
## Summary
- add admin pages for news section
- wire admin routes to list, view, edit and delete news
- link to forum thread from the news detail view
- require confirmation for news deletion
- show news admin in control centre
- link to writer profiles and show comments on admin news posts
- create deletion task for news posts

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6889f785470c832fb9c628523955c8b0