### PR TITLE
Rename blog query and update usage

### DIFF
--- a/handlers/blogs/bloggerPostsPage.go
+++ b/handlers/blogs/bloggerPostsPage.go
@@ -22,7 +22,7 @@ import (
 // BloggerPostsPage shows the posts written by a specific blogger.
 func BloggerPostsPage(w http.ResponseWriter, r *http.Request) {
 	type BlogRow struct {
-		*db.GetBlogEntriesForUserDescendingLanguagesRow
+		*db.GetBlogEntriesByAuthorForUserDescendingLanguagesRow
 		EditUrl string
 	}
 	type Data struct {
@@ -62,11 +62,11 @@ func BloggerPostsPage(w http.ResponseWriter, r *http.Request) {
 
 	buid := bu.Idusers
 
-	rows, err := queries.GetBlogEntriesForUserDescendingLanguages(r.Context(), db.GetBlogEntriesForUserDescendingLanguagesParams{
-		UsersIdusers:  buid,
-		ViewerIdusers: uid,
-		Limit:         15,
-		Offset:        int32(offset),
+	rows, err := queries.GetBlogEntriesByAuthorForUserDescendingLanguages(r.Context(), db.GetBlogEntriesByAuthorForUserDescendingLanguagesParams{
+		AuthorID: buid,
+		ViewerID: uid,
+		Limit:    15,
+		Offset:   int32(offset),
 	})
 	if err != nil {
 		switch {
@@ -90,7 +90,7 @@ func BloggerPostsPage(w http.ResponseWriter, r *http.Request) {
 			editUrl = fmt.Sprintf("/blogs/blog/%d/edit", row.Idblogs)
 		}
 		data.Rows = append(data.Rows, &BlogRow{
-			GetBlogEntriesForUserDescendingLanguagesRow: row,
+			GetBlogEntriesByAuthorForUserDescendingLanguagesRow: row,
 			EditUrl: editUrl,
 		})
 	}

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -25,7 +25,7 @@ import (
 
 func Page(w http.ResponseWriter, r *http.Request) {
 	type BlogRow struct {
-		*db.GetBlogEntriesForUserDescendingLanguagesRow
+		*db.GetBlogEntriesByAuthorForUserDescendingLanguagesRow
 		EditUrl string
 	}
 	type Data struct {
@@ -47,11 +47,11 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Blogs"
 	queries := cd.Queries()
-	rows, err := queries.GetBlogEntriesForUserDescendingLanguages(r.Context(), db.GetBlogEntriesForUserDescendingLanguagesParams{
-		UsersIdusers:  int32(userId),
-		ViewerIdusers: uid,
-		Limit:         15,
-		Offset:        int32(offset),
+	rows, err := queries.GetBlogEntriesByAuthorForUserDescendingLanguages(r.Context(), db.GetBlogEntriesByAuthorForUserDescendingLanguagesParams{
+		AuthorID: int32(userId),
+		ViewerID: uid,
+		Limit:    15,
+		Offset:   int32(offset),
 	})
 	if err != nil {
 		switch {
@@ -78,7 +78,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 			editUrl = fmt.Sprintf("/blogs/blog/%d/edit", row.Idblogs)
 		}
 		data.Rows = append(data.Rows, &BlogRow{
-			GetBlogEntriesForUserDescendingLanguagesRow: row,
+			GetBlogEntriesByAuthorForUserDescendingLanguagesRow: row,
 			EditUrl: editUrl,
 		})
 	}
@@ -210,11 +210,11 @@ func FeedGen(r *http.Request, queries *db.Queries, uid int, username string) (*f
 		Created:     time.Date(2005, 6, 25, 0, 0, 0, 0, time.UTC),
 	}
 
-	rows, err := queries.GetBlogEntriesForUserDescendingLanguages(r.Context(), db.GetBlogEntriesForUserDescendingLanguagesParams{
-		UsersIdusers:  int32(uid),
-		ViewerIdusers: int32(uid),
-		Limit:         15,
-		Offset:        0,
+	rows, err := queries.GetBlogEntriesByAuthorForUserDescendingLanguages(r.Context(), db.GetBlogEntriesByAuthorForUserDescendingLanguagesParams{
+		AuthorID: int32(uid),
+		ViewerID: int32(uid),
+		Limit:    15,
+		Offset:   0,
 	})
 	if err != nil {
 		switch {

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -13,6 +13,7 @@ SET forumthread_id = ?
 WHERE idblogs = ?;
 
 -- name: GetBlogEntriesForUserDescending :many
+-- name: GetBlogEntriesByAuthorForUserDescendingLanguages :many
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = sqlc.arg(Viewer_idusers) AS is_owner
 FROM blogs b
@@ -23,23 +24,23 @@ AND (b.users_idusers = sqlc.arg(Users_idusers) OR sqlc.arg(Users_idusers) = 0)
 ORDER BY b.written DESC
 LIMIT ? OFFSET ?;
 
--- name: GetBlogEntriesForUserDescendingLanguages :many
+-- name: GetBlogEntriesByAuthorForUserDescendingLanguages :many
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
-       b.users_idusers = sqlc.arg(Viewer_idusers) AS is_owner
+       b.users_idusers = sqlc.arg(viewer_id) AS is_owner
 FROM blogs b
 LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
-WHERE (b.users_idusers = sqlc.arg(Users_idusers) OR sqlc.arg(Users_idusers) = 0)
+WHERE (b.users_idusers = sqlc.arg(author_id) OR sqlc.arg(author_id) = 0)
 AND (
     b.language_idlanguage = 0
     OR b.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
-        WHERE ul.users_idusers = sqlc.arg(Viewer_idusers)
+        WHERE ul.users_idusers = sqlc.arg(viewer_id)
           AND ul.language_idlanguage = b.language_idlanguage
     )
     OR NOT EXISTS (
-        SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(Viewer_idusers)
+        SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
     )
 )
 ORDER BY b.written DESC


### PR DESCRIPTION
## Summary
- clarify viewer vs author naming for blog listing query
- regenerate sqlc code
- update blog handlers to call the new query

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a1c438554832fb423aaf60d4dd119