### PR TITLE
Ensure writing listings apply viewer filters

### DIFF
--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -154,14 +154,14 @@ func TestPublicWritingsLazy(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "Username", "Comments"}).
 		AddRow(1, 1, 0, 1, 0, "t", now, "w", "a", false, now, now, "u", 0)
 
-	mock.ExpectQuery("SELECT w.idwriting").WithArgs(int32(1), int32(0), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
+	mock.ExpectQuery("SELECT w.idwriting").WithArgs(int32(1), int32(0), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
 	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "article", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	rows2 := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "Username", "Comments"}).
 		AddRow(2, 1, 0, 1, 1, "t2", now, "w2", "a2", false, now, now, "u", 0)
 
-	mock.ExpectQuery("SELECT w.idwriting").WithArgs(int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows2)
+	mock.ExpectQuery("SELECT w.idwriting").WithArgs(int32(1), int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows2)
 	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "article", Valid: true}, "see", sql.NullInt32{Int32: 2, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 

--- a/handlers/admin/adminUserWritingsPage.go
+++ b/handlers/admin/adminUserWritingsPage.go
@@ -23,7 +23,7 @@ func adminUserWritingsPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.GetAllWritingsByUserAdmin(r.Context(), int32(id))
+	rows, err := queries.AdminGetAllWritingsByUser(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -32,7 +32,7 @@ func adminUserWritingsPage(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		*common.CoreData
 		User     *db.User
-		Writings []*db.GetAllWritingsByUserAdminRow
+		Writings []*db.AdminGetAllWritingsByUserRow
 	}{
 		CoreData: cd,
 		User:     &db.User{Idusers: user.Idusers, Username: user.Username},

--- a/handlers/writings/writing_category_change_task.go
+++ b/handlers/writings/writing_category_change_task.go
@@ -41,7 +41,7 @@ func (WritingCategoryChangeTask) Action(w http.ResponseWriter, r *http.Request) 
 		return common.UserError{ErrorMessage: fmt.Sprintf("invalid parent category: loop %v", path)}
 	}
 
-	if err := queries.UpdateWritingCategory(r.Context(), db.UpdateWritingCategoryParams{
+	if err := queries.AdminUpdateWritingCategory(r.Context(), db.AdminUpdateWritingCategoryParams{
 		Title: sql.NullString{
 			Valid:  true,
 			String: name,

--- a/handlers/writings/writing_category_create_task.go
+++ b/handlers/writings/writing_category_create_task.go
@@ -41,7 +41,7 @@ func (WritingCategoryCreateTask) Action(w http.ResponseWriter, r *http.Request) 
 	if path, loop := algorithms.WouldCreateLoop(parents, 0, int32(pcid)); loop && len(path) > 0 {
 		return common.UserError{ErrorMessage: "invalid parent category: loop detected"}
 	}
-	if err := queries.InsertWritingCategory(r.Context(), db.InsertWritingCategoryParams{
+	if err := queries.AdminInsertWritingCategory(r.Context(), db.AdminInsertWritingCategoryParams{
 		WritingCategoryID: int32(pcid),
 		Title: sql.NullString{
 			Valid:  true,

--- a/handlers/writings/writingsAdminCategoryPage.go
+++ b/handlers/writings/writingsAdminCategoryPage.go
@@ -26,7 +26,7 @@ func AdminCategoryPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Category not found", http.StatusNotFound)
 		return
 	}
-	writings, err := queries.GetWritingsByCategoryId(r.Context(), int32(cid))
+	writings, err := queries.AdminGetWritingsByCategoryId(r.Context(), int32(cid))
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -35,7 +35,7 @@ func AdminCategoryPage(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		*common.CoreData
 		Category *db.WritingCategory
-		Writings []*db.GetWritingsByCategoryIdRow
+		Writings []*db.AdminGetWritingsByCategoryIdRow
 	}{
 		CoreData: cd,
 		Category: cat,


### PR DESCRIPTION
## Summary
- filter writing listings by viewer language preferences
- mark writing category CRUD queries as admin tasks
- remove unused GetAllWritingCategories query
- update tests for new query parameters

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(hung, terminated)*
- `golangci-lint run ./...` *(hung, terminated)*
- `go test -tags 'nosqlite' ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cccaf12c0832fb7529affffeeceff