### PR TITLE
Update FAQ queries with permissions

### DIFF
--- a/handlers/faq/admin_question.go
+++ b/handlers/faq/admin_question.go
@@ -51,7 +51,10 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.UnansweredRows = unansweredRows
 
-	answeredRows, err := queries.GetFAQAnsweredQuestions(r.Context())
+	answeredRows, err := queries.GetFAQAnsweredQuestions(r.Context(), db.GetFAQAnsweredQuestionsParams{
+		ViewerID: cd.UserID,
+		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+	})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/faq/create_category_task.go
+++ b/handlers/faq/create_category_task.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 )
@@ -24,11 +25,12 @@ func (CreateCategoryTask) Match(r *http.Request, m *mux.RouteMatch) bool {
 
 func (CreateCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	text := r.PostFormValue("cname")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 
-	if err := queries.CreateFAQCategory(r.Context(), sql.NullString{
-		String: text,
-		Valid:  true,
+	if err := queries.CreateFAQCategory(r.Context(), db.CreateFAQCategoryParams{
+		Name:     sql.NullString{String: text, Valid: true},
+		ViewerID: cd.UserID,
 	}); err != nil {
 		return fmt.Errorf("create category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/faq/delete_category_task.go
+++ b/handlers/faq/delete_category_task.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 )
@@ -27,9 +28,13 @@ func (DeleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("cid parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 
-	if err := queries.DeleteFAQCategory(r.Context(), int32(cid)); err != nil {
+	if err := queries.DeleteFAQCategory(r.Context(), db.DeleteFAQCategoryParams{
+		Idfaqcategories: int32(cid),
+		ViewerID:        cd.UserID,
+	}); err != nil {
 		return fmt.Errorf("delete category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 

--- a/handlers/faq/delete_question_task.go
+++ b/handlers/faq/delete_question_task.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 )
@@ -27,9 +28,13 @@ func (DeleteQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("faq id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 
-	if err := queries.DeleteFAQ(r.Context(), int32(faq)); err != nil {
+	if err := queries.DeleteFAQ(r.Context(), db.DeleteFAQParams{
+		Idfaq:    int32(faq),
+		ViewerID: cd.UserID,
+	}); err != nil {
 		return fmt.Errorf("delete faq fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 

--- a/handlers/faq/edit_question_task.go
+++ b/handlers/faq/edit_question_task.go
@@ -37,7 +37,8 @@ func (EditQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("faq id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
@@ -49,6 +50,7 @@ func (EditQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Question:                     sql.NullString{Valid: true, String: question},
 		FaqcategoriesIdfaqcategories: int32(category),
 		Idfaq:                        int32(faq),
+		ViewerID:                     cd.UserID,
 	}); err != nil {
 		return fmt.Errorf("update faq question fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/faq/remove_question_task.go
+++ b/handlers/faq/remove_question_task.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 )
@@ -28,9 +29,13 @@ func (RemoveQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("faq id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 
-	if err := queries.DeleteFAQ(r.Context(), int32(faq)); err != nil {
+	if err := queries.DeleteFAQ(r.Context(), db.DeleteFAQParams{
+		Idfaq:    int32(faq),
+		ViewerID: cd.UserID,
+	}); err != nil {
 		return fmt.Errorf("delete faq fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 

--- a/handlers/faq/rename_category_task.go
+++ b/handlers/faq/rename_category_task.go
@@ -32,12 +32,14 @@ func (RenameCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if err := queries.RenameFAQCategory(r.Context(), db.RenameFAQCategoryParams{
 		Name: sql.NullString{
 			String: text,
 			Valid:  true,
 		},
 		Idfaqcategories: int32(cid),
+		ViewerID:        cd.UserID,
 	}); err != nil {
 		return fmt.Errorf("rename faq category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -105,7 +105,6 @@ func (q *Queries) GetForumThreadIdByNewsPostId(ctx context.Context, idsitenews i
 }
 
 const getNewsPostByIdWithWriterIdAndThreadCommentCount = `-- name: GetNewsPostByIdWithWriterIdAndThreadCommentCount :one
-
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
     UNION


### PR DESCRIPTION
## Summary
- add language & role filters in `GetFAQAnsweredQuestions`
- enforce admin rights for FAQ maintenance queries
- update handlers to pass viewer IDs
- regenerate sqlc code

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc96a464832fa2f4ef2d6d024b6f