### PR TITLE
Add admin query classification

### DIFF
--- a/cmd/goa4web/ipban_add.go
+++ b/cmd/goa4web/ipban_add.go
@@ -51,7 +51,7 @@ func (c *ipBanAddCmd) Run() error {
 		}
 		expires = sql.NullTime{Time: t, Valid: true}
 	}
-	err = queries.InsertBannedIp(ctx, dbpkg.InsertBannedIpParams{
+	err = queries.AdminInsertBannedIp(ctx, dbpkg.AdminInsertBannedIpParams{
 		IpNet:     c.IP,
 		Reason:    sql.NullString{String: c.Reason, Valid: c.Reason != ""},
 		ExpiresAt: expires,

--- a/cmd/goa4web/ipban_delete.go
+++ b/cmd/goa4web/ipban_delete.go
@@ -37,7 +37,7 @@ func (c *ipBanDeleteCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	if err := queries.CancelBannedIp(ctx, c.IP); err != nil {
+	if err := queries.AdminCancelBannedIp(ctx, c.IP); err != nil {
 		return fmt.Errorf("cancel banned ip: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/ipban_update.go
+++ b/cmd/goa4web/ipban_update.go
@@ -51,7 +51,7 @@ func (c *ipBanUpdateCmd) Run() error {
 		}
 		expires = sql.NullTime{Time: t, Valid: true}
 	}
-	err = queries.UpdateBannedIp(ctx, dbpkg.UpdateBannedIpParams{
+	err = queries.AdminUpdateBannedIp(ctx, dbpkg.AdminUpdateBannedIpParams{
 		Reason:    sql.NullString{String: c.Reason, Valid: c.Reason != ""},
 		ExpiresAt: expires,
 		ID:        int32(c.ID),

--- a/cmd/goa4web/links_delete.go
+++ b/cmd/goa4web/links_delete.go
@@ -37,9 +37,9 @@ func (c *linksDeleteCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	if err := queries.DeleteExternalLink(ctx, int32(c.ID)); err != nil {
-		return fmt.Errorf("delete link: %w", err)
-	}
+       if err := queries.AdminDeleteExternalLink(ctx, int32(c.ID)); err != nil {
+               return fmt.Errorf("delete link: %w", err)
+       }
 	return nil
 }
 

--- a/cmd/goa4web/links_list.go
+++ b/cmd/goa4web/links_list.go
@@ -31,7 +31,7 @@ func (c *linksListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	rows, err := queries.ListExternalLinks(ctx, dbpkg.ListExternalLinksParams{Limit: 200, Offset: 0})
+	rows, err := queries.AdminListExternalLinks(ctx, dbpkg.AdminListExternalLinksParams{Limit: 200, Offset: 0})
 	if err != nil {
 		return fmt.Errorf("list links: %w", err)
 	}

--- a/cmd/goa4web/links_refresh.go
+++ b/cmd/goa4web/links_refresh.go
@@ -38,7 +38,7 @@ func (c *linksRefreshCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	if err := queries.ClearExternalLinkCache(ctx, dbpkg.ClearExternalLinkCacheParams{UpdatedBy: sql.NullInt32{}, ID: int32(c.ID)}); err != nil {
+	if err := queries.AdminClearExternalLinkCache(ctx, dbpkg.AdminClearExternalLinkCacheParams{UpdatedBy: sql.NullInt32{}, ID: int32(c.ID)}); err != nil {
 		return fmt.Errorf("refresh link: %w", err)
 	}
 	return nil

--- a/handlers/admin/add_announcement_task.go
+++ b/handlers/admin/add_announcement_task.go
@@ -24,12 +24,18 @@ var _ tasks.AuditableTask = (*AddAnnouncementTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*AddAnnouncementTask)(nil)
 
 func (AddAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd == nil || !cd.HasRole("administrator") {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+		})
+	}
+	queries := cd.Queries()
 	nid, err := strconv.Atoi(r.PostFormValue("news_id"))
 	if err != nil {
 		return fmt.Errorf("news id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := queries.PromoteAnnouncement(r.Context(), int32(nid)); err != nil {
+	if err := queries.AdminPromoteAnnouncement(r.Context(), int32(nid)); err != nil {
 		return fmt.Errorf("promote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/adminAnnouncementsPage.go
+++ b/handlers/admin/adminAnnouncementsPage.go
@@ -15,14 +15,14 @@ import (
 func AdminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		Announcements []*db.ListAnnouncementsWithNewsForAdminRow
+               Announcements []*db.AdminListAnnouncementsWithNewsRow
 		NewsID        string
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Admin Announcements"
 	data := Data{CoreData: cd}
 	queries := cd.Queries()
-	rows, err := queries.ListAnnouncementsWithNewsForAdmin(r.Context())
+       rows, err := queries.AdminListAnnouncementsWithNews(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list announcements: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/adminExternalLinksPage.go
+++ b/handlers/admin/adminExternalLinksPage.go
@@ -21,7 +21,7 @@ func AdminExternalLinksPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "External Links"
 	queries := cd.Queries()
-	rows, err := queries.ListExternalLinks(r.Context(), db.ListExternalLinksParams{Limit: 200, Offset: 0})
+	rows, err := queries.AdminListExternalLinks(r.Context(), db.AdminListExternalLinksParams{Limit: 200, Offset: 0})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list external links: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/adminRequestQueuePage.go
+++ b/handlers/admin/adminRequestQueuePage.go
@@ -122,6 +122,10 @@ func handleRequestAction(w http.ResponseWriter, r *http.Request, status string) 
 	id, _ := strconv.Atoi(mux.Vars(r)["id"])
 	comment := r.PostFormValue("comment")
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd == nil || !cd.HasRole("administrator") {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	cd.PageTitle = fmt.Sprintf("Request %d", id)
 	queries := cd.Queries()
 	req, err := queries.GetAdminRequestByID(r.Context(), int32(id))

--- a/handlers/news/announcement_add_task.go
+++ b/handlers/news/announcement_add_task.go
@@ -36,9 +36,9 @@ func (AnnouncementAddTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	if ann == nil {
-		if err := queries.PromoteAnnouncement(r.Context(), int32(pid)); err != nil {
-			return fmt.Errorf("promote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-		}
+               if err := queries.AdminPromoteAnnouncement(r.Context(), int32(pid)); err != nil {
+                       return fmt.Errorf("promote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+               }
 	} else if !ann.Active {
 		if err := queries.SetAnnouncementActive(r.Context(), db.SetAnnouncementActiveParams{Active: true, ID: ann.ID}); err != nil {
 			return fmt.Errorf("activate announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -1,9 +1,9 @@
--- name: PromoteAnnouncement :exec
+-- name: AdminPromoteAnnouncement :exec
 -- admin task
 INSERT INTO site_announcements (site_news_id)
 VALUES (?);
 
--- name: DemoteAnnouncement :exec
+-- name: AdminDemoteAnnouncement :exec
 -- admin task
 DELETE FROM site_announcements WHERE id = ?;
 
@@ -55,7 +55,7 @@ WHERE a.active = 1
 ORDER BY a.created_at DESC
 LIMIT 1;
 
--- name: ListAnnouncementsWithNewsForAdmin :many
+-- name: AdminListAnnouncementsWithNews :many
 -- admin task
 SELECT a.id, a.site_news_id, a.active, a.created_at, n.news
 FROM site_announcements a

--- a/internal/db/queries-announcements.sql.go
+++ b/internal/db/queries-announcements.sql.go
@@ -11,13 +11,69 @@ import (
 	"time"
 )
 
-const demoteAnnouncement = `-- name: DemoteAnnouncement :exec
+const adminDemoteAnnouncement = `-- name: AdminDemoteAnnouncement :exec
 DELETE FROM site_announcements WHERE id = ?
 `
 
 // admin task
-func (q *Queries) DemoteAnnouncement(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, demoteAnnouncement, id)
+func (q *Queries) AdminDemoteAnnouncement(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, adminDemoteAnnouncement, id)
+	return err
+}
+
+const adminListAnnouncementsWithNews = `-- name: AdminListAnnouncementsWithNews :many
+SELECT a.id, a.site_news_id, a.active, a.created_at, n.news
+FROM site_announcements a
+JOIN site_news n ON n.idsiteNews = a.site_news_id
+ORDER BY a.created_at DESC
+`
+
+type AdminListAnnouncementsWithNewsRow struct {
+	ID         int32
+	SiteNewsID int32
+	Active     bool
+	CreatedAt  time.Time
+	News       sql.NullString
+}
+
+// admin task
+func (q *Queries) AdminListAnnouncementsWithNews(ctx context.Context) ([]*AdminListAnnouncementsWithNewsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListAnnouncementsWithNews)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*AdminListAnnouncementsWithNewsRow
+	for rows.Next() {
+		var i AdminListAnnouncementsWithNewsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.SiteNewsID,
+			&i.Active,
+			&i.CreatedAt,
+			&i.News,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const adminPromoteAnnouncement = `-- name: AdminPromoteAnnouncement :exec
+INSERT INTO site_announcements (site_news_id)
+VALUES (?)
+`
+
+// admin task
+func (q *Queries) AdminPromoteAnnouncement(ctx context.Context, siteNewsID int32) error {
+	_, err := q.db.ExecContext(ctx, adminPromoteAnnouncement, siteNewsID)
 	return err
 }
 
@@ -101,62 +157,6 @@ func (q *Queries) GetLatestAnnouncementByNewsID(ctx context.Context, siteNewsID 
 		&i.CreatedAt,
 	)
 	return &i, err
-}
-
-const listAnnouncementsWithNewsForAdmin = `-- name: ListAnnouncementsWithNewsForAdmin :many
-SELECT a.id, a.site_news_id, a.active, a.created_at, n.news
-FROM site_announcements a
-JOIN site_news n ON n.idsiteNews = a.site_news_id
-ORDER BY a.created_at DESC
-`
-
-type ListAnnouncementsWithNewsForAdminRow struct {
-	ID         int32
-	SiteNewsID int32
-	Active     bool
-	CreatedAt  time.Time
-	News       sql.NullString
-}
-
-// admin task
-func (q *Queries) ListAnnouncementsWithNewsForAdmin(ctx context.Context) ([]*ListAnnouncementsWithNewsForAdminRow, error) {
-	rows, err := q.db.QueryContext(ctx, listAnnouncementsWithNewsForAdmin)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*ListAnnouncementsWithNewsForAdminRow
-	for rows.Next() {
-		var i ListAnnouncementsWithNewsForAdminRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.SiteNewsID,
-			&i.Active,
-			&i.CreatedAt,
-			&i.News,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const promoteAnnouncement = `-- name: PromoteAnnouncement :exec
-INSERT INTO site_announcements (site_news_id)
-VALUES (?)
-`
-
-// admin task
-func (q *Queries) PromoteAnnouncement(ctx context.Context, siteNewsID int32) error {
-	_, err := q.db.ExecContext(ctx, promoteAnnouncement, siteNewsID)
-	return err
 }
 
 const setAnnouncementActive = `-- name: SetAnnouncementActive :exec

--- a/internal/db/queries-banned_ips.sql
+++ b/internal/db/queries-banned_ips.sql
@@ -1,11 +1,11 @@
--- name: InsertBannedIp :exec
+-- name: AdminInsertBannedIp :exec
 INSERT INTO banned_ips (ip_net, reason, expires_at)
 VALUES (?, ?, ?);
 
--- name: UpdateBannedIp :exec
+-- name: AdminUpdateBannedIp :exec
 UPDATE banned_ips SET reason = ?, expires_at = ? WHERE id = ?;
 
--- name: CancelBannedIp :exec
+-- name: AdminCancelBannedIp :exec
 UPDATE banned_ips SET canceled_at = CURRENT_TIMESTAMP WHERE ip_net = ? AND canceled_at IS NULL;
 
 

--- a/internal/db/queries-banned_ips.sql.go
+++ b/internal/db/queries-banned_ips.sql.go
@@ -10,28 +10,43 @@ import (
 	"database/sql"
 )
 
-const cancelBannedIp = `-- name: CancelBannedIp :exec
+const adminCancelBannedIp = `-- name: AdminCancelBannedIp :exec
 UPDATE banned_ips SET canceled_at = CURRENT_TIMESTAMP WHERE ip_net = ? AND canceled_at IS NULL
 `
 
-func (q *Queries) CancelBannedIp(ctx context.Context, ipNet string) error {
-	_, err := q.db.ExecContext(ctx, cancelBannedIp, ipNet)
+func (q *Queries) AdminCancelBannedIp(ctx context.Context, ipNet string) error {
+	_, err := q.db.ExecContext(ctx, adminCancelBannedIp, ipNet)
 	return err
 }
 
-const insertBannedIp = `-- name: InsertBannedIp :exec
+const adminInsertBannedIp = `-- name: AdminInsertBannedIp :exec
 INSERT INTO banned_ips (ip_net, reason, expires_at)
 VALUES (?, ?, ?)
 `
 
-type InsertBannedIpParams struct {
+type AdminInsertBannedIpParams struct {
 	IpNet     string
 	Reason    sql.NullString
 	ExpiresAt sql.NullTime
 }
 
-func (q *Queries) InsertBannedIp(ctx context.Context, arg InsertBannedIpParams) error {
-	_, err := q.db.ExecContext(ctx, insertBannedIp, arg.IpNet, arg.Reason, arg.ExpiresAt)
+func (q *Queries) AdminInsertBannedIp(ctx context.Context, arg AdminInsertBannedIpParams) error {
+	_, err := q.db.ExecContext(ctx, adminInsertBannedIp, arg.IpNet, arg.Reason, arg.ExpiresAt)
+	return err
+}
+
+const adminUpdateBannedIp = `-- name: AdminUpdateBannedIp :exec
+UPDATE banned_ips SET reason = ?, expires_at = ? WHERE id = ?
+`
+
+type AdminUpdateBannedIpParams struct {
+	Reason    sql.NullString
+	ExpiresAt sql.NullTime
+	ID        int32
+}
+
+func (q *Queries) AdminUpdateBannedIp(ctx context.Context, arg AdminUpdateBannedIpParams) error {
+	_, err := q.db.ExecContext(ctx, adminUpdateBannedIp, arg.Reason, arg.ExpiresAt, arg.ID)
 	return err
 }
 
@@ -101,19 +116,4 @@ func (q *Queries) ListBannedIps(ctx context.Context) ([]*BannedIp, error) {
 		return nil, err
 	}
 	return items, nil
-}
-
-const updateBannedIp = `-- name: UpdateBannedIp :exec
-UPDATE banned_ips SET reason = ?, expires_at = ? WHERE id = ?
-`
-
-type UpdateBannedIpParams struct {
-	Reason    sql.NullString
-	ExpiresAt sql.NullTime
-	ID        int32
-}
-
-func (q *Queries) UpdateBannedIp(ctx context.Context, arg UpdateBannedIpParams) error {
-	_, err := q.db.ExecContext(ctx, updateBannedIp, arg.Reason, arg.ExpiresAt, arg.ID)
-	return err
 }

--- a/internal/db/queries-externallinks.sql
+++ b/internal/db/queries-externallinks.sql
@@ -6,21 +6,14 @@ ON DUPLICATE KEY UPDATE clicks = clicks + 1;
 -- name: GetExternalLink :one
 SELECT * FROM external_links WHERE url = ? LIMIT 1;
 
--- name: ListExternalLinks :many
+-- name: AdminListExternalLinks :many
 SELECT * FROM external_links
 ORDER BY created_at DESC
 LIMIT ? OFFSET ?;
 
--- name: GetExternalLinkByID :one
-SELECT * FROM external_links WHERE id = ? LIMIT 1;
 
--- name: UpdateExternalLink :exec
-UPDATE external_links
-SET url = ?, card_title = ?, card_description = ?, card_image = ?, card_image_cache = ?, favicon_cache = ?, updated_at = CURRENT_TIMESTAMP, updated_by = ?
-WHERE id = ?;
-
--- name: DeleteExternalLink :exec
+-- name: AdminDeleteExternalLink :exec
 DELETE FROM external_links WHERE id = ?;
 
--- name: ClearExternalLinkCache :exec
+-- name: AdminClearExternalLinkCache :exec
 UPDATE external_links SET card_image_cache = NULL, favicon_cache = NULL, updated_at = CURRENT_TIMESTAMP, updated_by = ? WHERE id = ?;

--- a/internal/db/queries-externallinks.sql.go
+++ b/internal/db/queries-externallinks.sql.go
@@ -10,88 +10,42 @@ import (
 	"database/sql"
 )
 
-const clearExternalLinkCache = `-- name: ClearExternalLinkCache :exec
+const adminClearExternalLinkCache = `-- name: AdminClearExternalLinkCache :exec
 UPDATE external_links SET card_image_cache = NULL, favicon_cache = NULL, updated_at = CURRENT_TIMESTAMP, updated_by = ? WHERE id = ?
 `
 
-type ClearExternalLinkCacheParams struct {
+type AdminClearExternalLinkCacheParams struct {
 	UpdatedBy sql.NullInt32
 	ID        int32
 }
 
-func (q *Queries) ClearExternalLinkCache(ctx context.Context, arg ClearExternalLinkCacheParams) error {
-	_, err := q.db.ExecContext(ctx, clearExternalLinkCache, arg.UpdatedBy, arg.ID)
+func (q *Queries) AdminClearExternalLinkCache(ctx context.Context, arg AdminClearExternalLinkCacheParams) error {
+	_, err := q.db.ExecContext(ctx, adminClearExternalLinkCache, arg.UpdatedBy, arg.ID)
 	return err
 }
 
-const deleteExternalLink = `-- name: DeleteExternalLink :exec
+const adminDeleteExternalLink = `-- name: AdminDeleteExternalLink :exec
 DELETE FROM external_links WHERE id = ?
 `
 
-func (q *Queries) DeleteExternalLink(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, deleteExternalLink, id)
+func (q *Queries) AdminDeleteExternalLink(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, adminDeleteExternalLink, id)
 	return err
 }
 
-const getExternalLink = `-- name: GetExternalLink :one
-SELECT id, url, clicks, created_at, updated_at, updated_by, card_title, card_description, card_image, card_image_cache, favicon_cache FROM external_links WHERE url = ? LIMIT 1
-`
-
-func (q *Queries) GetExternalLink(ctx context.Context, url string) (*ExternalLink, error) {
-	row := q.db.QueryRowContext(ctx, getExternalLink, url)
-	var i ExternalLink
-	err := row.Scan(
-		&i.ID,
-		&i.Url,
-		&i.Clicks,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.UpdatedBy,
-		&i.CardTitle,
-		&i.CardDescription,
-		&i.CardImage,
-		&i.CardImageCache,
-		&i.FaviconCache,
-	)
-	return &i, err
-}
-
-const getExternalLinkByID = `-- name: GetExternalLinkByID :one
-SELECT id, url, clicks, created_at, updated_at, updated_by, card_title, card_description, card_image, card_image_cache, favicon_cache FROM external_links WHERE id = ? LIMIT 1
-`
-
-func (q *Queries) GetExternalLinkByID(ctx context.Context, id int32) (*ExternalLink, error) {
-	row := q.db.QueryRowContext(ctx, getExternalLinkByID, id)
-	var i ExternalLink
-	err := row.Scan(
-		&i.ID,
-		&i.Url,
-		&i.Clicks,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.UpdatedBy,
-		&i.CardTitle,
-		&i.CardDescription,
-		&i.CardImage,
-		&i.CardImageCache,
-		&i.FaviconCache,
-	)
-	return &i, err
-}
-
-const listExternalLinks = `-- name: ListExternalLinks :many
+const adminListExternalLinks = `-- name: AdminListExternalLinks :many
 SELECT id, url, clicks, created_at, updated_at, updated_by, card_title, card_description, card_image, card_image_cache, favicon_cache FROM external_links
 ORDER BY created_at DESC
 LIMIT ? OFFSET ?
 `
 
-type ListExternalLinksParams struct {
+type AdminListExternalLinksParams struct {
 	Limit  int32
 	Offset int32
 }
 
-func (q *Queries) ListExternalLinks(ctx context.Context, arg ListExternalLinksParams) ([]*ExternalLink, error) {
-	rows, err := q.db.QueryContext(ctx, listExternalLinks, arg.Limit, arg.Offset)
+func (q *Queries) AdminListExternalLinks(ctx context.Context, arg AdminListExternalLinksParams) ([]*ExternalLink, error) {
+	rows, err := q.db.QueryContext(ctx, adminListExternalLinks, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
@@ -125,6 +79,29 @@ func (q *Queries) ListExternalLinks(ctx context.Context, arg ListExternalLinksPa
 	return items, nil
 }
 
+const getExternalLink = `-- name: GetExternalLink :one
+SELECT id, url, clicks, created_at, updated_at, updated_by, card_title, card_description, card_image, card_image_cache, favicon_cache FROM external_links WHERE url = ? LIMIT 1
+`
+
+func (q *Queries) GetExternalLink(ctx context.Context, url string) (*ExternalLink, error) {
+	row := q.db.QueryRowContext(ctx, getExternalLink, url)
+	var i ExternalLink
+	err := row.Scan(
+		&i.ID,
+		&i.Url,
+		&i.Clicks,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.UpdatedBy,
+		&i.CardTitle,
+		&i.CardDescription,
+		&i.CardImage,
+		&i.CardImageCache,
+		&i.FaviconCache,
+	)
+	return &i, err
+}
+
 const registerExternalLinkClick = `-- name: RegisterExternalLinkClick :exec
 INSERT INTO external_links (url, clicks)
 VALUES (?, 1)
@@ -133,36 +110,5 @@ ON DUPLICATE KEY UPDATE clicks = clicks + 1
 
 func (q *Queries) RegisterExternalLinkClick(ctx context.Context, url string) error {
 	_, err := q.db.ExecContext(ctx, registerExternalLinkClick, url)
-	return err
-}
-
-const updateExternalLink = `-- name: UpdateExternalLink :exec
-UPDATE external_links
-SET url = ?, card_title = ?, card_description = ?, card_image = ?, card_image_cache = ?, favicon_cache = ?, updated_at = CURRENT_TIMESTAMP, updated_by = ?
-WHERE id = ?
-`
-
-type UpdateExternalLinkParams struct {
-	Url             string
-	CardTitle       sql.NullString
-	CardDescription sql.NullString
-	CardImage       sql.NullString
-	CardImageCache  sql.NullString
-	FaviconCache    sql.NullString
-	UpdatedBy       sql.NullInt32
-	ID              int32
-}
-
-func (q *Queries) UpdateExternalLink(ctx context.Context, arg UpdateExternalLinkParams) error {
-	_, err := q.db.ExecContext(ctx, updateExternalLink,
-		arg.Url,
-		arg.CardTitle,
-		arg.CardDescription,
-		arg.CardImage,
-		arg.CardImageCache,
-		arg.FaviconCache,
-		arg.UpdatedBy,
-		arg.ID,
-	)
 	return err
 }


### PR DESCRIPTION
## Summary
- prefix admin queries with `Admin` naming convention
- remove unused `GetExternalLinkByID` and `UpdateExternalLink` queries
- verify administrator role in admin tasks
- regenerate sqlc code

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cccc7dcd4832fb141aa14fec98a0f