### PR TITLE
Display role attributes

### DIFF
--- a/core/templates/site/admin/adminRolePage.gohtml
+++ b/core/templates/site/admin/adminRolePage.gohtml
@@ -1,5 +1,13 @@
 {{ template "head" $ }}
 <h2>Role {{ .Role.Name }} (ID {{ .Role.ID }})</h2>
+<table border="1">
+    <tr><th>Can Login</th><th>Is Admin</th><th>Public Profiles</th></tr>
+    <tr>
+        <td>{{ if .Role.CanLogin }}yes{{ else }}no{{ end }}</td>
+        <td>{{ if .Role.IsAdmin }}yes{{ else }}no{{ end }}</td>
+        <td>{{ if .Role.PublicProfileAllowedAt.Valid }}enabled{{ else }}disabled{{ end }}</td>
+    </tr>
+</table>
 <h3>Users</h3>
 <ul>
     {{- if .Users }}


### PR DESCRIPTION
## Summary
- show role details (login, admin, public profile) on the admin role page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_688cc5b306fc832fa3c382ef1d525b3e