### PR TITLE
Enhance search filters

### DIFF
--- a/handlers/forum/adminForumWordListHandler.go
+++ b/handlers/forum/adminForumWordListHandler.go
@@ -25,7 +25,7 @@ func AdminForumWordListPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := cd.Queries()
 
-	rows, err := queries.CompleteWordList(r.Context())
+	rows, err := queries.AdminCompleteWordList(r.Context())
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/news/searchResultNewsActionPage.go
+++ b/handlers/news/searchResultNewsActionPage.go
@@ -78,9 +78,13 @@ func NewsSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid
 
 	for i, word := range searchWords {
 		if i == 0 {
-			ids, err := queries.SiteNewsSearchFirst(r.Context(), sql.NullString{
-				String: word,
-				Valid:  true,
+			ids, err := queries.SiteNewsSearchFirst(r.Context(), db.SiteNewsSearchFirstParams{
+				ViewerID: uid,
+				Word: sql.NullString{
+					String: word,
+					Valid:  true,
+				},
+				UserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 			})
 			if err != nil {
 				switch {
@@ -94,11 +98,13 @@ func NewsSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, uid
 			newsIds = ids
 		} else {
 			ids, err := queries.SiteNewsSearchNext(r.Context(), db.SiteNewsSearchNextParams{
+				ViewerID: uid,
 				Word: sql.NullString{
 					String: word,
 					Valid:  true,
 				},
-				Ids: newsIds,
+				Ids:    newsIds,
+				UserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 			})
 			if err != nil {
 				switch {
@@ -145,11 +151,13 @@ func forumCommentSearchInRestrictedTopic(w http.ResponseWriter, r *http.Request,
 	for i, word := range searchWords {
 		if i == 0 {
 			ids, err := queries.CommentsSearchFirstInRestrictedTopic(r.Context(), db.CommentsSearchFirstInRestrictedTopicParams{
+				ViewerID: uid,
 				Word: sql.NullString{
 					String: word,
 					Valid:  true,
 				},
-				Ftids: forumTopicId,
+				Ftids:  forumTopicId,
+				UserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 			})
 			if err != nil {
 				switch {
@@ -163,12 +171,14 @@ func forumCommentSearchInRestrictedTopic(w http.ResponseWriter, r *http.Request,
 			commentIds = ids
 		} else {
 			ids, err := queries.CommentsSearchNextInRestrictedTopic(r.Context(), db.CommentsSearchNextInRestrictedTopicParams{
+				ViewerID: uid,
 				Word: sql.NullString{
 					String: word,
 					Valid:  true,
 				},
-				Ids:   commentIds,
-				Ftids: forumTopicId,
+				Ids:    commentIds,
+				Ftids:  forumTopicId,
+				UserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 			})
 			if err != nil {
 				switch {

--- a/handlers/news/search_test.go
+++ b/handlers/news/search_test.go
@@ -24,7 +24,7 @@ func TestNewsSearchFiltersUnauthorized(t *testing.T) {
 
 	firstRows := sqlmock.NewRows([]string{"site_news_id"}).AddRow(1).AddRow(2)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT DISTINCT cs.site_news_id")).
-		WithArgs(sql.NullString{String: "foo", Valid: true}).
+		WithArgs(int32(1), sql.NullString{String: "foo", Valid: true}, int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
 		WillReturnRows(firstRows)
 
 	newsRows := sqlmock.NewRows([]string{

--- a/handlers/search/admin_wordlist.go
+++ b/handlers/search/admin_wordlist.go
@@ -66,7 +66,7 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
 	if r.URL.Query().Get("download") != "" {
-		rows, err := queries.CompleteWordList(r.Context())
+		rows, err := queries.AdminCompleteWordList(r.Context())
 		if err != nil {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
@@ -89,12 +89,12 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 		totalCount int64
 	)
 	if letter != "" {
-		totalCount, err = queries.CountWordListByPrefix(r.Context(), letter)
+		totalCount, err = queries.AdminCountWordListByPrefix(r.Context(), letter)
 		if err != nil {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
-		prefRows, err2 := queries.WordListWithCountsByPrefix(r.Context(), db.WordListWithCountsByPrefixParams{
+		prefRows, err2 := queries.AdminWordListWithCountsByPrefix(r.Context(), db.AdminWordListWithCountsByPrefixParams{
 			Prefix: letter,
 			Limit:  int32(pageSize),
 			Offset: int32(offset),
@@ -107,12 +107,12 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 			rows = append(rows, WordCount{Word: r.Word, Count: r.Count})
 		}
 	} else {
-		totalCount, err = queries.CountWordList(r.Context())
+		totalCount, err = queries.AdminCountWordList(r.Context())
 		if err != nil {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
-		allRows, err2 := queries.WordListWithCounts(r.Context(), db.WordListWithCountsParams{
+		allRows, err2 := queries.AdminWordListWithCounts(r.Context(), db.AdminWordListWithCountsParams{
 			Limit:  int32(pageSize),
 			Offset: int32(offset),
 		})
@@ -154,7 +154,7 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 func adminSearchWordListDownloadPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
-	rows, err := queries.CompleteWordList(r.Context())
+	rows, err := queries.AdminCompleteWordList(r.Context())
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/search/reindex.go
+++ b/handlers/search/reindex.go
@@ -21,12 +21,12 @@ func indexText(ctx context.Context, q *db.Queries, cache map[string]int64, text 
 		id, ok := cache[w]
 		if !ok {
 			var err error
-			id, err = q.CreateSearchWord(ctx, w)
+			id, err = q.SystemCreateSearchWord(ctx, w)
 			if err != nil {
 				return err
 			}
 			if id == 0 {
-				sw, err := q.GetSearchWordByWordLowercased(ctx, w)
+				sw, err := q.SystemGetSearchWordByWordLowercased(ctx, w)
 				if err != nil {
 					return err
 				}

--- a/handlers/search/remakeBlogTask.go
+++ b/handlers/search/remakeBlogTask.go
@@ -36,7 +36,7 @@ func (RemakeBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 }
 
 func (RemakeBlogTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tasks.Task, error) {
-	if err := q.DeleteBlogsSearch(ctx); err != nil {
+	if err := q.SystemDeleteBlogsSearch(ctx); err != nil {
 		return nil, err
 	}
 	rows, err := q.SystemGetAllBlogsForIndex(ctx)
@@ -50,7 +50,7 @@ func (RemakeBlogTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tas
 			continue
 		}
 		if err := indexText(ctx, q, cache, text, func(c context.Context, wid int64, count int32) error {
-			return q.AddToBlogsSearch(c, dbpkg.AddToBlogsSearchParams{
+			return q.SystemAddToBlogsSearch(c, dbpkg.SystemAddToBlogsSearchParams{
 				BlogID:                         row.Idblogs,
 				SearchwordlistIdsearchwordlist: int32(wid),
 				WordCount:                      count,

--- a/handlers/search/remakeCommentsTask.go
+++ b/handlers/search/remakeCommentsTask.go
@@ -36,7 +36,7 @@ func (RemakeCommentsTask) Action(w http.ResponseWriter, r *http.Request) any {
 }
 
 func (RemakeCommentsTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tasks.Task, error) {
-	if err := q.DeleteCommentsSearch(ctx); err != nil {
+	if err := q.SystemDeleteCommentsSearch(ctx); err != nil {
 		return nil, err
 	}
 	rows, err := q.GetAllCommentsForIndex(ctx)
@@ -50,7 +50,7 @@ func (RemakeCommentsTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) 
 			continue
 		}
 		if err := indexText(ctx, q, cache, text, func(c context.Context, wid int64, count int32) error {
-			return q.AddToForumCommentSearch(c, dbpkg.AddToForumCommentSearchParams{
+			return q.SystemAddToForumCommentSearch(c, dbpkg.SystemAddToForumCommentSearchParams{
 				CommentID:                      row.Idcomments,
 				SearchwordlistIdsearchwordlist: int32(wid),
 				WordCount:                      count,

--- a/handlers/search/remakeImageTask.go
+++ b/handlers/search/remakeImageTask.go
@@ -36,7 +36,7 @@ func (RemakeImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 }
 
 func (RemakeImageTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tasks.Task, error) {
-	if err := q.DeleteImagePostSearch(ctx); err != nil {
+	if err := q.SystemDeleteImagePostSearch(ctx); err != nil {
 		return nil, err
 	}
 	rows, err := q.GetAllImagePostsForIndex(ctx)
@@ -50,7 +50,7 @@ func (RemakeImageTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (ta
 			continue
 		}
 		if err := indexText(ctx, q, cache, text, func(c context.Context, wid int64, count int32) error {
-			return q.AddToImagePostSearch(c, dbpkg.AddToImagePostSearchParams{
+			return q.SystemAddToImagePostSearch(c, dbpkg.SystemAddToImagePostSearchParams{
 				ImagePostID:                    row.Idimagepost,
 				SearchwordlistIdsearchwordlist: int32(wid),
 				WordCount:                      count,

--- a/handlers/search/remakeLinkerTask.go
+++ b/handlers/search/remakeLinkerTask.go
@@ -36,7 +36,7 @@ func (RemakeLinkerTask) Action(w http.ResponseWriter, r *http.Request) any {
 }
 
 func (RemakeLinkerTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tasks.Task, error) {
-	if err := q.DeleteLinkerSearch(ctx); err != nil {
+	if err := q.SystemDeleteLinkerSearch(ctx); err != nil {
 		return nil, err
 	}
 	rows, err := q.GetAllLinkersForIndex(ctx)
@@ -50,7 +50,7 @@ func (RemakeLinkerTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (t
 			continue
 		}
 		if err := indexText(ctx, q, cache, text, func(c context.Context, wid int64, count int32) error {
-			return q.AddToLinkerSearch(c, dbpkg.AddToLinkerSearchParams{
+			return q.SystemAddToLinkerSearch(c, dbpkg.SystemAddToLinkerSearchParams{
 				LinkerID:                       row.Idlinker,
 				SearchwordlistIdsearchwordlist: int32(wid),
 				WordCount:                      count,

--- a/handlers/search/remakeNewsTask.go
+++ b/handlers/search/remakeNewsTask.go
@@ -36,7 +36,7 @@ func (RemakeNewsTask) Action(w http.ResponseWriter, r *http.Request) any {
 }
 
 func (RemakeNewsTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tasks.Task, error) {
-	if err := q.DeleteSiteNewsSearch(ctx); err != nil {
+	if err := q.SystemDeleteSiteNewsSearch(ctx); err != nil {
 		return nil, err
 	}
 	rows, err := q.GetAllSiteNewsForIndex(ctx)
@@ -50,7 +50,7 @@ func (RemakeNewsTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tas
 			continue
 		}
 		if err := indexText(ctx, q, cache, text, func(c context.Context, wid int64, count int32) error {
-			return q.AddToSiteNewsSearch(c, dbpkg.AddToSiteNewsSearchParams{
+			return q.SystemAddToSiteNewsSearch(c, dbpkg.SystemAddToSiteNewsSearchParams{
 				SiteNewsID:                     row.Idsitenews,
 				SearchwordlistIdsearchwordlist: int32(wid),
 				WordCount:                      count,

--- a/handlers/search/remakeWritingTask.go
+++ b/handlers/search/remakeWritingTask.go
@@ -36,7 +36,7 @@ func (RemakeWritingTask) Action(w http.ResponseWriter, r *http.Request) any {
 }
 
 func (RemakeWritingTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (tasks.Task, error) {
-	if err := q.DeleteWritingSearch(ctx); err != nil {
+	if err := q.SystemDeleteWritingSearch(ctx); err != nil {
 		return nil, err
 	}
 	rows, err := q.GetAllWritingsForIndex(ctx)
@@ -50,7 +50,7 @@ func (RemakeWritingTask) BackgroundTask(ctx context.Context, q *dbpkg.Queries) (
 			continue
 		}
 		if err := indexText(ctx, q, cache, text, func(c context.Context, wid int64, count int32) error {
-			return q.AddToForumWritingSearch(c, dbpkg.AddToForumWritingSearchParams{
+			return q.SystemAddToForumWritingSearch(c, dbpkg.SystemAddToForumWritingSearchParams{
 				WritingID:                      row.Idwriting,
 				SearchwordlistIdsearchwordlist: int32(wid),
 				WordCount:                      count,

--- a/handlers/search/searchResultForumActionPage.go
+++ b/handlers/search/searchResultForumActionPage.go
@@ -66,9 +66,13 @@ func ForumCommentSearchNotInRestrictedTopic(w http.ResponseWriter, r *http.Reque
 
 	for i, word := range searchWords {
 		if i == 0 {
-			ids, err := queries.CommentsSearchFirstNotInRestrictedTopic(r.Context(), sql.NullString{
-				String: word,
-				Valid:  true,
+			ids, err := queries.CommentsSearchFirstNotInRestrictedTopic(r.Context(), db.CommentsSearchFirstNotInRestrictedTopicParams{
+				ViewerID: uid,
+				Word: sql.NullString{
+					String: word,
+					Valid:  true,
+				},
+				UserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 			})
 			if err != nil {
 				switch {
@@ -82,11 +86,13 @@ func ForumCommentSearchNotInRestrictedTopic(w http.ResponseWriter, r *http.Reque
 			commentIds = ids
 		} else {
 			ids, err := queries.CommentsSearchNextNotInRestrictedTopic(r.Context(), db.CommentsSearchNextNotInRestrictedTopicParams{
+				ViewerID: uid,
 				Word: sql.NullString{
 					String: word,
 					Valid:  true,
 				},
-				Ids: commentIds,
+				Ids:    commentIds,
+				UserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 			})
 			if err != nil {
 				switch {
@@ -133,11 +139,13 @@ func ForumCommentSearchInRestrictedTopic(w http.ResponseWriter, r *http.Request,
 	for i, word := range searchWords {
 		if i == 0 {
 			ids, err := queries.CommentsSearchFirstInRestrictedTopic(r.Context(), db.CommentsSearchFirstInRestrictedTopicParams{
+				ViewerID: uid,
 				Word: sql.NullString{
 					String: word,
 					Valid:  true,
 				},
-				Ftids: forumTopicId,
+				Ftids:  forumTopicId,
+				UserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 			})
 			if err != nil {
 				switch {
@@ -151,12 +159,14 @@ func ForumCommentSearchInRestrictedTopic(w http.ResponseWriter, r *http.Request,
 			commentIds = ids
 		} else {
 			ids, err := queries.CommentsSearchNextInRestrictedTopic(r.Context(), db.CommentsSearchNextInRestrictedTopicParams{
+				ViewerID: uid,
 				Word: sql.NullString{
 					String: word,
 					Valid:  true,
 				},
-				Ids:   commentIds,
-				Ftids: forumTopicId,
+				Ids:    commentIds,
+				Ftids:  forumTopicId,
+				UserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 			})
 			if err != nil {
 				switch {

--- a/handlers/search/searchResultLinkerActionPage.go
+++ b/handlers/search/searchResultLinkerActionPage.go
@@ -86,9 +86,13 @@ func LinkerSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, u
 
 	for i, word := range searchWords {
 		if i == 0 {
-			ids, err := queries.LinkerSearchFirst(r.Context(), sql.NullString{
-				String: word,
-				Valid:  true,
+			ids, err := queries.LinkerSearchFirst(r.Context(), db.LinkerSearchFirstParams{
+				ViewerID: uid,
+				Word: sql.NullString{
+					String: word,
+					Valid:  true,
+				},
+				UserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 			})
 			if err != nil {
 				switch {
@@ -102,11 +106,13 @@ func LinkerSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, u
 			LinkerIds = ids
 		} else {
 			ids, err := queries.LinkerSearchNext(r.Context(), db.LinkerSearchNextParams{
+				ViewerID: uid,
 				Word: sql.NullString{
 					String: word,
 					Valid:  true,
 				},
-				Ids: LinkerIds,
+				Ids:    LinkerIds,
+				UserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 			})
 			if err != nil {
 				switch {

--- a/handlers/search/searchResultWritingsActionPage.go
+++ b/handlers/search/searchResultWritingsActionPage.go
@@ -85,9 +85,13 @@ func WritingSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, 
 
 	for i, word := range searchWords {
 		if i == 0 {
-			ids, err := queries.WritingSearchFirst(r.Context(), sql.NullString{
-				String: word,
-				Valid:  true,
+			ids, err := queries.WritingSearchFirst(r.Context(), db.WritingSearchFirstParams{
+				ViewerID: uid,
+				Word: sql.NullString{
+					String: word,
+					Valid:  true,
+				},
+				UserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 			})
 			if err != nil {
 				switch {
@@ -101,11 +105,13 @@ func WritingSearch(w http.ResponseWriter, r *http.Request, queries *db.Queries, 
 			writingsIds = ids
 		} else {
 			ids, err := queries.WritingSearchNext(r.Context(), db.WritingSearchNextParams{
+				ViewerID: uid,
 				Word: sql.NullString{
 					String: word,
 					Valid:  true,
 				},
-				Ids: writingsIds,
+				Ids:    writingsIds,
+				UserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 			})
 			if err != nil {
 				switch {

--- a/workers/searchworker/tokenize.go
+++ b/workers/searchworker/tokenize.go
@@ -54,7 +54,7 @@ func SearchWordIdsFromText(w http.ResponseWriter, r *http.Request, text string, 
 	}
 	results := make([]WordCount, 0, len(counts))
 	for word, c := range counts {
-		id, err := queries.CreateSearchWord(r.Context(), strings.ToLower(word))
+		id, err := queries.SystemCreateSearchWord(r.Context(), strings.ToLower(word))
 		if err != nil {
 			log.Printf("Error: createSearchWord: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
@@ -68,7 +68,7 @@ func SearchWordIdsFromText(w http.ResponseWriter, r *http.Request, text string, 
 // InsertWordsToLinkerSearch associates search words with a linker post.
 func InsertWordsToLinkerSearch(w http.ResponseWriter, r *http.Request, words []WordCount, queries *db.Queries, lid int64) bool {
 	return InsertWords(w, r, words, func(ctx context.Context, wid int64, count int32) error {
-		return queries.AddToLinkerSearch(ctx, db.AddToLinkerSearchParams{
+		return queries.SystemAddToLinkerSearch(ctx, db.SystemAddToLinkerSearchParams{
 			LinkerID:                       int32(lid),
 			SearchwordlistIdsearchwordlist: int32(wid),
 			WordCount:                      count,
@@ -79,7 +79,7 @@ func InsertWordsToLinkerSearch(w http.ResponseWriter, r *http.Request, words []W
 // InsertWordsToImageSearch associates search words with an image post.
 func InsertWordsToImageSearch(w http.ResponseWriter, r *http.Request, words []WordCount, queries *db.Queries, pid int64) bool {
 	return InsertWords(w, r, words, func(ctx context.Context, wid int64, count int32) error {
-		return queries.AddToImagePostSearch(ctx, db.AddToImagePostSearchParams{
+		return queries.SystemAddToImagePostSearch(ctx, db.SystemAddToImagePostSearchParams{
 			ImagePostID:                    int32(pid),
 			SearchwordlistIdsearchwordlist: int32(wid),
 			WordCount:                      count,
@@ -90,7 +90,7 @@ func InsertWordsToImageSearch(w http.ResponseWriter, r *http.Request, words []Wo
 // InsertWordsToWritingSearch associates search words with a writing post.
 func InsertWordsToWritingSearch(w http.ResponseWriter, r *http.Request, words []WordCount, queries *db.Queries, wacid int64) bool {
 	return InsertWords(w, r, words, func(ctx context.Context, wid int64, count int32) error {
-		return queries.AddToForumWritingSearch(ctx, db.AddToForumWritingSearchParams{
+		return queries.SystemAddToForumWritingSearch(ctx, db.SystemAddToForumWritingSearchParams{
 			WritingID:                      int32(wacid),
 			SearchwordlistIdsearchwordlist: int32(wid),
 			WordCount:                      count,
@@ -101,7 +101,7 @@ func InsertWordsToWritingSearch(w http.ResponseWriter, r *http.Request, words []
 // InsertWordsToForumSearch associates search words with a forum comment.
 func InsertWordsToForumSearch(w http.ResponseWriter, r *http.Request, words []WordCount, queries *db.Queries, cid int64) bool {
 	return InsertWords(w, r, words, func(ctx context.Context, wid int64, count int32) error {
-		return queries.AddToForumCommentSearch(ctx, db.AddToForumCommentSearchParams{
+		return queries.SystemAddToForumCommentSearch(ctx, db.SystemAddToForumCommentSearchParams{
 			CommentID:                      int32(cid),
 			SearchwordlistIdsearchwordlist: int32(wid),
 			WordCount:                      count,

--- a/workers/searchworker/worker.go
+++ b/workers/searchworker/worker.go
@@ -64,25 +64,25 @@ func index(ctx context.Context, q *dbpkg.Queries, data IndexEventData) error {
 		counts[strings.ToLower(w)]++
 	}
 	for word, count := range counts {
-		id, err := q.CreateSearchWord(ctx, strings.ToLower(word))
+		id, err := q.SystemCreateSearchWord(ctx, strings.ToLower(word))
 		if err != nil {
 			return err
 		}
 		switch data.Type {
 		case TypeComment:
-			if err := q.AddToForumCommentSearch(ctx, dbpkg.AddToForumCommentSearchParams{CommentID: data.ID, SearchwordlistIdsearchwordlist: int32(id), WordCount: count}); err != nil {
+			if err := q.SystemAddToForumCommentSearch(ctx, dbpkg.SystemAddToForumCommentSearchParams{CommentID: data.ID, SearchwordlistIdsearchwordlist: int32(id), WordCount: count}); err != nil {
 				return err
 			}
 		case TypeWriting:
-			if err := q.AddToForumWritingSearch(ctx, dbpkg.AddToForumWritingSearchParams{WritingID: data.ID, SearchwordlistIdsearchwordlist: int32(id), WordCount: count}); err != nil {
+			if err := q.SystemAddToForumWritingSearch(ctx, dbpkg.SystemAddToForumWritingSearchParams{WritingID: data.ID, SearchwordlistIdsearchwordlist: int32(id), WordCount: count}); err != nil {
 				return err
 			}
 		case TypeLinker:
-			if err := q.AddToLinkerSearch(ctx, dbpkg.AddToLinkerSearchParams{LinkerID: data.ID, SearchwordlistIdsearchwordlist: int32(id), WordCount: count}); err != nil {
+			if err := q.SystemAddToLinkerSearch(ctx, dbpkg.SystemAddToLinkerSearchParams{LinkerID: data.ID, SearchwordlistIdsearchwordlist: int32(id), WordCount: count}); err != nil {
 				return err
 			}
 		case TypeImage:
-			if err := q.AddToImagePostSearch(ctx, dbpkg.AddToImagePostSearchParams{ImagePostID: data.ID, SearchwordlistIdsearchwordlist: int32(id), WordCount: count}); err != nil {
+			if err := q.SystemAddToImagePostSearch(ctx, dbpkg.SystemAddToImagePostSearchParams{ImagePostID: data.ID, SearchwordlistIdsearchwordlist: int32(id), WordCount: count}); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary
- add language and role filters to search queries
- mark admin and system tasks in SQL using prefixes
- regenerate sqlc code and update handlers for new query params

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688ccca4d96c832f9c0d81ead5793f24