### PR TITLE
Add user-permission check to FAQ revision insert

### DIFF
--- a/handlers/faq/create_question_task.go
+++ b/handlers/faq/create_question_task.go
@@ -49,7 +49,7 @@ func (CreateQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("insert faq fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	id, _ := res.LastInsertId()
-	_ = queries.InsertFAQRevision(r.Context(), db.InsertFAQRevisionParams{
+	_ = queries.AdminInsertFAQRevision(r.Context(), db.AdminInsertFAQRevisionParams{
 		FaqID:        int32(id),
 		UsersIdusers: uid,
 		Question:     sql.NullString{String: question, Valid: true},

--- a/handlers/faq/edit_question_task.go
+++ b/handlers/faq/edit_question_task.go
@@ -53,7 +53,7 @@ func (EditQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("update faq question fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	_ = queries.InsertFAQRevision(r.Context(), db.InsertFAQRevisionParams{
+	_ = queries.AdminInsertFAQRevision(r.Context(), db.AdminInsertFAQRevisionParams{
 		FaqID:        int32(faq),
 		UsersIdusers: uid,
 		Question:     sql.NullString{String: question, Valid: true},

--- a/internal/db/queries-faq.sql
+++ b/internal/db/queries-faq.sql
@@ -64,7 +64,24 @@ GROUP BY c.idfaqCategories;
 -- name: GetFAQByID :one
 SELECT * FROM faq WHERE idfaq = ?;
 
--- name: InsertFAQRevision :exec
+-- renamed to InsertFAQRevisionForUser
+-- name: InsertFAQRevisionForUser :exec
+INSERT INTO faq_revisions (faq_id, users_idusers, question, answer)
+SELECT sqlc.arg(faq_id), sqlc.arg(users_idusers), sqlc.arg(question), sqlc.arg(answer)
+WHERE EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section = 'faq'
+      AND g.item = 'question'
+      AND g.action = 'post'
+      AND g.active = 1
+      AND g.item_id = sqlc.arg(item_id)
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (
+          SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+      ))
+);
+
+-- name: AdminInsertFAQRevision :exec
 INSERT INTO faq_revisions (faq_id, users_idusers, question, answer)
 VALUES (?, ?, ?, ?);
 


### PR DESCRIPTION
## Summary
- add new permission-checked query `InsertFAQRevisionForUser`
- introduce `AdminInsertFAQRevision` for privileged actions
- update FAQ handlers to use admin query
- regenerate sqlc code

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cb177b180832f946364c4797bd2df