### PR TITLE
Enforce admin checks on external link queries

### DIFF
--- a/cmd/goa4web/links_delete.go
+++ b/cmd/goa4web/links_delete.go
@@ -37,7 +37,7 @@ func (c *linksDeleteCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	if err := queries.DeleteExternalLink(ctx, int32(c.ID)); err != nil {
+	if err := queries.DeleteExternalLink(ctx, dbpkg.DeleteExternalLinkParams{ID: int32(c.ID), AdminID: 0}); err != nil {
 		return fmt.Errorf("delete link: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/links_refresh.go
+++ b/cmd/goa4web/links_refresh.go
@@ -38,7 +38,7 @@ func (c *linksRefreshCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	if err := queries.ClearExternalLinkCache(ctx, dbpkg.ClearExternalLinkCacheParams{UpdatedBy: sql.NullInt32{}, ID: int32(c.ID)}); err != nil {
+	if err := queries.ClearExternalLinkCache(ctx, dbpkg.ClearExternalLinkCacheParams{UpdatedBy: sql.NullInt32{}, AdminID: 0, ID: int32(c.ID)}); err != nil {
 		return fmt.Errorf("refresh link: %w", err)
 	}
 	return nil

--- a/handlers/admin/external_links_tasks.go
+++ b/handlers/admin/external_links_tasks.go
@@ -30,7 +30,7 @@ func (RefreshExternalLinkTask) Action(w http.ResponseWriter, r *http.Request) an
 	uid := sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.ClearExternalLinkCache(r.Context(), db.ClearExternalLinkCacheParams{UpdatedBy: uid, ID: int32(id)}); err != nil {
+		if err := queries.ClearExternalLinkCache(r.Context(), db.ClearExternalLinkCacheParams{UpdatedBy: uid, AdminID: uid.Int32, ID: int32(id)}); err != nil {
 			return fmt.Errorf("clear external link cache fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if evt := cd.Event(); evt != nil {
@@ -64,9 +64,10 @@ func (DeleteExternalLinkTask) Action(w http.ResponseWriter, r *http.Request) any
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	queries := cd.Queries()
+	uid := sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.DeleteExternalLink(r.Context(), int32(id)); err != nil {
+		if err := queries.DeleteExternalLink(r.Context(), db.DeleteExternalLinkParams{ID: int32(id), AdminID: uid.Int32}); err != nil {
 			return fmt.Errorf("delete external link fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if evt := cd.Event(); evt != nil {

--- a/internal/db/queries-externallinks.sql
+++ b/internal/db/queries-externallinks.sql
@@ -5,22 +5,28 @@ ON DUPLICATE KEY UPDATE clicks = clicks + 1;
 
 -- name: GetExternalLink :one
 SELECT * FROM external_links WHERE url = ? LIMIT 1;
-
 -- name: ListExternalLinks :many
 SELECT * FROM external_links
 ORDER BY created_at DESC
 LIMIT ? OFFSET ?;
-
--- name: GetExternalLinkByID :one
-SELECT * FROM external_links WHERE id = ? LIMIT 1;
-
--- name: UpdateExternalLink :exec
-UPDATE external_links
-SET url = ?, card_title = ?, card_description = ?, card_image = ?, card_image_cache = ?, favicon_cache = ?, updated_at = CURRENT_TIMESTAMP, updated_by = ?
-WHERE id = ?;
-
 -- name: DeleteExternalLink :exec
-DELETE FROM external_links WHERE id = ?;
+DELETE FROM external_links
+WHERE external_links.id = sqlc.arg(id)
+  AND EXISTS (
+    SELECT 1 FROM user_roles ur
+    JOIN roles r ON ur.role_id = r.id AND r.is_admin = 1
+    WHERE ur.users_idusers = sqlc.arg(admin_id)
+  );
 
 -- name: ClearExternalLinkCache :exec
-UPDATE external_links SET card_image_cache = NULL, favicon_cache = NULL, updated_at = CURRENT_TIMESTAMP, updated_by = ? WHERE id = ?;
+UPDATE external_links
+SET card_image_cache = NULL,
+    favicon_cache    = NULL,
+    updated_at       = CURRENT_TIMESTAMP,
+    updated_by       = sqlc.arg(updated_by)
+WHERE external_links.id = sqlc.arg(id)
+  AND EXISTS (
+    SELECT 1 FROM user_roles ur
+    JOIN roles r ON ur.role_id = r.id AND r.is_admin = 1
+    WHERE ur.users_idusers = sqlc.arg(admin_id)
+  );

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -105,7 +105,6 @@ func (q *Queries) GetForumThreadIdByNewsPostId(ctx context.Context, idsitenews i
 }
 
 const getNewsPostByIdWithWriterIdAndThreadCommentCount = `-- name: GetNewsPostByIdWithWriterIdAndThreadCommentCount :one
-
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
     UNION


### PR DESCRIPTION
## Summary
- add admin checks in external link SQL queries
- drop unused external link queries
- regenerate sqlc code
- update admin tasks and CLI commands for new parameters
- run gofmt, go vet, golangci-lint, and go test

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc9646e8832fa7907603632f8526