### PR TITLE
Rename blog index queries

### DIFF
--- a/handlers/search/remakeBlogTask.go
+++ b/handlers/search/remakeBlogTask.go
@@ -39,9 +39,9 @@ func (RemakeBlogTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tas
 	if err := q.DeleteBlogsSearch(ctx); err != nil {
 		return nil, err
 	}
-	rows, err := q.GetAllBlogsForIndex(ctx)
+	rows, err := q.GetAllBlogsForIndexSystem(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("GetAllBlogsForIndex: %w", err)
+		return nil, fmt.Errorf("GetAllBlogsForIndexSystem: %w", err)
 	}
 	cache := map[string]int64{}
 	for _, row := range rows {
@@ -58,7 +58,7 @@ func (RemakeBlogTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tas
 		}); err != nil {
 			return nil, err
 		}
-		if err := q.SetBlogLastIndex(ctx, row.Idblogs); err != nil {
+		if err := q.SetBlogLastIndexSystem(ctx, row.Idblogs); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -220,10 +220,10 @@ GROUP BY u.idusers
 ORDER BY u.username
 LIMIT ? OFFSET ?;
 
--- name: SetBlogLastIndex :exec
+-- name: SetBlogLastIndexSystem :exec
 UPDATE blogs SET last_index = NOW() WHERE idblogs = ?;
 
 
--- name: GetAllBlogsForIndex :many
+-- name: GetAllBlogsForIndexSystem :many
 SELECT idblogs, blog FROM blogs WHERE deleted_at IS NULL;
 

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -195,24 +195,24 @@ func (q *Queries) GetAllBlogEntriesByUser(ctx context.Context, usersIdusers int3
 	return items, nil
 }
 
-const getAllBlogsForIndex = `-- name: GetAllBlogsForIndex :many
+const getAllBlogsForIndexSystem = `-- name: GetAllBlogsForIndexSystem :many
 SELECT idblogs, blog FROM blogs WHERE deleted_at IS NULL
 `
 
-type GetAllBlogsForIndexRow struct {
+type GetAllBlogsForIndexSystemRow struct {
 	Idblogs int32
 	Blog    sql.NullString
 }
 
-func (q *Queries) GetAllBlogsForIndex(ctx context.Context) ([]*GetAllBlogsForIndexRow, error) {
-	rows, err := q.db.QueryContext(ctx, getAllBlogsForIndex)
+func (q *Queries) GetAllBlogsForIndexSystem(ctx context.Context) ([]*GetAllBlogsForIndexSystemRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllBlogsForIndexSystem)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*GetAllBlogsForIndexRow
+	var items []*GetAllBlogsForIndexSystemRow
 	for rows.Next() {
-		var i GetAllBlogsForIndexRow
+		var i GetAllBlogsForIndexSystemRow
 		if err := rows.Scan(&i.Idblogs, &i.Blog); err != nil {
 			return nil, err
 		}
@@ -713,12 +713,12 @@ func (q *Queries) SearchBloggersForViewer(ctx context.Context, arg SearchBlogger
 	return items, nil
 }
 
-const setBlogLastIndex = `-- name: SetBlogLastIndex :exec
+const setBlogLastIndexSystem = `-- name: SetBlogLastIndexSystem :exec
 UPDATE blogs SET last_index = NOW() WHERE idblogs = ?
 `
 
-func (q *Queries) SetBlogLastIndex(ctx context.Context, idblogs int32) error {
-	_, err := q.db.ExecContext(ctx, setBlogLastIndex, idblogs)
+func (q *Queries) SetBlogLastIndexSystem(ctx context.Context, idblogs int32) error {
+	_, err := q.db.ExecContext(ctx, setBlogLastIndexSystem, idblogs)
 	return err
 }
 


### PR DESCRIPTION
## Summary
- rename SQL queries to `SetBlogLastIndexSystem` and `GetAllBlogsForIndexSystem`
- update handlers to use the new names
- regenerate sqlc code

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cb1518e9c832faa733f5fadf21aa2