### PR TITLE
Restrict language CRUD tasks to administrators

### DIFF
--- a/handlers/languages/create_language_task.go
+++ b/handlers/languages/create_language_task.go
@@ -21,7 +21,13 @@ var _ tasks.Task = (*CreateLanguageTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*CreateLanguageTask)(nil)
 
 func (CreateLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd == nil || !cd.HasRole("administrator") {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+		})
+	}
+	queries := cd.Queries()
 	cname := r.PostFormValue("cname")
 	res, err := queries.InsertLanguage(r.Context(), sql.NullString{String: cname, Valid: true})
 	if err != nil {

--- a/handlers/languages/delete_language_task.go
+++ b/handlers/languages/delete_language_task.go
@@ -21,7 +21,13 @@ var _ tasks.Task = (*DeleteLanguageTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*DeleteLanguageTask)(nil)
 
 func (DeleteLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd == nil || !cd.HasRole("administrator") {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+		})
+	}
+	queries := cd.Queries()
 	cid, err := strconv.Atoi(r.PostFormValue("cid"))
 	if err != nil {
 		return fmt.Errorf("cid parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/languages/rename_language_task.go
+++ b/handlers/languages/rename_language_task.go
@@ -23,7 +23,13 @@ var _ tasks.Task = (*RenameLanguageTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*RenameLanguageTask)(nil)
 
 func (RenameLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if cd == nil || !cd.HasRole("administrator") {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+		})
+	}
+	queries := cd.Queries()
 	cid, err := strconv.Atoi(r.PostFormValue("cid"))
 	if err != nil {
 		return fmt.Errorf("cid parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))


### PR DESCRIPTION
## Summary
- enforce admin checks on language create, rename, and delete tasks
- remove unnecessary `GetUserLanguagesForViewer` query and revert call sites to `GetUserLanguages`
- regenerate sqlc

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cccad6274832faa20e88098b60d31