### PR TITLE
Update blog indexing queries

### DIFF
--- a/handlers/search/remakeBlogTask.go
+++ b/handlers/search/remakeBlogTask.go
@@ -39,7 +39,7 @@ func (RemakeBlogTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tas
 	if err := q.DeleteBlogsSearch(ctx); err != nil {
 		return nil, err
 	}
-	rows, err := q.GetAllBlogsForIndex(ctx)
+	rows, err := q.SystemGetAllBlogsForIndex(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("GetAllBlogsForIndex: %w", err)
 	}
@@ -58,7 +58,7 @@ func (RemakeBlogTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tas
 		}); err != nil {
 			return nil, err
 		}
-		if err := q.SetBlogLastIndex(ctx, row.Idblogs); err != nil {
+		if err := q.SystemSetBlogLastIndex(ctx, row.Idblogs); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -220,10 +220,10 @@ GROUP BY u.idusers
 ORDER BY u.username
 LIMIT ? OFFSET ?;
 
--- name: SetBlogLastIndex :exec
+-- name: SystemSetBlogLastIndex :exec
 UPDATE blogs SET last_index = NOW() WHERE idblogs = ?;
 
 
--- name: GetAllBlogsForIndex :many
+-- name: SystemGetAllBlogsForIndex :many
 SELECT idblogs, blog FROM blogs WHERE deleted_at IS NULL;
 

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -195,38 +195,6 @@ func (q *Queries) GetAllBlogEntriesByUser(ctx context.Context, usersIdusers int3
 	return items, nil
 }
 
-const getAllBlogsForIndex = `-- name: GetAllBlogsForIndex :many
-SELECT idblogs, blog FROM blogs WHERE deleted_at IS NULL
-`
-
-type GetAllBlogsForIndexRow struct {
-	Idblogs int32
-	Blog    sql.NullString
-}
-
-func (q *Queries) GetAllBlogsForIndex(ctx context.Context) ([]*GetAllBlogsForIndexRow, error) {
-	rows, err := q.db.QueryContext(ctx, getAllBlogsForIndex)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*GetAllBlogsForIndexRow
-	for rows.Next() {
-		var i GetAllBlogsForIndexRow
-		if err := rows.Scan(&i.Idblogs, &i.Blog); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getBlogEntriesByAuthorForUserDescendingLanguages = `-- name: GetBlogEntriesByAuthorForUserDescendingLanguages :many
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = ? AS is_owner
@@ -713,12 +681,44 @@ func (q *Queries) SearchBloggersForViewer(ctx context.Context, arg SearchBlogger
 	return items, nil
 }
 
-const setBlogLastIndex = `-- name: SetBlogLastIndex :exec
+const systemGetAllBlogsForIndex = `-- name: SystemGetAllBlogsForIndex :many
+SELECT idblogs, blog FROM blogs WHERE deleted_at IS NULL
+`
+
+type SystemGetAllBlogsForIndexRow struct {
+	Idblogs int32
+	Blog    sql.NullString
+}
+
+func (q *Queries) SystemGetAllBlogsForIndex(ctx context.Context) ([]*SystemGetAllBlogsForIndexRow, error) {
+	rows, err := q.db.QueryContext(ctx, systemGetAllBlogsForIndex)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*SystemGetAllBlogsForIndexRow
+	for rows.Next() {
+		var i SystemGetAllBlogsForIndexRow
+		if err := rows.Scan(&i.Idblogs, &i.Blog); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const systemSetBlogLastIndex = `-- name: SystemSetBlogLastIndex :exec
 UPDATE blogs SET last_index = NOW() WHERE idblogs = ?
 `
 
-func (q *Queries) SetBlogLastIndex(ctx context.Context, idblogs int32) error {
-	_, err := q.db.ExecContext(ctx, setBlogLastIndex, idblogs)
+func (q *Queries) SystemSetBlogLastIndex(ctx context.Context, idblogs int32) error {
+	_, err := q.db.ExecContext(ctx, systemSetBlogLastIndex, idblogs)
 	return err
 }
 


### PR DESCRIPTION
## Summary
- rename queries used by background task
- regenerate sqlc code
- update background worker references

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cb1720a2c832fab498687cbe7961c