### PR TITLE
Prefix session queries with System/Admin prefixes

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -42,11 +42,9 @@ type AdminSection struct {
 
 // SessionManager defines optional hooks for storing and removing session
 // information. Implementations may persist session metadata in a database or
-// other storage.
-// SessionManager exposes methods used by CoreData to record session information.
-// Typically *db.Queries satisfies this interface.
+// other storage while exposing a storage-agnostic API to CoreData.
 type SessionManager interface {
-	InsertSession(ctx context.Context, arg db.InsertSessionParams) error
+	InsertSession(ctx context.Context, sessionID string, userID int32) error
 	DeleteSessionByID(ctx context.Context, sessionID string) error
 }
 

--- a/handlers/user/admin_sessions.go
+++ b/handlers/user/admin_sessions.go
@@ -14,11 +14,11 @@ import (
 func adminSessionsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-		Sessions []*db.ListSessionsRow
+		Sessions []*db.AdminListSessionsRow
 	}
 	data := Data{CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData)}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	items, err := queries.ListSessions(r.Context())
+	items, err := queries.AdminListSessions(r.Context())
 	if err != nil {
 		log.Printf("list sessions: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -42,7 +42,8 @@ func adminSessionsDeletePage(w http.ResponseWriter, r *http.Request) {
 	if sid == "" {
 		data.Errors = append(data.Errors, "missing sid")
 	} else {
-		if err := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries().DeleteSessionByID(r.Context(), sid); err != nil {
+		sm := data.CoreData.SessionManager()
+		if err := sm.DeleteSessionByID(r.Context(), sid); err != nil {
 			data.Errors = append(data.Errors, err.Error())
 		}
 	}

--- a/handlers/user/userLogoutPage.go
+++ b/handlers/user/userLogoutPage.go
@@ -33,9 +33,9 @@ func userLogoutPage(w http.ResponseWriter, r *http.Request) {
 	delete(session.Values, "UID")
 	delete(session.Values, "LoginTime")
 	delete(session.Values, "ExpiryTime")
-	queries := cd.Queries()
+	sm := cd.SessionManager()
 	if session.ID != "" {
-		if err := queries.DeleteSessionByID(r.Context(), session.ID); err != nil {
+		if err := sm.DeleteSessionByID(r.Context(), session.ID); err != nil {
 			log.Printf("delete session: %v", err)
 		}
 	}

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -203,18 +203,18 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 			}
 
 			queries := dbpkg.New(s.DB)
-			sm := queries
+			sm := dbpkg.NewSessionProxy(queries)
 			if s.Config.DBLogVerbosity > 0 {
 				log.Printf("db pool stats: %+v", s.DB.Stats())
 			}
 
 			if session.ID != "" {
 				if uid != 0 {
-					if err := queries.InsertSession(r.Context(), dbpkg.InsertSessionParams{SessionID: session.ID, UsersIdusers: uid}); err != nil {
+					if err := sm.InsertSession(r.Context(), session.ID, uid); err != nil {
 						log.Printf("insert session: %v", err)
 					}
 				} else {
-					if err := queries.DeleteSessionByID(r.Context(), session.ID); err != nil {
+					if err := sm.DeleteSessionByID(r.Context(), session.ID); err != nil {
 						log.Printf("delete session: %v", err)
 					}
 				}

--- a/internal/db/queries-sessions.sql
+++ b/internal/db/queries-sessions.sql
@@ -1,12 +1,12 @@
--- name: InsertSession :exec
+-- name: SystemInsertSession :exec
 INSERT INTO sessions (session_id, users_idusers)
 VALUES (?, ?)
 ON DUPLICATE KEY UPDATE users_idusers = VALUES(users_idusers);
 
--- name: DeleteSessionByID :exec
+-- name: SystemDeleteSessionByID :exec
 DELETE FROM sessions WHERE session_id = ?;
 
--- name: ListSessions :many
+-- name: AdminListSessions :many
 SELECT s.session_id, s.users_idusers, u.username
 FROM sessions s
 LEFT JOIN users u ON u.idusers = s.users_idusers

--- a/internal/db/queries-sessions.sql.go
+++ b/internal/db/queries-sessions.sql.go
@@ -10,53 +10,28 @@ import (
 	"database/sql"
 )
 
-const deleteSessionByID = `-- name: DeleteSessionByID :exec
-DELETE FROM sessions WHERE session_id = ?
-`
-
-func (q *Queries) DeleteSessionByID(ctx context.Context, sessionID string) error {
-	_, err := q.db.ExecContext(ctx, deleteSessionByID, sessionID)
-	return err
-}
-
-const insertSession = `-- name: InsertSession :exec
-INSERT INTO sessions (session_id, users_idusers)
-VALUES (?, ?)
-ON DUPLICATE KEY UPDATE users_idusers = VALUES(users_idusers)
-`
-
-type InsertSessionParams struct {
-	SessionID    string
-	UsersIdusers int32
-}
-
-func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) error {
-	_, err := q.db.ExecContext(ctx, insertSession, arg.SessionID, arg.UsersIdusers)
-	return err
-}
-
-const listSessions = `-- name: ListSessions :many
+const adminListSessions = `-- name: AdminListSessions :many
 SELECT s.session_id, s.users_idusers, u.username
 FROM sessions s
 LEFT JOIN users u ON u.idusers = s.users_idusers
 ORDER BY s.session_id
 `
 
-type ListSessionsRow struct {
+type AdminListSessionsRow struct {
 	SessionID    string
 	UsersIdusers int32
 	Username     sql.NullString
 }
 
-func (q *Queries) ListSessions(ctx context.Context) ([]*ListSessionsRow, error) {
-	rows, err := q.db.QueryContext(ctx, listSessions)
+func (q *Queries) AdminListSessions(ctx context.Context) ([]*AdminListSessionsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListSessions)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*ListSessionsRow
+	var items []*AdminListSessionsRow
 	for rows.Next() {
-		var i ListSessionsRow
+		var i AdminListSessionsRow
 		if err := rows.Scan(&i.SessionID, &i.UsersIdusers, &i.Username); err != nil {
 			return nil, err
 		}
@@ -69,4 +44,29 @@ func (q *Queries) ListSessions(ctx context.Context) ([]*ListSessionsRow, error) 
 		return nil, err
 	}
 	return items, nil
+}
+
+const systemDeleteSessionByID = `-- name: SystemDeleteSessionByID :exec
+DELETE FROM sessions WHERE session_id = ?
+`
+
+func (q *Queries) SystemDeleteSessionByID(ctx context.Context, sessionID string) error {
+	_, err := q.db.ExecContext(ctx, systemDeleteSessionByID, sessionID)
+	return err
+}
+
+const systemInsertSession = `-- name: SystemInsertSession :exec
+INSERT INTO sessions (session_id, users_idusers)
+VALUES (?, ?)
+ON DUPLICATE KEY UPDATE users_idusers = VALUES(users_idusers)
+`
+
+type SystemInsertSessionParams struct {
+	SessionID    string
+	UsersIdusers int32
+}
+
+func (q *Queries) SystemInsertSession(ctx context.Context, arg SystemInsertSessionParams) error {
+	_, err := q.db.ExecContext(ctx, systemInsertSession, arg.SessionID, arg.UsersIdusers)
+	return err
 }

--- a/internal/db/session_proxy.go
+++ b/internal/db/session_proxy.go
@@ -1,0 +1,24 @@
+package db
+
+import "context"
+
+// SessionProxy forwards session operations to Queries while satisfying
+// common.SessionManager without exposing database types.
+type SessionProxy struct {
+	*Queries
+}
+
+// NewSessionProxy returns a SessionProxy wrapping q.
+func NewSessionProxy(q *Queries) *SessionProxy {
+	return &SessionProxy{Queries: q}
+}
+
+// InsertSession stores or updates a session record.
+func (sp *SessionProxy) InsertSession(ctx context.Context, sessionID string, userID int32) error {
+	return sp.Queries.SystemInsertSession(ctx, SystemInsertSessionParams{SessionID: sessionID, UsersIdusers: userID})
+}
+
+// DeleteSessionByID removes a session record by ID.
+func (sp *SessionProxy) DeleteSessionByID(ctx context.Context, sessionID string) error {
+	return sp.Queries.SystemDeleteSessionByID(ctx, sessionID)
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -71,18 +71,18 @@ func CoreAdderMiddlewareWithDB(db *sql.DB, cfg *config.RuntimeConfig, verbosity 
 			}
 
 			queries := dbpkg.New(db)
-			sm := queries
+			sm := dbpkg.NewSessionProxy(queries)
 			if verbosity > 0 {
 				log.Printf("db pool stats: %+v", db.Stats())
 			}
 
 			if session.ID != "" {
 				if uid != 0 {
-					if err := queries.InsertSession(r.Context(), dbpkg.InsertSessionParams{SessionID: session.ID, UsersIdusers: uid}); err != nil {
+					if err := sm.InsertSession(r.Context(), session.ID, uid); err != nil {
 						log.Printf("insert session: %v", err)
 					}
 				} else {
-					if err := queries.DeleteSessionByID(r.Context(), session.ID); err != nil {
+					if err := sm.DeleteSessionByID(r.Context(), session.ID); err != nil {
 						log.Printf("delete session: %v", err)
 					}
 				}


### PR DESCRIPTION
## Summary
- prefix session SQL queries with `System` or `Admin` in function names
- regenerate sqlc code and update call sites
- decouple session manager from database structs via a `SessionProxy`
- expose unprefixed `InsertSession`/`DeleteSessionByID` methods on `SessionManager`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`
- `sqlc generate`


------
https://chatgpt.com/codex/tasks/task_e_688ccca5a778832fb2953ddd7f9940a4