### PR TITLE
Update comment queries for admin and system use

### DIFF
--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -65,7 +65,7 @@ func (c *userDeactivateCmd) Run() error {
 		tx.Rollback()
 		return fmt.Errorf("scrub user: %w", err)
 	}
-	comments, err := qtx.GetAllCommentsByUser(ctx, u.Idusers)
+	comments, err := qtx.GetAllCommentsByUserForAdmin(ctx, u.Idusers)
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("list comments: %w", err)

--- a/handlers/admin/adminCommentsPage.go
+++ b/handlers/admin/adminCommentsPage.go
@@ -14,14 +14,14 @@ func AdminCommentsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Comments"
 	queries := cd.Queries()
-	rows, err := queries.ListAllCommentsWithThreadInfo(r.Context(), db.ListAllCommentsWithThreadInfoParams{Limit: 50, Offset: 0})
+	rows, err := queries.ListAllCommentsWithThreadInfoForAdmin(r.Context(), db.ListAllCommentsWithThreadInfoForAdminParams{Limit: 50, Offset: 0})
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 	data := struct {
 		*common.CoreData
-		Comments []*db.ListAllCommentsWithThreadInfoRow
+		Comments []*db.ListAllCommentsWithThreadInfoForAdminRow
 	}{cd, rows}
 	handlers.TemplateHandler(w, r, "commentsPage.gohtml", data)
 }

--- a/handlers/admin/adminUserCommentsPage.go
+++ b/handlers/admin/adminUserCommentsPage.go
@@ -23,7 +23,7 @@ func adminUserCommentsPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.GetAllCommentsByUser(r.Context(), int32(id))
+	rows, err := queries.GetAllCommentsByUserForAdmin(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -32,7 +32,7 @@ func adminUserCommentsPage(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		*common.CoreData
 		User     *db.User
-		Comments []*db.GetAllCommentsByUserRow
+		Comments []*db.GetAllCommentsByUserForAdminRow
 	}{
 		CoreData: cd,
 		User:     &db.User{Idusers: user.Idusers, Username: user.Username},

--- a/handlers/search/remakeCommentsTask.go
+++ b/handlers/search/remakeCommentsTask.go
@@ -39,7 +39,7 @@ func (RemakeCommentsTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) 
 	if err := q.DeleteCommentsSearch(ctx); err != nil {
 		return nil, err
 	}
-	rows, err := q.GetAllCommentsForIndex(ctx)
+	rows, err := q.GetAllCommentsForIndexForSystem(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("GetAllCommentsForIndex: %w", err)
 	}
@@ -58,7 +58,7 @@ func (RemakeCommentsTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) 
 		}); err != nil {
 			return nil, err
 		}
-		if err := q.SetCommentLastIndex(ctx, row.Idcomments); err != nil {
+		if err := q.SetCommentLastIndexForSystem(ctx, row.Idcomments); err != nil {
 			return nil, err
 		}
 	}

