### PR TITLE
Refactor language queries

### DIFF
--- a/cmd/goa4web/lang_add.go
+++ b/cmd/goa4web/lang_add.go
@@ -40,7 +40,7 @@ func (c *langAddCmd) Run() error {
 	ctx := context.Background()
 	queries := dbpkg.New(db)
 	c.rootCmd.Verbosef("adding language %s (%s)", c.Name, c.Code)
-	if _, err := queries.InsertLanguage(ctx, sql.NullString{String: c.Name, Valid: true}); err != nil {
+	if _, err := queries.AdminInsertLanguage(ctx, sql.NullString{String: c.Name, Valid: true}); err != nil {
 		return fmt.Errorf("insert language: %w", err)
 	}
 	c.rootCmd.Infof("added language %s (%s)", c.Name, c.Code)

--- a/cmd/goa4web/lang_list.go
+++ b/cmd/goa4web/lang_list.go
@@ -31,7 +31,7 @@ func (c *langListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	langs, err := queries.AllLanguages(ctx)
+	langs, err := queries.AdminListLanguages(ctx)
 	if err != nil {
 		return fmt.Errorf("list languages: %w", err)
 	}

--- a/cmd/goa4web/lang_update.go
+++ b/cmd/goa4web/lang_update.go
@@ -39,7 +39,7 @@ func (c *langUpdateCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	err = queries.RenameLanguage(ctx, dbpkg.RenameLanguageParams{Nameof: sql.NullString{String: c.Name, Valid: true}, Idlanguage: int32(c.ID)})
+	err = queries.AdminRenameLanguage(ctx, dbpkg.AdminRenameLanguageParams{Nameof: sql.NullString{String: c.Name, Valid: true}, Idlanguage: int32(c.ID)})
 	if err != nil {
 		return fmt.Errorf("update language: %w", err)
 	}

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -591,7 +591,7 @@ func (cd *CoreData) Languages() ([]*db.Language, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		return cd.queries.FetchLanguages(cd.ctx)
+		return cd.queries.ListLanguagesForUser(cd.ctx, db.ListLanguagesForUserParams{ViewerID: cd.UserID})
 	})
 }
 
@@ -601,7 +601,7 @@ func (cd *CoreData) AllLanguages() ([]*db.Language, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		return cd.queries.FetchLanguages(cd.ctx)
+		return cd.queries.AdminListLanguages(cd.ctx)
 	})
 }
 

--- a/core/language/language.go
+++ b/core/language/language.go
@@ -64,6 +64,6 @@ func EnsureDefaultLanguage(ctx context.Context, q *db.Queries, name string) erro
 	if err := validateLanguageName(name); err != nil {
 		return err
 	}
-	_, err = q.InsertLanguage(ctx, sql.NullString{String: name, Valid: true})
+	_, err = q.AdminInsertLanguage(ctx, sql.NullString{String: name, Valid: true})
 	return err
 }

--- a/handlers/languages/admin.go
+++ b/handlers/languages/admin.go
@@ -30,7 +30,7 @@ func adminLanguagesPage(w http.ResponseWriter, r *http.Request) {
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 
-	rows, err := cd.Languages()
+	rows, err := cd.AllLanguages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -55,7 +55,7 @@ func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {
 	}
 	if cidi, err := strconv.Atoi(cid); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("strconv.Atoi: %w", err).Error())
