### PR TITLE
refactor: use role-based names for preference and email queries

### DIFF
--- a/cmd/goa4web/user_profile.go
+++ b/cmd/goa4web/user_profile.go
@@ -56,9 +56,9 @@ func (c *userProfileCmd) Run() error {
 	fmt.Printf("ID: %d\nUsername: %s\n", c.ID, u.Username.String)
 	var emails []*db.UserEmail
 	if c.UserID == 0 {
-		emails, _ = queries.GetUserEmailsByUserIDAdmin(ctx, int32(c.ID))
+		emails, _ = queries.AdminListUserEmails(ctx, int32(c.ID))
 	} else {
-		emails, _ = queries.GetUserEmailsByUserID(ctx, db.GetUserEmailsByUserIDParams{UserID: int32(c.ID), ViewerID: int32(c.UserID)})
+		emails, _ = queries.ListUserEmailsForLister(ctx, db.ListUserEmailsForListerParams{UserID: int32(c.ID), ListerID: int32(c.UserID)})
 	}
 	for _, e := range emails {
 		fmt.Printf("Email: %s verified:%t priority:%d\n", e.Email, e.VerifiedAt.Valid, e.NotificationPriority)

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -565,7 +565,7 @@ func (cd *CoreData) Preference() (*db.Preference, error) {
 		if cd.UserID == 0 || cd.queries == nil {
 			return nil, nil
 		}
-		return cd.queries.GetPreferenceByUserID(cd.ctx, cd.UserID)
+		return cd.queries.GetPreferenceForLister(cd.ctx, cd.UserID)
 	})
 }
 

--- a/handlers/admin/adminUserProfilePage.go
+++ b/handlers/admin/adminUserProfilePage.go
@@ -25,7 +25,7 @@ func adminUserProfilePage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	emails, _ := queries.GetUserEmailsByUserIDAdmin(r.Context(), int32(id))
+	emails, _ := queries.AdminListUserEmails(r.Context(), int32(id))
 	comments, _ := queries.ListAdminUserComments(r.Context(), int32(id))
 	roles, _ := queries.GetPermissionsByUserID(r.Context(), int32(id))
 	stats, _ := queries.AdminUserPostCountsByID(r.Context(), int32(id))

