### PR TITLE
Refactor FAQ queries for admin and user access

### DIFF
--- a/handlers/faq/admin_categories.go
+++ b/handlers/faq/admin_categories.go
@@ -14,7 +14,7 @@ import (
 func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		Rows []*db.GetFAQCategoriesWithQuestionCountRow
+               Rows []*db.AdminGetFAQCategoriesWithQuestionCountRow
 	}
 
 	data := Data{
@@ -25,7 +25,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
-	rows, err := queries.GetFAQCategoriesWithQuestionCount(r.Context())
+	rows, err := queries.AdminGetFAQCategoriesWithQuestionCount(r.Context())
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/faq/admin_edit_question_page.go
+++ b/handlers/faq/admin_edit_question_page.go
@@ -27,7 +27,7 @@ func AdminEditQuestionPage(w http.ResponseWriter, r *http.Request) {
 	var faq *db.Faq
 	if id != 0 {
 		var err error
-		faq, err = queries.GetFAQByID(r.Context(), int32(id))
+		faq, err = queries.AdminGetFAQByID(r.Context(), int32(id))
 		if err != nil {
 			switch {
 			case errors.Is(err, sql.ErrNoRows):
@@ -41,7 +41,7 @@ func AdminEditQuestionPage(w http.ResponseWriter, r *http.Request) {
 	} else {
 		faq = &db.Faq{Idfaq: 0}
 	}
-	cats, _ := queries.GetAllFAQCategories(r.Context())
+	cats, _ := queries.AdminGetAllFAQCategories(r.Context())
 	type Data struct {
 		*common.CoreData
 		Faq        *db.Faq

--- a/handlers/faq/admin_question.go
+++ b/handlers/faq/admin_question.go
@@ -27,7 +27,7 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
-	catrows, err := queries.GetAllFAQCategories(r.Context())
+	catrows, err := queries.AdminGetAllFAQCategories(r.Context())
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -40,7 +40,7 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 
 	cd.PageTitle = "FAQ Questions"
 
-	unansweredRows, err := queries.GetFAQUnansweredQuestions(r.Context())
+	unansweredRows, err := queries.AdminGetFAQUnansweredQuestions(r.Context())
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -51,7 +51,7 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.UnansweredRows = unansweredRows
 
-	answeredRows, err := queries.GetFAQAnsweredQuestions(r.Context())
+	answeredRows, err := queries.AdminGetFAQAnsweredQuestions(r.Context())
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -62,7 +62,7 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.AnsweredRows = answeredRows
 
-	dismissedRows, err := queries.GetFAQDismissedQuestions(r.Context())
+	dismissedRows, err := queries.AdminGetFAQDismissedQuestions(r.Context())
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/faq/admin_revision_page.go
+++ b/handlers/faq/admin_revision_page.go
@@ -24,7 +24,7 @@ func AdminRevisionHistoryPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	faq, err := queries.GetFAQByID(r.Context(), int32(id))
+	faq, err := queries.AdminGetFAQByID(r.Context(), int32(id))
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -35,7 +35,7 @@ func AdminRevisionHistoryPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	revs, _ := queries.GetFAQRevisionsForFAQ(r.Context(), int32(id))
+	revs, _ := queries.AdminGetFAQRevisionsForFAQ(r.Context(), int32(id))
 	type Data struct {
 		*common.CoreData
 		Faq       *db.Faq

--- a/handlers/faq/create_category_task.go
+++ b/handlers/faq/create_category_task.go
@@ -26,7 +26,7 @@ func (CreateCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	text := r.PostFormValue("cname")
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
-	if err := queries.CreateFAQCategory(r.Context(), sql.NullString{
+	if err := queries.AdminCreateFAQCategory(r.Context(), sql.NullString{
 		String: text,
 		Valid:  true,
 	}); err != nil {

--- a/handlers/faq/delete_category_task.go
+++ b/handlers/faq/delete_category_task.go
@@ -29,7 +29,7 @@ func (DeleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
-	if err := queries.DeleteFAQCategory(r.Context(), int32(cid)); err != nil {
+	if err := queries.AdminDeleteFAQCategory(r.Context(), int32(cid)); err != nil {
 		return fmt.Errorf("delete category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 

--- a/handlers/faq/delete_question_task.go
+++ b/handlers/faq/delete_question_task.go
@@ -29,7 +29,7 @@ func (DeleteQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
-	if err := queries.DeleteFAQ(r.Context(), int32(faq)); err != nil {
+	if err := queries.AdminDeleteFAQ(r.Context(), int32(faq)); err != nil {
 		return fmt.Errorf("delete faq fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 

--- a/handlers/faq/edit_question_task.go
+++ b/handlers/faq/edit_question_task.go
@@ -44,7 +44,7 @@ func (EditQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	if err := queries.UpdateFAQQuestionAnswer(r.Context(), db.UpdateFAQQuestionAnswerParams{
+       if err := queries.AdminUpdateFAQQuestionAnswer(r.Context(), db.AdminUpdateFAQQuestionAnswerParams{
 		Answer:                       sql.NullString{Valid: true, String: answer},
 		Question:                     sql.NullString{Valid: true, String: question},
 		FaqcategoriesIdfaqcategories: int32(category),

--- a/handlers/faq/page.go
+++ b/handlers/faq/page.go
@@ -3,6 +3,7 @@ package faq
 import (
 	"database/sql"
 	"errors"
+	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -20,7 +21,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type CategoryFAQs struct {
-		Category *db.GetAllAnsweredFAQWithFAQCategoriesRow
+               Category *db.GetAllAnsweredFAQWithFAQCategoriesForUserRow
 		FAQs     []*FAQ
 	}
 
@@ -34,9 +35,18 @@ func Page(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
+	session, _ := core.GetSession(r)
+	var uid int32
+	if session != nil {
+		uid, _ = session.Values["UID"].(int32)
+	}
+
 	var currentCategoryFAQs CategoryFAQs
 
-	faqRows, err := queries.GetAllAnsweredFAQWithFAQCategories(r.Context())
+	faqRows, err := queries.GetAllAnsweredFAQWithFAQCategoriesForUser(r.Context(), db.GetAllAnsweredFAQWithFAQCategoriesForUserParams{
+		ViewerID: uid,
+		UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
+	})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/faq/remove_question_task.go
+++ b/handlers/faq/remove_question_task.go
@@ -30,7 +30,7 @@ func (RemoveQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
-	if err := queries.DeleteFAQ(r.Context(), int32(faq)); err != nil {
+	if err := queries.AdminDeleteFAQ(r.Context(), int32(faq)); err != nil {
 		return fmt.Errorf("delete faq fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 

--- a/handlers/faq/rename_category_task.go
+++ b/handlers/faq/rename_category_task.go
@@ -32,7 +32,7 @@ func (RenameCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
-	if err := queries.RenameFAQCategory(r.Context(), db.RenameFAQCategoryParams{
+       if err := queries.AdminRenameFAQCategory(r.Context(), db.AdminRenameFAQCategoryParams{
 		Name: sql.NullString{
 			String: text,
 			Valid:  true,

--- a/internal/db/queries-faq.sql
+++ b/internal/db/queries-faq.sql
@@ -1,14 +1,14 @@
--- name: GetFAQUnansweredQuestions :many
+-- name: AdminGetFAQUnansweredQuestions :many
 SELECT *
 FROM faq
 WHERE faqCategories_idfaqCategories = '0' OR answer IS NULL;
 
--- name: GetFAQAnsweredQuestions :many
+-- name: AdminGetFAQAnsweredQuestions :many
 SELECT idfaq, faqCategories_idfaqCategories, language_idlanguage, users_idusers, answer, question
 FROM faq
 WHERE answer IS NOT NULL AND deleted_at IS NULL;
 
--- name: GetFAQDismissedQuestions :many
+-- name: AdminGetFAQDismissedQuestions :many
 SELECT idfaq, faqCategories_idfaqCategories, language_idlanguage, users_idusers, answer, question
 FROM faq
 WHERE deleted_at IS NOT NULL;
@@ -17,16 +17,50 @@ WHERE deleted_at IS NOT NULL;
 SELECT *
 FROM faq;
 
--- name: RenameFAQCategory :exec
+-- name: GetAllFAQQuestionsForUser :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT f.*
+FROM faq f
+WHERE EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section='faq'
+      AND g.item='question'
+      AND g.action='see'
+      AND g.active=1
+      AND g.item_id = f.idfaq
+      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+)
+  AND (
+      f.language_idlanguage = 0
+      OR f.language_idlanguage IS NULL
+      OR EXISTS (
+          SELECT 1 FROM user_language ul
+          WHERE ul.users_idusers = sqlc.arg(viewer_id)
+            AND ul.language_idlanguage = f.language_idlanguage
+      )
+      OR NOT EXISTS (
+          SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+      )
+  );
+
+-- name: AdminRenameFAQCategory :exec
 UPDATE faq_categories
 SET name = ?
 WHERE idfaqCategories = ?;
 
--- name: DeleteFAQCategory :exec
+-- name: AdminDeleteFAQCategory :exec
 UPDATE faq_categories SET deleted_at = NOW()
 WHERE idfaqCategories = ?;
 
--- name: CreateFAQCategory :exec
+-- name: AdminCreateFAQCategory :exec
 INSERT INTO faq_categories (name)
 VALUES (?);
 
@@ -34,16 +68,16 @@ VALUES (?);
 INSERT INTO faq (question, users_idusers, language_idlanguage)
 VALUES (?, ?, ?);
 
--- name: UpdateFAQQuestionAnswer :exec
+-- name: AdminUpdateFAQQuestionAnswer :exec
 UPDATE faq
 SET answer = ?, question = ?, faqCategories_idfaqCategories = ?
 WHERE idfaq = ?;
 
--- name: DeleteFAQ :exec
+-- name: AdminDeleteFAQ :exec
 UPDATE faq SET deleted_at = NOW()
 WHERE idfaq = ?;
 
--- name: GetAllFAQCategories :many
+-- name: AdminGetAllFAQCategories :many
 SELECT *
 FROM faq_categories;
 
@@ -54,19 +88,87 @@ LEFT JOIN faq_categories c ON c.idfaqCategories = f.faqCategories_idfaqCategorie
 WHERE c.idfaqCategories <> 0 AND f.answer IS NOT NULL
 ORDER BY c.idfaqCategories;
 
--- name: GetFAQCategoriesWithQuestionCount :many
+-- name: GetAllAnsweredFAQWithFAQCategoriesForUser :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT c.*, f.*
+FROM faq f
+LEFT JOIN faq_categories c ON c.idfaqCategories = f.faqCategories_idfaqCategories
+WHERE c.idfaqCategories <> 0
+  AND f.answer IS NOT NULL
+  AND EXISTS (
+      SELECT 1 FROM grants g
+      WHERE g.section='faq'
+        AND g.item='question'
+        AND g.action='see'
+        AND g.active=1
+        AND g.item_id = f.idfaq
+        AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+        AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
+  AND (
+      f.language_idlanguage = 0
+      OR f.language_idlanguage IS NULL
+      OR EXISTS (
+          SELECT 1 FROM user_language ul
+          WHERE ul.users_idusers = sqlc.arg(viewer_id)
+            AND ul.language_idlanguage = f.language_idlanguage
+      )
+      OR NOT EXISTS (
+          SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+      )
+  )
+ORDER BY c.idfaqCategories;
+
+-- name: AdminGetFAQCategoriesWithQuestionCount :many
 SELECT c.*, COUNT(f.idfaq) AS QuestionCount
 FROM faq_categories c
 LEFT JOIN faq f ON f.faqCategories_idfaqCategories = c.idfaqCategories
 GROUP BY c.idfaqCategories;
 
 
--- name: GetFAQByID :one
+-- name: AdminGetFAQByID :one
 SELECT * FROM faq WHERE idfaq = ?;
 
 -- name: InsertFAQRevision :exec
 INSERT INTO faq_revisions (faq_id, users_idusers, question, answer)
 VALUES (?, ?, ?, ?);
 
--- name: GetFAQRevisionsForFAQ :many
+-- name: InsertFAQRevisionForUser :exec
+INSERT INTO faq_revisions (faq_id, users_idusers, question, answer)
+SELECT sqlc.arg(faq_id), sqlc.arg(users_idusers), sqlc.arg(question), sqlc.arg(answer)
+FROM faq f
+WHERE f.idfaq = sqlc.arg(faq_id)
+  AND (
+      f.language_idlanguage = 0
+      OR f.language_idlanguage IS NULL
+      OR EXISTS (
+          SELECT 1 FROM user_language ul
+          WHERE ul.users_idusers = sqlc.arg(viewer_id)
+            AND ul.language_idlanguage = f.language_idlanguage
+      )
+      OR NOT EXISTS (
+          SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+      )
+  )
+  AND EXISTS (
+      SELECT 1 FROM grants g
+      WHERE g.section='faq'
+        AND g.item='question'
+        AND g.action='post'
+        AND g.active=1
+        AND g.item_id = f.idfaq
+        AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+        AND (g.role_id IS NULL OR g.role_id IN (
+            SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+        ))
+  );
+
+-- name: AdminGetFAQRevisionsForFAQ :many
 SELECT * FROM faq_revisions WHERE faq_id = ? ORDER BY id DESC;


### PR DESCRIPTION
## Summary
- rename admin FAQ queries with `Admin` prefix
- add user-aware FAQ queries with grant and language checks
- call new admin functions in tasks and handlers
- filter FAQ page using new user query
- regenerate sqlc files

## Testing
- `go mod tidy`
- `sqlc generate`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cb17579b4832fa83e487c9ae8954b