### PR TITLE
Ensure news queries filter by language

### DIFF
--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -30,7 +30,7 @@ func TestCoreDataLatestNewsLazy(t *testing.T) {
 		"users_idusers", "news", "occurred", "comments",
 	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, 0)
 
-	mock.ExpectQuery("SELECT u.username").WithArgs(int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
+	mock.ExpectQuery("SELECT u.username").WithArgs(int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
 	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "news", sql.NullString{String: "post", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnError(sql.ErrNoRows)

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -65,7 +65,7 @@ func TestLatestNewsRespectsPermissions(t *testing.T) {
 		"users_idusers", "news", "occurred", "comments",
 	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, 0).AddRow("w", 1, 2, 0, 1, 1, "b", now, 0)
 
-	mock.ExpectQuery("SELECT u.username").WithArgs(int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
+	mock.ExpectQuery("SELECT u.username").WithArgs(int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
 
 	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "news", sql.NullString{String: "post", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))

--- a/handlers/news/routes_admin.go
+++ b/handlers/news/routes_admin.go
@@ -8,10 +8,10 @@ import (
 // RegisterAdminRoutes attaches news admin endpoints to ar.
 func RegisterAdminRoutes(ar *mux.Router) {
 	nr := ar.PathPrefix("/news").Subrouter()
-	nr.HandleFunc("", AdminNewsPage).Methods("GET")
-	nr.HandleFunc("/{post}", AdminNewsPostPage).Methods("GET")
-	nr.HandleFunc("/{post}/edit", adminNewsEditFormPage).Methods("GET")
-	nr.HandleFunc("/{post}/edit", handlers.TaskHandler(editTask)).Methods("POST").MatcherFunc(editTask.Matcher())
-	nr.HandleFunc("/{post}/delete", AdminNewsDeleteConfirmPage).Methods("GET")
-	nr.HandleFunc("/{post}/delete", handlers.TaskHandler(deleteNewsPostTask)).Methods("POST").MatcherFunc(deleteNewsPostTask.Matcher())
+	nr.HandleFunc("", handlers.VerifyAccess(AdminNewsPage, "administrator")).Methods("GET")
+	nr.HandleFunc("/{post}", handlers.VerifyAccess(AdminNewsPostPage, "administrator")).Methods("GET")
+	nr.HandleFunc("/{post}/edit", handlers.VerifyAccess(adminNewsEditFormPage, "administrator")).Methods("GET")
+	nr.HandleFunc("/{post}/edit", handlers.VerifyAccess(handlers.TaskHandler(editTask), "administrator")).Methods("POST").MatcherFunc(editTask.Matcher())
+	nr.HandleFunc("/{post}/delete", handlers.VerifyAccess(AdminNewsDeleteConfirmPage, "administrator")).Methods("GET")
+	nr.HandleFunc("/{post}/delete", handlers.VerifyAccess(handlers.TaskHandler(deleteNewsPostTask), "administrator")).Methods("POST").MatcherFunc(deleteNewsPostTask.Matcher())
 }

--- a/handlers/news/search_test.go
+++ b/handlers/news/search_test.go
@@ -33,7 +33,7 @@ func TestNewsSearchFiltersUnauthorized(t *testing.T) {
 		"Comments",
 	}).AddRow("bob", 1, 1, 0, 1, 1, "text", time.Unix(0, 0), 0)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.username AS writerName")).
-		WithArgs(int32(1), int32(1), int32(2), sql.NullInt32{Int32: 1, Valid: true}).
+		WithArgs(int32(1), int32(1), int32(2), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
 		WillReturnRows(newsRows)
 
 	form := url.Values{"searchwords": {"foo"}}

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -105,7 +105,6 @@ func (q *Queries) GetForumThreadIdByNewsPostId(ctx context.Context, idsitenews i
 }
 
 const getNewsPostByIdWithWriterIdAndThreadCommentCount = `-- name: GetNewsPostByIdWithWriterIdAndThreadCommentCount :one
-
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
     UNION
@@ -179,7 +178,20 @@ SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthr
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
-WHERE s.Idsitenews IN (/*SLICE:newsids*/?) AND EXISTS (
+WHERE s.Idsitenews IN (/*SLICE:newsids*/?)
+  AND (
+      NOT EXISTS (
+          SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
+      )
+      OR s.language_idlanguage = 0
+      OR s.language_idlanguage IS NULL
+      OR s.language_idlanguage IN (
+          SELECT ul.language_idlanguage
+          FROM user_language ul
+          WHERE ul.users_idusers = ?
+      )
+  )
+  AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='news'
       AND g.item='post'
@@ -222,6 +234,8 @@ func (q *Queries) GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount(ctx 
 	} else {
 		query = strings.Replace(query, "/*SLICE:newsids*/?", "NULL", 1)
 	}
+	queryParams = append(queryParams, arg.ViewerID)
+	queryParams = append(queryParams, arg.ViewerID)
 	queryParams = append(queryParams, arg.UserID)
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
@@ -231,95 +245,6 @@ func (q *Queries) GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount(ctx 
 	var items []*GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow
 	for rows.Next() {
 		var i GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow
-		if err := rows.Scan(
-			&i.Writername,
-			&i.Writerid,
-			&i.Idsitenews,
-			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
-			&i.UsersIdusers,
-			&i.News,
-			&i.Occurred,
-			&i.Comments,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getNewsPostsByIdsWithWriterIdAndThreadCommentCount = `-- name: GetNewsPostsByIdsWithWriterIdAndThreadCommentCount :many
-WITH RECURSIVE role_ids(id) AS (
-    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
-    UNION
-    SELECT r2.id
-    FROM role_ids ri
-    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
-    JOIN roles r2 ON r2.name = g.action
-)
-SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
-FROM site_news s
-LEFT JOIN users u ON s.users_idusers = u.idusers
-LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
-WHERE s.Idsitenews IN (/*SLICE:newsids*/?) AND EXISTS (
-    SELECT 1 FROM grants g
-    WHERE g.section='news'
-      AND (g.item='post' OR g.item IS NULL)
-      AND g.action='see'
-      AND g.active=1
-      AND (g.item_id = s.idsiteNews OR g.item_id IS NULL)
-      AND (g.user_id = ? OR g.user_id IS NULL)
-      AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
-)
-ORDER BY s.occurred DESC
-`
-
-type GetNewsPostsByIdsWithWriterIdAndThreadCommentCountParams struct {
-	ViewerID int32
-	Newsids  []int32
-	UserID   sql.NullInt32
-}
-
-type GetNewsPostsByIdsWithWriterIdAndThreadCommentCountRow struct {
-	Writername         sql.NullString
-	Writerid           sql.NullInt32
-	Idsitenews         int32
-	ForumthreadID      int32
-	LanguageIdlanguage int32
-	UsersIdusers       int32
-	News               sql.NullString
-	Occurred           sql.NullTime
-	Comments           sql.NullInt32
-}
-
-func (q *Queries) GetNewsPostsByIdsWithWriterIdAndThreadCommentCount(ctx context.Context, arg GetNewsPostsByIdsWithWriterIdAndThreadCommentCountParams) ([]*GetNewsPostsByIdsWithWriterIdAndThreadCommentCountRow, error) {
-	query := getNewsPostsByIdsWithWriterIdAndThreadCommentCount
-	var queryParams []interface{}
-	queryParams = append(queryParams, arg.ViewerID)
-	if len(arg.Newsids) > 0 {
-		for _, v := range arg.Newsids {
-			queryParams = append(queryParams, v)
-		}
-		query = strings.Replace(query, "/*SLICE:newsids*/?", strings.Repeat(",?", len(arg.Newsids))[1:], 1)
-	} else {
-		query = strings.Replace(query, "/*SLICE:newsids*/?", "NULL", 1)
-	}
-	queryParams = append(queryParams, arg.UserID)
-	rows, err := q.db.QueryContext(ctx, query, queryParams...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*GetNewsPostsByIdsWithWriterIdAndThreadCommentCountRow
-	for rows.Next() {
-		var i GetNewsPostsByIdsWithWriterIdAndThreadCommentCountRow
 		if err := rows.Scan(
 			&i.Writername,
 			&i.Writerid,
@@ -357,7 +282,17 @@ SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthr
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
-WHERE EXISTS (
+WHERE (
+    NOT EXISTS (
+        SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
+    )
+    OR s.language_idlanguage = 0
+    OR s.language_idlanguage IS NULL
+    OR s.language_idlanguage IN (
+        SELECT ul.language_idlanguage FROM user_language ul WHERE ul.users_idusers = ?
+    )
+)
+  AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='news'
       AND (g.item='post' OR g.item IS NULL)
@@ -392,6 +327,8 @@ type GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow struct {
 
 func (q *Queries) GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(ctx context.Context, arg GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams) ([]*GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow, error) {
 	rows, err := q.db.QueryContext(ctx, getNewsPostsWithWriterUsernameAndThreadCommentCountDescending,
+		arg.ViewerID,
+		arg.ViewerID,
 		arg.ViewerID,
 		arg.UserID,
 		arg.Limit,


### PR DESCRIPTION
## Summary
- remove unused query from `queries-news.sql`
- filter news listing and search by viewer language
- protect admin news routes with explicit admin checks
- update unit tests for new query parameters

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688ccc9c6074832f9ce5a7ebcbda7294