### PR TITLE
Rename announcement queries for admin tasks

### DIFF
--- a/handlers/admin/add_announcement_task.go
+++ b/handlers/admin/add_announcement_task.go
@@ -29,7 +29,7 @@ func (AddAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("news id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := queries.CreateAnnouncement(r.Context(), int32(nid)); err != nil {
+	if err := queries.PromoteAnnouncement(r.Context(), int32(nid)); err != nil {
 		return fmt.Errorf("create announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/adminAnnouncementsPage.go
+++ b/handlers/admin/adminAnnouncementsPage.go
@@ -15,14 +15,14 @@ import (
 func AdminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		Announcements []*db.ListAnnouncementsWithNewsRow
+		Announcements []*db.ListAnnouncementsWithNewsForAdminRow
 		NewsID        string
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Admin Announcements"
 	data := Data{CoreData: cd}
 	queries := cd.Queries()
-	rows, err := queries.ListAnnouncementsWithNews(r.Context())
+	rows, err := queries.ListAnnouncementsWithNewsForAdmin(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list announcements: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/delete_announcement_task.go
+++ b/handlers/admin/delete_announcement_task.go
@@ -30,7 +30,7 @@ func (DeleteAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.DeleteAnnouncement(r.Context(), int32(id)); err != nil {
+		if err := queries.DemoteAnnouncement(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("delete announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/news/announcement_add_task.go
+++ b/handlers/news/announcement_add_task.go
@@ -36,7 +36,7 @@ func (AnnouncementAddTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	if ann == nil {
-		if err := queries.CreateAnnouncement(r.Context(), int32(pid)); err != nil {
+		if err := queries.PromoteAnnouncement(r.Context(), int32(pid)); err != nil {
 			return fmt.Errorf("create announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	} else if !ann.Active {

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -1,8 +1,10 @@
--- name: CreateAnnouncement :exec
+-- name: PromoteAnnouncement :exec
+-- This admin task adds a news post to the announcements.
 INSERT INTO site_announcements (site_news_id)
 VALUES (?);
 
--- name: DeleteAnnouncement :exec
+-- name: DemoteAnnouncement :exec
+-- This admin task removes an announcement.
 DELETE FROM site_announcements WHERE id = ?;
 
 -- name: GetLatestAnnouncementByNewsID :one
@@ -41,7 +43,8 @@ WHERE a.active = 1
 ORDER BY a.created_at DESC
 LIMIT 1;
 
--- name: ListAnnouncementsWithNews :many
+-- name: ListAnnouncementsWithNewsForAdmin :many
+-- This admin task lists announcements with their news content.
 SELECT a.id, a.site_news_id, a.active, a.created_at, n.news
 FROM site_announcements a
 JOIN site_news n ON n.idsiteNews = a.site_news_id


### PR DESCRIPTION
## Summary
- update announcement SQL queries
- regenerate sqlc wrappers
- use new query names in handlers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688c00091790832f92899621cb36becc