### PR TITLE
Add user notification filters

### DIFF
--- a/handlers/admin/purge_notifications_task.go
+++ b/handlers/admin/purge_notifications_task.go
@@ -21,7 +21,7 @@ var _ tasks.AuditableTask = (*PurgeNotificationsTask)(nil)
 
 func (PurgeNotificationsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	if err := queries.PurgeReadNotifications(r.Context()); err != nil {
+	if err := queries.AdminPurgeReadNotifications(r.Context()); err != nil {
 		return fmt.Errorf("purge notifications fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/purge_read_notifications_task.go
+++ b/handlers/admin/purge_read_notifications_task.go
@@ -20,7 +20,7 @@ var _ tasks.AuditableTask = (*PurgeReadNotificationsTask)(nil)
 
 func (PurgeReadNotificationsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	if err := queries.PurgeReadNotifications(r.Context()); err != nil {
+	if err := queries.AdminPurgeReadNotifications(r.Context()); err != nil {
 		return fmt.Errorf("purge notifications fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -105,7 +105,6 @@ func (q *Queries) GetForumThreadIdByNewsPostId(ctx context.Context, idsitenews i
 }
 
 const getNewsPostByIdWithWriterIdAndThreadCommentCount = `-- name: GetNewsPostByIdWithWriterIdAndThreadCommentCount :one
-
 WITH RECURSIVE role_ids(id) AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
     UNION

--- a/internal/db/queries-notifications.sql
+++ b/internal/db/queries-notifications.sql
@@ -12,6 +12,20 @@ FROM notifications
 WHERE users_idusers = ? AND read_at IS NULL
 ORDER BY id DESC;
 
+-- name: ListUserNotifications :many
+SELECT id, users_idusers, link, message, created_at, read_at
+FROM notifications
+WHERE users_idusers = ?
+ORDER BY id DESC
+LIMIT ? OFFSET ?;
+
+-- name: ListUserUnreadNotifications :many
+SELECT id, users_idusers, link, message, created_at, read_at
+FROM notifications
+WHERE users_idusers = ? AND read_at IS NULL
+ORDER BY id DESC
+LIMIT ? OFFSET ?;
+
 -- name: MarkNotificationRead :exec
 UPDATE notifications SET read_at = NOW() WHERE id = ?;
 
@@ -26,7 +40,7 @@ SELECT id, users_idusers, link, message, created_at, read_at
 FROM notifications
 WHERE id = ?;
 
--- name: PurgeReadNotifications :exec
+-- name: AdminPurgeReadNotifications :exec
 DELETE FROM notifications
 WHERE read_at IS NOT NULL AND read_at < (NOW() - INTERVAL 24 HOUR);
 

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -37,7 +37,7 @@ func TestNotificationsQueries(t *testing.T) {
 		t.Fatalf("mark: %v", err)
 	}
 	mock.ExpectExec("DELETE FROM notifications").WillReturnResult(sqlmock.NewResult(1, 1))
-	if err := q.PurgeReadNotifications(context.Background()); err != nil {
+	if err := q.AdminPurgeReadNotifications(context.Background()); err != nil {
 		t.Fatalf("purge: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -170,7 +170,7 @@ func (n *Notifier) NotificationPurgeWorker(ctx context.Context, interval time.Du
 	for {
 		select {
 		case <-ticker.C:
-			if err := n.Queries.PurgeReadNotifications(ctx); err != nil {
+			if err := n.Queries.AdminPurgeReadNotifications(ctx); err != nil {
 				log.Printf("purge notifications: %v", err)
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
## Summary
- add paginated queries for listing user notifications and wire them into the notification page
- prefix read notification purge query with `Admin` and update callers
- regenerate sqlc code and format the repo

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc9d7574832f8ed08c0f7ce4d83d