### PR TITLE
Rename admin queries

### DIFF
--- a/cmd/goa4web/blog_deactivate.go
+++ b/cmd/goa4web/blog_deactivate.go
@@ -48,7 +48,7 @@ func (c *blogDeactivateCmd) Run() error {
 	if b.ForumthreadID.Valid {
 		threadID = b.ForumthreadID.Int32
 	}
-	if err := queries.ArchiveBlog(ctx, dbpkg.ArchiveBlogParams{
+	if err := queries.ArchiveBlogForAdmin(ctx, dbpkg.ArchiveBlogForAdminParams{
 		Idblogs:            b.Idblogs,
 		ForumthreadID:      threadID,
 		UsersIdusers:       b.UsersIdusers,
@@ -58,7 +58,7 @@ func (c *blogDeactivateCmd) Run() error {
 	}); err != nil {
 		return fmt.Errorf("archive blog: %w", err)
 	}
-	if err := queries.ScrubBlog(ctx, dbpkg.ScrubBlogParams{Blog: sql.NullString{String: "", Valid: true}, Idblogs: b.Idblogs}); err != nil {
+	if err := queries.ScrubBlogForAdmin(ctx, dbpkg.ScrubBlogForAdminParams{Blog: sql.NullString{String: "", Valid: true}, Idblogs: b.Idblogs}); err != nil {
 		return fmt.Errorf("scrub blog: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/ipban_add.go
+++ b/cmd/goa4web/ipban_add.go
@@ -51,7 +51,7 @@ func (c *ipBanAddCmd) Run() error {
 		}
 		expires = sql.NullTime{Time: t, Valid: true}
 	}
-	err = queries.InsertBannedIp(ctx, dbpkg.InsertBannedIpParams{
+	err = queries.InsertBannedIpForAdmin(ctx, dbpkg.InsertBannedIpForAdminParams{
 		IpNet:     c.IP,
 		Reason:    sql.NullString{String: c.Reason, Valid: c.Reason != ""},
 		ExpiresAt: expires,

--- a/cmd/goa4web/ipban_delete.go
+++ b/cmd/goa4web/ipban_delete.go
@@ -37,7 +37,7 @@ func (c *ipBanDeleteCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	if err := queries.CancelBannedIp(ctx, c.IP); err != nil {
+	if err := queries.CancelBannedIpForAdmin(ctx, c.IP); err != nil {
 		return fmt.Errorf("cancel banned ip: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/ipban_list.go
+++ b/cmd/goa4web/ipban_list.go
@@ -31,7 +31,7 @@ func (c *ipBanListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	rows, err := queries.ListBannedIps(ctx)
+	rows, err := queries.ListBannedIpsForAdmin(ctx)
 	if err != nil {
 		return fmt.Errorf("list banned ips: %w", err)
 	}

--- a/cmd/goa4web/ipban_update.go
+++ b/cmd/goa4web/ipban_update.go
@@ -51,7 +51,7 @@ func (c *ipBanUpdateCmd) Run() error {
 		}
 		expires = sql.NullTime{Time: t, Valid: true}
 	}
-	err = queries.UpdateBannedIp(ctx, dbpkg.UpdateBannedIpParams{
+	err = queries.UpdateBannedIpForAdmin(ctx, dbpkg.UpdateBannedIpForAdminParams{
 		Reason:    sql.NullString{String: c.Reason, Valid: c.Reason != ""},
 		ExpiresAt: expires,
 		ID:        int32(c.ID),

--- a/cmd/goa4web/links_delete.go
+++ b/cmd/goa4web/links_delete.go
@@ -37,7 +37,7 @@ func (c *linksDeleteCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	if err := queries.DeleteExternalLink(ctx, int32(c.ID)); err != nil {
+	if err := queries.DeleteExternalLinkForAdmin(ctx, int32(c.ID)); err != nil {
 		return fmt.Errorf("delete link: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/links_list.go
+++ b/cmd/goa4web/links_list.go
@@ -31,7 +31,7 @@ func (c *linksListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	rows, err := queries.ListExternalLinks(ctx, dbpkg.ListExternalLinksParams{Limit: 200, Offset: 0})
+	rows, err := queries.ListExternalLinksForAdmin(ctx, dbpkg.ListExternalLinksForAdminParams{Limit: 200, Offset: 0})
 	if err != nil {
 		return fmt.Errorf("list links: %w", err)
 	}

--- a/cmd/goa4web/links_refresh.go
+++ b/cmd/goa4web/links_refresh.go
@@ -38,7 +38,7 @@ func (c *linksRefreshCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	if err := queries.ClearExternalLinkCache(ctx, dbpkg.ClearExternalLinkCacheParams{UpdatedBy: sql.NullInt32{}, ID: int32(c.ID)}); err != nil {
+	if err := queries.ClearExternalLinkCacheForAdmin(ctx, dbpkg.ClearExternalLinkCacheForAdminParams{UpdatedBy: sql.NullInt32{}, ID: int32(c.ID)}); err != nil {
 		return fmt.Errorf("refresh link: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/user_activate.go
+++ b/cmd/goa4web/user_activate.go
@@ -53,33 +53,33 @@ func (c *userActivateCmd) Run() error {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	qtx := queries.WithTx(tx)
-	if err := qtx.RestoreUser(ctx, int32(c.ID)); err != nil {
+	if err := qtx.RestoreUserForAdmin(ctx, int32(c.ID)); err != nil {
 		tx.Rollback()
 		return fmt.Errorf("restore user: %w", err)
 	}
-	rows, err := qtx.PendingDeactivatedComments(ctx, int32(c.ID))
+	rows, err := qtx.PendingDeactivatedCommentsForAdmin(ctx, int32(c.ID))
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select comments: %w", err)
 	}
 	for _, row := range rows {
-		if err := qtx.RestoreComment(ctx, dbpkg.RestoreCommentParams{Text: row.Text, Idcomments: row.Idcomments}); err != nil {
+		if err := qtx.RestoreCommentForAdmin(ctx, dbpkg.RestoreCommentForAdminParams{Text: row.Text, Idcomments: row.Idcomments}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("restore comment: %w", err)
 		}
-		if err := qtx.MarkCommentRestored(ctx, row.Idcomments); err != nil {
+		if err := qtx.MarkCommentRestoredForAdmin(ctx, row.Idcomments); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark comment restored: %w", err)
 		}
 	}
 
-	rowsW, err := qtx.PendingDeactivatedWritings(ctx, int32(c.ID))
+	rowsW, err := qtx.PendingDeactivatedWritingsForAdmin(ctx, int32(c.ID))
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select writings: %w", err)
 	}
 	for _, w := range rowsW {
-		if err := qtx.RestoreWriting(ctx, dbpkg.RestoreWritingParams{
+		if err := qtx.RestoreWritingForAdmin(ctx, dbpkg.RestoreWritingForAdminParams{
 			Title:     w.Title,
 			Writing:   w.Writing,
 			Abstract:  w.Abstract,
@@ -89,55 +89,55 @@ func (c *userActivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("restore writing: %w", err)
 		}
-		if err := qtx.MarkWritingRestored(ctx, w.Idwriting); err != nil {
+		if err := qtx.MarkWritingRestoredForAdmin(ctx, w.Idwriting); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark writing restored: %w", err)
 		}
 	}
 
-	rowsB, err := qtx.PendingDeactivatedBlogs(ctx, int32(c.ID))
+	rowsB, err := qtx.PendingDeactivatedBlogsForAdmin(ctx, int32(c.ID))
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select blogs: %w", err)
 	}
 	for _, b := range rowsB {
-		if err := qtx.RestoreBlog(ctx, dbpkg.RestoreBlogParams{Blog: b.Blog, Idblogs: b.Idblogs}); err != nil {
+		if err := qtx.RestoreBlogForAdmin(ctx, dbpkg.RestoreBlogForAdminParams{Blog: b.Blog, Idblogs: b.Idblogs}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("restore blog: %w", err)
 		}
-		if err := qtx.MarkBlogRestored(ctx, b.Idblogs); err != nil {
+		if err := qtx.MarkBlogRestoredForAdmin(ctx, b.Idblogs); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark blog restored: %w", err)
 		}
 	}
 
-	rowsI, err := qtx.PendingDeactivatedImageposts(ctx, int32(c.ID))
+	rowsI, err := qtx.PendingDeactivatedImagepostsForAdmin(ctx, int32(c.ID))
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select imageposts: %w", err)
 	}
 	for _, img := range rowsI {
-		if err := qtx.RestoreImagepost(ctx, dbpkg.RestoreImagepostParams{Description: img.Description, Thumbnail: img.Thumbnail, Fullimage: img.Fullimage, Idimagepost: img.Idimagepost}); err != nil {
+		if err := qtx.RestoreImagepostForAdmin(ctx, dbpkg.RestoreImagepostForAdminParams{Description: img.Description, Thumbnail: img.Thumbnail, Fullimage: img.Fullimage, Idimagepost: img.Idimagepost}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("restore imagepost: %w", err)
 		}
-		if err := qtx.MarkImagepostRestored(ctx, img.Idimagepost); err != nil {
+		if err := qtx.MarkImagepostRestoredForAdmin(ctx, img.Idimagepost); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark imagepost restored: %w", err)
 		}
 	}
 
-	rowsL, err := qtx.PendingDeactivatedLinks(ctx, int32(c.ID))
+	rowsL, err := qtx.PendingDeactivatedLinksForAdmin(ctx, int32(c.ID))
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select links: %w", err)
 	}
 	for _, l := range rowsL {
-		if err := qtx.RestoreLink(ctx, dbpkg.RestoreLinkParams{Title: l.Title, Url: l.Url, Description: l.Description, Idlinker: l.Idlinker}); err != nil {
+		if err := qtx.RestoreLinkForAdmin(ctx, dbpkg.RestoreLinkForAdminParams{Title: l.Title, Url: l.Url, Description: l.Description, Idlinker: l.Idlinker}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("restore link: %w", err)
 		}
-		if err := qtx.MarkLinkRestored(ctx, l.Idlinker); err != nil {
+		if err := qtx.MarkLinkRestoredForAdmin(ctx, l.Idlinker); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark link restored: %w", err)
 		}

--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -56,12 +56,12 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	qtx := queries.WithTx(tx)
-	if err := qtx.ArchiveUser(ctx, u.Idusers); err != nil {
+	if err := qtx.ArchiveUserForAdmin(ctx, u.Idusers); err != nil {
 		tx.Rollback()
 		return fmt.Errorf("archive user: %w", err)
 	}
 	newName := randomString(16)
-	if err := qtx.ScrubUser(ctx, dbpkg.ScrubUserParams{Username: sql.NullString{String: newName, Valid: true}, Idusers: u.Idusers}); err != nil {
+	if err := qtx.ScrubUserForAdmin(ctx, dbpkg.ScrubUserForAdminParams{Username: sql.NullString{String: newName, Valid: true}, Idusers: u.Idusers}); err != nil {
 		tx.Rollback()
 		return fmt.Errorf("scrub user: %w", err)
 	}
@@ -71,7 +71,7 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("list comments: %w", err)
 	}
 	for _, cm := range comments {
-		if err := qtx.ArchiveComment(ctx, dbpkg.ArchiveCommentParams{
+		if err := qtx.ArchiveCommentForAdmin(ctx, dbpkg.ArchiveCommentForAdminParams{
 			Idcomments:         cm.Idcomments,
 			ForumthreadID:      cm.ForumthreadID,
 			UsersIdusers:       cm.UsersIdusers,
@@ -83,7 +83,7 @@ func (c *userDeactivateCmd) Run() error {
 			return fmt.Errorf("archive comment: %w", err)
 		}
 		scrub := scrubText(cm.Text.String)
-		if err := qtx.ScrubComment(ctx, dbpkg.ScrubCommentParams{Text: sql.NullString{String: scrub, Valid: true}, Idcomments: cm.Idcomments}); err != nil {
+		if err := qtx.ScrubCommentForAdmin(ctx, dbpkg.ScrubCommentForAdminParams{Text: sql.NullString{String: scrub, Valid: true}, Idcomments: cm.Idcomments}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("scrub comment: %w", err)
 		}
@@ -98,7 +98,7 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("list writings: %w", err)
 	}
 	for _, w := range writings {
-		if err := qtx.ArchiveWriting(ctx, dbpkg.ArchiveWritingParams{
+		if err := qtx.ArchiveWritingForAdmin(ctx, dbpkg.ArchiveWritingForAdminParams{
 			Idwriting:          w.Idwriting,
 			UsersIdusers:       w.UsersIdusers,
 			ForumthreadID:      w.ForumthreadID,
@@ -113,7 +113,7 @@ func (c *userDeactivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("archive writing: %w", err)
 		}
-		if err := qtx.ScrubWriting(ctx, dbpkg.ScrubWritingParams{
+		if err := qtx.ScrubWritingForAdmin(ctx, dbpkg.ScrubWritingForAdminParams{
 			Title:     sql.NullString{String: scrubText(w.Title.String), Valid: w.Title.Valid},
 			Writing:   sql.NullString{String: scrubText(w.Writing.String), Valid: w.Writing.Valid},
 			Abstract:  sql.NullString{String: scrubText(w.Abstract.String), Valid: w.Abstract.Valid},
@@ -133,7 +133,7 @@ func (c *userDeactivateCmd) Run() error {
 		if b.ForumthreadID.Valid {
 			threadID = b.ForumthreadID.Int32
 		}
-		if err := qtx.ArchiveBlog(ctx, dbpkg.ArchiveBlogParams{
+		if err := qtx.ArchiveBlogForAdmin(ctx, dbpkg.ArchiveBlogForAdminParams{
 			Idblogs:            b.Idblogs,
 			ForumthreadID:      threadID,
 			UsersIdusers:       b.UsersIdusers,
@@ -144,7 +144,7 @@ func (c *userDeactivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("archive blog: %w", err)
 		}
-		if err := qtx.ScrubBlog(ctx, dbpkg.ScrubBlogParams{Blog: sql.NullString{String: scrubText(b.Blog.String), Valid: b.Blog.Valid}, Idblogs: b.Idblogs}); err != nil {
+		if err := qtx.ScrubBlogForAdmin(ctx, dbpkg.ScrubBlogForAdminParams{Blog: sql.NullString{String: scrubText(b.Blog.String), Valid: b.Blog.Valid}, Idblogs: b.Idblogs}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("scrub blog: %w", err)
 		}
@@ -155,7 +155,7 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("list images: %w", err)
 	}
 	for _, img := range imgs {
-		if err := qtx.ArchiveImagepost(ctx, dbpkg.ArchiveImagepostParams{
+		if err := qtx.ArchiveImagepostForAdmin(ctx, dbpkg.ArchiveImagepostForAdminParams{
 			Idimagepost:            img.Idimagepost,
 			ForumthreadID:          img.ForumthreadID,
 			UsersIdusers:           img.UsersIdusers,
@@ -170,7 +170,7 @@ func (c *userDeactivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("archive imagepost: %w", err)
 		}
-		if err := qtx.ScrubImagepost(ctx, img.Idimagepost); err != nil {
+		if err := qtx.ScrubImagepostForAdmin(ctx, img.Idimagepost); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("scrub imagepost: %w", err)
 		}
@@ -181,7 +181,7 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("list links: %w", err)
 	}
 	for _, l := range links {
-		if err := qtx.ArchiveLink(ctx, dbpkg.ArchiveLinkParams{
+		if err := qtx.ArchiveLinkForAdmin(ctx, dbpkg.ArchiveLinkForAdminParams{
 			Idlinker:           l.Idlinker,
 			LanguageIdlanguage: l.LanguageIdlanguage,
 			UsersIdusers:       l.UsersIdusers,
@@ -195,7 +195,7 @@ func (c *userDeactivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("archive link: %w", err)
 		}
-		if err := qtx.ScrubLink(ctx, dbpkg.ScrubLinkParams{Title: sql.NullString{String: scrubText(l.Title.String), Valid: l.Title.Valid}, Idlinker: l.Idlinker}); err != nil {
+		if err := qtx.ScrubLinkForAdmin(ctx, dbpkg.ScrubLinkForAdminParams{Title: sql.NullString{String: scrubText(l.Title.String), Valid: l.Title.Valid}, Idlinker: l.Idlinker}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("scrub link: %w", err)
 		}

--- a/handlers/admin/add_ip_ban_task.go
+++ b/handlers/admin/add_ip_ban_task.go
@@ -39,7 +39,7 @@ func (AddIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	if ipNet != "" {
-		if err := queries.InsertBannedIp(r.Context(), db.InsertBannedIpParams{
+		if err := queries.InsertBannedIpForAdmin(r.Context(), db.InsertBannedIpForAdminParams{
 			IpNet:     ipNet,
 			Reason:    sql.NullString{String: reason, Valid: reason != ""},
 			ExpiresAt: expires,

--- a/handlers/admin/adminAuditLogPage.go
+++ b/handlers/admin/adminAuditLogPage.go
@@ -26,7 +26,7 @@ func copyValues(v url.Values) url.Values {
 func AdminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		Rows     []*db.ListAuditLogsRow
+		Rows     []*db.ListAuditLogsForAdminRow
 		User     string
 		Action   string
 		NextLink string
@@ -55,7 +55,7 @@ func AdminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 		actionFilter = "%" + data.Action + "%"
 	}
 
-	rows, err := queries.ListAuditLogs(r.Context(), db.ListAuditLogsParams{
+	rows, err := queries.ListAuditLogsForAdmin(r.Context(), db.ListAuditLogsForAdminParams{
 		Username: sql.NullString{String: usernameFilter, Valid: true},
 		Action:   actionFilter,
 		Limit:    int32(data.PageSize + 1),

--- a/handlers/admin/adminCommentTasks.go
+++ b/handlers/admin/adminCommentTasks.go
@@ -24,7 +24,7 @@ var _ tasks.Task = (*DeleteCommentTask)(nil)
 func (DeleteCommentTask) Action(w http.ResponseWriter, r *http.Request) any {
 	id, _ := strconv.Atoi(mux.Vars(r)["id"])
 	q := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	if err := q.ScrubComment(r.Context(), db.ScrubCommentParams{Text: sql.NullString{String: "", Valid: true}, Idcomments: int32(id)}); err != nil {
+	if err := q.ScrubCommentForAdmin(r.Context(), db.ScrubCommentForAdminParams{Text: sql.NullString{String: "", Valid: true}, Idcomments: int32(id)}); err != nil {
 		return fmt.Errorf("delete comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	return nil
@@ -62,7 +62,7 @@ func (BanCommentTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("fetch comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := q.ArchiveComment(r.Context(), db.ArchiveCommentParams{
+	if err := q.ArchiveCommentForAdmin(r.Context(), db.ArchiveCommentForAdminParams{
 		Idcomments:         c.Idcomments,
 		ForumthreadID:      c.ForumthreadID,
 		UsersIdusers:       c.UsersIdusers,
@@ -72,7 +72,7 @@ func (BanCommentTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}); err != nil {
 		return fmt.Errorf("archive comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := q.ScrubComment(r.Context(), db.ScrubCommentParams{Text: sql.NullString{String: "", Valid: true}, Idcomments: c.Idcomments}); err != nil {
+	if err := q.ScrubCommentForAdmin(r.Context(), db.ScrubCommentForAdminParams{Text: sql.NullString{String: "", Valid: true}, Idcomments: c.Idcomments}); err != nil {
 		return fmt.Errorf("scrub comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	return nil

--- a/handlers/admin/adminDLQPage.go
+++ b/handlers/admin/adminDLQPage.go
@@ -63,15 +63,15 @@ func AdminDLQPage(w http.ResponseWriter, r *http.Request) {
 	for _, n := range names {
 		switch n {
 		case "db":
-			if rows, err := queries.ListDeadLetters(r.Context(), 100); err == nil {
+			if rows, err := queries.ListDeadLettersForAdmin(r.Context(), 100); err == nil {
 				data.Errors = rows
 			} else {
 				log.Printf("list dead letters: %v", err)
 			}
-			if c, err := queries.CountDeadLetters(r.Context()); err == nil {
+			if c, err := queries.CountDeadLettersSystem(r.Context()); err == nil {
 				data.DBCount = c
 			}
-			if lt, err := queries.LatestDeadLetter(r.Context()); err == nil {
+			if lt, err := queries.LatestDeadLetterForAdmin(r.Context()); err == nil {
 				if t, ok := lt.(time.Time); ok {
 					data.DBLatest = t.Format(time.RFC3339)
 				}
@@ -123,7 +123,7 @@ func (DeleteDLQTask) Action(w http.ResponseWriter, r *http.Request) any {
 				continue
 			}
 			id, _ := strconv.Atoi(idStr)
-			if err := queries.DeleteDeadLetter(r.Context(), int32(id)); err != nil {
+			if err := queries.DeleteDeadLetterForAdmin(r.Context(), int32(id)); err != nil {
 				return fmt.Errorf("delete error %w", handlers.ErrRedirectOnSamePageHandler(err))
 			}
 			if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
@@ -143,7 +143,7 @@ func (DeleteDLQTask) Action(w http.ResponseWriter, r *http.Request) any {
 				t = tt
 			}
 		}
-		if err := queries.PurgeDeadLettersBefore(r.Context(), t); err != nil {
+		if err := queries.PurgeDeadLettersBeforeForAdmin(r.Context(), t); err != nil {
 			return fmt.Errorf("purge errors %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/adminExternalLinksPage.go
+++ b/handlers/admin/adminExternalLinksPage.go
@@ -21,7 +21,7 @@ func AdminExternalLinksPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "External Links"
 	queries := cd.Queries()
-	rows, err := queries.ListExternalLinks(r.Context(), db.ListExternalLinksParams{Limit: 200, Offset: 0})
+	rows, err := queries.ListExternalLinksForAdmin(r.Context(), db.ListExternalLinksForAdminParams{Limit: 200, Offset: 0})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list external links: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/adminIPBanPage.go
+++ b/handlers/admin/adminIPBanPage.go
@@ -22,7 +22,7 @@ func AdminIPBanPage(w http.ResponseWriter, r *http.Request) {
 	cd.PageTitle = "IP Bans"
 	data := Data{CoreData: cd}
 	queries := cd.Queries()
-	rows, err := queries.ListBannedIps(r.Context())
+	rows, err := queries.ListBannedIpsForAdmin(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list banned ips: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/delete_ip_ban_task.go
+++ b/handlers/admin/delete_ip_ban_task.go
@@ -30,7 +30,7 @@ func (DeleteIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {
 	var ips []string
 	for _, ip := range r.Form["ip"] {
 		ipNet := NormalizeIPNet(ip)
-		if err := queries.CancelBannedIp(r.Context(), ipNet); err != nil {
+		if err := queries.CancelBannedIpForAdmin(r.Context(), ipNet); err != nil {
 			return fmt.Errorf("cancel banned ip %s fail %w", ipNet, handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if ipNet != "" {

--- a/handlers/admin/external_links_tasks.go
+++ b/handlers/admin/external_links_tasks.go
@@ -30,7 +30,7 @@ func (RefreshExternalLinkTask) Action(w http.ResponseWriter, r *http.Request) an
 	uid := sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.ClearExternalLinkCache(r.Context(), db.ClearExternalLinkCacheParams{UpdatedBy: uid, ID: int32(id)}); err != nil {
+               if err := queries.ClearExternalLinkCacheForAdmin(r.Context(), db.ClearExternalLinkCacheForAdminParams{UpdatedBy: uid, ID: int32(id)}); err != nil {
 			return fmt.Errorf("clear external link cache fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if evt := cd.Event(); evt != nil {
@@ -66,7 +66,7 @@ func (DeleteExternalLinkTask) Action(w http.ResponseWriter, r *http.Request) any
 	queries := cd.Queries()
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.DeleteExternalLink(r.Context(), int32(id)); err != nil {
+               if err := queries.DeleteExternalLinkForAdmin(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("delete external link fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if evt := cd.Event(); evt != nil {

--- a/handlers/externallink/redirect.go
+++ b/handlers/externallink/redirect.go
@@ -25,14 +25,14 @@ func RedirectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.URL.Query().Get("go") != "" {
-		if err := cd.Queries().RegisterExternalLinkClick(r.Context(), raw); err != nil {
+		if err := cd.Queries().RegisterExternalLinkClickSystem(r.Context(), raw); err != nil {
 			log.Printf("record external link click: %v", err)
 		}
 		http.Redirect(w, r, raw, http.StatusTemporaryRedirect)
 		return
 	}
 
-	link, err := cd.Queries().GetExternalLink(r.Context(), raw)
+	link, err := cd.Queries().GetExternalLinkSystem(r.Context(), raw)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("get external link: %v", err)
 	}

--- a/internal/db/queries-auditlog.sql
+++ b/internal/db/queries-auditlog.sql
@@ -1,7 +1,7 @@
--- name: InsertAuditLog :exec
+-- name: InsertAuditLogSystem :exec
 INSERT INTO audit_log (users_idusers, action, path, details, data) VALUES (?, ?, ?, ?, ?);
 
--- name: ListAuditLogs :many
+-- name: ListAuditLogsForAdmin :many
 SELECT a.id, a.users_idusers, a.action, a.path, a.details, a.data, a.created_at, u.username
 FROM audit_log a
 LEFT JOIN users u ON a.users_idusers = u.idusers

--- a/internal/db/queries-auditlog.sql.go
+++ b/internal/db/queries-auditlog.sql.go
@@ -11,11 +11,11 @@ import (
 	"time"
 )
 
-const insertAuditLog = `-- name: InsertAuditLog :exec
+const insertAuditLogSystem = `-- name: InsertAuditLogSystem :exec
 INSERT INTO audit_log (users_idusers, action, path, details, data) VALUES (?, ?, ?, ?, ?)
 `
 
-type InsertAuditLogParams struct {
+type InsertAuditLogSystemParams struct {
 	UsersIdusers int32
 	Action       string
 	Path         string
@@ -23,8 +23,8 @@ type InsertAuditLogParams struct {
 	Data         sql.NullString
 }
 
-func (q *Queries) InsertAuditLog(ctx context.Context, arg InsertAuditLogParams) error {
-	_, err := q.db.ExecContext(ctx, insertAuditLog,
+func (q *Queries) InsertAuditLogSystem(ctx context.Context, arg InsertAuditLogSystemParams) error {
+	_, err := q.db.ExecContext(ctx, insertAuditLogSystem,
 		arg.UsersIdusers,
 		arg.Action,
 		arg.Path,
@@ -34,7 +34,7 @@ func (q *Queries) InsertAuditLog(ctx context.Context, arg InsertAuditLogParams) 
 	return err
 }
 
-const listAuditLogs = `-- name: ListAuditLogs :many
+const listAuditLogsForAdmin = `-- name: ListAuditLogsForAdmin :many
 SELECT a.id, a.users_idusers, a.action, a.path, a.details, a.data, a.created_at, u.username
 FROM audit_log a
 LEFT JOIN users u ON a.users_idusers = u.idusers
@@ -43,14 +43,14 @@ ORDER BY a.id DESC
 LIMIT ? OFFSET ?
 `
 
-type ListAuditLogsParams struct {
+type ListAuditLogsForAdminParams struct {
 	Username sql.NullString
 	Action   string
 	Limit    int32
 	Offset   int32
 }
 
-type ListAuditLogsRow struct {
+type ListAuditLogsForAdminRow struct {
 	ID           int32
 	UsersIdusers int32
 	Action       string
@@ -61,8 +61,8 @@ type ListAuditLogsRow struct {
 	Username     sql.NullString
 }
 
-func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([]*ListAuditLogsRow, error) {
-	rows, err := q.db.QueryContext(ctx, listAuditLogs,
+func (q *Queries) ListAuditLogsForAdmin(ctx context.Context, arg ListAuditLogsForAdminParams) ([]*ListAuditLogsForAdminRow, error) {
+	rows, err := q.db.QueryContext(ctx, listAuditLogsForAdmin,
 		arg.Username,
 		arg.Action,
 		arg.Limit,
@@ -72,9 +72,9 @@ func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*ListAuditLogsRow
+	var items []*ListAuditLogsForAdminRow
 	for rows.Next() {
-		var i ListAuditLogsRow
+		var i ListAuditLogsForAdminRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.UsersIdusers,

--- a/internal/db/queries-banned_ips.sql
+++ b/internal/db/queries-banned_ips.sql
@@ -1,18 +1,18 @@
--- name: InsertBannedIp :exec
+-- name: InsertBannedIpForAdmin :exec
 INSERT INTO banned_ips (ip_net, reason, expires_at)
 VALUES (?, ?, ?);
 
--- name: UpdateBannedIp :exec
+-- name: UpdateBannedIpForAdmin :exec
 UPDATE banned_ips SET reason = ?, expires_at = ? WHERE id = ?;
 
--- name: CancelBannedIp :exec
+-- name: CancelBannedIpForAdmin :exec
 UPDATE banned_ips SET canceled_at = CURRENT_TIMESTAMP WHERE ip_net = ? AND canceled_at IS NULL;
 
--- name: GetBannedIpByAddress :one
+-- name: GetBannedIpByAddressForAdmin :one
 SELECT * FROM banned_ips WHERE ip_net = ?;
 
--- name: ListActiveBans :many
+-- name: ListActiveBansSystem :many
 SELECT * FROM banned_ips WHERE canceled_at IS NULL AND (expires_at IS NULL OR expires_at > NOW());
 
--- name: ListBannedIps :many
+-- name: ListBannedIpsForAdmin :many
 SELECT * FROM banned_ips ORDER BY created_at DESC;

--- a/internal/db/queries-banned_ips.sql.go
+++ b/internal/db/queries-banned_ips.sql.go
@@ -10,21 +10,21 @@ import (
 	"database/sql"
 )
 
-const cancelBannedIp = `-- name: CancelBannedIp :exec
+const cancelBannedIpForAdmin = `-- name: CancelBannedIpForAdmin :exec
 UPDATE banned_ips SET canceled_at = CURRENT_TIMESTAMP WHERE ip_net = ? AND canceled_at IS NULL
 `
 
-func (q *Queries) CancelBannedIp(ctx context.Context, ipNet string) error {
-	_, err := q.db.ExecContext(ctx, cancelBannedIp, ipNet)
+func (q *Queries) CancelBannedIpForAdmin(ctx context.Context, ipNet string) error {
+	_, err := q.db.ExecContext(ctx, cancelBannedIpForAdmin, ipNet)
 	return err
 }
 
-const getBannedIpByAddress = `-- name: GetBannedIpByAddress :one
+const getBannedIpByAddressForAdmin = `-- name: GetBannedIpByAddressForAdmin :one
 SELECT id, ip_net, reason, created_at, expires_at, canceled_at FROM banned_ips WHERE ip_net = ?
 `
 
-func (q *Queries) GetBannedIpByAddress(ctx context.Context, ipNet string) (*BannedIp, error) {
-	row := q.db.QueryRowContext(ctx, getBannedIpByAddress, ipNet)
+func (q *Queries) GetBannedIpByAddressForAdmin(ctx context.Context, ipNet string) (*BannedIp, error) {
+	row := q.db.QueryRowContext(ctx, getBannedIpByAddressForAdmin, ipNet)
 	var i BannedIp
 	err := row.Scan(
 		&i.ID,
@@ -37,28 +37,28 @@ func (q *Queries) GetBannedIpByAddress(ctx context.Context, ipNet string) (*Bann
 	return &i, err
 }
 
-const insertBannedIp = `-- name: InsertBannedIp :exec
+const insertBannedIpForAdmin = `-- name: InsertBannedIpForAdmin :exec
 INSERT INTO banned_ips (ip_net, reason, expires_at)
 VALUES (?, ?, ?)
 `
 
-type InsertBannedIpParams struct {
+type InsertBannedIpForAdminParams struct {
 	IpNet     string
 	Reason    sql.NullString
 	ExpiresAt sql.NullTime
 }
 
-func (q *Queries) InsertBannedIp(ctx context.Context, arg InsertBannedIpParams) error {
-	_, err := q.db.ExecContext(ctx, insertBannedIp, arg.IpNet, arg.Reason, arg.ExpiresAt)
+func (q *Queries) InsertBannedIpForAdmin(ctx context.Context, arg InsertBannedIpForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, insertBannedIpForAdmin, arg.IpNet, arg.Reason, arg.ExpiresAt)
 	return err
 }
 
-const listActiveBans = `-- name: ListActiveBans :many
+const listActiveBansSystem = `-- name: ListActiveBansSystem :many
 SELECT id, ip_net, reason, created_at, expires_at, canceled_at FROM banned_ips WHERE canceled_at IS NULL AND (expires_at IS NULL OR expires_at > NOW())
 `
 
-func (q *Queries) ListActiveBans(ctx context.Context) ([]*BannedIp, error) {
-	rows, err := q.db.QueryContext(ctx, listActiveBans)
+func (q *Queries) ListActiveBansSystem(ctx context.Context) ([]*BannedIp, error) {
+	rows, err := q.db.QueryContext(ctx, listActiveBansSystem)
 	if err != nil {
 		return nil, err
 	}
@@ -87,12 +87,12 @@ func (q *Queries) ListActiveBans(ctx context.Context) ([]*BannedIp, error) {
 	return items, nil
 }
 
-const listBannedIps = `-- name: ListBannedIps :many
+const listBannedIpsForAdmin = `-- name: ListBannedIpsForAdmin :many
 SELECT id, ip_net, reason, created_at, expires_at, canceled_at FROM banned_ips ORDER BY created_at DESC
 `
 
-func (q *Queries) ListBannedIps(ctx context.Context) ([]*BannedIp, error) {
-	rows, err := q.db.QueryContext(ctx, listBannedIps)
+func (q *Queries) ListBannedIpsForAdmin(ctx context.Context) ([]*BannedIp, error) {
+	rows, err := q.db.QueryContext(ctx, listBannedIpsForAdmin)
 	if err != nil {
 		return nil, err
 	}
@@ -121,17 +121,17 @@ func (q *Queries) ListBannedIps(ctx context.Context) ([]*BannedIp, error) {
 	return items, nil
 }
 
-const updateBannedIp = `-- name: UpdateBannedIp :exec
+const updateBannedIpForAdmin = `-- name: UpdateBannedIpForAdmin :exec
 UPDATE banned_ips SET reason = ?, expires_at = ? WHERE id = ?
 `
 
-type UpdateBannedIpParams struct {
+type UpdateBannedIpForAdminParams struct {
 	Reason    sql.NullString
 	ExpiresAt sql.NullTime
 	ID        int32
 }
 
-func (q *Queries) UpdateBannedIp(ctx context.Context, arg UpdateBannedIpParams) error {
-	_, err := q.db.ExecContext(ctx, updateBannedIp, arg.Reason, arg.ExpiresAt, arg.ID)
+func (q *Queries) UpdateBannedIpForAdmin(ctx context.Context, arg UpdateBannedIpForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, updateBannedIpForAdmin, arg.Reason, arg.ExpiresAt, arg.ID)
 	return err
 }

--- a/internal/db/queries-deactivation.sql
+++ b/internal/db/queries-deactivation.sql
@@ -1,97 +1,97 @@
 -- Queries for user deactivation and restoration
 
--- name: ArchiveUser :exec
+-- name: ArchiveUserForAdmin :exec
 INSERT INTO deactivated_users (idusers, email, passwd, passwd_algorithm, username, deleted_at)
 SELECT u.idusers, u.email, u.passwd, u.passwd_algorithm, u.username, NOW()
 FROM users u WHERE u.idusers = ?;
 
--- name: ScrubUser :exec
+-- name: ScrubUserForAdmin :exec
 UPDATE users SET username = ?, email = '', passwd = '', passwd_algorithm = '', deleted_at = NOW()
 WHERE idusers = ?;
 
--- name: ArchiveComment :exec
+-- name: ArchiveCommentForAdmin :exec
 INSERT INTO deactivated_comments (idcomments, forumthread_id, users_idusers, language_idlanguage, written, text, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubComment :exec
+-- name: ScrubCommentForAdmin :exec
 UPDATE comments SET text = ?, deleted_at = NOW() WHERE idcomments = ?;
 
--- name: PendingDeactivatedComments :many
+-- name: PendingDeactivatedCommentsForAdmin :many
 SELECT idcomments, text FROM deactivated_comments
 WHERE users_idusers = ? AND restored_at IS NULL;
 
--- name: RestoreComment :exec
+-- name: RestoreCommentForAdmin :exec
 UPDATE comments SET text = ?, deleted_at = NULL WHERE idcomments = ?;
 
--- name: MarkCommentRestored :exec
+-- name: MarkCommentRestoredForAdmin :exec
 UPDATE deactivated_comments SET restored_at = NOW() WHERE idcomments = ?;
 
--- name: ArchiveWriting :exec
+-- name: ArchiveWritingForAdmin :exec
 INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_id, language_idlanguage, writing_category_id, title, published, writing, abstract, private, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubWriting :exec
+-- name: ScrubWritingForAdmin :exec
 UPDATE writing SET title = ?, writing = ?, abstract = ?, deleted_at = NOW() WHERE idwriting = ?;
 
--- name: PendingDeactivatedWritings :many
+-- name: PendingDeactivatedWritingsForAdmin :many
 SELECT idwriting, title, writing, abstract, private FROM deactivated_writings
 WHERE users_idusers = ? AND restored_at IS NULL;
 
--- name: RestoreWriting :exec
+-- name: RestoreWritingForAdmin :exec
 UPDATE writing SET title = ?, writing = ?, abstract = ?, private = ?, deleted_at = NULL WHERE idwriting = ?;
 
--- name: MarkWritingRestored :exec
+-- name: MarkWritingRestoredForAdmin :exec
 UPDATE deactivated_writings SET restored_at = NOW() WHERE idwriting = ?;
 
--- name: ArchiveBlog :exec
+-- name: ArchiveBlogForAdmin :exec
 INSERT INTO deactivated_blogs (idblogs, forumthread_id, users_idusers, language_idlanguage, blog, written, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubBlog :exec
+-- name: ScrubBlogForAdmin :exec
 UPDATE blogs SET blog = ?, deleted_at = NOW() WHERE idblogs = ?;
 
--- name: PendingDeactivatedBlogs :many
+-- name: PendingDeactivatedBlogsForAdmin :many
 SELECT idblogs, blog FROM deactivated_blogs WHERE users_idusers = ? AND restored_at IS NULL;
 
--- name: RestoreBlog :exec
+-- name: RestoreBlogForAdmin :exec
 UPDATE blogs SET blog = ?, deleted_at = NULL WHERE idblogs = ?;
 
--- name: MarkBlogRestored :exec
+-- name: MarkBlogRestoredForAdmin :exec
 UPDATE deactivated_blogs SET restored_at = NOW() WHERE idblogs = ?;
 
--- name: ArchiveImagepost :exec
+-- name: ArchiveImagepostForAdmin :exec
 INSERT INTO deactivated_imageposts (idimagepost, forumthread_id, users_idusers, imageboard_idimageboard, posted, description, thumbnail, fullimage, file_size, approved, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubImagepost :exec
+-- name: ScrubImagepostForAdmin :exec
 UPDATE imagepost SET description = '', thumbnail = '', fullimage = '', deleted_at = NOW() WHERE idimagepost = ?;
 
--- name: PendingDeactivatedImageposts :many
+-- name: PendingDeactivatedImagepostsForAdmin :many
 SELECT idimagepost, description, thumbnail, fullimage FROM deactivated_imageposts WHERE users_idusers = ? AND restored_at IS NULL;
 
--- name: RestoreImagepost :exec
+-- name: RestoreImagepostForAdmin :exec
 UPDATE imagepost SET description = ?, thumbnail = ?, fullimage = ?, deleted_at = NULL WHERE idimagepost = ?;
 
--- name: MarkImagepostRestored :exec
+-- name: MarkImagepostRestoredForAdmin :exec
 UPDATE deactivated_imageposts SET restored_at = NOW() WHERE idimagepost = ?;
 
--- name: ArchiveLink :exec
+-- name: ArchiveLinkForAdmin :exec
 INSERT INTO deactivated_linker (idlinker, language_idlanguage, users_idusers, linker_category_id, forumthread_id, title, url, description, listed, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubLink :exec
+-- name: ScrubLinkForAdmin :exec
 UPDATE linker SET title = ?, url = '', description = '', deleted_at = NOW() WHERE idlinker = ?;
 
--- name: PendingDeactivatedLinks :many
+-- name: PendingDeactivatedLinksForAdmin :many
 SELECT idlinker, title, url, description FROM deactivated_linker WHERE users_idusers = ? AND restored_at IS NULL;
 
--- name: RestoreLink :exec
+-- name: RestoreLinkForAdmin :exec
 UPDATE linker SET title = ?, url = ?, description = ?, deleted_at = NULL WHERE idlinker = ?;
 
--- name: MarkLinkRestored :exec
+-- name: MarkLinkRestoredForAdmin :exec
 UPDATE deactivated_linker SET restored_at = NOW() WHERE idlinker = ?;
 
--- name: RestoreUser :exec
+-- name: RestoreUserForAdmin :exec
 UPDATE users u JOIN deactivated_users d ON u.idusers = d.idusers
 SET u.email = d.email, u.passwd = d.passwd, u.passwd_algorithm = d.passwd_algorithm, u.username = d.username, u.deleted_at = NULL, d.restored_at = NOW()
 WHERE u.idusers = ? AND d.restored_at IS NULL;

--- a/internal/db/queries-deactivation.sql.go
+++ b/internal/db/queries-deactivation.sql.go
@@ -10,12 +10,12 @@ import (
 	"database/sql"
 )
 
-const archiveBlog = `-- name: ArchiveBlog :exec
+const archiveBlogForAdmin = `-- name: ArchiveBlogForAdmin :exec
 INSERT INTO deactivated_blogs (idblogs, forumthread_id, users_idusers, language_idlanguage, blog, written, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveBlogParams struct {
+type ArchiveBlogForAdminParams struct {
 	Idblogs            int32
 	ForumthreadID      int32
 	UsersIdusers       int32
@@ -24,8 +24,8 @@ type ArchiveBlogParams struct {
 	Written            sql.NullTime
 }
 
-func (q *Queries) ArchiveBlog(ctx context.Context, arg ArchiveBlogParams) error {
-	_, err := q.db.ExecContext(ctx, archiveBlog,
+func (q *Queries) ArchiveBlogForAdmin(ctx context.Context, arg ArchiveBlogForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, archiveBlogForAdmin,
 		arg.Idblogs,
 		arg.ForumthreadID,
 		arg.UsersIdusers,
@@ -36,12 +36,12 @@ func (q *Queries) ArchiveBlog(ctx context.Context, arg ArchiveBlogParams) error 
 	return err
 }
 
-const archiveComment = `-- name: ArchiveComment :exec
+const archiveCommentForAdmin = `-- name: ArchiveCommentForAdmin :exec
 INSERT INTO deactivated_comments (idcomments, forumthread_id, users_idusers, language_idlanguage, written, text, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveCommentParams struct {
+type ArchiveCommentForAdminParams struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
@@ -50,8 +50,8 @@ type ArchiveCommentParams struct {
 	Text               sql.NullString
 }
 
-func (q *Queries) ArchiveComment(ctx context.Context, arg ArchiveCommentParams) error {
-	_, err := q.db.ExecContext(ctx, archiveComment,
+func (q *Queries) ArchiveCommentForAdmin(ctx context.Context, arg ArchiveCommentForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, archiveCommentForAdmin,
 		arg.Idcomments,
 		arg.ForumthreadID,
 		arg.UsersIdusers,
@@ -62,12 +62,12 @@ func (q *Queries) ArchiveComment(ctx context.Context, arg ArchiveCommentParams) 
 	return err
 }
 
-const archiveImagepost = `-- name: ArchiveImagepost :exec
+const archiveImagepostForAdmin = `-- name: ArchiveImagepostForAdmin :exec
 INSERT INTO deactivated_imageposts (idimagepost, forumthread_id, users_idusers, imageboard_idimageboard, posted, description, thumbnail, fullimage, file_size, approved, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveImagepostParams struct {
+type ArchiveImagepostForAdminParams struct {
 	Idimagepost            int32
 	ForumthreadID          int32
 	UsersIdusers           int32
@@ -80,8 +80,8 @@ type ArchiveImagepostParams struct {
 	Approved               sql.NullBool
 }
 
-func (q *Queries) ArchiveImagepost(ctx context.Context, arg ArchiveImagepostParams) error {
-	_, err := q.db.ExecContext(ctx, archiveImagepost,
+func (q *Queries) ArchiveImagepostForAdmin(ctx context.Context, arg ArchiveImagepostForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, archiveImagepostForAdmin,
 		arg.Idimagepost,
 		arg.ForumthreadID,
 		arg.UsersIdusers,
@@ -96,12 +96,12 @@ func (q *Queries) ArchiveImagepost(ctx context.Context, arg ArchiveImagepostPara
 	return err
 }
 
-const archiveLink = `-- name: ArchiveLink :exec
+const archiveLinkForAdmin = `-- name: ArchiveLinkForAdmin :exec
 INSERT INTO deactivated_linker (idlinker, language_idlanguage, users_idusers, linker_category_id, forumthread_id, title, url, description, listed, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveLinkParams struct {
+type ArchiveLinkForAdminParams struct {
 	Idlinker           int32
 	LanguageIdlanguage int32
 	UsersIdusers       int32
@@ -113,8 +113,8 @@ type ArchiveLinkParams struct {
 	Listed             sql.NullTime
 }
 
-func (q *Queries) ArchiveLink(ctx context.Context, arg ArchiveLinkParams) error {
-	_, err := q.db.ExecContext(ctx, archiveLink,
+func (q *Queries) ArchiveLinkForAdmin(ctx context.Context, arg ArchiveLinkForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, archiveLinkForAdmin,
 		arg.Idlinker,
 		arg.LanguageIdlanguage,
 		arg.UsersIdusers,
@@ -128,7 +128,7 @@ func (q *Queries) ArchiveLink(ctx context.Context, arg ArchiveLinkParams) error 
 	return err
 }
 
-const archiveUser = `-- name: ArchiveUser :exec
+const archiveUserForAdmin = `-- name: ArchiveUserForAdmin :exec
 
 INSERT INTO deactivated_users (idusers, email, passwd, passwd_algorithm, username, deleted_at)
 SELECT u.idusers, u.email, u.passwd, u.passwd_algorithm, u.username, NOW()
@@ -136,17 +136,17 @@ FROM users u WHERE u.idusers = ?
 `
 
 // Queries for user deactivation and restoration
-func (q *Queries) ArchiveUser(ctx context.Context, idusers int32) error {
-	_, err := q.db.ExecContext(ctx, archiveUser, idusers)
+func (q *Queries) ArchiveUserForAdmin(ctx context.Context, idusers int32) error {
+	_, err := q.db.ExecContext(ctx, archiveUserForAdmin, idusers)
 	return err
 }
 
-const archiveWriting = `-- name: ArchiveWriting :exec
+const archiveWritingForAdmin = `-- name: ArchiveWritingForAdmin :exec
 INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_id, language_idlanguage, writing_category_id, title, published, writing, abstract, private, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveWritingParams struct {
+type ArchiveWritingForAdminParams struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
@@ -159,8 +159,8 @@ type ArchiveWritingParams struct {
 	Private            sql.NullBool
 }
 
-func (q *Queries) ArchiveWriting(ctx context.Context, arg ArchiveWritingParams) error {
-	_, err := q.db.ExecContext(ctx, archiveWriting,
+func (q *Queries) ArchiveWritingForAdmin(ctx context.Context, arg ArchiveWritingForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, archiveWritingForAdmin,
 		arg.Idwriting,
 		arg.UsersIdusers,
 		arg.ForumthreadID,
@@ -175,69 +175,69 @@ func (q *Queries) ArchiveWriting(ctx context.Context, arg ArchiveWritingParams) 
 	return err
 }
 
-const markBlogRestored = `-- name: MarkBlogRestored :exec
+const markBlogRestoredForAdmin = `-- name: MarkBlogRestoredForAdmin :exec
 UPDATE deactivated_blogs SET restored_at = NOW() WHERE idblogs = ?
 `
 
-func (q *Queries) MarkBlogRestored(ctx context.Context, idblogs int32) error {
-	_, err := q.db.ExecContext(ctx, markBlogRestored, idblogs)
+func (q *Queries) MarkBlogRestoredForAdmin(ctx context.Context, idblogs int32) error {
+	_, err := q.db.ExecContext(ctx, markBlogRestoredForAdmin, idblogs)
 	return err
 }
 
-const markCommentRestored = `-- name: MarkCommentRestored :exec
+const markCommentRestoredForAdmin = `-- name: MarkCommentRestoredForAdmin :exec
 UPDATE deactivated_comments SET restored_at = NOW() WHERE idcomments = ?
 `
 
-func (q *Queries) MarkCommentRestored(ctx context.Context, idcomments int32) error {
-	_, err := q.db.ExecContext(ctx, markCommentRestored, idcomments)
+func (q *Queries) MarkCommentRestoredForAdmin(ctx context.Context, idcomments int32) error {
+	_, err := q.db.ExecContext(ctx, markCommentRestoredForAdmin, idcomments)
 	return err
 }
 
-const markImagepostRestored = `-- name: MarkImagepostRestored :exec
+const markImagepostRestoredForAdmin = `-- name: MarkImagepostRestoredForAdmin :exec
 UPDATE deactivated_imageposts SET restored_at = NOW() WHERE idimagepost = ?
 `
 
-func (q *Queries) MarkImagepostRestored(ctx context.Context, idimagepost int32) error {
-	_, err := q.db.ExecContext(ctx, markImagepostRestored, idimagepost)
+func (q *Queries) MarkImagepostRestoredForAdmin(ctx context.Context, idimagepost int32) error {
+	_, err := q.db.ExecContext(ctx, markImagepostRestoredForAdmin, idimagepost)
 	return err
 }
 
-const markLinkRestored = `-- name: MarkLinkRestored :exec
+const markLinkRestoredForAdmin = `-- name: MarkLinkRestoredForAdmin :exec
 UPDATE deactivated_linker SET restored_at = NOW() WHERE idlinker = ?
 `
 
-func (q *Queries) MarkLinkRestored(ctx context.Context, idlinker int32) error {
-	_, err := q.db.ExecContext(ctx, markLinkRestored, idlinker)
+func (q *Queries) MarkLinkRestoredForAdmin(ctx context.Context, idlinker int32) error {
+	_, err := q.db.ExecContext(ctx, markLinkRestoredForAdmin, idlinker)
 	return err
 }
 
-const markWritingRestored = `-- name: MarkWritingRestored :exec
+const markWritingRestoredForAdmin = `-- name: MarkWritingRestoredForAdmin :exec
 UPDATE deactivated_writings SET restored_at = NOW() WHERE idwriting = ?
 `
 
-func (q *Queries) MarkWritingRestored(ctx context.Context, idwriting int32) error {
-	_, err := q.db.ExecContext(ctx, markWritingRestored, idwriting)
+func (q *Queries) MarkWritingRestoredForAdmin(ctx context.Context, idwriting int32) error {
+	_, err := q.db.ExecContext(ctx, markWritingRestoredForAdmin, idwriting)
 	return err
 }
 
-const pendingDeactivatedBlogs = `-- name: PendingDeactivatedBlogs :many
+const pendingDeactivatedBlogsForAdmin = `-- name: PendingDeactivatedBlogsForAdmin :many
 SELECT idblogs, blog FROM deactivated_blogs WHERE users_idusers = ? AND restored_at IS NULL
 `
 
-type PendingDeactivatedBlogsRow struct {
+type PendingDeactivatedBlogsForAdminRow struct {
 	Idblogs int32
 	Blog    sql.NullString
 }
 
-func (q *Queries) PendingDeactivatedBlogs(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedBlogsRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedBlogs, usersIdusers)
+func (q *Queries) PendingDeactivatedBlogsForAdmin(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedBlogsForAdminRow, error) {
+	rows, err := q.db.QueryContext(ctx, pendingDeactivatedBlogsForAdmin, usersIdusers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedBlogsRow
+	var items []*PendingDeactivatedBlogsForAdminRow
 	for rows.Next() {
-		var i PendingDeactivatedBlogsRow
+		var i PendingDeactivatedBlogsForAdminRow
 		if err := rows.Scan(&i.Idblogs, &i.Blog); err != nil {
 			return nil, err
 		}
@@ -252,25 +252,25 @@ func (q *Queries) PendingDeactivatedBlogs(ctx context.Context, usersIdusers int3
 	return items, nil
 }
 
-const pendingDeactivatedComments = `-- name: PendingDeactivatedComments :many
+const pendingDeactivatedCommentsForAdmin = `-- name: PendingDeactivatedCommentsForAdmin :many
 SELECT idcomments, text FROM deactivated_comments
 WHERE users_idusers = ? AND restored_at IS NULL
 `
 
-type PendingDeactivatedCommentsRow struct {
+type PendingDeactivatedCommentsForAdminRow struct {
 	Idcomments int32
 	Text       sql.NullString
 }
 
-func (q *Queries) PendingDeactivatedComments(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedCommentsRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedComments, usersIdusers)
+func (q *Queries) PendingDeactivatedCommentsForAdmin(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedCommentsForAdminRow, error) {
+	rows, err := q.db.QueryContext(ctx, pendingDeactivatedCommentsForAdmin, usersIdusers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedCommentsRow
+	var items []*PendingDeactivatedCommentsForAdminRow
 	for rows.Next() {
-		var i PendingDeactivatedCommentsRow
+		var i PendingDeactivatedCommentsForAdminRow
 		if err := rows.Scan(&i.Idcomments, &i.Text); err != nil {
 			return nil, err
 		}
@@ -285,26 +285,26 @@ func (q *Queries) PendingDeactivatedComments(ctx context.Context, usersIdusers i
 	return items, nil
 }
 
-const pendingDeactivatedImageposts = `-- name: PendingDeactivatedImageposts :many
+const pendingDeactivatedImagepostsForAdmin = `-- name: PendingDeactivatedImagepostsForAdmin :many
 SELECT idimagepost, description, thumbnail, fullimage FROM deactivated_imageposts WHERE users_idusers = ? AND restored_at IS NULL
 `
 
-type PendingDeactivatedImagepostsRow struct {
+type PendingDeactivatedImagepostsForAdminRow struct {
 	Idimagepost int32
 	Description sql.NullString
 	Thumbnail   sql.NullString
 	Fullimage   sql.NullString
 }
 
-func (q *Queries) PendingDeactivatedImageposts(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedImagepostsRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedImageposts, usersIdusers)
+func (q *Queries) PendingDeactivatedImagepostsForAdmin(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedImagepostsForAdminRow, error) {
+	rows, err := q.db.QueryContext(ctx, pendingDeactivatedImagepostsForAdmin, usersIdusers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedImagepostsRow
+	var items []*PendingDeactivatedImagepostsForAdminRow
 	for rows.Next() {
-		var i PendingDeactivatedImagepostsRow
+		var i PendingDeactivatedImagepostsForAdminRow
 		if err := rows.Scan(
 			&i.Idimagepost,
 			&i.Description,
@@ -324,26 +324,26 @@ func (q *Queries) PendingDeactivatedImageposts(ctx context.Context, usersIdusers
 	return items, nil
 }
 
-const pendingDeactivatedLinks = `-- name: PendingDeactivatedLinks :many
+const pendingDeactivatedLinksForAdmin = `-- name: PendingDeactivatedLinksForAdmin :many
 SELECT idlinker, title, url, description FROM deactivated_linker WHERE users_idusers = ? AND restored_at IS NULL
 `
 
-type PendingDeactivatedLinksRow struct {
+type PendingDeactivatedLinksForAdminRow struct {
 	Idlinker    int32
 	Title       sql.NullString
 	Url         sql.NullString
 	Description sql.NullString
 }
 
-func (q *Queries) PendingDeactivatedLinks(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedLinksRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedLinks, usersIdusers)
+func (q *Queries) PendingDeactivatedLinksForAdmin(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedLinksForAdminRow, error) {
+	rows, err := q.db.QueryContext(ctx, pendingDeactivatedLinksForAdmin, usersIdusers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedLinksRow
+	var items []*PendingDeactivatedLinksForAdminRow
 	for rows.Next() {
-		var i PendingDeactivatedLinksRow
+		var i PendingDeactivatedLinksForAdminRow
 		if err := rows.Scan(
 			&i.Idlinker,
 			&i.Title,
@@ -363,12 +363,12 @@ func (q *Queries) PendingDeactivatedLinks(ctx context.Context, usersIdusers int3
 	return items, nil
 }
 
-const pendingDeactivatedWritings = `-- name: PendingDeactivatedWritings :many
+const pendingDeactivatedWritingsForAdmin = `-- name: PendingDeactivatedWritingsForAdmin :many
 SELECT idwriting, title, writing, abstract, private FROM deactivated_writings
 WHERE users_idusers = ? AND restored_at IS NULL
 `
 
-type PendingDeactivatedWritingsRow struct {
+type PendingDeactivatedWritingsForAdminRow struct {
 	Idwriting int32
 	Title     sql.NullString
 	Writing   sql.NullString
@@ -376,15 +376,15 @@ type PendingDeactivatedWritingsRow struct {
 	Private   sql.NullBool
 }
 
-func (q *Queries) PendingDeactivatedWritings(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedWritingsRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedWritings, usersIdusers)
+func (q *Queries) PendingDeactivatedWritingsForAdmin(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedWritingsForAdminRow, error) {
+	rows, err := q.db.QueryContext(ctx, pendingDeactivatedWritingsForAdmin, usersIdusers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedWritingsRow
+	var items []*PendingDeactivatedWritingsForAdminRow
 	for rows.Next() {
-		var i PendingDeactivatedWritingsRow
+		var i PendingDeactivatedWritingsForAdminRow
 		if err := rows.Scan(
 			&i.Idwriting,
 			&i.Title,
@@ -405,47 +405,47 @@ func (q *Queries) PendingDeactivatedWritings(ctx context.Context, usersIdusers i
 	return items, nil
 }
 
-const restoreBlog = `-- name: RestoreBlog :exec
+const restoreBlogForAdmin = `-- name: RestoreBlogForAdmin :exec
 UPDATE blogs SET blog = ?, deleted_at = NULL WHERE idblogs = ?
 `
 
-type RestoreBlogParams struct {
+type RestoreBlogForAdminParams struct {
 	Blog    sql.NullString
 	Idblogs int32
 }
 
-func (q *Queries) RestoreBlog(ctx context.Context, arg RestoreBlogParams) error {
-	_, err := q.db.ExecContext(ctx, restoreBlog, arg.Blog, arg.Idblogs)
+func (q *Queries) RestoreBlogForAdmin(ctx context.Context, arg RestoreBlogForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, restoreBlogForAdmin, arg.Blog, arg.Idblogs)
 	return err
 }
 
-const restoreComment = `-- name: RestoreComment :exec
+const restoreCommentForAdmin = `-- name: RestoreCommentForAdmin :exec
 UPDATE comments SET text = ?, deleted_at = NULL WHERE idcomments = ?
 `
 
-type RestoreCommentParams struct {
+type RestoreCommentForAdminParams struct {
 	Text       sql.NullString
 	Idcomments int32
 }
 
-func (q *Queries) RestoreComment(ctx context.Context, arg RestoreCommentParams) error {
-	_, err := q.db.ExecContext(ctx, restoreComment, arg.Text, arg.Idcomments)
+func (q *Queries) RestoreCommentForAdmin(ctx context.Context, arg RestoreCommentForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, restoreCommentForAdmin, arg.Text, arg.Idcomments)
 	return err
 }
 
-const restoreImagepost = `-- name: RestoreImagepost :exec
+const restoreImagepostForAdmin = `-- name: RestoreImagepostForAdmin :exec
 UPDATE imagepost SET description = ?, thumbnail = ?, fullimage = ?, deleted_at = NULL WHERE idimagepost = ?
 `
 
-type RestoreImagepostParams struct {
+type RestoreImagepostForAdminParams struct {
 	Description sql.NullString
 	Thumbnail   sql.NullString
 	Fullimage   sql.NullString
 	Idimagepost int32
 }
 
-func (q *Queries) RestoreImagepost(ctx context.Context, arg RestoreImagepostParams) error {
-	_, err := q.db.ExecContext(ctx, restoreImagepost,
+func (q *Queries) RestoreImagepostForAdmin(ctx context.Context, arg RestoreImagepostForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, restoreImagepostForAdmin,
 		arg.Description,
 		arg.Thumbnail,
 		arg.Fullimage,
@@ -454,19 +454,19 @@ func (q *Queries) RestoreImagepost(ctx context.Context, arg RestoreImagepostPara
 	return err
 }
 
-const restoreLink = `-- name: RestoreLink :exec
+const restoreLinkForAdmin = `-- name: RestoreLinkForAdmin :exec
 UPDATE linker SET title = ?, url = ?, description = ?, deleted_at = NULL WHERE idlinker = ?
 `
 
-type RestoreLinkParams struct {
+type RestoreLinkForAdminParams struct {
 	Title       sql.NullString
 	Url         sql.NullString
 	Description sql.NullString
 	Idlinker    int32
 }
 
-func (q *Queries) RestoreLink(ctx context.Context, arg RestoreLinkParams) error {
-	_, err := q.db.ExecContext(ctx, restoreLink,
+func (q *Queries) RestoreLinkForAdmin(ctx context.Context, arg RestoreLinkForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, restoreLinkForAdmin,
 		arg.Title,
 		arg.Url,
 		arg.Description,
@@ -475,22 +475,22 @@ func (q *Queries) RestoreLink(ctx context.Context, arg RestoreLinkParams) error 
 	return err
 }
 
-const restoreUser = `-- name: RestoreUser :exec
+const restoreUserForAdmin = `-- name: RestoreUserForAdmin :exec
 UPDATE users u JOIN deactivated_users d ON u.idusers = d.idusers
 SET u.email = d.email, u.passwd = d.passwd, u.passwd_algorithm = d.passwd_algorithm, u.username = d.username, u.deleted_at = NULL, d.restored_at = NOW()
 WHERE u.idusers = ? AND d.restored_at IS NULL
 `
 
-func (q *Queries) RestoreUser(ctx context.Context, idusers int32) error {
-	_, err := q.db.ExecContext(ctx, restoreUser, idusers)
+func (q *Queries) RestoreUserForAdmin(ctx context.Context, idusers int32) error {
+	_, err := q.db.ExecContext(ctx, restoreUserForAdmin, idusers)
 	return err
 }
 
-const restoreWriting = `-- name: RestoreWriting :exec
+const restoreWritingForAdmin = `-- name: RestoreWritingForAdmin :exec
 UPDATE writing SET title = ?, writing = ?, abstract = ?, private = ?, deleted_at = NULL WHERE idwriting = ?
 `
 
-type RestoreWritingParams struct {
+type RestoreWritingForAdminParams struct {
 	Title     sql.NullString
 	Writing   sql.NullString
 	Abstract  sql.NullString
@@ -498,8 +498,8 @@ type RestoreWritingParams struct {
 	Idwriting int32
 }
 
-func (q *Queries) RestoreWriting(ctx context.Context, arg RestoreWritingParams) error {
-	_, err := q.db.ExecContext(ctx, restoreWriting,
+func (q *Queries) RestoreWritingForAdmin(ctx context.Context, arg RestoreWritingForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, restoreWritingForAdmin,
 		arg.Title,
 		arg.Writing,
 		arg.Abstract,
@@ -509,85 +509,85 @@ func (q *Queries) RestoreWriting(ctx context.Context, arg RestoreWritingParams) 
 	return err
 }
 
-const scrubBlog = `-- name: ScrubBlog :exec
+const scrubBlogForAdmin = `-- name: ScrubBlogForAdmin :exec
 UPDATE blogs SET blog = ?, deleted_at = NOW() WHERE idblogs = ?
 `
 
-type ScrubBlogParams struct {
+type ScrubBlogForAdminParams struct {
 	Blog    sql.NullString
 	Idblogs int32
 }
 
-func (q *Queries) ScrubBlog(ctx context.Context, arg ScrubBlogParams) error {
-	_, err := q.db.ExecContext(ctx, scrubBlog, arg.Blog, arg.Idblogs)
+func (q *Queries) ScrubBlogForAdmin(ctx context.Context, arg ScrubBlogForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, scrubBlogForAdmin, arg.Blog, arg.Idblogs)
 	return err
 }
 
-const scrubComment = `-- name: ScrubComment :exec
+const scrubCommentForAdmin = `-- name: ScrubCommentForAdmin :exec
 UPDATE comments SET text = ?, deleted_at = NOW() WHERE idcomments = ?
 `
 
-type ScrubCommentParams struct {
+type ScrubCommentForAdminParams struct {
 	Text       sql.NullString
 	Idcomments int32
 }
 
-func (q *Queries) ScrubComment(ctx context.Context, arg ScrubCommentParams) error {
-	_, err := q.db.ExecContext(ctx, scrubComment, arg.Text, arg.Idcomments)
+func (q *Queries) ScrubCommentForAdmin(ctx context.Context, arg ScrubCommentForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, scrubCommentForAdmin, arg.Text, arg.Idcomments)
 	return err
 }
 
-const scrubImagepost = `-- name: ScrubImagepost :exec
+const scrubImagepostForAdmin = `-- name: ScrubImagepostForAdmin :exec
 UPDATE imagepost SET description = '', thumbnail = '', fullimage = '', deleted_at = NOW() WHERE idimagepost = ?
 `
 
-func (q *Queries) ScrubImagepost(ctx context.Context, idimagepost int32) error {
-	_, err := q.db.ExecContext(ctx, scrubImagepost, idimagepost)
+func (q *Queries) ScrubImagepostForAdmin(ctx context.Context, idimagepost int32) error {
+	_, err := q.db.ExecContext(ctx, scrubImagepostForAdmin, idimagepost)
 	return err
 }
 
-const scrubLink = `-- name: ScrubLink :exec
+const scrubLinkForAdmin = `-- name: ScrubLinkForAdmin :exec
 UPDATE linker SET title = ?, url = '', description = '', deleted_at = NOW() WHERE idlinker = ?
 `
 
-type ScrubLinkParams struct {
+type ScrubLinkForAdminParams struct {
 	Title    sql.NullString
 	Idlinker int32
 }
 
-func (q *Queries) ScrubLink(ctx context.Context, arg ScrubLinkParams) error {
-	_, err := q.db.ExecContext(ctx, scrubLink, arg.Title, arg.Idlinker)
+func (q *Queries) ScrubLinkForAdmin(ctx context.Context, arg ScrubLinkForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, scrubLinkForAdmin, arg.Title, arg.Idlinker)
 	return err
 }
 
-const scrubUser = `-- name: ScrubUser :exec
+const scrubUserForAdmin = `-- name: ScrubUserForAdmin :exec
 UPDATE users SET username = ?, email = '', passwd = '', passwd_algorithm = '', deleted_at = NOW()
 WHERE idusers = ?
 `
 
-type ScrubUserParams struct {
+type ScrubUserForAdminParams struct {
 	Username sql.NullString
 	Idusers  int32
 }
 
-func (q *Queries) ScrubUser(ctx context.Context, arg ScrubUserParams) error {
-	_, err := q.db.ExecContext(ctx, scrubUser, arg.Username, arg.Idusers)
+func (q *Queries) ScrubUserForAdmin(ctx context.Context, arg ScrubUserForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, scrubUserForAdmin, arg.Username, arg.Idusers)
 	return err
 }
 
-const scrubWriting = `-- name: ScrubWriting :exec
+const scrubWritingForAdmin = `-- name: ScrubWritingForAdmin :exec
 UPDATE writing SET title = ?, writing = ?, abstract = ?, deleted_at = NOW() WHERE idwriting = ?
 `
 
-type ScrubWritingParams struct {
+type ScrubWritingForAdminParams struct {
 	Title     sql.NullString
 	Writing   sql.NullString
 	Abstract  sql.NullString
 	Idwriting int32
 }
 
-func (q *Queries) ScrubWriting(ctx context.Context, arg ScrubWritingParams) error {
-	_, err := q.db.ExecContext(ctx, scrubWriting,
+func (q *Queries) ScrubWritingForAdmin(ctx context.Context, arg ScrubWritingForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, scrubWritingForAdmin,
 		arg.Title,
 		arg.Writing,
 		arg.Abstract,

--- a/internal/db/queries-dlq.sql
+++ b/internal/db/queries-dlq.sql
@@ -1,19 +1,19 @@
--- name: InsertDeadLetter :exec
+-- name: InsertDeadLetterSystem :exec
 INSERT INTO dead_letters (message) VALUES (?);
 
--- name: ListDeadLetters :many
+-- name: ListDeadLettersForAdmin :many
 SELECT id, message, created_at FROM dead_letters
 ORDER BY id DESC
 LIMIT ?;
 
--- name: DeleteDeadLetter :exec
+-- name: DeleteDeadLetterForAdmin :exec
 DELETE FROM dead_letters WHERE id = ?;
 
--- name: PurgeDeadLettersBefore :exec
+-- name: PurgeDeadLettersBeforeForAdmin :exec
 DELETE FROM dead_letters WHERE created_at < ?;
 
--- name: CountDeadLetters :one
+-- name: CountDeadLettersSystem :one
 SELECT COUNT(*) FROM dead_letters;
 
--- name: LatestDeadLetter :one
+-- name: LatestDeadLetterForAdmin :one
 SELECT MAX(created_at) FROM dead_letters;

--- a/internal/db/queries-dlq.sql.go
+++ b/internal/db/queries-dlq.sql.go
@@ -10,54 +10,54 @@ import (
 	"time"
 )
 
-const countDeadLetters = `-- name: CountDeadLetters :one
+const countDeadLettersSystem = `-- name: CountDeadLettersSystem :one
 SELECT COUNT(*) FROM dead_letters
 `
 
-func (q *Queries) CountDeadLetters(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countDeadLetters)
+func (q *Queries) CountDeadLettersSystem(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countDeadLettersSystem)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
 }
 
-const deleteDeadLetter = `-- name: DeleteDeadLetter :exec
+const deleteDeadLetterForAdmin = `-- name: DeleteDeadLetterForAdmin :exec
 DELETE FROM dead_letters WHERE id = ?
 `
 
-func (q *Queries) DeleteDeadLetter(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, deleteDeadLetter, id)
+func (q *Queries) DeleteDeadLetterForAdmin(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, deleteDeadLetterForAdmin, id)
 	return err
 }
 
-const insertDeadLetter = `-- name: InsertDeadLetter :exec
+const insertDeadLetterSystem = `-- name: InsertDeadLetterSystem :exec
 INSERT INTO dead_letters (message) VALUES (?)
 `
 
-func (q *Queries) InsertDeadLetter(ctx context.Context, message string) error {
-	_, err := q.db.ExecContext(ctx, insertDeadLetter, message)
+func (q *Queries) InsertDeadLetterSystem(ctx context.Context, message string) error {
+	_, err := q.db.ExecContext(ctx, insertDeadLetterSystem, message)
 	return err
 }
 
-const latestDeadLetter = `-- name: LatestDeadLetter :one
+const latestDeadLetterForAdmin = `-- name: LatestDeadLetterForAdmin :one
 SELECT MAX(created_at) FROM dead_letters
 `
 
-func (q *Queries) LatestDeadLetter(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, latestDeadLetter)
+func (q *Queries) LatestDeadLetterForAdmin(ctx context.Context) (interface{}, error) {
+	row := q.db.QueryRowContext(ctx, latestDeadLetterForAdmin)
 	var max interface{}
 	err := row.Scan(&max)
 	return max, err
 }
 
-const listDeadLetters = `-- name: ListDeadLetters :many
+const listDeadLettersForAdmin = `-- name: ListDeadLettersForAdmin :many
 SELECT id, message, created_at FROM dead_letters
 ORDER BY id DESC
 LIMIT ?
 `
 
-func (q *Queries) ListDeadLetters(ctx context.Context, limit int32) ([]*DeadLetter, error) {
-	rows, err := q.db.QueryContext(ctx, listDeadLetters, limit)
+func (q *Queries) ListDeadLettersForAdmin(ctx context.Context, limit int32) ([]*DeadLetter, error) {
+	rows, err := q.db.QueryContext(ctx, listDeadLettersForAdmin, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -79,11 +79,11 @@ func (q *Queries) ListDeadLetters(ctx context.Context, limit int32) ([]*DeadLett
 	return items, nil
 }
 
-const purgeDeadLettersBefore = `-- name: PurgeDeadLettersBefore :exec
+const purgeDeadLettersBeforeForAdmin = `-- name: PurgeDeadLettersBeforeForAdmin :exec
 DELETE FROM dead_letters WHERE created_at < ?
 `
 
-func (q *Queries) PurgeDeadLettersBefore(ctx context.Context, createdAt time.Time) error {
-	_, err := q.db.ExecContext(ctx, purgeDeadLettersBefore, createdAt)
+func (q *Queries) PurgeDeadLettersBeforeForAdmin(ctx context.Context, createdAt time.Time) error {
+	_, err := q.db.ExecContext(ctx, purgeDeadLettersBeforeForAdmin, createdAt)
 	return err
 }

--- a/internal/db/queries-externallinks.sql
+++ b/internal/db/queries-externallinks.sql
@@ -1,26 +1,26 @@
--- name: RegisterExternalLinkClick :exec
+-- name: RegisterExternalLinkClickSystem :exec
 INSERT INTO external_links (url, clicks)
 VALUES (?, 1)
 ON DUPLICATE KEY UPDATE clicks = clicks + 1;
 
--- name: GetExternalLink :one
+-- name: GetExternalLinkSystem :one
 SELECT * FROM external_links WHERE url = ? LIMIT 1;
 
--- name: ListExternalLinks :many
+-- name: ListExternalLinksForAdmin :many
 SELECT * FROM external_links
 ORDER BY created_at DESC
 LIMIT ? OFFSET ?;
 
--- name: GetExternalLinkByID :one
+-- name: GetExternalLinkByIDForAdmin :one
 SELECT * FROM external_links WHERE id = ? LIMIT 1;
 
--- name: UpdateExternalLink :exec
+-- name: UpdateExternalLinkForAdmin :exec
 UPDATE external_links
 SET url = ?, card_title = ?, card_description = ?, card_image = ?, card_image_cache = ?, favicon_cache = ?, updated_at = CURRENT_TIMESTAMP, updated_by = ?
 WHERE id = ?;
 
--- name: DeleteExternalLink :exec
+-- name: DeleteExternalLinkForAdmin :exec
 DELETE FROM external_links WHERE id = ?;
 
--- name: ClearExternalLinkCache :exec
+-- name: ClearExternalLinkCacheForAdmin :exec
 UPDATE external_links SET card_image_cache = NULL, favicon_cache = NULL, updated_at = CURRENT_TIMESTAMP, updated_by = ? WHERE id = ?;

--- a/internal/db/queries-externallinks.sql.go
+++ b/internal/db/queries-externallinks.sql.go
@@ -10,58 +10,35 @@ import (
 	"database/sql"
 )
 
-const clearExternalLinkCache = `-- name: ClearExternalLinkCache :exec
+const clearExternalLinkCacheForAdmin = `-- name: ClearExternalLinkCacheForAdmin :exec
 UPDATE external_links SET card_image_cache = NULL, favicon_cache = NULL, updated_at = CURRENT_TIMESTAMP, updated_by = ? WHERE id = ?
 `
 
-type ClearExternalLinkCacheParams struct {
+type ClearExternalLinkCacheForAdminParams struct {
 	UpdatedBy sql.NullInt32
 	ID        int32
 }
 
-func (q *Queries) ClearExternalLinkCache(ctx context.Context, arg ClearExternalLinkCacheParams) error {
-	_, err := q.db.ExecContext(ctx, clearExternalLinkCache, arg.UpdatedBy, arg.ID)
+func (q *Queries) ClearExternalLinkCacheForAdmin(ctx context.Context, arg ClearExternalLinkCacheForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, clearExternalLinkCacheForAdmin, arg.UpdatedBy, arg.ID)
 	return err
 }
 
-const deleteExternalLink = `-- name: DeleteExternalLink :exec
+const deleteExternalLinkForAdmin = `-- name: DeleteExternalLinkForAdmin :exec
 DELETE FROM external_links WHERE id = ?
 `
 
-func (q *Queries) DeleteExternalLink(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, deleteExternalLink, id)
+func (q *Queries) DeleteExternalLinkForAdmin(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, deleteExternalLinkForAdmin, id)
 	return err
 }
 
-const getExternalLink = `-- name: GetExternalLink :one
-SELECT id, url, clicks, created_at, updated_at, updated_by, card_title, card_description, card_image, card_image_cache, favicon_cache FROM external_links WHERE url = ? LIMIT 1
-`
-
-func (q *Queries) GetExternalLink(ctx context.Context, url string) (*ExternalLink, error) {
-	row := q.db.QueryRowContext(ctx, getExternalLink, url)
-	var i ExternalLink
-	err := row.Scan(
-		&i.ID,
-		&i.Url,
-		&i.Clicks,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.UpdatedBy,
-		&i.CardTitle,
-		&i.CardDescription,
-		&i.CardImage,
-		&i.CardImageCache,
-		&i.FaviconCache,
-	)
-	return &i, err
-}
-
-const getExternalLinkByID = `-- name: GetExternalLinkByID :one
+const getExternalLinkByIDForAdmin = `-- name: GetExternalLinkByIDForAdmin :one
 SELECT id, url, clicks, created_at, updated_at, updated_by, card_title, card_description, card_image, card_image_cache, favicon_cache FROM external_links WHERE id = ? LIMIT 1
 `
 
-func (q *Queries) GetExternalLinkByID(ctx context.Context, id int32) (*ExternalLink, error) {
-	row := q.db.QueryRowContext(ctx, getExternalLinkByID, id)
+func (q *Queries) GetExternalLinkByIDForAdmin(ctx context.Context, id int32) (*ExternalLink, error) {
+	row := q.db.QueryRowContext(ctx, getExternalLinkByIDForAdmin, id)
 	var i ExternalLink
 	err := row.Scan(
 		&i.ID,
@@ -79,19 +56,42 @@ func (q *Queries) GetExternalLinkByID(ctx context.Context, id int32) (*ExternalL
 	return &i, err
 }
 
-const listExternalLinks = `-- name: ListExternalLinks :many
+const getExternalLinkSystem = `-- name: GetExternalLinkSystem :one
+SELECT id, url, clicks, created_at, updated_at, updated_by, card_title, card_description, card_image, card_image_cache, favicon_cache FROM external_links WHERE url = ? LIMIT 1
+`
+
+func (q *Queries) GetExternalLinkSystem(ctx context.Context, url string) (*ExternalLink, error) {
+	row := q.db.QueryRowContext(ctx, getExternalLinkSystem, url)
+	var i ExternalLink
+	err := row.Scan(
+		&i.ID,
+		&i.Url,
+		&i.Clicks,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.UpdatedBy,
+		&i.CardTitle,
+		&i.CardDescription,
+		&i.CardImage,
+		&i.CardImageCache,
+		&i.FaviconCache,
+	)
+	return &i, err
+}
+
+const listExternalLinksForAdmin = `-- name: ListExternalLinksForAdmin :many
 SELECT id, url, clicks, created_at, updated_at, updated_by, card_title, card_description, card_image, card_image_cache, favicon_cache FROM external_links
 ORDER BY created_at DESC
 LIMIT ? OFFSET ?
 `
 
-type ListExternalLinksParams struct {
+type ListExternalLinksForAdminParams struct {
 	Limit  int32
 	Offset int32
 }
 
-func (q *Queries) ListExternalLinks(ctx context.Context, arg ListExternalLinksParams) ([]*ExternalLink, error) {
-	rows, err := q.db.QueryContext(ctx, listExternalLinks, arg.Limit, arg.Offset)
+func (q *Queries) ListExternalLinksForAdmin(ctx context.Context, arg ListExternalLinksForAdminParams) ([]*ExternalLink, error) {
+	rows, err := q.db.QueryContext(ctx, listExternalLinksForAdmin, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
@@ -125,24 +125,24 @@ func (q *Queries) ListExternalLinks(ctx context.Context, arg ListExternalLinksPa
 	return items, nil
 }
 
-const registerExternalLinkClick = `-- name: RegisterExternalLinkClick :exec
+const registerExternalLinkClickSystem = `-- name: RegisterExternalLinkClickSystem :exec
 INSERT INTO external_links (url, clicks)
 VALUES (?, 1)
 ON DUPLICATE KEY UPDATE clicks = clicks + 1
 `
 
-func (q *Queries) RegisterExternalLinkClick(ctx context.Context, url string) error {
-	_, err := q.db.ExecContext(ctx, registerExternalLinkClick, url)
+func (q *Queries) RegisterExternalLinkClickSystem(ctx context.Context, url string) error {
+	_, err := q.db.ExecContext(ctx, registerExternalLinkClickSystem, url)
 	return err
 }
 
-const updateExternalLink = `-- name: UpdateExternalLink :exec
+const updateExternalLinkForAdmin = `-- name: UpdateExternalLinkForAdmin :exec
 UPDATE external_links
 SET url = ?, card_title = ?, card_description = ?, card_image = ?, card_image_cache = ?, favicon_cache = ?, updated_at = CURRENT_TIMESTAMP, updated_by = ?
 WHERE id = ?
 `
 
-type UpdateExternalLinkParams struct {
+type UpdateExternalLinkForAdminParams struct {
 	Url             string
 	CardTitle       sql.NullString
 	CardDescription sql.NullString
@@ -153,8 +153,8 @@ type UpdateExternalLinkParams struct {
 	ID              int32
 }
 
-func (q *Queries) UpdateExternalLink(ctx context.Context, arg UpdateExternalLinkParams) error {
-	_, err := q.db.ExecContext(ctx, updateExternalLink,
+func (q *Queries) UpdateExternalLinkForAdmin(ctx context.Context, arg UpdateExternalLinkForAdminParams) error {
+	_, err := q.db.ExecContext(ctx, updateExternalLinkForAdmin,
 		arg.Url,
 		arg.CardTitle,
 		arg.CardDescription,

--- a/internal/dlq/db/db.go
+++ b/internal/dlq/db/db.go
@@ -17,7 +17,7 @@ func (d DLQ) Record(ctx context.Context, message string) error {
 	if d.Queries == nil {
 		return fmt.Errorf("no db")
 	}
-	return d.Queries.InsertDeadLetter(ctx, message)
+	return d.Queries.InsertDeadLetterSystem(ctx, message)
 }
 
 // Register registers the database provider.

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -47,7 +47,7 @@ func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ip := requestIP(r)
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-			bans, err := cd.Queries().ListActiveBans(r.Context())
+			bans, err := cd.Queries().ListActiveBansSystem(r.Context())
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 				return

--- a/internal/notifications/dlq.go
+++ b/internal/notifications/dlq.go
@@ -19,7 +19,7 @@ func (n *Notifier) dlqRecordAndNotify(ctx context.Context, q dlq.DLQ, msg string
 		return nil
 	}
 	if dbq, ok := q.(db.DLQ); ok {
-		if count, err := dbq.Queries.CountDeadLetters(ctx); err == nil {
+		if count, err := dbq.Queries.CountDeadLettersSystem(ctx); err == nil {
 			if isPow10(count) {
 				data := EmailData{
 					Item: struct {

--- a/workers/auditworker/worker.go
+++ b/workers/auditworker/worker.go
@@ -34,7 +34,7 @@ func Worker(ctx context.Context, bus *eventbus.Bus, q *dbpkg.Queries) {
 			}
 			details := aud.AuditRecord(evt.Data)
 			data, _ := json.Marshal(evt.Data)
-			if err := q.InsertAuditLog(ctx, dbpkg.InsertAuditLogParams{
+			if err := q.InsertAuditLogSystem(ctx, dbpkg.InsertAuditLogSystemParams{
 				UsersIdusers: evt.UserID,
 				Action:       named.Name(),
 				Path:         evt.Path,


### PR DESCRIPTION
## Summary
- append `ForAdmin` or `System` to admin-only query names
- regenerate sqlc code and update handlers/CLI tools
- use new queries throughout the app

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cb1539188832fbbf05e05c8f73e1d