### PR TITLE
Add grant checks to blog creation and updates

### DIFF
--- a/cmd/goa4web/blog_create.go
+++ b/cmd/goa4web/blog_create.go
@@ -41,10 +41,13 @@ func (c *blogCreateCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
+	uid := int32(c.UserID)
 	_, err = queries.CreateBlogEntry(ctx, dbpkg.CreateBlogEntryParams{
-		UsersIdusers:       int32(c.UserID),
+		UsersIdusers:       uid,
 		LanguageIdlanguage: int32(c.LangID),
 		Blog:               sql.NullString{String: c.Text, Valid: true},
+		UserID:             sql.NullInt32{Int32: uid, Valid: uid != 0},
+		ViewerID:           uid,
 	})
 	if err != nil {
 		return fmt.Errorf("create blog: %w", err)

--- a/cmd/goa4web/blog_update.go
+++ b/cmd/goa4web/blog_update.go
@@ -16,6 +16,7 @@ type blogUpdateCmd struct {
 	ID     int
 	LangID int
 	Text   string
+	UserID int
 }
 
 func parseBlogUpdateCmd(parent *blogCmd, args []string) (*blogUpdateCmd, error) {
@@ -24,6 +25,7 @@ func parseBlogUpdateCmd(parent *blogCmd, args []string) (*blogUpdateCmd, error) 
 	c.fs.IntVar(&c.ID, "id", 0, "blog id")
 	c.fs.IntVar(&c.LangID, "lang", 0, "language id")
 	c.fs.StringVar(&c.Text, "text", "", "blog text")
+	c.fs.IntVar(&c.UserID, "user", 0, "viewer user id")
 	if err := c.fs.Parse(args); err != nil {
 		return nil, err
 	}
@@ -41,10 +43,13 @@ func (c *blogUpdateCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
+	uid := int32(c.UserID)
 	err = queries.UpdateBlogEntry(ctx, dbpkg.UpdateBlogEntryParams{
 		LanguageIdlanguage: int32(c.LangID),
 		Blog:               sql.NullString{String: c.Text, Valid: c.Text != ""},
 		Idblogs:            int32(c.ID),
+		UserID:             sql.NullInt32{Int32: uid, Valid: uid != 0},
+		ViewerID:           uid,
 	})
 	if err != nil {
 		return fmt.Errorf("update blog: %w", err)

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -79,6 +79,8 @@ func (AddBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 			String: text,
 			Valid:  true,
 		},
+		UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
+		ViewerID: uid,
 	})
 	if err != nil {
 		return fmt.Errorf("blog create fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -52,6 +52,8 @@ func (EditBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 			String: text,
 			Valid:  true,
 		},
+		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		ViewerID: cd.UserID,
 	}); err != nil {
 		return fmt.Errorf("update blog fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}


### PR DESCRIPTION
## Summary
- enforce grants on `CreateBlogEntry` and `UpdateBlogEntry`
- regenerate sqlc models
- adapt blog CLI and handlers to pass `viewer_id` and `user_id`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688c00375360832f93d6b2b69b85f11f