### PR TITLE
Rename blog indexing queries

### DIFF
--- a/handlers/search/remakeBlogTask.go
+++ b/handlers/search/remakeBlogTask.go
@@ -39,9 +39,9 @@ func (RemakeBlogTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tas
 	if err := q.DeleteBlogsSearch(ctx); err != nil {
 		return nil, err
 	}
-	rows, err := q.GetAllBlogsForIndexSystem(ctx)
+	rows, err := q.SystemGetAllBlogsForIndex(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("GetAllBlogsForIndexSystem: %w", err)
+		return nil, fmt.Errorf("SystemGetAllBlogsForIndex: %w", err)
 	}
 	cache := map[string]int64{}
 	for _, row := range rows {
@@ -58,7 +58,7 @@ func (RemakeBlogTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tas
 		}); err != nil {
 			return nil, err
 		}
-		if err := q.SetBlogLastIndexSystem(ctx, row.Idblogs); err != nil {
+		if err := q.SystemSetBlogLastIndex(ctx, row.Idblogs); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -292,10 +292,10 @@ GROUP BY u.idusers
 ORDER BY u.username
 LIMIT ? OFFSET ?;
 
--- name: SetBlogLastIndexSystem :exec
+-- name: SystemSetBlogLastIndex :exec
 UPDATE blogs SET last_index = NOW() WHERE idblogs = ?;
 
 
--- name: GetAllBlogsForIndexSystem :many
+-- name: SystemGetAllBlogsForIndex :many
 SELECT idblogs, blog FROM blogs WHERE deleted_at IS NULL;
 

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -275,38 +275,6 @@ func (q *Queries) GetAllBlogEntriesByUserForAdmin(ctx context.Context, usersIdus
 	return items, nil
 }
 
-const getAllBlogsForIndexSystem = `-- name: GetAllBlogsForIndexSystem :many
-SELECT idblogs, blog FROM blogs WHERE deleted_at IS NULL
-`
-
-type GetAllBlogsForIndexSystemRow struct {
-	Idblogs int32
-	Blog    sql.NullString
-}
-
-func (q *Queries) GetAllBlogsForIndexSystem(ctx context.Context) ([]*GetAllBlogsForIndexSystemRow, error) {
-	rows, err := q.db.QueryContext(ctx, getAllBlogsForIndexSystem)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*GetAllBlogsForIndexSystemRow
-	for rows.Next() {
-		var i GetAllBlogsForIndexSystemRow
-		if err := rows.Scan(&i.Idblogs, &i.Blog); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getBlogEntriesByAuthorForUserDescendingLanguages = `-- name: GetBlogEntriesByAuthorForUserDescendingLanguages :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
@@ -779,12 +747,44 @@ func (q *Queries) SearchBloggersForViewer(ctx context.Context, arg SearchBlogger
 	return items, nil
 }
 
-const setBlogLastIndexSystem = `-- name: SetBlogLastIndexSystem :exec
+const systemGetAllBlogsForIndex = `-- name: SystemGetAllBlogsForIndex :many
+SELECT idblogs, blog FROM blogs WHERE deleted_at IS NULL
+`
+
+type SystemGetAllBlogsForIndexRow struct {
+	Idblogs int32
+	Blog    sql.NullString
+}
+
+func (q *Queries) SystemGetAllBlogsForIndex(ctx context.Context) ([]*SystemGetAllBlogsForIndexRow, error) {
+	rows, err := q.db.QueryContext(ctx, systemGetAllBlogsForIndex)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*SystemGetAllBlogsForIndexRow
+	for rows.Next() {
+		var i SystemGetAllBlogsForIndexRow
+		if err := rows.Scan(&i.Idblogs, &i.Blog); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const systemSetBlogLastIndex = `-- name: SystemSetBlogLastIndex :exec
 UPDATE blogs SET last_index = NOW() WHERE idblogs = ?
 `
 
-func (q *Queries) SetBlogLastIndexSystem(ctx context.Context, idblogs int32) error {
-	_, err := q.db.ExecContext(ctx, setBlogLastIndexSystem, idblogs)
+func (q *Queries) SystemSetBlogLastIndex(ctx context.Context, idblogs int32) error {
+	_, err := q.db.ExecContext(ctx, systemSetBlogLastIndex, idblogs)
 	return err
 }
 


### PR DESCRIPTION
## Summary
- rename SetBlogLastIndex and GetAllBlogsForIndex queries
- regenerate sqlc code
- update background worker to use new query names
- run `go mod tidy`, `go fmt`, `go vet`, and `golangci-lint`

## Testing
- `go vet ./...`
- `golangci-lint run ./...`

------
https://chatgpt.com/codex/tasks/task_e_688cb6869a94832f80c5848764ff880b