### PR TITLE
refactor: enforce admin query naming

### DIFF
--- a/cmd/goa4web/blog_deactivate.go
+++ b/cmd/goa4web/blog_deactivate.go
@@ -49,7 +49,7 @@ func (c *blogDeactivateCmd) Run() error {
 	if b.ForumthreadID.Valid {
 		threadID = b.ForumthreadID.Int32
 	}
-	if err := queries.ArchiveBlog(ctx, db.ArchiveBlogParams{
+	if err := queries.AdminArchiveBlog(ctx, db.AdminArchiveBlogParams{
 		Idblogs:            b.Idblogs,
 		ForumthreadID:      threadID,
 		UsersIdusers:       b.UsersIdusers,
@@ -59,7 +59,7 @@ func (c *blogDeactivateCmd) Run() error {
 	}); err != nil {
 		return fmt.Errorf("archive blog: %w", err)
 	}
-	if err := queries.ScrubBlog(ctx, db.ScrubBlogParams{Blog: sql.NullString{String: "", Valid: true}, Idblogs: b.Idblogs}); err != nil {
+	if err := queries.AdminScrubBlog(ctx, db.AdminScrubBlogParams{Blog: sql.NullString{String: "", Valid: true}, Idblogs: b.Idblogs}); err != nil {
 		return fmt.Errorf("scrub blog: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/user_activate.go
+++ b/cmd/goa4web/user_activate.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"math"
 
 	"github.com/arran4/goa4web/internal/db"
 )
@@ -53,33 +54,33 @@ func (c *userActivateCmd) Run() error {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	qtx := queries.WithTx(tx)
-	if err := qtx.RestoreUser(ctx, int32(c.ID)); err != nil {
+	if err := qtx.AdminRestoreUser(ctx, int32(c.ID)); err != nil {
 		tx.Rollback()
 		return fmt.Errorf("restore user: %w", err)
 	}
-	rows, err := qtx.PendingDeactivatedComments(ctx, int32(c.ID))
+	rows, err := qtx.AdminListPendingDeactivatedComments(ctx, db.AdminListPendingDeactivatedCommentsParams{UsersIdusers: int32(c.ID), Limit: math.MaxInt32, Offset: 0})
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select comments: %w", err)
 	}
 	for _, row := range rows {
-		if err := qtx.RestoreComment(ctx, db.RestoreCommentParams{Text: row.Text, Idcomments: row.Idcomments}); err != nil {
+		if err := qtx.AdminRestoreComment(ctx, db.AdminRestoreCommentParams{Text: row.Text, Idcomments: row.Idcomments}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("restore comment: %w", err)
 		}
-		if err := qtx.MarkCommentRestored(ctx, row.Idcomments); err != nil {
+		if err := qtx.AdminMarkCommentRestored(ctx, row.Idcomments); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark comment restored: %w", err)
 		}
 	}
 
-	rowsW, err := qtx.PendingDeactivatedWritings(ctx, int32(c.ID))
+	rowsW, err := qtx.AdminListPendingDeactivatedWritings(ctx, db.AdminListPendingDeactivatedWritingsParams{UsersIdusers: int32(c.ID), Limit: math.MaxInt32, Offset: 0})
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select writings: %w", err)
 	}
 	for _, w := range rowsW {
-		if err := qtx.RestoreWriting(ctx, db.RestoreWritingParams{
+		if err := qtx.AdminRestoreWriting(ctx, db.AdminRestoreWritingParams{
 			Title:     w.Title,
 			Writing:   w.Writing,
 			Abstract:  w.Abstract,
@@ -89,55 +90,55 @@ func (c *userActivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("restore writing: %w", err)
 		}
-		if err := qtx.MarkWritingRestored(ctx, w.Idwriting); err != nil {
+		if err := qtx.AdminMarkWritingRestored(ctx, w.Idwriting); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark writing restored: %w", err)
 		}
 	}
 
-	rowsB, err := qtx.PendingDeactivatedBlogs(ctx, int32(c.ID))
+	rowsB, err := qtx.AdminListPendingDeactivatedBlogs(ctx, db.AdminListPendingDeactivatedBlogsParams{UsersIdusers: int32(c.ID), Limit: math.MaxInt32, Offset: 0})
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select blogs: %w", err)
 	}
 	for _, b := range rowsB {
-		if err := qtx.RestoreBlog(ctx, db.RestoreBlogParams{Blog: b.Blog, Idblogs: b.Idblogs}); err != nil {
+		if err := qtx.AdminRestoreBlog(ctx, db.AdminRestoreBlogParams{Blog: b.Blog, Idblogs: b.Idblogs}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("restore blog: %w", err)
 		}
-		if err := qtx.MarkBlogRestored(ctx, b.Idblogs); err != nil {
+		if err := qtx.AdminMarkBlogRestored(ctx, b.Idblogs); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark blog restored: %w", err)
 		}
 	}
 
-	rowsI, err := qtx.PendingDeactivatedImageposts(ctx, int32(c.ID))
+	rowsI, err := qtx.AdminListPendingDeactivatedImageposts(ctx, db.AdminListPendingDeactivatedImagepostsParams{UsersIdusers: int32(c.ID), Limit: math.MaxInt32, Offset: 0})
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select imageposts: %w", err)
 	}
 	for _, img := range rowsI {
-		if err := qtx.RestoreImagepost(ctx, db.RestoreImagepostParams{Description: img.Description, Thumbnail: img.Thumbnail, Fullimage: img.Fullimage, Idimagepost: img.Idimagepost}); err != nil {
+		if err := qtx.AdminRestoreImagepost(ctx, db.AdminRestoreImagepostParams{Description: img.Description, Thumbnail: img.Thumbnail, Fullimage: img.Fullimage, Idimagepost: img.Idimagepost}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("restore imagepost: %w", err)
 		}
-		if err := qtx.MarkImagepostRestored(ctx, img.Idimagepost); err != nil {
+		if err := qtx.AdminMarkImagepostRestored(ctx, img.Idimagepost); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark imagepost restored: %w", err)
 		}
 	}
 
-	rowsL, err := qtx.PendingDeactivatedLinks(ctx, int32(c.ID))
+	rowsL, err := qtx.AdminListPendingDeactivatedLinks(ctx, db.AdminListPendingDeactivatedLinksParams{UsersIdusers: int32(c.ID), Limit: math.MaxInt32, Offset: 0})
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("select links: %w", err)
 	}
 	for _, l := range rowsL {
-		if err := qtx.RestoreLink(ctx, db.RestoreLinkParams{Title: l.Title, Url: l.Url, Description: l.Description, Idlinker: l.Idlinker}); err != nil {
+		if err := qtx.AdminRestoreLink(ctx, db.AdminRestoreLinkParams{Title: l.Title, Url: l.Url, Description: l.Description, Idlinker: l.Idlinker}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("restore link: %w", err)
 		}
-		if err := qtx.MarkLinkRestored(ctx, l.Idlinker); err != nil {
+		if err := qtx.AdminMarkLinkRestored(ctx, l.Idlinker); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("mark link restored: %w", err)
 		}

--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -56,12 +56,12 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	qtx := queries.WithTx(tx)
-	if err := qtx.ArchiveUser(ctx, u.Idusers); err != nil {
+	if err := qtx.AdminArchiveUser(ctx, u.Idusers); err != nil {
 		tx.Rollback()
 		return fmt.Errorf("archive user: %w", err)
 	}
 	newName := randomString(16)
-	if err := qtx.ScrubUser(ctx, db.ScrubUserParams{Username: sql.NullString{String: newName, Valid: true}, Idusers: u.Idusers}); err != nil {
+	if err := qtx.AdminScrubUser(ctx, db.AdminScrubUserParams{Username: sql.NullString{String: newName, Valid: true}, Idusers: u.Idusers}); err != nil {
 		tx.Rollback()
 		return fmt.Errorf("scrub user: %w", err)
 	}
@@ -71,7 +71,7 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("list comments: %w", err)
 	}
 	for _, cm := range comments {
-		if err := qtx.ArchiveComment(ctx, db.ArchiveCommentParams{
+		if err := qtx.AdminArchiveComment(ctx, db.AdminArchiveCommentParams{
 			Idcomments:         cm.Idcomments,
 			ForumthreadID:      cm.ForumthreadID,
 			UsersIdusers:       cm.UsersIdusers,
@@ -83,7 +83,7 @@ func (c *userDeactivateCmd) Run() error {
 			return fmt.Errorf("archive comment: %w", err)
 		}
 		scrub := scrubText(cm.Text.String)
-		if err := qtx.ScrubComment(ctx, db.ScrubCommentParams{Text: sql.NullString{String: scrub, Valid: true}, Idcomments: cm.Idcomments}); err != nil {
+		if err := qtx.AdminScrubComment(ctx, db.AdminScrubCommentParams{Text: sql.NullString{String: scrub, Valid: true}, Idcomments: cm.Idcomments}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("scrub comment: %w", err)
 		}
@@ -94,7 +94,7 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("list writings: %w", err)
 	}
 	for _, w := range writings {
-		if err := qtx.ArchiveWriting(ctx, db.ArchiveWritingParams{
+		if err := qtx.AdminArchiveWriting(ctx, db.AdminArchiveWritingParams{
 			Idwriting:          w.Idwriting,
 			UsersIdusers:       w.UsersIdusers,
 			ForumthreadID:      w.ForumthreadID,
@@ -109,7 +109,7 @@ func (c *userDeactivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("archive writing: %w", err)
 		}
-		if err := qtx.ScrubWriting(ctx, db.ScrubWritingParams{
+		if err := qtx.AdminScrubWriting(ctx, db.AdminScrubWritingParams{
 			Title:     sql.NullString{String: scrubText(w.Title.String), Valid: w.Title.Valid},
 			Writing:   sql.NullString{String: scrubText(w.Writing.String), Valid: w.Writing.Valid},
 			Abstract:  sql.NullString{String: scrubText(w.Abstract.String), Valid: w.Abstract.Valid},
@@ -132,7 +132,7 @@ func (c *userDeactivateCmd) Run() error {
 		if b.ForumthreadID.Valid {
 			threadID = b.ForumthreadID.Int32
 		}
-		if err := qtx.ArchiveBlog(ctx, db.ArchiveBlogParams{
+		if err := qtx.AdminArchiveBlog(ctx, db.AdminArchiveBlogParams{
 			Idblogs:            b.Idblogs,
 			ForumthreadID:      threadID,
 			UsersIdusers:       b.UsersIdusers,
@@ -143,7 +143,7 @@ func (c *userDeactivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("archive blog: %w", err)
 		}
-		if err := qtx.ScrubBlog(ctx, db.ScrubBlogParams{Blog: sql.NullString{String: scrubText(b.Blog.String), Valid: b.Blog.Valid}, Idblogs: b.Idblogs}); err != nil {
+		if err := qtx.AdminScrubBlog(ctx, db.AdminScrubBlogParams{Blog: sql.NullString{String: scrubText(b.Blog.String), Valid: b.Blog.Valid}, Idblogs: b.Idblogs}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("scrub blog: %w", err)
 		}
@@ -154,7 +154,7 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("list images: %w", err)
 	}
 	for _, img := range imgs {
-		if err := qtx.ArchiveImagepost(ctx, db.ArchiveImagepostParams{
+		if err := qtx.AdminArchiveImagepost(ctx, db.AdminArchiveImagepostParams{
 			Idimagepost:            img.Idimagepost,
 			ForumthreadID:          img.ForumthreadID,
 			UsersIdusers:           img.UsersIdusers,
@@ -169,7 +169,7 @@ func (c *userDeactivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("archive imagepost: %w", err)
 		}
-		if err := qtx.ScrubImagepost(ctx, img.Idimagepost); err != nil {
+		if err := qtx.AdminScrubImagepost(ctx, img.Idimagepost); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("scrub imagepost: %w", err)
 		}
@@ -180,7 +180,7 @@ func (c *userDeactivateCmd) Run() error {
 		return fmt.Errorf("list links: %w", err)
 	}
 	for _, l := range links {
-		if err := qtx.ArchiveLink(ctx, db.ArchiveLinkParams{
+		if err := qtx.AdminArchiveLink(ctx, db.AdminArchiveLinkParams{
 			Idlinker:           l.Idlinker,
 			LanguageIdlanguage: l.LanguageIdlanguage,
 			UsersIdusers:       l.UsersIdusers,
@@ -194,7 +194,7 @@ func (c *userDeactivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("archive link: %w", err)
 		}
-		if err := qtx.ScrubLink(ctx, db.ScrubLinkParams{Title: sql.NullString{String: scrubText(l.Title.String), Valid: l.Title.Valid}, Idlinker: l.Idlinker}); err != nil {
+		if err := qtx.AdminScrubLink(ctx, db.AdminScrubLinkParams{Title: sql.NullString{String: scrubText(l.Title.String), Valid: l.Title.Valid}, Idlinker: l.Idlinker}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("scrub link: %w", err)
 		}

--- a/handlers/admin/adminCommentTasks.go
+++ b/handlers/admin/adminCommentTasks.go
@@ -24,7 +24,7 @@ var _ tasks.Task = (*DeleteCommentTask)(nil)
 func (DeleteCommentTask) Action(w http.ResponseWriter, r *http.Request) any {
 	id, _ := strconv.Atoi(mux.Vars(r)["id"])
 	q := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	if err := q.ScrubComment(r.Context(), db.ScrubCommentParams{Text: sql.NullString{String: "", Valid: true}, Idcomments: int32(id)}); err != nil {
+	if err := q.AdminScrubComment(r.Context(), db.AdminScrubCommentParams{Text: sql.NullString{String: "", Valid: true}, Idcomments: int32(id)}); err != nil {
 		return fmt.Errorf("delete comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	return nil
@@ -62,7 +62,7 @@ func (BanCommentTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("fetch comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := q.ArchiveComment(r.Context(), db.ArchiveCommentParams{
+	if err := q.AdminArchiveComment(r.Context(), db.AdminArchiveCommentParams{
 		Idcomments:         c.Idcomments,
 		ForumthreadID:      c.ForumthreadID,
 		UsersIdusers:       c.UsersIdusers,
@@ -72,7 +72,7 @@ func (BanCommentTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}); err != nil {
 		return fmt.Errorf("archive comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := q.ScrubComment(r.Context(), db.ScrubCommentParams{Text: sql.NullString{String: "", Valid: true}, Idcomments: c.Idcomments}); err != nil {
+	if err := q.AdminScrubComment(r.Context(), db.AdminScrubCommentParams{Text: sql.NullString{String: "", Valid: true}, Idcomments: c.Idcomments}); err != nil {
 		return fmt.Errorf("scrub comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	return nil

--- a/handlers/imagebbs/imagebbsAdminApprove.go
+++ b/handlers/imagebbs/imagebbsAdminApprove.go
@@ -32,7 +32,7 @@ func (ApprovePostTask) Action(w http.ResponseWriter, r *http.Request) any {
 		})
 	}
 	queries := cd.Queries()
-	if err := queries.ApproveImagePost(r.Context(), int32(pid)); err != nil {
+	if err := queries.AdminApproveImagePost(r.Context(), int32(pid)); err != nil {
 		return fmt.Errorf("approve image post fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if evt := cd.Event(); evt != nil {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -17,6 +17,14 @@ type Querier interface {
 	//   username (string)
 	//   email (string)
 	AdminAllUsers(ctx context.Context) ([]*AdminAllUsersRow, error)
+	AdminApproveImagePost(ctx context.Context, idimagepost int32) error
+	AdminArchiveBlog(ctx context.Context, arg AdminArchiveBlogParams) error
+	AdminArchiveComment(ctx context.Context, arg AdminArchiveCommentParams) error
+	AdminArchiveImagepost(ctx context.Context, arg AdminArchiveImagepostParams) error
+	AdminArchiveLink(ctx context.Context, arg AdminArchiveLinkParams) error
+	// Queries for user deactivation and restoration
+	AdminArchiveUser(ctx context.Context, idusers int32) error
+	AdminArchiveWriting(ctx context.Context, arg AdminArchiveWritingParams) error
 	AdminCancelBannedIp(ctx context.Context, ipNet string) error
 	AdminClearExternalLinkCache(ctx context.Context, arg AdminClearExternalLinkCacheParams) error
 	// This query selects all words from the "searchwordlist" table and prints them.
@@ -73,6 +81,11 @@ type Querier interface {
 	// admin task
 	AdminListGrantsByRoleID(ctx context.Context, roleID sql.NullInt32) ([]*Grant, error)
 	AdminListLoginAttempts(ctx context.Context) ([]*LoginAttempt, error)
+	AdminListPendingDeactivatedBlogs(ctx context.Context, arg AdminListPendingDeactivatedBlogsParams) ([]*AdminListPendingDeactivatedBlogsRow, error)
+	AdminListPendingDeactivatedComments(ctx context.Context, arg AdminListPendingDeactivatedCommentsParams) ([]*AdminListPendingDeactivatedCommentsRow, error)
+	AdminListPendingDeactivatedImageposts(ctx context.Context, arg AdminListPendingDeactivatedImagepostsParams) ([]*AdminListPendingDeactivatedImagepostsRow, error)
+	AdminListPendingDeactivatedLinks(ctx context.Context, arg AdminListPendingDeactivatedLinksParams) ([]*AdminListPendingDeactivatedLinksRow, error)
+	AdminListPendingDeactivatedWritings(ctx context.Context, arg AdminListPendingDeactivatedWritingsParams) ([]*AdminListPendingDeactivatedWritingsRow, error)
 	AdminListPendingRequests(ctx context.Context) ([]*AdminRequestQueue, error)
 	AdminListPendingUsers(ctx context.Context) ([]*AdminListPendingUsersRow, error)
 	AdminListRequestComments(ctx context.Context, requestID int32) ([]*AdminRequestComment, error)
@@ -91,6 +104,11 @@ type Querier interface {
 	AdminListUserIDsByRole(ctx context.Context, name string) ([]int32, error)
 	// admin task
 	AdminListUsersByRoleID(ctx context.Context, roleID int32) ([]*AdminListUsersByRoleIDRow, error)
+	AdminMarkBlogRestored(ctx context.Context, idblogs int32) error
+	AdminMarkCommentRestored(ctx context.Context, idcomments int32) error
+	AdminMarkImagepostRestored(ctx context.Context, idimagepost int32) error
+	AdminMarkLinkRestored(ctx context.Context, idlinker int32) error
+	AdminMarkWritingRestored(ctx context.Context, idwriting int32) error
 	// admin task
 	AdminPromoteAnnouncement(ctx context.Context, siteNewsID int32) error
 	AdminPurgeReadNotifications(ctx context.Context) error
@@ -101,6 +119,18 @@ type Querier interface {
 	//   ? - New name for the language (string)
 	//   ? - Language ID to be updated (int)
 	AdminRenameLanguage(ctx context.Context, arg AdminRenameLanguageParams) error
+	AdminRestoreBlog(ctx context.Context, arg AdminRestoreBlogParams) error
+	AdminRestoreComment(ctx context.Context, arg AdminRestoreCommentParams) error
+	AdminRestoreImagepost(ctx context.Context, arg AdminRestoreImagepostParams) error
+	AdminRestoreLink(ctx context.Context, arg AdminRestoreLinkParams) error
+	AdminRestoreUser(ctx context.Context, idusers int32) error
+	AdminRestoreWriting(ctx context.Context, arg AdminRestoreWritingParams) error
+	AdminScrubBlog(ctx context.Context, arg AdminScrubBlogParams) error
+	AdminScrubComment(ctx context.Context, arg AdminScrubCommentParams) error
+	AdminScrubImagepost(ctx context.Context, idimagepost int32) error
+	AdminScrubLink(ctx context.Context, arg AdminScrubLinkParams) error
+	AdminScrubUser(ctx context.Context, arg AdminScrubUserParams) error
+	AdminScrubWriting(ctx context.Context, arg AdminScrubWritingParams) error
 	AdminSetTemplateOverride(ctx context.Context, arg AdminSetTemplateOverrideParams) error
 	AdminUpdateBannedIp(ctx context.Context, arg AdminUpdateBannedIpParams) error
 	AdminUpdateRequestStatus(ctx context.Context, arg AdminUpdateRequestStatusParams) error
@@ -114,14 +144,6 @@ type Querier interface {
 	AdminWordListWithCounts(ctx context.Context, arg AdminWordListWithCountsParams) ([]*AdminWordListWithCountsRow, error)
 	AdminWordListWithCountsByPrefix(ctx context.Context, arg AdminWordListWithCountsByPrefixParams) ([]*AdminWordListWithCountsByPrefixRow, error)
 	AdminWritingCategoryCounts(ctx context.Context) ([]*AdminWritingCategoryCountsRow, error)
-	ApproveImagePost(ctx context.Context, idimagepost int32) error
-	ArchiveBlog(ctx context.Context, arg ArchiveBlogParams) error
-	ArchiveComment(ctx context.Context, arg ArchiveCommentParams) error
-	ArchiveImagepost(ctx context.Context, arg ArchiveImagepostParams) error
-	ArchiveLink(ctx context.Context, arg ArchiveLinkParams) error
-	// Queries for user deactivation and restoration
-	ArchiveUser(ctx context.Context, idusers int32) error
-	ArchiveWriting(ctx context.Context, arg ArchiveWritingParams) error
 	AssignLinkerThisThreadId(ctx context.Context, arg AssignLinkerThisThreadIdParams) error
 	AssignNewsThisThreadId(ctx context.Context, arg AssignNewsThisThreadIdParams) error
 	AssignThreadIdToBlogEntry(ctx context.Context, arg AssignThreadIdToBlogEntryParams) error
@@ -328,20 +350,10 @@ type Querier interface {
 	ListWritingsByIDsForLister(ctx context.Context, arg ListWritingsByIDsForListerParams) ([]*ListWritingsByIDsForListerRow, error)
 	Login(ctx context.Context, username sql.NullString) (*LoginRow, error)
 	MakeThread(ctx context.Context, forumtopicIdforumtopic int32) (int64, error)
-	MarkBlogRestored(ctx context.Context, idblogs int32) error
-	MarkCommentRestored(ctx context.Context, idcomments int32) error
 	MarkEmailSent(ctx context.Context, id int32) error
-	MarkImagepostRestored(ctx context.Context, idimagepost int32) error
-	MarkLinkRestored(ctx context.Context, idlinker int32) error
 	MarkNotificationRead(ctx context.Context, id int32) error
 	MarkNotificationUnread(ctx context.Context, id int32) error
 	MarkPasswordResetVerified(ctx context.Context, id int32) error
-	MarkWritingRestored(ctx context.Context, idwriting int32) error
-	PendingDeactivatedBlogs(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedBlogsRow, error)
-	PendingDeactivatedComments(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedCommentsRow, error)
-	PendingDeactivatedImageposts(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedImagepostsRow, error)
-	PendingDeactivatedLinks(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedLinksRow, error)
-	PendingDeactivatedWritings(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedWritingsRow, error)
 	// Remove password reset entries that have expired or were already verified
 	PurgePasswordResetsBefore(ctx context.Context, createdAt time.Time) (sql.Result, error)
 	RebuildAllForumTopicMetaColumns(ctx context.Context) error
@@ -350,18 +362,6 @@ type Querier interface {
 	RegisterExternalLinkClick(ctx context.Context, url string) error
 	RenameFAQCategory(ctx context.Context, arg RenameFAQCategoryParams) error
 	RenameLinkerCategory(ctx context.Context, arg RenameLinkerCategoryParams) error
-	RestoreBlog(ctx context.Context, arg RestoreBlogParams) error
-	RestoreComment(ctx context.Context, arg RestoreCommentParams) error
-	RestoreImagepost(ctx context.Context, arg RestoreImagepostParams) error
-	RestoreLink(ctx context.Context, arg RestoreLinkParams) error
-	RestoreUser(ctx context.Context, idusers int32) error
-	RestoreWriting(ctx context.Context, arg RestoreWritingParams) error
-	ScrubBlog(ctx context.Context, arg ScrubBlogParams) error
-	ScrubComment(ctx context.Context, arg ScrubCommentParams) error
-	ScrubImagepost(ctx context.Context, idimagepost int32) error
-	ScrubLink(ctx context.Context, arg ScrubLinkParams) error
-	ScrubUser(ctx context.Context, arg ScrubUserParams) error
-	ScrubWriting(ctx context.Context, arg ScrubWritingParams) error
 	SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId(ctx context.Context, arg SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueIdParams) (int64, error)
 	SetAnnouncementActive(ctx context.Context, arg SetAnnouncementActiveParams) error
 	SetCommentLastIndex(ctx context.Context, idcomments int32) error

--- a/internal/db/queries-deactivation.sql
+++ b/internal/db/queries-deactivation.sql
@@ -1,97 +1,102 @@
 -- Queries for user deactivation and restoration
 
--- name: ArchiveUser :exec
+-- name: AdminArchiveUser :exec
 INSERT INTO deactivated_users (idusers, email, passwd, passwd_algorithm, username, deleted_at)
 SELECT u.idusers, u.email, u.passwd, u.passwd_algorithm, u.username, NOW()
 FROM users u WHERE u.idusers = ?;
 
--- name: ScrubUser :exec
+-- name: AdminScrubUser :exec
 UPDATE users SET username = ?, email = '', passwd = '', passwd_algorithm = '', deleted_at = NOW()
 WHERE idusers = ?;
 
--- name: ArchiveComment :exec
+-- name: AdminArchiveComment :exec
 INSERT INTO deactivated_comments (idcomments, forumthread_id, users_idusers, language_idlanguage, written, text, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubComment :exec
+-- name: AdminScrubComment :exec
 UPDATE comments SET text = ?, deleted_at = NOW() WHERE idcomments = ?;
 
--- name: PendingDeactivatedComments :many
+-- name: AdminListPendingDeactivatedComments :many
 SELECT idcomments, text FROM deactivated_comments
-WHERE users_idusers = ? AND restored_at IS NULL;
+WHERE users_idusers = ? AND restored_at IS NULL
+LIMIT ? OFFSET ?;
 
--- name: RestoreComment :exec
+-- name: AdminRestoreComment :exec
 UPDATE comments SET text = ?, deleted_at = NULL WHERE idcomments = ?;
 
--- name: MarkCommentRestored :exec
+-- name: AdminMarkCommentRestored :exec
 UPDATE deactivated_comments SET restored_at = NOW() WHERE idcomments = ?;
 
--- name: ArchiveWriting :exec
+-- name: AdminArchiveWriting :exec
 INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_id, language_idlanguage, writing_category_id, title, published, writing, abstract, private, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubWriting :exec
+-- name: AdminScrubWriting :exec
 UPDATE writing SET title = ?, writing = ?, abstract = ?, deleted_at = NOW() WHERE idwriting = ?;
 
--- name: PendingDeactivatedWritings :many
+-- name: AdminListPendingDeactivatedWritings :many
 SELECT idwriting, title, writing, abstract, private FROM deactivated_writings
-WHERE users_idusers = ? AND restored_at IS NULL;
+WHERE users_idusers = ? AND restored_at IS NULL
+LIMIT ? OFFSET ?;
 
--- name: RestoreWriting :exec
+-- name: AdminRestoreWriting :exec
 UPDATE writing SET title = ?, writing = ?, abstract = ?, private = ?, deleted_at = NULL WHERE idwriting = ?;
 
--- name: MarkWritingRestored :exec
+-- name: AdminMarkWritingRestored :exec
 UPDATE deactivated_writings SET restored_at = NOW() WHERE idwriting = ?;
 
--- name: ArchiveBlog :exec
+-- name: AdminArchiveBlog :exec
 INSERT INTO deactivated_blogs (idblogs, forumthread_id, users_idusers, language_idlanguage, blog, written, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubBlog :exec
+-- name: AdminScrubBlog :exec
 UPDATE blogs SET blog = ?, deleted_at = NOW() WHERE idblogs = ?;
 
--- name: PendingDeactivatedBlogs :many
-SELECT idblogs, blog FROM deactivated_blogs WHERE users_idusers = ? AND restored_at IS NULL;
+-- name: AdminListPendingDeactivatedBlogs :many
+SELECT idblogs, blog FROM deactivated_blogs WHERE users_idusers = ? AND restored_at IS NULL
+LIMIT ? OFFSET ?;
 
--- name: RestoreBlog :exec
+-- name: AdminRestoreBlog :exec
 UPDATE blogs SET blog = ?, deleted_at = NULL WHERE idblogs = ?;
 
--- name: MarkBlogRestored :exec
+-- name: AdminMarkBlogRestored :exec
 UPDATE deactivated_blogs SET restored_at = NOW() WHERE idblogs = ?;
 
--- name: ArchiveImagepost :exec
+-- name: AdminArchiveImagepost :exec
 INSERT INTO deactivated_imageposts (idimagepost, forumthread_id, users_idusers, imageboard_idimageboard, posted, description, thumbnail, fullimage, file_size, approved, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubImagepost :exec
+-- name: AdminScrubImagepost :exec
 UPDATE imagepost SET description = '', thumbnail = '', fullimage = '', deleted_at = NOW() WHERE idimagepost = ?;
 
--- name: PendingDeactivatedImageposts :many
-SELECT idimagepost, description, thumbnail, fullimage FROM deactivated_imageposts WHERE users_idusers = ? AND restored_at IS NULL;
+-- name: AdminListPendingDeactivatedImageposts :many
+SELECT idimagepost, description, thumbnail, fullimage FROM deactivated_imageposts WHERE users_idusers = ? AND restored_at IS NULL
+LIMIT ? OFFSET ?;
 
--- name: RestoreImagepost :exec
+-- name: AdminRestoreImagepost :exec
 UPDATE imagepost SET description = ?, thumbnail = ?, fullimage = ?, deleted_at = NULL WHERE idimagepost = ?;
 
--- name: MarkImagepostRestored :exec
+-- name: AdminMarkImagepostRestored :exec
 UPDATE deactivated_imageposts SET restored_at = NOW() WHERE idimagepost = ?;
 
--- name: ArchiveLink :exec
+-- name: AdminArchiveLink :exec
 INSERT INTO deactivated_linker (idlinker, language_idlanguage, users_idusers, linker_category_id, forumthread_id, title, url, description, listed, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
 
--- name: ScrubLink :exec
+-- name: AdminScrubLink :exec
 UPDATE linker SET title = ?, url = '', description = '', deleted_at = NOW() WHERE idlinker = ?;
 
--- name: PendingDeactivatedLinks :many
-SELECT idlinker, title, url, description FROM deactivated_linker WHERE users_idusers = ? AND restored_at IS NULL;
+-- name: AdminListPendingDeactivatedLinks :many
+SELECT idlinker, title, url, description FROM deactivated_linker WHERE users_idusers = ? AND restored_at IS NULL
+LIMIT ? OFFSET ?;
 
--- name: RestoreLink :exec
+-- name: AdminRestoreLink :exec
 UPDATE linker SET title = ?, url = ?, description = ?, deleted_at = NULL WHERE idlinker = ?;
 
--- name: MarkLinkRestored :exec
+-- name: AdminMarkLinkRestored :exec
 UPDATE deactivated_linker SET restored_at = NOW() WHERE idlinker = ?;
 
--- name: RestoreUser :exec
+-- name: AdminRestoreUser :exec
 UPDATE users u JOIN deactivated_users d ON u.idusers = d.idusers
 SET u.email = d.email, u.passwd = d.passwd, u.passwd_algorithm = d.passwd_algorithm, u.username = d.username, u.deleted_at = NULL, d.restored_at = NOW()
 WHERE u.idusers = ? AND d.restored_at IS NULL;

--- a/internal/db/queries-deactivation.sql.go
+++ b/internal/db/queries-deactivation.sql.go
@@ -10,12 +10,12 @@ import (
 	"database/sql"
 )
 
-const archiveBlog = `-- name: ArchiveBlog :exec
+const adminArchiveBlog = `-- name: AdminArchiveBlog :exec
 INSERT INTO deactivated_blogs (idblogs, forumthread_id, users_idusers, language_idlanguage, blog, written, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveBlogParams struct {
+type AdminArchiveBlogParams struct {
 	Idblogs            int32
 	ForumthreadID      int32
 	UsersIdusers       int32
@@ -24,8 +24,8 @@ type ArchiveBlogParams struct {
 	Written            sql.NullTime
 }
 
-func (q *Queries) ArchiveBlog(ctx context.Context, arg ArchiveBlogParams) error {
-	_, err := q.db.ExecContext(ctx, archiveBlog,
+func (q *Queries) AdminArchiveBlog(ctx context.Context, arg AdminArchiveBlogParams) error {
+	_, err := q.db.ExecContext(ctx, adminArchiveBlog,
 		arg.Idblogs,
 		arg.ForumthreadID,
 		arg.UsersIdusers,
@@ -36,12 +36,12 @@ func (q *Queries) ArchiveBlog(ctx context.Context, arg ArchiveBlogParams) error 
 	return err
 }
 
-const archiveComment = `-- name: ArchiveComment :exec
+const adminArchiveComment = `-- name: AdminArchiveComment :exec
 INSERT INTO deactivated_comments (idcomments, forumthread_id, users_idusers, language_idlanguage, written, text, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveCommentParams struct {
+type AdminArchiveCommentParams struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
@@ -50,8 +50,8 @@ type ArchiveCommentParams struct {
 	Text               sql.NullString
 }
 
-func (q *Queries) ArchiveComment(ctx context.Context, arg ArchiveCommentParams) error {
-	_, err := q.db.ExecContext(ctx, archiveComment,
+func (q *Queries) AdminArchiveComment(ctx context.Context, arg AdminArchiveCommentParams) error {
+	_, err := q.db.ExecContext(ctx, adminArchiveComment,
 		arg.Idcomments,
 		arg.ForumthreadID,
 		arg.UsersIdusers,
@@ -62,12 +62,12 @@ func (q *Queries) ArchiveComment(ctx context.Context, arg ArchiveCommentParams) 
 	return err
 }
 
-const archiveImagepost = `-- name: ArchiveImagepost :exec
+const adminArchiveImagepost = `-- name: AdminArchiveImagepost :exec
 INSERT INTO deactivated_imageposts (idimagepost, forumthread_id, users_idusers, imageboard_idimageboard, posted, description, thumbnail, fullimage, file_size, approved, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveImagepostParams struct {
+type AdminArchiveImagepostParams struct {
 	Idimagepost            int32
 	ForumthreadID          int32
 	UsersIdusers           int32
@@ -80,8 +80,8 @@ type ArchiveImagepostParams struct {
 	Approved               sql.NullBool
 }
 
-func (q *Queries) ArchiveImagepost(ctx context.Context, arg ArchiveImagepostParams) error {
-	_, err := q.db.ExecContext(ctx, archiveImagepost,
+func (q *Queries) AdminArchiveImagepost(ctx context.Context, arg AdminArchiveImagepostParams) error {
+	_, err := q.db.ExecContext(ctx, adminArchiveImagepost,
 		arg.Idimagepost,
 		arg.ForumthreadID,
 		arg.UsersIdusers,
@@ -96,12 +96,12 @@ func (q *Queries) ArchiveImagepost(ctx context.Context, arg ArchiveImagepostPara
 	return err
 }
 
-const archiveLink = `-- name: ArchiveLink :exec
+const adminArchiveLink = `-- name: AdminArchiveLink :exec
 INSERT INTO deactivated_linker (idlinker, language_idlanguage, users_idusers, linker_category_id, forumthread_id, title, url, description, listed, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveLinkParams struct {
+type AdminArchiveLinkParams struct {
 	Idlinker           int32
 	LanguageIdlanguage int32
 	UsersIdusers       int32
@@ -113,8 +113,8 @@ type ArchiveLinkParams struct {
 	Listed             sql.NullTime
 }
 
-func (q *Queries) ArchiveLink(ctx context.Context, arg ArchiveLinkParams) error {
-	_, err := q.db.ExecContext(ctx, archiveLink,
+func (q *Queries) AdminArchiveLink(ctx context.Context, arg AdminArchiveLinkParams) error {
+	_, err := q.db.ExecContext(ctx, adminArchiveLink,
 		arg.Idlinker,
 		arg.LanguageIdlanguage,
 		arg.UsersIdusers,
@@ -128,7 +128,7 @@ func (q *Queries) ArchiveLink(ctx context.Context, arg ArchiveLinkParams) error 
 	return err
 }
 
-const archiveUser = `-- name: ArchiveUser :exec
+const adminArchiveUser = `-- name: AdminArchiveUser :exec
 
 INSERT INTO deactivated_users (idusers, email, passwd, passwd_algorithm, username, deleted_at)
 SELECT u.idusers, u.email, u.passwd, u.passwd_algorithm, u.username, NOW()
@@ -136,17 +136,17 @@ FROM users u WHERE u.idusers = ?
 `
 
 // Queries for user deactivation and restoration
-func (q *Queries) ArchiveUser(ctx context.Context, idusers int32) error {
-	_, err := q.db.ExecContext(ctx, archiveUser, idusers)
+func (q *Queries) AdminArchiveUser(ctx context.Context, idusers int32) error {
+	_, err := q.db.ExecContext(ctx, adminArchiveUser, idusers)
 	return err
 }
 
-const archiveWriting = `-- name: ArchiveWriting :exec
+const adminArchiveWriting = `-- name: AdminArchiveWriting :exec
 INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_id, language_idlanguage, writing_category_id, title, published, writing, abstract, private, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
-type ArchiveWritingParams struct {
+type AdminArchiveWritingParams struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
@@ -159,8 +159,8 @@ type ArchiveWritingParams struct {
 	Private            sql.NullBool
 }
 
-func (q *Queries) ArchiveWriting(ctx context.Context, arg ArchiveWritingParams) error {
-	_, err := q.db.ExecContext(ctx, archiveWriting,
+func (q *Queries) AdminArchiveWriting(ctx context.Context, arg AdminArchiveWritingParams) error {
+	_, err := q.db.ExecContext(ctx, adminArchiveWriting,
 		arg.Idwriting,
 		arg.UsersIdusers,
 		arg.ForumthreadID,
@@ -175,69 +175,31 @@ func (q *Queries) ArchiveWriting(ctx context.Context, arg ArchiveWritingParams) 
 	return err
 }
 
-const markBlogRestored = `-- name: MarkBlogRestored :exec
-UPDATE deactivated_blogs SET restored_at = NOW() WHERE idblogs = ?
-`
-
-func (q *Queries) MarkBlogRestored(ctx context.Context, idblogs int32) error {
-	_, err := q.db.ExecContext(ctx, markBlogRestored, idblogs)
-	return err
-}
-
-const markCommentRestored = `-- name: MarkCommentRestored :exec
-UPDATE deactivated_comments SET restored_at = NOW() WHERE idcomments = ?
-`
-
-func (q *Queries) MarkCommentRestored(ctx context.Context, idcomments int32) error {
-	_, err := q.db.ExecContext(ctx, markCommentRestored, idcomments)
-	return err
-}
-
-const markImagepostRestored = `-- name: MarkImagepostRestored :exec
-UPDATE deactivated_imageposts SET restored_at = NOW() WHERE idimagepost = ?
-`
-
-func (q *Queries) MarkImagepostRestored(ctx context.Context, idimagepost int32) error {
-	_, err := q.db.ExecContext(ctx, markImagepostRestored, idimagepost)
-	return err
-}
-
-const markLinkRestored = `-- name: MarkLinkRestored :exec
-UPDATE deactivated_linker SET restored_at = NOW() WHERE idlinker = ?
-`
-
-func (q *Queries) MarkLinkRestored(ctx context.Context, idlinker int32) error {
-	_, err := q.db.ExecContext(ctx, markLinkRestored, idlinker)
-	return err
-}
-
-const markWritingRestored = `-- name: MarkWritingRestored :exec
-UPDATE deactivated_writings SET restored_at = NOW() WHERE idwriting = ?
-`
-
-func (q *Queries) MarkWritingRestored(ctx context.Context, idwriting int32) error {
-	_, err := q.db.ExecContext(ctx, markWritingRestored, idwriting)
-	return err
-}
-
-const pendingDeactivatedBlogs = `-- name: PendingDeactivatedBlogs :many
+const adminListPendingDeactivatedBlogs = `-- name: AdminListPendingDeactivatedBlogs :many
 SELECT idblogs, blog FROM deactivated_blogs WHERE users_idusers = ? AND restored_at IS NULL
+LIMIT ? OFFSET ?
 `
 
-type PendingDeactivatedBlogsRow struct {
+type AdminListPendingDeactivatedBlogsParams struct {
+	UsersIdusers int32
+	Limit        int32
+	Offset       int32
+}
+
+type AdminListPendingDeactivatedBlogsRow struct {
 	Idblogs int32
 	Blog    sql.NullString
 }
 
-func (q *Queries) PendingDeactivatedBlogs(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedBlogsRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedBlogs, usersIdusers)
+func (q *Queries) AdminListPendingDeactivatedBlogs(ctx context.Context, arg AdminListPendingDeactivatedBlogsParams) ([]*AdminListPendingDeactivatedBlogsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListPendingDeactivatedBlogs, arg.UsersIdusers, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedBlogsRow
+	var items []*AdminListPendingDeactivatedBlogsRow
 	for rows.Next() {
-		var i PendingDeactivatedBlogsRow
+		var i AdminListPendingDeactivatedBlogsRow
 		if err := rows.Scan(&i.Idblogs, &i.Blog); err != nil {
 			return nil, err
 		}
@@ -252,25 +214,32 @@ func (q *Queries) PendingDeactivatedBlogs(ctx context.Context, usersIdusers int3
 	return items, nil
 }
 
-const pendingDeactivatedComments = `-- name: PendingDeactivatedComments :many
+const adminListPendingDeactivatedComments = `-- name: AdminListPendingDeactivatedComments :many
 SELECT idcomments, text FROM deactivated_comments
 WHERE users_idusers = ? AND restored_at IS NULL
+LIMIT ? OFFSET ?
 `
 
-type PendingDeactivatedCommentsRow struct {
+type AdminListPendingDeactivatedCommentsParams struct {
+	UsersIdusers int32
+	Limit        int32
+	Offset       int32
+}
+
+type AdminListPendingDeactivatedCommentsRow struct {
 	Idcomments int32
 	Text       sql.NullString
 }
 
-func (q *Queries) PendingDeactivatedComments(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedCommentsRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedComments, usersIdusers)
+func (q *Queries) AdminListPendingDeactivatedComments(ctx context.Context, arg AdminListPendingDeactivatedCommentsParams) ([]*AdminListPendingDeactivatedCommentsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListPendingDeactivatedComments, arg.UsersIdusers, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedCommentsRow
+	var items []*AdminListPendingDeactivatedCommentsRow
 	for rows.Next() {
-		var i PendingDeactivatedCommentsRow
+		var i AdminListPendingDeactivatedCommentsRow
 		if err := rows.Scan(&i.Idcomments, &i.Text); err != nil {
 			return nil, err
 		}
@@ -285,26 +254,33 @@ func (q *Queries) PendingDeactivatedComments(ctx context.Context, usersIdusers i
 	return items, nil
 }
 
-const pendingDeactivatedImageposts = `-- name: PendingDeactivatedImageposts :many
+const adminListPendingDeactivatedImageposts = `-- name: AdminListPendingDeactivatedImageposts :many
 SELECT idimagepost, description, thumbnail, fullimage FROM deactivated_imageposts WHERE users_idusers = ? AND restored_at IS NULL
+LIMIT ? OFFSET ?
 `
 
-type PendingDeactivatedImagepostsRow struct {
+type AdminListPendingDeactivatedImagepostsParams struct {
+	UsersIdusers int32
+	Limit        int32
+	Offset       int32
+}
+
+type AdminListPendingDeactivatedImagepostsRow struct {
 	Idimagepost int32
 	Description sql.NullString
 	Thumbnail   sql.NullString
 	Fullimage   sql.NullString
 }
 
-func (q *Queries) PendingDeactivatedImageposts(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedImagepostsRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedImageposts, usersIdusers)
+func (q *Queries) AdminListPendingDeactivatedImageposts(ctx context.Context, arg AdminListPendingDeactivatedImagepostsParams) ([]*AdminListPendingDeactivatedImagepostsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListPendingDeactivatedImageposts, arg.UsersIdusers, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedImagepostsRow
+	var items []*AdminListPendingDeactivatedImagepostsRow
 	for rows.Next() {
-		var i PendingDeactivatedImagepostsRow
+		var i AdminListPendingDeactivatedImagepostsRow
 		if err := rows.Scan(
 			&i.Idimagepost,
 			&i.Description,
@@ -324,26 +300,33 @@ func (q *Queries) PendingDeactivatedImageposts(ctx context.Context, usersIdusers
 	return items, nil
 }
 
-const pendingDeactivatedLinks = `-- name: PendingDeactivatedLinks :many
+const adminListPendingDeactivatedLinks = `-- name: AdminListPendingDeactivatedLinks :many
 SELECT idlinker, title, url, description FROM deactivated_linker WHERE users_idusers = ? AND restored_at IS NULL
+LIMIT ? OFFSET ?
 `
 
-type PendingDeactivatedLinksRow struct {
+type AdminListPendingDeactivatedLinksParams struct {
+	UsersIdusers int32
+	Limit        int32
+	Offset       int32
+}
+
+type AdminListPendingDeactivatedLinksRow struct {
 	Idlinker    int32
 	Title       sql.NullString
 	Url         sql.NullString
 	Description sql.NullString
 }
 
-func (q *Queries) PendingDeactivatedLinks(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedLinksRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedLinks, usersIdusers)
+func (q *Queries) AdminListPendingDeactivatedLinks(ctx context.Context, arg AdminListPendingDeactivatedLinksParams) ([]*AdminListPendingDeactivatedLinksRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListPendingDeactivatedLinks, arg.UsersIdusers, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedLinksRow
+	var items []*AdminListPendingDeactivatedLinksRow
 	for rows.Next() {
-		var i PendingDeactivatedLinksRow
+		var i AdminListPendingDeactivatedLinksRow
 		if err := rows.Scan(
 			&i.Idlinker,
 			&i.Title,
@@ -363,12 +346,19 @@ func (q *Queries) PendingDeactivatedLinks(ctx context.Context, usersIdusers int3
 	return items, nil
 }
 
-const pendingDeactivatedWritings = `-- name: PendingDeactivatedWritings :many
+const adminListPendingDeactivatedWritings = `-- name: AdminListPendingDeactivatedWritings :many
 SELECT idwriting, title, writing, abstract, private FROM deactivated_writings
 WHERE users_idusers = ? AND restored_at IS NULL
+LIMIT ? OFFSET ?
 `
 
-type PendingDeactivatedWritingsRow struct {
+type AdminListPendingDeactivatedWritingsParams struct {
+	UsersIdusers int32
+	Limit        int32
+	Offset       int32
+}
+
+type AdminListPendingDeactivatedWritingsRow struct {
 	Idwriting int32
 	Title     sql.NullString
 	Writing   sql.NullString
@@ -376,15 +366,15 @@ type PendingDeactivatedWritingsRow struct {
 	Private   sql.NullBool
 }
 
-func (q *Queries) PendingDeactivatedWritings(ctx context.Context, usersIdusers int32) ([]*PendingDeactivatedWritingsRow, error) {
-	rows, err := q.db.QueryContext(ctx, pendingDeactivatedWritings, usersIdusers)
+func (q *Queries) AdminListPendingDeactivatedWritings(ctx context.Context, arg AdminListPendingDeactivatedWritingsParams) ([]*AdminListPendingDeactivatedWritingsRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListPendingDeactivatedWritings, arg.UsersIdusers, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*PendingDeactivatedWritingsRow
+	var items []*AdminListPendingDeactivatedWritingsRow
 	for rows.Next() {
-		var i PendingDeactivatedWritingsRow
+		var i AdminListPendingDeactivatedWritingsRow
 		if err := rows.Scan(
 			&i.Idwriting,
 			&i.Title,
@@ -405,47 +395,92 @@ func (q *Queries) PendingDeactivatedWritings(ctx context.Context, usersIdusers i
 	return items, nil
 }
 
-const restoreBlog = `-- name: RestoreBlog :exec
+const adminMarkBlogRestored = `-- name: AdminMarkBlogRestored :exec
+UPDATE deactivated_blogs SET restored_at = NOW() WHERE idblogs = ?
+`
+
+func (q *Queries) AdminMarkBlogRestored(ctx context.Context, idblogs int32) error {
+	_, err := q.db.ExecContext(ctx, adminMarkBlogRestored, idblogs)
+	return err
+}
+
+const adminMarkCommentRestored = `-- name: AdminMarkCommentRestored :exec
+UPDATE deactivated_comments SET restored_at = NOW() WHERE idcomments = ?
+`
+
+func (q *Queries) AdminMarkCommentRestored(ctx context.Context, idcomments int32) error {
+	_, err := q.db.ExecContext(ctx, adminMarkCommentRestored, idcomments)
+	return err
+}
+
+const adminMarkImagepostRestored = `-- name: AdminMarkImagepostRestored :exec
+UPDATE deactivated_imageposts SET restored_at = NOW() WHERE idimagepost = ?
+`
+
+func (q *Queries) AdminMarkImagepostRestored(ctx context.Context, idimagepost int32) error {
+	_, err := q.db.ExecContext(ctx, adminMarkImagepostRestored, idimagepost)
+	return err
+}
+
+const adminMarkLinkRestored = `-- name: AdminMarkLinkRestored :exec
+UPDATE deactivated_linker SET restored_at = NOW() WHERE idlinker = ?
+`
+
+func (q *Queries) AdminMarkLinkRestored(ctx context.Context, idlinker int32) error {
+	_, err := q.db.ExecContext(ctx, adminMarkLinkRestored, idlinker)
+	return err
+}
+
+const adminMarkWritingRestored = `-- name: AdminMarkWritingRestored :exec
+UPDATE deactivated_writings SET restored_at = NOW() WHERE idwriting = ?
+`
+
+func (q *Queries) AdminMarkWritingRestored(ctx context.Context, idwriting int32) error {
+	_, err := q.db.ExecContext(ctx, adminMarkWritingRestored, idwriting)
+	return err
+}
+
+const adminRestoreBlog = `-- name: AdminRestoreBlog :exec
 UPDATE blogs SET blog = ?, deleted_at = NULL WHERE idblogs = ?
 `
 
-type RestoreBlogParams struct {
+type AdminRestoreBlogParams struct {
 	Blog    sql.NullString
 	Idblogs int32
 }
 
-func (q *Queries) RestoreBlog(ctx context.Context, arg RestoreBlogParams) error {
-	_, err := q.db.ExecContext(ctx, restoreBlog, arg.Blog, arg.Idblogs)
+func (q *Queries) AdminRestoreBlog(ctx context.Context, arg AdminRestoreBlogParams) error {
+	_, err := q.db.ExecContext(ctx, adminRestoreBlog, arg.Blog, arg.Idblogs)
 	return err
 }
 
-const restoreComment = `-- name: RestoreComment :exec
+const adminRestoreComment = `-- name: AdminRestoreComment :exec
 UPDATE comments SET text = ?, deleted_at = NULL WHERE idcomments = ?
 `
 
-type RestoreCommentParams struct {
+type AdminRestoreCommentParams struct {
 	Text       sql.NullString
 	Idcomments int32
 }
 
-func (q *Queries) RestoreComment(ctx context.Context, arg RestoreCommentParams) error {
-	_, err := q.db.ExecContext(ctx, restoreComment, arg.Text, arg.Idcomments)
+func (q *Queries) AdminRestoreComment(ctx context.Context, arg AdminRestoreCommentParams) error {
+	_, err := q.db.ExecContext(ctx, adminRestoreComment, arg.Text, arg.Idcomments)
 	return err
 }
 
-const restoreImagepost = `-- name: RestoreImagepost :exec
+const adminRestoreImagepost = `-- name: AdminRestoreImagepost :exec
 UPDATE imagepost SET description = ?, thumbnail = ?, fullimage = ?, deleted_at = NULL WHERE idimagepost = ?
 `
 
-type RestoreImagepostParams struct {
+type AdminRestoreImagepostParams struct {
 	Description sql.NullString
 	Thumbnail   sql.NullString
 	Fullimage   sql.NullString
 	Idimagepost int32
 }
 
-func (q *Queries) RestoreImagepost(ctx context.Context, arg RestoreImagepostParams) error {
-	_, err := q.db.ExecContext(ctx, restoreImagepost,
+func (q *Queries) AdminRestoreImagepost(ctx context.Context, arg AdminRestoreImagepostParams) error {
+	_, err := q.db.ExecContext(ctx, adminRestoreImagepost,
 		arg.Description,
 		arg.Thumbnail,
 		arg.Fullimage,
@@ -454,19 +489,19 @@ func (q *Queries) RestoreImagepost(ctx context.Context, arg RestoreImagepostPara
 	return err
 }
 
-const restoreLink = `-- name: RestoreLink :exec
+const adminRestoreLink = `-- name: AdminRestoreLink :exec
 UPDATE linker SET title = ?, url = ?, description = ?, deleted_at = NULL WHERE idlinker = ?
 `
 
-type RestoreLinkParams struct {
+type AdminRestoreLinkParams struct {
 	Title       sql.NullString
 	Url         sql.NullString
 	Description sql.NullString
 	Idlinker    int32
 }
 
-func (q *Queries) RestoreLink(ctx context.Context, arg RestoreLinkParams) error {
-	_, err := q.db.ExecContext(ctx, restoreLink,
+func (q *Queries) AdminRestoreLink(ctx context.Context, arg AdminRestoreLinkParams) error {
+	_, err := q.db.ExecContext(ctx, adminRestoreLink,
 		arg.Title,
 		arg.Url,
 		arg.Description,
@@ -475,22 +510,22 @@ func (q *Queries) RestoreLink(ctx context.Context, arg RestoreLinkParams) error 
 	return err
 }
 
-const restoreUser = `-- name: RestoreUser :exec
+const adminRestoreUser = `-- name: AdminRestoreUser :exec
 UPDATE users u JOIN deactivated_users d ON u.idusers = d.idusers
 SET u.email = d.email, u.passwd = d.passwd, u.passwd_algorithm = d.passwd_algorithm, u.username = d.username, u.deleted_at = NULL, d.restored_at = NOW()
 WHERE u.idusers = ? AND d.restored_at IS NULL
 `
 
-func (q *Queries) RestoreUser(ctx context.Context, idusers int32) error {
-	_, err := q.db.ExecContext(ctx, restoreUser, idusers)
+func (q *Queries) AdminRestoreUser(ctx context.Context, idusers int32) error {
+	_, err := q.db.ExecContext(ctx, adminRestoreUser, idusers)
 	return err
 }
 
-const restoreWriting = `-- name: RestoreWriting :exec
+const adminRestoreWriting = `-- name: AdminRestoreWriting :exec
 UPDATE writing SET title = ?, writing = ?, abstract = ?, private = ?, deleted_at = NULL WHERE idwriting = ?
 `
 
-type RestoreWritingParams struct {
+type AdminRestoreWritingParams struct {
 	Title     sql.NullString
 	Writing   sql.NullString
 	Abstract  sql.NullString
@@ -498,8 +533,8 @@ type RestoreWritingParams struct {
 	Idwriting int32
 }
 
-func (q *Queries) RestoreWriting(ctx context.Context, arg RestoreWritingParams) error {
-	_, err := q.db.ExecContext(ctx, restoreWriting,
+func (q *Queries) AdminRestoreWriting(ctx context.Context, arg AdminRestoreWritingParams) error {
+	_, err := q.db.ExecContext(ctx, adminRestoreWriting,
 		arg.Title,
 		arg.Writing,
 		arg.Abstract,
@@ -509,85 +544,85 @@ func (q *Queries) RestoreWriting(ctx context.Context, arg RestoreWritingParams) 
 	return err
 }
 
-const scrubBlog = `-- name: ScrubBlog :exec
+const adminScrubBlog = `-- name: AdminScrubBlog :exec
 UPDATE blogs SET blog = ?, deleted_at = NOW() WHERE idblogs = ?
 `
 
-type ScrubBlogParams struct {
+type AdminScrubBlogParams struct {
 	Blog    sql.NullString
 	Idblogs int32
 }
 
-func (q *Queries) ScrubBlog(ctx context.Context, arg ScrubBlogParams) error {
-	_, err := q.db.ExecContext(ctx, scrubBlog, arg.Blog, arg.Idblogs)
+func (q *Queries) AdminScrubBlog(ctx context.Context, arg AdminScrubBlogParams) error {
+	_, err := q.db.ExecContext(ctx, adminScrubBlog, arg.Blog, arg.Idblogs)
 	return err
 }
 
-const scrubComment = `-- name: ScrubComment :exec
+const adminScrubComment = `-- name: AdminScrubComment :exec
 UPDATE comments SET text = ?, deleted_at = NOW() WHERE idcomments = ?
 `
 
-type ScrubCommentParams struct {
+type AdminScrubCommentParams struct {
 	Text       sql.NullString
 	Idcomments int32
 }
 
-func (q *Queries) ScrubComment(ctx context.Context, arg ScrubCommentParams) error {
-	_, err := q.db.ExecContext(ctx, scrubComment, arg.Text, arg.Idcomments)
+func (q *Queries) AdminScrubComment(ctx context.Context, arg AdminScrubCommentParams) error {
+	_, err := q.db.ExecContext(ctx, adminScrubComment, arg.Text, arg.Idcomments)
 	return err
 }
 
-const scrubImagepost = `-- name: ScrubImagepost :exec
+const adminScrubImagepost = `-- name: AdminScrubImagepost :exec
 UPDATE imagepost SET description = '', thumbnail = '', fullimage = '', deleted_at = NOW() WHERE idimagepost = ?
 `
 
-func (q *Queries) ScrubImagepost(ctx context.Context, idimagepost int32) error {
-	_, err := q.db.ExecContext(ctx, scrubImagepost, idimagepost)
+func (q *Queries) AdminScrubImagepost(ctx context.Context, idimagepost int32) error {
+	_, err := q.db.ExecContext(ctx, adminScrubImagepost, idimagepost)
 	return err
 }
 
-const scrubLink = `-- name: ScrubLink :exec
+const adminScrubLink = `-- name: AdminScrubLink :exec
 UPDATE linker SET title = ?, url = '', description = '', deleted_at = NOW() WHERE idlinker = ?
 `
 
-type ScrubLinkParams struct {
+type AdminScrubLinkParams struct {
 	Title    sql.NullString
 	Idlinker int32
 }
 
-func (q *Queries) ScrubLink(ctx context.Context, arg ScrubLinkParams) error {
-	_, err := q.db.ExecContext(ctx, scrubLink, arg.Title, arg.Idlinker)
+func (q *Queries) AdminScrubLink(ctx context.Context, arg AdminScrubLinkParams) error {
+	_, err := q.db.ExecContext(ctx, adminScrubLink, arg.Title, arg.Idlinker)
 	return err
 }
 
-const scrubUser = `-- name: ScrubUser :exec
+const adminScrubUser = `-- name: AdminScrubUser :exec
 UPDATE users SET username = ?, email = '', passwd = '', passwd_algorithm = '', deleted_at = NOW()
 WHERE idusers = ?
 `
 
-type ScrubUserParams struct {
+type AdminScrubUserParams struct {
 	Username sql.NullString
 	Idusers  int32
 }
 
-func (q *Queries) ScrubUser(ctx context.Context, arg ScrubUserParams) error {
-	_, err := q.db.ExecContext(ctx, scrubUser, arg.Username, arg.Idusers)
+func (q *Queries) AdminScrubUser(ctx context.Context, arg AdminScrubUserParams) error {
+	_, err := q.db.ExecContext(ctx, adminScrubUser, arg.Username, arg.Idusers)
 	return err
 }
 
-const scrubWriting = `-- name: ScrubWriting :exec
+const adminScrubWriting = `-- name: AdminScrubWriting :exec
 UPDATE writing SET title = ?, writing = ?, abstract = ?, deleted_at = NOW() WHERE idwriting = ?
 `
 
-type ScrubWritingParams struct {
+type AdminScrubWritingParams struct {
 	Title     sql.NullString
 	Writing   sql.NullString
 	Abstract  sql.NullString
 	Idwriting int32
 }
 
-func (q *Queries) ScrubWriting(ctx context.Context, arg ScrubWritingParams) error {
-	_, err := q.db.ExecContext(ctx, scrubWriting,
+func (q *Queries) AdminScrubWriting(ctx context.Context, arg AdminScrubWritingParams) error {
+	_, err := q.db.ExecContext(ctx, adminScrubWriting,
 		arg.Title,
 		arg.Writing,
 		arg.Abstract,

--- a/internal/db/queries-imagebbs.sql
+++ b/internal/db/queries-imagebbs.sql
@@ -56,7 +56,7 @@ SELECT * FROM imageboard WHERE idimageboard = ?;
 -- name: DeleteImageBoard :exec
 UPDATE imageboard SET deleted_at = NOW() WHERE idimageboard = ?;
 
--- name: ApproveImagePost :exec
+-- name: AdminApproveImagePost :exec
 UPDATE imagepost SET approved = 1 WHERE idimagepost = ?;
 
 

--- a/internal/db/queries-imagebbs.sql.go
+++ b/internal/db/queries-imagebbs.sql.go
@@ -10,6 +10,15 @@ import (
 	"database/sql"
 )
 
+const adminApproveImagePost = `-- name: AdminApproveImagePost :exec
+UPDATE imagepost SET approved = 1 WHERE idimagepost = ?
+`
+
+func (q *Queries) AdminApproveImagePost(ctx context.Context, idimagepost int32) error {
+	_, err := q.db.ExecContext(ctx, adminApproveImagePost, idimagepost)
+	return err
+}
+
 const adminListBoards = `-- name: AdminListBoards :many
 SELECT b.idimageboard, b.imageboard_idimageboard, b.title, b.description, b.approval_required
 FROM imageboard b
@@ -48,15 +57,6 @@ func (q *Queries) AdminListBoards(ctx context.Context, arg AdminListBoardsParams
 		return nil, err
 	}
 	return items, nil
-}
-
-const approveImagePost = `-- name: ApproveImagePost :exec
-UPDATE imagepost SET approved = 1 WHERE idimagepost = ?
-`
-
-func (q *Queries) ApproveImagePost(ctx context.Context, idimagepost int32) error {
-	_, err := q.db.ExecContext(ctx, approveImagePost, idimagepost)
-	return err
 }
 
 const createImageBoard = `-- name: CreateImageBoard :exec


### PR DESCRIPTION
## Summary
- prefix deactivation queries with Admin and paginate list operations
- rename image post approval to AdminApproveImagePost
- update admin handlers and CLI commands to use new query names

## Testing
- `go vet ./...` *(fails: undefined: common.WithCustomQueries; queries.DB undefined)*
- `golangci-lint run`
- `go test ./...` *(fails: queries.DB undefined in multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_688eaf83b1f4832fa81f329f051cb78f