### PR TITLE
Classify login attempts queries

### DIFF
--- a/handlers/auth/login_task.go
+++ b/handlers/auth/login_task.go
@@ -53,7 +53,7 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 	ip := strings.Split(r.RemoteAddr, ":")[0]
 	if cfg.LoginAttemptThreshold > 0 {
 		since := time.Now().Add(-time.Duration(cfg.LoginAttemptWindow) * time.Minute)
-		cnt, err := queries.CountRecentLoginAttempts(r.Context(), db.CountRecentLoginAttemptsParams{Username: username, IpAddress: ip, CreatedAt: since})
+		cnt, err := queries.SystemCountRecentLoginAttempts(r.Context(), db.SystemCountRecentLoginAttemptsParams{Username: username, IpAddress: ip, CreatedAt: since})
 		if err != nil {
 			log.Printf("count login attempts: %v", err)
 		} else if cnt >= int64(cfg.LoginAttemptThreshold) {
@@ -64,7 +64,7 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 	row, err := queries.Login(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			if err := queries.InsertLoginAttempt(r.Context(), db.InsertLoginAttemptParams{Username: username, IpAddress: strings.Split(r.RemoteAddr, ":")[0]}); err != nil {
+			if err := queries.SystemInsertLoginAttempt(r.Context(), db.SystemInsertLoginAttemptParams{Username: username, IpAddress: strings.Split(r.RemoteAddr, ":")[0]}); err != nil {
 				log.Printf("insert login attempt: %v", err)
 			}
 			return loginFormHandler{msg: "No such user"}
@@ -94,7 +94,7 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 				return handlers.TemplateWithDataHandler("passwordVerifyPage.gohtml", data)
 			}
 		} else {
-			if err := queries.InsertLoginAttempt(r.Context(), db.InsertLoginAttemptParams{Username: username, IpAddress: strings.Split(r.RemoteAddr, ":")[0]}); err != nil {
+			if err := queries.SystemInsertLoginAttempt(r.Context(), db.SystemInsertLoginAttemptParams{Username: username, IpAddress: strings.Split(r.RemoteAddr, ":")[0]}); err != nil {
 				log.Printf("insert login attempt: %v", err)
 			}
 			return loginFormHandler{msg: "Invalid password"}

--- a/handlers/user/admin_loginattempts.go
+++ b/handlers/user/admin_loginattempts.go
@@ -18,7 +18,7 @@ func adminLoginAttemptsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data := Data{CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData)}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	items, err := queries.ListLoginAttempts(r.Context())
+	items, err := queries.AdminListLoginAttempts(r.Context())
 	if err != nil {
 		log.Printf("list login attempts: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/internal/db/queries-login_attempts.sql
+++ b/internal/db/queries-login_attempts.sql
@@ -1,13 +1,13 @@
--- name: InsertLoginAttempt :exec
+-- name: SystemInsertLoginAttempt :exec
 INSERT INTO login_attempts (username, ip_address)
 VALUES (?, ?);
 
--- name: ListLoginAttempts :many
-SELECT *
+-- name: AdminListLoginAttempts :many
+SELECT id, username, ip_address, created_at
 FROM login_attempts
 ORDER BY id DESC;
 
 
--- name: CountRecentLoginAttempts :one
+-- name: SystemCountRecentLoginAttempts :one
 SELECT COUNT(*) FROM login_attempts
 WHERE (username = ? OR ip_address = ?) AND created_at > ?;

--- a/internal/db/queries-login_attempts.sql.go
+++ b/internal/db/queries-login_attempts.sql.go
@@ -10,47 +10,14 @@ import (
 	"time"
 )
 
-const countRecentLoginAttempts = `-- name: CountRecentLoginAttempts :one
-SELECT COUNT(*) FROM login_attempts
-WHERE (username = ? OR ip_address = ?) AND created_at > ?
-`
-
-type CountRecentLoginAttemptsParams struct {
-	Username  string
-	IpAddress string
-	CreatedAt time.Time
-}
-
-func (q *Queries) CountRecentLoginAttempts(ctx context.Context, arg CountRecentLoginAttemptsParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countRecentLoginAttempts, arg.Username, arg.IpAddress, arg.CreatedAt)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
-}
-
-const insertLoginAttempt = `-- name: InsertLoginAttempt :exec
-INSERT INTO login_attempts (username, ip_address)
-VALUES (?, ?)
-`
-
-type InsertLoginAttemptParams struct {
-	Username  string
-	IpAddress string
-}
-
-func (q *Queries) InsertLoginAttempt(ctx context.Context, arg InsertLoginAttemptParams) error {
-	_, err := q.db.ExecContext(ctx, insertLoginAttempt, arg.Username, arg.IpAddress)
-	return err
-}
-
-const listLoginAttempts = `-- name: ListLoginAttempts :many
+const adminListLoginAttempts = `-- name: AdminListLoginAttempts :many
 SELECT id, username, ip_address, created_at
 FROM login_attempts
 ORDER BY id DESC
 `
 
-func (q *Queries) ListLoginAttempts(ctx context.Context) ([]*LoginAttempt, error) {
-	rows, err := q.db.QueryContext(ctx, listLoginAttempts)
+func (q *Queries) AdminListLoginAttempts(ctx context.Context) ([]*LoginAttempt, error) {
+	rows, err := q.db.QueryContext(ctx, adminListLoginAttempts)
 	if err != nil {
 		return nil, err
 	}
@@ -75,4 +42,37 @@ func (q *Queries) ListLoginAttempts(ctx context.Context) ([]*LoginAttempt, error
 		return nil, err
 	}
 	return items, nil
+}
+
+const systemCountRecentLoginAttempts = `-- name: SystemCountRecentLoginAttempts :one
+SELECT COUNT(*) FROM login_attempts
+WHERE (username = ? OR ip_address = ?) AND created_at > ?
+`
+
+type SystemCountRecentLoginAttemptsParams struct {
+	Username  string
+	IpAddress string
+	CreatedAt time.Time
+}
+
+func (q *Queries) SystemCountRecentLoginAttempts(ctx context.Context, arg SystemCountRecentLoginAttemptsParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, systemCountRecentLoginAttempts, arg.Username, arg.IpAddress, arg.CreatedAt)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const systemInsertLoginAttempt = `-- name: SystemInsertLoginAttempt :exec
+INSERT INTO login_attempts (username, ip_address)
+VALUES (?, ?)
+`
+
+type SystemInsertLoginAttemptParams struct {
+	Username  string
+	IpAddress string
+}
+
+func (q *Queries) SystemInsertLoginAttempt(ctx context.Context, arg SystemInsertLoginAttemptParams) error {
+	_, err := q.db.ExecContext(ctx, systemInsertLoginAttempt, arg.Username, arg.IpAddress)
+	return err
 }


### PR DESCRIPTION
## Summary
- rename login attempt queries using `Admin`/`System` prefixes instead of comments
- update auth and admin handlers for new query names and regenerate sqlc code

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc9baf50832f9a70fa6efcc1a248