### PR TITLE
Add role checks for email queries

### DIFF
--- a/handlers/admin/adminUserProfilePage.go
+++ b/handlers/admin/adminUserProfilePage.go
@@ -25,7 +25,7 @@ func adminUserProfilePage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	emails, _ := queries.GetUserEmailsByUserID(r.Context(), int32(id))
+	emails, _ := queries.GetUserEmailsByUserIDAdmin(r.Context(), int32(id))
 	comments, _ := queries.ListAdminUserComments(r.Context(), int32(id))
 	roles, _ := queries.GetPermissionsByUserID(r.Context(), int32(id))
 	stats, _ := queries.UserPostCountsByID(r.Context(), int32(id))

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -36,7 +36,7 @@ func userEmailPage(w http.ResponseWriter, r *http.Request) {
 	user, _ := cd.CurrentUser()
 	pref, _ := cd.Preference()
 
-	emails, _ := queries.GetUserEmailsByUserID(r.Context(), cd.UserID)
+	emails, _ := queries.GetUserEmailsByUserID(r.Context(), db.GetUserEmailsByUserIDParams{UserID: cd.UserID, ViewerID: cd.UserID})
 	var verified, unverified []*db.UserEmail
 	for _, e := range emails {
 		if e.VerifiedAt.Valid {

--- a/handlers/user/userNotificationsPage.go
+++ b/handlers/user/userNotificationsPage.go
@@ -40,7 +40,7 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	emails, _ := queries.GetUserEmailsByUserID(r.Context(), uid)
+	emails, _ := queries.GetUserEmailsByUserID(r.Context(), db.GetUserEmailsByUserIDParams{UserID: uid, ViewerID: uid})
 	var maxPr int32
 	for _, e := range emails {
 		if e.NotificationPriority > maxPr {

--- a/internal/db/queries-user_emails.sql.go
+++ b/internal/db/queries-user_emails.sql.go
@@ -10,15 +10,6 @@ import (
 	"database/sql"
 )
 
-const clearNotificationPriority = `-- name: ClearNotificationPriority :exec
-UPDATE user_emails SET notification_priority = 0 WHERE user_id = ?
-`
-
-func (q *Queries) ClearNotificationPriority(ctx context.Context, userID int32) error {
-	_, err := q.db.ExecContext(ctx, clearNotificationPriority, userID)
-	return err
-}
-
 const deleteUserEmail = `-- name: DeleteUserEmail :exec
 DELETE FROM user_emails WHERE id = ?
 `
@@ -140,13 +131,73 @@ func (q *Queries) GetUserEmailByID(ctx context.Context, id int32) (*UserEmail, e
 }
 
 const getUserEmailsByUserID = `-- name: GetUserEmailsByUserID :many
+WITH RECURSIVE role_ids(id) AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
+    UNION
+    SELECT r2.id
+    FROM role_ids ri
+    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
+    JOIN roles r2 ON r2.name = g.action
+)
+SELECT ue.id, ue.user_id, ue.email, ue.verified_at, ue.last_verification_code, ue.verification_expires_at, ue.notification_priority
+FROM user_emails ue
+WHERE ue.user_id = ?
+  AND (
+      ? = ue.user_id
+      OR EXISTS (
+          SELECT 1
+          FROM role_ids ri
+          JOIN roles r ON r.id = ri.id
+          WHERE r.is_admin = 1
+      )
+  )
+`
+
+type GetUserEmailsByUserIDParams struct {
+	ViewerID int32
+	UserID   int32
+}
+
+func (q *Queries) GetUserEmailsByUserID(ctx context.Context, arg GetUserEmailsByUserIDParams) ([]*UserEmail, error) {
+	rows, err := q.db.QueryContext(ctx, getUserEmailsByUserID, arg.ViewerID, arg.UserID, arg.ViewerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*UserEmail
+	for rows.Next() {
+		var i UserEmail
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.Email,
+			&i.VerifiedAt,
+			&i.LastVerificationCode,
+			&i.VerificationExpiresAt,
+			&i.NotificationPriority,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getUserEmailsByUserIDAdmin = `-- name: GetUserEmailsByUserIDAdmin :many
 SELECT id, user_id, email, verified_at, last_verification_code, verification_expires_at, notification_priority
 FROM user_emails
 WHERE user_id = ?
+ORDER BY notification_priority DESC, id
 `
 
-func (q *Queries) GetUserEmailsByUserID(ctx context.Context, userID int32) ([]*UserEmail, error) {
-	rows, err := q.db.QueryContext(ctx, getUserEmailsByUserID, userID)
+func (q *Queries) GetUserEmailsByUserIDAdmin(ctx context.Context, userID int32) ([]*UserEmail, error) {
+	rows, err := q.db.QueryContext(ctx, getUserEmailsByUserIDAdmin, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -283,42 +334,4 @@ type UpdateUserEmailVerificationParams struct {
 func (q *Queries) UpdateUserEmailVerification(ctx context.Context, arg UpdateUserEmailVerificationParams) error {
 	_, err := q.db.ExecContext(ctx, updateUserEmailVerification, arg.VerifiedAt, arg.ID)
 	return err
-}
-
-const listEmailsByUserID = `-- name: listEmailsByUserID :many
-SELECT id, user_id, email, verified_at, last_verification_code, verification_expires_at, notification_priority
-FROM user_emails
-WHERE user_id = ?
-ORDER BY notification_priority DESC, id
-`
-
-func (q *Queries) listEmailsByUserID(ctx context.Context, userID int32) ([]*UserEmail, error) {
-	rows, err := q.db.QueryContext(ctx, listEmailsByUserID, userID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*UserEmail
-	for rows.Next() {
-		var i UserEmail
-		if err := rows.Scan(
-			&i.ID,
-			&i.UserID,
-			&i.Email,
-			&i.VerifiedAt,
-			&i.LastVerificationCode,
-			&i.VerificationExpiresAt,
-			&i.NotificationPriority,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }


### PR DESCRIPTION
## Summary
- secure email listing with role checks
- delete unused email queries
- support viewer parameter when listing emails
- update call sites to pass viewer ID
- expose viewer flag on `user profile` command
- add admin email listing query and use it when viewer ID isn't supplied

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cccaabfd4832f8f4b402f0e98a893