### PR TITLE
Add admin markers to queries

### DIFF
--- a/cmd/goa4web/user_comments_add.go
+++ b/cmd/goa4web/user_comments_add.go
@@ -54,7 +54,7 @@ func (c *userCommentsAddCmd) Run() error {
 		c.ID = int(u.Idusers)
 	}
 	c.rootCmd.Verbosef("adding comment for user %d", c.ID)
-	if err := queries.InsertAdminUserComment(ctx, dbpkg.InsertAdminUserCommentParams{UsersIdusers: int32(c.ID), Comment: c.Comment}); err != nil {
+	if err := queries.AdminInsertUserComment(ctx, dbpkg.AdminInsertUserCommentParams{UsersIdusers: int32(c.ID), Comment: c.Comment}); err != nil {
 		return fmt.Errorf("insert comment: %w", err)
 	}
 	c.rootCmd.Infof("added comment for user %d", c.ID)

--- a/cmd/goa4web/user_comments_list.go
+++ b/cmd/goa4web/user_comments_list.go
@@ -47,7 +47,7 @@ func (c *userCommentsListCmd) Run() error {
 		}
 		c.ID = int(u.Idusers)
 	}
-	rows, err := queries.ListAdminUserComments(ctx, int32(c.ID))
+	rows, err := queries.AdminListUserComments(ctx, int32(c.ID))
 	if err != nil {
 		return fmt.Errorf("list comments: %w", err)
 	}

