### PR TITLE
Fix blog entry queries for grants

### DIFF
--- a/handlers/search/searchResultBlogsActionPage.go
+++ b/handlers/search/searchResultBlogsActionPage.go
@@ -75,6 +75,8 @@ func (SearchBlogsTask) Action(w http.ResponseWriter, r *http.Request) any {
 }
 
 func BlogSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid int32) ([]*db.Blog, bool, bool, error) {
+	viewerID := uid
+	userID := uid
 	searchWords := searchutil.BreakupTextToWords(r.PostFormValue("searchwords"))
 	var blogIds []int32
 
@@ -114,7 +116,11 @@ func BlogSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid
 		}
 	}
 
-	rows, err := queries.GetBlogEntriesByIdsDescending(r.Context(), blogIds)
+	rows, err := queries.GetBlogEntriesByIdsDescendingForUser(r.Context(), db.GetBlogEntriesByIdsDescendingForUserParams{
+		ViewerID: viewerID,
+		UserID:   sql.NullInt32{Int32: userID, Valid: userID != 0},
+		Blogids:  blogIds,
+	})
 	if err != nil {
 		log.Printf("getBlogEntriesByIdsDescending Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -46,6 +46,13 @@ WITH RECURSIVE role_ids(id) AS (
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = sqlc.arg(viewer_id) AS is_owner
 FROM blogs b
+JOIN grants g ON g.item_id = b.idblogs
+    AND g.section = 'blogs'
+    AND g.item = 'entry'
+    AND g.action = 'see'
+    AND g.active = 1
+    AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+    AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE (
@@ -59,16 +66,6 @@ WHERE (
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
     )
-)
-AND EXISTS (
-    SELECT 1 FROM grants g
-    WHERE g.section = 'blogs'
-      AND g.item = 'entry'
-      AND g.action = 'see'
-      AND g.active = 1
-      AND g.item_id = b.idblogs
-      AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
-      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
 ORDER BY b.written DESC
 LIMIT ? OFFSET ?;
@@ -95,12 +92,39 @@ AND (
 ORDER BY b.written DESC
 LIMIT ? OFFSET ?;
 
--- name: GetBlogEntriesByIdsDescending :many
+-- name: GetBlogEntriesByIdsDescendingForUser :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written
 FROM blogs b
+JOIN grants g ON g.item_id = b.idblogs
+    AND g.section = 'blogs'
+    AND g.item = 'entry'
+    AND g.action = 'see'
+    AND g.active = 1
+    AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
+    AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE b.idblogs IN (sqlc.slice(blogIds))
+  AND (
+      b.language_idlanguage = 0
+      OR b.language_idlanguage IS NULL
+      OR EXISTS (
+          SELECT 1 FROM user_language ul
+          WHERE ul.users_idusers = sqlc.arg(viewer_id)
+            AND ul.language_idlanguage = b.language_idlanguage
+      )
+      OR NOT EXISTS (
+          SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+      )
+  )
 ORDER BY b.written DESC
 ;
 

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -310,16 +310,49 @@ func (q *Queries) GetBlogEntriesByAuthorForUserDescendingLanguages(ctx context.C
 	return items, nil
 }
 
-const getBlogEntriesByIdsDescending = `-- name: GetBlogEntriesByIdsDescending :many
+const getBlogEntriesByIdsDescendingForUser = `-- name: GetBlogEntriesByIdsDescendingForUser :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written
 FROM blogs b
+JOIN grants g ON g.item_id = b.idblogs
+    AND g.section = 'blogs'
+    AND g.item = 'entry'
+    AND g.action = 'see'
+    AND g.active = 1
+    AND (g.user_id = ? OR g.user_id IS NULL)
+    AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE b.idblogs IN (/*SLICE:blogids*/?)
+  AND (
+      b.language_idlanguage = 0
+      OR b.language_idlanguage IS NULL
+      OR EXISTS (
+          SELECT 1 FROM user_language ul
+          WHERE ul.users_idusers = ?
+            AND ul.language_idlanguage = b.language_idlanguage
+      )
+      OR NOT EXISTS (
+          SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
+      )
+  )
 ORDER BY b.written DESC
 `
 
-type GetBlogEntriesByIdsDescendingRow struct {
+type GetBlogEntriesByIdsDescendingForUserParams struct {
+	ViewerID int32
+	UserID   sql.NullInt32
+	Blogids  []int32
+}
+
+type GetBlogEntriesByIdsDescendingForUserRow struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
@@ -328,25 +361,29 @@ type GetBlogEntriesByIdsDescendingRow struct {
 	Written            time.Time
 }
 
-func (q *Queries) GetBlogEntriesByIdsDescending(ctx context.Context, blogids []int32) ([]*GetBlogEntriesByIdsDescendingRow, error) {
-	query := getBlogEntriesByIdsDescending
+func (q *Queries) GetBlogEntriesByIdsDescendingForUser(ctx context.Context, arg GetBlogEntriesByIdsDescendingForUserParams) ([]*GetBlogEntriesByIdsDescendingForUserRow, error) {
+	query := getBlogEntriesByIdsDescendingForUser
 	var queryParams []interface{}
-	if len(blogids) > 0 {
-		for _, v := range blogids {
+	queryParams = append(queryParams, arg.ViewerID)
+	queryParams = append(queryParams, arg.UserID)
+	if len(arg.Blogids) > 0 {
+		for _, v := range arg.Blogids {
 			queryParams = append(queryParams, v)
 		}
-		query = strings.Replace(query, "/*SLICE:blogids*/?", strings.Repeat(",?", len(blogids))[1:], 1)
+		query = strings.Replace(query, "/*SLICE:blogids*/?", strings.Repeat(",?", len(arg.Blogids))[1:], 1)
 	} else {
 		query = strings.Replace(query, "/*SLICE:blogids*/?", "NULL", 1)
 	}
+	queryParams = append(queryParams, arg.ViewerID)
+	queryParams = append(queryParams, arg.ViewerID)
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*GetBlogEntriesByIdsDescendingRow
+	var items []*GetBlogEntriesByIdsDescendingForUserRow
 	for rows.Next() {
-		var i GetBlogEntriesByIdsDescendingRow
+		var i GetBlogEntriesByIdsDescendingForUserRow
 		if err := rows.Scan(
 			&i.Idblogs,
 			&i.ForumthreadID,
@@ -380,6 +417,13 @@ WITH RECURSIVE role_ids(id) AS (
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = ? AS is_owner
 FROM blogs b
+JOIN grants g ON g.item_id = b.idblogs
+    AND g.section = 'blogs'
+    AND g.item = 'entry'
+    AND g.action = 'see'
+    AND g.active = 1
+    AND (g.user_id = ? OR g.user_id IS NULL)
+    AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE (
@@ -393,16 +437,6 @@ WHERE (
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
     )
-)
-AND EXISTS (
-    SELECT 1 FROM grants g
-    WHERE g.section = 'blogs'
-      AND g.item = 'entry'
-      AND g.action = 'see'
-      AND g.active = 1
-      AND g.item_id = b.idblogs
-      AND (g.user_id = ? OR g.user_id IS NULL)
-      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
 ORDER BY b.written DESC
 LIMIT ? OFFSET ?
@@ -431,9 +465,9 @@ func (q *Queries) GetBlogEntriesForViewerDescending(ctx context.Context, arg Get
 	rows, err := q.db.QueryContext(ctx, getBlogEntriesForViewerDescending,
 		arg.ViewerID,
 		arg.ViewerID,
-		arg.ViewerID,
-		arg.ViewerID,
 		arg.UserID,
+		arg.ViewerID,
+		arg.ViewerID,
 		arg.Limit,
 		arg.Offset,
 	)


### PR DESCRIPTION
## Summary
- join grants in the viewer blog list query
- rename and expand GetBlogEntriesByIdsDescending to GetBlogEntriesByIdsDescendingForUser
- update search handler to use the new query
- regenerate sqlc code

## Testing
- `go vet ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cb168ee10832fbe730e051d2b386d