### PR TITLE
Refactor user queries and regenerate sqlc

### DIFF
--- a/cmd/goa4web/user_list.go
+++ b/cmd/goa4web/user_list.go
@@ -47,7 +47,7 @@ func (c *userListCmd) Run() error {
 		rows, err = queries.ListUserInfo(ctx)
 	} else {
 		// fall back to basic user list when no extra columns requested
-		basic, err2 := queries.AllUsers(ctx)
+		basic, err2 := queries.AdminAllUsers(ctx)
 		if err2 != nil {
 			return fmt.Errorf("list users: %w", err2)
 		}

--- a/config/email.go
+++ b/config/email.go
@@ -36,9 +36,9 @@ func GetAdminEmails(ctx context.Context, q *db.Queries, cfg *RuntimeConfig) []st
 		return emails
 	}
 	if q != nil {
-		rows, err := q.ListAdministratorEmails(ctx)
+		rows, err := q.AdminListAdministratorEmails(ctx)
 		if err != nil {
-			log.Printf("list admin emails: %v", err)
+			log.Printf("AdminListAdministratorEmails: %v", err)
 			return emails
 		}
 		for _, e := range rows {

--- a/handlers/admin/adminNotificationsPage.go
+++ b/handlers/admin/adminNotificationsPage.go
@@ -46,7 +46,7 @@ func AdminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	data.Usernames = map[int32]string{}
-	if rows, err := queries.UsersByID(r.Context(), ids); err == nil {
+	if rows, err := queries.AdminUsersByID(r.Context(), ids); err == nil {
 		for _, r := range rows {
 			if r.Username.Valid {
 				data.Usernames[r.Idusers] = r.Username.String

--- a/handlers/admin/adminUserListPage.go
+++ b/handlers/admin/adminUserListPage.go
@@ -13,14 +13,14 @@ func adminUserListPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Users"
 	queries := cd.Queries()
-	users, err := queries.AllUsers(r.Context())
+	users, err := queries.AdminAllUsers(r.Context())
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 	data := struct {
 		*common.CoreData
-		Users []*db.AllUsersRow
+		Users []*db.AdminAllUsersRow
 	}{
 		CoreData: cd,
 		Users:    users,

--- a/handlers/admin/send_notification_task.go
+++ b/handlers/admin/send_notification_task.go
@@ -43,13 +43,13 @@ func (SendNotificationTask) Action(w http.ResponseWriter, r *http.Request) any {
 			ids = append(ids, u.Idusers)
 		}
 	} else if role != "" && role != "anonymous" {
-		rows, err := queries.ListUserIDsByRole(r.Context(), role)
+		rows, err := queries.AdminListUserIDsByRole(r.Context(), role)
 		if err != nil {
 			return fmt.Errorf("list role fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		ids = append(ids, rows...)
 	} else {
-		rows, err := queries.AllUserIDs(r.Context())
+		rows, err := queries.AdminAllUserIDs(r.Context())
 		if err != nil {
 			return fmt.Errorf("list users fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -53,7 +53,7 @@ func (RegisterTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	queries := cd.Queries()
 
-	if _, err := queries.UserByUsername(r.Context(), sql.NullString{
+	if _, err := queries.GetUserByUsername(r.Context(), sql.NullString{
 		String: username,
 		Valid:  true,
 	}); errors.Is(err, sql.ErrNoRows) {

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -44,9 +44,9 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 		data.Roles = roles
 	}
 
-	users, err := queries.AllUsers(r.Context())
+	users, err := queries.AdminAllUsers(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		log.Printf("AllUsers Error: %s", err)
+		log.Printf("AdminAllUsers Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}

--- a/handlers/news/newsAdminUserLevelsPage.go
+++ b/handlers/news/newsAdminUserLevelsPage.go
@@ -40,9 +40,9 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 		data.Roles = roles
 	}
 
-	users, err := queries.AllUsers(r.Context())
+	users, err := queries.AdminAllUsers(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		log.Printf("AllUsers Error: %s", err)
+		log.Printf("AdminAllUsers Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}

--- a/handlers/user/admin_pending.go
+++ b/handlers/user/admin_pending.go
@@ -15,14 +15,14 @@ import (
 
 func adminPendingUsersPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	rows, err := queries.ListPendingUsers(r.Context())
+	rows, err := queries.AdminListPendingUsers(r.Context())
 	if err != nil && err != sql.ErrNoRows {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 	data := struct {
 		*common.CoreData
-		Rows []*db.ListPendingUsersRow
+		Rows []*db.AdminListPendingUsersRow
 	}{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Rows:     rows,

--- a/handlers/writings/writingsAdminUserLevelsPage.go
+++ b/handlers/writings/writingsAdminUserLevelsPage.go
@@ -40,9 +40,9 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 		data.Roles = roles
 	}
 
-	users, err := queries.AllUsers(r.Context())
+	users, err := queries.AdminAllUsers(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		log.Printf("AllUsers Error: %s", err)
+		log.Printf("AdminAllUsers Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -1,12 +1,14 @@
--- name: AllUsers :many
--- This query selects all admin users from the "users" table.
+-- name: AdminAllUsers :many
 -- Result:
 --   idusers (int)
 --   username (string)
 --   email (string)
 SELECT u.idusers, u.username,
        (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
-FROM users u;
+FROM users u
+JOIN user_roles ur ON ur.users_idusers = u.idusers
+JOIN roles r ON ur.role_id = r.id
+WHERE r.is_admin = 1;
 
 -- name: GetUserByUsername :one
 SELECT idusers,
@@ -35,14 +37,6 @@ LEFT JOIN user_emails ue ON ue.id = (
 )
 WHERE u.idusers = ?;
 
--- name: UserByUsername :one
-SELECT idusers,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = users.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
-       username,
-       public_profile_enabled_at
-FROM users
-WHERE username = ?;
-
 -- name: UserByEmail :one
 SELECT u.idusers, ue.email, u.username
 FROM users u JOIN user_emails ue ON ue.user_id = u.idusers
@@ -54,46 +48,7 @@ INSERT INTO users (username)
 VALUES (?)
 ;
 
--- name: ListUsersSubscribedToBlogs :many
-SELECT *, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers ORDER BY ue.id LIMIT 1) AS email
-FROM blogs t, users u, preferences p
-WHERE t.idblogs=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=t.users_idusers AND u.idusers!=?
-GROUP BY u.idusers;
-
--- name: ListUsersSubscribedToNews :many
-SELECT idsitenews, forumthread_id, t.language_idlanguage, t.users_idusers,
-    news, occurred, u.idusers, u.username, u.deleted_at,
-    p.idpreferences, p.language_idlanguage, p.users_idusers, p.emailforumupdates,
-    p.page_size, p.auto_subscribe_replies,
-    (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers ORDER BY ue.id LIMIT 1) AS email
-FROM site_news t, users u, preferences p
-WHERE t.idsiteNews=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=t.users_idusers AND u.idusers!=?
-GROUP BY u.idusers;
-
--- name: ListUsersSubscribedToLinker :many
-SELECT *, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers ORDER BY ue.id LIMIT 1) AS email
-FROM linker t, users u, preferences p
-WHERE t.idlinker=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=t.users_idusers AND u.idusers!=?
-GROUP BY u.idusers;
-
--- name: ListUsersSubscribedToWriting :many
-SELECT *, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers ORDER BY ue.id LIMIT 1) AS email
-FROM writing t, users u, preferences p
-WHERE t.idwriting=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=t.users_idusers AND u.idusers!=?
-GROUP BY u.idusers;
-
--- name: ListUsersSubscribedToThread :many
-SELECT c.idcomments, c.forumthread_id, c.users_idusers, c.language_idlanguage,
-    c.written, c.text, u.idusers,
-    (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers ORDER BY ue.id LIMIT 1) AS email,
-    u.username,
-    p.idpreferences, p.language_idlanguage, p.users_idusers, p.emailforumupdates, p.page_size, p.auto_subscribe_replies
-FROM comments c, users u, preferences p
-WHERE c.forumthread_id=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=c.users_idusers AND u.idusers!=?
-GROUP BY u.idusers;
-
-
--- name: ListAdministratorEmails :many
+-- name: AdminListAdministratorEmails :many
 SELECT (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
 FROM users u
 JOIN user_roles ur ON ur.users_idusers = u.idusers
@@ -103,7 +58,7 @@ WHERE r.is_admin = 1;
 -- name: UpdateUserEmail :exec
 UPDATE user_emails SET email = ? WHERE user_id = ?;
 
--- name: ListPendingUsers :many
+-- name: AdminListPendingUsers :many
 SELECT u.idusers, u.username,
        (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
 FROM users u
@@ -114,24 +69,8 @@ WHERE NOT EXISTS (
 )
 ORDER BY u.idusers;
 
--- name: ListUsers :many
-SELECT u.idusers,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
-       u.username
-FROM users u
-ORDER BY u.idusers
-LIMIT ? OFFSET ?;
 
--- name: SearchUsers :many
-SELECT u.idusers,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
-       u.username
-FROM users u
-WHERE LOWER(u.username) LIKE LOWER(sqlc.arg(pattern)) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(sqlc.arg(pattern))
-ORDER BY u.idusers
-LIMIT ? OFFSET ?;
-
--- name: ListUserIDsByRole :many
+-- name: AdminListUserIDsByRole :many
 SELECT u.idusers
 FROM users u
 JOIN user_roles ur ON ur.users_idusers = u.idusers
@@ -139,10 +78,10 @@ JOIN roles r ON ur.role_id = r.id
 WHERE r.name = ?
 ORDER BY u.idusers;
 
--- name: AllUserIDs :many
+-- name: AdminAllUserIDs :many
 SELECT idusers FROM users ORDER BY idusers;
 
--- name: UsersByID :many
+-- name: AdminUsersByID :many
 SELECT idusers, username
 FROM users
 WHERE idusers IN (sqlc.slice('ids'));

--- a/internal/db/queries-users.sql.go
+++ b/internal/db/queries-users.sql.go
@@ -9,15 +9,14 @@ import (
 	"context"
 	"database/sql"
 	"strings"
-	"time"
 )
 
-const allUserIDs = `-- name: AllUserIDs :many
+const adminAllUserIDs = `-- name: AdminAllUserIDs :many
 SELECT idusers FROM users ORDER BY idusers
 `
 
-func (q *Queries) AllUserIDs(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, allUserIDs)
+func (q *Queries) AdminAllUserIDs(ctx context.Context) ([]int32, error) {
+	rows, err := q.db.QueryContext(ctx, adminAllUserIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -39,34 +38,184 @@ func (q *Queries) AllUserIDs(ctx context.Context) ([]int32, error) {
 	return items, nil
 }
 
-const allUsers = `-- name: AllUsers :many
+const adminAllUsers = `-- name: AdminAllUsers :many
 SELECT u.idusers, u.username,
        (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
 FROM users u
+JOIN user_roles ur ON ur.users_idusers = u.idusers
+JOIN roles r ON ur.role_id = r.id
+WHERE r.is_admin = 1
 `
 
-type AllUsersRow struct {
+type AdminAllUsersRow struct {
 	Idusers  int32
 	Username sql.NullString
 	Email    string
 }
 
-// This query selects all admin users from the "users" table.
 // Result:
 //
 //	idusers (int)
 //	username (string)
 //	email (string)
-func (q *Queries) AllUsers(ctx context.Context) ([]*AllUsersRow, error) {
-	rows, err := q.db.QueryContext(ctx, allUsers)
+func (q *Queries) AdminAllUsers(ctx context.Context) ([]*AdminAllUsersRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminAllUsers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*AllUsersRow
+	var items []*AdminAllUsersRow
 	for rows.Next() {
-		var i AllUsersRow
+		var i AdminAllUsersRow
 		if err := rows.Scan(&i.Idusers, &i.Username, &i.Email); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const adminListAdministratorEmails = `-- name: AdminListAdministratorEmails :many
+SELECT (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
+FROM users u
+JOIN user_roles ur ON ur.users_idusers = u.idusers
+JOIN roles r ON ur.role_id = r.id
+WHERE r.is_admin = 1
+`
+
+func (q *Queries) AdminListAdministratorEmails(ctx context.Context) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, adminListAdministratorEmails)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var email string
+		if err := rows.Scan(&email); err != nil {
+			return nil, err
+		}
+		items = append(items, email)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const adminListPendingUsers = `-- name: AdminListPendingUsers :many
+SELECT u.idusers, u.username,
+       (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
+FROM users u
+WHERE NOT EXISTS (
+    SELECT 1 FROM user_roles ur
+    JOIN roles r ON ur.role_id = r.id
+    WHERE ur.users_idusers = u.idusers AND (r.can_login = 1 OR r.name = 'rejected')
+)
+ORDER BY u.idusers
+`
+
+type AdminListPendingUsersRow struct {
+	Idusers  int32
+	Username sql.NullString
+	Email    string
+}
+
+func (q *Queries) AdminListPendingUsers(ctx context.Context) ([]*AdminListPendingUsersRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListPendingUsers)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*AdminListPendingUsersRow
+	for rows.Next() {
+		var i AdminListPendingUsersRow
+		if err := rows.Scan(&i.Idusers, &i.Username, &i.Email); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const adminListUserIDsByRole = `-- name: AdminListUserIDsByRole :many
+SELECT u.idusers
+FROM users u
+JOIN user_roles ur ON ur.users_idusers = u.idusers
+JOIN roles r ON ur.role_id = r.id
+WHERE r.name = ?
+ORDER BY u.idusers
+`
+
+func (q *Queries) AdminListUserIDsByRole(ctx context.Context, name string) ([]int32, error) {
+	rows, err := q.db.QueryContext(ctx, adminListUserIDsByRole, name)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int32
+	for rows.Next() {
+		var idusers int32
+		if err := rows.Scan(&idusers); err != nil {
+			return nil, err
+		}
+		items = append(items, idusers)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const adminUsersByID = `-- name: AdminUsersByID :many
+SELECT idusers, username
+FROM users
+WHERE idusers IN (/*SLICE:ids*/?)
+`
+
+type AdminUsersByIDRow struct {
+	Idusers  int32
+	Username sql.NullString
+}
+
+func (q *Queries) AdminUsersByID(ctx context.Context, ids []int32) ([]*AdminUsersByIDRow, error) {
+	query := adminUsersByID
+	var queryParams []interface{}
+	if len(ids) > 0 {
+		for _, v := range ids {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:ids*/?", strings.Repeat(",?", len(ids))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:ids*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*AdminUsersByIDRow
+	for rows.Next() {
+		var i AdminUsersByIDRow
+		if err := rows.Scan(&i.Idusers, &i.Username); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -147,546 +296,6 @@ func (q *Queries) InsertUser(ctx context.Context, username sql.NullString) (sql.
 	return q.db.ExecContext(ctx, insertUser, username)
 }
 
-const listAdministratorEmails = `-- name: ListAdministratorEmails :many
-SELECT (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
-FROM users u
-JOIN user_roles ur ON ur.users_idusers = u.idusers
-JOIN roles r ON ur.role_id = r.id
-WHERE r.is_admin = 1
-`
-
-func (q *Queries) ListAdministratorEmails(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listAdministratorEmails)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []string
-	for rows.Next() {
-		var email string
-		if err := rows.Scan(&email); err != nil {
-			return nil, err
-		}
-		items = append(items, email)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listPendingUsers = `-- name: ListPendingUsers :many
-SELECT u.idusers, u.username,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
-FROM users u
-WHERE NOT EXISTS (
-    SELECT 1 FROM user_roles ur
-    JOIN roles r ON ur.role_id = r.id
-    WHERE ur.users_idusers = u.idusers AND (r.can_login = 1 OR r.name = 'rejected')
-)
-ORDER BY u.idusers
-`
-
-type ListPendingUsersRow struct {
-	Idusers  int32
-	Username sql.NullString
-	Email    string
-}
-
-func (q *Queries) ListPendingUsers(ctx context.Context) ([]*ListPendingUsersRow, error) {
-	rows, err := q.db.QueryContext(ctx, listPendingUsers)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*ListPendingUsersRow
-	for rows.Next() {
-		var i ListPendingUsersRow
-		if err := rows.Scan(&i.Idusers, &i.Username, &i.Email); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listUserIDsByRole = `-- name: ListUserIDsByRole :many
-SELECT u.idusers
-FROM users u
-JOIN user_roles ur ON ur.users_idusers = u.idusers
-JOIN roles r ON ur.role_id = r.id
-WHERE r.name = ?
-ORDER BY u.idusers
-`
-
-func (q *Queries) ListUserIDsByRole(ctx context.Context, name string) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, listUserIDsByRole, name)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []int32
-	for rows.Next() {
-		var idusers int32
-		if err := rows.Scan(&idusers); err != nil {
-			return nil, err
-		}
-		items = append(items, idusers)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listUsers = `-- name: ListUsers :many
-SELECT u.idusers,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
-       u.username
-FROM users u
-ORDER BY u.idusers
-LIMIT ? OFFSET ?
-`
-
-type ListUsersParams struct {
-	Limit  int32
-	Offset int32
-}
-
-type ListUsersRow struct {
-	Idusers  int32
-	Email    string
-	Username sql.NullString
-}
-
-func (q *Queries) ListUsers(ctx context.Context, arg ListUsersParams) ([]*ListUsersRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUsers, arg.Limit, arg.Offset)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*ListUsersRow
-	for rows.Next() {
-		var i ListUsersRow
-		if err := rows.Scan(&i.Idusers, &i.Email, &i.Username); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listUsersSubscribedToBlogs = `-- name: ListUsersSubscribedToBlogs :many
-SELECT idblogs, forumthread_id, t.users_idusers, t.language_idlanguage, blog, written, t.deleted_at, last_index, idusers, username, u.deleted_at, public_profile_enabled_at, idpreferences, p.language_idlanguage, p.users_idusers, emailforumupdates, page_size, auto_subscribe_replies, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers ORDER BY ue.id LIMIT 1) AS email
-FROM blogs t, users u, preferences p
-WHERE t.idblogs=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=t.users_idusers AND u.idusers!=?
-GROUP BY u.idusers
-`
-
-type ListUsersSubscribedToBlogsParams struct {
-	Idblogs int32
-	Idusers int32
-}
-
-type ListUsersSubscribedToBlogsRow struct {
-	Idblogs                int32
-	ForumthreadID          sql.NullInt32
-	UsersIdusers           int32
-	LanguageIdlanguage     int32
-	Blog                   sql.NullString
-	Written                time.Time
-	DeletedAt              sql.NullTime
-	LastIndex              sql.NullTime
-	Idusers                int32
-	Username               sql.NullString
-	DeletedAt_2            sql.NullTime
-	PublicProfileEnabledAt sql.NullTime
-	Idpreferences          int32
-	LanguageIdlanguage_2   int32
-	UsersIdusers_2         int32
-	Emailforumupdates      sql.NullBool
-	PageSize               int32
-	AutoSubscribeReplies   bool
-	Email                  string
-}
-
-func (q *Queries) ListUsersSubscribedToBlogs(ctx context.Context, arg ListUsersSubscribedToBlogsParams) ([]*ListUsersSubscribedToBlogsRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUsersSubscribedToBlogs, arg.Idblogs, arg.Idusers)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*ListUsersSubscribedToBlogsRow
-	for rows.Next() {
-		var i ListUsersSubscribedToBlogsRow
-		if err := rows.Scan(
-			&i.Idblogs,
-			&i.ForumthreadID,
-			&i.UsersIdusers,
-			&i.LanguageIdlanguage,
-			&i.Blog,
-			&i.Written,
-			&i.DeletedAt,
-			&i.LastIndex,
-			&i.Idusers,
-			&i.Username,
-			&i.DeletedAt_2,
-			&i.PublicProfileEnabledAt,
-			&i.Idpreferences,
-			&i.LanguageIdlanguage_2,
-			&i.UsersIdusers_2,
-			&i.Emailforumupdates,
-			&i.PageSize,
-			&i.AutoSubscribeReplies,
-			&i.Email,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listUsersSubscribedToLinker = `-- name: ListUsersSubscribedToLinker :many
-SELECT idlinker, t.language_idlanguage, t.users_idusers, linker_category_id, forumthread_id, title, url, description, listed, t.deleted_at, last_index, idusers, username, u.deleted_at, public_profile_enabled_at, idpreferences, p.language_idlanguage, p.users_idusers, emailforumupdates, page_size, auto_subscribe_replies, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers ORDER BY ue.id LIMIT 1) AS email
-FROM linker t, users u, preferences p
-WHERE t.idlinker=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=t.users_idusers AND u.idusers!=?
-GROUP BY u.idusers
-`
-
-type ListUsersSubscribedToLinkerParams struct {
-	Idlinker int32
-	Idusers  int32
-}
-
-type ListUsersSubscribedToLinkerRow struct {
-	Idlinker               int32
-	LanguageIdlanguage     int32
-	UsersIdusers           int32
-	LinkerCategoryID       int32
-	ForumthreadID          int32
-	Title                  sql.NullString
-	Url                    sql.NullString
-	Description            sql.NullString
-	Listed                 sql.NullTime
-	DeletedAt              sql.NullTime
-	LastIndex              sql.NullTime
-	Idusers                int32
-	Username               sql.NullString
-	DeletedAt_2            sql.NullTime
-	PublicProfileEnabledAt sql.NullTime
-	Idpreferences          int32
-	LanguageIdlanguage_2   int32
-	UsersIdusers_2         int32
-	Emailforumupdates      sql.NullBool
-	PageSize               int32
-	AutoSubscribeReplies   bool
-	Email                  string
-}
-
-func (q *Queries) ListUsersSubscribedToLinker(ctx context.Context, arg ListUsersSubscribedToLinkerParams) ([]*ListUsersSubscribedToLinkerRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUsersSubscribedToLinker, arg.Idlinker, arg.Idusers)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*ListUsersSubscribedToLinkerRow
-	for rows.Next() {
-		var i ListUsersSubscribedToLinkerRow
-		if err := rows.Scan(
-			&i.Idlinker,
-			&i.LanguageIdlanguage,
-			&i.UsersIdusers,
-			&i.LinkerCategoryID,
-			&i.ForumthreadID,
-			&i.Title,
-			&i.Url,
-			&i.Description,
-			&i.Listed,
-			&i.DeletedAt,
-			&i.LastIndex,
-			&i.Idusers,
-			&i.Username,
-			&i.DeletedAt_2,
-			&i.PublicProfileEnabledAt,
-			&i.Idpreferences,
-			&i.LanguageIdlanguage_2,
-			&i.UsersIdusers_2,
-			&i.Emailforumupdates,
-			&i.PageSize,
-			&i.AutoSubscribeReplies,
-			&i.Email,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listUsersSubscribedToNews = `-- name: ListUsersSubscribedToNews :many
-SELECT idsitenews, forumthread_id, t.language_idlanguage, t.users_idusers,
-    news, occurred, u.idusers, u.username, u.deleted_at,
-    p.idpreferences, p.language_idlanguage, p.users_idusers, p.emailforumupdates,
-    p.page_size, p.auto_subscribe_replies,
-    (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers ORDER BY ue.id LIMIT 1) AS email
-FROM site_news t, users u, preferences p
-WHERE t.idsiteNews=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=t.users_idusers AND u.idusers!=?
-GROUP BY u.idusers
-`
-
-type ListUsersSubscribedToNewsParams struct {
-	Idsitenews int32
-	Idusers    int32
-}
-
-type ListUsersSubscribedToNewsRow struct {
-	Idsitenews           int32
-	ForumthreadID        int32
-	LanguageIdlanguage   int32
-	UsersIdusers         int32
-	News                 sql.NullString
-	Occurred             sql.NullTime
-	Idusers              int32
-	Username             sql.NullString
-	DeletedAt            sql.NullTime
-	Idpreferences        int32
-	LanguageIdlanguage_2 int32
-	UsersIdusers_2       int32
-	Emailforumupdates    sql.NullBool
-	PageSize             int32
-	AutoSubscribeReplies bool
-	Email                string
-}
-
-func (q *Queries) ListUsersSubscribedToNews(ctx context.Context, arg ListUsersSubscribedToNewsParams) ([]*ListUsersSubscribedToNewsRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUsersSubscribedToNews, arg.Idsitenews, arg.Idusers)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*ListUsersSubscribedToNewsRow
-	for rows.Next() {
-		var i ListUsersSubscribedToNewsRow
-		if err := rows.Scan(
-			&i.Idsitenews,
-			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
-			&i.UsersIdusers,
-			&i.News,
-			&i.Occurred,
-			&i.Idusers,
-			&i.Username,
-			&i.DeletedAt,
-			&i.Idpreferences,
-			&i.LanguageIdlanguage_2,
-			&i.UsersIdusers_2,
-			&i.Emailforumupdates,
-			&i.PageSize,
-			&i.AutoSubscribeReplies,
-			&i.Email,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listUsersSubscribedToThread = `-- name: ListUsersSubscribedToThread :many
-SELECT c.idcomments, c.forumthread_id, c.users_idusers, c.language_idlanguage,
-    c.written, c.text, u.idusers,
-    (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers ORDER BY ue.id LIMIT 1) AS email,
-    u.username,
-    p.idpreferences, p.language_idlanguage, p.users_idusers, p.emailforumupdates, p.page_size, p.auto_subscribe_replies
-FROM comments c, users u, preferences p
-WHERE c.forumthread_id=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=c.users_idusers AND u.idusers!=?
-GROUP BY u.idusers
-`
-
-type ListUsersSubscribedToThreadParams struct {
-	ForumthreadID int32
-	Idusers       int32
-}
-
-type ListUsersSubscribedToThreadRow struct {
-	Idcomments           int32
-	ForumthreadID        int32
-	UsersIdusers         int32
-	LanguageIdlanguage   int32
-	Written              sql.NullTime
-	Text                 sql.NullString
-	Idusers              int32
-	Email                string
-	Username             sql.NullString
-	Idpreferences        int32
-	LanguageIdlanguage_2 int32
-	UsersIdusers_2       int32
-	Emailforumupdates    sql.NullBool
-	PageSize             int32
-	AutoSubscribeReplies bool
-}
-
-func (q *Queries) ListUsersSubscribedToThread(ctx context.Context, arg ListUsersSubscribedToThreadParams) ([]*ListUsersSubscribedToThreadRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUsersSubscribedToThread, arg.ForumthreadID, arg.Idusers)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*ListUsersSubscribedToThreadRow
-	for rows.Next() {
-		var i ListUsersSubscribedToThreadRow
-		if err := rows.Scan(
-			&i.Idcomments,
-			&i.ForumthreadID,
-			&i.UsersIdusers,
-			&i.LanguageIdlanguage,
-			&i.Written,
-			&i.Text,
-			&i.Idusers,
-			&i.Email,
-			&i.Username,
-			&i.Idpreferences,
-			&i.LanguageIdlanguage_2,
-			&i.UsersIdusers_2,
-			&i.Emailforumupdates,
-			&i.PageSize,
-			&i.AutoSubscribeReplies,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listUsersSubscribedToWriting = `-- name: ListUsersSubscribedToWriting :many
-SELECT idwriting, t.users_idusers, forumthread_id, t.language_idlanguage, writing_category_id, title, published, writing, abstract, private, t.deleted_at, last_index, idusers, username, u.deleted_at, public_profile_enabled_at, idpreferences, p.language_idlanguage, p.users_idusers, emailforumupdates, page_size, auto_subscribe_replies, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers ORDER BY ue.id LIMIT 1) AS email
-FROM writing t, users u, preferences p
-WHERE t.idwriting=? AND u.idusers=p.users_idusers AND p.emailforumupdates=1 AND u.idusers=t.users_idusers AND u.idusers!=?
-GROUP BY u.idusers
-`
-
-type ListUsersSubscribedToWritingParams struct {
-	Idwriting int32
-	Idusers   int32
-}
-
-type ListUsersSubscribedToWritingRow struct {
-	Idwriting              int32
-	UsersIdusers           int32
-	ForumthreadID          int32
-	LanguageIdlanguage     int32
-	WritingCategoryID      int32
-	Title                  sql.NullString
-	Published              sql.NullTime
-	Writing                sql.NullString
-	Abstract               sql.NullString
-	Private                sql.NullBool
-	DeletedAt              sql.NullTime
-	LastIndex              sql.NullTime
-	Idusers                int32
-	Username               sql.NullString
-	DeletedAt_2            sql.NullTime
-	PublicProfileEnabledAt sql.NullTime
-	Idpreferences          int32
-	LanguageIdlanguage_2   int32
-	UsersIdusers_2         int32
-	Emailforumupdates      sql.NullBool
-	PageSize               int32
-	AutoSubscribeReplies   bool
-	Email                  string
-}
-
-func (q *Queries) ListUsersSubscribedToWriting(ctx context.Context, arg ListUsersSubscribedToWritingParams) ([]*ListUsersSubscribedToWritingRow, error) {
-	rows, err := q.db.QueryContext(ctx, listUsersSubscribedToWriting, arg.Idwriting, arg.Idusers)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*ListUsersSubscribedToWritingRow
-	for rows.Next() {
-		var i ListUsersSubscribedToWritingRow
-		if err := rows.Scan(
-			&i.Idwriting,
-			&i.UsersIdusers,
-			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
-			&i.WritingCategoryID,
-			&i.Title,
-			&i.Published,
-			&i.Writing,
-			&i.Abstract,
-			&i.Private,
-			&i.DeletedAt,
-			&i.LastIndex,
-			&i.Idusers,
-			&i.Username,
-			&i.DeletedAt_2,
-			&i.PublicProfileEnabledAt,
-			&i.Idpreferences,
-			&i.LanguageIdlanguage_2,
-			&i.UsersIdusers_2,
-			&i.Emailforumupdates,
-			&i.PageSize,
-			&i.AutoSubscribeReplies,
-			&i.Email,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const login = `-- name: Login :one
 SELECT u.idusers,
        (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
@@ -716,56 +325,6 @@ func (q *Queries) Login(ctx context.Context, username sql.NullString) (*LoginRow
 		&i.Username,
 	)
 	return &i, err
-}
-
-const searchUsers = `-- name: SearchUsers :many
-SELECT u.idusers,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
-       u.username
-FROM users u
-WHERE LOWER(u.username) LIKE LOWER(?) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(?)
-ORDER BY u.idusers
-LIMIT ? OFFSET ?
-`
-
-type SearchUsersParams struct {
-	Pattern string
-	Limit   int32
-	Offset  int32
-}
-
-type SearchUsersRow struct {
-	Idusers  int32
-	Email    string
-	Username sql.NullString
-}
-
-func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]*SearchUsersRow, error) {
-	rows, err := q.db.QueryContext(ctx, searchUsers,
-		arg.Pattern,
-		arg.Pattern,
-		arg.Limit,
-		arg.Offset,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*SearchUsersRow
-	for rows.Next() {
-		var i SearchUsersRow
-		if err := rows.Scan(&i.Idusers, &i.Email, &i.Username); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }
 
 const updatePublicProfileEnabledAtByUserID = `-- name: UpdatePublicProfileEnabledAtByUserID :exec
@@ -814,76 +373,4 @@ func (q *Queries) UserByEmail(ctx context.Context, email string) (*UserByEmailRo
 	var i UserByEmailRow
 	err := row.Scan(&i.Idusers, &i.Email, &i.Username)
 	return &i, err
-}
-
-const userByUsername = `-- name: UserByUsername :one
-SELECT idusers,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = users.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
-       username,
-       public_profile_enabled_at
-FROM users
-WHERE username = ?
-`
-
-type UserByUsernameRow struct {
-	Idusers                int32
-	Email                  string
-	Username               sql.NullString
-	PublicProfileEnabledAt sql.NullTime
-}
-
-func (q *Queries) UserByUsername(ctx context.Context, username sql.NullString) (*UserByUsernameRow, error) {
-	row := q.db.QueryRowContext(ctx, userByUsername, username)
-	var i UserByUsernameRow
-	err := row.Scan(
-		&i.Idusers,
-		&i.Email,
-		&i.Username,
-		&i.PublicProfileEnabledAt,
-	)
-	return &i, err
-}
-
-const usersByID = `-- name: UsersByID :many
-SELECT idusers, username
-FROM users
-WHERE idusers IN (/*SLICE:ids*/?)
-`
-
-type UsersByIDRow struct {
-	Idusers  int32
-	Username sql.NullString
-}
-
-func (q *Queries) UsersByID(ctx context.Context, ids []int32) ([]*UsersByIDRow, error) {
-	query := usersByID
-	var queryParams []interface{}
-	if len(ids) > 0 {
-		for _, v := range ids {
-			queryParams = append(queryParams, v)
-		}
-		query = strings.Replace(query, "/*SLICE:ids*/?", strings.Repeat(",?", len(ids))[1:], 1)
-	} else {
-		query = strings.Replace(query, "/*SLICE:ids*/?", "NULL", 1)
-	}
-	rows, err := q.db.QueryContext(ctx, query, queryParams...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*UsersByIDRow
-	for rows.Next() {
-		var i UsersByIDRow
-		if err := rows.Scan(&i.Idusers, &i.Username); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -100,9 +100,9 @@ func (n *Notifier) adminEmails(ctx context.Context) []string {
 		return emails
 	}
 	if n.Queries != nil {
-		rows, err := n.Queries.ListAdministratorEmails(ctx)
+		rows, err := n.Queries.AdminListAdministratorEmails(ctx)
 		if err != nil {
-			log.Printf("list admin emails: %v", err)
+			log.Printf("AdminListAdministratorEmails: %v", err)
 			return emails
 		}
 		for _, e := range rows {


### PR DESCRIPTION
## Summary
- restrict `AllUsers` query to administrators
- drop unused subscription and search queries
- annotate admin-only statements and regenerate sqlc
- update registration check to use `GetUserByUsername`
- prefix admin-only query names with `Admin` and update callers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cccae2e30832f8c8a5c4c49d53514