### PR TITLE
Rename system query functions for pending emails and writing categories

### DIFF
--- a/cmd/goa4web/email_queue_resend.go
+++ b/cmd/goa4web/email_queue_resend.go
@@ -43,7 +43,7 @@ func (c *emailQueueResendCmd) Run() error {
 	}
 	provider := c.rootCmd.emailReg.ProviderFromConfig(c.rootCmd.cfg)
 	if provider != nil {
-		addr, err := emailqueue.ResolveQueuedEmailAddress(ctx, queries, c.rootCmd.cfg, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
+		addr, err := emailqueue.ResolveQueuedEmailAddress(ctx, queries, c.rootCmd.cfg, &db.SystemListPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
 		if err != nil {
 			return err
 		}

--- a/cmd/goa4web/writing_tree.go
+++ b/cmd/goa4web/writing_tree.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math"
 
 	"github.com/arran4/goa4web/internal/db"
 )
@@ -31,7 +32,7 @@ func (c *writingTreeCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := db.New(db)
-	rows, err := queries.FetchAllCategories(ctx)
+	rows, err := queries.SystemListWritingCategories(ctx, db.SystemListWritingCategoriesParams{Limit: math.MaxInt32, Offset: 0})
 	if err != nil {
 		return fmt.Errorf("tree: %w", err)
 	}

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"net/mail"
 	"strconv"
@@ -870,7 +871,7 @@ func (cd *CoreData) WritingCategories() ([]*db.WritingCategory, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		return cd.queries.FetchAllCategories(cd.ctx)
+		return cd.queries.SystemListWritingCategories(cd.ctx, db.SystemListWritingCategoriesParams{Limit: math.MaxInt32, Offset: 0})
 	})
 }
 

--- a/handlers/admin/resend_queue_task.go
+++ b/handlers/admin/resend_queue_task.go
@@ -58,7 +58,7 @@ func (ResendQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	for _, e := range emails {
-		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, cd.Config, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
+		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, cd.Config, &db.SystemListPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
 		if err != nil {
 			return fmt.Errorf("resolve address fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/admin/resend_sent_task.go
+++ b/handlers/admin/resend_sent_task.go
@@ -35,7 +35,7 @@ func (ResendSentEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
 		if err != nil {
 			return fmt.Errorf("get email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
-		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, cd.Config, &db.FetchPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
+		addr, err := emailqueue.ResolveQueuedEmailAddress(r.Context(), queries, cd.Config, &db.SystemListPendingEmailsRow{ID: e.ID, ToUserID: e.ToUserID, Body: e.Body, ErrorCount: e.ErrorCount, DirectEmail: e.DirectEmail})
 		if err != nil {
 			return fmt.Errorf("resolve address fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/writings/writing_category_change_task.go
+++ b/handlers/writings/writing_category_change_task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -62,7 +63,7 @@ func (WritingCategoryChangeTask) Action(w http.ResponseWriter, r *http.Request) 
 func writingCategoryWouldLoop(ctx context.Context, queries db.Querier, cid, parentID int32) ([]int32, bool, error) {
 	var parents map[int32]int32
 	if queries != nil {
-		cats, err := queries.FetchAllCategories(ctx)
+		cats, err := queries.SystemListWritingCategories(ctx, db.SystemListWritingCategoriesParams{Limit: math.MaxInt32, Offset: 0})
 		if err != nil {
 			return nil, false, err
 		}

--- a/handlers/writings/writing_category_create_task.go
+++ b/handlers/writings/writing_category_create_task.go
@@ -3,6 +3,7 @@ package writings
 import (
 	"database/sql"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -30,7 +31,7 @@ func (WritingCategoryCreateTask) Action(w http.ResponseWriter, r *http.Request) 
 	}
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	cats, err := queries.FetchAllCategories(r.Context())
+	cats, err := queries.SystemListWritingCategories(r.Context(), db.SystemListWritingCategoriesParams{Limit: math.MaxInt32, Offset: 0})
 	if err != nil {
 		return fmt.Errorf("fetch categories %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -181,8 +181,6 @@ type Querier interface {
 	// Parameters:
 	//   ? - Permission ID to be deleted (int)
 	DeleteUserRole(ctx context.Context, iduserRoles int32) error
-	FetchAllCategories(ctx context.Context) ([]*WritingCategory, error)
-	FetchPendingEmails(ctx context.Context, limit int32) ([]*FetchPendingEmailsRow, error)
 	FindForumTopicByTitle(ctx context.Context, title sql.NullString) (*Forumtopic, error)
 	GetActiveAnnouncementWithNewsForLister(ctx context.Context, arg GetActiveAnnouncementWithNewsForListerParams) (*GetActiveAnnouncementWithNewsForListerRow, error)
 	GetAdministratorUserRole(ctx context.Context, usersIdusers int32) (*UserRole, error)
@@ -411,10 +409,12 @@ type Querier interface {
 	SystemListDeadLetters(ctx context.Context, limit int32) ([]*DeadLetter, error)
 	// SystemListLanguages lists all languages.
 	SystemListLanguages(ctx context.Context) ([]*Language, error)
+	SystemListPendingEmails(ctx context.Context, arg SystemListPendingEmailsParams) ([]*SystemListPendingEmailsRow, error)
 	SystemListPublicWritingsByAuthor(ctx context.Context, arg SystemListPublicWritingsByAuthorParams) ([]*SystemListPublicWritingsByAuthorRow, error)
 	SystemListPublicWritingsInCategory(ctx context.Context, arg SystemListPublicWritingsInCategoryParams) ([]*SystemListPublicWritingsInCategoryRow, error)
 	SystemListUserInfo(ctx context.Context) ([]*SystemListUserInfoRow, error)
 	SystemListVerifiedEmailsByUserID(ctx context.Context, userID int32) ([]*UserEmail, error)
+	SystemListWritingCategories(ctx context.Context, arg SystemListWritingCategoriesParams) ([]*WritingCategory, error)
 	SystemPurgeDeadLettersBefore(ctx context.Context, createdAt time.Time) error
 	SystemSetBlogLastIndex(ctx context.Context, id int32) error
 	UpdateAutoSubscribeRepliesForLister(ctx context.Context, arg UpdateAutoSubscribeRepliesForListerParams) error

--- a/internal/db/queries-pending_emails.sql
+++ b/internal/db/queries-pending_emails.sql
@@ -2,12 +2,12 @@
 INSERT INTO pending_emails (to_user_id, body, direct_email)
 VALUES (?, ?, ?);
 
--- name: FetchPendingEmails :many
+-- name: SystemListPendingEmails :many
 SELECT id, to_user_id, body, error_count, direct_email
 FROM pending_emails
 WHERE sent_at IS NULL
 ORDER BY id
-LIMIT ?;
+LIMIT ? OFFSET ?;
 
 -- name: MarkEmailSent :exec
 UPDATE pending_emails SET sent_at = NOW() WHERE id = ?;

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -153,10 +153,11 @@ UPDATE writing_category
 SET title = ?, description = ?, writing_category_id = ?
 WHERE idwritingCategory = ?;
 
--- name: FetchAllCategories :many
+-- name: SystemListWritingCategories :many
 SELECT wc.*
 FROM writing_category wc
-;
+ORDER BY wc.idwritingcategory
+LIMIT ? OFFSET ?;
 
 -- name: ListWritingCategoriesForLister :many
 WITH RECURSIVE role_ids(id) AS (

--- a/specs/email_queue.md
+++ b/specs/email_queue.md
@@ -24,7 +24,7 @@ The admin interface uses the same method when previewing templates. Rows in the
 signalled. After sending a message the worker waits at least
 `EmailWorkerInterval` seconds before attempting the next delivery. The
 `ProcessPendingEmail` function fetches one queued message with
-`FetchPendingEmails(ctx, 1)`, loads the recipient address and sends the email via
+`SystemListPendingEmails(ctx, db.SystemListPendingEmailsParams{Limit: 1, Offset: 0})`, loads the recipient address and sends the email via
 the configured provider. Successful deliveries mark the row as sent. Failures
 increment `error_count`. Once the count exceeds four the message is copied to the
 DLQ (if configured) and removed from the queue.

--- a/specs/query_naming.md
+++ b/specs/query_naming.md
@@ -34,3 +34,16 @@ require a user ID and are intended for privileged operations.
 
 These rules are verified by tests and should be followed for all new
 queries.
+
+## Additional rules
+
+- Admin and system commands used by CLI tools or background workers must use
+  the `System` or `Admin` prefix and must never accept a user ID.
+- User-facing queries include the required role in the function name using a
+  `For<Role>` suffix and matching `<Role>ID` parameters. Prefer descriptive role
+  names such as `Writer`, `Lister`, `Commenter`, or `Replier`.
+- The legacy `See`/`Seer` terminology is replaced by `List`/`Lister`.
+- All list queries paginate with both `LIMIT` and `OFFSET`. User and admin lists
+  must apply the caller's pagination and language settings.
+- User queries should validate grants in SQL and again in Go code for defence in
+  depth.

--- a/workers/emailqueue/email_queue.go
+++ b/workers/emailqueue/email_queue.go
@@ -96,7 +96,7 @@ func hasVerificationRecord(ctx context.Context, q db.Querier, addr string) bool 
 // ResolveQueuedEmailAddress resolves the recipient for a queued email.
 // When the user record is missing or lacks a valid address the admin or direct
 // email logic is applied.
-func ResolveQueuedEmailAddress(ctx context.Context, q db.Querier, cfg *config.RuntimeConfig, e *db.FetchPendingEmailsRow) (mail.Address, error) {
+func ResolveQueuedEmailAddress(ctx context.Context, q db.Querier, cfg *config.RuntimeConfig, e *db.SystemListPendingEmailsRow) (mail.Address, error) {
 	if e.ToUserID.Valid && e.ToUserID.Int32 != 0 {
 		user, err := q.GetUserById(ctx, e.ToUserID.Int32)
 		if err == nil && user.Email.Valid && user.Email.String != "" {
@@ -146,7 +146,7 @@ func ProcessPendingEmail(ctx context.Context, q db.Querier, provider email.Provi
 		log.Println("No mail provider specified")
 		return false
 	}
-	emails, err := q.FetchPendingEmails(ctx, 1)
+	emails, err := q.SystemListPendingEmails(ctx, db.SystemListPendingEmailsParams{Limit: 1, Offset: 0})
 	if err != nil {
 		log.Printf("fetch queue: %v", err)
 		return false


### PR DESCRIPTION
## Summary
- rename FetchPendingEmails to SystemListPendingEmails and add pagination
- rename FetchAllCategories to SystemListWritingCategories and update callers
- expand query naming spec with additional rules

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: undefined: common.WithCustomQueries and queries.DB)*
- `golangci-lint run` *(fails: many typecheck errors e.g. db.New undefined)*
- `go test ./...` *(fails: queries.DB undefined and related build errors)*

------
https://chatgpt.com/codex/tasks/task_e_688eaf83b1f4832fa81f329f051cb78f