### PR TITLE
chore: prefix system assignment queries

### DIFF
--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -152,7 +152,7 @@ func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 			return fmt.Errorf("makeThread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		pthid = int32(pthidi)
-		if err := queries.AssignThreadIdToBlogEntry(r.Context(), db.AssignThreadIdToBlogEntryParams{
+		if err := queries.SystemAssignBlogEntryThreadID(r.Context(), db.SystemAssignBlogEntryThreadIDParams{
 			ForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
 			Idblogs:       int32(bid),
 		}); err != nil {

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -279,7 +279,7 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			return fmt.Errorf("make thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		pthid = int32(pthidi)
-		if err := queries.AssignLinkerThisThreadId(r.Context(), db.AssignLinkerThisThreadIdParams{
+		if err := queries.SystemAssignLinkerThreadID(r.Context(), db.SystemAssignLinkerThreadIDParams{
 			ForumthreadID: pthid,
 			Idlinker:      int32(linkId),
 		}); err != nil {

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -148,7 +148,7 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		pthid = int32(pthidi)
-		if err := queries.AssignLinkerThisThreadId(r.Context(), db.AssignLinkerThisThreadIdParams{
+		if err := queries.SystemAssignLinkerThreadID(r.Context(), db.SystemAssignLinkerThreadIDParams{
 			ForumthreadID: pthid,
 			Idlinker:      int32(linkId),
 		}); err != nil {

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -147,7 +147,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			return fmt.Errorf("make thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		pthid = int32(pthidi)
-		if err := queries.AssignNewsThisThreadId(r.Context(), db.AssignNewsThisThreadIdParams{
+		if err := queries.SystemAssignNewsThreadID(r.Context(), db.SystemAssignNewsThreadIDParams{
 			ForumthreadID: pthid,
 			Idsitenews:    int32(pid),
 		}); err != nil {

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -121,7 +121,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			return fmt.Errorf("make thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		pthid = int32(pthidi)
-		if err := queries.AssignWritingThisThreadId(r.Context(), db.AssignWritingThisThreadIdParams{ForumthreadID: pthid, Idwriting: int32(aid)}); err != nil {
+		if err := queries.SystemAssignWritingThreadID(r.Context(), db.SystemAssignWritingThreadIDParams{ForumthreadID: pthid, Idwriting: int32(aid)}); err != nil {
 			return fmt.Errorf("assign article thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	}

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -142,7 +142,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		pthid := int32(pthidi)
-		if err := queries.AssignWritingThisThreadId(r.Context(), db.AssignWritingThisThreadIdParams{
+		if err := queries.SystemAssignWritingThreadID(r.Context(), db.SystemAssignWritingThreadIDParams{
 			ForumthreadID: pthid,
 			Idwriting:     writing.Idwriting,
 		}); err != nil {
@@ -357,7 +357,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		pthid = int32(pthidi)
-		if err := queries.AssignWritingThisThreadId(r.Context(), db.AssignWritingThisThreadIdParams{
+		if err := queries.SystemAssignWritingThreadID(r.Context(), db.SystemAssignWritingThreadIDParams{
 			ForumthreadID: pthid,
 			Idwriting:     int32(aid),
 		}); err != nil {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -144,10 +144,6 @@ type Querier interface {
 	AdminWordListWithCounts(ctx context.Context, arg AdminWordListWithCountsParams) ([]*AdminWordListWithCountsRow, error)
 	AdminWordListWithCountsByPrefix(ctx context.Context, arg AdminWordListWithCountsByPrefixParams) ([]*AdminWordListWithCountsByPrefixRow, error)
 	AdminWritingCategoryCounts(ctx context.Context) ([]*AdminWritingCategoryCountsRow, error)
-	AssignLinkerThisThreadId(ctx context.Context, arg AssignLinkerThisThreadIdParams) error
-	AssignNewsThisThreadId(ctx context.Context, arg AssignNewsThisThreadIdParams) error
-	AssignThreadIdToBlogEntry(ctx context.Context, arg AssignThreadIdToBlogEntryParams) error
-	AssignWritingThisThreadId(ctx context.Context, arg AssignWritingThisThreadIdParams) error
 	BlogsSearchFirst(ctx context.Context, arg BlogsSearchFirstParams) ([]int32, error)
 	BlogsSearchNext(ctx context.Context, arg BlogsSearchNextParams) ([]int32, error)
 	CheckGrant(ctx context.Context, arg CheckGrantParams) (int32, error)
@@ -377,6 +373,10 @@ type Querier interface {
 	SystemAddToImagePostSearch(ctx context.Context, arg SystemAddToImagePostSearchParams) error
 	SystemAddToLinkerSearch(ctx context.Context, arg SystemAddToLinkerSearchParams) error
 	SystemAddToSiteNewsSearch(ctx context.Context, arg SystemAddToSiteNewsSearchParams) error
+	SystemAssignBlogEntryThreadID(ctx context.Context, arg SystemAssignBlogEntryThreadIDParams) error
+	SystemAssignLinkerThreadID(ctx context.Context, arg SystemAssignLinkerThreadIDParams) error
+	SystemAssignNewsThreadID(ctx context.Context, arg SystemAssignNewsThreadIDParams) error
+	SystemAssignWritingThreadID(ctx context.Context, arg SystemAssignWritingThreadIDParams) error
 	SystemCountDeadLetters(ctx context.Context) (int64, error)
 	// SystemCountLanguages counts all languages.
 	SystemCountLanguages(ctx context.Context) (int64, error)

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -31,7 +31,7 @@ WHERE EXISTS (
       ))
 );
 
--- name: AssignThreadIdToBlogEntry :exec
+-- name: SystemAssignBlogEntryThreadID :exec
 UPDATE blogs
 SET forumthread_id = ?
 WHERE idblogs = ?;

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -76,22 +76,6 @@ func (q *Queries) AdminGetAllBlogEntriesByUser(ctx context.Context, arg AdminGet
 	return items, nil
 }
 
-const assignThreadIdToBlogEntry = `-- name: AssignThreadIdToBlogEntry :exec
-UPDATE blogs
-SET forumthread_id = ?
-WHERE idblogs = ?
-`
-
-type AssignThreadIdToBlogEntryParams struct {
-	ForumthreadID sql.NullInt32
-	Idblogs       int32
-}
-
-func (q *Queries) AssignThreadIdToBlogEntry(ctx context.Context, arg AssignThreadIdToBlogEntryParams) error {
-	_, err := q.db.ExecContext(ctx, assignThreadIdToBlogEntry, arg.ForumthreadID, arg.Idblogs)
-	return err
-}
-
 const blogsSearchFirst = `-- name: BlogsSearchFirst :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
@@ -790,6 +774,22 @@ func (q *Queries) ListBloggersSearchForLister(ctx context.Context, arg ListBlogg
 		return nil, err
 	}
 	return items, nil
+}
+
+const systemAssignBlogEntryThreadID = `-- name: SystemAssignBlogEntryThreadID :exec
+UPDATE blogs
+SET forumthread_id = ?
+WHERE idblogs = ?
+`
+
+type SystemAssignBlogEntryThreadIDParams struct {
+	ForumthreadID sql.NullInt32
+	Idblogs       int32
+}
+
+func (q *Queries) SystemAssignBlogEntryThreadID(ctx context.Context, arg SystemAssignBlogEntryThreadIDParams) error {
+	_, err := q.db.ExecContext(ctx, systemAssignBlogEntryThreadID, arg.ForumthreadID, arg.Idblogs)
+	return err
 }
 
 const systemGetAllBlogsForIndex = `-- name: SystemGetAllBlogsForIndex :many

--- a/internal/db/queries-linker.sql
+++ b/internal/db/queries-linker.sql
@@ -129,7 +129,7 @@ WHERE idlinker = ?
     WHERE ur.users_idusers = sqlc.arg(admin_id) AND r.is_admin = 1
   );
 
--- name: AssignLinkerThisThreadId :exec
+-- name: SystemAssignLinkerThreadID :exec
 UPDATE linker SET forumthread_id = ? WHERE idlinker = ?;
 
 -- name: GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending :many

--- a/internal/db/queries-linker.sql.go
+++ b/internal/db/queries-linker.sql.go
@@ -11,20 +11,6 @@ import (
 	"strings"
 )
 
-const assignLinkerThisThreadId = `-- name: AssignLinkerThisThreadId :exec
-UPDATE linker SET forumthread_id = ? WHERE idlinker = ?
-`
-
-type AssignLinkerThisThreadIdParams struct {
-	ForumthreadID int32
-	Idlinker      int32
-}
-
-func (q *Queries) AssignLinkerThisThreadId(ctx context.Context, arg AssignLinkerThisThreadIdParams) error {
-	_, err := q.db.ExecContext(ctx, assignLinkerThisThreadId, arg.ForumthreadID, arg.Idlinker)
-	return err
-}
-
 const countLinksByCategory = `-- name: CountLinksByCategory :one
 SELECT COUNT(*) FROM linker WHERE linker_category_id = ?
 `
@@ -1327,6 +1313,20 @@ UPDATE linker SET last_index = NOW() WHERE idlinker = ?
 
 func (q *Queries) SetLinkerLastIndex(ctx context.Context, idlinker int32) error {
 	_, err := q.db.ExecContext(ctx, setLinkerLastIndex, idlinker)
+	return err
+}
+
+const systemAssignLinkerThreadID = `-- name: SystemAssignLinkerThreadID :exec
+UPDATE linker SET forumthread_id = ? WHERE idlinker = ?
+`
+
+type SystemAssignLinkerThreadIDParams struct {
+	ForumthreadID int32
+	Idlinker      int32
+}
+
+func (q *Queries) SystemAssignLinkerThreadID(ctx context.Context, arg SystemAssignLinkerThreadIDParams) error {
+	_, err := q.db.ExecContext(ctx, systemAssignLinkerThreadID, arg.ForumthreadID, arg.Idlinker)
 	return err
 }
 

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -14,7 +14,7 @@ FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 WHERE s.idsiteNews = ?;
 
--- name: AssignNewsThisThreadId :exec
+-- name: SystemAssignNewsThreadID :exec
 UPDATE site_news SET forumthread_id = ? WHERE idsiteNews = ?;
 
 -- name: GetNewsPostByIdWithWriterIdAndThreadCommentCount :one

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -11,20 +11,6 @@ import (
 	"strings"
 )
 
-const assignNewsThisThreadId = `-- name: AssignNewsThisThreadId :exec
-UPDATE site_news SET forumthread_id = ? WHERE idsiteNews = ?
-`
-
-type AssignNewsThisThreadIdParams struct {
-	ForumthreadID int32
-	Idsitenews    int32
-}
-
-func (q *Queries) AssignNewsThisThreadId(ctx context.Context, arg AssignNewsThisThreadIdParams) error {
-	_, err := q.db.ExecContext(ctx, assignNewsThisThreadId, arg.ForumthreadID, arg.Idsitenews)
-	return err
-}
-
 const createNewsPost = `-- name: CreateNewsPost :execlastid
 INSERT INTO site_news (news, users_idusers, occurred, language_idlanguage)
 VALUES (?, ?, NOW(), ?)
@@ -356,6 +342,20 @@ UPDATE site_news SET last_index = NOW() WHERE idsiteNews = ?
 
 func (q *Queries) SetSiteNewsLastIndex(ctx context.Context, idsitenews int32) error {
 	_, err := q.db.ExecContext(ctx, setSiteNewsLastIndex, idsitenews)
+	return err
+}
+
+const systemAssignNewsThreadID = `-- name: SystemAssignNewsThreadID :exec
+UPDATE site_news SET forumthread_id = ? WHERE idsiteNews = ?
+`
+
+type SystemAssignNewsThreadIDParams struct {
+	ForumthreadID int32
+	Idsitenews    int32
+}
+
+func (q *Queries) SystemAssignNewsThreadID(ctx context.Context, arg SystemAssignNewsThreadIDParams) error {
+	_, err := q.db.ExecContext(ctx, systemAssignNewsThreadID, arg.ForumthreadID, arg.Idsitenews)
 	return err
 }
 

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -177,7 +177,7 @@ WHERE EXISTS (
 );
 
 
--- name: AssignWritingThisThreadId :exec
+-- name: SystemAssignWritingThreadID :exec
 UPDATE writing SET forumthread_id = ? WHERE idwriting = ?;
 
 

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -175,20 +175,6 @@ func (q *Queries) AdminUpdateWritingCategory(ctx context.Context, arg AdminUpdat
 	return err
 }
 
-const assignWritingThisThreadId = `-- name: AssignWritingThisThreadId :exec
-UPDATE writing SET forumthread_id = ? WHERE idwriting = ?
-`
-
-type AssignWritingThisThreadIdParams struct {
-	ForumthreadID int32
-	Idwriting     int32
-}
-
-func (q *Queries) AssignWritingThisThreadId(ctx context.Context, arg AssignWritingThisThreadIdParams) error {
-	_, err := q.db.ExecContext(ctx, assignWritingThisThreadId, arg.ForumthreadID, arg.Idwriting)
-	return err
-}
-
 const getAllWritingsByAuthorForLister = `-- name: GetAllWritingsByAuthorForLister :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
@@ -992,6 +978,20 @@ UPDATE writing SET last_index = NOW() WHERE idwriting = ?
 
 func (q *Queries) SetWritingLastIndex(ctx context.Context, idwriting int32) error {
 	_, err := q.db.ExecContext(ctx, setWritingLastIndex, idwriting)
+	return err
+}
+
+const systemAssignWritingThreadID = `-- name: SystemAssignWritingThreadID :exec
+UPDATE writing SET forumthread_id = ? WHERE idwriting = ?
+`
+
+type SystemAssignWritingThreadIDParams struct {
+	ForumthreadID int32
+	Idwriting     int32
+}
+
+func (q *Queries) SystemAssignWritingThreadID(ctx context.Context, arg SystemAssignWritingThreadIDParams) error {
+	_, err := q.db.ExecContext(ctx, systemAssignWritingThreadID, arg.ForumthreadID, arg.Idwriting)
 	return err
 }
 

--- a/specs/query_naming.md
+++ b/specs/query_naming.md
@@ -39,6 +39,9 @@ queries.
 
 - Admin and system commands used by CLI tools or background workers must use
   the `System` or `Admin` prefix and must never accept a user ID.
+- Internal bookkeeping operations (for example assigning thread IDs) use
+  the `System` prefix with a descriptive verb, e.g.
+  `SystemAssignBlogEntryThreadID`.
 - User-facing queries include the required role in the function name using a
   `For<Role>` suffix and matching `<Role>ID` parameters. Prefer descriptive role
   names such as `Writer`, `Lister`, `Commenter`, or `Replier`.


### PR DESCRIPTION
## Summary
- standardize thread assignment queries with `System` prefix
- document System naming for internal bookkeeping

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: queries.DB undefined; undefined: common.WithCustomQueries)*
- `golangci-lint run` *(fails: typecheck: db.New undefined, etc.)*
- `go test ./...` *(fails: queries.DB undefined, db.New undefined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688eb69ad22c832f9a751efc59b17911