### PR TITLE
refactor: align language queries with naming spec

### DIFF
--- a/cmd/goa4web/lang_add.go
+++ b/cmd/goa4web/lang_add.go
@@ -40,7 +40,7 @@ func (c *langAddCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(db)
 	c.rootCmd.Verbosef("adding language %s (%s)", c.Name, c.Code)
-	if _, err := queries.InsertLanguage(ctx, sql.NullString{String: c.Name, Valid: true}); err != nil {
+	if _, err := queries.AdminInsertLanguage(ctx, sql.NullString{String: c.Name, Valid: true}); err != nil {
 		return fmt.Errorf("insert language: %w", err)
 	}
 	c.rootCmd.Infof("added language %s (%s)", c.Name, c.Code)

--- a/cmd/goa4web/lang_list.go
+++ b/cmd/goa4web/lang_list.go
@@ -31,7 +31,7 @@ func (c *langListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := db.New(db)
-	langs, err := queries.AllLanguages(ctx)
+	langs, err := queries.SystemListLanguages(ctx)
 	if err != nil {
 		return fmt.Errorf("list languages: %w", err)
 	}

--- a/cmd/goa4web/lang_update.go
+++ b/cmd/goa4web/lang_update.go
@@ -39,7 +39,7 @@ func (c *langUpdateCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := db.New(db)
-	err = queries.RenameLanguage(ctx, db.RenameLanguageParams{Nameof: sql.NullString{String: c.Name, Valid: true}, Idlanguage: int32(c.ID)})
+	err = queries.AdminRenameLanguage(ctx, db.AdminRenameLanguageParams{Nameof: sql.NullString{String: c.Name, Valid: true}, Idlanguage: int32(c.ID)})
 	if err != nil {
 		return fmt.Errorf("update language: %w", err)
 	}

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -590,7 +590,7 @@ func (cd *CoreData) Languages() ([]*db.Language, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		return cd.queries.FetchLanguages(cd.ctx)
+		return cd.queries.SystemListLanguages(cd.ctx)
 	})
 }
 
@@ -600,7 +600,7 @@ func (cd *CoreData) AllLanguages() ([]*db.Language, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		return cd.queries.FetchLanguages(cd.ctx)
+		return cd.queries.SystemListLanguages(cd.ctx)
 	})
 }
 
@@ -616,7 +616,7 @@ func (cd *CoreData) PreferredLanguageID(siteDefault string) int32 {
 		if cd.queries == nil || siteDefault == "" {
 			return 0, nil
 		}
-		langID, err := cd.queries.GetLanguageIDByName(cd.ctx, sql.NullString{String: siteDefault, Valid: true})
+		langID, err := cd.queries.SystemGetLanguageIDByName(cd.ctx, sql.NullString{String: siteDefault, Valid: true})
 		if err != nil {
 			return 0, nil
 		}

--- a/core/language/language.go
+++ b/core/language/language.go
@@ -29,7 +29,7 @@ func ValidateDefaultLanguage(ctx context.Context, q db.Querier, name string) err
 	if err := validateLanguageName(name); err != nil {
 		return err
 	}
-	_, err := q.GetLanguageIDByName(ctx, sql.NullString{String: name, Valid: true})
+	_, err := q.SystemGetLanguageIDByName(ctx, sql.NullString{String: name, Valid: true})
 	if errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("unknown language %q", name)
 	}
@@ -41,7 +41,7 @@ func ResolveDefaultLanguageID(ctx context.Context, q db.Querier, name string) in
 	if name == "" {
 		return 0
 	}
-	id, err := q.GetLanguageIDByName(ctx, sql.NullString{String: name, Valid: true})
+	id, err := q.SystemGetLanguageIDByName(ctx, sql.NullString{String: name, Valid: true})
 	if err != nil {
 		return 0
 	}
@@ -54,7 +54,7 @@ func EnsureDefaultLanguage(ctx context.Context, q db.Querier, name string) error
 	if name == "" {
 		return nil
 	}
