### PR TITLE
Add role edit page

### DIFF
--- a/core/templates/site/admin/adminRolePage.gohtml
+++ b/core/templates/site/admin/adminRolePage.gohtml
@@ -1,5 +1,6 @@
 {{ template "head" $ }}
 <h2>Role {{ .Role.Name }} (ID {{ .Role.ID }})</h2>
+<p><a href="/admin/role/{{ .Role.ID }}/edit">Edit Role</a></p>
 <table border="1">
     <tr><th>Can Login</th><th>Is Admin</th><th>Public Profiles</th></tr>
     <tr>

--- a/core/templates/site/admin/roleEditPage.gohtml
+++ b/core/templates/site/admin/roleEditPage.gohtml
@@ -1,0 +1,11 @@
+{{ template "head" $ }}
+[<a href="/admin">Admin:</a> <a href="/admin/roles">Roles</a>: <a href="/admin/role/{{.Role.ID}}/edit">(This page/Refresh)</a>]<br />
+<form method="post">
+    {{ csrfField }}
+    <input type="hidden" name="id" value="{{.Role.ID}}">
+    Name: <input name="name" value="{{.Role.Name}}"><br>
+    Can Login: <input type="checkbox" name="can_login" {{if .Role.CanLogin}}checked{{end}}><br>
+    Is Admin: <input type="checkbox" name="is_admin" {{if .Role.IsAdmin}}checked{{end}}><br>
+    <input type="submit" value="Save">
+</form>
+{{ template "tail" $ }}

--- a/core/templates/site/admin/rolesPage.gohtml
+++ b/core/templates/site/admin/rolesPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <table border="1">
-    <tr><th>ID</th><th>Name</th><th>Can Login</th><th>Is Admin</th><th>Public Profiles</th></tr>
+    <tr><th>ID</th><th>Name</th><th>Can Login</th><th>Is Admin</th><th>Public Profiles</th><th>Edit</th></tr>
     {{- range .Roles }}
     <tr>
         <td><a href="/admin/role/{{ .ID }}">{{ .ID }}</a></td>
@@ -22,6 +22,7 @@
                 {{ end }}
             </form>
         </td>
+        <td><a href="/admin/role/{{ .ID }}/edit">Edit</a></td>
     </tr>
     {{- end }}
 </table>

--- a/handlers/admin/adminRoleEditPage.go
+++ b/handlers/admin/adminRoleEditPage.go
@@ -1,0 +1,60 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// adminRoleEditFormPage shows a form to update a role.
+func adminRoleEditFormPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	idStr := mux.Vars(r)["id"]
+	id, _ := strconv.Atoi(idStr)
+
+	role, err := queries.GetRoleByID(r.Context(), int32(id))
+	if err != nil {
+		http.Error(w, "role not found", http.StatusNotFound)
+		return
+	}
+	cd.PageTitle = fmt.Sprintf("Edit Role %s", role.Name)
+	data := struct {
+		*common.CoreData
+		Role *db.Role
+	}{CoreData: cd, Role: role}
+	handlers.TemplateHandler(w, r, "roleEditPage.gohtml", data)
+}
+
+// adminRoleEditSavePage persists role updates.
+func adminRoleEditSavePage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	idStr := mux.Vars(r)["id"]
+	id, _ := strconv.Atoi(idStr)
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+	name := r.PostFormValue("name")
+	canLogin := r.PostFormValue("can_login") != ""
+	isAdmin := r.PostFormValue("is_admin") != ""
+
+	data := struct {
+		*common.CoreData
+		Errors []string
+		Back   string
+	}{CoreData: cd, Back: fmt.Sprintf("/admin/role/%d", id)}
+
+	if _, err := queries.DB().ExecContext(r.Context(), "UPDATE roles SET name=?, can_login=?, is_admin=? WHERE id=?", name, canLogin, isAdmin, id); err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("update role: %w", err).Error())
+	}
+	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
+}

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -82,6 +82,8 @@ func (h *Handlers) RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navRe
 	ar.HandleFunc("/user/{id}/subscriptions", adminUserSubscriptionsPage).Methods("GET")
 	ar.HandleFunc("/user/{id}/comment", adminUserAddCommentPage).Methods("POST")
 	ar.HandleFunc("/role/{id}", adminRolePage).Methods("GET")
+	ar.HandleFunc("/role/{id}/edit", adminRoleEditFormPage).Methods("GET")
+	ar.HandleFunc("/role/{id}/edit", adminRoleEditSavePage).Methods("POST")
 	ar.HandleFunc("/role/{id}/grant", handlers.TaskHandler(roleGrantCreateTask)).Methods("POST").MatcherFunc(roleGrantCreateTask.Matcher())
 	ar.HandleFunc("/grant/delete", handlers.TaskHandler(roleGrantDeleteTask)).Methods("POST").MatcherFunc(roleGrantDeleteTask.Matcher())
 	ar.HandleFunc("/user/{id}/reset", adminUserResetPasswordConfirmPage).Methods("GET")


### PR DESCRIPTION
## Summary
- add handler for editing role details
- provide admin template for the new form
- link edit page from role detail and list views
- register routes for role editing

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc3359c0832fb3f68fcacdd7c7b5