### PR TITLE
Show direct email addresses in admin pages

### DIFF
--- a/handlers/admin/adminFailedEmailsPage.go
+++ b/handlers/admin/adminFailedEmailsPage.go
@@ -69,14 +69,25 @@ func AdminFailedEmailsPage(w http.ResponseWriter, r *http.Request) {
 
 	for _, e := range rows {
 		emailStr := ""
-		if e.ToUserID.Valid {
+		if e.ToUserID.Valid && !e.DirectEmail {
 			if u, ok := users[e.ToUserID.Int32]; ok && u.Email.Valid && u.Email.String != "" {
 				emailStr = u.Email.String
 			}
 		}
 		subj := ""
 		if m, err := mail.ReadMessage(strings.NewReader(e.Body)); err == nil {
+			if emailStr == "" {
+				emailStr = m.Header.Get("To")
+			}
 			subj = m.Header.Get("Subject")
+		}
+		if emailStr == "" {
+			emailStr = "(unknown)"
+		}
+		if e.DirectEmail {
+			emailStr += " (direct)"
+		} else if !e.ToUserID.Valid {
+			emailStr += " (userless)"
 		}
 		data.Emails = append(data.Emails, EmailItem{e, emailStr, subj})
 	}

--- a/handlers/admin/adminSentEmailsPage.go
+++ b/handlers/admin/adminSentEmailsPage.go
@@ -69,14 +69,25 @@ func AdminSentEmailsPage(w http.ResponseWriter, r *http.Request) {
 
 	for _, e := range rows {
 		emailStr := ""
-		if e.ToUserID.Valid {
+		if e.ToUserID.Valid && !e.DirectEmail {
 			if u, ok := users[e.ToUserID.Int32]; ok && u.Email.Valid && u.Email.String != "" {
 				emailStr = u.Email.String
 			}
 		}
 		subj := ""
 		if m, err := mail.ReadMessage(strings.NewReader(e.Body)); err == nil {
+			if emailStr == "" {
+				emailStr = m.Header.Get("To")
+			}
 			subj = m.Header.Get("Subject")
+		}
+		if emailStr == "" {
+			emailStr = "(unknown)"
+		}
+		if e.DirectEmail {
+			emailStr += " (direct)"
+		} else if !e.ToUserID.Valid {
+			emailStr += " (userless)"
 		}
 		data.Emails = append(data.Emails, EmailItem{e, emailStr, subj})
 	}


### PR DESCRIPTION
## Summary
- display direct and userless recipient info for sent, failed and queued email entries

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68889dec9404832fb3ff85d10097b45e