### PR TITLE
Add ability to create role grants

### DIFF
--- a/core/templates/site/admin/adminRolePage.gohtml
+++ b/core/templates/site/admin/adminRolePage.gohtml
@@ -29,5 +29,16 @@
         </td>
     </tr>
     {{- end }}
+    <tr>
+        <form method="post" action="/admin/role/{{ $.Role.ID }}/grant">
+        {{ csrfField }}
+            <td>NEW</td>
+            <td><input name="section"></td>
+            <td><input name="item"></td>
+            <td><input name="item_id"></td>
+            <td><input name="action"></td>
+            <td><input type="submit" name="task" value="Create grant"></td>
+        </form>
+    </tr>
 </table>
 {{ template "tail" $ }}

--- a/handlers/admin/role_grant_create_task.go
+++ b/handlers/admin/role_grant_create_task.go
@@ -1,0 +1,64 @@
+package admin
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/gorilla/mux"
+)
+
+// RoleGrantCreateTask creates a new grant for a role.
+type RoleGrantCreateTask struct{ tasks.TaskString }
+
+var roleGrantCreateTask = &RoleGrantCreateTask{TaskString: TaskRoleGrantCreate}
+
+var _ tasks.Task = (*RoleGrantCreateTask)(nil)
+
+func (RoleGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	roleID, err := strconv.Atoi(mux.Vars(r)["id"])
+	if err != nil {
+		return fmt.Errorf("role id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	section := r.PostFormValue("section")
+	item := r.PostFormValue("item")
+	action := r.PostFormValue("action")
+	itemIDStr := r.PostFormValue("item_id")
+	var itemID sql.NullInt32
+	if itemIDStr != "" {
+		id, err := strconv.Atoi(itemIDStr)
+		if err != nil {
+			return fmt.Errorf("item id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		itemID = sql.NullInt32{Int32: int32(id), Valid: true}
+	}
+	if section == "" || action == "" {
+		return fmt.Errorf("missing section or action %w", handlers.ErrRedirectOnSamePageHandler(fmt.Errorf("")))
+	}
+	if _, err = queries.CreateGrant(r.Context(), db.CreateGrantParams{
+		UserID:   sql.NullInt32{},
+		RoleID:   sql.NullInt32{Int32: int32(roleID), Valid: true},
+		Section:  section,
+		Item:     sql.NullString{String: item, Valid: item != ""},
+		RuleType: "allow",
+		ItemID:   itemID,
+		ItemRule: sql.NullString{},
+		Action:   action,
+		Extra:    sql.NullString{},
+	}); err != nil {
+		log.Printf("CreateGrant: %v", err)
+		return fmt.Errorf("create grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	return handlers.RefreshDirectHandler{TargetURL: fmt.Sprintf("/admin/role/%d", roleID)}
+}

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -82,6 +82,7 @@ func (h *Handlers) RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navRe
 	ar.HandleFunc("/user/{id}/subscriptions", adminUserSubscriptionsPage).Methods("GET")
 	ar.HandleFunc("/user/{id}/comment", adminUserAddCommentPage).Methods("POST")
 	ar.HandleFunc("/role/{id}", adminRolePage).Methods("GET")
+	ar.HandleFunc("/role/{id}/grant", handlers.TaskHandler(roleGrantCreateTask)).Methods("POST").MatcherFunc(roleGrantCreateTask.Matcher())
 	ar.HandleFunc("/grant/delete", handlers.TaskHandler(roleGrantDeleteTask)).Methods("POST").MatcherFunc(roleGrantDeleteTask.Matcher())
 	ar.HandleFunc("/user/{id}/reset", adminUserResetPasswordConfirmPage).Methods("GET")
 	ar.HandleFunc("/user/{id}/reset", handlers.TaskHandler(userPasswordResetTask)).Methods("POST").MatcherFunc(userPasswordResetTask.Matcher())

--- a/handlers/admin/tasks.go
+++ b/handlers/admin/tasks.go
@@ -278,6 +278,9 @@ const (
 	// TaskToggleRolePublicProfile toggles whether a role allows public profiles.
 	TaskToggleRolePublicProfile tasks.TaskString = "Toggle role public profile"
 
+	// TaskRoleGrantCreate adds a grant to a role.
+	TaskRoleGrantCreate tasks.TaskString = "Create grant"
+
 	// TaskRoleGrantDelete removes a grant from a role.
 	TaskRoleGrantDelete tasks.TaskString = "Delete grant"
 )

--- a/handlers/admin/tasks_register.go
+++ b/handlers/admin/tasks_register.go
@@ -33,6 +33,7 @@ func (h *Handlers) RegisterTasks() []tasks.NamedTask {
 		newsUserAllow,
 		newsUserRemove,
 		userPasswordResetTask,
+		roleGrantCreateTask,
 		roleGrantDeleteTask,
 		h.NewServerShutdownTask(),
 	}


### PR DESCRIPTION
## Summary
- allow creating grants from the role detail page
- implement `RoleGrantCreateTask` and register its route
- expose a small form in adminRolePage for adding grants

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a1788ab54832f95742d083a042494