### PR TITLE
Update announcement queries with language filtering

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -103,7 +103,7 @@ type CoreData struct {
 	emailProvider lazy.Value[MailProvider]
 
 	allRoles                 lazy.Value[[]*db.Role]
-	announcement             lazy.Value[*db.GetActiveAnnouncementWithNewsRow]
+	announcement             lazy.Value[*db.GetActiveAnnouncementWithNewsForUserRow]
 	annMu                    sync.Mutex
 	bloggers                 lazy.Value[[]*db.BloggerCountRow]
 	bookmarks                lazy.Value[*db.GetBookmarksForUserRow]
@@ -640,12 +640,12 @@ func (cd *CoreData) AllRoles() ([]*db.Role, error) {
 }
 
 // Announcement returns the active announcement row loaded lazily.
-func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsRow {
-	ann, err := cd.announcement.Load(func() (*db.GetActiveAnnouncementWithNewsRow, error) {
+func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsForUserRow {
+	ann, err := cd.announcement.Load(func() (*db.GetActiveAnnouncementWithNewsForUserRow, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		row, err := cd.queries.GetActiveAnnouncementWithNews(cd.ctx, db.GetActiveAnnouncementWithNewsParams{
+		row, err := cd.queries.GetActiveAnnouncementWithNewsForUser(cd.ctx, db.GetActiveAnnouncementWithNewsForUserParams{
 			ViewerID: cd.UserID,
 			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 		})
@@ -661,7 +661,7 @@ func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsRow {
 }
 
 // AnnouncementLoaded returns the cached active announcement without querying the database.
-func (cd *CoreData) AnnouncementLoaded() *db.GetActiveAnnouncementWithNewsRow {
+func (cd *CoreData) AnnouncementLoaded() *db.GetActiveAnnouncementWithNewsForUserRow {
 	ann, ok := cd.announcement.Peek()
 	if !ok {
 		return nil

--- a/handlers/admin/add_announcement_task.go
+++ b/handlers/admin/add_announcement_task.go
@@ -29,7 +29,7 @@ func (AddAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("news id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := queries.CreateAnnouncement(r.Context(), int32(nid)); err != nil {
+	if err := queries.AdminPromoteAnnouncement(r.Context(), int32(nid)); err != nil {
 		return fmt.Errorf("create announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/adminAnnouncementsPage.go
+++ b/handlers/admin/adminAnnouncementsPage.go
@@ -15,14 +15,14 @@ import (
 func AdminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		Announcements []*db.ListAnnouncementsWithNewsRow
+		Announcements []*db.AdminListAnnouncementsWithNewsRow
 		NewsID        string
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Admin Announcements"
 	data := Data{CoreData: cd}
 	queries := cd.Queries()
-	rows, err := queries.ListAnnouncementsWithNews(r.Context())
+	rows, err := queries.AdminListAnnouncementsWithNews(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list announcements: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/delete_announcement_task.go
+++ b/handlers/admin/delete_announcement_task.go
@@ -30,7 +30,7 @@ func (DeleteAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.DeleteAnnouncement(r.Context(), int32(id)); err != nil {
+		if err := queries.AdminDemoteAnnouncement(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("delete announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/news/announcement_add_task.go
+++ b/handlers/news/announcement_add_task.go
@@ -36,7 +36,7 @@ func (AnnouncementAddTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	if ann == nil {
-		if err := queries.CreateAnnouncement(r.Context(), int32(pid)); err != nil {
+		if err := queries.AdminPromoteAnnouncement(r.Context(), int32(pid)); err != nil {
 			return fmt.Errorf("create announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	} else if !ann.Active {

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -1,8 +1,8 @@
--- name: CreateAnnouncement :exec
+-- name: AdminPromoteAnnouncement :exec
 INSERT INTO site_announcements (site_news_id)
 VALUES (?);
 
--- name: DeleteAnnouncement :exec
+-- name: AdminDemoteAnnouncement :exec
 DELETE FROM site_announcements WHERE id = ?;
 
 -- name: GetLatestAnnouncementByNewsID :one
@@ -15,7 +15,7 @@ LIMIT 1;
 -- name: SetAnnouncementActive :exec
 UPDATE site_announcements SET active = ? WHERE id = ?;
 
--- name: GetActiveAnnouncementWithNews :one
+-- name: GetActiveAnnouncementWithNewsForUser :one
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
     UNION
@@ -28,6 +28,18 @@ SELECT a.id, n.idsiteNews, n.news
 FROM site_announcements a
 JOIN site_news n ON n.idsiteNews = a.site_news_id
 WHERE a.active = 1
+  AND (
+      n.language_idlanguage = 0
+      OR n.language_idlanguage IS NULL
+      OR EXISTS (
+          SELECT 1 FROM user_language ul
+          WHERE ul.users_idusers = sqlc.arg(viewer_id)
+            AND ul.language_idlanguage = n.language_idlanguage
+      )
+      OR NOT EXISTS (
+          SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+      )
+  )
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='news'
@@ -41,7 +53,7 @@ WHERE a.active = 1
 ORDER BY a.created_at DESC
 LIMIT 1;
 
--- name: ListAnnouncementsWithNews :many
+-- name: AdminListAnnouncementsWithNews :many
 SELECT a.id, a.site_news_id, a.active, a.created_at, n.news
 FROM site_announcements a
 JOIN site_news n ON n.idsiteNews = a.site_news_id


### PR DESCRIPTION
## Summary
- rename announcement SQL queries and regenerate code
- update call sites for new names
- filter announcements by user languages

## Testing
- `sqlc generate`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`

------
https://chatgpt.com/codex/tasks/task_e_688c0016f344832f90b0d2357f0f18a4