### PR TITLE
Prefix admin request comment queries

### DIFF
--- a/handlers/admin/adminRequestQueuePage.go
+++ b/handlers/admin/adminRequestQueuePage.go
@@ -77,7 +77,7 @@ func adminRequestPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
-	comments, _ := queries.ListAdminRequestComments(r.Context(), int32(id))
+	comments, _ := queries.AdminListRequestComments(r.Context(), int32(id))
 	user, _ := queries.GetUserById(r.Context(), req.UsersIdusers)
 	data := struct {
 		*common.CoreData
@@ -110,7 +110,7 @@ func adminRequestAddCommentPage(w http.ResponseWriter, r *http.Request) {
 	}
 	if comment == "" || id == 0 {
 		data.Errors = append(data.Errors, "invalid")
-	} else if err := queries.InsertAdminRequestComment(r.Context(), db.InsertAdminRequestCommentParams{RequestID: int32(id), Comment: comment}); err != nil {
+	} else if err := queries.AdminInsertRequestComment(r.Context(), db.AdminInsertRequestCommentParams{RequestID: int32(id), Comment: comment}); err != nil {
 		data.Errors = append(data.Errors, err.Error())
 	} else {
 		data.Messages = append(data.Messages, "comment added")
@@ -146,11 +146,11 @@ func handleRequestAction(w http.ResponseWriter, r *http.Request, status string) 
 	} else {
 		auto = fmt.Sprintf("status changed to %s", status)
 		data.Messages = append(data.Messages, auto)
-		if err := queries.InsertAdminRequestComment(r.Context(), db.InsertAdminRequestCommentParams{RequestID: int32(id), Comment: auto}); err != nil {
+		if err := queries.AdminInsertRequestComment(r.Context(), db.AdminInsertRequestCommentParams{RequestID: int32(id), Comment: auto}); err != nil {
 			data.Errors = append(data.Errors, err.Error())
 		}
 		if comment != "" {
-			if err := queries.InsertAdminRequestComment(r.Context(), db.InsertAdminRequestCommentParams{RequestID: int32(id), Comment: comment}); err != nil {
+			if err := queries.AdminInsertRequestComment(r.Context(), db.AdminInsertRequestCommentParams{RequestID: int32(id), Comment: comment}); err != nil {
 				data.Errors = append(data.Errors, err.Error())
 			}
 		}

--- a/handlers/auth/email_association_request_task.go
+++ b/handlers/auth/email_association_request_task.go
@@ -53,7 +53,7 @@ func (EmailAssociationRequestTask) Action(w http.ResponseWriter, r *http.Request
 		return fmt.Errorf("insert admin request %w", err)
 	}
 	id, _ := res.LastInsertId()
-	_ = queries.InsertAdminRequestComment(r.Context(), db.InsertAdminRequestCommentParams{RequestID: int32(id), Comment: reason})
+	_ = queries.AdminInsertRequestComment(r.Context(), db.AdminInsertRequestCommentParams{RequestID: int32(id), Comment: reason})
 	_ = queries.InsertAdminUserComment(r.Context(), db.InsertAdminUserCommentParams{UsersIdusers: row.Idusers, Comment: "email association requested"})
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 		if evt := cd.Event(); evt != nil {

--- a/internal/db/queries-admin_request_comments.sql
+++ b/internal/db/queries-admin_request_comments.sql
@@ -1,8 +1,8 @@
--- name: InsertAdminRequestComment :exec
+-- name: AdminInsertRequestComment :exec
 INSERT INTO admin_request_comments (request_id, comment)
 VALUES (?, ?);
 
--- name: ListAdminRequestComments :many
+-- name: AdminListRequestComments :many
 SELECT id, request_id, comment, created_at
 FROM admin_request_comments
 WHERE request_id = ?

--- a/internal/db/queries-admin_request_comments.sql.go
+++ b/internal/db/queries-admin_request_comments.sql.go
@@ -9,30 +9,30 @@ import (
 	"context"
 )
 
-const insertAdminRequestComment = `-- name: InsertAdminRequestComment :exec
+const adminInsertRequestComment = `-- name: AdminInsertRequestComment :exec
 INSERT INTO admin_request_comments (request_id, comment)
 VALUES (?, ?)
 `
 
-type InsertAdminRequestCommentParams struct {
+type AdminInsertRequestCommentParams struct {
 	RequestID int32
 	Comment   string
 }
 
-func (q *Queries) InsertAdminRequestComment(ctx context.Context, arg InsertAdminRequestCommentParams) error {
-	_, err := q.db.ExecContext(ctx, insertAdminRequestComment, arg.RequestID, arg.Comment)
+func (q *Queries) AdminInsertRequestComment(ctx context.Context, arg AdminInsertRequestCommentParams) error {
+	_, err := q.db.ExecContext(ctx, adminInsertRequestComment, arg.RequestID, arg.Comment)
 	return err
 }
 
-const listAdminRequestComments = `-- name: ListAdminRequestComments :many
+const adminListRequestComments = `-- name: AdminListRequestComments :many
 SELECT id, request_id, comment, created_at
 FROM admin_request_comments
 WHERE request_id = ?
 ORDER BY id DESC
 `
 
-func (q *Queries) ListAdminRequestComments(ctx context.Context, requestID int32) ([]*AdminRequestComment, error) {
-	rows, err := q.db.QueryContext(ctx, listAdminRequestComments, requestID)
+func (q *Queries) AdminListRequestComments(ctx context.Context, requestID int32) ([]*AdminRequestComment, error) {
+	rows, err := q.db.QueryContext(ctx, adminListRequestComments, requestID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- prefix admin request comment queries with `Admin`
- regenerate sqlc code for admin request comments and update handlers

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc8b56bc832fa5b8306d037cd92e