### PR TITLE
Fix announcement language filter

### DIFF
--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -29,15 +29,15 @@ FROM site_announcements a
 JOIN site_news n ON n.idsiteNews = a.site_news_id
 WHERE a.active = 1
   AND (
-      n.language_idlanguage = 0
-      OR n.language_idlanguage IS NULL
-      OR EXISTS (
-          SELECT 1 FROM user_language ul
-          WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = n.language_idlanguage
-      )
-      OR NOT EXISTS (
+      NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+      )
+      OR n.language_idlanguage = 0
+      OR n.language_idlanguage IS NULL
+      OR n.language_idlanguage IN (
+          SELECT ul.language_idlanguage
+          FROM user_language ul
+          WHERE ul.users_idusers = sqlc.arg(viewer_id)
       )
   )
   AND EXISTS (

--- a/internal/db/queries-announcements.sql.go
+++ b/internal/db/queries-announcements.sql.go
@@ -88,15 +88,15 @@ FROM site_announcements a
 JOIN site_news n ON n.idsiteNews = a.site_news_id
 WHERE a.active = 1
   AND (
-      n.language_idlanguage = 0
-      OR n.language_idlanguage IS NULL
-      OR EXISTS (
-          SELECT 1 FROM user_language ul
-          WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = n.language_idlanguage
-      )
-      OR NOT EXISTS (
+      NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
+      )
+      OR n.language_idlanguage = 0
+      OR n.language_idlanguage IS NULL
+      OR n.language_idlanguage IN (
+          SELECT ul.language_idlanguage
+          FROM user_language ul
+          WHERE ul.users_idusers = ?
       )
   )
   AND EXISTS (


### PR DESCRIPTION
## Summary
- apply standard language filter logic in announcement query
- regenerate sqlc code

## Testing
- `go vet ./...`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_688cb163d3c0832fb0ce96f16d236ca6