### PR TITLE
Update comment queries with filters

### DIFF
--- a/handlers/admin/adminCommentsPage.go
+++ b/handlers/admin/adminCommentsPage.go
@@ -14,7 +14,11 @@ func AdminCommentsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Comments"
 	queries := cd.Queries()
-	rows, err := queries.AdminListAllCommentsWithThreadInfo(r.Context(), db.AdminListAllCommentsWithThreadInfoParams{Limit: 50, Offset: 0})
+	rows, err := queries.AdminListAllCommentsWithThreadInfo(r.Context(), db.AdminListAllCommentsWithThreadInfoParams{
+		ViewerID: cd.UserID,
+		Limit:    50,
+		Offset:   0,
+	})
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/blogs/blogsCommentPage_replyable_test.go
+++ b/handlers/blogs/blogsCommentPage_replyable_test.go
@@ -64,7 +64,7 @@ func TestCommentPageLockedThreadDisablesReply(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(int32(2), int32(1), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(threadRows)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
-		WithArgs(int32(2), int32(2), int32(1), sql.NullInt32{Int32: 2, Valid: true}).
+		WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).
 		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "deleted_at", "posterusername"}))
 
 	rr := httptest.NewRecorder()
@@ -104,7 +104,7 @@ func TestCommentPageUnlockedThreadShowsReply(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(int32(2), int32(1), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(threadRows)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
-		WithArgs(int32(2), int32(2), int32(1), sql.NullInt32{Int32: 2, Valid: true}).
+		WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).
 		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "deleted_at", "posterusername"}))
 
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- apply language & permission filters to comment listings
- require admin permission in admin comment queries
- adjust CLI/admin handlers for new parameters
- drop unused GetCommentsByIds query
- update tests and regenerate sqlc code
- remove unnecessary viewer check from admin comment query

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc93b064832f9a9d738643ea4c59