### PR TITLE
Add admin prefix to request queue queries

### DIFF
--- a/handlers/admin/adminRequestQueuePage.go
+++ b/handlers/admin/adminRequestQueuePage.go
@@ -17,7 +17,7 @@ func AdminRequestQueuePage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Admin Requests"
 	queries := cd.Queries()
-	rows, err := queries.ListPendingAdminRequests(r.Context())
+	rows, err := queries.AdminListPendingRequests(r.Context())
 	if err != nil && err != sql.ErrNoRows {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -44,7 +44,7 @@ func AdminRequestArchivePage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Request Archive"
 	queries := cd.Queries()
-	rows, err := queries.ListArchivedAdminRequests(r.Context())
+	rows, err := queries.AdminListArchivedRequests(r.Context())
 	if err != nil && err != sql.ErrNoRows {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -72,7 +72,7 @@ func adminRequestPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = fmt.Sprintf("Request %d", id)
 	queries := cd.Queries()
-	req, err := queries.GetAdminRequestByID(r.Context(), int32(id))
+	req, err := queries.AdminGetRequestByID(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
@@ -124,7 +124,7 @@ func handleRequestAction(w http.ResponseWriter, r *http.Request, status string) 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = fmt.Sprintf("Request %d", id)
 	queries := cd.Queries()
-	req, err := queries.GetAdminRequestByID(r.Context(), int32(id))
+	req, err := queries.AdminGetRequestByID(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
@@ -141,7 +141,7 @@ func handleRequestAction(w http.ResponseWriter, r *http.Request, status string) 
 
 	var auto string
 
-	if err := queries.UpdateAdminRequestStatus(r.Context(), db.UpdateAdminRequestStatusParams{Status: status, ID: int32(id)}); err != nil {
+	if err := queries.AdminUpdateRequestStatus(r.Context(), db.AdminUpdateRequestStatusParams{Status: status, ID: int32(id)}); err != nil {
 		data.Errors = append(data.Errors, err.Error())
 	} else {
 		auto = fmt.Sprintf("status changed to %s", status)

--- a/handlers/auth/email_association_request_task.go
+++ b/handlers/auth/email_association_request_task.go
@@ -40,7 +40,7 @@ func (EmailAssociationRequestTask) Action(w http.ResponseWriter, r *http.Request
 	if row.Email != "" {
 		return handlers.RefreshDirectHandler{TargetURL: "/login"}
 	}
-	res, err := queries.InsertAdminRequestQueue(r.Context(), db.InsertAdminRequestQueueParams{
+	res, err := queries.AdminInsertRequestQueue(r.Context(), db.AdminInsertRequestQueueParams{
 		UsersIdusers:   row.Idusers,
 		ChangeTable:    "user_emails",
 		ChangeField:    "email",

--- a/internal/db/queries-admin_request_queue.sql
+++ b/internal/db/queries-admin_request_queue.sql
@@ -1,23 +1,23 @@
--- name: InsertAdminRequestQueue :execresult
+-- name: AdminInsertRequestQueue :execresult
 INSERT INTO admin_request_queue (users_idusers, change_table, change_field, change_row_id, change_value, contact_options)
 VALUES (?, ?, ?, ?, ?, ?);
 
--- name: ListPendingAdminRequests :many
+-- name: AdminListPendingRequests :many
 SELECT id, users_idusers, change_table, change_field, change_row_id, change_value, contact_options, status, created_at, acted_at
 FROM admin_request_queue
 WHERE status = 'pending'
 ORDER BY id;
 
--- name: ListArchivedAdminRequests :many
+-- name: AdminListArchivedRequests :many
 SELECT id, users_idusers, change_table, change_field, change_row_id, change_value, contact_options, status, created_at, acted_at
 FROM admin_request_queue
 WHERE status <> 'pending'
 ORDER BY id DESC;
 
--- name: GetAdminRequestByID :one
+-- name: AdminGetRequestByID :one
 SELECT id, users_idusers, change_table, change_field, change_row_id, change_value, contact_options, status, created_at, acted_at
 FROM admin_request_queue
 WHERE id = ?;
 
--- name: UpdateAdminRequestStatus :exec
+-- name: AdminUpdateRequestStatus :exec
 UPDATE admin_request_queue SET status = ?, acted_at = NOW() WHERE id = ?;

--- a/internal/db/queries-admin_request_queue.sql.go
+++ b/internal/db/queries-admin_request_queue.sql.go
@@ -10,14 +10,14 @@ import (
 	"database/sql"
 )
 
-const getAdminRequestByID = `-- name: GetAdminRequestByID :one
+const adminGetRequestByID = `-- name: AdminGetRequestByID :one
 SELECT id, users_idusers, change_table, change_field, change_row_id, change_value, contact_options, status, created_at, acted_at
 FROM admin_request_queue
 WHERE id = ?
 `
 
-func (q *Queries) GetAdminRequestByID(ctx context.Context, id int32) (*AdminRequestQueue, error) {
-	row := q.db.QueryRowContext(ctx, getAdminRequestByID, id)
+func (q *Queries) AdminGetRequestByID(ctx context.Context, id int32) (*AdminRequestQueue, error) {
+	row := q.db.QueryRowContext(ctx, adminGetRequestByID, id)
 	var i AdminRequestQueue
 	err := row.Scan(
 		&i.ID,
@@ -34,12 +34,12 @@ func (q *Queries) GetAdminRequestByID(ctx context.Context, id int32) (*AdminRequ
 	return &i, err
 }
 
-const insertAdminRequestQueue = `-- name: InsertAdminRequestQueue :execresult
+const adminInsertRequestQueue = `-- name: AdminInsertRequestQueue :execresult
 INSERT INTO admin_request_queue (users_idusers, change_table, change_field, change_row_id, change_value, contact_options)
 VALUES (?, ?, ?, ?, ?, ?)
 `
 
-type InsertAdminRequestQueueParams struct {
+type AdminInsertRequestQueueParams struct {
 	UsersIdusers   int32
 	ChangeTable    string
 	ChangeField    string
@@ -48,8 +48,8 @@ type InsertAdminRequestQueueParams struct {
 	ContactOptions sql.NullString
 }
 
-func (q *Queries) InsertAdminRequestQueue(ctx context.Context, arg InsertAdminRequestQueueParams) (sql.Result, error) {
-	return q.db.ExecContext(ctx, insertAdminRequestQueue,
+func (q *Queries) AdminInsertRequestQueue(ctx context.Context, arg AdminInsertRequestQueueParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, adminInsertRequestQueue,
 		arg.UsersIdusers,
 		arg.ChangeTable,
 		arg.ChangeField,
@@ -59,15 +59,15 @@ func (q *Queries) InsertAdminRequestQueue(ctx context.Context, arg InsertAdminRe
 	)
 }
 
-const listArchivedAdminRequests = `-- name: ListArchivedAdminRequests :many
+const adminListArchivedRequests = `-- name: AdminListArchivedRequests :many
 SELECT id, users_idusers, change_table, change_field, change_row_id, change_value, contact_options, status, created_at, acted_at
 FROM admin_request_queue
 WHERE status <> 'pending'
 ORDER BY id DESC
 `
 
-func (q *Queries) ListArchivedAdminRequests(ctx context.Context) ([]*AdminRequestQueue, error) {
-	rows, err := q.db.QueryContext(ctx, listArchivedAdminRequests)
+func (q *Queries) AdminListArchivedRequests(ctx context.Context) ([]*AdminRequestQueue, error) {
+	rows, err := q.db.QueryContext(ctx, adminListArchivedRequests)
 	if err != nil {
 		return nil, err
 	}
@@ -100,15 +100,15 @@ func (q *Queries) ListArchivedAdminRequests(ctx context.Context) ([]*AdminReques
 	return items, nil
 }
 
-const listPendingAdminRequests = `-- name: ListPendingAdminRequests :many
+const adminListPendingRequests = `-- name: AdminListPendingRequests :many
 SELECT id, users_idusers, change_table, change_field, change_row_id, change_value, contact_options, status, created_at, acted_at
 FROM admin_request_queue
 WHERE status = 'pending'
 ORDER BY id
 `
 
-func (q *Queries) ListPendingAdminRequests(ctx context.Context) ([]*AdminRequestQueue, error) {
-	rows, err := q.db.QueryContext(ctx, listPendingAdminRequests)
+func (q *Queries) AdminListPendingRequests(ctx context.Context) ([]*AdminRequestQueue, error) {
+	rows, err := q.db.QueryContext(ctx, adminListPendingRequests)
 	if err != nil {
 		return nil, err
 	}
@@ -141,16 +141,16 @@ func (q *Queries) ListPendingAdminRequests(ctx context.Context) ([]*AdminRequest
 	return items, nil
 }
 
-const updateAdminRequestStatus = `-- name: UpdateAdminRequestStatus :exec
+const adminUpdateRequestStatus = `-- name: AdminUpdateRequestStatus :exec
 UPDATE admin_request_queue SET status = ?, acted_at = NOW() WHERE id = ?
 `
 
-type UpdateAdminRequestStatusParams struct {
+type AdminUpdateRequestStatusParams struct {
 	Status string
 	ID     int32
 }
 
-func (q *Queries) UpdateAdminRequestStatus(ctx context.Context, arg UpdateAdminRequestStatusParams) error {
-	_, err := q.db.ExecContext(ctx, updateAdminRequestStatus, arg.Status, arg.ID)
+func (q *Queries) AdminUpdateRequestStatus(ctx context.Context, arg AdminUpdateRequestStatusParams) error {
+	_, err := q.db.ExecContext(ctx, adminUpdateRequestStatus, arg.Status, arg.ID)
 	return err
 }


### PR DESCRIPTION
## Summary
- prefix all `admin_request_queue` sqlc queries with `Admin`
- regenerate sqlc code and update call sites

## Testing
- `sqlc generate`
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccc8cbc38832fabecd5f31258c6ec