### PR TITLE
Add viewer-filtered FAQ queries

### DIFF
--- a/cmd/goa4web/faq_read.go
+++ b/cmd/goa4web/faq_read.go
@@ -43,7 +43,7 @@ func (c *faqReadCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	rows, err := queries.GetAllFAQQuestions(ctx)
+	rows, err := queries.GetAllFAQQuestionsForAdmin(ctx)
 	if err != nil {
 		return fmt.Errorf("get faq: %w", err)
 	}

--- a/cmd/goa4web/faq_tree.go
+++ b/cmd/goa4web/faq_tree.go
@@ -31,7 +31,7 @@ func (c *faqTreeCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	rows, err := queries.GetAllAnsweredFAQWithFAQCategories(ctx)
+	rows, err := queries.GetAllAnsweredFAQWithFAQCategoriesForAdmin(ctx)
 	if err != nil {
 		return fmt.Errorf("tree: %w", err)
 	}

--- a/handlers/faq/page.go
+++ b/handlers/faq/page.go
@@ -20,7 +20,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type CategoryFAQs struct {
-		Category *db.GetAllAnsweredFAQWithFAQCategoriesRow
+		Category *db.GetAllAnsweredFAQWithFAQCategoriesForViewerRow
 		FAQs     []*FAQ
 	}
 
@@ -36,7 +36,10 @@ func Page(w http.ResponseWriter, r *http.Request) {
 
 	var currentCategoryFAQs CategoryFAQs
 
-	faqRows, err := queries.GetAllAnsweredFAQWithFAQCategories(r.Context())
+	faqRows, err := queries.GetAllAnsweredFAQWithFAQCategoriesForViewer(r.Context(), db.GetAllAnsweredFAQWithFAQCategoriesForViewerParams{
+		ViewerID: cd.UserID,
+		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+	})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):


### PR DESCRIPTION
## Summary
- add viewer and admin variants for FAQ queries
- apply grant and language filters to viewer queries
- update Go code to use new query names
- regenerate sqlc models

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cb1547de0832f8d4f33cc7d7aa3b4