### PR TITLE
Update pending email queries with filters

### DIFF
--- a/cmd/goa4web/email_queue_delete.go
+++ b/cmd/goa4web/email_queue_delete.go
@@ -36,7 +36,7 @@ func (c *emailQueueDeleteCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	if err := queries.DeletePendingEmail(ctx, int32(c.ID)); err != nil {
+	if err := queries.AdminDeletePendingEmail(ctx, int32(c.ID)); err != nil {
 		return fmt.Errorf("delete email: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/email_queue_list.go
+++ b/cmd/goa4web/email_queue_list.go
@@ -34,7 +34,7 @@ func (c *emailQueueListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	rows, err := queries.ListUnsentPendingEmails(ctx)
+	rows, err := queries.AdminListUnsentPendingEmails(ctx, dbpkg.AdminListUnsentPendingEmailsParams{})
 	if err != nil {
 		return fmt.Errorf("list emails: %w", err)
 	}

--- a/cmd/goa4web/email_queue_resend.go
+++ b/cmd/goa4web/email_queue_resend.go
@@ -37,7 +37,7 @@ func (c *emailQueueResendCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := dbpkg.New(db)
-	e, err := queries.GetPendingEmailByID(ctx, int32(c.ID))
+	e, err := queries.AdminGetPendingEmailByID(ctx, int32(c.ID))
 	if err != nil {
 		return fmt.Errorf("get email: %w", err)
 	}

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"net/mail"
+	"strconv"
 	"strings"
 
 	"github.com/arran4/goa4web/core/common"
@@ -14,7 +15,7 @@ import (
 
 func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 	type EmailItem struct {
-		*db.ListUnsentPendingEmailsRow
+		*db.AdminListUnsentPendingEmailsRow
 		Email   string
 		Subject string
 	}
@@ -28,7 +29,12 @@ func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 		CoreData: cd,
 	}
 	queries := cd.Queries()
-	rows, err := queries.ListUnsentPendingEmails(r.Context())
+	langID, _ := strconv.Atoi(r.URL.Query().Get("lang"))
+	role := r.URL.Query().Get("role")
+	rows, err := queries.AdminListUnsentPendingEmails(r.Context(), db.AdminListUnsentPendingEmailsParams{
+		LanguageID: int32(langID),
+		RoleName:   role,
+	})
 	if err != nil {
 		log.Printf("list pending emails: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -83,7 +83,7 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 	}
 }
 
-func TestListUnsentPendingEmails(t *testing.T) {
+func TestAdminListUnsentPendingEmails(t *testing.T) {
 	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
@@ -91,8 +91,8 @@ func TestListUnsentPendingEmails(t *testing.T) {
 	defer sqldb.Close()
 	q := db.New(sqldb)
 	rows := sqlmock.NewRows([]string{"id", "to_user_id", "body", "error_count", "created_at", "direct_email"}).AddRow(1, 2, "b", 0, time.Now(), false)
-	mock.ExpectQuery("SELECT id, to_user_id, body, error_count, created_at, direct_email FROM pending_emails WHERE sent_at IS NULL ORDER BY id").WillReturnRows(rows)
-	if _, err := q.ListUnsentPendingEmails(context.Background()); err != nil {
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT pe.id, pe.to_user_id, pe.body, pe.error_count, pe.created_at, pe.direct_email FROM pending_emails pe LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers LEFT JOIN roles r ON ur.role_id = r.id WHERE pe.sent_at IS NULL   AND (? IS NULL OR p.language_idlanguage = ?)   AND (? IS NULL OR r.name = ?) ORDER BY pe.id")).WillReturnRows(rows)
+	if _, err := q.AdminListUnsentPendingEmails(context.Background(), db.AdminListUnsentPendingEmailsParams{}); err != nil {
 		t.Fatalf("list: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/handlers/admin/delete_queue_task.go
+++ b/handlers/admin/delete_queue_task.go
@@ -28,7 +28,7 @@ func (DeleteQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.DeletePendingEmail(r.Context(), int32(id)); err != nil {
+		if err := queries.AdminDeletePendingEmail(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("delete email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/resend_queue_task.go
+++ b/handlers/admin/resend_queue_task.go
@@ -30,11 +30,11 @@ func (ResendQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err := r.ParseForm(); err != nil {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	var emails []*db.GetPendingEmailByIDRow
+	var emails []*db.AdminGetPendingEmailByIDRow
 	var ids []int32
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		e, err := queries.GetPendingEmailByID(r.Context(), int32(id))
+		e, err := queries.AdminGetPendingEmailByID(r.Context(), int32(id))
 		if err != nil {
 			return fmt.Errorf("get email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/admin/resend_sent_task.go
+++ b/handlers/admin/resend_sent_task.go
@@ -31,7 +31,7 @@ func (ResendSentEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		e, err := queries.GetPendingEmailByID(r.Context(), int32(id))
+		e, err := queries.AdminGetPendingEmailByID(r.Context(), int32(id))
 		if err != nil {
 			return fmt.Errorf("get email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/admin/retry_sent_task.go
+++ b/handlers/admin/retry_sent_task.go
@@ -28,7 +28,7 @@ func (RetrySentEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		e, err := queries.GetPendingEmailByID(r.Context(), int32(id))
+		e, err := queries.AdminGetPendingEmailByID(r.Context(), int32(id))
 		if err != nil {
 			return fmt.Errorf("get email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/internal/db/queries-pending_emails.sql
+++ b/internal/db/queries-pending_emails.sql
@@ -12,18 +12,26 @@ LIMIT ?;
 -- name: MarkEmailSent :exec
 UPDATE pending_emails SET sent_at = NOW() WHERE id = ?;
 
--- name: ListUnsentPendingEmails :many
-SELECT id, to_user_id, body, error_count, created_at, direct_email
-FROM pending_emails
-WHERE sent_at IS NULL
-ORDER BY id;
+-- name: AdminListUnsentPendingEmails :many
+-- admin task
+SELECT pe.id, pe.to_user_id, pe.body, pe.error_count, pe.created_at, pe.direct_email
+FROM pending_emails pe
+LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers
+LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers
+LEFT JOIN roles r ON ur.role_id = r.id
+WHERE pe.sent_at IS NULL
+  AND (sqlc.arg(language_id) IS NULL OR p.language_idlanguage = sqlc.arg(language_id))
+  AND (sqlc.arg(role_name) IS NULL OR r.name = sqlc.arg(role_name))
+ORDER BY pe.id;
 
--- name: GetPendingEmailByID :one
+-- name: AdminGetPendingEmailByID :one
+-- admin task
 SELECT id, to_user_id, body, error_count, direct_email
 FROM pending_emails
 WHERE id = ?;
 
--- name: DeletePendingEmail :exec
+-- name: AdminDeletePendingEmail :exec
+-- admin task
 DELETE FROM pending_emails WHERE id = ?;
 
 -- name: IncrementEmailError :exec
@@ -32,16 +40,28 @@ UPDATE pending_emails SET error_count = error_count + 1 WHERE id = ?;
 -- name: GetPendingEmailErrorCount :one
 SELECT error_count FROM pending_emails WHERE id = ?;
 
--- name: ListSentEmails :many
-SELECT id, to_user_id, body, error_count, created_at, sent_at, direct_email
-FROM pending_emails
-WHERE sent_at IS NOT NULL
-ORDER BY sent_at DESC
+-- name: AdminListSentEmails :many
+-- admin task
+SELECT pe.id, pe.to_user_id, pe.body, pe.error_count, pe.created_at, pe.sent_at, pe.direct_email
+FROM pending_emails pe
+LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers
+LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers
+LEFT JOIN roles r ON ur.role_id = r.id
+WHERE pe.sent_at IS NOT NULL
+  AND (sqlc.arg(language_id) IS NULL OR p.language_idlanguage = sqlc.arg(language_id))
+  AND (sqlc.arg(role_name) IS NULL OR r.name = sqlc.arg(role_name))
+ORDER BY pe.sent_at DESC
 LIMIT ? OFFSET ?;
 
--- name: ListFailedEmails :many
-SELECT id, to_user_id, body, error_count, created_at, direct_email
-FROM pending_emails
-WHERE sent_at IS NULL AND error_count > 0
-ORDER BY id
+-- name: AdminListFailedEmails :many
+-- admin task
+SELECT pe.id, pe.to_user_id, pe.body, pe.error_count, pe.created_at, pe.direct_email
+FROM pending_emails pe
+LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers
+LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers
+LEFT JOIN roles r ON ur.role_id = r.id
+WHERE pe.sent_at IS NULL AND pe.error_count > 0
+  AND (sqlc.arg(language_id) IS NULL OR p.language_idlanguage = sqlc.arg(language_id))
+  AND (sqlc.arg(role_name) IS NULL OR r.name = sqlc.arg(role_name))
+ORDER BY pe.id
 LIMIT ? OFFSET ?;

--- a/workers/emailqueue/email_queue.go
+++ b/workers/emailqueue/email_queue.go
@@ -175,7 +175,7 @@ func ProcessPendingEmail(ctx context.Context, q *db.Queries, provider email.Prov
 				msg := fmt.Sprintf("email %d to %s failed: %v\n%s", e.ID, addr.Address, err, e.Body)
 				_ = dlqProvider.Record(ctx, msg)
 			}
-			if delErr := q.DeletePendingEmail(ctx, e.ID); delErr != nil {
+			if delErr := q.AdminDeletePendingEmail(ctx, e.ID); delErr != nil {
 				log.Printf("delete email: %v", delErr)
 			}
 		}


### PR DESCRIPTION
## Summary
- add admin task markers and language/role filters to pending email queries
- regenerate sqlc code
- update handlers and CLI for new query params
- prefix admin email queries with `Admin`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc9f789c832f970348dcd6cb42e9