--- a/cmd/goa4web/user_profile.go
+++ b/cmd/goa4web/user_profile.go
@@ -56,7 +56,7 @@ func (c *userProfileCmd) Run() error {
 	for _, e := range emails {
 		fmt.Printf("Email: %s verified:%t priority:%d\n", e.Email, e.VerifiedAt.Valid, e.NotificationPriority)
 	}
-	comments, _ := queries.ListAdminUserComments(ctx, int32(c.ID))
+	comments, _ := queries.AdminListUserComments(ctx, int32(c.ID))
 	if len(comments) > 0 {
 		fmt.Println("Admin comments:")
 		for _, cm := range comments {

--- a/cmd/goa4web/user_reject.go
+++ b/cmd/goa4web/user_reject.go
@@ -55,7 +55,7 @@ func (c *userRejectCmd) Run() error {
 		return fmt.Errorf("add role: %w", err)
 	}
 	if c.Reason != "" {
-		if err := queries.InsertAdminUserComment(ctx, dbpkg.InsertAdminUserCommentParams{UsersIdusers: int32(c.ID), Comment: c.Reason}); err != nil {
+		if err := queries.AdminInsertUserComment(ctx, dbpkg.AdminInsertUserCommentParams{UsersIdusers: int32(c.ID), Comment: c.Reason}); err != nil {
 			log.Printf("insert admin user comment: %v", err)
 		}
 	}

--- a/handlers/admin/add_announcement_task.go
+++ b/handlers/admin/add_announcement_task.go
@@ -29,7 +29,7 @@ func (AddAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("news id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := queries.PromoteAnnouncement(r.Context(), int32(nid)); err != nil {
+	if err := queries.AdminPromoteAnnouncement(r.Context(), int32(nid)); err != nil {
 		return fmt.Errorf("promote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/adminAnnouncementsPage.go
+++ b/handlers/admin/adminAnnouncementsPage.go
@@ -15,14 +15,14 @@ import (
 func AdminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		Announcements []*db.ListAnnouncementsWithNewsForAdminRow
+		Announcements []*db.AdminListAnnouncementsWithNewsRow
 		NewsID        string
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Admin Announcements"
 	data := Data{CoreData: cd}
 	queries := cd.Queries()
-	rows, err := queries.ListAnnouncementsWithNewsForAdmin(r.Context())
+	rows, err := queries.AdminListAnnouncementsWithNews(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list announcements: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/adminUserProfilePage.go
+++ b/handlers/admin/adminUserProfilePage.go
@@ -26,7 +26,7 @@ func adminUserProfilePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	emails, _ := queries.GetUserEmailsByUserID(r.Context(), int32(id))
-	comments, _ := queries.ListAdminUserComments(r.Context(), int32(id))
+	comments, _ := queries.AdminListUserComments(r.Context(), int32(id))
 	roles, _ := queries.GetPermissionsByUserID(r.Context(), int32(id))
 	stats, _ := queries.UserPostCountsByID(r.Context(), int32(id))
 	bm, _ := queries.GetBookmarksForUser(r.Context(), int32(id))
@@ -80,7 +80,7 @@ func adminUserAddCommentPage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, "empty comment")
 	} else {
 		queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-		if err := queries.InsertAdminUserComment(r.Context(), db.InsertAdminUserCommentParams{UsersIdusers: int32(id), Comment: comment}); err != nil {
+		if err := queries.AdminInsertUserComment(r.Context(), db.AdminInsertUserCommentParams{UsersIdusers: int32(id), Comment: comment}); err != nil {
 			data.Errors = append(data.Errors, err.Error())
 		} else {
 			data.Messages = append(data.Messages, "comment added")

--- a/handlers/admin/delete_announcement_task.go
+++ b/handlers/admin/delete_announcement_task.go
@@ -30,7 +30,7 @@ func (DeleteAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.DemoteAnnouncement(r.Context(), int32(id)); err != nil {
+		if err := queries.AdminDemoteAnnouncement(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("demote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/auth/email_association_request_task.go
+++ b/handlers/auth/email_association_request_task.go
@@ -40,7 +40,7 @@ func (EmailAssociationRequestTask) Action(w http.ResponseWriter, r *http.Request
 	if row.Email != "" {
 		return handlers.RefreshDirectHandler{TargetURL: "/login"}
 	}
-	res, err := queries.InsertAdminRequestQueue(r.Context(), db.InsertAdminRequestQueueParams{
+	res, err := queries.AdminInsertRequestQueue(r.Context(), db.AdminInsertRequestQueueParams{
 		UsersIdusers:   row.Idusers,
 		ChangeTable:    "user_emails",
 		ChangeField:    "email",
@@ -53,8 +53,8 @@ func (EmailAssociationRequestTask) Action(w http.ResponseWriter, r *http.Request
 		return fmt.Errorf("insert admin request %w", err)
 	}
 	id, _ := res.LastInsertId()
-	_ = queries.InsertAdminRequestComment(r.Context(), db.InsertAdminRequestCommentParams{RequestID: int32(id), Comment: reason})
-	_ = queries.InsertAdminUserComment(r.Context(), db.InsertAdminUserCommentParams{UsersIdusers: row.Idusers, Comment: "email association requested"})
+	_ = queries.AdminInsertRequestComment(r.Context(), db.AdminInsertRequestCommentParams{RequestID: int32(id), Comment: reason})
+	_ = queries.AdminInsertUserComment(r.Context(), db.AdminInsertUserCommentParams{UsersIdusers: row.Idusers, Comment: "email association requested"})
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 		if evt := cd.Event(); evt != nil {
 			if evt.Data == nil {

--- a/handlers/news/announcement_add_task.go
+++ b/handlers/news/announcement_add_task.go
@@ -36,7 +36,7 @@ func (AnnouncementAddTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	if ann == nil {
-		if err := queries.PromoteAnnouncement(r.Context(), int32(pid)); err != nil {
+		if err := queries.AdminPromoteAnnouncement(r.Context(), int32(pid)); err != nil {
 			return fmt.Errorf("promote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	} else if !ann.Active {

--- a/handlers/user/admin_pending.go
+++ b/handlers/user/admin_pending.go
@@ -81,7 +81,7 @@ func adminPendingUsersReject(w http.ResponseWriter, r *http.Request) {
 			data.Messages = append(data.Messages, "user rejected")
 		}
 		if reason != "" {
-			if err := queries.InsertAdminUserComment(r.Context(), db.InsertAdminUserCommentParams{UsersIdusers: id, Comment: reason}); err != nil {
+			if err := queries.AdminInsertUserComment(r.Context(), db.AdminInsertUserCommentParams{UsersIdusers: id, Comment: reason}); err != nil {
 				log.Printf("insert admin user comment: %v", err)
 			} else {
 				data.Messages = append(data.Messages, "comment recorded")

--- a/handlers/user/admin_users.go
+++ b/handlers/user/admin_users.go
@@ -86,7 +86,7 @@ func adminUsersPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 	for _, u := range rows {
-		if c, err := queries.LatestAdminUserComment(r.Context(), u.Idusers); err == nil {
+		if c, err := queries.AdminGetLatestUserComment(r.Context(), u.Idusers); err == nil {
 			data.Comments[u.Idusers] = c
 		}
 	}

--- a/internal/db/queries-admin_request_comments.sql
+++ b/internal/db/queries-admin_request_comments.sql
@@ -1,8 +1,8 @@
--- name: InsertAdminRequestComment :exec
+-- name: AdminInsertRequestComment :exec
 INSERT INTO admin_request_comments (request_id, comment)
 VALUES (?, ?);
 
--- name: ListAdminRequestComments :many
+-- name: AdminListRequestComments :many
 SELECT id, request_id, comment, created_at
 FROM admin_request_comments
 WHERE request_id = ?

--- a/internal/db/queries-admin_request_comments.sql.go
+++ b/internal/db/queries-admin_request_comments.sql.go
@@ -9,30 +9,30 @@ import (
 	"context"
 )
 
-const insertAdminRequestComment = `-- name: InsertAdminRequestComment :exec
+const adminInsertRequestComment = `-- name: AdminInsertRequestComment :exec
 INSERT INTO admin_request_comments (request_id, comment)
 VALUES (?, ?)
 `
 
-type InsertAdminRequestCommentParams struct {
+type AdminInsertRequestCommentParams struct {
 	RequestID int32
 	Comment   string
 }
 
-func (q *Queries) InsertAdminRequestComment(ctx context.Context, arg InsertAdminRequestCommentParams) error {
-	_, err := q.db.ExecContext(ctx, insertAdminRequestComment, arg.RequestID, arg.Comment)
+func (q *Queries) AdminInsertRequestComment(ctx context.Context, arg AdminInsertRequestCommentParams) error {
+	_, err := q.db.ExecContext(ctx, adminInsertRequestComment, arg.RequestID, arg.Comment)
 	return err
 }
 
-const listAdminRequestComments = `-- name: ListAdminRequestComments :many
+const adminListRequestComments = `-- name: AdminListRequestComments :many
 SELECT id, request_id, comment, created_at
 FROM admin_request_comments
 WHERE request_id = ?
 ORDER BY id DESC
 `
 
-func (q *Queries) ListAdminRequestComments(ctx context.Context, requestID int32) ([]*AdminRequestComment, error) {
-	rows, err := q.db.QueryContext(ctx, listAdminRequestComments, requestID)
+func (q *Queries) AdminListRequestComments(ctx context.Context, requestID int32) ([]*AdminRequestComment, error) {
+	rows, err := q.db.QueryContext(ctx, adminListRequestComments, requestID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/queries-admin_request_queue.sql
+++ b/internal/db/queries-admin_request_queue.sql
@@ -1,23 +1,23 @@
--- name: InsertAdminRequestQueue :execresult
+-- name: AdminInsertRequestQueue :execresult
 INSERT INTO admin_request_queue (users_idusers, change_table, change_field, change_row_id, change_value, contact_options)
 VALUES (?, ?, ?, ?, ?, ?);
 
--- name: ListPendingAdminRequests :many
+-- name: AdminListPendingRequests :many
 SELECT id, users_idusers, change_table, change_field, change_row_id, change_value, contact_options, status, created_at, acted_at
 FROM admin_request_queue
 WHERE status = 'pending'
 ORDER BY id;
 
--- name: ListArchivedAdminRequests :many
+-- name: AdminListArchivedRequests :many
 SELECT id, users_idusers, change_table, change_field, change_row_id, change_value, contact_options, status, created_at, acted_at
 FROM admin_request_queue
 WHERE status <> 'pending'
 ORDER BY id DESC;
 
--- name: GetAdminRequestByID :one
+-- name: AdminGetRequestByID :one
 SELECT id, users_idusers, change_table, change_field, change_row_id, change_value, contact_options, status, created_at, acted_at
 FROM admin_request_queue
 WHERE id = ?;
 
--- name: UpdateAdminRequestStatus :exec
+-- name: AdminUpdateRequestStatus :exec
 UPDATE admin_request_queue SET status = ?, acted_at = NOW() WHERE id = ?;

--- a/internal/db/queries-admin_request_queue.sql.go
+++ b/internal/db/queries-admin_request_queue.sql.go
@@ -10,14 +10,14 @@ import (
 	"database/sql"
 )
 
-const getAdminRequestByID = `-- name: GetAdminRequestByID :one
+const adminGetRequestByID = `-- name: AdminGetRequestByID :one
 SELECT id, users_idusers, change_table, change_field, change_row_id, change_value, contact_options, status, created_at, acted_at
 FROM admin_request_queue
 WHERE id = ?
 `
 
-func (q *Queries) GetAdminRequestByID(ctx context.Context, id int32) (*AdminRequestQueue, error) {
-	row := q.db.QueryRowContext(ctx, getAdminRequestByID, id)
+func (q *Queries) AdminGetRequestByID(ctx context.Context, id int32) (*AdminRequestQueue, error) {
+	row := q.db.QueryRowContext(ctx, adminGetRequestByID, id)
 	var i AdminRequestQueue
 	err := row.Scan(
 		&i.ID,
@@ -34,12 +34,12 @@ func (q *Queries) GetAdminRequestByID(ctx context.Context, id int32) (*AdminRequ
 	return &i, err
 }
 
-const insertAdminRequestQueue = `-- name: InsertAdminRequestQueue :execresult
+const adminInsertRequestQueue = `-- name: AdminInsertRequestQueue :execresult
 INSERT INTO admin_request_queue (users_idusers, change_table, change_field, change_row_id, change_value, contact_options)
 VALUES (?, ?, ?, ?, ?, ?)
 `
 
-type InsertAdminRequestQueueParams struct {
+type AdminInsertRequestQueueParams struct {
 	UsersIdusers   int32
 	ChangeTable    string
 	ChangeField    string
@@ -48,8 +48,8 @@ type InsertAdminRequestQueueParams struct {
 	ContactOptions sql.NullString
 }
 
-func (q *Queries) InsertAdminRequestQueue(ctx context.Context, arg InsertAdminRequestQueueParams) (sql.Result, error) {
-	return q.db.ExecContext(ctx, insertAdminRequestQueue,
+func (q *Queries) AdminInsertRequestQueue(ctx context.Context, arg AdminInsertRequestQueueParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, adminInsertRequestQueue,
 		arg.UsersIdusers,
 		arg.ChangeTable,
 		arg.ChangeField,
@@ -59,15 +59,15 @@ func (q *Queries) InsertAdminRequestQueue(ctx context.Context, arg InsertAdminRe
 	)
 }
 
-const listArchivedAdminRequests = `-- name: ListArchivedAdminRequests :many
+const adminListArchivedRequests = `-- name: AdminListArchivedRequests :many
 SELECT id, users_idusers, change_table, change_field, change_row_id, change_value, contact_options, status, created_at, acted_at
 FROM admin_request_queue
 WHERE status <> 'pending'
 ORDER BY id DESC
 `
 
-func (q *Queries) ListArchivedAdminRequests(ctx context.Context) ([]*AdminRequestQueue, error) {
-	rows, err := q.db.QueryContext(ctx, listArchivedAdminRequests)
+func (q *Queries) AdminListArchivedRequests(ctx context.Context) ([]*AdminRequestQueue, error) {
+	rows, err := q.db.QueryContext(ctx, adminListArchivedRequests)
 	if err != nil {
 		return nil, err
 	}
@@ -100,15 +100,15 @@ func (q *Queries) ListArchivedAdminRequests(ctx context.Context) ([]*AdminReques
 	return items, nil
 }
 
-const listPendingAdminRequests = `-- name: ListPendingAdminRequests :many
+const adminListPendingRequests = `-- name: AdminListPendingRequests :many
 SELECT id, users_idusers, change_table, change_field, change_row_id, change_value, contact_options, status, created_at, acted_at
 FROM admin_request_queue
 WHERE status = 'pending'
 ORDER BY id
 `
 
-func (q *Queries) ListPendingAdminRequests(ctx context.Context) ([]*AdminRequestQueue, error) {
-	rows, err := q.db.QueryContext(ctx, listPendingAdminRequests)
+func (q *Queries) AdminListPendingRequests(ctx context.Context) ([]*AdminRequestQueue, error) {
+	rows, err := q.db.QueryContext(ctx, adminListPendingRequests)
 	if err != nil {
 		return nil, err
 	}
@@ -141,16 +141,16 @@ func (q *Queries) ListPendingAdminRequests(ctx context.Context) ([]*AdminRequest
 	return items, nil
 }
 
-const updateAdminRequestStatus = `-- name: UpdateAdminRequestStatus :exec
+const adminUpdateRequestStatus = `-- name: AdminUpdateRequestStatus :exec
 UPDATE admin_request_queue SET status = ?, acted_at = NOW() WHERE id = ?
 `
 
-type UpdateAdminRequestStatusParams struct {
+type AdminUpdateRequestStatusParams struct {
 	Status string
 	ID     int32
 }
 
-func (q *Queries) UpdateAdminRequestStatus(ctx context.Context, arg UpdateAdminRequestStatusParams) error {
-	_, err := q.db.ExecContext(ctx, updateAdminRequestStatus, arg.Status, arg.ID)
+func (q *Queries) AdminUpdateRequestStatus(ctx context.Context, arg AdminUpdateRequestStatusParams) error {
+	_, err := q.db.ExecContext(ctx, adminUpdateRequestStatus, arg.Status, arg.ID)
 	return err
 }

--- a/internal/db/queries-admin_user_comments.sql
+++ b/internal/db/queries-admin_user_comments.sql
@@ -1,14 +1,14 @@
--- name: InsertAdminUserComment :exec
+-- name: AdminInsertUserComment :exec
 INSERT INTO admin_user_comments (users_idusers, comment)
 VALUES (?, ?);
 
--- name: ListAdminUserComments :many
+-- name: AdminListUserComments :many
 SELECT id, users_idusers, comment, created_at
 FROM admin_user_comments
 WHERE users_idusers = ?
 ORDER BY id DESC;
 
--- name: LatestAdminUserComment :one
+-- name: AdminGetLatestUserComment :one
 SELECT id, users_idusers, comment, created_at
 FROM admin_user_comments
 WHERE users_idusers = ?

--- a/internal/db/queries-admin_user_comments.sql.go
+++ b/internal/db/queries-admin_user_comments.sql.go
@@ -9,22 +9,7 @@ import (
 	"context"
 )
 
-const insertAdminUserComment = `-- name: InsertAdminUserComment :exec
-INSERT INTO admin_user_comments (users_idusers, comment)
-VALUES (?, ?)
-`
-
-type InsertAdminUserCommentParams struct {
-	UsersIdusers int32
-	Comment      string
-}
-
-func (q *Queries) InsertAdminUserComment(ctx context.Context, arg InsertAdminUserCommentParams) error {
-	_, err := q.db.ExecContext(ctx, insertAdminUserComment, arg.UsersIdusers, arg.Comment)
-	return err
-}
-
-const latestAdminUserComment = `-- name: LatestAdminUserComment :one
+const adminGetLatestUserComment = `-- name: AdminGetLatestUserComment :one
 SELECT id, users_idusers, comment, created_at
 FROM admin_user_comments
 WHERE users_idusers = ?
@@ -32,8 +17,8 @@ ORDER BY id DESC
 LIMIT 1
 `
 
-func (q *Queries) LatestAdminUserComment(ctx context.Context, usersIdusers int32) (*AdminUserComment, error) {
-	row := q.db.QueryRowContext(ctx, latestAdminUserComment, usersIdusers)
+func (q *Queries) AdminGetLatestUserComment(ctx context.Context, usersIdusers int32) (*AdminUserComment, error) {
+	row := q.db.QueryRowContext(ctx, adminGetLatestUserComment, usersIdusers)
 	var i AdminUserComment
 	err := row.Scan(
 		&i.ID,
@@ -44,15 +29,30 @@ func (q *Queries) LatestAdminUserComment(ctx context.Context, usersIdusers int32
 	return &i, err
 }
 
-const listAdminUserComments = `-- name: ListAdminUserComments :many
+const adminInsertUserComment = `-- name: AdminInsertUserComment :exec
+INSERT INTO admin_user_comments (users_idusers, comment)
+VALUES (?, ?)
+`
+
+type AdminInsertUserCommentParams struct {
+	UsersIdusers int32
+	Comment      string
+}
+
+func (q *Queries) AdminInsertUserComment(ctx context.Context, arg AdminInsertUserCommentParams) error {
+	_, err := q.db.ExecContext(ctx, adminInsertUserComment, arg.UsersIdusers, arg.Comment)
+	return err
+}
+
+const adminListUserComments = `-- name: AdminListUserComments :many
 SELECT id, users_idusers, comment, created_at
 FROM admin_user_comments
 WHERE users_idusers = ?
 ORDER BY id DESC
 `
 
-func (q *Queries) ListAdminUserComments(ctx context.Context, usersIdusers int32) ([]*AdminUserComment, error) {
-	rows, err := q.db.QueryContext(ctx, listAdminUserComments, usersIdusers)
+func (q *Queries) AdminListUserComments(ctx context.Context, usersIdusers int32) ([]*AdminUserComment, error) {
+	rows, err := q.db.QueryContext(ctx, adminListUserComments, usersIdusers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -1,10 +1,8 @@
--- name: PromoteAnnouncement :exec
--- admin task
+-- name: AdminPromoteAnnouncement :exec
 INSERT INTO site_announcements (site_news_id)
 VALUES (?);
 
--- name: DemoteAnnouncement :exec
--- admin task
+-- name: AdminDemoteAnnouncement :exec
 DELETE FROM site_announcements WHERE id = ?;
 
 -- name: GetLatestAnnouncementByNewsID :one
@@ -55,8 +53,7 @@ WHERE a.active = 1
 ORDER BY a.created_at DESC
 LIMIT 1;
 
--- name: ListAnnouncementsWithNewsForAdmin :many
--- admin task
+-- name: AdminListAnnouncementsWithNews :many
 SELECT a.id, a.site_news_id, a.active, a.created_at, n.news
 FROM site_announcements a
 JOIN site_news n ON n.idsiteNews = a.site_news_id

--- a/internal/db/queries-announcements.sql.go
+++ b/internal/db/queries-announcements.sql.go
@@ -11,13 +11,66 @@ import (
 	"time"
 )
 
-const demoteAnnouncement = `-- name: DemoteAnnouncement :exec
+const adminDemoteAnnouncement = `-- name: AdminDemoteAnnouncement :exec
 DELETE FROM site_announcements WHERE id = ?
 `
 
-// admin task
-func (q *Queries) DemoteAnnouncement(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, demoteAnnouncement, id)
+func (q *Queries) AdminDemoteAnnouncement(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, adminDemoteAnnouncement, id)
+	return err
+}
+
+const adminListAnnouncementsWithNews = `-- name: AdminListAnnouncementsWithNews :many
+SELECT a.id, a.site_news_id, a.active, a.created_at, n.news
+FROM site_announcements a
+JOIN site_news n ON n.idsiteNews = a.site_news_id
+ORDER BY a.created_at DESC
+`
+
+type AdminListAnnouncementsWithNewsRow struct {
+	ID         int32
+	SiteNewsID int32
+	Active     bool
+	CreatedAt  time.Time
+	News       sql.NullString
+}
+
+func (q *Queries) AdminListAnnouncementsWithNews(ctx context.Context) ([]*AdminListAnnouncementsWithNewsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListAnnouncementsWithNews)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*AdminListAnnouncementsWithNewsRow
+	for rows.Next() {
+		var i AdminListAnnouncementsWithNewsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.SiteNewsID,
+			&i.Active,
+			&i.CreatedAt,
+			&i.News,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const adminPromoteAnnouncement = `-- name: AdminPromoteAnnouncement :exec
+INSERT INTO site_announcements (site_news_id)
+VALUES (?)
+`
+
+func (q *Queries) AdminPromoteAnnouncement(ctx context.Context, siteNewsID int32) error {
+	_, err := q.db.ExecContext(ctx, adminPromoteAnnouncement, siteNewsID)
 	return err
 }
 
@@ -101,62 +154,6 @@ func (q *Queries) GetLatestAnnouncementByNewsID(ctx context.Context, siteNewsID 
 		&i.CreatedAt,
 	)
 	return &i, err
-}
-
-const listAnnouncementsWithNewsForAdmin = `-- name: ListAnnouncementsWithNewsForAdmin :many
-SELECT a.id, a.site_news_id, a.active, a.created_at, n.news
-FROM site_announcements a
-JOIN site_news n ON n.idsiteNews = a.site_news_id
-ORDER BY a.created_at DESC
-`
-
-type ListAnnouncementsWithNewsForAdminRow struct {
-	ID         int32
-	SiteNewsID int32
-	Active     bool
-	CreatedAt  time.Time
-	News       sql.NullString
-}
-
-// admin task
-func (q *Queries) ListAnnouncementsWithNewsForAdmin(ctx context.Context) ([]*ListAnnouncementsWithNewsForAdminRow, error) {
-	rows, err := q.db.QueryContext(ctx, listAnnouncementsWithNewsForAdmin)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*ListAnnouncementsWithNewsForAdminRow
-	for rows.Next() {
-		var i ListAnnouncementsWithNewsForAdminRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.SiteNewsID,
-			&i.Active,
-			&i.CreatedAt,
-			&i.News,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const promoteAnnouncement = `-- name: PromoteAnnouncement :exec
-INSERT INTO site_announcements (site_news_id)
-VALUES (?)
-`
-
-// admin task
-func (q *Queries) PromoteAnnouncement(ctx context.Context, siteNewsID int32) error {
-	_, err := q.db.ExecContext(ctx, promoteAnnouncement, siteNewsID)
-	return err
 }
 
 const setAnnouncementActive = `-- name: SetAnnouncementActive :exec


### PR DESCRIPTION
## Summary
- prefix admin queries with `Admin`
- regenerate sqlc output and update handlers

## Testing
- `sqlc generate`
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cccc2b538832f833dcd08ac61309a