-	} else if err := queries.RenameLanguage(r.Context(), db.RenameLanguageParams{
+	} else if err := queries.AdminRenameLanguage(r.Context(), db.AdminRenameLanguageParams{
 		Nameof:     sql.NullString{Valid: true, String: cname},
 		Idlanguage: int32(cidi),
 	}); err != nil {
@@ -87,7 +87,7 @@ func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("strconv.Atoi: %w", err).Error())
 	} else {
 		var name string
-		if rows, err := queries.FetchLanguages(r.Context()); err == nil {
+		if rows, err := queries.AdminListLanguages(r.Context()); err == nil {
 			for _, l := range rows {
 				if l.Idlanguage == int32(cidi) {
 					name = l.Nameof.String
@@ -95,7 +95,7 @@ func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-		if err := queries.DeleteLanguage(r.Context(), int32(cidi)); err != nil {
+		if err := queries.AdminDeleteLanguage(r.Context(), int32(cidi)); err != nil {
 			data.Errors = append(data.Errors, fmt.Errorf("DeleteLanguage: %w", err).Error())
 		} else if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 			if evt := cd.Event(); evt != nil {
@@ -121,7 +121,7 @@ func adminLanguagesCreatePage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/admin/languages",
 	}
-	if res, err := queries.InsertLanguage(r.Context(), sql.NullString{
+	if res, err := queries.AdminInsertLanguage(r.Context(), sql.NullString{
 		String: cname,
 		Valid:  true,
 	}); err != nil {

--- a/handlers/languages/create_language_task.go
+++ b/handlers/languages/create_language_task.go
@@ -23,7 +23,7 @@ var _ notif.AdminEmailTemplateProvider = (*CreateLanguageTask)(nil)
 func (CreateLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cname := r.PostFormValue("cname")
-	res, err := queries.InsertLanguage(r.Context(), sql.NullString{String: cname, Valid: true})
+	res, err := queries.AdminInsertLanguage(r.Context(), sql.NullString{String: cname, Valid: true})
 	if err != nil {
 		return fmt.Errorf("create language fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/languages/delete_language_task.go
+++ b/handlers/languages/delete_language_task.go
@@ -27,7 +27,7 @@ func (DeleteLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("cid parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	var name string
-	if rows, err := queries.FetchLanguages(r.Context()); err == nil {
+	if rows, err := queries.AdminListLanguages(r.Context()); err == nil {
 		for _, l := range rows {
 			if l.Idlanguage == int32(cid) {
 				name = l.Nameof.String
@@ -35,7 +35,7 @@ func (DeleteLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 		}
 	}
-	if err := queries.DeleteLanguage(r.Context(), int32(cid)); err != nil {
+	if err := queries.AdminDeleteLanguage(r.Context(), int32(cid)); err != nil {
 		return fmt.Errorf("delete language fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/languages/rename_language_task.go
+++ b/handlers/languages/rename_language_task.go
@@ -29,7 +29,7 @@ func (RenameLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("cid parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	cname := r.PostFormValue("cname")
-	if err := queries.RenameLanguage(r.Context(), db.RenameLanguageParams{
+	if err := queries.AdminRenameLanguage(r.Context(), db.AdminRenameLanguageParams{
 		Nameof:     sql.NullString{Valid: true, String: cname},
 		Idlanguage: int32(cid),
 	}); err != nil {

--- a/handlers/linker/linkerAdminLinkPage.go
+++ b/handlers/linker/linkerAdminLinkPage.go
@@ -34,7 +34,7 @@ func adminLinkPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cats, _ := queries.GetAllLinkerCategories(r.Context())
-	langs, _ := cd.Languages()
+	langs, _ := cd.AllLanguages()
 
 	cd.PageTitle = fmt.Sprintf("Edit Link %d", id)
 	data := struct {

--- a/handlers/news/admin_pages.go
+++ b/handlers/news/admin_pages.go
@@ -132,7 +132,7 @@ func adminNewsEditFormPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/admin/news?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	}
-	langs, err := cd.Languages()
+	langs, err := cd.AllLanguages()
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -45,7 +45,7 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	langs, err := cd.Languages()
+	langs, err := cd.AllLanguages()
 	if err != nil {
 		log.Printf("Error getting languages: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -92,7 +92,7 @@ func updateLanguageSelections(r *http.Request, cd *common.CoreData, queries *db.
 		return err
 	}
 
-	langs, err := cd.Languages()
+	langs, err := cd.AllLanguages()
 	if err != nil {
 		return err
 	}

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -160,7 +160,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 
 	languageRows, err := cd.Languages()
 	if err != nil {
-		log.Printf("FetchLanguages Error: %s", err)
+		log.Printf("ListLanguagesForUser Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/db/queries-languages.sql
+++ b/internal/db/queries-languages.sql
@@ -1,4 +1,5 @@
--- name: RenameLanguage :exec
+-- admin task
+-- name: AdminRenameLanguage :exec
 -- This query updates the "nameof" field in the "language" table based on the provided "cid".
 -- Parameters:
 --   ? - New name for the language (string)
@@ -7,30 +8,37 @@ UPDATE language
 SET nameof = ?
 WHERE idlanguage = ?;
 
--- name: DeleteLanguage :exec
+-- admin task
+-- name: AdminDeleteLanguage :exec
 -- This query deletes a record from the "language" table based on the provided "cid".
 -- Parameters:
 --   ? - Language ID to be deleted (int)
 DELETE FROM language
 WHERE idlanguage = ?;
 
--- name: CreateLanguage :exec
--- This query inserts a new record into the "language" table.
--- Parameters:
---   ? - Name of the new language (string)
+
+-- admin task
+-- name: AdminInsertLanguage :execresult
 INSERT INTO language (nameof)
 VALUES (?);
 
--- name: InsertLanguage :execresult
-INSERT INTO language (nameof)
-VALUES (?);
+-- user listing
+-- name: ListLanguagesForUser :many
+SELECT idlanguage, nameof
+FROM language
+WHERE NOT EXISTS (
+    SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+) OR EXISTS (
+    SELECT 1 FROM user_language ul
+    WHERE ul.users_idusers = sqlc.arg(viewer_id)
+      AND ul.language_idlanguage = idlanguage
+)
+ORDER BY nameof;
 
--- name: FetchLanguages :many
-SELECT *
-FROM language;
-
--- name: AllLanguages :many
-SELECT * FROM language;
+-- admin task
+-- name: AdminListLanguages :many
+SELECT idlanguage, nameof FROM language
+ORDER BY nameof;
 
 -- name: GetLanguageIDByName :one
 SELECT idlanguage FROM language WHERE nameof = ?;

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -105,7 +105,6 @@ func (q *Queries) GetForumThreadIdByNewsPostId(ctx context.Context, idsitenews i
 }
 
 const getNewsPostByIdWithWriterIdAndThreadCommentCount = `-- name: GetNewsPostByIdWithWriterIdAndThreadCommentCount :one
-
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
     UNION


### PR DESCRIPTION
## Summary
- add separate admin queries for managing languages
- filter languages on user listings
- drop unused CreateLanguage and AllLanguages queries
- regenerate sqlc models
- run `go fmt`, `go vet`, `golangci-lint`, and `go test`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc991a70832fb53051254c1581de