### PR TITLE
Filter site announcement by viewer language

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -103,7 +103,7 @@ type CoreData struct {
 	emailProvider lazy.Value[MailProvider]
 
 	allRoles                 lazy.Value[[]*db.Role]
-	announcement             lazy.Value[*db.GetActiveAnnouncementWithNewsRow]
+	announcement             lazy.Value[*db.GetActiveAnnouncementWithNewsForUserRow]
 	annMu                    sync.Mutex
 	bloggers                 lazy.Value[[]*db.BloggerCountRow]
 	bookmarks                lazy.Value[*db.GetBookmarksForUserRow]
@@ -640,12 +640,12 @@ func (cd *CoreData) AllRoles() ([]*db.Role, error) {
 }
 
 // Announcement returns the active announcement row loaded lazily.
-func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsRow {
-	ann, err := cd.announcement.Load(func() (*db.GetActiveAnnouncementWithNewsRow, error) {
+func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsForUserRow {
+	ann, err := cd.announcement.Load(func() (*db.GetActiveAnnouncementWithNewsForUserRow, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		row, err := cd.queries.GetActiveAnnouncementWithNews(cd.ctx, db.GetActiveAnnouncementWithNewsParams{
+		row, err := cd.queries.GetActiveAnnouncementWithNewsForUser(cd.ctx, db.GetActiveAnnouncementWithNewsForUserParams{
 			ViewerID: cd.UserID,
 			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 		})
@@ -661,7 +661,7 @@ func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsRow {
 }
 
 // AnnouncementLoaded returns the cached active announcement without querying the database.
-func (cd *CoreData) AnnouncementLoaded() *db.GetActiveAnnouncementWithNewsRow {
+func (cd *CoreData) AnnouncementLoaded() *db.GetActiveAnnouncementWithNewsForUserRow {
 	ann, ok := cd.announcement.Peek()
 	if !ok {
 		return nil

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -15,7 +15,7 @@ LIMIT 1;
 -- name: SetAnnouncementActive :exec
 UPDATE site_announcements SET active = ? WHERE id = ?;
 
--- name: GetActiveAnnouncementWithNews :one
+-- name: GetActiveAnnouncementWithNewsForUser :one
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
     UNION
@@ -28,6 +28,18 @@ SELECT a.id, n.idsiteNews, n.news
 FROM site_announcements a
 JOIN site_news n ON n.idsiteNews = a.site_news_id
 WHERE a.active = 1
+  AND (
+        n.language_idlanguage = 0
+        OR n.language_idlanguage IS NULL
+        OR EXISTS (
+            SELECT 1 FROM user_language ul
+            WHERE ul.users_idusers = sqlc.arg(viewer_id)
+              AND ul.language_idlanguage = n.language_idlanguage
+        )
+        OR NOT EXISTS (
+            SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+        )
+  )
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='news'


### PR DESCRIPTION
## Summary
- filter `site_news.language_idlanguage` in GetActiveAnnouncementWithNewsForUser
- rename query and update generated code
- update CoreData to call the renamed query

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_688c001127cc832fbf4676250813ed29