### PR TITLE
Refine thread queries

### DIFF
--- a/handlers/admin/adminUserForumPage.go
+++ b/handlers/admin/adminUserForumPage.go
@@ -23,7 +23,7 @@ func adminUserForumPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.GetThreadsStartedByUserWithTopic(r.Context(), int32(id))
+	rows, err := queries.AdminGetThreadsStartedByUserWithTopic(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -32,7 +32,7 @@ func adminUserForumPage(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		*common.CoreData
 		User    *db.User
-		Threads []*db.GetThreadsStartedByUserWithTopicRow
+		Threads []*db.AdminGetThreadsStartedByUserWithTopicRow
 	}{
 		CoreData: cd,
 		User:     &db.User{Idusers: user.Idusers, Username: user.Username},

--- a/handlers/blogs/blogsCommentPage_replyable_test.go
+++ b/handlers/blogs/blogsCommentPage_replyable_test.go
@@ -61,7 +61,7 @@ func TestCommentPageLockedThreadDisablesReply(t *testing.T) {
 
 	threadRows := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername"}).
 		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), true, "bob")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(int32(2), int32(1), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(threadRows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(threadRows)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
 		WithArgs(int32(2), int32(2), int32(1), sql.NullInt32{Int32: 2, Valid: true}).
@@ -101,7 +101,7 @@ func TestCommentPageUnlockedThreadShowsReply(t *testing.T) {
 
 	threadRows := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername"}).
 		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), false, "bob")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(int32(2), int32(1), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(threadRows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(threadRows)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
 		WithArgs(int32(2), int32(2), int32(1), sql.NullInt32{Int32: 2, Valid: true}).

--- a/handlers/forum/adminForumHandler.go
+++ b/handlers/forum/adminForumHandler.go
@@ -123,7 +123,7 @@ func AdminForumRemakeForumThreadPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Messages = append(data.Messages, "Recalculating forum thread metadata...")
 
-	if err := queries.RecalculateAllForumThreadMetaData(r.Context()); err != nil {
+	if err := queries.AdminRecalculateAllForumThreadMetaData(r.Context()); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("recalculateForumThreadByIdMetaData_firstpost: %w", err).Error())
 	} else {
 		data.Messages = append(data.Messages, "Thread metadata rebuild complete.")

--- a/handlers/forum/matchers_test.go
+++ b/handlers/forum/matchers_test.go
@@ -24,7 +24,7 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 	defer sqldb.Close()
 
 	mock.ExpectQuery("SELECT th.idforumthread").
-		WithArgs(int32(0), int32(2), sql.NullInt32{Int32: 0, Valid: false}).
+		WithArgs(int32(0), int32(2), int32(0), int32(0), sql.NullInt32{Int32: 0, Valid: false}).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername",
 		}).AddRow(2, 0, 0, 1, sql.NullInt32{}, sql.NullTime{}, sql.NullBool{}, sql.NullString{}))
@@ -35,9 +35,9 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "title", "description", "threads", "comments", "lastaddition", "LastPosterUsername",
 		}).AddRow(1, 0, 0, sql.NullString{}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullTime{}, sql.NullString{}))
 
-	// handler will trigger another load
+		// handler will trigger another load
 	mock.ExpectQuery("SELECT th.idforumthread").
-		WithArgs(int32(0), int32(2), sql.NullInt32{Int32: 0, Valid: false}).
+		WithArgs(int32(0), int32(2), int32(0), int32(0), sql.NullInt32{Int32: 0, Valid: false}).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername",
 		}).AddRow(2, 0, 0, 1, sql.NullInt32{}, sql.NullTime{}, sql.NullBool{}, sql.NullString{}))
@@ -82,7 +82,7 @@ func TestRequireThreadAndTopicFalse(t *testing.T) {
 	defer sqldb.Close()
 
 	mock.ExpectQuery("SELECT th.idforumthread").
-		WithArgs(int32(0), int32(2), sql.NullInt32{Int32: 0, Valid: false}).
+		WithArgs(int32(0), int32(2), int32(0), int32(0), sql.NullInt32{Int32: 0, Valid: false}).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername",
 		}).AddRow(2, 0, 0, 3, sql.NullInt32{}, sql.NullTime{}, sql.NullBool{}, sql.NullString{}))
@@ -127,7 +127,7 @@ func TestRequireThreadAndTopicError(t *testing.T) {
 	defer sqldb.Close()
 
 	mock.ExpectQuery("SELECT th.idforumthread").
-		WithArgs(int32(0), int32(2), sql.NullInt32{Int32: 0, Valid: false}).
+		WithArgs(int32(0), int32(2), int32(0), int32(0), sql.NullInt32{Int32: 0, Valid: false}).
 		WillReturnError(sql.ErrNoRows)
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)

--- a/handlers/forum/thread_delete.go
+++ b/handlers/forum/thread_delete.go
@@ -7,7 +7,7 @@ import (
 
 // ThreadDelete removes a forum thread and updates topic statistics.
 func ThreadDelete(ctx context.Context, q *db.Queries, threadID, topicID int32) error {
-	if err := q.DeleteForumThread(ctx, threadID); err != nil {
+	if err := q.AdminDeleteForumThread(ctx, threadID); err != nil {
 		return err
 	}
 	return q.RebuildForumTopicByIdMetaColumns(ctx, topicID)

--- a/handlers/forum/thread_delete_test.go
+++ b/handlers/forum/thread_delete_test.go
@@ -16,7 +16,7 @@ func TestThreadDelete(t *testing.T) {
 	defer sqldb.Close()
 
 	q := db.New(sqldb)
-	mock.ExpectExec("DeleteForumThread").
+	mock.ExpectExec("AdminDeleteForumThread").
 		WithArgs(int32(1)).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("RebuildForumTopicByIdMetaColumns").

--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -114,7 +114,7 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	threads, err := queries.GetThreadsStartedByUser(r.Context(), int32(uid))
+	threads, err := queries.AdminGetThreadsStartedByUser(r.Context(), int32(uid))
 	if err != nil {
 		log.Printf("fetch threads: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/workers/postcountworker/postupdate.go
+++ b/workers/postcountworker/postupdate.go
@@ -10,7 +10,7 @@ import (
 // PostUpdate refreshes metadata on the given forum thread and topic.
 // It recalculates thread counters and rebuilds the topic aggregates.
 func PostUpdate(ctx context.Context, q *db.Queries, threadID, topicID int32) error {
-	if err := q.RecalculateForumThreadByIdMetaData(ctx, threadID); err != nil {
+	if err := q.AdminRecalculateForumThreadByIdMetaData(ctx, threadID); err != nil {
 		return fmt.Errorf("recalc thread metadata: %w", err)
 	}
 	if err := q.RebuildForumTopicByIdMetaColumns(ctx, topicID); err != nil {

--- a/workers/postcountworker/postupdate_test.go
+++ b/workers/postcountworker/postupdate_test.go
@@ -16,7 +16,7 @@ func TestPostUpdate(t *testing.T) {
 	defer db.Close()
 
 	q := dbpkg.New(db)
-	mock.ExpectExec("RecalculateForumThreadByIdMetaData").
+	mock.ExpectExec("AdminRecalculateForumThreadByIdMetaData").
 		WithArgs(int32(1)).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("RebuildForumTopicByIdMetaColumns").


### PR DESCRIPTION
## Summary
- prefix admin-only thread queries with `Admin` instead of `-- admin task`
- regenerate sqlc output and update call sites
- update tests for additional viewer arguments

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccca970d0832f935529746e8b4ebe