### PR TITLE
Refactor banned IP queries

### DIFF
--- a/cmd/goa4web/ipban_add.go
+++ b/cmd/goa4web/ipban_add.go
@@ -51,7 +51,7 @@ func (c *ipBanAddCmd) Run() error {
 		}
 		expires = sql.NullTime{Time: t, Valid: true}
 	}
-	err = queries.InsertBannedIp(ctx, dbpkg.InsertBannedIpParams{
+	err = queries.AdminInsertBannedIp(ctx, dbpkg.AdminInsertBannedIpParams{
 		IpNet:     c.IP,
 		Reason:    sql.NullString{String: c.Reason, Valid: c.Reason != ""},
 		ExpiresAt: expires,

--- a/cmd/goa4web/ipban_delete.go
+++ b/cmd/goa4web/ipban_delete.go
@@ -37,7 +37,7 @@ func (c *ipBanDeleteCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	if err := queries.CancelBannedIp(ctx, c.IP); err != nil {
+	if err := queries.AdminCancelBannedIp(ctx, c.IP); err != nil {
 		return fmt.Errorf("cancel banned ip: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/ipban_list.go
+++ b/cmd/goa4web/ipban_list.go
@@ -31,7 +31,7 @@ func (c *ipBanListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	rows, err := queries.ListBannedIps(ctx)
+	rows, err := queries.AdminListBannedIps(ctx)
 	if err != nil {
 		return fmt.Errorf("list banned ips: %w", err)
 	}

--- a/cmd/goa4web/ipban_update.go
+++ b/cmd/goa4web/ipban_update.go
@@ -51,7 +51,7 @@ func (c *ipBanUpdateCmd) Run() error {
 		}
 		expires = sql.NullTime{Time: t, Valid: true}
 	}
-	err = queries.UpdateBannedIp(ctx, dbpkg.UpdateBannedIpParams{
+	err = queries.AdminUpdateBannedIp(ctx, dbpkg.AdminUpdateBannedIpParams{
 		Reason:    sql.NullString{String: c.Reason, Valid: c.Reason != ""},
 		ExpiresAt: expires,
 		ID:        int32(c.ID),

--- a/handlers/admin/add_ip_ban_task.go
+++ b/handlers/admin/add_ip_ban_task.go
@@ -39,7 +39,7 @@ func (AddIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	if ipNet != "" {
-		if err := queries.InsertBannedIp(r.Context(), db.InsertBannedIpParams{
+		if err := queries.AdminInsertBannedIp(r.Context(), db.AdminInsertBannedIpParams{
 			IpNet:     ipNet,
 			Reason:    sql.NullString{String: reason, Valid: reason != ""},
 			ExpiresAt: expires,

--- a/handlers/admin/adminIPBanPage.go
+++ b/handlers/admin/adminIPBanPage.go
@@ -22,7 +22,7 @@ func AdminIPBanPage(w http.ResponseWriter, r *http.Request) {
 	cd.PageTitle = "IP Bans"
 	data := Data{CoreData: cd}
 	queries := cd.Queries()
-	rows, err := queries.ListBannedIps(r.Context())
+	rows, err := queries.AdminListBannedIps(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list banned ips: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/delete_ip_ban_task.go
+++ b/handlers/admin/delete_ip_ban_task.go
@@ -30,7 +30,7 @@ func (DeleteIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {
 	var ips []string
 	for _, ip := range r.Form["ip"] {
 		ipNet := NormalizeIPNet(ip)
-		if err := queries.CancelBannedIp(r.Context(), ipNet); err != nil {
+		if err := queries.AdminCancelBannedIp(r.Context(), ipNet); err != nil {
 			return fmt.Errorf("cancel banned ip %s fail %w", ipNet, handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if ipNet != "" {

--- a/internal/db/queries-banned_ips.sql
+++ b/internal/db/queries-banned_ips.sql
@@ -1,16 +1,24 @@
--- name: InsertBannedIp :exec
+-- name: AdminInsertBannedIp :exec
+-- admin task
 INSERT INTO banned_ips (ip_net, reason, expires_at)
 VALUES (?, ?, ?);
 
--- name: UpdateBannedIp :exec
+-- name: AdminUpdateBannedIp :exec
+-- admin task
 UPDATE banned_ips SET reason = ?, expires_at = ? WHERE id = ?;
 
--- name: CancelBannedIp :exec
+-- name: AdminCancelBannedIp :exec
+-- admin task
 UPDATE banned_ips SET canceled_at = CURRENT_TIMESTAMP WHERE ip_net = ? AND canceled_at IS NULL;
 
 
--- name: ListActiveBans :many
-SELECT * FROM banned_ips WHERE canceled_at IS NULL AND (expires_at IS NULL OR expires_at > NOW());
+-- name: SystemListActiveBans :many
+SELECT ip_net
+FROM banned_ips
+WHERE canceled_at IS NULL AND (expires_at IS NULL OR expires_at > NOW());
 
--- name: ListBannedIps :many
-SELECT * FROM banned_ips ORDER BY created_at DESC;
+-- name: AdminListBannedIps :many
+-- admin task
+SELECT id, ip_net, reason, created_at, expires_at, canceled_at
+FROM banned_ips
+ORDER BY created_at DESC;

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -47,20 +47,20 @@ func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ip := requestIP(r)
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-			bans, err := cd.Queries().ListActiveBans(r.Context())
+			bans, err := cd.Queries().SystemListActiveBans(r.Context())
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 				return
 			}
 			addr, parseErr := netip.ParseAddr(ip)
 			if parseErr == nil {
-				for _, b := range bans {
-					if p, err := netip.ParsePrefix(b.IpNet); err == nil {
+				for _, ipnet := range bans {
+					if p, err := netip.ParsePrefix(ipnet); err == nil {
 						if p.Contains(addr) {
 							http.Error(w, "Forbidden", http.StatusForbidden)
 							return
 						}
-					} else if b.IpNet == ip {
+					} else if ipnet == ip {
 						http.Error(w, "Forbidden", http.StatusForbidden)
 						return
 					}


### PR DESCRIPTION
## Summary
- mark banned IP queries as admin or system functions
- restrict IP ban operations to admin calls
- trim returned columns from active ban lookup
- update Go code for new query names

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc90f2c8832faba648b9045760cc