### PR TITLE
Enforce admin tagging for audit queries

### DIFF
--- a/cmd/goa4web/audit.go
+++ b/cmd/goa4web/audit.go
@@ -35,7 +35,7 @@ func (c *auditCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	rows, err := queries.GetRecentAuditLogs(ctx, int32(c.Limit))
+	rows, err := queries.AdminGetRecentAuditLogs(ctx, int32(c.Limit))
 	if err != nil {
 		return fmt.Errorf("audit logs: %w", err)
 	}

--- a/handlers/admin/adminAuditLogPage.go
+++ b/handlers/admin/adminAuditLogPage.go
@@ -26,7 +26,7 @@ func copyValues(v url.Values) url.Values {
 func AdminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		Rows     []*db.ListAuditLogsRow
+		Rows     []*db.AdminListAuditLogsRow
 		User     string
 		Action   string
 		NextLink string
@@ -55,7 +55,7 @@ func AdminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 		actionFilter = "%" + data.Action + "%"
 	}
 
-	rows, err := queries.ListAuditLogs(r.Context(), db.ListAuditLogsParams{
+	rows, err := queries.AdminListAuditLogs(r.Context(), db.AdminListAuditLogsParams{
 		Username: sql.NullString{String: usernameFilter, Valid: true},
 		Action:   actionFilter,
 		Limit:    int32(data.PageSize + 1),

--- a/internal/db/queries-auditlog.sql
+++ b/internal/db/queries-auditlog.sql
@@ -1,7 +1,7 @@
 -- name: InsertAuditLog :exec
 INSERT INTO audit_log (users_idusers, action, path, details, data) VALUES (?, ?, ?, ?, ?);
 
--- name: ListAuditLogs :many
+-- name: AdminListAuditLogs :many
 SELECT a.id, a.users_idusers, a.action, a.path, a.details, a.data, a.created_at, u.username
 FROM audit_log a
 LEFT JOIN users u ON a.users_idusers = u.idusers

--- a/internal/db/queries-auditlog.sql.go
+++ b/internal/db/queries-auditlog.sql.go
@@ -11,30 +11,7 @@ import (
 	"time"
 )
 
-const insertAuditLog = `-- name: InsertAuditLog :exec
-INSERT INTO audit_log (users_idusers, action, path, details, data) VALUES (?, ?, ?, ?, ?)
-`
-
-type InsertAuditLogParams struct {
-	UsersIdusers int32
-	Action       string
-	Path         string
-	Details      sql.NullString
-	Data         sql.NullString
-}
-
-func (q *Queries) InsertAuditLog(ctx context.Context, arg InsertAuditLogParams) error {
-	_, err := q.db.ExecContext(ctx, insertAuditLog,
-		arg.UsersIdusers,
-		arg.Action,
-		arg.Path,
-		arg.Details,
-		arg.Data,
-	)
-	return err
-}
-
-const listAuditLogs = `-- name: ListAuditLogs :many
+const adminListAuditLogs = `-- name: AdminListAuditLogs :many
 SELECT a.id, a.users_idusers, a.action, a.path, a.details, a.data, a.created_at, u.username
 FROM audit_log a
 LEFT JOIN users u ON a.users_idusers = u.idusers
@@ -43,14 +20,14 @@ ORDER BY a.id DESC
 LIMIT ? OFFSET ?
 `
 
-type ListAuditLogsParams struct {
+type AdminListAuditLogsParams struct {
 	Username sql.NullString
 	Action   string
 	Limit    int32
 	Offset   int32
 }
 
-type ListAuditLogsRow struct {
+type AdminListAuditLogsRow struct {
 	ID           int32
 	UsersIdusers int32
 	Action       string
@@ -61,8 +38,8 @@ type ListAuditLogsRow struct {
 	Username     sql.NullString
 }
 
-func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([]*ListAuditLogsRow, error) {
-	rows, err := q.db.QueryContext(ctx, listAuditLogs,
+func (q *Queries) AdminListAuditLogs(ctx context.Context, arg AdminListAuditLogsParams) ([]*AdminListAuditLogsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListAuditLogs,
 		arg.Username,
 		arg.Action,
 		arg.Limit,
@@ -72,9 +49,9 @@ func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*ListAuditLogsRow
+	var items []*AdminListAuditLogsRow
 	for rows.Next() {
-		var i ListAuditLogsRow
+		var i AdminListAuditLogsRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.UsersIdusers,
@@ -96,4 +73,27 @@ func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([
 		return nil, err
 	}
 	return items, nil
+}
+
+const insertAuditLog = `-- name: InsertAuditLog :exec
+INSERT INTO audit_log (users_idusers, action, path, details, data) VALUES (?, ?, ?, ?, ?)
+`
+
+type InsertAuditLogParams struct {
+	UsersIdusers int32
+	Action       string
+	Path         string
+	Details      sql.NullString
+	Data         sql.NullString
+}
+
+func (q *Queries) InsertAuditLog(ctx context.Context, arg InsertAuditLogParams) error {
+	_, err := q.db.ExecContext(ctx, insertAuditLog,
+		arg.UsersIdusers,
+		arg.Action,
+		arg.Path,
+		arg.Details,
+		arg.Data,
+	)
+	return err
 }

--- a/internal/db/queries-stats.sql
+++ b/internal/db/queries-stats.sql
@@ -83,7 +83,7 @@ LEFT JOIN sessions s ON s.users_idusers = u.idusers
 GROUP BY u.idusers
 ORDER BY u.idusers;
 
--- name: GetRecentAuditLogs :many
+-- name: AdminGetRecentAuditLogs :many
 SELECT a.id, a.users_idusers, u.username, a.action, a.path, a.details, a.data, a.created_at
 FROM audit_log a LEFT JOIN users u ON a.users_idusers = u.idusers
 ORDER BY a.id DESC LIMIT ?;


### PR DESCRIPTION
## Summary
- prefix audit log queries with `Admin`
- call new admin queries from CLI and admin page
- regenerate sqlc outputs

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688cccc464e4832f8e47b4971edc3584