### PR TITLE
Implement viewer-aware blog query

### DIFF
--- a/cmd/goa4web/blog_list.go
+++ b/cmd/goa4web/blog_list.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"flag"
 	"fmt"
 
@@ -37,11 +38,12 @@ func (c *blogListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	rows, err := queries.GetBlogEntriesForUserDescending(ctx, dbpkg.GetBlogEntriesForUserDescendingParams{
-		UsersIdusers:       int32(c.UserID),
-		LanguageIdlanguage: 0,
-		Limit:              int32(c.Limit),
-		Offset:             int32(c.Offset),
+	uid := int32(c.UserID)
+	rows, err := queries.GetBlogEntriesForViewerDescending(ctx, dbpkg.GetBlogEntriesForViewerDescendingParams{
+		ViewerID: uid,
+		UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
+		Limit:    int32(c.Limit),
+		Offset:   int32(c.Offset),
 	})
 	if err != nil {
 		return fmt.Errorf("list blogs: %w", err)

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -12,14 +12,42 @@ UPDATE blogs
 SET forumthread_id = ?
 WHERE idblogs = ?;
 
--- name: GetBlogEntriesForUserDescending :many
+-- name: GetBlogEntriesForViewerDescending :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
-       b.users_idusers = sqlc.arg(Viewer_idusers) AS is_owner
+       b.users_idusers = sqlc.arg(viewer_id) AS is_owner
 FROM blogs b
 LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
-WHERE (b.language_idlanguage = sqlc.arg(Language_idlanguage) OR sqlc.arg(Language_idlanguage) = 0)
-AND (b.users_idusers = sqlc.arg(Users_idusers) OR sqlc.arg(Users_idusers) = 0)
+WHERE (
+    b.language_idlanguage = 0
+    OR b.language_idlanguage IS NULL
+    OR EXISTS (
+        SELECT 1 FROM user_language ul
+        WHERE ul.users_idusers = sqlc.arg(viewer_id)
+          AND ul.language_idlanguage = b.language_idlanguage
+    )
+    OR NOT EXISTS (
+        SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+    )
+)
+AND EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section = 'blogs'
+      AND g.item = 'entry'
+      AND g.action = 'see'
+      AND g.active = 1
+      AND g.item_id = b.idblogs
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+)
 ORDER BY b.written DESC
 LIMIT ? OFFSET ?;
 


### PR DESCRIPTION
## Summary
- update blog listing query with standard role/language checks
- rename query to `GetBlogEntriesForViewerDescending`
- regenerate sqlc code
- update CLI to use the new query

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_688c00456c7c832fbb14b7c6c2d22278