### PR TITLE
Restrict role queries to admin context

### DIFF
--- a/cmd/goa4web/role_users.go
+++ b/cmd/goa4web/role_users.go
@@ -35,7 +35,7 @@ func (c *roleUsersCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	rows, err := queries.ListRolesWithUsers(ctx)
+	rows, err := queries.AdminListRolesWithUsers(ctx)
 	if err != nil {
 		return fmt.Errorf("list roles with users: %w", err)
 	}

--- a/cmd/goa4web/user_list_roles.go
+++ b/cmd/goa4web/user_list_roles.go
@@ -31,7 +31,7 @@ func (c *userListRolesCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	roles, err := queries.ListRoles(ctx)
+	roles, err := queries.AdminListRoles(ctx)
 	if err != nil {
 		return fmt.Errorf("list roles: %w", err)
 	}

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -635,7 +635,7 @@ func (cd *CoreData) AllRoles() ([]*db.Role, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		return cd.queries.ListRoles(cd.ctx)
+		return cd.queries.AdminListRoles(cd.ctx)
 	})
 }
 

--- a/handlers/admin/adminRolePage.go
+++ b/handlers/admin/adminRolePage.go
@@ -22,20 +22,20 @@ func adminRolePage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
 
-	role, err := queries.GetRoleByID(r.Context(), int32(id))
+	role, err := queries.AdminGetRoleByID(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "role not found", http.StatusNotFound)
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Role %s", role.Name)
 
-	users, err := queries.ListUsersByRoleID(r.Context(), int32(id))
+	users, err := queries.AdminListUsersByRoleID(r.Context(), int32(id))
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 
-	grants, err := queries.ListGrantsByRoleID(r.Context(), sql.NullInt32{Int32: int32(id), Valid: true})
+	grants, err := queries.AdminListGrantsByRoleID(r.Context(), sql.NullInt32{Int32: int32(id), Valid: true})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -82,7 +82,7 @@ func adminRolePage(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		*common.CoreData
 		Role   *db.Role
-		Users  []*db.ListUsersByRoleIDRow
+		Users  []*db.AdminListUsersByRoleIDRow
 		Grants []GrantInfo
 	}{
 		CoreData: cd,

--- a/handlers/admin/role_public_profile_task.go
+++ b/handlers/admin/role_public_profile_task.go
@@ -33,7 +33,7 @@ func (RolePublicProfileTask) Action(w http.ResponseWriter, r *http.Request) any 
 	if enable {
 		ts = sql.NullTime{Time: time.Now(), Valid: true}
 	}
-	if err := queries.UpdateRolePublicProfileAllowed(r.Context(), db.UpdateRolePublicProfileAllowedParams{PublicProfileAllowedAt: ts, ID: int32(id)}); err != nil {
+	if err := queries.AdminUpdateRolePublicProfileAllowed(r.Context(), db.AdminUpdateRolePublicProfileAllowedParams{PublicProfileAllowedAt: ts, ID: int32(id)}); err != nil {
 		return fmt.Errorf("update role fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/forum/category_grant_create_task.go
+++ b/handlers/forum/category_grant_create_task.go
@@ -49,7 +49,7 @@ func (CategoryGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) an
 	}
 	var rid sql.NullInt32
 	if role != "" {
-		roles, err := queries.ListRoles(r.Context())
+		roles, err := queries.AdminListRoles(r.Context())
 		if err != nil {
 			log.Printf("ListRoles: %v", err)
 			return fmt.Errorf("list roles %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/forum/topic_grant_create_task.go
+++ b/handlers/forum/topic_grant_create_task.go
@@ -49,7 +49,7 @@ func (TopicGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	var rid sql.NullInt32
 	if role != "" {
-		roles, err := queries.ListRoles(r.Context())
+		roles, err := queries.AdminListRoles(r.Context())
 		if err != nil {
 			log.Printf("ListRoles: %v", err)
 			return fmt.Errorf("list roles %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/linker/category_grant_create_task.go
+++ b/handlers/linker/category_grant_create_task.go
@@ -49,7 +49,7 @@ func (CategoryGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) an
 	}
 	var rid sql.NullInt32
 	if role != "" {
-		roles, err := queries.ListRoles(r.Context())
+		roles, err := queries.AdminListRoles(r.Context())
 		if err != nil {
 			log.Printf("ListRoles: %v", err)
 			return fmt.Errorf("list roles %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/writings/category_grant_create_task.go
+++ b/handlers/writings/category_grant_create_task.go
@@ -49,7 +49,7 @@ func (CategoryGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) an
 	}
 	var rid sql.NullInt32
 	if role != "" {
-		roles, err := queries.ListRoles(r.Context())
+		roles, err := queries.AdminListRoles(r.Context())
 		if err != nil {
 			log.Printf("ListRoles: %v", err)
 			return fmt.Errorf("list roles %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/writings/writing_category_grant_create_task.go
+++ b/handlers/writings/writing_category_grant_create_task.go
@@ -49,7 +49,7 @@ func (WritingCategoryGrantCreateTask) Action(w http.ResponseWriter, r *http.Requ
 	}
 	var rid sql.NullInt32
 	if role != "" {
-		roles, err := queries.ListRoles(r.Context())
+		roles, err := queries.AdminListRoles(r.Context())
 		if err != nil {
 			log.Printf("ListRoles: %v", err)
 			return fmt.Errorf("list roles %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/internal/db/queries-roles.sql
+++ b/internal/db/queries-roles.sql
@@ -1,7 +1,9 @@
--- name: ListRoles :many
+-- name: AdminListRoles :many
+-- admin task
 SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id;
 
--- name: ListRolesWithUsers :many
+-- name: AdminListRolesWithUsers :many
+-- admin task
 SELECT r.id, r.name, GROUP_CONCAT(u.username ORDER BY u.username) AS users
 FROM roles r
 LEFT JOIN user_roles ur ON ur.role_id = r.id
@@ -9,18 +11,22 @@ LEFT JOIN users u ON u.idusers = ur.users_idusers
 GROUP BY r.id
 ORDER BY r.id;
 
--- name: UpdateRolePublicProfileAllowed :exec
+-- name: AdminUpdateRolePublicProfileAllowed :exec
+-- admin task
 UPDATE roles SET public_profile_allowed_at = ? WHERE id = ?;
 
--- name: GetRoleByID :one
+-- name: AdminGetRoleByID :one
+-- admin task
 SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles WHERE id = ?;
 
--- name: ListUsersByRoleID :many
+-- name: AdminListUsersByRoleID :many
+-- admin task
 SELECT u.idusers, u.username, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers ORDER BY ue.id LIMIT 1) AS email
 FROM users u
 JOIN user_roles ur ON ur.users_idusers = u.idusers
 WHERE ur.role_id = ?
 ORDER BY u.username;
 
--- name: ListGrantsByRoleID :many
+-- name: AdminListGrantsByRoleID :many
+-- admin task
 SELECT * FROM grants WHERE role_id = ? ORDER BY id;


### PR DESCRIPTION
## Summary
- mark role management queries as admin-only in SQL
- update callers to use new Admin-prefixed query names
- regenerate sqlc code

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccca43600832f978a11b0673a9d40