### PR TITLE
Rename announcement query and document viewer access

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -103,7 +103,7 @@ type CoreData struct {
 	emailProvider lazy.Value[MailProvider]
 
 	allRoles                 lazy.Value[[]*db.Role]
-	announcement             lazy.Value[*db.GetActiveAnnouncementWithNewsForUserRow]
+	announcement             lazy.Value[*db.GetActiveAnnouncementWithNewsForViewerRow]
 	annMu                    sync.Mutex
 	bloggers                 lazy.Value[[]*db.BloggerCountRow]
 	bookmarks                lazy.Value[*db.GetBookmarksForUserRow]
@@ -640,12 +640,12 @@ func (cd *CoreData) AllRoles() ([]*db.Role, error) {
 }
 
 // Announcement returns the active announcement row loaded lazily.
-func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsForUserRow {
-	ann, err := cd.announcement.Load(func() (*db.GetActiveAnnouncementWithNewsForUserRow, error) {
+func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsForViewerRow {
+	ann, err := cd.announcement.Load(func() (*db.GetActiveAnnouncementWithNewsForViewerRow, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		row, err := cd.queries.GetActiveAnnouncementWithNewsForUser(cd.ctx, db.GetActiveAnnouncementWithNewsForUserParams{
+		row, err := cd.queries.GetActiveAnnouncementWithNewsForViewer(cd.ctx, db.GetActiveAnnouncementWithNewsForViewerParams{
 			ViewerID: cd.UserID,
 			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 		})
@@ -661,7 +661,7 @@ func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsForUserRow {
 }
 
 // AnnouncementLoaded returns the cached active announcement without querying the database.
-func (cd *CoreData) AnnouncementLoaded() *db.GetActiveAnnouncementWithNewsForUserRow {
+func (cd *CoreData) AnnouncementLoaded() *db.GetActiveAnnouncementWithNewsForViewerRow {
 	ann, ok := cd.announcement.Peek()
 	if !ok {
 		return nil

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -15,7 +15,7 @@ LIMIT 1;
 -- name: SetAnnouncementActive :exec
 UPDATE site_announcements SET active = ? WHERE id = ?;
 
--- name: GetActiveAnnouncementWithNewsForUser :one
+-- name: GetActiveAnnouncementWithNewsForViewer :one
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
     UNION

--- a/internal/db/queries-announcements.sql.go
+++ b/internal/db/queries-announcements.sql.go
@@ -74,7 +74,7 @@ func (q *Queries) AdminPromoteAnnouncement(ctx context.Context, siteNewsID int32
 	return err
 }
 
-const getActiveAnnouncementWithNewsForUser = `-- name: GetActiveAnnouncementWithNewsForUser :one
+const getActiveAnnouncementWithNewsForViewer = `-- name: GetActiveAnnouncementWithNewsForViewer :one
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
     UNION
@@ -113,25 +113,25 @@ ORDER BY a.created_at DESC
 LIMIT 1
 `
 
-type GetActiveAnnouncementWithNewsForUserParams struct {
+type GetActiveAnnouncementWithNewsForViewerParams struct {
 	ViewerID int32
 	UserID   sql.NullInt32
 }
 
-type GetActiveAnnouncementWithNewsForUserRow struct {
+type GetActiveAnnouncementWithNewsForViewerRow struct {
 	ID         int32
 	Idsitenews int32
 	News       sql.NullString
 }
 
-func (q *Queries) GetActiveAnnouncementWithNewsForUser(ctx context.Context, arg GetActiveAnnouncementWithNewsForUserParams) (*GetActiveAnnouncementWithNewsForUserRow, error) {
-	row := q.db.QueryRowContext(ctx, getActiveAnnouncementWithNewsForUser,
+func (q *Queries) GetActiveAnnouncementWithNewsForViewer(ctx context.Context, arg GetActiveAnnouncementWithNewsForViewerParams) (*GetActiveAnnouncementWithNewsForViewerRow, error) {
+	row := q.db.QueryRowContext(ctx, getActiveAnnouncementWithNewsForViewer,
 		arg.ViewerID,
 		arg.ViewerID,
 		arg.ViewerID,
 		arg.UserID,
 	)
-	var i GetActiveAnnouncementWithNewsForUserRow
+	var i GetActiveAnnouncementWithNewsForViewerRow
 	err := row.Scan(&i.ID, &i.Idsitenews, &i.News)
 	return &i, err
 }

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -130,6 +130,10 @@ When a writer publishes a post they automatically receive an `edit` grant tied t
 
 Other content sections such as blogs and writings follow the same pattern: authors can post entries and receive item-scoped `edit` grants while administrators hold broader `edit` privileges.
 
+### Announcements
+
+Active announcements reference a news post and are only shown to viewers permitted to `view` that post. The `GetActiveAnnouncementWithNewsForViewer` query filters by `viewer_id` and checks the `news` section grants for the linked post.
+
 ### SQL Query Filtering
 
 Many queries now filter results directly in SQL using `viewer_id` together with the viewer's effective roles. Each query matches against grants so only records the viewer may access are returned. The table below lists the combinations used for each section.


### PR DESCRIPTION
## Summary
- update announcement SQL query name to `GetActiveAnnouncementWithNewsForViewer`
- regenerate sqlc code and adjust Go call sites
- note viewer-level announcement access in permissions spec

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688caf923754832fba589078fc662fbb