### PR TITLE
Fix admin handlers to use sqlc admin queries

### DIFF
--- a/handlers/admin/adminRoleEditPage.go
+++ b/handlers/admin/adminRoleEditPage.go
@@ -20,7 +20,7 @@ func adminRoleEditFormPage(w http.ResponseWriter, r *http.Request) {
 	idStr := mux.Vars(r)["id"]
 	id, _ := strconv.Atoi(idStr)
 
-	role, err := queries.GetRoleByID(r.Context(), int32(id))
+	role, err := queries.AdminGetRoleByID(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "role not found", http.StatusNotFound)
 		return

--- a/handlers/admin/role_grant_update_task.go
+++ b/handlers/admin/role_grant_update_task.go
@@ -53,7 +53,7 @@ func (RoleGrantUpdateTask) Action(w http.ResponseWriter, r *http.Request) any {
 			desired[a] = struct{}{}
 		}
 	}
-	grants, err := queries.ListGrantsByRoleID(r.Context(), sql.NullInt32{Int32: int32(roleID), Valid: true})
+	grants, err := queries.AdminListGrantsByRoleID(r.Context(), sql.NullInt32{Int32: int32(roleID), Valid: true})
 	if err != nil {
 		return fmt.Errorf("list grants %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}


### PR DESCRIPTION
## Summary
- use AdminGetRoleByID to load roles
- use AdminListGrantsByRoleID when updating role grants

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d8fba2128832fae1ca54a81aa37d8