### PR TITLE
Rename blog admin query

### DIFF
--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -123,7 +123,7 @@ func (c *userDeactivateCmd) Run() error {
 			return fmt.Errorf("scrub writing: %w", err)
 		}
 	}
-	blogs, err := qtx.GetAllBlogEntriesByUser(ctx, u.Idusers)
+	blogs, err := qtx.GetAllBlogEntriesByUserForAdmin(ctx, u.Idusers)
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("list blogs: %w", err)

--- a/handlers/admin/adminUserBlogsPage.go
+++ b/handlers/admin/adminUserBlogsPage.go
@@ -23,7 +23,7 @@ func adminUserBlogsPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.GetAllBlogEntriesByUser(r.Context(), int32(id))
+	rows, err := queries.GetAllBlogEntriesByUserForAdmin(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -32,7 +32,7 @@ func adminUserBlogsPage(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		*common.CoreData
 		User  *db.User
-		Blogs []*db.GetAllBlogEntriesByUserRow
+		Blogs []*db.GetAllBlogEntriesByUserForAdminRow
 	}{
 		CoreData: cd,
 		User:     &db.User{Idusers: user.Idusers, Username: user.Username},

--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -108,7 +108,7 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 		ws = append(ws, writingExport{wrow, catMap[wrow.WritingCategoryID]})
 	}
 
-	blogs, err := queries.GetAllBlogEntriesByUser(r.Context(), int32(uid))
+	blogs, err := queries.GetAllBlogEntriesByUserForAdmin(r.Context(), int32(uid))
 	if err != nil {
 		log.Printf("fetch blogs: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -135,7 +135,7 @@ AND cs.blog_id IN (sqlc.slice('ids'))
 ;
 
 
--- name: GetAllBlogEntriesByUser :many
+-- name: GetAllBlogEntriesByUserForAdmin :many
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0)
 FROM blogs b
 LEFT JOIN users u ON b.users_idusers=u.idusers

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -143,7 +143,7 @@ func (q *Queries) CreateBlogEntry(ctx context.Context, arg CreateBlogEntryParams
 	return result.LastInsertId()
 }
 
-const getAllBlogEntriesByUser = `-- name: GetAllBlogEntriesByUser :many
+const getAllBlogEntriesByUserForAdmin = `-- name: GetAllBlogEntriesByUserForAdmin :many
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0)
 FROM blogs b
 LEFT JOIN users u ON b.users_idusers=u.idusers
@@ -152,7 +152,7 @@ WHERE b.users_idusers = ?
 ORDER BY b.written DESC
 `
 
-type GetAllBlogEntriesByUserRow struct {
+type GetAllBlogEntriesByUserForAdminRow struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
@@ -163,15 +163,15 @@ type GetAllBlogEntriesByUserRow struct {
 	Comments           int32
 }
 
-func (q *Queries) GetAllBlogEntriesByUser(ctx context.Context, usersIdusers int32) ([]*GetAllBlogEntriesByUserRow, error) {
-	rows, err := q.db.QueryContext(ctx, getAllBlogEntriesByUser, usersIdusers)
+func (q *Queries) GetAllBlogEntriesByUserForAdmin(ctx context.Context, usersIdusers int32) ([]*GetAllBlogEntriesByUserForAdminRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllBlogEntriesByUserForAdmin, usersIdusers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*GetAllBlogEntriesByUserRow
+	var items []*GetAllBlogEntriesByUserForAdminRow
 	for rows.Next() {
-		var i GetAllBlogEntriesByUserRow
+		var i GetAllBlogEntriesByUserForAdminRow
 		if err := rows.Scan(
 			&i.Idblogs,
 			&i.ForumthreadID,


### PR DESCRIPTION
## Summary
- rename `GetAllBlogEntriesByUser` query to `GetAllBlogEntriesByUserForAdmin`
- update generated SQLC code
- adjust admin handlers and deactivation command to call the new query

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cb15144f0832f867af9ae1dc8ba6b