### PR TITLE
Align admin user queries with naming spec and tests

### DIFF
--- a/cmd/goa4web/user_list.go
+++ b/cmd/goa4web/user_list.go
@@ -47,7 +47,7 @@ func (c *userListCmd) Run() error {
 		rows, err = queries.SystemListUserInfo(ctx)
 	} else {
 		// fall back to basic user list when no extra columns requested
-		basic, err2 := queries.AdminAllUsers(ctx)
+		basic, err2 := queries.AdminListAllUsers(ctx)
 		if err2 != nil {
 			return fmt.Errorf("list users: %w", err2)
 		}

--- a/handlers/admin/adminNotificationsPage.go
+++ b/handlers/admin/adminNotificationsPage.go
@@ -46,7 +46,7 @@ func AdminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	data.Usernames = map[int32]string{}
-	if rows, err := queries.AdminUsersByID(r.Context(), ids); err == nil {
+	if rows, err := queries.AdminListUsersByID(r.Context(), ids); err == nil {
 		for _, r := range rows {
 			if r.Username.Valid {
 				data.Usernames[r.Idusers] = r.Username.String

--- a/handlers/admin/adminUserListPage.go
+++ b/handlers/admin/adminUserListPage.go
@@ -13,14 +13,14 @@ func adminUserListPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Users"
 	queries := cd.Queries()
-	users, err := queries.AdminAllUsers(r.Context())
+	users, err := queries.AdminListAllUsers(r.Context())
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 	data := struct {
 		*common.CoreData
-		Users []*db.AdminAllUsersRow
+		Users []*db.AdminListAllUsersRow
 	}{
 		CoreData: cd,
 		Users:    users,

--- a/handlers/admin/send_notification_task.go
+++ b/handlers/admin/send_notification_task.go
@@ -49,7 +49,7 @@ func (SendNotificationTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 		ids = append(ids, rows...)
 	} else {
-		rows, err := queries.AdminAllUserIDs(r.Context())
+		rows, err := queries.AdminListAllUserIDs(r.Context())
 		if err != nil {
 			return fmt.Errorf("list users fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -44,9 +44,9 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 		data.Roles = roles
 	}
 
-	users, err := queries.AdminAllUsers(r.Context())
+	users, err := queries.AdminListAllUsers(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		log.Printf("AdminAllUsers Error: %s", err)
+		log.Printf("AdminListAllUsers Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}

--- a/handlers/news/newsAdminUserLevelsPage.go
+++ b/handlers/news/newsAdminUserLevelsPage.go
@@ -40,9 +40,9 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 		data.Roles = roles
 	}
 
-	users, err := queries.AdminAllUsers(r.Context())
+	users, err := queries.AdminListAllUsers(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		log.Printf("AdminAllUsers Error: %s", err)
+		log.Printf("AdminListAllUsers Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}

--- a/handlers/writings/writingsAdminUserLevelsPage.go
+++ b/handlers/writings/writingsAdminUserLevelsPage.go
@@ -40,9 +40,9 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 		data.Roles = roles
 	}
 
-	users, err := queries.AdminAllUsers(r.Context())
+	users, err := queries.AdminListAllUsers(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		log.Printf("AdminAllUsers Error: %s", err)
+		log.Printf("AdminListAllUsers Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -11,12 +11,6 @@ import (
 )
 
 type Querier interface {
-	AdminAllUserIDs(ctx context.Context) ([]int32, error)
-	// Result:
-	//   idusers (int)
-	//   username (string)
-	//   email (string)
-	AdminAllUsers(ctx context.Context) ([]*AdminAllUsersRow, error)
 	AdminApproveImagePost(ctx context.Context, idimagepost int32) error
 	AdminArchiveBlog(ctx context.Context, arg AdminArchiveBlogParams) error
 	AdminArchiveComment(ctx context.Context, arg AdminArchiveCommentParams) error
@@ -70,6 +64,12 @@ type Querier interface {
 	AdminInsertWritingCategory(ctx context.Context, arg AdminInsertWritingCategoryParams) error
 	AdminListAdministratorEmails(ctx context.Context) ([]string, error)
 	AdminListAllCommentsWithThreadInfo(ctx context.Context, arg AdminListAllCommentsWithThreadInfoParams) ([]*AdminListAllCommentsWithThreadInfoRow, error)
+	AdminListAllUserIDs(ctx context.Context) ([]int32, error)
+	// Result:
+	//   idusers (int)
+	//   username (string)
+	//   email (string)
+	AdminListAllUsers(ctx context.Context) ([]*AdminListAllUsersRow, error)
 	// admin task
 	AdminListAnnouncementsWithNews(ctx context.Context) ([]*AdminListAnnouncementsWithNewsRow, error)
 	AdminListArchivedRequests(ctx context.Context) ([]*AdminRequestQueue, error)
@@ -102,6 +102,7 @@ type Querier interface {
 	AdminListUploadedImages(ctx context.Context, arg AdminListUploadedImagesParams) ([]*UploadedImage, error)
 	AdminListUserEmails(ctx context.Context, userID int32) ([]*UserEmail, error)
 	AdminListUserIDsByRole(ctx context.Context, name string) ([]int32, error)
+	AdminListUsersByID(ctx context.Context, ids []int32) ([]*AdminListUsersByIDRow, error)
 	// admin task
 	AdminListUsersByRoleID(ctx context.Context, roleID int32) ([]*AdminListUsersByRoleIDRow, error)
 	AdminMarkBlogRestored(ctx context.Context, idblogs int32) error
@@ -139,7 +140,6 @@ type Querier interface {
 	AdminUpdateWritingCategory(ctx context.Context, arg AdminUpdateWritingCategoryParams) error
 	AdminUserPostCounts(ctx context.Context) ([]*AdminUserPostCountsRow, error)
 	AdminUserPostCountsByID(ctx context.Context, idusers int32) (*AdminUserPostCountsByIDRow, error)
-	AdminUsersByID(ctx context.Context, ids []int32) ([]*AdminUsersByIDRow, error)
 	// Show each search word with total usage counts across all search tables.
 	AdminWordListWithCounts(ctx context.Context, arg AdminWordListWithCountsParams) ([]*AdminWordListWithCountsRow, error)
 	AdminWordListWithCountsByPrefix(ctx context.Context, arg AdminWordListWithCountsByPrefixParams) ([]*AdminWordListWithCountsByPrefixRow, error)

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -1,4 +1,4 @@
--- name: AdminAllUsers :many
+-- name: AdminListAllUsers :many
 -- Result:
 --   idusers (int)
 --   username (string)
@@ -78,10 +78,10 @@ JOIN roles r ON ur.role_id = r.id
 WHERE r.name = ?
 ORDER BY u.idusers;
 
--- name: AdminAllUserIDs :many
+-- name: AdminListAllUserIDs :many
 SELECT idusers FROM users ORDER BY idusers;
 
--- name: AdminUsersByID :many
+-- name: AdminListUsersByID :many
 SELECT idusers, username
 FROM users
 WHERE idusers IN (sqlc.slice('ids'));

--- a/internal/db/queries-users.sql.go
+++ b/internal/db/queries-users.sql.go
@@ -11,76 +11,6 @@ import (
 	"strings"
 )
 
-const adminAllUserIDs = `-- name: AdminAllUserIDs :many
-SELECT idusers FROM users ORDER BY idusers
-`
-
-func (q *Queries) AdminAllUserIDs(ctx context.Context) ([]int32, error) {
-	rows, err := q.db.QueryContext(ctx, adminAllUserIDs)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []int32
-	for rows.Next() {
-		var idusers int32
-		if err := rows.Scan(&idusers); err != nil {
-			return nil, err
-		}
-		items = append(items, idusers)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const adminAllUsers = `-- name: AdminAllUsers :many
-SELECT u.idusers, u.username,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
-FROM users u
-JOIN user_roles ur ON ur.users_idusers = u.idusers
-JOIN roles r ON ur.role_id = r.id
-WHERE r.is_admin = 1
-`
-
-type AdminAllUsersRow struct {
-	Idusers  int32
-	Username sql.NullString
-	Email    string
-}
-
-// Result:
-//
-//	idusers (int)
-//	username (string)
-//	email (string)
-func (q *Queries) AdminAllUsers(ctx context.Context) ([]*AdminAllUsersRow, error) {
-	rows, err := q.db.QueryContext(ctx, adminAllUsers)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*AdminAllUsersRow
-	for rows.Next() {
-		var i AdminAllUsersRow
-		if err := rows.Scan(&i.Idusers, &i.Username, &i.Email); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const adminListAdministratorEmails = `-- name: AdminListAdministratorEmails :many
 SELECT (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
 FROM users u
@@ -102,6 +32,76 @@ func (q *Queries) AdminListAdministratorEmails(ctx context.Context) ([]string, e
 			return nil, err
 		}
 		items = append(items, email)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const adminListAllUserIDs = `-- name: AdminListAllUserIDs :many
+SELECT idusers FROM users ORDER BY idusers
+`
+
+func (q *Queries) AdminListAllUserIDs(ctx context.Context) ([]int32, error) {
+	rows, err := q.db.QueryContext(ctx, adminListAllUserIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int32
+	for rows.Next() {
+		var idusers int32
+		if err := rows.Scan(&idusers); err != nil {
+			return nil, err
+		}
+		items = append(items, idusers)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const adminListAllUsers = `-- name: AdminListAllUsers :many
+SELECT u.idusers, u.username,
+       (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
+FROM users u
+JOIN user_roles ur ON ur.users_idusers = u.idusers
+JOIN roles r ON ur.role_id = r.id
+WHERE r.is_admin = 1
+`
+
+type AdminListAllUsersRow struct {
+	Idusers  int32
+	Username sql.NullString
+	Email    string
+}
+
+// Result:
+//
+//	idusers (int)
+//	username (string)
+//	email (string)
+func (q *Queries) AdminListAllUsers(ctx context.Context) ([]*AdminListAllUsersRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListAllUsers)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*AdminListAllUsersRow
+	for rows.Next() {
+		var i AdminListAllUsersRow
+		if err := rows.Scan(&i.Idusers, &i.Username, &i.Email); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -185,19 +185,19 @@ func (q *Queries) AdminListUserIDsByRole(ctx context.Context, name string) ([]in
 	return items, nil
 }
 
-const adminUsersByID = `-- name: AdminUsersByID :many
+const adminListUsersByID = `-- name: AdminListUsersByID :many
 SELECT idusers, username
 FROM users
 WHERE idusers IN (/*SLICE:ids*/?)
 `
 
-type AdminUsersByIDRow struct {
+type AdminListUsersByIDRow struct {
 	Idusers  int32
 	Username sql.NullString
 }
 
-func (q *Queries) AdminUsersByID(ctx context.Context, ids []int32) ([]*AdminUsersByIDRow, error) {
-	query := adminUsersByID
+func (q *Queries) AdminListUsersByID(ctx context.Context, ids []int32) ([]*AdminListUsersByIDRow, error) {
+	query := adminListUsersByID
 	var queryParams []interface{}
 	if len(ids) > 0 {
 		for _, v := range ids {
@@ -212,9 +212,9 @@ func (q *Queries) AdminUsersByID(ctx context.Context, ids []int32) ([]*AdminUser
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*AdminUsersByIDRow
+	var items []*AdminListUsersByIDRow
 	for rows.Next() {
-		var i AdminUsersByIDRow
+		var i AdminListUsersByIDRow
 		if err := rows.Scan(&i.Idusers, &i.Username); err != nil {
 			return nil, err
 		}

--- a/internal/db/queries_users_admin_test.go
+++ b/internal/db/queries_users_admin_test.go
@@ -1,0 +1,60 @@
+package db
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestQueries_AdminListAllUserIDs(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := New(db)
+
+	rows := sqlmock.NewRows([]string{"idusers"}).AddRow(1).AddRow(2)
+	mock.ExpectQuery(regexp.QuoteMeta(adminListAllUserIDs)).
+		WillReturnRows(rows)
+
+	res, err := q.AdminListAllUserIDs(context.Background())
+	if err != nil {
+		t.Fatalf("AdminListAllUserIDs: %v", err)
+	}
+	if len(res) != 2 || res[0] != 1 || res[1] != 2 {
+		t.Fatalf("unexpected result %v", res)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestQueries_AdminListAllUsers(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := New(db)
+
+	rows := sqlmock.NewRows([]string{"idusers", "username", "email"}).
+		AddRow(1, "bob", "bob@example.com")
+	mock.ExpectQuery(regexp.QuoteMeta(adminListAllUsers)).
+		WillReturnRows(rows)
+
+	res, err := q.AdminListAllUsers(context.Background())
+	if err != nil {
+		t.Fatalf("AdminListAllUsers: %v", err)
+	}
+	if len(res) != 1 || res[0].Idusers != 1 || res[0].Username.String != "bob" || res[0].Email != "bob@example.com" {
+		t.Fatalf("unexpected result %+v", res)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/specs/query_naming.md
+++ b/specs/query_naming.md
@@ -26,6 +26,10 @@ each user's pagination and language preferences and enforce permissions
 within the SQL itself. Admin and system queries must never require a user
 ID.
 
+Admin queries are always prefixed with `Admin` and must omit any user ID
+parameters. System-level operations invoked from CLI tools or background
+workers use the `System` prefix and likewise must not depend on a user ID.
+
 ## Grants
 
 User queries should check grants both in SQL and in Go code to ensure


### PR DESCRIPTION
## Summary
- rename admin user listing queries to use `AdminList` prefix and reflect interface methods
- document admin/system query prefixes in query naming spec
- add tests for `AdminListAllUserIDs` and `AdminListAllUsers`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: "queries.DB undefined" in multiple packages)*
- `golangci-lint run` *(fails: many typecheck errors)*
- `go test ./...` *(fails: "queries.DB undefined" in multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_688eb69ad22c832f9a751efc59b17911