### PR TITLE
Prefix admin and system sql queries

### DIFF
--- a/cmd/goa4web/blog_deactivate.go
+++ b/cmd/goa4web/blog_deactivate.go
@@ -48,7 +48,7 @@ func (c *blogDeactivateCmd) Run() error {
 	if b.ForumthreadID.Valid {
 		threadID = b.ForumthreadID.Int32
 	}
-	if err := queries.ArchiveBlog(ctx, dbpkg.ArchiveBlogParams{
+	if err := queries.AdminArchiveBlog(ctx, dbpkg.AdminArchiveBlogParams{
 		Idblogs:            b.Idblogs,
 		ForumthreadID:      threadID,
 		UsersIdusers:       b.UsersIdusers,
@@ -58,7 +58,7 @@ func (c *blogDeactivateCmd) Run() error {
 	}); err != nil {
 		return fmt.Errorf("archive blog: %w", err)
 	}
-	if err := queries.ScrubBlog(ctx, dbpkg.ScrubBlogParams{Blog: sql.NullString{String: "", Valid: true}, Idblogs: b.Idblogs}); err != nil {
+	if err := queries.AdminScrubBlog(ctx, dbpkg.AdminScrubBlogParams{Blog: sql.NullString{String: "", Valid: true}, Idblogs: b.Idblogs}); err != nil {
 		return fmt.Errorf("scrub blog: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/ipban_add.go
+++ b/cmd/goa4web/ipban_add.go
@@ -51,7 +51,7 @@ func (c *ipBanAddCmd) Run() error {
 		}
 		expires = sql.NullTime{Time: t, Valid: true}
 	}
-	err = queries.InsertBannedIp(ctx, dbpkg.InsertBannedIpParams{
+	err = queries.AdminInsertBannedIp(ctx, dbpkg.AdminInsertBannedIpParams{
 		IpNet:     c.IP,
 		Reason:    sql.NullString{String: c.Reason, Valid: c.Reason != ""},
 		ExpiresAt: expires,

--- a/cmd/goa4web/ipban_delete.go
+++ b/cmd/goa4web/ipban_delete.go
@@ -37,7 +37,7 @@ func (c *ipBanDeleteCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	if err := queries.CancelBannedIp(ctx, c.IP); err != nil {
+	if err := queries.AdminCancelBannedIp(ctx, c.IP); err != nil {
 		return fmt.Errorf("cancel banned ip: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/ipban_list.go
+++ b/cmd/goa4web/ipban_list.go
@@ -31,7 +31,7 @@ func (c *ipBanListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	rows, err := queries.ListBannedIps(ctx)
+	rows, err := queries.AdminListBannedIps(ctx)
 	if err != nil {
 		return fmt.Errorf("list banned ips: %w", err)
 	}

--- a/cmd/goa4web/ipban_update.go
+++ b/cmd/goa4web/ipban_update.go
@@ -51,7 +51,7 @@ func (c *ipBanUpdateCmd) Run() error {
 		}
 		expires = sql.NullTime{Time: t, Valid: true}
 	}
-	err = queries.UpdateBannedIp(ctx, dbpkg.UpdateBannedIpParams{
+	err = queries.AdminUpdateBannedIp(ctx, dbpkg.AdminUpdateBannedIpParams{
 		Reason:    sql.NullString{String: c.Reason, Valid: c.Reason != ""},
 		ExpiresAt: expires,
 		ID:        int32(c.ID),

--- a/cmd/goa4web/user_activate.go
+++ b/cmd/goa4web/user_activate.go
@@ -53,33 +53,33 @@ func (c *userActivateCmd) Run() error {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	qtx := queries.WithTx(tx)
-	if err := qtx.RestoreUser(ctx, int32(c.ID)); err != nil {
+	if err := qtx.AdminRestoreUser(ctx, int32(c.ID)); err != nil {
 		tx.Rollback()
 		return fmt.Errorf("restore user: %w", err)
 	}
-	rows, err := qtx.PendingDeactivatedComments(ctx, int32(c.ID))
+	rows, err := qtx.AdminPendingDeactivatedComments(ctx, int32(c.ID))
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select comments: %w", err)
 	}
 	for _, row := range rows {
-		if err := qtx.RestoreComment(ctx, dbpkg.RestoreCommentParams{Text: row.Text, Idcomments: row.Idcomments}); err != nil {
+		if err := qtx.AdminRestoreComment(ctx, dbpkg.AdminRestoreCommentParams{Text: row.Text, Idcomments: row.Idcomments}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("restore comment: %w", err)
 		}
-		if err := qtx.MarkCommentRestored(ctx, row.Idcomments); err != nil {
+		if err := qtx.AdminMarkCommentRestored(ctx, row.Idcomments); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark comment restored: %w", err)
 		}
 	}
 
-	rowsW, err := qtx.PendingDeactivatedWritings(ctx, int32(c.ID))
+	rowsW, err := qtx.AdminPendingDeactivatedWritings(ctx, int32(c.ID))
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select writings: %w", err)
 	}
 	for _, w := range rowsW {
-		if err := qtx.RestoreWriting(ctx, dbpkg.RestoreWritingParams{
+		if err := qtx.AdminRestoreWriting(ctx, dbpkg.AdminRestoreWritingParams{
 			Title:     w.Title,
 			Writing:   w.Writing,
 			Abstract:  w.Abstract,
@@ -89,55 +89,55 @@ func (c *userActivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("restore writing: %w", err)
 		}
-		if err := qtx.MarkWritingRestored(ctx, w.Idwriting); err != nil {
+		if err := qtx.AdminMarkWritingRestored(ctx, w.Idwriting); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark writing restored: %w", err)
 		}
 	}
 
-	rowsB, err := qtx.PendingDeactivatedBlogs(ctx, int32(c.ID))
+	rowsB, err := qtx.AdminPendingDeactivatedBlogs(ctx, int32(c.ID))
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select blogs: %w", err)
 	}
 	for _, b := range rowsB {
-		if err := qtx.RestoreBlog(ctx, dbpkg.RestoreBlogParams{Blog: b.Blog, Idblogs: b.Idblogs}); err != nil {
+		if err := qtx.AdminRestoreBlog(ctx, dbpkg.AdminRestoreBlogParams{Blog: b.Blog, Idblogs: b.Idblogs}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("restore blog: %w", err)
 		}
-		if err := qtx.MarkBlogRestored(ctx, b.Idblogs); err != nil {
+		if err := qtx.AdminMarkBlogRestored(ctx, b.Idblogs); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark blog restored: %w", err)
 		}
 	}
 
-	rowsI, err := qtx.PendingDeactivatedImageposts(ctx, int32(c.ID))
+	rowsI, err := qtx.AdminPendingDeactivatedImageposts(ctx, int32(c.ID))
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select imageposts: %w", err)
 	}
 	for _, img := range rowsI {
-		if err := qtx.RestoreImagepost(ctx, dbpkg.RestoreImagepostParams{Description: img.Description, Thumbnail: img.Thumbnail, Fullimage: img.Fullimage, Idimagepost: img.Idimagepost}); err != nil {
+		if err := qtx.AdminRestoreImagepost(ctx, dbpkg.AdminRestoreImagepostParams{Description: img.Description, Thumbnail: img.Thumbnail, Fullimage: img.Fullimage, Idimagepost: img.Idimagepost}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("restore imagepost: %w", err)
 		}
-		if err := qtx.MarkImagepostRestored(ctx, img.Idimagepost); err != nil {
+		if err := qtx.AdminMarkImagepostRestored(ctx, img.Idimagepost); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark imagepost restored: %w", err)
 		}
 	}
 
-	rowsL, err := qtx.PendingDeactivatedLinks(ctx, int32(c.ID))
+	rowsL, err := qtx.AdminPendingDeactivatedLinks(ctx, int32(c.ID))
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select links: %w", err)
 	}
 	for _, l := range rowsL {
-		if err := qtx.RestoreLink(ctx, dbpkg.RestoreLinkParams{Title: l.Title, Url: l.Url, Description: l.Description, Idlinker: l.Idlinker}); err != nil {
+		if err := qtx.AdminRestoreLink(ctx, dbpkg.AdminRestoreLinkParams{Title: l.Title, Url: l.Url, Description: l.Description, Idlinker: l.Idlinker}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("restore link: %w", err)
 		}
-		if err := qtx.MarkLinkRestored(ctx, l.Idlinker); err != nil {
+		if err := qtx.AdminMarkLinkRestored(ctx, l.Idlinker); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark link restored: %w", err)
 		}

--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -56,12 +56,12 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	qtx := queries.WithTx(tx)
-	if err := qtx.ArchiveUser(ctx, u.Idusers); err != nil {
+	if err := qtx.AdminArchiveUser(ctx, u.Idusers); err != nil {
 		tx.Rollback()
 		return fmt.Errorf("archive user: %w", err)
 	}
 	newName := randomString(16)
-	if err := qtx.ScrubUser(ctx, dbpkg.ScrubUserParams{Username: sql.NullString{String: newName, Valid: true}, Idusers: u.Idusers}); err != nil {
+	if err := qtx.AdminScrubUser(ctx, dbpkg.AdminScrubUserParams{Username: sql.NullString{String: newName, Valid: true}, Idusers: u.Idusers}); err != nil {
 		tx.Rollback()
 		return fmt.Errorf("scrub user: %w", err)
 	}
@@ -71,7 +71,7 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("list comments: %w", err)
 	}
 	for _, cm := range comments {
-		if err := qtx.ArchiveComment(ctx, dbpkg.ArchiveCommentParams{
+		if err := qtx.AdminArchiveComment(ctx, dbpkg.AdminArchiveCommentParams{
 			Idcomments:         cm.Idcomments,
 			ForumthreadID:      cm.ForumthreadID,
 			UsersIdusers:       cm.UsersIdusers,
@@ -83,7 +83,7 @@ func (c *userDeactivateCmd) Run() error {
 			return fmt.Errorf("archive comment: %w", err)
 		}
 		scrub := scrubText(cm.Text.String)
-		if err := qtx.ScrubComment(ctx, dbpkg.ScrubCommentParams{Text: sql.NullString{String: scrub, Valid: true}, Idcomments: cm.Idcomments}); err != nil {
+		if err := qtx.AdminScrubComment(ctx, dbpkg.AdminScrubCommentParams{Text: sql.NullString{String: scrub, Valid: true}, Idcomments: cm.Idcomments}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("scrub comment: %w", err)
 		}
@@ -98,7 +98,7 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("list writings: %w", err)
 	}
 	for _, w := range writings {
-		if err := qtx.ArchiveWriting(ctx, dbpkg.ArchiveWritingParams{
+		if err := qtx.AdminArchiveWriting(ctx, dbpkg.AdminArchiveWritingParams{
 			Idwriting:          w.Idwriting,
 			UsersIdusers:       w.UsersIdusers,
 			ForumthreadID:      w.ForumthreadID,
@@ -113,7 +113,7 @@ func (c *userDeactivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("archive writing: %w", err)
 		}
-		if err := qtx.ScrubWriting(ctx, dbpkg.ScrubWritingParams{
+		if err := qtx.AdminScrubWriting(ctx, dbpkg.AdminScrubWritingParams{
 			Title:     sql.NullString{String: scrubText(w.Title.String), Valid: w.Title.Valid},
 			Writing:   sql.NullString{String: scrubText(w.Writing.String), Valid: w.Writing.Valid},
 			Abstract:  sql.NullString{String: scrubText(w.Abstract.String), Valid: w.Abstract.Valid},
@@ -133,7 +133,7 @@ func (c *userDeactivateCmd) Run() error {
 		if b.ForumthreadID.Valid {
 			threadID = b.ForumthreadID.Int32
 		}
-		if err := qtx.ArchiveBlog(ctx, dbpkg.ArchiveBlogParams{
+		if err := qtx.AdminArchiveBlog(ctx, dbpkg.AdminArchiveBlogParams{
 			Idblogs:            b.Idblogs,
 			ForumthreadID:      threadID,
 			UsersIdusers:       b.UsersIdusers,
@@ -144,7 +144,7 @@ func (c *userDeactivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("archive blog: %w", err)
 		}
-		if err := qtx.ScrubBlog(ctx, dbpkg.ScrubBlogParams{Blog: sql.NullString{String: scrubText(b.Blog.String), Valid: b.Blog.Valid}, Idblogs: b.Idblogs}); err != nil {
+		if err := qtx.AdminScrubBlog(ctx, dbpkg.AdminScrubBlogParams{Blog: sql.NullString{String: scrubText(b.Blog.String), Valid: b.Blog.Valid}, Idblogs: b.Idblogs}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("scrub blog: %w", err)
 		}
@@ -155,7 +155,7 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("list images: %w", err)
 	}
 	for _, img := range imgs {
-		if err := qtx.ArchiveImagepost(ctx, dbpkg.ArchiveImagepostParams{
+		if err := qtx.AdminArchiveImagepost(ctx, dbpkg.AdminArchiveImagepostParams{
 			Idimagepost:            img.Idimagepost,
 			ForumthreadID:          img.ForumthreadID,
 			UsersIdusers:           img.UsersIdusers,
@@ -170,7 +170,7 @@ func (c *userDeactivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("archive imagepost: %w", err)
 		}
-		if err := qtx.ScrubImagepost(ctx, img.Idimagepost); err != nil {
+		if err := qtx.AdminScrubImagepost(ctx, img.Idimagepost); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("scrub imagepost: %w", err)
 		}
@@ -181,7 +181,7 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("list links: %w", err)
 	}
 	for _, l := range links {
-		if err := qtx.ArchiveLink(ctx, dbpkg.ArchiveLinkParams{
+		if err := qtx.AdminArchiveLink(ctx, dbpkg.AdminArchiveLinkParams{
 			Idlinker:           l.Idlinker,
 			LanguageIdlanguage: l.LanguageIdlanguage,
 			UsersIdusers:       l.UsersIdusers,
@@ -195,7 +195,7 @@ func (c *userDeactivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("archive link: %w", err)
 		}
-		if err := qtx.ScrubLink(ctx, dbpkg.ScrubLinkParams{Title: sql.NullString{String: scrubText(l.Title.String), Valid: l.Title.Valid}, Idlinker: l.Idlinker}); err != nil {
+		if err := qtx.AdminScrubLink(ctx, dbpkg.AdminScrubLinkParams{Title: sql.NullString{String: scrubText(l.Title.String), Valid: l.Title.Valid}, Idlinker: l.Idlinker}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("scrub link: %w", err)
 		}

--- a/handlers/admin/add_ip_ban_task.go
+++ b/handlers/admin/add_ip_ban_task.go
@@ -39,7 +39,7 @@ func (AddIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	if ipNet != "" {
-		if err := queries.InsertBannedIp(r.Context(), db.InsertBannedIpParams{
+		if err := queries.AdminInsertBannedIp(r.Context(), db.AdminInsertBannedIpParams{
 			IpNet:     ipNet,
 			Reason:    sql.NullString{String: reason, Valid: reason != ""},
 			ExpiresAt: expires,

--- a/handlers/admin/adminAuditLogPage.go
+++ b/handlers/admin/adminAuditLogPage.go
@@ -26,7 +26,7 @@ func copyValues(v url.Values) url.Values {
 func AdminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		Rows     []*db.ListAuditLogsRow
+		Rows     []*db.AdminListAuditLogsRow
 		User     string
 		Action   string
 		NextLink string
@@ -55,7 +55,7 @@ func AdminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 		actionFilter = "%" + data.Action + "%"
 	}
 
-	rows, err := queries.ListAuditLogs(r.Context(), db.ListAuditLogsParams{
+	rows, err := queries.AdminListAuditLogs(r.Context(), db.AdminListAuditLogsParams{
 		Username: sql.NullString{String: usernameFilter, Valid: true},
 		Action:   actionFilter,
 		Limit:    int32(data.PageSize + 1),

--- a/handlers/admin/adminCommentTasks.go
+++ b/handlers/admin/adminCommentTasks.go
@@ -24,7 +24,7 @@ var _ tasks.Task = (*DeleteCommentTask)(nil)
 func (DeleteCommentTask) Action(w http.ResponseWriter, r *http.Request) any {
 	id, _ := strconv.Atoi(mux.Vars(r)["id"])
 	q := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	if err := q.ScrubComment(r.Context(), db.ScrubCommentParams{Text: sql.NullString{String: "", Valid: true}, Idcomments: int32(id)}); err != nil {
+	if err := q.AdminScrubComment(r.Context(), db.AdminScrubCommentParams{Text: sql.NullString{String: "", Valid: true}, Idcomments: int32(id)}); err != nil {
 		return fmt.Errorf("delete comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	return nil
@@ -62,7 +62,7 @@ func (BanCommentTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("fetch comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := q.ArchiveComment(r.Context(), db.ArchiveCommentParams{
+	if err := q.AdminArchiveComment(r.Context(), db.AdminArchiveCommentParams{
 		Idcomments:         c.Idcomments,
 		ForumthreadID:      c.ForumthreadID,
 		UsersIdusers:       c.UsersIdusers,
@@ -72,7 +72,7 @@ func (BanCommentTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}); err != nil {
 		return fmt.Errorf("archive comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := q.ScrubComment(r.Context(), db.ScrubCommentParams{Text: sql.NullString{String: "", Valid: true}, Idcomments: c.Idcomments}); err != nil {
+	if err := q.AdminScrubComment(r.Context(), db.AdminScrubCommentParams{Text: sql.NullString{String: "", Valid: true}, Idcomments: c.Idcomments}); err != nil {
 		return fmt.Errorf("scrub comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	return nil

--- a/handlers/admin/adminDLQPage.go
+++ b/handlers/admin/adminDLQPage.go
@@ -63,15 +63,15 @@ func AdminDLQPage(w http.ResponseWriter, r *http.Request) {
 	for _, n := range names {
 		switch n {
 		case "db":
-			if rows, err := queries.ListDeadLetters(r.Context(), 100); err == nil {
+			if rows, err := queries.AdminListDeadLetters(r.Context(), 100); err == nil {
 				data.Errors = rows
 			} else {
 				log.Printf("list dead letters: %v", err)
 			}
-			if c, err := queries.CountDeadLetters(r.Context()); err == nil {
+			if c, err := queries.SystemCountDeadLetters(r.Context()); err == nil {
 				data.DBCount = c
 			}
-			if lt, err := queries.LatestDeadLetter(r.Context()); err == nil {
+			if lt, err := queries.AdminLatestDeadLetter(r.Context()); err == nil {
 				if t, ok := lt.(time.Time); ok {
 					data.DBLatest = t.Format(time.RFC3339)
 				}
@@ -123,7 +123,7 @@ func (DeleteDLQTask) Action(w http.ResponseWriter, r *http.Request) any {
 				continue
 			}
 			id, _ := strconv.Atoi(idStr)
-			if err := queries.DeleteDeadLetter(r.Context(), int32(id)); err != nil {
+			if err := queries.AdminDeleteDeadLetter(r.Context(), int32(id)); err != nil {
 				return fmt.Errorf("delete error %w", handlers.ErrRedirectOnSamePageHandler(err))
 			}
 			if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
@@ -143,7 +143,7 @@ func (DeleteDLQTask) Action(w http.ResponseWriter, r *http.Request) any {
 				t = tt
 			}
 		}
-		if err := queries.PurgeDeadLettersBefore(r.Context(), t); err != nil {
+		if err := queries.AdminPurgeDeadLettersBefore(r.Context(), t); err != nil {
 			return fmt.Errorf("purge errors %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/adminIPBanPage.go
+++ b/handlers/admin/adminIPBanPage.go
@@ -22,7 +22,7 @@ func AdminIPBanPage(w http.ResponseWriter, r *http.Request) {
 	cd.PageTitle = "IP Bans"
 	data := Data{CoreData: cd}
 	queries := cd.Queries()
-	rows, err := queries.ListBannedIps(r.Context())
+	rows, err := queries.AdminListBannedIps(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list banned ips: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/delete_ip_ban_task.go
+++ b/handlers/admin/delete_ip_ban_task.go
@@ -30,7 +30,7 @@ func (DeleteIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {
 	var ips []string
 	for _, ip := range r.Form["ip"] {
 		ipNet := NormalizeIPNet(ip)
-		if err := queries.CancelBannedIp(r.Context(), ipNet); err != nil {
+		if err := queries.AdminCancelBannedIp(r.Context(), ipNet); err != nil {
 			return fmt.Errorf("cancel banned ip %s fail %w", ipNet, handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if ipNet != "" {

--- a/internal/db/queries-auditlog.sql
+++ b/internal/db/queries-auditlog.sql
@@ -1,7 +1,7 @@
--- name: InsertAuditLog :exec
+-- name: SystemInsertAuditLog :exec
 INSERT INTO audit_log (users_idusers, action, path, details, data) VALUES (?, ?, ?, ?, ?);
 
--- name: ListAuditLogs :many
+-- name: AdminListAuditLogs :many
 SELECT a.id, a.users_idusers, a.action, a.path, a.details, a.data, a.created_at, u.username
 FROM audit_log a
 LEFT JOIN users u ON a.users_idusers = u.idusers

--- a/internal/db/queries-auditlog.sql.go
+++ b/internal/db/queries-auditlog.sql.go
@@ -11,30 +11,7 @@ import (
 	"time"
 )
 
-const insertAuditLog = `-- name: InsertAuditLog :exec
-INSERT INTO audit_log (users_idusers, action, path, details, data) VALUES (?, ?, ?, ?, ?)
-`
-
-type InsertAuditLogParams struct {
-	UsersIdusers int32
-	Action       string
-	Path         string
-	Details      sql.NullString
-	Data         sql.NullString
-}
-
-func (q *Queries) InsertAuditLog(ctx context.Context, arg InsertAuditLogParams) error {
-	_, err := q.db.ExecContext(ctx, insertAuditLog,
-		arg.UsersIdusers,
-		arg.Action,
-		arg.Path,
-		arg.Details,
-		arg.Data,
-	)
-	return err
-}
-
-const listAuditLogs = `-- name: ListAuditLogs :many
+const adminListAuditLogs = `-- name: AdminListAuditLogs :many
 SELECT a.id, a.users_idusers, a.action, a.path, a.details, a.data, a.created_at, u.username
 FROM audit_log a
 LEFT JOIN users u ON a.users_idusers = u.idusers
@@ -43,14 +20,14 @@ ORDER BY a.id DESC
 LIMIT ? OFFSET ?
 `
 
-type ListAuditLogsParams struct {
+type AdminListAuditLogsParams struct {
 	Username sql.NullString
 	Action   string
 	Limit    int32
 	Offset   int32
 }
 
-type ListAuditLogsRow struct {
+type AdminListAuditLogsRow struct {
 	ID           int32
 	UsersIdusers int32
 	Action       string
@@ -61,8 +38,8 @@ type ListAuditLogsRow struct {
 	Username     sql.NullString
 }
 
-func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([]*ListAuditLogsRow, error) {
-	rows, err := q.db.QueryContext(ctx, listAuditLogs,
+func (q *Queries) AdminListAuditLogs(ctx context.Context, arg AdminListAuditLogsParams) ([]*AdminListAuditLogsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListAuditLogs,
 		arg.Username,
 		arg.Action,
 		arg.Limit,
@@ -72,9 +49,9 @@ func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*ListAuditLogsRow
+	var items []*AdminListAuditLogsRow
 	for rows.Next() {
-		var i ListAuditLogsRow
+		var i AdminListAuditLogsRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.UsersIdusers,
@@ -96,4 +73,27 @@ func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([
 		return nil, err
 	}
 	return items, nil
+}
+
+const systemInsertAuditLog = `-- name: SystemInsertAuditLog :exec
+INSERT INTO audit_log (users_idusers, action, path, details, data) VALUES (?, ?, ?, ?, ?)
+`
+
+type SystemInsertAuditLogParams struct {
+	UsersIdusers int32
+	Action       string
+	Path         string
+	Details      sql.NullString
+	Data         sql.NullString
+}
+
+func (q *Queries) SystemInsertAuditLog(ctx context.Context, arg SystemInsertAuditLogParams) error {
+	_, err := q.db.ExecContext(ctx, systemInsertAuditLog,
+		arg.UsersIdusers,
+		arg.Action,
+		arg.Path,
+		arg.Details,
+		arg.Data,
+	)
+	return err
 }

--- a/internal/db/queries-banned_ips.sql
+++ b/internal/db/queries-banned_ips.sql
@@ -1,18 +1,18 @@
--- name: InsertBannedIp :exec
+-- name: AdminInsertBannedIp :exec
 INSERT INTO banned_ips (ip_net, reason, expires_at)
 VALUES (?, ?, ?);
 
--- name: UpdateBannedIp :exec
+-- name: AdminUpdateBannedIp :exec
 UPDATE banned_ips SET reason = ?, expires_at = ? WHERE id = ?;
 
--- name: CancelBannedIp :exec
+-- name: AdminCancelBannedIp :exec
 UPDATE banned_ips SET canceled_at = CURRENT_TIMESTAMP WHERE ip_net = ? AND canceled_at IS NULL;
 
--- name: GetBannedIpByAddress :one
+-- name: SystemGetBannedIpByAddress :one
 SELECT * FROM banned_ips WHERE ip_net = ?;
 
--- name: ListActiveBans :many
+-- name: SystemListActiveBans :many
 SELECT * FROM banned_ips WHERE canceled_at IS NULL AND (expires_at IS NULL OR expires_at > NOW());
 
--- name: ListBannedIps :many
+-- name: AdminListBannedIps :many
 SELECT * FROM banned_ips ORDER BY created_at DESC;

--- a/internal/db/queries-banned_ips.sql.go
+++ b/internal/db/queries-banned_ips.sql.go
@@ -10,21 +10,86 @@ import (
 	"database/sql"
 )
 
-const cancelBannedIp = `-- name: CancelBannedIp :exec
+const adminCancelBannedIp = `-- name: AdminCancelBannedIp :exec
 UPDATE banned_ips SET canceled_at = CURRENT_TIMESTAMP WHERE ip_net = ? AND canceled_at IS NULL
 `
 
-func (q *Queries) CancelBannedIp(ctx context.Context, ipNet string) error {
-	_, err := q.db.ExecContext(ctx, cancelBannedIp, ipNet)
+func (q *Queries) AdminCancelBannedIp(ctx context.Context, ipNet string) error {
+	_, err := q.db.ExecContext(ctx, adminCancelBannedIp, ipNet)
 	return err
 }
 
-const getBannedIpByAddress = `-- name: GetBannedIpByAddress :one
+const adminInsertBannedIp = `-- name: AdminInsertBannedIp :exec
+INSERT INTO banned_ips (ip_net, reason, expires_at)
+VALUES (?, ?, ?)
+`
+
+type AdminInsertBannedIpParams struct {
+	IpNet     string
+	Reason    sql.NullString
+	ExpiresAt sql.NullTime
+}
+
+func (q *Queries) AdminInsertBannedIp(ctx context.Context, arg AdminInsertBannedIpParams) error {
+	_, err := q.db.ExecContext(ctx, adminInsertBannedIp, arg.IpNet, arg.Reason, arg.ExpiresAt)
+	return err
+}
+
+const adminListBannedIps = `-- name: AdminListBannedIps :many
+SELECT id, ip_net, reason, created_at, expires_at, canceled_at FROM banned_ips ORDER BY created_at DESC
+`
+
+func (q *Queries) AdminListBannedIps(ctx context.Context) ([]*BannedIp, error) {
+	rows, err := q.db.QueryContext(ctx, adminListBannedIps)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*BannedIp
+	for rows.Next() {
+		var i BannedIp
+		if err := rows.Scan(
+			&i.ID,
+			&i.IpNet,
+			&i.Reason,
+			&i.CreatedAt,
+			&i.ExpiresAt,
+			&i.CanceledAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const adminUpdateBannedIp = `-- name: AdminUpdateBannedIp :exec
+UPDATE banned_ips SET reason = ?, expires_at = ? WHERE id = ?
+`
+
+type AdminUpdateBannedIpParams struct {
+	Reason    sql.NullString
+	ExpiresAt sql.NullTime
+	ID        int32
+}
+
+func (q *Queries) AdminUpdateBannedIp(ctx context.Context, arg AdminUpdateBannedIpParams) error {
+	_, err := q.db.ExecContext(ctx, adminUpdateBannedIp, arg.Reason, arg.ExpiresAt, arg.ID)
+	return err
+}
+
+const systemGetBannedIpByAddress = `-- name: SystemGetBannedIpByAddress :one
 SELECT id, ip_net, reason, created_at, expires_at, canceled_at FROM banned_ips WHERE ip_net = ?
 `
 
-func (q *Queries) GetBannedIpByAddress(ctx context.Context, ipNet string) (*BannedIp, error) {
-	row := q.db.QueryRowContext(ctx, getBannedIpByAddress, ipNet)
+func (q *Queries) SystemGetBannedIpByAddress(ctx context.Context, ipNet string) (*BannedIp, error) {
+	row := q.db.QueryRowContext(ctx, systemGetBannedIpByAddress, ipNet)
 	var i BannedIp
 	err := row.Scan(
 		&i.ID,
@@ -37,28 +102,12 @@ func (q *Queries) GetBannedIpByAddress(ctx context.Context, ipNet string) (*Bann
 	return &i, err
 }
 
-const insertBannedIp = `-- name: InsertBannedIp :exec
-INSERT INTO banned_ips (ip_net, reason, expires_at)
-VALUES (?, ?, ?)
-`
-
-type InsertBannedIpParams struct {
-	IpNet     string
-	Reason    sql.NullString
-	ExpiresAt sql.NullTime
-}
-
-func (q *Queries) InsertBannedIp(ctx context.Context, arg InsertBannedIpParams) error {
-	_, err := q.db.ExecContext(ctx, insertBannedIp, arg.IpNet, arg.Reason, arg.ExpiresAt)
-	return err
-}
-
-const listActiveBans = `-- name: ListActiveBans :many
+const systemListActiveBans = `-- name: SystemListActiveBans :many
 SELECT id, ip_net, reason, created_at, expires_at, canceled_at FROM banned_ips WHERE canceled_at IS NULL AND (expires_at IS NULL OR expires_at > NOW())
 `
 
-func (q *Queries) ListActiveBans(ctx context.Context) ([]*BannedIp, error) {
-	rows, err := q.db.QueryContext(ctx, listActiveBans)
+func (q *Queries) SystemListActiveBans(ctx context.Context) ([]*BannedIp, error) {
+	rows, err := q.db.QueryContext(ctx, systemListActiveBans)
 	if err != nil {
 		return nil, err
 	}
@@ -85,53 +134,4 @@ func (q *Queries) ListActiveBans(ctx context.Context) ([]*BannedIp, error) {
 		return nil, err
 	}
 	return items, nil
-}
-
-const listBannedIps = `-- name: ListBannedIps :many
-SELECT id, ip_net, reason, created_at, expires_at, canceled_at FROM banned_ips ORDER BY created_at DESC
-`
-
-func (q *Queries) ListBannedIps(ctx context.Context) ([]*BannedIp, error) {
-	rows, err := q.db.QueryContext(ctx, listBannedIps)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*BannedIp
-	for rows.Next() {
-		var i BannedIp
-		if err := rows.Scan(
-			&i.ID,
-			&i.IpNet,
-			&i.Reason,
-			&i.CreatedAt,
-			&i.ExpiresAt,
-			&i.CanceledAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const updateBannedIp = `-- name: UpdateBannedIp :exec
-UPDATE banned_ips SET reason = ?, expires_at = ? WHERE id = ?
-`
-
-type UpdateBannedIpParams struct {
-	Reason    sql.NullString
-	ExpiresAt sql.NullTime
-	ID        int32
-}
-
-func (q *Queries) UpdateBannedIp(ctx context.Context, arg UpdateBannedIpParams) error {
-	_, err := q.db.ExecContext(ctx, updateBannedIp, arg.Reason, arg.ExpiresAt, arg.ID)
-	return err
 }

--- a/internal/db/queries-deactivation.sql
+++ b/internal/db/queries-deactivation.sql
@@ -1,97 +1,97 @@
 -- Queries for user deactivation and restoration
 
--- name: ArchiveUser :exec
+-- name: AdminArchiveUser :exec
 INSERT INTO deactivated_users (idusers, email, passwd, passwd_algorithm, username, deleted_at)
 SELECT u.idusers, u.email, u.passwd, u.passwd_algorithm, u.username, NOW()
 FROM users u WHERE u.idusers = ?;
 
--- name: ScrubUser :exec
+-- name: AdminScrubUser :exec
 UPDATE users SET username = ?, email = '', passwd = '', passwd_algorithm = '', deleted_at = NOW()
 WHERE idusers = ?;
 
--- name: ArchiveComment :exec
+-- name: AdminArchiveComment :exec
 INSERT INTO deactivated_comments (idcomments, forumthread_id, users_idusers, language_idlanguage, written, text, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubComment :exec
+-- name: AdminScrubComment :exec
 UPDATE comments SET text = ?, deleted_at = NOW() WHERE idcomments = ?;
 
--- name: PendingDeactivatedComments :many
+-- name: AdminPendingDeactivatedComments :many
 SELECT idcomments, text FROM deactivated_comments
 WHERE users_idusers = ? AND restored_at IS NULL;
 
--- name: RestoreComment :exec
+-- name: AdminRestoreComment :exec
 UPDATE comments SET text = ?, deleted_at = NULL WHERE idcomments = ?;
 
--- name: MarkCommentRestored :exec
+-- name: AdminMarkCommentRestored :exec
 UPDATE deactivated_comments SET restored_at = NOW() WHERE idcomments = ?;
 
--- name: ArchiveWriting :exec
+-- name: AdminArchiveWriting :exec
 INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_id, language_idlanguage, writing_category_id, title, published, writing, abstract, private, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubWriting :exec
+-- name: AdminScrubWriting :exec
 UPDATE writing SET title = ?, writing = ?, abstract = ?, deleted_at = NOW() WHERE idwriting = ?;
 
--- name: PendingDeactivatedWritings :many
+-- name: AdminPendingDeactivatedWritings :many
 SELECT idwriting, title, writing, abstract, private FROM deactivated_writings
 WHERE users_idusers = ? AND restored_at IS NULL;
 
--- name: RestoreWriting :exec
+-- name: AdminRestoreWriting :exec
 UPDATE writing SET title = ?, writing = ?, abstract = ?, private = ?, deleted_at = NULL WHERE idwriting = ?;
 
--- name: MarkWritingRestored :exec
+-- name: AdminMarkWritingRestored :exec
 UPDATE deactivated_writings SET restored_at = NOW() WHERE idwriting = ?;
 
--- name: ArchiveBlog :exec
+-- name: AdminArchiveBlog :exec
 INSERT INTO deactivated_blogs (idblogs, forumthread_id, users_idusers, language_idlanguage, blog, written, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubBlog :exec
+-- name: AdminScrubBlog :exec
 UPDATE blogs SET blog = ?, deleted_at = NOW() WHERE idblogs = ?;
 
--- name: PendingDeactivatedBlogs :many
+-- name: AdminPendingDeactivatedBlogs :many
 SELECT idblogs, blog FROM deactivated_blogs WHERE users_idusers = ? AND restored_at IS NULL;
 
--- name: RestoreBlog :exec
+-- name: AdminRestoreBlog :exec
 UPDATE blogs SET blog = ?, deleted_at = NULL WHERE idblogs = ?;
 
--- name: MarkBlogRestored :exec
+-- name: AdminMarkBlogRestored :exec
 UPDATE deactivated_blogs SET restored_at = NOW() WHERE idblogs = ?;
 
--- name: ArchiveImagepost :exec
+-- name: AdminArchiveImagepost :exec
 INSERT INTO deactivated_imageposts (idimagepost, forumthread_id, users_idusers, imageboard_idimageboard, posted, description, thumbnail, fullimage, file_size, approved, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubImagepost :exec
+-- name: AdminScrubImagepost :exec
 UPDATE imagepost SET description = '', thumbnail = '', fullimage = '', deleted_at = NOW() WHERE idimagepost = ?;
 
--- name: PendingDeactivatedImageposts :many
+-- name: AdminPendingDeactivatedImageposts :many
 SELECT idimagepost, description, thumbnail, fullimage FROM deactivated_imageposts WHERE users_idusers = ? AND restored_at IS NULL;
 
--- name: RestoreImagepost :exec
+-- name: AdminRestoreImagepost :exec
 UPDATE imagepost SET description = ?, thumbnail = ?, fullimage = ?, deleted_at = NULL WHERE idimagepost = ?;
 
--- name: MarkImagepostRestored :exec
+-- name: AdminMarkImagepostRestored :exec
 UPDATE deactivated_imageposts SET restored_at = NOW() WHERE idimagepost = ?;
 
--- name: ArchiveLink :exec
+-- name: AdminArchiveLink :exec
 INSERT INTO deactivated_linker (idlinker, language_idlanguage, users_idusers, linker_category_id, forumthread_id, title, url, description, listed, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubLink :exec
+-- name: AdminScrubLink :exec
 UPDATE linker SET title = ?, url = '', description = '', deleted_at = NOW() WHERE idlinker = ?;
 
--- name: PendingDeactivatedLinks :many
+-- name: AdminPendingDeactivatedLinks :many
 SELECT idlinker, title, url, description FROM deactivated_linker WHERE users_idusers = ? AND restored_at IS NULL;
 
--- name: RestoreLink :exec
+-- name: AdminRestoreLink :exec
 UPDATE linker SET title = ?, url = ?, description = ?, deleted_at = NULL WHERE idlinker = ?;
 
--- name: MarkLinkRestored :exec
+-- name: AdminMarkLinkRestored :exec
 UPDATE deactivated_linker SET restored_at = NOW() WHERE idlinker = ?;
 
--- name: RestoreUser :exec
+-- name: AdminRestoreUser :exec
 UPDATE users u JOIN deactivated_users d ON u.idusers = d.idusers
 SET u.email = d.email, u.passwd = d.passwd, u.passwd_algorithm = d.passwd_algorithm, u.username = d.username, u.deleted_at = NULL, d.restored_at = NOW()
 WHERE u.idusers = ? AND d.restored_at IS NULL;

--- a/internal/db/queries-deactivation.sql.go
+++ b/internal/db/queries-deactivation.sql.go
@@ -10,12 +10,12 @@ import (
 	"database/sql"
 )
 
-const archiveBlog = `-- name: ArchiveBlog :exec
+const adminArchiveBlog = `-- name: AdminArchiveBlog :exec
 INSERT INTO deactivated_blogs (idblogs, forumthread_id, users_idusers, language_idlanguage, blog, written, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveBlogParams struct {
+type AdminArchiveBlogParams struct {
 	Idblogs            int32
 	ForumthreadID      int32
 	UsersIdusers       int32
@@ -24,8 +24,8 @@ type ArchiveBlogParams struct {
 	Written            sql.NullTime
 }
 
-func (q *Queries) ArchiveBlog(ctx context.Context, arg ArchiveBlogParams) error {
-	_, err := q.db.ExecContext(ctx, archiveBlog,
+func (q *Queries) AdminArchiveBlog(ctx context.Context, arg AdminArchiveBlogParams) error {
+	_, err := q.db.ExecContext(ctx, adminArchiveBlog,
 		arg.Idblogs,
 		arg.ForumthreadID,
 		arg.UsersIdusers,
@@ -36,12 +36,12 @@ func (q *Queries) ArchiveBlog(ctx context.Context, arg ArchiveBlogParams) error 
 	return err
 }
 
-const archiveComment = `-- name: ArchiveComment :exec
+const adminArchiveComment = `-- name: AdminArchiveComment :exec
 INSERT INTO deactivated_comments (idcomments, forumthread_id, users_idusers, language_idlanguage, written, text, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveCommentParams struct {
+type AdminArchiveCommentParams struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
@@ -50,8 +50,8 @@ type ArchiveCommentParams struct {
 	Text               sql.NullString
 }
 
-func (q *Queries) ArchiveComment(ctx context.Context, arg ArchiveCommentParams) error {
-	_, err := q.db.ExecContext(ctx, archiveComment,
+func (q *Queries) AdminArchiveComment(ctx context.Context, arg AdminArchiveCommentParams) error {
+	_, err := q.db.ExecContext(ctx, adminArchiveComment,
 		arg.Idcomments,
 		arg.ForumthreadID,
 		arg.UsersIdusers,
@@ -62,12 +62,12 @@ func (q *Queries) ArchiveComment(ctx context.Context, arg ArchiveCommentParams) 
 	return err
 }
 
-const archiveImagepost = `-- name: ArchiveImagepost :exec
+const adminArchiveImagepost = `-- name: AdminArchiveImagepost :exec
 INSERT INTO deactivated_imageposts (idimagepost, forumthread_id, users_idusers, imageboard_idimageboard, posted, description, thumbnail, fullimage, file_size, approved, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveImagepostParams struct {
+type AdminArchiveImagepostParams struct {
 	Idimagepost            int32
 	ForumthreadID          int32
 	UsersIdusers           int32
@@ -80,8 +80,8 @@ type ArchiveImagepostParams struct {
 	Approved               sql.NullBool
 }
 
-func (q *Queries) ArchiveImagepost(ctx context.Context, arg ArchiveImagepostParams) error {
-	_, err := q.db.ExecContext(ctx, archiveImagepost,
+func (q *Queries) AdminArchiveImagepost(ctx context.Context, arg AdminArchiveImagepostParams) error {
+	_, err := q.db.ExecContext(ctx, adminArchiveImagepost,
 		arg.Idimagepost,
 		arg.ForumthreadID,
 		arg.UsersIdusers,
@@ -96,12 +96,12 @@ func (q *Queries) ArchiveImagepost(ctx context.Context, arg ArchiveImagepostPara
 	return err
 }
 
-const archiveLink = `-- name: ArchiveLink :exec
+const adminArchiveLink = `-- name: AdminArchiveLink :exec
 INSERT INTO deactivated_linker (idlinker, language_idlanguage, users_idusers, linker_category_id, forumthread_id, title, url, description, listed, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveLinkParams struct {
+type AdminArchiveLinkParams struct {
 	Idlinker           int32
 	LanguageIdlanguage int32
 	UsersIdusers       int32
@@ -113,8 +113,8 @@ type ArchiveLinkParams struct {
 	Listed             sql.NullTime
 }
 
-func (q *Queries) ArchiveLink(ctx context.Context, arg ArchiveLinkParams) error {
-	_, err := q.db.ExecContext(ctx, archiveLink,
+func (q *Queries) AdminArchiveLink(ctx context.Context, arg AdminArchiveLinkParams) error {
+	_, err := q.db.ExecContext(ctx, adminArchiveLink,
 		arg.Idlinker,
 		arg.LanguageIdlanguage,
 		arg.UsersIdusers,
@@ -128,7 +128,7 @@ func (q *Queries) ArchiveLink(ctx context.Context, arg ArchiveLinkParams) error 
 	return err
 }
 
-const archiveUser = `-- name: ArchiveUser :exec
+const adminArchiveUser = `-- name: AdminArchiveUser :exec
 
 INSERT INTO deactivated_users (idusers, email, passwd, passwd_algorithm, username, deleted_at)
 SELECT u.idusers, u.email, u.passwd, u.passwd_algorithm, u.username, NOW()
@@ -136,17 +136,17 @@ FROM users u WHERE u.idusers = ?
 `
 
 // Queries for user deactivation and restoration
-func (q *Queries) ArchiveUser(ctx context.Context, idusers int32) error {
-	_, err := q.db.ExecContext(ctx, archiveUser, idusers)
+func (q *Queries) AdminArchiveUser(ctx context.Context, idusers int32) error {
+	_, err := q.db.ExecContext(ctx, adminArchiveUser, idusers)
 	return err
 }
 
-const archiveWriting = `-- name: ArchiveWriting :exec
+const adminArchiveWriting = `-- name: AdminArchiveWriting :exec
 INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_id, language_idlanguage, writing_category_id, title, published, writing, abstract, private, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveWritingParams struct {
+type AdminArchiveWritingParams struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
@@ -159,8 +159,8 @@ type ArchiveWritingParams struct {
 	Private            sql.NullBool
 }
 
-func (q *Queries) ArchiveWriting(ctx context.Context, arg ArchiveWritingParams) error {
-	_, err := q.db.ExecContext(ctx, archiveWriting,
+func (q *Queries) AdminArchiveWriting(ctx context.Context, arg AdminArchiveWritingParams) error {
+	_, err := q.db.ExecContext(ctx, adminArchiveWriting,
 		arg.Idwriting,
 		arg.UsersIdusers,
 		arg.ForumthreadID,
@@ -175,69 +175,69 @@ func (q *Queries) ArchiveWriting(ctx context.Context, arg ArchiveWritingParams) 
 	return err
 }
 
-const markBlogRestored = `-- name: MarkBlogRestored :exec
+const adminMarkBlogRestored = `-- name: AdminMarkBlogRestored :exec
 UPDATE deactivated_blogs SET restored_at = NOW() WHERE idblogs = ?
 `
 
-func (q *Queries) MarkBlogRestored(ctx context.Context, idblogs int32) error {
-	_, err := q.db.ExecContext(ctx, markBlogRestored, idblogs)
+func (q *Queries) AdminMarkBlogRestored(ctx context.Context, idblogs int32) error {
+	_, err := q.db.ExecContext(ctx, adminMarkBlogRestored, idblogs)
 	return err
 }
 
-const markCommentRestored = `-- name: MarkCommentRestored :exec
+const adminMarkCommentRestored = `-- name: AdminMarkCommentRestored :exec
 UPDATE deactivated_comments SET restored_at = NOW() WHERE idcomments = ?
 `
 
-func (q *Queries) MarkCommentRestored(ctx context.Context, idcomments int32) error {
-	_, err := q.db.ExecContext(ctx, markCommentRestored, idcomments)
+func (q *Queries) AdminMarkCommentRestored(ctx context.Context, idcomments int32) error {
+	_, err := q.db.ExecContext(ctx, adminMarkCommentRestored, idcomments)
 	return err
 }
 
-const markImagepostRestored = `-- name: MarkImagepostRestored :exec
+const adminMarkImagepostRestored = `-- name: AdminMarkImagepostRestored :exec
 UPDATE deactivated_imageposts SET restored_at = NOW() WHERE idimagepost = ?
 `
 
-func (q *Queries) MarkImagepostRestored(ctx context.Context, idimagepost int32) error {
-	_, err := q.db.ExecContext(ctx, markImagepostRestored, idimagepost)
+func (q *Queries) AdminMarkImagepostRestored(ctx context.Context, idimagepost int32) error {
+	_, err := q.db.ExecContext(ctx, adminMarkImagepostRestored, idimagepost)
 	return err
 }
 
-const markLinkRestored = `-- name: MarkLinkRestored :exec
+const adminMarkLinkRestored = `-- name: AdminMarkLinkRestored :exec
 UPDATE deactivated_linker SET restored_at = NOW() WHERE idlinker = ?
 `
 
-func (q *Queries) MarkLinkRestored(ctx context.Context, idlinker int32) error {
-	_, err := q.db.ExecContext(ctx, markLinkRestored, idlinker)
+func (q *Queries) AdminMarkLinkRestored(ctx context.Context, idlinker int32) error {
+	_, err := q.db.ExecContext(ctx, adminMarkLinkRestored, idlinker)
 	return err
 }
 
-const markWritingRestored = `-- name: MarkWritingRestored :exec
+const adminMarkWritingRestored = `-- name: AdminMarkWritingRestored :exec
 UPDATE deactivated_writings SET restored_at = NOW() WHERE idwriting = ?
 `
 
-func (q *Queries) MarkWritingRestored(ctx context.Context, idwriting int32) error {
-	_, err := q.db.ExecContext(ctx, markWritingRestored, idwriting)
+func (q *Queries) AdminMarkWritingRestored(ctx context.Context, idwriting int32) error {
+	_, err := q.db.ExecContext(ctx, adminMarkWritingRestored, idwriting)
 	return err
 }
 
-const pendingDeactivatedBlogs = `-- name: PendingDeactivatedBlogs :many
+const adminPendingDeactivatedBlogs = `-- name: AdminPendingDeactivatedBlogs :many
 SELECT idblogs, blog FROM deactivated_blogs WHERE users_idusers = ? AND restored_at IS NULL
 `
 
-type PendingDeactivatedBlogsRow struct {
+type AdminPendingDeactivatedBlogsRow struct {
 	Idblogs int32
 	Blog    sql.NullString
 }
 
-func (q *Queries) PendingDeactivatedBlogs(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedBlogsRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedBlogs, usersIdusers)
+func (q *Queries) AdminPendingDeactivatedBlogs(ctx context.Context, usersIdusers int32) ([]*AdminPendingDeactivatedBlogsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminPendingDeactivatedBlogs, usersIdusers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedBlogsRow
+	var items []*AdminPendingDeactivatedBlogsRow
 	for rows.Next() {
-		var i PendingDeactivatedBlogsRow
+		var i AdminPendingDeactivatedBlogsRow
 		if err := rows.Scan(&i.Idblogs, &i.Blog); err != nil {
 			return nil, err
 		}
@@ -252,25 +252,25 @@ func (q *Queries) PendingDeactivatedBlogs(ctx context.Context, usersIdusers int3
 	return items, nil
 }
 
-const pendingDeactivatedComments = `-- name: PendingDeactivatedComments :many
+const adminPendingDeactivatedComments = `-- name: AdminPendingDeactivatedComments :many
 SELECT idcomments, text FROM deactivated_comments
 WHERE users_idusers = ? AND restored_at IS NULL
 `
 
-type PendingDeactivatedCommentsRow struct {
+type AdminPendingDeactivatedCommentsRow struct {
 	Idcomments int32
 	Text       sql.NullString
 }
 
-func (q *Queries) PendingDeactivatedComments(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedCommentsRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedComments, usersIdusers)
+func (q *Queries) AdminPendingDeactivatedComments(ctx context.Context, usersIdusers int32) ([]*AdminPendingDeactivatedCommentsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminPendingDeactivatedComments, usersIdusers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedCommentsRow
+	var items []*AdminPendingDeactivatedCommentsRow
 	for rows.Next() {
-		var i PendingDeactivatedCommentsRow
+		var i AdminPendingDeactivatedCommentsRow
 		if err := rows.Scan(&i.Idcomments, &i.Text); err != nil {
 			return nil, err
 		}
@@ -285,26 +285,26 @@ func (q *Queries) PendingDeactivatedComments(ctx context.Context, usersIdusers i
 	return items, nil
 }
 
-const pendingDeactivatedImageposts = `-- name: PendingDeactivatedImageposts :many
+const adminPendingDeactivatedImageposts = `-- name: AdminPendingDeactivatedImageposts :many
 SELECT idimagepost, description, thumbnail, fullimage FROM deactivated_imageposts WHERE users_idusers = ? AND restored_at IS NULL
 `
 
-type PendingDeactivatedImagepostsRow struct {
+type AdminPendingDeactivatedImagepostsRow struct {
 	Idimagepost int32
 	Description sql.NullString
 	Thumbnail   sql.NullString
 	Fullimage   sql.NullString
 }
 
-func (q *Queries) PendingDeactivatedImageposts(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedImagepostsRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedImageposts, usersIdusers)
+func (q *Queries) AdminPendingDeactivatedImageposts(ctx context.Context, usersIdusers int32) ([]*AdminPendingDeactivatedImagepostsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminPendingDeactivatedImageposts, usersIdusers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedImagepostsRow
+	var items []*AdminPendingDeactivatedImagepostsRow
 	for rows.Next() {
-		var i PendingDeactivatedImagepostsRow
+		var i AdminPendingDeactivatedImagepostsRow
 		if err := rows.Scan(
 			&i.Idimagepost,
 			&i.Description,
@@ -324,26 +324,26 @@ func (q *Queries) PendingDeactivatedImageposts(ctx context.Context, usersIdusers
 	return items, nil
 }
 
-const pendingDeactivatedLinks = `-- name: PendingDeactivatedLinks :many
+const adminPendingDeactivatedLinks = `-- name: AdminPendingDeactivatedLinks :many
 SELECT idlinker, title, url, description FROM deactivated_linker WHERE users_idusers = ? AND restored_at IS NULL
 `
 
-type PendingDeactivatedLinksRow struct {
+type AdminPendingDeactivatedLinksRow struct {
 	Idlinker    int32
 	Title       sql.NullString
 	Url         sql.NullString
 	Description sql.NullString
 }
 
-func (q *Queries) PendingDeactivatedLinks(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedLinksRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedLinks, usersIdusers)
+func (q *Queries) AdminPendingDeactivatedLinks(ctx context.Context, usersIdusers int32) ([]*AdminPendingDeactivatedLinksRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminPendingDeactivatedLinks, usersIdusers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedLinksRow
+	var items []*AdminPendingDeactivatedLinksRow
 	for rows.Next() {
-		var i PendingDeactivatedLinksRow
+		var i AdminPendingDeactivatedLinksRow
 		if err := rows.Scan(
 			&i.Idlinker,
 			&i.Title,
@@ -363,12 +363,12 @@ func (q *Queries) PendingDeactivatedLinks(ctx context.Context, usersIdusers int3
 	return items, nil
 }
 
-const pendingDeactivatedWritings = `-- name: PendingDeactivatedWritings :many
+const adminPendingDeactivatedWritings = `-- name: AdminPendingDeactivatedWritings :many
 SELECT idwriting, title, writing, abstract, private FROM deactivated_writings
 WHERE users_idusers = ? AND restored_at IS NULL
 `
 
-type PendingDeactivatedWritingsRow struct {
+type AdminPendingDeactivatedWritingsRow struct {
 	Idwriting int32
 	Title     sql.NullString
 	Writing   sql.NullString
@@ -376,15 +376,15 @@ type PendingDeactivatedWritingsRow struct {
 	Private   sql.NullBool
 }
 
-func (q *Queries) PendingDeactivatedWritings(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedWritingsRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedWritings, usersIdusers)
+func (q *Queries) AdminPendingDeactivatedWritings(ctx context.Context, usersIdusers int32) ([]*AdminPendingDeactivatedWritingsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminPendingDeactivatedWritings, usersIdusers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedWritingsRow
+	var items []*AdminPendingDeactivatedWritingsRow
 	for rows.Next() {
-		var i PendingDeactivatedWritingsRow
+		var i AdminPendingDeactivatedWritingsRow
 		if err := rows.Scan(
 			&i.Idwriting,
 			&i.Title,
@@ -405,47 +405,47 @@ func (q *Queries) PendingDeactivatedWritings(ctx context.Context, usersIdusers i
 	return items, nil
 }
 
-const restoreBlog = `-- name: RestoreBlog :exec
+const adminRestoreBlog = `-- name: AdminRestoreBlog :exec
 UPDATE blogs SET blog = ?, deleted_at = NULL WHERE idblogs = ?
 `
 
-type RestoreBlogParams struct {
+type AdminRestoreBlogParams struct {
 	Blog    sql.NullString
 	Idblogs int32
 }
 
-func (q *Queries) RestoreBlog(ctx context.Context, arg RestoreBlogParams) error {
-	_, err := q.db.ExecContext(ctx, restoreBlog, arg.Blog, arg.Idblogs)
+func (q *Queries) AdminRestoreBlog(ctx context.Context, arg AdminRestoreBlogParams) error {
+	_, err := q.db.ExecContext(ctx, adminRestoreBlog, arg.Blog, arg.Idblogs)
 	return err
 }
 
-const restoreComment = `-- name: RestoreComment :exec
+const adminRestoreComment = `-- name: AdminRestoreComment :exec
 UPDATE comments SET text = ?, deleted_at = NULL WHERE idcomments = ?
 `
 
-type RestoreCommentParams struct {
+type AdminRestoreCommentParams struct {
 	Text       sql.NullString
 	Idcomments int32
 }
 
-func (q *Queries) RestoreComment(ctx context.Context, arg RestoreCommentParams) error {
-	_, err := q.db.ExecContext(ctx, restoreComment, arg.Text, arg.Idcomments)
+func (q *Queries) AdminRestoreComment(ctx context.Context, arg AdminRestoreCommentParams) error {
+	_, err := q.db.ExecContext(ctx, adminRestoreComment, arg.Text, arg.Idcomments)
 	return err
 }
 
-const restoreImagepost = `-- name: RestoreImagepost :exec
+const adminRestoreImagepost = `-- name: AdminRestoreImagepost :exec
 UPDATE imagepost SET description = ?, thumbnail = ?, fullimage = ?, deleted_at = NULL WHERE idimagepost = ?
 `
 
-type RestoreImagepostParams struct {
+type AdminRestoreImagepostParams struct {
 	Description sql.NullString
 	Thumbnail   sql.NullString
 	Fullimage   sql.NullString
 	Idimagepost int32
 }
 
-func (q *Queries) RestoreImagepost(ctx context.Context, arg RestoreImagepostParams) error {
-	_, err := q.db.ExecContext(ctx, restoreImagepost,
+func (q *Queries) AdminRestoreImagepost(ctx context.Context, arg AdminRestoreImagepostParams) error {
+	_, err := q.db.ExecContext(ctx, adminRestoreImagepost,
 		arg.Description,
 		arg.Thumbnail,
 		arg.Fullimage,
@@ -454,19 +454,19 @@ func (q *Queries) RestoreImagepost(ctx context.Context, arg RestoreImagepostPara
 	return err
 }
 
-const restoreLink = `-- name: RestoreLink :exec
+const adminRestoreLink = `-- name: AdminRestoreLink :exec
 UPDATE linker SET title = ?, url = ?, description = ?, deleted_at = NULL WHERE idlinker = ?
 `
 
-type RestoreLinkParams struct {
+type AdminRestoreLinkParams struct {
 	Title       sql.NullString
 	Url         sql.NullString
 	Description sql.NullString
 	Idlinker    int32
 }
 
-func (q *Queries) RestoreLink(ctx context.Context, arg RestoreLinkParams) error {
-	_, err := q.db.ExecContext(ctx, restoreLink,
+func (q *Queries) AdminRestoreLink(ctx context.Context, arg AdminRestoreLinkParams) error {
+	_, err := q.db.ExecContext(ctx, adminRestoreLink,
 		arg.Title,
 		arg.Url,
 		arg.Description,
@@ -475,22 +475,22 @@ func (q *Queries) RestoreLink(ctx context.Context, arg RestoreLinkParams) error 
 	return err
 }
 
-const restoreUser = `-- name: RestoreUser :exec
+const adminRestoreUser = `-- name: AdminRestoreUser :exec
 UPDATE users u JOIN deactivated_users d ON u.idusers = d.idusers
 SET u.email = d.email, u.passwd = d.passwd, u.passwd_algorithm = d.passwd_algorithm, u.username = d.username, u.deleted_at = NULL, d.restored_at = NOW()
 WHERE u.idusers = ? AND d.restored_at IS NULL
 `
 
-func (q *Queries) RestoreUser(ctx context.Context, idusers int32) error {
-	_, err := q.db.ExecContext(ctx, restoreUser, idusers)
+func (q *Queries) AdminRestoreUser(ctx context.Context, idusers int32) error {
+	_, err := q.db.ExecContext(ctx, adminRestoreUser, idusers)
 	return err
 }
 
-const restoreWriting = `-- name: RestoreWriting :exec
+const adminRestoreWriting = `-- name: AdminRestoreWriting :exec
 UPDATE writing SET title = ?, writing = ?, abstract = ?, private = ?, deleted_at = NULL WHERE idwriting = ?
 `
 
-type RestoreWritingParams struct {
+type AdminRestoreWritingParams struct {
 	Title     sql.NullString
 	Writing   sql.NullString
 	Abstract  sql.NullString
@@ -498,8 +498,8 @@ type RestoreWritingParams struct {
 	Idwriting int32
 }
 
-func (q *Queries) RestoreWriting(ctx context.Context, arg RestoreWritingParams) error {
-	_, err := q.db.ExecContext(ctx, restoreWriting,
+func (q *Queries) AdminRestoreWriting(ctx context.Context, arg AdminRestoreWritingParams) error {
+	_, err := q.db.ExecContext(ctx, adminRestoreWriting,
 		arg.Title,
 		arg.Writing,
 		arg.Abstract,
@@ -509,85 +509,85 @@ func (q *Queries) RestoreWriting(ctx context.Context, arg RestoreWritingParams) 
 	return err
 }
 
-const scrubBlog = `-- name: ScrubBlog :exec
+const adminScrubBlog = `-- name: AdminScrubBlog :exec
 UPDATE blogs SET blog = ?, deleted_at = NOW() WHERE idblogs = ?
 `
 
-type ScrubBlogParams struct {
+type AdminScrubBlogParams struct {
 	Blog    sql.NullString
 	Idblogs int32
 }
 
-func (q *Queries) ScrubBlog(ctx context.Context, arg ScrubBlogParams) error {
-	_, err := q.db.ExecContext(ctx, scrubBlog, arg.Blog, arg.Idblogs)
+func (q *Queries) AdminScrubBlog(ctx context.Context, arg AdminScrubBlogParams) error {
+	_, err := q.db.ExecContext(ctx, adminScrubBlog, arg.Blog, arg.Idblogs)
 	return err
 }
 
-const scrubComment = `-- name: ScrubComment :exec
+const adminScrubComment = `-- name: AdminScrubComment :exec
 UPDATE comments SET text = ?, deleted_at = NOW() WHERE idcomments = ?
 `
 
-type ScrubCommentParams struct {
+type AdminScrubCommentParams struct {
 	Text       sql.NullString
 	Idcomments int32
 }
 
-func (q *Queries) ScrubComment(ctx context.Context, arg ScrubCommentParams) error {
-	_, err := q.db.ExecContext(ctx, scrubComment, arg.Text, arg.Idcomments)
+func (q *Queries) AdminScrubComment(ctx context.Context, arg AdminScrubCommentParams) error {
+	_, err := q.db.ExecContext(ctx, adminScrubComment, arg.Text, arg.Idcomments)
 	return err
 }
 
-const scrubImagepost = `-- name: ScrubImagepost :exec
+const adminScrubImagepost = `-- name: AdminScrubImagepost :exec
 UPDATE imagepost SET description = '', thumbnail = '', fullimage = '', deleted_at = NOW() WHERE idimagepost = ?
 `
 
-func (q *Queries) ScrubImagepost(ctx context.Context, idimagepost int32) error {
-	_, err := q.db.ExecContext(ctx, scrubImagepost, idimagepost)
+func (q *Queries) AdminScrubImagepost(ctx context.Context, idimagepost int32) error {
+	_, err := q.db.ExecContext(ctx, adminScrubImagepost, idimagepost)
 	return err
 }
 
-const scrubLink = `-- name: ScrubLink :exec
+const adminScrubLink = `-- name: AdminScrubLink :exec
 UPDATE linker SET title = ?, url = '', description = '', deleted_at = NOW() WHERE idlinker = ?
 `
 
-type ScrubLinkParams struct {
+type AdminScrubLinkParams struct {
 	Title    sql.NullString
 	Idlinker int32
 }
 
-func (q *Queries) ScrubLink(ctx context.Context, arg ScrubLinkParams) error {
-	_, err := q.db.ExecContext(ctx, scrubLink, arg.Title, arg.Idlinker)
+func (q *Queries) AdminScrubLink(ctx context.Context, arg AdminScrubLinkParams) error {
+	_, err := q.db.ExecContext(ctx, adminScrubLink, arg.Title, arg.Idlinker)
 	return err
 }
 
-const scrubUser = `-- name: ScrubUser :exec
+const adminScrubUser = `-- name: AdminScrubUser :exec
 UPDATE users SET username = ?, email = '', passwd = '', passwd_algorithm = '', deleted_at = NOW()
 WHERE idusers = ?
 `
 
-type ScrubUserParams struct {
+type AdminScrubUserParams struct {
 	Username sql.NullString
 	Idusers  int32
 }
 
-func (q *Queries) ScrubUser(ctx context.Context, arg ScrubUserParams) error {
-	_, err := q.db.ExecContext(ctx, scrubUser, arg.Username, arg.Idusers)
+func (q *Queries) AdminScrubUser(ctx context.Context, arg AdminScrubUserParams) error {
+	_, err := q.db.ExecContext(ctx, adminScrubUser, arg.Username, arg.Idusers)
 	return err
 }
 
-const scrubWriting = `-- name: ScrubWriting :exec
+const adminScrubWriting = `-- name: AdminScrubWriting :exec
 UPDATE writing SET title = ?, writing = ?, abstract = ?, deleted_at = NOW() WHERE idwriting = ?
 `
 
-type ScrubWritingParams struct {
+type AdminScrubWritingParams struct {
 	Title     sql.NullString
 	Writing   sql.NullString
 	Abstract  sql.NullString
 	Idwriting int32
 }
 
-func (q *Queries) ScrubWriting(ctx context.Context, arg ScrubWritingParams) error {
-	_, err := q.db.ExecContext(ctx, scrubWriting,
+func (q *Queries) AdminScrubWriting(ctx context.Context, arg AdminScrubWritingParams) error {
+	_, err := q.db.ExecContext(ctx, adminScrubWriting,
 		arg.Title,
 		arg.Writing,
 		arg.Abstract,

--- a/internal/db/queries-dlq.sql
+++ b/internal/db/queries-dlq.sql
@@ -1,19 +1,19 @@
--- name: InsertDeadLetter :exec
+-- name: SystemInsertDeadLetter :exec
 INSERT INTO dead_letters (message) VALUES (?);
 
--- name: ListDeadLetters :many
+-- name: AdminListDeadLetters :many
 SELECT id, message, created_at FROM dead_letters
 ORDER BY id DESC
 LIMIT ?;
 
--- name: DeleteDeadLetter :exec
+-- name: AdminDeleteDeadLetter :exec
 DELETE FROM dead_letters WHERE id = ?;
 
--- name: PurgeDeadLettersBefore :exec
+-- name: AdminPurgeDeadLettersBefore :exec
 DELETE FROM dead_letters WHERE created_at < ?;
 
--- name: CountDeadLetters :one
+-- name: SystemCountDeadLetters :one
 SELECT COUNT(*) FROM dead_letters;
 
--- name: LatestDeadLetter :one
+-- name: AdminLatestDeadLetter :one
 SELECT MAX(created_at) FROM dead_letters;

--- a/internal/db/queries-dlq.sql.go
+++ b/internal/db/queries-dlq.sql.go
@@ -10,54 +10,34 @@ import (
 	"time"
 )
 
-const countDeadLetters = `-- name: CountDeadLetters :one
-SELECT COUNT(*) FROM dead_letters
-`
-
-func (q *Queries) CountDeadLetters(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countDeadLetters)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
-}
-
-const deleteDeadLetter = `-- name: DeleteDeadLetter :exec
+const adminDeleteDeadLetter = `-- name: AdminDeleteDeadLetter :exec
 DELETE FROM dead_letters WHERE id = ?
 `
 
-func (q *Queries) DeleteDeadLetter(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, deleteDeadLetter, id)
+func (q *Queries) AdminDeleteDeadLetter(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, adminDeleteDeadLetter, id)
 	return err
 }
 
-const insertDeadLetter = `-- name: InsertDeadLetter :exec
-INSERT INTO dead_letters (message) VALUES (?)
-`
-
-func (q *Queries) InsertDeadLetter(ctx context.Context, message string) error {
-	_, err := q.db.ExecContext(ctx, insertDeadLetter, message)
-	return err
-}
-
-const latestDeadLetter = `-- name: LatestDeadLetter :one
+const adminLatestDeadLetter = `-- name: AdminLatestDeadLetter :one
 SELECT MAX(created_at) FROM dead_letters
 `
 
-func (q *Queries) LatestDeadLetter(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, latestDeadLetter)
+func (q *Queries) AdminLatestDeadLetter(ctx context.Context) (interface{}, error) {
+	row := q.db.QueryRowContext(ctx, adminLatestDeadLetter)
 	var max interface{}
 	err := row.Scan(&max)
 	return max, err
 }
 
-const listDeadLetters = `-- name: ListDeadLetters :many
+const adminListDeadLetters = `-- name: AdminListDeadLetters :many
 SELECT id, message, created_at FROM dead_letters
 ORDER BY id DESC
 LIMIT ?
 `
 
-func (q *Queries) ListDeadLetters(ctx context.Context, limit int32) ([]*DeadLetter, error) {
-	rows, err := q.db.QueryContext(ctx, listDeadLetters, limit)
+func (q *Queries) AdminListDeadLetters(ctx context.Context, limit int32) ([]*DeadLetter, error) {
+	rows, err := q.db.QueryContext(ctx, adminListDeadLetters, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -79,11 +59,31 @@ func (q *Queries) ListDeadLetters(ctx context.Context, limit int32) ([]*DeadLett
 	return items, nil
 }
 
-const purgeDeadLettersBefore = `-- name: PurgeDeadLettersBefore :exec
+const adminPurgeDeadLettersBefore = `-- name: AdminPurgeDeadLettersBefore :exec
 DELETE FROM dead_letters WHERE created_at < ?
 `
 
-func (q *Queries) PurgeDeadLettersBefore(ctx context.Context, createdAt time.Time) error {
-	_, err := q.db.ExecContext(ctx, purgeDeadLettersBefore, createdAt)
+func (q *Queries) AdminPurgeDeadLettersBefore(ctx context.Context, createdAt time.Time) error {
+	_, err := q.db.ExecContext(ctx, adminPurgeDeadLettersBefore, createdAt)
+	return err
+}
+
+const systemCountDeadLetters = `-- name: SystemCountDeadLetters :one
+SELECT COUNT(*) FROM dead_letters
+`
+
+func (q *Queries) SystemCountDeadLetters(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, systemCountDeadLetters)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const systemInsertDeadLetter = `-- name: SystemInsertDeadLetter :exec
+INSERT INTO dead_letters (message) VALUES (?)
+`
+
+func (q *Queries) SystemInsertDeadLetter(ctx context.Context, message string) error {
+	_, err := q.db.ExecContext(ctx, systemInsertDeadLetter, message)
 	return err
 }

--- a/internal/dlq/db/db.go
+++ b/internal/dlq/db/db.go
@@ -17,7 +17,7 @@ func (d DLQ) Record(ctx context.Context, message string) error {
 	if d.Queries == nil {
 		return fmt.Errorf("no db")
 	}
-	return d.Queries.InsertDeadLetter(ctx, message)
+	return d.Queries.SystemInsertDeadLetter(ctx, message)
 }
 
 // Register registers the database provider.

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -47,7 +47,7 @@ func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ip := requestIP(r)
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-			bans, err := cd.Queries().ListActiveBans(r.Context())
+			bans, err := cd.Queries().SystemListActiveBans(r.Context())
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 				return

--- a/internal/notifications/dlq.go
+++ b/internal/notifications/dlq.go
@@ -19,7 +19,7 @@ func (n *Notifier) dlqRecordAndNotify(ctx context.Context, q dlq.DLQ, msg string
 		return nil
 	}
 	if dbq, ok := q.(db.DLQ); ok {
-		if count, err := dbq.Queries.CountDeadLetters(ctx); err == nil {
+		if count, err := dbq.Queries.SystemCountDeadLetters(ctx); err == nil {
 			if isPow10(count) {
 				data := EmailData{
 					Item: struct {

--- a/workers/auditworker/worker.go
+++ b/workers/auditworker/worker.go
@@ -34,7 +34,7 @@ func Worker(ctx context.Context, bus *eventbus.Bus, q *dbpkg.Queries) {
 			}
 			details := aud.AuditRecord(evt.Data)
 			data, _ := json.Marshal(evt.Data)
-			if err := q.InsertAuditLog(ctx, dbpkg.InsertAuditLogParams{
+			if err := q.SystemInsertAuditLog(ctx, dbpkg.SystemInsertAuditLogParams{
 				UsersIdusers: evt.UserID,
 				Action:       named.Name(),
 				Path:         evt.Path,


### PR DESCRIPTION
## Summary
- prefix admin and system query names in sql files
- regenerate sqlc code and update calling code across handlers and workers
- format the repo and run vet and lint

## Testing
- `go vet ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cb17afb8c832f893f2e470b8ed1dc