### PR TITLE
Add post grant check for blog writes

### DIFF
--- a/cmd/goa4web/blog_create.go
+++ b/cmd/goa4web/blog_create.go
@@ -45,6 +45,8 @@ func (c *blogCreateCmd) Run() error {
 		UsersIdusers:       int32(c.UserID),
 		LanguageIdlanguage: int32(c.LangID),
 		Blog:               sql.NullString{String: c.Text, Valid: true},
+		UserID:             sql.NullInt32{Int32: int32(c.UserID), Valid: true},
+		ViewerID:           int32(c.UserID),
 	})
 	if err != nil {
 		return fmt.Errorf("create blog: %w", err)

--- a/cmd/goa4web/blog_update.go
+++ b/cmd/goa4web/blog_update.go
@@ -45,6 +45,8 @@ func (c *blogUpdateCmd) Run() error {
 		LanguageIdlanguage: int32(c.LangID),
 		Blog:               sql.NullString{String: c.Text, Valid: c.Text != ""},
 		Idblogs:            int32(c.ID),
+		UserID:             sql.NullInt32{},
+		ViewerID:           0,
 	})
 	if err != nil {
 		return fmt.Errorf("update blog: %w", err)

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -79,6 +79,8 @@ func (AddBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 			String: text,
 			Valid:  true,
 		},
+		UserID:   sql.NullInt32{Int32: uid, Valid: true},
+		ViewerID: uid,
 	})
 	if err != nil {
 		return fmt.Errorf("blog create fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -52,6 +52,8 @@ func (EditBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 			String: text,
 			Valid:  true,
 		},
+		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		ViewerID: cd.UserID,
 	}); err != nil {
 		return fmt.Errorf("update blog fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -107,17 +107,36 @@ func (q *Queries) BlogsSearchNext(ctx context.Context, arg BlogsSearchNextParams
 
 const createBlogEntry = `-- name: CreateBlogEntry :execlastid
 INSERT INTO blogs (users_idusers, language_idlanguage, blog, written)
-VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+SELECT ?, ?, ?, CURRENT_TIMESTAMP
+WHERE EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section = 'blogs'
+      AND g.item = 'entry'
+      AND g.action = 'post'
+      AND g.active = 1
+      AND (g.user_id = ? OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (
+          SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+      ))
+)
 `
 
 type CreateBlogEntryParams struct {
 	UsersIdusers       int32
 	LanguageIdlanguage int32
 	Blog               sql.NullString
+	UserID             sql.NullInt32
+	ViewerID           int32
 }
 
 func (q *Queries) CreateBlogEntry(ctx context.Context, arg CreateBlogEntryParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, createBlogEntry, arg.UsersIdusers, arg.LanguageIdlanguage, arg.Blog)
+	result, err := q.db.ExecContext(ctx, createBlogEntry,
+		arg.UsersIdusers,
+		arg.LanguageIdlanguage,
+		arg.Blog,
+		arg.UserID,
+		arg.ViewerID,
+	)
 	if err != nil {
 		return 0, err
 	}
@@ -680,15 +699,34 @@ const updateBlogEntry = `-- name: UpdateBlogEntry :exec
 UPDATE blogs
 SET language_idlanguage = ?, blog = ?
 WHERE idblogs = ?
+  AND EXISTS (
+      SELECT 1 FROM grants g
+      WHERE g.section = 'blogs'
+        AND g.item = 'entry'
+        AND g.action = 'post'
+        AND g.active = 1
+        AND (g.user_id = ? OR g.user_id IS NULL)
+        AND (g.role_id IS NULL OR g.role_id IN (
+            SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+        ))
+  )
 `
 
 type UpdateBlogEntryParams struct {
 	LanguageIdlanguage int32
 	Blog               sql.NullString
 	Idblogs            int32
+	UserID             sql.NullInt32
+	ViewerID           int32
 }
 
 func (q *Queries) UpdateBlogEntry(ctx context.Context, arg UpdateBlogEntryParams) error {
-	_, err := q.db.ExecContext(ctx, updateBlogEntry, arg.LanguageIdlanguage, arg.Blog, arg.Idblogs)
+	_, err := q.db.ExecContext(ctx, updateBlogEntry,
+		arg.LanguageIdlanguage,
+		arg.Blog,
+		arg.Idblogs,
+		arg.UserID,
+		arg.ViewerID,
+	)
 	return err
 }


### PR DESCRIPTION
## Summary
- validate 'post' grants in CreateBlogEntry and UpdateBlogEntry SQL
- regenerate database code
- pass viewer information to blog add/edit operations and CLI commands

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`

------
https://chatgpt.com/codex/tasks/task_e_688c003fa6d8832fa6b215f9ac6fc97e