### PR TITLE
Fix admin comment handling

### DIFF
--- a/handlers/auth/email_association_request_task.go
+++ b/handlers/auth/email_association_request_task.go
@@ -54,7 +54,6 @@ func (EmailAssociationRequestTask) Action(w http.ResponseWriter, r *http.Request
 	}
 	id, _ := res.LastInsertId()
 	_ = queries.InsertAdminRequestComment(r.Context(), db.InsertAdminRequestCommentParams{RequestID: int32(id), Comment: reason})
-	_ = queries.InsertAdminUserComment(r.Context(), db.InsertAdminUserCommentParams{UsersIdusers: row.Idusers, Comment: "email association requested"})
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 		if evt := cd.Event(); evt != nil {
 			if evt.Data == nil {

--- a/handlers/auth/forgotPassword_no_email_test.go
+++ b/handlers/auth/forgotPassword_no_email_test.go
@@ -53,7 +53,6 @@ func TestEmailAssociationRequestTask(t *testing.T) {
 	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "", "u", nil))
 	mock.ExpectExec("INSERT INTO admin_request_queue").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO admin_request_comments").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("INSERT INTO admin_user_comments").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -105,7 +105,6 @@ func (q *Queries) GetForumThreadIdByNewsPostId(ctx context.Context, idsitenews i
 }
 
 const getNewsPostByIdWithWriterIdAndThreadCommentCount = `-- name: GetNewsPostByIdWithWriterIdAndThreadCommentCount :one
-
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
     UNION


### PR DESCRIPTION
## Summary
- ensure admin user comments aren't created by user-level tasks
- update tests for admin user comment removal
- regenerate SQL code

## Testing
- `sqlc generate`
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc8f3004832fb71257feee250c7b