### PR TITLE
refactor: align image board queries with naming spec

### DIFF
--- a/cmd/goa4web/board_create.go
+++ b/cmd/goa4web/board_create.go
@@ -38,11 +38,11 @@ func (c *boardCreateCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := db.New(db)
-	err = queries.CreateImageBoard(ctx, db.CreateImageBoardParams{
-		ImageboardIdimageboard: int32(c.Parent),
-		Title:                  sql.NullString{String: c.Name, Valid: c.Name != ""},
-		Description:            sql.NullString{String: c.Description, Valid: c.Description != ""},
-		ApprovalRequired:       false,
+	err = queries.AdminCreateImageBoard(ctx, db.AdminCreateImageBoardParams{
+		ParentID:         int32(c.Parent),
+		Title:            sql.NullString{String: c.Name, Valid: c.Name != ""},
+		Description:      sql.NullString{String: c.Description, Valid: c.Description != ""},
+		ApprovalRequired: false,
 	})
 	if err != nil {
 		return fmt.Errorf("create board: %w", err)

--- a/cmd/goa4web/board_delete.go
+++ b/cmd/goa4web/board_delete.go
@@ -41,7 +41,7 @@ func (c *boardDeleteCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := db.New(db)
-	if err := queries.DeleteImageBoard(ctx, int32(c.ID)); err != nil {
+	if err := queries.AdminDeleteImageBoard(ctx, int32(c.ID)); err != nil {
 		return fmt.Errorf("delete board: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/board_update.go
+++ b/cmd/goa4web/board_update.go
@@ -46,12 +46,12 @@ func (c *boardUpdateCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := db.New(db)
-	err = queries.UpdateImageBoard(ctx, db.UpdateImageBoardParams{
-		Title:                  sql.NullString{String: c.Name, Valid: c.Name != ""},
-		Description:            sql.NullString{String: c.Description, Valid: c.Description != ""},
-		ImageboardIdimageboard: int32(c.Parent),
-		ApprovalRequired:       c.ApprovalNeeded,
-		Idimageboard:           int32(c.ID),
+	err = queries.AdminUpdateImageBoard(ctx, db.AdminUpdateImageBoardParams{
+		Title:            sql.NullString{String: c.Name, Valid: c.Name != ""},
+		Description:      sql.NullString{String: c.Description, Valid: c.Description != ""},
+		ParentID:         int32(c.Parent),
+		ApprovalRequired: c.ApprovalNeeded,
+		BoardID:          int32(c.ID),
 	})
 	if err != nil {
 		return fmt.Errorf("update board: %w", err)

--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -148,7 +148,7 @@ func (c *userDeactivateCmd) Run() error {
 			return fmt.Errorf("scrub blog: %w", err)
 		}
 	}
-	imgs, err := qtx.GetImagePostsByUserDescending(ctx, db.GetImagePostsByUserDescendingParams{UsersIdusers: u.Idusers, Limit: math.MaxInt32, Offset: 0})
+	imgs, err := qtx.AdminListImagePostsByPoster(ctx, db.AdminListImagePostsByPosterParams{PosterID: u.Idusers, Limit: math.MaxInt32, Offset: 0})
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("list images: %w", err)

--- a/handlers/admin/adminRolePage.go
+++ b/handlers/admin/adminRolePage.go
@@ -174,7 +174,7 @@ func adminRolePage(w http.ResponseWriter, r *http.Request) {
 				}
 			case "imagebbs":
 				if g.Item.String == "board" {
-					if b, err := queries.GetImageBoardById(r.Context(), g.ItemID.Int32); err == nil && b.Title.Valid {
+					if b, err := queries.AdminGetImageBoardByID(r.Context(), g.ItemID.Int32); err == nil && b.Title.Valid {
 						gi.Info = b.Title.String
 					}
 				}

--- a/handlers/admin/adminUserImagebbsPage.go
+++ b/handlers/admin/adminUserImagebbsPage.go
@@ -23,10 +23,10 @@ func adminUserImagebbsPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.GetImagePostsByUserDescendingAll(r.Context(), db.GetImagePostsByUserDescendingAllParams{
-		UsersIdusers: int32(id),
-		Limit:        100,
-		Offset:       0,
+	rows, err := queries.AdminListAllImagePostsByPoster(r.Context(), db.AdminListAllImagePostsByPosterParams{
+		PosterID: int32(id),
+		Limit:    100,
+		Offset:   0,
 	})
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -36,7 +36,7 @@ func adminUserImagebbsPage(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		*common.CoreData
 		User  *db.User
-		Posts []*db.GetImagePostsByUserDescendingAllRow
+		Posts []*db.AdminListAllImagePostsByPosterRow
 	}{
 		CoreData: cd,
 		User:     &db.User{Idusers: user.Idusers, Username: user.Username},

--- a/handlers/imagebbs/imagebbsAdminApprove.go
+++ b/handlers/imagebbs/imagebbsAdminApprove.go
@@ -32,7 +32,7 @@ func (ApprovePostTask) Action(w http.ResponseWriter, r *http.Request) any {
 		})
 	}
 	queries := cd.Queries()
-	if err := queries.ApproveImagePost(r.Context(), int32(pid)); err != nil {
+	if err := queries.AdminApproveImagePost(r.Context(), int32(pid)); err != nil {
 		return fmt.Errorf("approve image post fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if evt := cd.Event(); evt != nil {

--- a/handlers/imagebbs/imagebbsAdminBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardPage.go
@@ -56,11 +56,12 @@ func (ModifyBoardTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return common.UserError{ErrorMessage: fmt.Sprintf("invalid parent board: loop %v", path)}
 	}
 
-	err = queries.UpdateImageBoard(r.Context(), db.UpdateImageBoardParams{
-		ImageboardIdimageboard: int32(parentBoardId),
-		Title:                  sql.NullString{Valid: true, String: name},
-		Description:            sql.NullString{Valid: true, String: desc},
-		Idimageboard:           int32(bid),
+	err = queries.AdminUpdateImageBoard(r.Context(), db.AdminUpdateImageBoardParams{
+		ParentID:         int32(parentBoardId),
+		Title:            sql.NullString{Valid: true, String: name},
+		Description:      sql.NullString{Valid: true, String: desc},
+		ApprovalRequired: false,
+		BoardID:          int32(bid),
 	})
 	if err != nil {
 		return fmt.Errorf("update image board fail %w", handlers.ErrRedirectOnSamePageHandler(err))
@@ -87,7 +88,7 @@ func AdminBoardPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	board, err := queries.GetImageBoardById(r.Context(), int32(bid))
+	board, err := queries.AdminGetImageBoardByID(r.Context(), int32(bid))
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/imagebbs/imagebbsAdminNewBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminNewBoardPage.go
@@ -57,10 +57,11 @@ func (NewBoardTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return common.UserError{ErrorMessage: fmt.Sprintf("invalid parent board: loop %v", path)}
 	}
 
-	err = queries.CreateImageBoard(r.Context(), db.CreateImageBoardParams{
-		ImageboardIdimageboard: int32(parentBoardId),
-		Title:                  sql.NullString{Valid: true, String: name},
-		Description:            sql.NullString{Valid: true, String: desc},
+	err = queries.AdminCreateImageBoard(r.Context(), db.AdminCreateImageBoardParams{
+		ParentID:         int32(parentBoardId),
+		Title:            sql.NullString{Valid: true, String: name},
+		Description:      sql.NullString{Valid: true, String: desc},
+		ApprovalRequired: false,
 	})
 	if err != nil {
 		return fmt.Errorf("create image board fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -117,7 +117,11 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	queries := cd.Queries()
 
-	board, err := queries.GetImageBoardById(r.Context(), int32(bid))
+	board, err := queries.GetImageBoardByIDForLister(r.Context(), db.GetImageBoardByIDForListerParams{
+		ListerID:     uid,
+		BoardID:      int32(bid),
+		ListerUserID: sql.NullInt32{Int32: uid, Valid: true},
+	})
 	if err != nil {
 		return fmt.Errorf("get image board fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
@@ -192,14 +196,14 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	approved := !board.ApprovalRequired
 
-	pid, err := queries.CreateImagePost(r.Context(), db.CreateImagePostParams{
-		ImageboardIdimageboard: int32(bid),
-		Thumbnail:              sql.NullString{Valid: true, String: relThumb},
-		Fullimage:              sql.NullString{Valid: true, String: relFull},
-		UsersIdusers:           uid,
-		Description:            sql.NullString{Valid: true, String: text},
-		Approved:               approved,
-		FileSize:               int32(size),
+	pid, err := queries.CreateImagePostForPoster(r.Context(), db.CreateImagePostForPosterParams{
+		BoardID:     int32(bid),
+		Thumbnail:   sql.NullString{Valid: true, String: relThumb},
+		Fullimage:   sql.NullString{Valid: true, String: relFull},
+		PosterID:    uid,
+		Description: sql.NullString{Valid: true, String: text},
+		Approved:    approved,
+		FileSize:    int32(size),
 	})
 	if err != nil {
 		return fmt.Errorf("create image post fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -276,9 +276,9 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			return fmt.Errorf("make thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		pthid = int32(pthidi)
-		if err := queries.UpdateImagePostByIdForumThreadId(r.Context(), db.UpdateImagePostByIdForumThreadIdParams{
-			ForumthreadID: pthid,
-			Idimagepost:   int32(bid),
+		if err := queries.AdminSetImagePostForumThreadID(r.Context(), db.AdminSetImagePostForumThreadIDParams{
+			ForumThreadID: pthid,
+			ImagePostID:   int32(bid),
 		}); err != nil {
 			return fmt.Errorf("assign imagebbs to thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/internal/db/queries_imagebbs_test.go
+++ b/internal/db/queries_imagebbs_test.go
@@ -34,3 +34,30 @@ func TestQueries_ListBoardsByParentIDForLister(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestQueries_GetImageBoardByIDForLister(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := New(db)
+
+	rows := sqlmock.NewRows([]string{"idimageboard", "imageboard_idimageboard", "title", "description", "approval_required"}).
+		AddRow(2, 0, nil, nil, 0)
+	viewer := sql.NullInt32{}
+	mock.ExpectQuery(regexp.QuoteMeta(getImageBoardByIDForLister)).
+		WithArgs(int32(1), int32(2), viewer).
+		WillReturnRows(rows)
+
+	res, err := q.GetImageBoardByIDForLister(context.Background(), GetImageBoardByIDForListerParams{ListerID: 1, BoardID: 2, ListerUserID: viewer})
+	if err != nil {
+		t.Fatalf("GetImageBoardByIDForLister: %v", err)
+	}
+	if res.Idimageboard != 2 {
+		t.Fatalf("unexpected board id %d", res.Idimageboard)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/specs/query_naming.md
+++ b/specs/query_naming.md
@@ -21,16 +21,24 @@ All query names must begin with a prefix indicating the required role:
 ## Lists
 
 Queries returning multiple rows must start with the `List` prefix and
-include pagination (`LIMIT`/`OFFSET`). User and admin lists must respect
-each user's pagination and language preferences and enforce permissions
-within the SQL itself. Admin and system queries must never require a user
-ID.
+include pagination (`LIMIT`/`OFFSET`). All lists **must** paginate and
+adhere to the caller's pagination settings. User-facing lists must also
+respect the user's language preferences and enforce permissions within
+the SQL itself. Admin and system lists are privileged operations and must
+not require a user ID.
 
 ## Grants
 
 User queries should check grants both in SQL and in Go code to ensure
 authorisation rules are enforced. Admin and system queries should not
 require a user ID and are intended for privileged operations.
+
+When a query operates on behalf of a user the required role must appear
+in the function name as `For<Role>` (for example `CreateImagePostForPoster`).
+Corresponding parameter names should use the same role (such as
+`PosterID`). Admin and system commands must be clearly labelled with
+their respective prefixes and must not accept a user ID. Commands used by
+CLI tools are considered system operations.
 
 These rules are verified by tests and should be followed for all new
 queries.


### PR DESCRIPTION
## Summary
- expand query naming specification
- rename image board queries with explicit role prefixes and user roles
- check lister access when fetching image boards
- add tests for new grant-aware query

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: queries.DB undefined, etc.)*
- `golangci-lint run` *(fails: db.New undefined, typecheck errors)*
- `go test ./...` *(fails: queries.DB undefined, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688eaf83b1f4832fa81f329f051cb78f