### PR TITLE
Rename announcement queries

### DIFF
--- a/handlers/admin/add_announcement_task.go
+++ b/handlers/admin/add_announcement_task.go
@@ -29,8 +29,8 @@ func (AddAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("news id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := queries.AdminPromoteAnnouncement(r.Context(), int32(nid)); err != nil {
-		return fmt.Errorf("create announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	if err := queries.PromoteAnnouncement(r.Context(), int32(nid)); err != nil {
+		return fmt.Errorf("promote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 		if evt := cd.Event(); evt != nil {

--- a/handlers/admin/adminAnnouncementsPage.go
+++ b/handlers/admin/adminAnnouncementsPage.go
@@ -15,14 +15,14 @@ import (
 func AdminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		Announcements []*db.AdminListAnnouncementsWithNewsRow
+		Announcements []*db.ListAnnouncementsWithNewsForAdminRow
 		NewsID        string
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Admin Announcements"
 	data := Data{CoreData: cd}
 	queries := cd.Queries()
-	rows, err := queries.AdminListAnnouncementsWithNews(r.Context())
+	rows, err := queries.ListAnnouncementsWithNewsForAdmin(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list announcements: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/delete_announcement_task.go
+++ b/handlers/admin/delete_announcement_task.go
@@ -30,8 +30,8 @@ func (DeleteAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.AdminDemoteAnnouncement(r.Context(), int32(id)); err != nil {
-			return fmt.Errorf("delete announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		if err := queries.DemoteAnnouncement(r.Context(), int32(id)); err != nil {
+			return fmt.Errorf("demote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 			if evt := cd.Event(); evt != nil {

--- a/handlers/news/announcement_add_task.go
+++ b/handlers/news/announcement_add_task.go
@@ -36,8 +36,8 @@ func (AnnouncementAddTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	if ann == nil {
-		if err := queries.AdminPromoteAnnouncement(r.Context(), int32(pid)); err != nil {
-			return fmt.Errorf("create announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		if err := queries.PromoteAnnouncement(r.Context(), int32(pid)); err != nil {
+			return fmt.Errorf("promote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	} else if !ann.Active {
 		if err := queries.SetAnnouncementActive(r.Context(), db.SetAnnouncementActiveParams{Active: true, ID: ann.ID}); err != nil {

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -1,8 +1,10 @@
--- name: AdminPromoteAnnouncement :exec
+-- name: PromoteAnnouncement :exec
+-- admin task
 INSERT INTO site_announcements (site_news_id)
 VALUES (?);
 
--- name: AdminDemoteAnnouncement :exec
+-- name: DemoteAnnouncement :exec
+-- admin task
 DELETE FROM site_announcements WHERE id = ?;
 
 -- name: GetLatestAnnouncementByNewsID :one
@@ -53,7 +55,8 @@ WHERE a.active = 1
 ORDER BY a.created_at DESC
 LIMIT 1;
 
--- name: AdminListAnnouncementsWithNews :many
+-- name: ListAnnouncementsWithNewsForAdmin :many
+-- admin task
 SELECT a.id, a.site_news_id, a.active, a.created_at, n.news
 FROM site_announcements a
 JOIN site_news n ON n.idsiteNews = a.site_news_id

--- a/internal/db/queries-announcements.sql.go
+++ b/internal/db/queries-announcements.sql.go
@@ -11,66 +11,13 @@ import (
 	"time"
 )
 
-const adminDemoteAnnouncement = `-- name: AdminDemoteAnnouncement :exec
+const demoteAnnouncement = `-- name: DemoteAnnouncement :exec
 DELETE FROM site_announcements WHERE id = ?
 `
 
-func (q *Queries) AdminDemoteAnnouncement(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, adminDemoteAnnouncement, id)
-	return err
-}
-
-const adminListAnnouncementsWithNews = `-- name: AdminListAnnouncementsWithNews :many
-SELECT a.id, a.site_news_id, a.active, a.created_at, n.news
-FROM site_announcements a
-JOIN site_news n ON n.idsiteNews = a.site_news_id
-ORDER BY a.created_at DESC
-`
-
-type AdminListAnnouncementsWithNewsRow struct {
-	ID         int32
-	SiteNewsID int32
-	Active     bool
-	CreatedAt  time.Time
-	News       sql.NullString
-}
-
-func (q *Queries) AdminListAnnouncementsWithNews(ctx context.Context) ([]*AdminListAnnouncementsWithNewsRow, error) {
-	rows, err := q.db.QueryContext(ctx, adminListAnnouncementsWithNews)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*AdminListAnnouncementsWithNewsRow
-	for rows.Next() {
-		var i AdminListAnnouncementsWithNewsRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.SiteNewsID,
-			&i.Active,
-			&i.CreatedAt,
-			&i.News,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const adminPromoteAnnouncement = `-- name: AdminPromoteAnnouncement :exec
-INSERT INTO site_announcements (site_news_id)
-VALUES (?)
-`
-
-func (q *Queries) AdminPromoteAnnouncement(ctx context.Context, siteNewsID int32) error {
-	_, err := q.db.ExecContext(ctx, adminPromoteAnnouncement, siteNewsID)
+// admin task
+func (q *Queries) DemoteAnnouncement(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, demoteAnnouncement, id)
 	return err
 }
 
@@ -154,6 +101,62 @@ func (q *Queries) GetLatestAnnouncementByNewsID(ctx context.Context, siteNewsID 
 		&i.CreatedAt,
 	)
 	return &i, err
+}
+
+const listAnnouncementsWithNewsForAdmin = `-- name: ListAnnouncementsWithNewsForAdmin :many
+SELECT a.id, a.site_news_id, a.active, a.created_at, n.news
+FROM site_announcements a
+JOIN site_news n ON n.idsiteNews = a.site_news_id
+ORDER BY a.created_at DESC
+`
+
+type ListAnnouncementsWithNewsForAdminRow struct {
+	ID         int32
+	SiteNewsID int32
+	Active     bool
+	CreatedAt  time.Time
+	News       sql.NullString
+}
+
+// admin task
+func (q *Queries) ListAnnouncementsWithNewsForAdmin(ctx context.Context) ([]*ListAnnouncementsWithNewsForAdminRow, error) {
+	rows, err := q.db.QueryContext(ctx, listAnnouncementsWithNewsForAdmin)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListAnnouncementsWithNewsForAdminRow
+	for rows.Next() {
+		var i ListAnnouncementsWithNewsForAdminRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.SiteNewsID,
+			&i.Active,
+			&i.CreatedAt,
+			&i.News,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const promoteAnnouncement = `-- name: PromoteAnnouncement :exec
+INSERT INTO site_announcements (site_news_id)
+VALUES (?)
+`
+
+// admin task
+func (q *Queries) PromoteAnnouncement(ctx context.Context, siteNewsID int32) error {
+	_, err := q.db.ExecContext(ctx, promoteAnnouncement, siteNewsID)
+	return err
 }
 
 const setAnnouncementActive = `-- name: SetAnnouncementActive :exec


### PR DESCRIPTION
## Summary
- update announcement SQL query names in internal DB queries file
- regenerate sqlc wrappers
- use the new query functions in admin and news handlers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688caf91b55c832fa4264f7e3071ffae