### PR TITLE
docs: outline query naming tasks

### DIFF
--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -254,3 +254,12 @@ The same lookup pattern covers every action. Whether a user wants to `post`,
 `reply`, `comment`, `write` or `edit`, the query matches grants by `viewer_id`
 and roles using the unified action names above. This ensures consistent
 terminology across sections and avoids duplicated rules.
+
+## Query Naming Conventions
+
+SQL queries now include the intended audience as part of the name. Operations
+exposed through the administrator interface use the `Admin` prefix while
+background or maintenance queries use the `System` prefix. Queries returning
+results for a viewer include a `ForViewer` or `ForUser` suffix as appropriate.
+The file `specs/sql_query_naming_tasks.md` lists outstanding renames following
+this convention.

--- a/specs/sql_query_naming_tasks.md
+++ b/specs/sql_query_naming_tasks.md
@@ -1,0 +1,46 @@
+# SQL Query Naming Update Tasks
+
+The following tasks continue the migration towards explicit query names that
+indicate whether an operation is for a user, an administrator, or a system
+background task. Each task touches only a single package to minimise merge
+conflicts.
+
+1. **Announcements** – rename `ListAnnouncementsWithNews` to
+   `AdminListAnnouncementsWithNews` and change `CreateAnnouncement`/
+   `DeleteAnnouncement` to `PromoteAnnouncement`/`DemoteAnnouncement`.
+   Add language filtering and rename `GetActiveAnnouncementWithNews` to
+   `GetActiveAnnouncementWithNewsForUser`.
+2. **Audit Log** – prefix all queries in `queries-auditlog.sql` with `Admin` and
+   adjust call sites accordingly.
+3. **Banned IPs** – prefix queries in `queries-banned_ips.sql` with `Admin`.
+4. **Blog Entry Grants** – add grant checks to
+   `CreateBlogEntry` and `UpdateBlogEntry`. Rename
+   `GetBlogEntriesForUserDescending` to
+   `GetBlogEntriesDescendingForViewer` and ensure language filtering.
+5. **Blog Search** – introduce `BlogsSearchFirstForViewer` and
+   `BlogsSearchNextForViewer` with grant checks.
+6. **Blog Listing** – rename `GetAllBlogEntriesByUser` to
+   `AdminGetAllBlogEntriesByUser`.
+7. **Bloggers** – verify the queries and rename them to
+   `ListBloggersForViewer` and `SearchBloggersForViewer` if not already.
+8. **Blog Index Maintenance** – mark `SetBlogLastIndex` and
+   `GetAllBlogsForIndex` as system queries.
+9. **Comments** – add grant checks to `GetCommentsByThreadIdForUser` and rename
+   `GetAllCommentsByUser` and `ListAllCommentsWithThreadInfo` with `Admin`
+   prefixes.
+10. **Deactivation, DLQ and External Links** – prefix all queries in
+    `queries-deactivation.sql`, `queries-dlq.sql` and
+    `queries-externallinks.sql` with `Admin` or `System` as appropriate.
+11. **FAQ Management** – rename admin queries such as
+    `GetFAQUnansweredQuestions`, `GetFAQAnsweredQuestions`,
+    `GetFAQDismissedQuestions` and others using the `Admin` prefix.
+    Introduce `GetAllFAQQuestionsForViewer` with language and grant
+    filtering and update related call sites.
+12. **FAQ Revisions** – split `InsertFAQRevision` into a user-facing variant
+    with grant checks and an admin variant for manual edits.
+13. **Role and Permission Queries** – audit remaining SQL files and apply the
+    same naming scheme so each query clearly states whether it is for a user,
+    administrator or system task.
+
+These tasks provide a roadmap for aligning the query layer with the naming
+convention described in `permissions.md`.


### PR DESCRIPTION
## Summary
- document tasks to rename SQL queries following admin/user/system convention
- explain the naming scheme in the permissions spec

## Testing
- `go vet ./...`
- `go mod tidy`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688b38eaaa20832fa2ed9eac907fcd6b