### PR TITLE
Ensure audit log queries are admin-only

### DIFF
--- a/handlers/admin/adminAuditLogPage.go
+++ b/handlers/admin/adminAuditLogPage.go
@@ -26,7 +26,7 @@ func copyValues(v url.Values) url.Values {
 func AdminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		Rows     []*db.ListAuditLogsRow
+		Rows     []*db.AdminListAuditLogsRow
 		User     string
 		Action   string
 		NextLink string
@@ -55,7 +55,7 @@ func AdminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 		actionFilter = "%" + data.Action + "%"
 	}
 
-	rows, err := queries.ListAuditLogs(r.Context(), db.ListAuditLogsParams{
+	rows, err := queries.AdminListAuditLogs(r.Context(), db.AdminListAuditLogsParams{
 		Username: sql.NullString{String: usernameFilter, Valid: true},
 		Action:   actionFilter,
 		Limit:    int32(data.PageSize + 1),

--- a/internal/db/queries-auditlog.sql
+++ b/internal/db/queries-auditlog.sql
@@ -1,7 +1,10 @@
--- name: InsertAuditLog :exec
-INSERT INTO audit_log (users_idusers, action, path, details, data) VALUES (?, ?, ?, ?, ?);
+-- name: AdminInsertAuditLog :exec
+-- admin task
+INSERT INTO audit_log (users_idusers, action, path, details, data)
+VALUES (?, ?, ?, ?, ?);
 
--- name: ListAuditLogs :many
+-- name: AdminListAuditLogs :many
+-- admin task
 SELECT a.id, a.users_idusers, a.action, a.path, a.details, a.data, a.created_at, u.username
 FROM audit_log a
 LEFT JOIN users u ON a.users_idusers = u.idusers

--- a/internal/db/queries-auditlog.sql.go
+++ b/internal/db/queries-auditlog.sql.go
@@ -11,11 +11,12 @@ import (
 	"time"
 )
 
-const insertAuditLog = `-- name: InsertAuditLog :exec
-INSERT INTO audit_log (users_idusers, action, path, details, data) VALUES (?, ?, ?, ?, ?)
+const adminInsertAuditLog = `-- name: AdminInsertAuditLog :exec
+INSERT INTO audit_log (users_idusers, action, path, details, data)
+VALUES (?, ?, ?, ?, ?)
 `
 
-type InsertAuditLogParams struct {
+type AdminInsertAuditLogParams struct {
 	UsersIdusers int32
 	Action       string
 	Path         string
@@ -23,8 +24,9 @@ type InsertAuditLogParams struct {
 	Data         sql.NullString
 }
 
-func (q *Queries) InsertAuditLog(ctx context.Context, arg InsertAuditLogParams) error {
-	_, err := q.db.ExecContext(ctx, insertAuditLog,
+// admin task
+func (q *Queries) AdminInsertAuditLog(ctx context.Context, arg AdminInsertAuditLogParams) error {
+	_, err := q.db.ExecContext(ctx, adminInsertAuditLog,
 		arg.UsersIdusers,
 		arg.Action,
 		arg.Path,
@@ -34,7 +36,7 @@ func (q *Queries) InsertAuditLog(ctx context.Context, arg InsertAuditLogParams) 
 	return err
 }
 
-const listAuditLogs = `-- name: ListAuditLogs :many
+const adminListAuditLogs = `-- name: AdminListAuditLogs :many
 SELECT a.id, a.users_idusers, a.action, a.path, a.details, a.data, a.created_at, u.username
 FROM audit_log a
 LEFT JOIN users u ON a.users_idusers = u.idusers
@@ -43,14 +45,14 @@ ORDER BY a.id DESC
 LIMIT ? OFFSET ?
 `
 
-type ListAuditLogsParams struct {
+type AdminListAuditLogsParams struct {
 	Username sql.NullString
 	Action   string
 	Limit    int32
 	Offset   int32
 }
 
-type ListAuditLogsRow struct {
+type AdminListAuditLogsRow struct {
 	ID           int32
 	UsersIdusers int32
 	Action       string
@@ -61,8 +63,9 @@ type ListAuditLogsRow struct {
 	Username     sql.NullString
 }
 
-func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([]*ListAuditLogsRow, error) {
-	rows, err := q.db.QueryContext(ctx, listAuditLogs,
+// admin task
+func (q *Queries) AdminListAuditLogs(ctx context.Context, arg AdminListAuditLogsParams) ([]*AdminListAuditLogsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListAuditLogs,
 		arg.Username,
 		arg.Action,
 		arg.Limit,
@@ -72,9 +75,9 @@ func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*ListAuditLogsRow
+	var items []*AdminListAuditLogsRow
 	for rows.Next() {
-		var i ListAuditLogsRow
+		var i AdminListAuditLogsRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.UsersIdusers,

--- a/workers/auditworker/worker.go
+++ b/workers/auditworker/worker.go
@@ -34,7 +34,7 @@ func Worker(ctx context.Context, bus *eventbus.Bus, q *dbpkg.Queries) {
 			}
 			details := aud.AuditRecord(evt.Data)
 			data, _ := json.Marshal(evt.Data)
-			if err := q.InsertAuditLog(ctx, dbpkg.InsertAuditLogParams{
+			if err := q.AdminInsertAuditLog(ctx, dbpkg.AdminInsertAuditLogParams{
 				UsersIdusers: evt.UserID,
 				Action:       named.Name(),
 				Path:         evt.Path,


### PR DESCRIPTION
## Summary
- restrict audit log queries so only admins may execute them
- update admin page and worker to use the new admin queries
- regenerate sqlc output

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc8f8800832f8aeb6510265de27f