--- a/handlers/user/saveEmailTask.go
+++ b/handlers/user/saveEmailTask.go
@@ -50,21 +50,21 @@ func (SaveEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			err = queries.InsertEmailPreference(r.Context(), db.InsertEmailPreferenceParams{
-				Emailforumupdates:    sql.NullBool{Bool: updates, Valid: true},
+			err = queries.InsertEmailPreferenceForLister(r.Context(), db.InsertEmailPreferenceForListerParams{
+				EmailForumUpdates:    sql.NullBool{Bool: updates, Valid: true},
 				AutoSubscribeReplies: auto,
-				UsersIdusers:         uid,
+				ListerID:             uid,
 			})
 		}
 	} else {
-		err = queries.UpdateEmailForumUpdatesByUserID(r.Context(), db.UpdateEmailForumUpdatesByUserIDParams{
-			Emailforumupdates: sql.NullBool{Bool: updates, Valid: true},
-			UsersIdusers:      uid,
+		err = queries.UpdateEmailForumUpdatesForLister(r.Context(), db.UpdateEmailForumUpdatesForListerParams{
+			EmailForumUpdates: sql.NullBool{Bool: updates, Valid: true},
+			ListerID:          uid,
 		})
 		if err == nil {
-			err = queries.UpdateAutoSubscribeRepliesByUserID(r.Context(), db.UpdateAutoSubscribeRepliesByUserIDParams{
+			err = queries.UpdateAutoSubscribeRepliesForLister(r.Context(), db.UpdateAutoSubscribeRepliesForListerParams{
 				AutoSubscribeReplies: auto,
-				UsersIdusers:         uid,
+				ListerID:             uid,
 			})
 		}
 	}

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -36,7 +36,7 @@ func userEmailPage(w http.ResponseWriter, r *http.Request) {
 	user, _ := cd.CurrentUser()
 	pref, _ := cd.Preference()
 
-	emails, _ := queries.GetUserEmailsByUserID(r.Context(), db.GetUserEmailsByUserIDParams{UserID: cd.UserID, ViewerID: cd.UserID})
+	emails, _ := queries.ListUserEmailsForLister(r.Context(), db.ListUserEmailsForListerParams{UserID: cd.UserID, ListerID: cd.UserID})
 	var verified, unverified []*db.UserEmail
 	for _, e := range emails {
 		if e.VerifiedAt.Valid {

--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -121,17 +121,17 @@ func updateDefaultLanguage(r *http.Request, queries db.Querier, uid int32) error
 	}
 
 	if errors.Is(err, sql.ErrNoRows) {
-		return queries.InsertPreference(r.Context(), db.InsertPreferenceParams{
-			LanguageIdlanguage: int32(langID),
-			UsersIdusers:       uid,
-			PageSize:           int32(cd.Config.PageSizeDefault),
+		return queries.InsertPreferenceForLister(r.Context(), db.InsertPreferenceForListerParams{
+			LanguageID: int32(langID),
+			ListerID:   uid,
+			PageSize:   int32(cd.Config.PageSizeDefault),
 		})
 	}
 
 	pref.LanguageIdlanguage = int32(langID)
-	return queries.UpdatePreference(r.Context(), db.UpdatePreferenceParams{
-		LanguageIdlanguage: pref.LanguageIdlanguage,
-		UsersIdusers:       uid,
-		PageSize:           pref.PageSize,
+	return queries.UpdatePreferenceForLister(r.Context(), db.UpdatePreferenceForListerParams{
+		LanguageID: pref.LanguageIdlanguage,
+		ListerID:   uid,
+		PageSize:   pref.PageSize,
 	})
 }

--- a/handlers/user/userNotificationsPage.go
+++ b/handlers/user/userNotificationsPage.go
@@ -57,7 +57,7 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	emails, _ := queries.GetUserEmailsByUserID(r.Context(), db.GetUserEmailsByUserIDParams{UserID: uid, ViewerID: uid})
+	emails, _ := queries.ListUserEmailsForLister(r.Context(), db.ListUserEmailsForListerParams{UserID: uid, ListerID: uid})
 	var maxPr int32
 	for _, e := range emails {
 		if e.NotificationPriority > maxPr {

--- a/handlers/user/userPagingPage.go
+++ b/handlers/user/userPagingPage.go
@@ -72,17 +72,17 @@ func (PagingSaveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if errors.Is(err, sql.ErrNoRows) {
-		err = queries.InsertPreference(r.Context(), db.InsertPreferenceParams{
-			LanguageIdlanguage: 0,
-			UsersIdusers:       uid,
-			PageSize:           int32(size),
+		err = queries.InsertPreferenceForLister(r.Context(), db.InsertPreferenceForListerParams{
+			LanguageID: 0,
+			ListerID:   uid,
+			PageSize:   int32(size),
 		})
 	} else {
 		pref.PageSize = int32(size)
-		err = queries.UpdatePreference(r.Context(), db.UpdatePreferenceParams{
-			LanguageIdlanguage: pref.LanguageIdlanguage,
-			UsersIdusers:       uid,
-			PageSize:           pref.PageSize,
+		err = queries.UpdatePreferenceForLister(r.Context(), db.UpdatePreferenceForListerParams{
+			LanguageID: pref.LanguageIdlanguage,
+			ListerID:   uid,
+			PageSize:   pref.PageSize,
 		})
 	}
 	if err != nil {

--- a/internal/db/queries-preferences.sql
+++ b/internal/db/queries-preferences.sql
@@ -1,25 +1,25 @@
--- name: UpdateEmailForumUpdatesByUserID :exec
+-- name: UpdateEmailForumUpdatesForLister :exec
 UPDATE preferences
-SET emailforumupdates = ?
-WHERE users_idusers = ?;
+SET emailforumupdates = sqlc.arg(email_forum_updates)
+WHERE users_idusers = sqlc.arg(lister_id);
 
--- name: InsertEmailPreference :exec
+-- name: InsertEmailPreferenceForLister :exec
 INSERT INTO preferences (emailforumupdates, auto_subscribe_replies, users_idusers)
-VALUES (?, ?, ?);
+VALUES (sqlc.arg(email_forum_updates), sqlc.arg(auto_subscribe_replies), sqlc.arg(lister_id));
 
--- name: UpdateAutoSubscribeRepliesByUserID :exec
+-- name: UpdateAutoSubscribeRepliesForLister :exec
 UPDATE preferences
-SET auto_subscribe_replies = ?
-WHERE users_idusers = ?;
+SET auto_subscribe_replies = sqlc.arg(auto_subscribe_replies)
+WHERE users_idusers = sqlc.arg(lister_id);
 
--- name: GetPreferenceByUserID :one
+-- name: GetPreferenceForLister :one
 SELECT idpreferences, language_idlanguage, users_idusers, emailforumupdates, page_size, auto_subscribe_replies
 FROM preferences
-WHERE users_idusers = ?;
+WHERE users_idusers = sqlc.arg(lister_id);
 
--- name: InsertPreference :exec
+-- name: InsertPreferenceForLister :exec
 INSERT INTO preferences (language_idlanguage, users_idusers, page_size)
-VALUES (?, ?, ?);
+VALUES (sqlc.arg(language_id), sqlc.arg(lister_id), sqlc.arg(page_size));
 
--- name: UpdatePreference :exec
-UPDATE preferences SET language_idlanguage = ?, page_size = ? WHERE users_idusers = ?;
+-- name: UpdatePreferenceForLister :exec
+UPDATE preferences SET language_idlanguage = sqlc.arg(language_id), page_size = sqlc.arg(page_size) WHERE users_idusers = sqlc.arg(lister_id);

--- a/internal/db/queries-preferences.sql.go
+++ b/internal/db/queries-preferences.sql.go
@@ -10,14 +10,14 @@ import (
 	"database/sql"
 )
 
-const getPreferenceByUserID = `-- name: GetPreferenceByUserID :one
+const getPreferenceForLister = `-- name: GetPreferenceForLister :one
 SELECT idpreferences, language_idlanguage, users_idusers, emailforumupdates, page_size, auto_subscribe_replies
 FROM preferences
 WHERE users_idusers = ?
 `
 
-func (q *Queries) GetPreferenceByUserID(ctx context.Context, usersIdusers int32) (*Preference, error) {
-	row := q.db.QueryRowContext(ctx, getPreferenceByUserID, usersIdusers)
+func (q *Queries) GetPreferenceForLister(ctx context.Context, listerID int32) (*Preference, error) {
+	row := q.db.QueryRowContext(ctx, getPreferenceForLister, listerID)
 	var i Preference
 	err := row.Scan(
 		&i.Idpreferences,
@@ -30,81 +30,81 @@ func (q *Queries) GetPreferenceByUserID(ctx context.Context, usersIdusers int32)
 	return &i, err
 }
 
-const insertEmailPreference = `-- name: InsertEmailPreference :exec
+const insertEmailPreferenceForLister = `-- name: InsertEmailPreferenceForLister :exec
 INSERT INTO preferences (emailforumupdates, auto_subscribe_replies, users_idusers)
 VALUES (?, ?, ?)
 `
 
-type InsertEmailPreferenceParams struct {
-	Emailforumupdates    sql.NullBool
+type InsertEmailPreferenceForListerParams struct {
+	EmailForumUpdates    sql.NullBool
 	AutoSubscribeReplies bool
-	UsersIdusers         int32
+	ListerID             int32
 }
 
-func (q *Queries) InsertEmailPreference(ctx context.Context, arg InsertEmailPreferenceParams) error {
-	_, err := q.db.ExecContext(ctx, insertEmailPreference, arg.Emailforumupdates, arg.AutoSubscribeReplies, arg.UsersIdusers)
+func (q *Queries) InsertEmailPreferenceForLister(ctx context.Context, arg InsertEmailPreferenceForListerParams) error {
+	_, err := q.db.ExecContext(ctx, insertEmailPreferenceForLister, arg.EmailForumUpdates, arg.AutoSubscribeReplies, arg.ListerID)
 	return err
 }
 
-const insertPreference = `-- name: InsertPreference :exec
+const insertPreferenceForLister = `-- name: InsertPreferenceForLister :exec
 INSERT INTO preferences (language_idlanguage, users_idusers, page_size)
 VALUES (?, ?, ?)
 `
 
-type InsertPreferenceParams struct {
-	LanguageIdlanguage int32
-	UsersIdusers       int32
-	PageSize           int32
+type InsertPreferenceForListerParams struct {
+	LanguageID int32
+	ListerID   int32
+	PageSize   int32
 }
 
-func (q *Queries) InsertPreference(ctx context.Context, arg InsertPreferenceParams) error {
-	_, err := q.db.ExecContext(ctx, insertPreference, arg.LanguageIdlanguage, arg.UsersIdusers, arg.PageSize)
+func (q *Queries) InsertPreferenceForLister(ctx context.Context, arg InsertPreferenceForListerParams) error {
+	_, err := q.db.ExecContext(ctx, insertPreferenceForLister, arg.LanguageID, arg.ListerID, arg.PageSize)
 	return err
 }
 
-const updateAutoSubscribeRepliesByUserID = `-- name: UpdateAutoSubscribeRepliesByUserID :exec
+const updateAutoSubscribeRepliesForLister = `-- name: UpdateAutoSubscribeRepliesForLister :exec
 UPDATE preferences
 SET auto_subscribe_replies = ?
 WHERE users_idusers = ?
 `
 
-type UpdateAutoSubscribeRepliesByUserIDParams struct {
+type UpdateAutoSubscribeRepliesForListerParams struct {
 	AutoSubscribeReplies bool
-	UsersIdusers         int32
+	ListerID             int32
 }
 
-func (q *Queries) UpdateAutoSubscribeRepliesByUserID(ctx context.Context, arg UpdateAutoSubscribeRepliesByUserIDParams) error {
-	_, err := q.db.ExecContext(ctx, updateAutoSubscribeRepliesByUserID, arg.AutoSubscribeReplies, arg.UsersIdusers)
+func (q *Queries) UpdateAutoSubscribeRepliesForLister(ctx context.Context, arg UpdateAutoSubscribeRepliesForListerParams) error {
+	_, err := q.db.ExecContext(ctx, updateAutoSubscribeRepliesForLister, arg.AutoSubscribeReplies, arg.ListerID)
 	return err
 }
 
-const updateEmailForumUpdatesByUserID = `-- name: UpdateEmailForumUpdatesByUserID :exec
+const updateEmailForumUpdatesForLister = `-- name: UpdateEmailForumUpdatesForLister :exec
 UPDATE preferences
 SET emailforumupdates = ?
 WHERE users_idusers = ?
 `
 
-type UpdateEmailForumUpdatesByUserIDParams struct {
-	Emailforumupdates sql.NullBool
-	UsersIdusers      int32
+type UpdateEmailForumUpdatesForListerParams struct {
+	EmailForumUpdates sql.NullBool
+	ListerID          int32
 }
 
-func (q *Queries) UpdateEmailForumUpdatesByUserID(ctx context.Context, arg UpdateEmailForumUpdatesByUserIDParams) error {
-	_, err := q.db.ExecContext(ctx, updateEmailForumUpdatesByUserID, arg.Emailforumupdates, arg.UsersIdusers)
+func (q *Queries) UpdateEmailForumUpdatesForLister(ctx context.Context, arg UpdateEmailForumUpdatesForListerParams) error {
+	_, err := q.db.ExecContext(ctx, updateEmailForumUpdatesForLister, arg.EmailForumUpdates, arg.ListerID)
 	return err
 }
 
-const updatePreference = `-- name: UpdatePreference :exec
+const updatePreferenceForLister = `-- name: UpdatePreferenceForLister :exec
 UPDATE preferences SET language_idlanguage = ?, page_size = ? WHERE users_idusers = ?
 `
 
-type UpdatePreferenceParams struct {
-	LanguageIdlanguage int32
-	PageSize           int32
-	UsersIdusers       int32
+type UpdatePreferenceForListerParams struct {
+	LanguageID int32
+	PageSize   int32
+	ListerID   int32
 }
 
-func (q *Queries) UpdatePreference(ctx context.Context, arg UpdatePreferenceParams) error {
-	_, err := q.db.ExecContext(ctx, updatePreference, arg.LanguageIdlanguage, arg.PageSize, arg.UsersIdusers)
+func (q *Queries) UpdatePreferenceForLister(ctx context.Context, arg UpdatePreferenceForListerParams) error {
+	_, err := q.db.ExecContext(ctx, updatePreferenceForLister, arg.LanguageID, arg.PageSize, arg.ListerID)
 	return err
 }

--- a/internal/db/queries-user_emails.sql
+++ b/internal/db/queries-user_emails.sql
@@ -2,15 +2,15 @@
 INSERT INTO user_emails (user_id, email, verified_at, last_verification_code, verification_expires_at, notification_priority)
 VALUES (?, ?, ?, ?, ?, ?);
 
--- name: GetUserEmailsByUserID :many
+-- name: ListUserEmailsForLister :many
 WITH RECURSIVE role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT ue.id, ue.user_id, ue.email, ue.verified_at, ue.last_verification_code, ue.verification_expires_at, ue.notification_priority
 FROM user_emails ue
 WHERE ue.user_id = sqlc.arg(user_id)
   AND (
-      sqlc.arg(viewer_id) = ue.user_id
+      sqlc.arg(lister_id) = ue.user_id
       OR EXISTS (
           SELECT 1
           FROM role_ids ri
@@ -19,16 +19,16 @@ WHERE ue.user_id = sqlc.arg(user_id)
       )
   );
 
--- name: GetUserEmailsByUserIDAdmin :many
+-- name: AdminListUserEmails :many
 SELECT id, user_id, email, verified_at, last_verification_code, verification_expires_at, notification_priority
 FROM user_emails
-WHERE user_id = ?
+WHERE user_id = sqlc.arg(user_id)
 ORDER BY notification_priority DESC, id;
 
--- name: ListVerifiedEmailsByUserID :many
+-- name: SystemListVerifiedEmailsByUserID :many
 SELECT id, user_id, email, verified_at, last_verification_code, verification_expires_at, notification_priority
 FROM user_emails
-WHERE user_id = ? AND verified_at IS NOT NULL
+WHERE user_id = sqlc.arg(user_id) AND verified_at IS NOT NULL
 ORDER BY notification_priority DESC, id;
 
 

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -149,7 +149,7 @@ type NotificationData struct {
 func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, tp SelfNotificationTemplateProvider) error {
 	if et := tp.SelfEmailTemplate(); et != nil {
 		if b, ok := evt.Task.(SelfEmailBroadcaster); ok && b.SelfEmailBroadcast() {
-			emails, err := n.Queries.ListVerifiedEmailsByUserID(ctx, evt.UserID)
+			emails, err := n.Queries.SystemListVerifiedEmailsByUserID(ctx, evt.UserID)
 			if err == nil {
 				for _, e := range emails {
 					if err := n.renderAndQueueEmailFromTemplates(ctx, &evt.UserID, e.Email, et, evt.Data); err != nil {
@@ -322,7 +322,7 @@ func (n *Notifier) notifySubscribers(ctx context.Context, evt eventbus.TaskEvent
 func (n *Notifier) handleAutoSubscribe(ctx context.Context, evt eventbus.TaskEvent, tp AutoSubscribeProvider) error {
 	var auto bool
 	var email bool
-	pref, err := n.Queries.GetPreferenceByUserID(ctx, evt.UserID)
+	pref, err := n.Queries.GetPreferenceForLister(ctx, evt.UserID)
 	if err != nil {
 		return fmt.Errorf("get preference by user_id: %w", err)
 	}


### PR DESCRIPTION
## Summary
- rename preference queries to use ForLister naming and explicit parameters
- align user email queries with List/Admin/System prefixes
- update handlers and worker code to use new query names

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: undefined fields such as `queries.DB` and missing `db.New`)*
- `golangci-lint run` *(fails: typecheck errors like `db.New undefined`)*
- `go test ./...` *(fails: build errors for undefined symbols)*


------
https://chatgpt.com/codex/tasks/task_e_688eaa271cfc832fa743721c40674372