### PR TITLE
Mark dead letter queries as system

### DIFF
--- a/handlers/admin/adminDLQPage.go
+++ b/handlers/admin/adminDLQPage.go
@@ -63,15 +63,15 @@ func AdminDLQPage(w http.ResponseWriter, r *http.Request) {
 	for _, n := range names {
 		switch n {
 		case "db":
-			if rows, err := queries.ListDeadLetters(r.Context(), 100); err == nil {
+			if rows, err := queries.SystemListDeadLetters(r.Context(), 100); err == nil {
 				data.Errors = rows
 			} else {
 				log.Printf("list dead letters: %v", err)
 			}
-			if c, err := queries.CountDeadLetters(r.Context()); err == nil {
+			if c, err := queries.SystemCountDeadLetters(r.Context()); err == nil {
 				data.DBCount = c
 			}
-			if lt, err := queries.LatestDeadLetter(r.Context()); err == nil {
+			if lt, err := queries.SystemLatestDeadLetter(r.Context()); err == nil {
 				if t, ok := lt.(time.Time); ok {
 					data.DBLatest = t.Format(time.RFC3339)
 				}
@@ -123,7 +123,7 @@ func (DeleteDLQTask) Action(w http.ResponseWriter, r *http.Request) any {
 				continue
 			}
 			id, _ := strconv.Atoi(idStr)
-			if err := queries.DeleteDeadLetter(r.Context(), int32(id)); err != nil {
+			if err := queries.SystemDeleteDeadLetter(r.Context(), int32(id)); err != nil {
 				return fmt.Errorf("delete error %w", handlers.ErrRedirectOnSamePageHandler(err))
 			}
 			if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
@@ -143,7 +143,7 @@ func (DeleteDLQTask) Action(w http.ResponseWriter, r *http.Request) any {
 				t = tt
 			}
 		}
-		if err := queries.PurgeDeadLettersBefore(r.Context(), t); err != nil {
+		if err := queries.SystemPurgeDeadLettersBefore(r.Context(), t); err != nil {
 			return fmt.Errorf("purge errors %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/internal/db/queries-dlq.sql
+++ b/internal/db/queries-dlq.sql
@@ -1,19 +1,20 @@
--- name: InsertDeadLetter :exec
+-- System query only used internally
+-- name: SystemInsertDeadLetter :exec
 INSERT INTO dead_letters (message) VALUES (?);
 
--- name: ListDeadLetters :many
+-- name: SystemListDeadLetters :many
 SELECT id, message, created_at FROM dead_letters
 ORDER BY id DESC
 LIMIT ?;
 
--- name: DeleteDeadLetter :exec
+-- name: SystemDeleteDeadLetter :exec
 DELETE FROM dead_letters WHERE id = ?;
 
--- name: PurgeDeadLettersBefore :exec
+-- name: SystemPurgeDeadLettersBefore :exec
 DELETE FROM dead_letters WHERE created_at < ?;
 
--- name: CountDeadLetters :one
+-- name: SystemCountDeadLetters :one
 SELECT COUNT(*) FROM dead_letters;
 
--- name: LatestDeadLetter :one
+-- name: SystemLatestDeadLetter :one
 SELECT MAX(created_at) FROM dead_letters;

--- a/internal/db/queries-dlq.sql.go
+++ b/internal/db/queries-dlq.sql.go
@@ -10,54 +10,55 @@ import (
 	"time"
 )
 
-const countDeadLetters = `-- name: CountDeadLetters :one
+const systemCountDeadLetters = `-- name: SystemCountDeadLetters :one
 SELECT COUNT(*) FROM dead_letters
 `
 
-func (q *Queries) CountDeadLetters(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countDeadLetters)
+func (q *Queries) SystemCountDeadLetters(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, systemCountDeadLetters)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
 }
 
-const deleteDeadLetter = `-- name: DeleteDeadLetter :exec
+const systemDeleteDeadLetter = `-- name: SystemDeleteDeadLetter :exec
 DELETE FROM dead_letters WHERE id = ?
 `
 
-func (q *Queries) DeleteDeadLetter(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, deleteDeadLetter, id)
+func (q *Queries) SystemDeleteDeadLetter(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, systemDeleteDeadLetter, id)
 	return err
 }
 
-const insertDeadLetter = `-- name: InsertDeadLetter :exec
+const systemInsertDeadLetter = `-- name: SystemInsertDeadLetter :exec
 INSERT INTO dead_letters (message) VALUES (?)
 `
 
-func (q *Queries) InsertDeadLetter(ctx context.Context, message string) error {
-	_, err := q.db.ExecContext(ctx, insertDeadLetter, message)
+// System query only used internally
+func (q *Queries) SystemInsertDeadLetter(ctx context.Context, message string) error {
+	_, err := q.db.ExecContext(ctx, systemInsertDeadLetter, message)
 	return err
 }
 
-const latestDeadLetter = `-- name: LatestDeadLetter :one
+const systemLatestDeadLetter = `-- name: SystemLatestDeadLetter :one
 SELECT MAX(created_at) FROM dead_letters
 `
 
-func (q *Queries) LatestDeadLetter(ctx context.Context) (interface{}, error) {
-	row := q.db.QueryRowContext(ctx, latestDeadLetter)
+func (q *Queries) SystemLatestDeadLetter(ctx context.Context) (interface{}, error) {
+	row := q.db.QueryRowContext(ctx, systemLatestDeadLetter)
 	var max interface{}
 	err := row.Scan(&max)
 	return max, err
 }
 
-const listDeadLetters = `-- name: ListDeadLetters :many
+const systemListDeadLetters = `-- name: SystemListDeadLetters :many
 SELECT id, message, created_at FROM dead_letters
 ORDER BY id DESC
 LIMIT ?
 `
 
-func (q *Queries) ListDeadLetters(ctx context.Context, limit int32) ([]*DeadLetter, error) {
-	rows, err := q.db.QueryContext(ctx, listDeadLetters, limit)
+func (q *Queries) SystemListDeadLetters(ctx context.Context, limit int32) ([]*DeadLetter, error) {
+	rows, err := q.db.QueryContext(ctx, systemListDeadLetters, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -79,11 +80,11 @@ func (q *Queries) ListDeadLetters(ctx context.Context, limit int32) ([]*DeadLett
 	return items, nil
 }
 
-const purgeDeadLettersBefore = `-- name: PurgeDeadLettersBefore :exec
+const systemPurgeDeadLettersBefore = `-- name: SystemPurgeDeadLettersBefore :exec
 DELETE FROM dead_letters WHERE created_at < ?
 `
 
-func (q *Queries) PurgeDeadLettersBefore(ctx context.Context, createdAt time.Time) error {
-	_, err := q.db.ExecContext(ctx, purgeDeadLettersBefore, createdAt)
+func (q *Queries) SystemPurgeDeadLettersBefore(ctx context.Context, createdAt time.Time) error {
+	_, err := q.db.ExecContext(ctx, systemPurgeDeadLettersBefore, createdAt)
 	return err
 }

--- a/internal/dlq/db/db.go
+++ b/internal/dlq/db/db.go
@@ -17,7 +17,7 @@ func (d DLQ) Record(ctx context.Context, message string) error {
 	if d.Queries == nil {
 		return fmt.Errorf("no db")
 	}
-	return d.Queries.InsertDeadLetter(ctx, message)
+	return d.Queries.SystemInsertDeadLetter(ctx, message)
 }
 
 // Register registers the database provider.

--- a/internal/notifications/dlq.go
+++ b/internal/notifications/dlq.go
@@ -19,7 +19,7 @@ func (n *Notifier) dlqRecordAndNotify(ctx context.Context, q dlq.DLQ, msg string
 		return nil
 	}
 	if dbq, ok := q.(db.DLQ); ok {
-		if count, err := dbq.Queries.CountDeadLetters(ctx); err == nil {
+		if count, err := dbq.Queries.SystemCountDeadLetters(ctx); err == nil {
 			if isPow10(count) {
 				data := EmailData{
 					Item: struct {


### PR DESCRIPTION
## Summary
- mark the DLQ queries as System-only
- adjust code to use the new System query names
- regenerate sqlc output

## Testing
- `go vet ./...`
- `go mod tidy`
- `golangci-lint run ./...`
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc950eb8832f8a3f3ddb429e7e93