### PR TITLE
Rename admin comment queries

### DIFF
--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -65,7 +65,7 @@ func (c *userDeactivateCmd) Run() error {
 		tx.Rollback()
 		return fmt.Errorf("scrub user: %w", err)
 	}
-	comments, err := qtx.GetAllCommentsByUser(ctx, u.Idusers)
+	comments, err := qtx.AdminGetAllCommentsByUser(ctx, u.Idusers)
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("list comments: %w", err)

--- a/handlers/admin/adminCommentsPage.go
+++ b/handlers/admin/adminCommentsPage.go
@@ -14,14 +14,14 @@ func AdminCommentsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Comments"
 	queries := cd.Queries()
-	rows, err := queries.ListAllCommentsWithThreadInfo(r.Context(), db.ListAllCommentsWithThreadInfoParams{Limit: 50, Offset: 0})
+	rows, err := queries.AdminListAllCommentsWithThreadInfo(r.Context(), db.AdminListAllCommentsWithThreadInfoParams{Limit: 50, Offset: 0})
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 	data := struct {
 		*common.CoreData
-		Comments []*db.ListAllCommentsWithThreadInfoRow
+		Comments []*db.AdminListAllCommentsWithThreadInfoRow
 	}{cd, rows}
 	handlers.TemplateHandler(w, r, "commentsPage.gohtml", data)
 }

--- a/handlers/admin/adminUserCommentsPage.go
+++ b/handlers/admin/adminUserCommentsPage.go
@@ -23,7 +23,7 @@ func adminUserCommentsPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.GetAllCommentsByUser(r.Context(), int32(id))
+	rows, err := queries.AdminGetAllCommentsByUser(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -32,7 +32,7 @@ func adminUserCommentsPage(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		*common.CoreData
 		User     *db.User
-		Comments []*db.GetAllCommentsByUserRow
+		Comments []*db.AdminGetAllCommentsByUserRow
 	}{
 		CoreData: cd,
 		User:     &db.User{Idusers: user.Idusers, Username: user.Username},

--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -120,7 +120,7 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	comments, err := queries.GetAllCommentsByUser(r.Context(), int32(uid))
+	comments, err := queries.AdminGetAllCommentsByUser(r.Context(), int32(uid))
 	if err != nil {
 		log.Printf("fetch comments: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -104,7 +104,7 @@ WHERE c.forumthread_id=sqlc.arg(thread_id) AND c.forumthread_id!=0 AND EXISTS (
 ORDER BY c.written;
 
 
--- name: GetAllCommentsByUser :many
+-- name: AdminGetAllCommentsByUser :many
 SELECT c.*, th.forumtopic_idforumtopic
 FROM comments c
 LEFT JOIN forumthread th ON c.forumthread_id = th.idforumthread
@@ -118,7 +118,7 @@ UPDATE comments SET last_index = NOW() WHERE idcomments = ?;
 -- name: GetAllCommentsForIndex :many
 SELECT idcomments, text FROM comments WHERE deleted_at IS NULL;
 
--- name: ListAllCommentsWithThreadInfo :many
+-- name: AdminListAllCommentsWithThreadInfo :many
 SELECT c.idcomments, c.written, c.text, c.deleted_at,
        th.idforumthread, t.idforumtopic, t.title AS forumtopic_title,
        u.idusers, u.username AS posterusername


### PR DESCRIPTION
## Summary
- rename GetAllCommentsByUser and ListAllCommentsWithThreadInfo
- regenerate sqlc code and update admin handlers

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`

------
https://chatgpt.com/codex/tasks/task_e_688cb1729d48832f883f427bce38d6b2