### PR TITLE
Fix FAQ listing permissions

### DIFF
--- a/internal/db/queries-faq.sql
+++ b/internal/db/queries-faq.sql
@@ -76,10 +76,10 @@ WHERE c.idfaqCategories <> 0
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='faq'
-        AND g.item='question'
+        AND (g.item='question' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = f.idfaq
+        AND (g.item_id = f.idfaq OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-faq.sql.go
+++ b/internal/db/queries-faq.sql.go
@@ -85,10 +85,10 @@ WHERE c.idfaqCategories <> 0
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='faq'
-        AND g.item='question'
+        AND (g.item='question' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = f.idfaq
+        AND (g.item_id = f.idfaq OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )


### PR DESCRIPTION
## Summary
- broaden FAQ `see` permission matching so lists don't require item-specific grants

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cbab27a78832f811a8cba1ba71b4e