### PR TITLE
Add explicit admin checks for announcement tasks

### DIFF
--- a/handlers/admin/add_announcement_task.go
+++ b/handlers/admin/add_announcement_task.go
@@ -24,7 +24,14 @@ var _ tasks.AuditableTask = (*AddAnnouncementTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*AddAnnouncementTask)(nil)
 
 func (AddAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd == nil || !cd.HasRole("administrator") {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+		})
+	}
+
+	queries := cd.Queries()
 	nid, err := strconv.Atoi(r.PostFormValue("news_id"))
 	if err != nil {
 		return fmt.Errorf("news id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/admin/delete_announcement_task.go
+++ b/handlers/admin/delete_announcement_task.go
@@ -24,7 +24,14 @@ var _ tasks.AuditableTask = (*DeleteAnnouncementTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*DeleteAnnouncementTask)(nil)
 
 func (DeleteAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd == nil || !cd.HasRole("administrator") {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+		})
+	}
+
+	queries := cd.Queries()
 	if err := r.ParseForm(); err != nil {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/news/announcement_add_task.go
+++ b/handlers/news/announcement_add_task.go
@@ -24,8 +24,14 @@ var announcementAddTask = &AnnouncementAddTask{TaskString: TaskAdd}
 var _ tasks.Task = (*AnnouncementAddTask)(nil)
 
 func (AnnouncementAddTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd == nil || !cd.HasRole("administrator") {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+		})
+	}
+
+	queries := cd.Queries()
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
 

--- a/handlers/news/announcement_delete_task.go
+++ b/handlers/news/announcement_delete_task.go
@@ -24,8 +24,14 @@ var announcementDeleteTask = &AnnouncementDeleteTask{TaskString: TaskDelete}
 var _ tasks.Task = (*AnnouncementDeleteTask)(nil)
 
 func (AnnouncementDeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd == nil || !cd.HasRole("administrator") {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+		})
+	}
+
+	queries := cd.Queries()
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
 


### PR DESCRIPTION
## Summary
- enforce admin role checks when promoting or demoting announcements

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc8eab14832f9169eaf46c5bd537