### PR TITLE
Add role-filtered uploaded image queries

### DIFF
--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 51
+	ExpectedSchemaVersion = 52
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/handlers/user/userGalleryPage.go
+++ b/handlers/user/userGalleryPage.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"database/sql"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -45,10 +46,12 @@ func userGalleryPage(w http.ResponseWriter, r *http.Request) {
 
 	offset := (page - 1) * size
 
-	rows, err := queries.ListUploadedImagesByUser(r.Context(), db.ListUploadedImagesByUserParams{
-		UsersIdusers: uid,
-		Limit:        int32(size + 1),
-		Offset:       int32(offset),
+	rows, err := queries.ListUploadedImagesByUserForViewer(r.Context(), db.ListUploadedImagesByUserForViewerParams{
+		ViewerID:      uid,
+		UserID:        uid,
+		ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0},
+		Limit:         int32(size + 1),
+		Offset:        int32(offset),
 	})
 	if err != nil {
 		log.Printf("list images: %v", err)

--- a/internal/db/queries-uploadimages.sql
+++ b/internal/db/queries-uploadimages.sql
@@ -3,12 +3,33 @@ INSERT INTO uploaded_images (
     users_idusers, path, width, height, file_size, uploaded
 ) VALUES (?, ?, ?, ?, ?, NOW());
 
--- name: GetUploadedImage :one
-SELECT * FROM uploaded_images WHERE iduploadedimage = ?;
+-- name: ListUploadedImagesByUserForViewer :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT ui.iduploadedimage, ui.users_idusers, ui.path, ui.width, ui.height, ui.file_size, ui.uploaded
+FROM uploaded_images ui
+WHERE ui.users_idusers = sqlc.arg(user_id)
+  AND EXISTS (
+      SELECT 1 FROM grants g
+      WHERE g.section='images'
+        AND (g.item='upload' OR g.item IS NULL)
+        AND g.action='see'
+        AND g.active=1
+        AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
+        AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
+ORDER BY uploaded DESC
+LIMIT ? OFFSET ?;
 
--- name: ListUploadedImagesByUser :many
+-- name: AdminListUploadedImages :many
+-- Admin
 SELECT iduploadedimage, users_idusers, path, width, height, file_size, uploaded
 FROM uploaded_images
-WHERE users_idusers = ?
 ORDER BY uploaded DESC
 LIMIT ? OFFSET ?;

--- a/migrations/0052.mysql.sql
+++ b/migrations/0052.mysql.sql
@@ -1,0 +1,9 @@
+-- Grant upload listing to login roles
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'images', 'upload', 'allow', 'see', 1
+FROM roles r
+WHERE r.can_login = 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+-- Update schema version
+UPDATE schema_version SET version = 52 WHERE version = 51;

--- a/migrations/0052.postgres.sql
+++ b/migrations/0052.postgres.sql
@@ -1,0 +1,9 @@
+-- Grant upload listing to login roles
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'images', 'upload', 'allow', 'see', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
+-- Update schema version
+UPDATE schema_version SET version = 52 WHERE version = 51;

--- a/migrations/0052.sqlite.sql
+++ b/migrations/0052.sqlite.sql
@@ -1,0 +1,9 @@
+-- Grant upload listing to login roles
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'images', 'upload', 'allow', 'see', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
+-- Update schema version
+UPDATE schema_version SET version = 52 WHERE version = 51;


### PR DESCRIPTION
## Summary
- enforce grants for uploaded image listings
- allow admins to review uploaded image metadata
- seed upload listing grant for all login-enabled roles
- adjust gallery handler for new params

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cccaa4138832face989b6eca3a9f1