### PR TITLE
Update announcement admin queries

### DIFF
--- a/handlers/admin/add_announcement_task.go
+++ b/handlers/admin/add_announcement_task.go
@@ -29,7 +29,7 @@ func (AddAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("news id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := queries.PromoteAnnouncement(r.Context(), int32(nid)); err != nil {
+	if err := queries.AdminPromoteAnnouncement(r.Context(), int32(nid)); err != nil {
 		return fmt.Errorf("promote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/delete_announcement_task.go
+++ b/handlers/admin/delete_announcement_task.go
@@ -30,7 +30,7 @@ func (DeleteAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.DemoteAnnouncement(r.Context(), int32(id)); err != nil {
+		if err := queries.AdminDemoteAnnouncement(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("demote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/news/announcement_add_task.go
+++ b/handlers/news/announcement_add_task.go
@@ -36,7 +36,7 @@ func (AnnouncementAddTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	if ann == nil {
-		if err := queries.PromoteAnnouncement(r.Context(), int32(pid)); err != nil {
+		if err := queries.AdminPromoteAnnouncement(r.Context(), int32(pid)); err != nil {
 			return fmt.Errorf("promote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	} else if !ann.Active {

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -1,9 +1,9 @@
--- name: PromoteAnnouncement :exec
+-- name: AdminPromoteAnnouncement :exec
 -- admin task
 INSERT INTO site_announcements (site_news_id)
 VALUES (?);
 
--- name: DemoteAnnouncement :exec
+-- name: AdminDemoteAnnouncement :exec
 -- admin task
 DELETE FROM site_announcements WHERE id = ?;
 

--- a/internal/db/queries-announcements.sql.go
+++ b/internal/db/queries-announcements.sql.go
@@ -11,13 +11,24 @@ import (
 	"time"
 )
 
-const demoteAnnouncement = `-- name: DemoteAnnouncement :exec
+const adminDemoteAnnouncement = `-- name: AdminDemoteAnnouncement :exec
 DELETE FROM site_announcements WHERE id = ?
 `
 
 // admin task
-func (q *Queries) DemoteAnnouncement(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, demoteAnnouncement, id)
+func (q *Queries) AdminDemoteAnnouncement(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, adminDemoteAnnouncement, id)
+	return err
+}
+
+const adminPromoteAnnouncement = `-- name: AdminPromoteAnnouncement :exec
+INSERT INTO site_announcements (site_news_id)
+VALUES (?)
+`
+
+// admin task
+func (q *Queries) AdminPromoteAnnouncement(ctx context.Context, siteNewsID int32) error {
+	_, err := q.db.ExecContext(ctx, adminPromoteAnnouncement, siteNewsID)
 	return err
 }
 
@@ -146,17 +157,6 @@ func (q *Queries) ListAnnouncementsWithNewsForAdmin(ctx context.Context) ([]*Lis
 		return nil, err
 	}
 	return items, nil
-}
-
-const promoteAnnouncement = `-- name: PromoteAnnouncement :exec
-INSERT INTO site_announcements (site_news_id)
-VALUES (?)
-`
-
-// admin task
-func (q *Queries) PromoteAnnouncement(ctx context.Context, siteNewsID int32) error {
-	_, err := q.db.ExecContext(ctx, promoteAnnouncement, siteNewsID)
-	return err
 }
 
 const setAnnouncementActive = `-- name: SetAnnouncementActive :exec

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -105,7 +105,6 @@ func (q *Queries) GetForumThreadIdByNewsPostId(ctx context.Context, idsitenews i
 }
 
 const getNewsPostByIdWithWriterIdAndThreadCommentCount = `-- name: GetNewsPostByIdWithWriterIdAndThreadCommentCount :one
-
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
     UNION


### PR DESCRIPTION
## Summary
- rename PromoteAnnouncement and DemoteAnnouncement queries to AdminPromoteAnnouncement/AdminDemoteAnnouncement
- regenerate sqlc models
- update handlers to use the renamed queries

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cccc3886c832fb240309f6e84e975