### PR TITLE
Remove unused user listing queries

### DIFF
--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -105,7 +105,6 @@ func (q *Queries) GetForumThreadIdByNewsPostId(ctx context.Context, idsitenews i
 }
 
 const getNewsPostByIdWithWriterIdAndThreadCommentCount = `-- name: GetNewsPostByIdWithWriterIdAndThreadCommentCount :one
-
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
     UNION

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -114,23 +114,6 @@ WHERE NOT EXISTS (
 )
 ORDER BY u.idusers;
 
--- name: ListUsers :many
-SELECT u.idusers,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
-       u.username
-FROM users u
-ORDER BY u.idusers
-LIMIT ? OFFSET ?;
-
--- name: SearchUsers :many
-SELECT u.idusers,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
-       u.username
-FROM users u
-WHERE LOWER(u.username) LIKE LOWER(sqlc.arg(pattern)) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(sqlc.arg(pattern))
-ORDER BY u.idusers
-LIMIT ? OFFSET ?;
-
 -- name: ListUserIDsByRole :many
 SELECT u.idusers
 FROM users u


### PR DESCRIPTION
## Summary
- drop unused `ListUsers` and `SearchUsers` SQL queries
- regenerate database code via `sqlc`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cccc9f0e8832fa2d74745828b8be5