--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -120,7 +120,7 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	comments, err := queries.GetAllCommentsByUser(r.Context(), int32(uid))
+	comments, err := queries.GetAllCommentsByUserForAdmin(r.Context(), int32(uid))
 	if err != nil {
 		log.Printf("fetch comments: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -104,21 +104,21 @@ WHERE c.forumthread_id=sqlc.arg(thread_id) AND c.forumthread_id!=0 AND EXISTS (
 ORDER BY c.written;
 
 
--- name: GetAllCommentsByUser :many
+-- name: GetAllCommentsByUserForAdmin :many
 SELECT c.*, th.forumtopic_idforumtopic
 FROM comments c
 LEFT JOIN forumthread th ON c.forumthread_id = th.idforumthread
 WHERE c.users_idusers = ?
 ORDER BY c.written;
 
--- name: SetCommentLastIndex :exec
+-- name: SetCommentLastIndexForSystem :exec
 UPDATE comments SET last_index = NOW() WHERE idcomments = ?;
 
 
--- name: GetAllCommentsForIndex :many
+-- name: GetAllCommentsForIndexForSystem :many
 SELECT idcomments, text FROM comments WHERE deleted_at IS NULL;
 
--- name: ListAllCommentsWithThreadInfo :many
+-- name: ListAllCommentsWithThreadInfoForAdmin :many
 SELECT c.idcomments, c.written, c.text, c.deleted_at,
        th.idforumthread, t.idforumtopic, t.title AS forumtopic_title,
        u.idusers, u.username AS posterusername

--- a/internal/db/queries-comments.sql.go
+++ b/internal/db/queries-comments.sql.go
@@ -36,7 +36,7 @@ func (q *Queries) CreateComment(ctx context.Context, arg CreateCommentParams) (i
 	return result.LastInsertId()
 }
 
-const getAllCommentsByUser = `-- name: GetAllCommentsByUser :many
+const getAllCommentsByUserForAdmin = `-- name: GetAllCommentsByUserForAdmin :many
 SELECT c.idcomments, c.forumthread_id, c.users_idusers, c.language_idlanguage, c.written, c.text, c.deleted_at, c.last_index, th.forumtopic_idforumtopic
 FROM comments c
 LEFT JOIN forumthread th ON c.forumthread_id = th.idforumthread
@@ -44,7 +44,7 @@ WHERE c.users_idusers = ?
 ORDER BY c.written
 `
 
-type GetAllCommentsByUserRow struct {
+type GetAllCommentsByUserForAdminRow struct {
 	Idcomments             int32
 	ForumthreadID          int32
 	UsersIdusers           int32
@@ -56,15 +56,15 @@ type GetAllCommentsByUserRow struct {
 	ForumtopicIdforumtopic sql.NullInt32
 }
 
-func (q *Queries) GetAllCommentsByUser(ctx context.Context, usersIdusers int32) ([]*GetAllCommentsByUserRow, error) {
-	rows, err := q.db.QueryContext(ctx, getAllCommentsByUser, usersIdusers)
+func (q *Queries) GetAllCommentsByUserForAdmin(ctx context.Context, usersIdusers int32) ([]*GetAllCommentsByUserForAdminRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllCommentsByUserForAdmin, usersIdusers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*GetAllCommentsByUserRow
+	var items []*GetAllCommentsByUserForAdminRow
 	for rows.Next() {
-		var i GetAllCommentsByUserRow
+		var i GetAllCommentsByUserForAdminRow
 		if err := rows.Scan(
 			&i.Idcomments,
 			&i.ForumthreadID,
@@ -89,24 +89,24 @@ func (q *Queries) GetAllCommentsByUser(ctx context.Context, usersIdusers int32) 
 	return items, nil
 }
 
-const getAllCommentsForIndex = `-- name: GetAllCommentsForIndex :many
+const getAllCommentsForIndexForSystem = `-- name: GetAllCommentsForIndexForSystem :many
 SELECT idcomments, text FROM comments WHERE deleted_at IS NULL
 `
 
-type GetAllCommentsForIndexRow struct {
+type GetAllCommentsForIndexForSystemRow struct {
 	Idcomments int32
 	Text       sql.NullString
 }
 
-func (q *Queries) GetAllCommentsForIndex(ctx context.Context) ([]*GetAllCommentsForIndexRow, error) {
-	rows, err := q.db.QueryContext(ctx, getAllCommentsForIndex)
+func (q *Queries) GetAllCommentsForIndexForSystem(ctx context.Context) ([]*GetAllCommentsForIndexForSystemRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllCommentsForIndexForSystem)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*GetAllCommentsForIndexRow
+	var items []*GetAllCommentsForIndexForSystemRow
 	for rows.Next() {
-		var i GetAllCommentsForIndexRow
+		var i GetAllCommentsForIndexForSystemRow
 		if err := rows.Scan(&i.Idcomments, &i.Text); err != nil {
 			return nil, err
 		}
@@ -453,7 +453,7 @@ func (q *Queries) GetCommentsByThreadIdForUser(ctx context.Context, arg GetComme
 	return items, nil
 }
 
-const listAllCommentsWithThreadInfo = `-- name: ListAllCommentsWithThreadInfo :many
+const listAllCommentsWithThreadInfoForAdmin = `-- name: ListAllCommentsWithThreadInfoForAdmin :many
 SELECT c.idcomments, c.written, c.text, c.deleted_at,
        th.idforumthread, t.idforumtopic, t.title AS forumtopic_title,
        u.idusers, u.username AS posterusername
@@ -465,12 +465,12 @@ ORDER BY c.written DESC
 LIMIT ? OFFSET ?
 `
 
-type ListAllCommentsWithThreadInfoParams struct {
+type ListAllCommentsWithThreadInfoForAdminParams struct {
 	Limit  int32
 	Offset int32
 }
 
-type ListAllCommentsWithThreadInfoRow struct {
+type ListAllCommentsWithThreadInfoForAdminRow struct {
 	Idcomments      int32
 	Written         sql.NullTime
 	Text            sql.NullString
@@ -482,15 +482,15 @@ type ListAllCommentsWithThreadInfoRow struct {
 	Posterusername  sql.NullString
 }
 
-func (q *Queries) ListAllCommentsWithThreadInfo(ctx context.Context, arg ListAllCommentsWithThreadInfoParams) ([]*ListAllCommentsWithThreadInfoRow, error) {
-	rows, err := q.db.QueryContext(ctx, listAllCommentsWithThreadInfo, arg.Limit, arg.Offset)
+func (q *Queries) ListAllCommentsWithThreadInfoForAdmin(ctx context.Context, arg ListAllCommentsWithThreadInfoForAdminParams) ([]*ListAllCommentsWithThreadInfoForAdminRow, error) {
+	rows, err := q.db.QueryContext(ctx, listAllCommentsWithThreadInfoForAdmin, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*ListAllCommentsWithThreadInfoRow
+	var items []*ListAllCommentsWithThreadInfoForAdminRow
 	for rows.Next() {
-		var i ListAllCommentsWithThreadInfoRow
+		var i ListAllCommentsWithThreadInfoForAdminRow
 		if err := rows.Scan(
 			&i.Idcomments,
 			&i.Written,
@@ -515,12 +515,12 @@ func (q *Queries) ListAllCommentsWithThreadInfo(ctx context.Context, arg ListAll
 	return items, nil
 }
 
-const setCommentLastIndex = `-- name: SetCommentLastIndex :exec
+const setCommentLastIndexForSystem = `-- name: SetCommentLastIndexForSystem :exec
 UPDATE comments SET last_index = NOW() WHERE idcomments = ?
 `
 
-func (q *Queries) SetCommentLastIndex(ctx context.Context, idcomments int32) error {
-	_, err := q.db.ExecContext(ctx, setCommentLastIndex, idcomments)
+func (q *Queries) SetCommentLastIndexForSystem(ctx context.Context, idcomments int32) error {
+	_, err := q.db.ExecContext(ctx, setCommentLastIndexForSystem, idcomments)
 	return err
 }
 

--- a/workers/searchworker/worker.go
+++ b/workers/searchworker/worker.go
@@ -89,7 +89,7 @@ func index(ctx context.Context, q *dbpkg.Queries, data IndexEventData) error {
 	}
 	switch data.Type {
 	case TypeComment:
-		return q.SetCommentLastIndex(ctx, data.ID)
+		return q.SetCommentLastIndexForSystem(ctx, data.ID)
 	case TypeWriting:
 		return q.SetWritingLastIndex(ctx, data.ID)
 	case TypeLinker:


### PR DESCRIPTION
## Summary
- rename admin comment listing queries in SQL
- regenerate db code and update usages
- adjust search worker and tasks for renamed functions
- tweak user deactivation and export handlers

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cb1528a54832f954ac90b4c5c185d