-	count, err := q.CountLanguages(ctx)
+	count, err := q.SystemCountLanguages(ctx)
 	if err != nil {
 		return err
 	}
@@ -64,6 +64,6 @@ func EnsureDefaultLanguage(ctx context.Context, q db.Querier, name string) error
 	if err := validateLanguageName(name); err != nil {
 		return err
 	}
-	_, err = q.InsertLanguage(ctx, sql.NullString{String: name, Valid: true})
+	_, err = q.AdminInsertLanguage(ctx, sql.NullString{String: name, Valid: true})
 	return err
 }

--- a/handlers/admin/adminRolePage.go
+++ b/handlers/admin/adminRolePage.go
@@ -49,7 +49,7 @@ func adminRolePage(w http.ResponseWriter, r *http.Request) {
 	for _, c := range forumCats {
 		catMap[c.Idforumcategory] = c
 	}
-	langs, _ := queries.FetchLanguages(r.Context())
+	langs, _ := queries.SystemListLanguages(r.Context())
 	langMap := map[int32]string{}
 	for _, l := range langs {
 		if l.Nameof.Valid {

--- a/handlers/languages/admin.go
+++ b/handlers/languages/admin.go
@@ -55,11 +55,11 @@ func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {
 	}
 	if cidi, err := strconv.Atoi(cid); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("strconv.Atoi: %w", err).Error())
-	} else if err := queries.RenameLanguage(r.Context(), db.RenameLanguageParams{
+	} else if err := queries.AdminRenameLanguage(r.Context(), db.AdminRenameLanguageParams{
 		Nameof:     sql.NullString{Valid: true, String: cname},
 		Idlanguage: int32(cidi),
 	}); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("RenameLanguage: %w", err).Error())
+		data.Errors = append(data.Errors, fmt.Errorf("AdminRenameLanguage: %w", err).Error())
 	} else if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 		if evt := cd.Event(); evt != nil {
 			if evt.Data == nil {
@@ -87,7 +87,7 @@ func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
 		data.Errors = append(data.Errors, fmt.Errorf("strconv.Atoi: %w", err).Error())
 	} else {
 		var name string
-		if rows, err := queries.FetchLanguages(r.Context()); err == nil {
+		if rows, err := queries.SystemListLanguages(r.Context()); err == nil {
 			for _, l := range rows {
 				if l.Idlanguage == int32(cidi) {
 					name = l.Nameof.String
@@ -95,8 +95,8 @@ func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-		if err := queries.DeleteLanguage(r.Context(), int32(cidi)); err != nil {
-			data.Errors = append(data.Errors, fmt.Errorf("DeleteLanguage: %w", err).Error())
+		if err := queries.AdminDeleteLanguage(r.Context(), int32(cidi)); err != nil {
+			data.Errors = append(data.Errors, fmt.Errorf("AdminDeleteLanguage: %w", err).Error())
 		} else if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 			if evt := cd.Event(); evt != nil {
 				if evt.Data == nil {
@@ -121,11 +121,11 @@ func adminLanguagesCreatePage(w http.ResponseWriter, r *http.Request) {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/admin/languages",
 	}
-	if res, err := queries.InsertLanguage(r.Context(), sql.NullString{
+	if res, err := queries.AdminInsertLanguage(r.Context(), sql.NullString{
 		String: cname,
 		Valid:  true,
 	}); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
+		data.Errors = append(data.Errors, fmt.Errorf("AdminInsertLanguage: %w", err).Error())
 	} else if id, err := res.LastInsertId(); err == nil {
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 			if evt := cd.Event(); evt != nil {

--- a/handlers/languages/create_language_task.go
+++ b/handlers/languages/create_language_task.go
@@ -29,7 +29,7 @@ func (CreateLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	queries := cd.Queries()
 	cname := r.PostFormValue("cname")
-	res, err := queries.InsertLanguage(r.Context(), sql.NullString{String: cname, Valid: true})
+	res, err := queries.AdminInsertLanguage(r.Context(), sql.NullString{String: cname, Valid: true})
 	if err != nil {
 		return fmt.Errorf("create language fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/languages/delete_language_task.go
+++ b/handlers/languages/delete_language_task.go
@@ -33,7 +33,7 @@ func (DeleteLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("cid parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	var name string
-	if rows, err := queries.FetchLanguages(r.Context()); err == nil {
+	if rows, err := queries.SystemListLanguages(r.Context()); err == nil {
 		for _, l := range rows {
 			if l.Idlanguage == int32(cid) {
 				name = l.Nameof.String
@@ -41,7 +41,7 @@ func (DeleteLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 		}
 	}
-	if err := queries.DeleteLanguage(r.Context(), int32(cid)); err != nil {
+	if err := queries.AdminDeleteLanguage(r.Context(), int32(cid)); err != nil {
 		return fmt.Errorf("delete language fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/languages/rename_language_task.go
+++ b/handlers/languages/rename_language_task.go
@@ -35,7 +35,7 @@ func (RenameLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("cid parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	cname := r.PostFormValue("cname")
-	if err := queries.RenameLanguage(r.Context(), db.RenameLanguageParams{
+	if err := queries.AdminRenameLanguage(r.Context(), db.AdminRenameLanguageParams{
 		Nameof:     sql.NullString{Valid: true, String: cname},
 		Idlanguage: int32(cid),
 	}); err != nil {

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -160,7 +160,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 
 	languageRows, err := cd.Languages()
 	if err != nil {
-		log.Printf("FetchLanguages Error: %s", err)
+		log.Printf("SystemListLanguages error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -24,8 +24,16 @@ type Querier interface {
 	AdminCountThreadsByBoard(ctx context.Context, imageboardIdimageboard int32) (int64, error)
 	AdminCountWordList(ctx context.Context) (int64, error)
 	AdminCountWordListByPrefix(ctx context.Context, prefix interface{}) (int64, error)
+	// AdminCreateLanguage adds a new language.
+	// Parameters:
+	//   ? - Name of the new language (string)
+	AdminCreateLanguage(ctx context.Context, nameof sql.NullString) error
 	AdminDeleteExternalLink(ctx context.Context, id int32) error
 	AdminDeleteForumThread(ctx context.Context, idforumthread int32) error
+	// AdminDeleteLanguage removes a language entry.
+	// Parameters:
+	//   ? - Language ID to be deleted (int)
+	AdminDeleteLanguage(ctx context.Context, idlanguage int32) error
 	// admin task
 	AdminDeletePendingEmail(ctx context.Context, id int32) error
 	AdminDeleteTemplateOverride(ctx context.Context, name string) error
@@ -47,6 +55,8 @@ type Querier interface {
 	AdminGetWritingsByCategoryId(ctx context.Context, writingCategoryID int32) ([]*AdminGetWritingsByCategoryIdRow, error)
 	AdminImageboardPostCounts(ctx context.Context) ([]*AdminImageboardPostCountsRow, error)
 	AdminInsertBannedIp(ctx context.Context, arg AdminInsertBannedIpParams) error
+	// AdminInsertLanguage adds a new language returning a result.
+	AdminInsertLanguage(ctx context.Context, nameof sql.NullString) (sql.Result, error)
 	AdminInsertRequestComment(ctx context.Context, arg AdminInsertRequestCommentParams) error
 	AdminInsertRequestQueue(ctx context.Context, arg AdminInsertRequestQueueParams) (sql.Result, error)
 	AdminInsertWritingCategory(ctx context.Context, arg AdminInsertWritingCategoryParams) error
@@ -85,6 +95,11 @@ type Querier interface {
 	AdminPurgeReadNotifications(ctx context.Context) error
 	AdminRecalculateAllForumThreadMetaData(ctx context.Context) error
 	AdminRecalculateForumThreadByIdMetaData(ctx context.Context, idforumthread int32) error
+	// AdminRenameLanguage updates the language name.
+	// Parameters:
+	//   ? - New name for the language (string)
+	//   ? - Language ID to be updated (int)
+	AdminRenameLanguage(ctx context.Context, arg AdminRenameLanguageParams) error
 	AdminSetTemplateOverride(ctx context.Context, arg AdminSetTemplateOverrideParams) error
 	AdminUpdateBannedIp(ctx context.Context, arg AdminUpdateBannedIpParams) error
 	AdminUpdateRequestStatus(ctx context.Context, arg AdminUpdateRequestStatusParams) error
@@ -98,7 +113,6 @@ type Querier interface {
 	AdminWordListWithCounts(ctx context.Context, arg AdminWordListWithCountsParams) ([]*AdminWordListWithCountsRow, error)
 	AdminWordListWithCountsByPrefix(ctx context.Context, arg AdminWordListWithCountsByPrefixParams) ([]*AdminWordListWithCountsByPrefixRow, error)
 	AdminWritingCategoryCounts(ctx context.Context) ([]*AdminWritingCategoryCountsRow, error)
-	AllLanguages(ctx context.Context) ([]*Language, error)
 	ApproveImagePost(ctx context.Context, idimagepost int32) error
 	ArchiveBlog(ctx context.Context, arg ArchiveBlogParams) error
 	ArchiveComment(ctx context.Context, arg ArchiveCommentParams) error
@@ -119,7 +133,6 @@ type Querier interface {
 	CommentsSearchFirstNotInRestrictedTopic(ctx context.Context, arg CommentsSearchFirstNotInRestrictedTopicParams) ([]int32, error)
 	CommentsSearchNextInRestrictedTopic(ctx context.Context, arg CommentsSearchNextInRestrictedTopicParams) ([]int32, error)
 	CommentsSearchNextNotInRestrictedTopic(ctx context.Context, arg CommentsSearchNextNotInRestrictedTopicParams) ([]int32, error)
-	CountLanguages(ctx context.Context) (int64, error)
 	CountLinksByCategory(ctx context.Context, linkerCategoryID int32) (int64, error)
 	CountUnreadNotifications(ctx context.Context, usersIdusers int32) (int64, error)
 	CreateBlogEntry(ctx context.Context, arg CreateBlogEntryParams) (int64, error)
@@ -133,10 +146,6 @@ type Querier interface {
 	CreateGrant(ctx context.Context, arg CreateGrantParams) (int64, error)
 	CreateImageBoard(ctx context.Context, arg CreateImageBoardParams) error
 	CreateImagePost(ctx context.Context, arg CreateImagePostParams) (int64, error)
-	// This query inserts a new record into the "language" table.
-	// Parameters:
-	//   ? - Name of the new language (string)
-	CreateLanguage(ctx context.Context, nameof sql.NullString) error
 	CreateLinkerCategory(ctx context.Context, arg CreateLinkerCategoryParams) error
 	CreateLinkerItem(ctx context.Context, arg CreateLinkerItemParams) error
 	CreateLinkerQueuedItem(ctx context.Context, arg CreateLinkerQueuedItemParams) error
@@ -156,10 +165,6 @@ type Querier interface {
 	DeleteForumTopic(ctx context.Context, idforumtopic int32) error
 	DeleteGrant(ctx context.Context, id int32) error
 	DeleteImageBoard(ctx context.Context, idimageboard int32) error
-	// This query deletes a record from the "language" table based on the provided "cid".
-	// Parameters:
-	//   ? - Language ID to be deleted (int)
-	DeleteLanguage(ctx context.Context, idlanguage int32) error
 	DeleteLinkerCategory(ctx context.Context, arg DeleteLinkerCategoryParams) error
 	DeleteLinkerQueuedItem(ctx context.Context, arg DeleteLinkerQueuedItemParams) error
 	DeleteNotification(ctx context.Context, id int32) error
@@ -176,7 +181,6 @@ type Querier interface {
 	//   ? - Permission ID to be deleted (int)
 	DeleteUserRole(ctx context.Context, iduserRoles int32) error
 	FetchAllCategories(ctx context.Context) ([]*WritingCategory, error)
-	FetchLanguages(ctx context.Context) ([]*Language, error)
 	FetchPendingEmails(ctx context.Context, limit int32) ([]*FetchPendingEmailsRow, error)
 	FindForumTopicByTitle(ctx context.Context, title sql.NullString) (*Forumtopic, error)
 	GetActiveAnnouncementWithNewsForLister(ctx context.Context, arg GetActiveAnnouncementWithNewsForListerParams) (*GetActiveAnnouncementWithNewsForListerRow, error)
@@ -230,7 +234,6 @@ type Querier interface {
 	GetImagePostInfoByPath(ctx context.Context, arg GetImagePostInfoByPathParams) (*GetImagePostInfoByPathRow, error)
 	GetImagePostsByUserDescending(ctx context.Context, arg GetImagePostsByUserDescendingParams) ([]*GetImagePostsByUserDescendingRow, error)
 	GetImagePostsByUserDescendingAll(ctx context.Context, arg GetImagePostsByUserDescendingAllParams) ([]*GetImagePostsByUserDescendingAllRow, error)
-	GetLanguageIDByName(ctx context.Context, nameof sql.NullString) (int32, error)
 	GetLatestAnnouncementByNewsID(ctx context.Context, siteNewsID int32) (*SiteAnnouncement, error)
 	GetLinkerCategoriesWithCount(ctx context.Context) ([]*GetLinkerCategoriesWithCountRow, error)
 	GetLinkerCategoryById(ctx context.Context, idlinkercategory int32) (*LinkerCategory, error)
@@ -282,7 +285,6 @@ type Querier interface {
 	InsertAuditLog(ctx context.Context, arg InsertAuditLogParams) error
 	InsertEmailPreference(ctx context.Context, arg InsertEmailPreferenceParams) error
 	InsertFAQRevisionForUser(ctx context.Context, arg InsertFAQRevisionForUserParams) error
-	InsertLanguage(ctx context.Context, nameof sql.NullString) (sql.Result, error)
 	InsertNotification(ctx context.Context, arg InsertNotificationParams) error
 	InsertPassword(ctx context.Context, arg InsertPasswordParams) error
 	InsertPendingEmail(ctx context.Context, arg InsertPendingEmailParams) error
@@ -348,11 +350,6 @@ type Querier interface {
 	RecentNotifications(ctx context.Context, limit int32) ([]*Notification, error)
 	RegisterExternalLinkClick(ctx context.Context, url string) error
 	RenameFAQCategory(ctx context.Context, arg RenameFAQCategoryParams) error
-	// This query updates the "nameof" field in the "language" table based on the provided "cid".
-	// Parameters:
-	//   ? - New name for the language (string)
-	//   ? - Language ID to be updated (int)
-	RenameLanguage(ctx context.Context, arg RenameLanguageParams) error
 	RenameLinkerCategory(ctx context.Context, arg RenameLinkerCategoryParams) error
 	RestoreBlog(ctx context.Context, arg RestoreBlogParams) error
 	RestoreComment(ctx context.Context, arg RestoreCommentParams) error
@@ -384,6 +381,8 @@ type Querier interface {
 	SystemAddToLinkerSearch(ctx context.Context, arg SystemAddToLinkerSearchParams) error
 	SystemAddToSiteNewsSearch(ctx context.Context, arg SystemAddToSiteNewsSearchParams) error
 	SystemCountDeadLetters(ctx context.Context) (int64, error)
+	// SystemCountLanguages counts all languages.
+	SystemCountLanguages(ctx context.Context) (int64, error)
 	SystemCountRecentLoginAttempts(ctx context.Context, arg SystemCountRecentLoginAttemptsParams) (int64, error)
 	SystemCreateSearchWord(ctx context.Context, word string) (int64, error)
 	// This query deletes all data from the "blogs_search" table.
@@ -400,6 +399,8 @@ type Querier interface {
 	// This query deletes all data from the "writing_search" table.
 	SystemDeleteWritingSearch(ctx context.Context) error
 	SystemGetAllBlogsForIndex(ctx context.Context) ([]*SystemGetAllBlogsForIndexRow, error)
+	// SystemGetLanguageIDByName resolves a language ID by name.
+	SystemGetLanguageIDByName(ctx context.Context, nameof sql.NullString) (int32, error)
 	SystemGetSearchWordByWordLowercased(ctx context.Context, lcase string) (*Searchwordlist, error)
 	SystemGetTemplateOverride(ctx context.Context, name string) (string, error)
 	// System query only used internally
@@ -409,6 +410,8 @@ type Querier interface {
 	SystemLatestDeadLetter(ctx context.Context) (interface{}, error)
 	SystemListBoardsByParentID(ctx context.Context, arg SystemListBoardsByParentIDParams) ([]*Imageboard, error)
 	SystemListDeadLetters(ctx context.Context, limit int32) ([]*DeadLetter, error)
+	// SystemListLanguages lists all languages.
+	SystemListLanguages(ctx context.Context) ([]*Language, error)
 	SystemListPublicWritingsByAuthor(ctx context.Context, arg SystemListPublicWritingsByAuthorParams) ([]*SystemListPublicWritingsByAuthorRow, error)
 	SystemListPublicWritingsInCategory(ctx context.Context, arg SystemListPublicWritingsInCategoryParams) ([]*SystemListPublicWritingsInCategoryRow, error)
 	SystemListUserInfo(ctx context.Context) ([]*SystemListUserInfoRow, error)

--- a/internal/db/queries-languages.sql
+++ b/internal/db/queries-languages.sql
@@ -1,40 +1,41 @@
--- name: RenameLanguage :exec
--- This query updates the "nameof" field in the "language" table based on the provided "cid".
+-- AdminRenameLanguage updates the language name.
 -- Parameters:
 --   ? - New name for the language (string)
 --   ? - Language ID to be updated (int)
+-- name: AdminRenameLanguage :exec
 UPDATE language
 SET nameof = ?
 WHERE idlanguage = ?;
 
--- name: DeleteLanguage :exec
--- This query deletes a record from the "language" table based on the provided "cid".
+-- AdminDeleteLanguage removes a language entry.
 -- Parameters:
 --   ? - Language ID to be deleted (int)
+-- name: AdminDeleteLanguage :exec
 DELETE FROM language
 WHERE idlanguage = ?;
 
--- name: CreateLanguage :exec
--- This query inserts a new record into the "language" table.
+-- AdminCreateLanguage adds a new language.
 -- Parameters:
 --   ? - Name of the new language (string)
+-- name: AdminCreateLanguage :exec
 INSERT INTO language (nameof)
 VALUES (?);
 
--- name: InsertLanguage :execresult
+-- AdminInsertLanguage adds a new language returning a result.
+-- name: AdminInsertLanguage :execresult
 INSERT INTO language (nameof)
 VALUES (?);
 
--- name: FetchLanguages :many
+-- SystemListLanguages lists all languages.
+-- name: SystemListLanguages :many
 SELECT *
 FROM language;
 
--- name: AllLanguages :many
-SELECT * FROM language;
-
--- name: GetLanguageIDByName :one
+-- SystemGetLanguageIDByName resolves a language ID by name.
+-- name: SystemGetLanguageIDByName :one
 SELECT idlanguage FROM language WHERE nameof = ?;
 
 
--- name: CountLanguages :one
+-- SystemCountLanguages counts all languages.
+-- name: SystemCountLanguages :one
 SELECT COUNT(*) FROM language;

--- a/internal/db/queries-languages.sql.go
+++ b/internal/db/queries-languages.sql.go
@@ -10,137 +10,114 @@ import (
 	"database/sql"
 )
 
-const allLanguages = `-- name: AllLanguages :many
-SELECT idlanguage, nameof FROM language
-`
-
-func (q *Queries) AllLanguages(ctx context.Context) ([]*Language, error) {
-	rows, err := q.db.QueryContext(ctx, allLanguages)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*Language
-	for rows.Next() {
-		var i Language
-		if err := rows.Scan(&i.Idlanguage, &i.Nameof); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const countLanguages = `-- name: CountLanguages :one
-SELECT COUNT(*) FROM language
-`
-
-func (q *Queries) CountLanguages(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countLanguages)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
-}
-
-const createLanguage = `-- name: CreateLanguage :exec
+const adminCreateLanguage = `-- name: AdminCreateLanguage :exec
 INSERT INTO language (nameof)
 VALUES (?)
 `
 
-// This query inserts a new record into the "language" table.
+// AdminCreateLanguage adds a new language.
 // Parameters:
 //
 //	? - Name of the new language (string)
-func (q *Queries) CreateLanguage(ctx context.Context, nameof sql.NullString) error {
-	_, err := q.db.ExecContext(ctx, createLanguage, nameof)
+func (q *Queries) AdminCreateLanguage(ctx context.Context, nameof sql.NullString) error {
+	_, err := q.db.ExecContext(ctx, adminCreateLanguage, nameof)
 	return err
 }
 
-const deleteLanguage = `-- name: DeleteLanguage :exec
+const adminDeleteLanguage = `-- name: AdminDeleteLanguage :exec
 DELETE FROM language
 WHERE idlanguage = ?
 `
 
-// This query deletes a record from the "language" table based on the provided "cid".
+// AdminDeleteLanguage removes a language entry.
 // Parameters:
 //
 //	? - Language ID to be deleted (int)
-func (q *Queries) DeleteLanguage(ctx context.Context, idlanguage int32) error {
-	_, err := q.db.ExecContext(ctx, deleteLanguage, idlanguage)
+func (q *Queries) AdminDeleteLanguage(ctx context.Context, idlanguage int32) error {
+	_, err := q.db.ExecContext(ctx, adminDeleteLanguage, idlanguage)
 	return err
 }
 
-const fetchLanguages = `-- name: FetchLanguages :many
-SELECT idlanguage, nameof
-FROM language
-`
-
-func (q *Queries) FetchLanguages(ctx context.Context) ([]*Language, error) {
-	rows, err := q.db.QueryContext(ctx, fetchLanguages)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*Language
-	for rows.Next() {
-		var i Language
-		if err := rows.Scan(&i.Idlanguage, &i.Nameof); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getLanguageIDByName = `-- name: GetLanguageIDByName :one
-SELECT idlanguage FROM language WHERE nameof = ?
-`
-
-func (q *Queries) GetLanguageIDByName(ctx context.Context, nameof sql.NullString) (int32, error) {
-	row := q.db.QueryRowContext(ctx, getLanguageIDByName, nameof)
-	var idlanguage int32
-	err := row.Scan(&idlanguage)
-	return idlanguage, err
-}
-
-const insertLanguage = `-- name: InsertLanguage :execresult
+const adminInsertLanguage = `-- name: AdminInsertLanguage :execresult
 INSERT INTO language (nameof)
 VALUES (?)
 `
 
-func (q *Queries) InsertLanguage(ctx context.Context, nameof sql.NullString) (sql.Result, error) {
-	return q.db.ExecContext(ctx, insertLanguage, nameof)
+// AdminInsertLanguage adds a new language returning a result.
+func (q *Queries) AdminInsertLanguage(ctx context.Context, nameof sql.NullString) (sql.Result, error) {
+	return q.db.ExecContext(ctx, adminInsertLanguage, nameof)
 }
 
-const renameLanguage = `-- name: RenameLanguage :exec
+const adminRenameLanguage = `-- name: AdminRenameLanguage :exec
 UPDATE language
 SET nameof = ?
 WHERE idlanguage = ?
 `
 
-type RenameLanguageParams struct {
+type AdminRenameLanguageParams struct {
 	Nameof     sql.NullString
 	Idlanguage int32
 }
 
-// This query updates the "nameof" field in the "language" table based on the provided "cid".
+// AdminRenameLanguage updates the language name.
 // Parameters:
 //
 //	? - New name for the language (string)
 //	? - Language ID to be updated (int)
-func (q *Queries) RenameLanguage(ctx context.Context, arg RenameLanguageParams) error {
-	_, err := q.db.ExecContext(ctx, renameLanguage, arg.Nameof, arg.Idlanguage)
+func (q *Queries) AdminRenameLanguage(ctx context.Context, arg AdminRenameLanguageParams) error {
+	_, err := q.db.ExecContext(ctx, adminRenameLanguage, arg.Nameof, arg.Idlanguage)
 	return err
+}
+
+const systemCountLanguages = `-- name: SystemCountLanguages :one
+SELECT COUNT(*) FROM language
+`
+
+// SystemCountLanguages counts all languages.
+func (q *Queries) SystemCountLanguages(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, systemCountLanguages)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const systemGetLanguageIDByName = `-- name: SystemGetLanguageIDByName :one
+SELECT idlanguage FROM language WHERE nameof = ?
+`
+
+// SystemGetLanguageIDByName resolves a language ID by name.
+func (q *Queries) SystemGetLanguageIDByName(ctx context.Context, nameof sql.NullString) (int32, error) {
+	row := q.db.QueryRowContext(ctx, systemGetLanguageIDByName, nameof)
+	var idlanguage int32
+	err := row.Scan(&idlanguage)
+	return idlanguage, err
+}
+
+const systemListLanguages = `-- name: SystemListLanguages :many
+SELECT idlanguage, nameof
+FROM language
+`
+
+// SystemListLanguages lists all languages.
+func (q *Queries) SystemListLanguages(ctx context.Context) ([]*Language, error) {
+	rows, err := q.db.QueryContext(ctx, systemListLanguages)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*Language
+	for rows.Next() {
+		var i Language
+		if err := rows.Scan(&i.Idlanguage, &i.Nameof); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/specs/query_naming.md
+++ b/specs/query_naming.md
@@ -14,20 +14,23 @@ All query names must begin with a prefix indicating the required role:
   required role using a `For<Role>` suffix (for example `ForLister`,
   `ForWriter`, `ForCommenter`, `ForReplier`). Parameter names should
   mirror the role and use the `<Role>ID` form (e.g. `ListerID`,
-  `WriterID`). Historic `See`/`Seer` terminology is replaced by
-  `List`/`Lister`.
+  `WriterID`). When a clearer role name exists (`Writer`, `Lister`,
+  `Commenter`, `Replier`, etc.) it should be used. Historic `See`/`Seer`
+  terminology is replaced by `List`/`Lister`.
 
 ## Lists
 
 Queries returning multiple rows must start with the `List` prefix and
-support pagination (`LIMIT`/`OFFSET`). User and admin lists must respect
-language preferences and enforce permissions within the SQL itself.
-Admin and system queries must never require a user ID.
+include pagination (`LIMIT`/`OFFSET`). User and admin lists must respect
+each user's pagination and language preferences and enforce permissions
+within the SQL itself. Admin and system queries must never require a user
+ID.
 
 ## Grants
 
 User queries should check grants both in SQL and in Go code to ensure
-authorisation rules are enforced.
+authorisation rules are enforced. Admin and system queries should not
+require a user ID and are intended for privileged operations.
 
 These rules are verified by tests and should be followed for all new
 queries.


### PR DESCRIPTION
## Summary
- rename language queries with System/Admin prefixes and list naming
- update handlers, CLI commands, and core utilities to new language query names
- document expanded query naming guidelines

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: undefined: common.WithCustomQueries, queries.DB undefined, etc.)*
- `golangci-lint run` *(fails: typecheck errors e.g. db.New undefined)*
- `go test ./...` *(fails: queries.DB undefined, undefined: common.WithCustomQueries, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688eaa271cfc832fa743721c40674372