### PR TITLE
refactor: reduce direct DB usage

### DIFF
--- a/cmd/goa4web/audit.go
+++ b/cmd/goa4web/audit.go
@@ -29,12 +29,12 @@ func parseAuditCmd(parent *rootCmd, args []string) (*auditCmd, error) {
 }
 
 func (c *auditCmd) Run() error {
-	sdb, err := c.DB()
+	conn, err := c.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(sdb)
+	queries := db.New(conn)
 	rows, err := queries.AdminGetRecentAuditLogs(ctx, int32(c.Limit))
 	if err != nil {
 		return fmt.Errorf("audit logs: %w", err)

--- a/cmd/goa4web/blog_comments_list.go
+++ b/cmd/goa4web/blog_comments_list.go
@@ -41,12 +41,12 @@ func (c *blogCommentsListCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	listerID := int32(c.UserID)
 	b, err := queries.GetBlogEntryForListerByID(ctx, db.GetBlogEntryForListerByIDParams{
 		ListerID: listerID,

--- a/cmd/goa4web/blog_comments_read.go
+++ b/cmd/goa4web/blog_comments_read.go
@@ -53,12 +53,12 @@ func (c *blogCommentsReadCmd) Run() error {
 	if c.BlogID == 0 {
 		return fmt.Errorf("blog id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	uid := int32(c.UserID)
 	b, err := queries.GetBlogEntryForListerByID(ctx, db.GetBlogEntryForListerByIDParams{
 		ListerID: uid,

--- a/cmd/goa4web/blog_create.go
+++ b/cmd/goa4web/blog_create.go
@@ -35,12 +35,12 @@ func (c *blogCreateCmd) Run() error {
 	if c.UserID == 0 || c.LangID == 0 || c.Text == "" {
 		return fmt.Errorf("user, lang and text required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	_, err = queries.CreateBlogEntry(ctx, db.CreateBlogEntryParams{
 		UsersIdusers:       int32(c.UserID),
 		LanguageIdlanguage: int32(c.LangID),

--- a/cmd/goa4web/blog_deactivate.go
+++ b/cmd/goa4web/blog_deactivate.go
@@ -31,12 +31,12 @@ func (c *blogDeactivateCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	b, err := queries.GetBlogEntryForListerByID(ctx, db.GetBlogEntryForListerByIDParams{
 		ListerID: 0,
 		ID:       int32(c.ID),

--- a/cmd/goa4web/blog_list.go
+++ b/cmd/goa4web/blog_list.go
@@ -32,12 +32,12 @@ func parseBlogListCmd(parent *blogCmd, args []string) (*blogListCmd, error) {
 }
 
 func (c *blogListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	uid := int32(c.UserID)
 	rows, err := queries.ListBlogEntriesForLister(ctx, db.ListBlogEntriesForListerParams{
 		ListerID: uid,

--- a/cmd/goa4web/blog_read.go
+++ b/cmd/goa4web/blog_read.go
@@ -39,12 +39,12 @@ func (c *blogReadCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	row, err := queries.GetBlogEntryForListerByID(ctx, db.GetBlogEntryForListerByIDParams{
 		ListerID: 0,
 		ID:       int32(c.ID),

--- a/cmd/goa4web/blog_update.go
+++ b/cmd/goa4web/blog_update.go
@@ -35,12 +35,12 @@ func (c *blogUpdateCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	err = queries.UpdateBlogEntry(ctx, db.UpdateBlogEntryParams{
 		LanguageIdlanguage: int32(c.LangID),
 		Blog:               sql.NullString{String: c.Text, Valid: c.Text != ""},

--- a/cmd/goa4web/board_create.go
+++ b/cmd/goa4web/board_create.go
@@ -32,12 +32,12 @@ func parseBoardCreateCmd(parent *boardCmd, args []string) (*boardCreateCmd, erro
 }
 
 func (c *boardCreateCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	err = queries.CreateImageBoard(ctx, db.CreateImageBoardParams{
 		ImageboardIdimageboard: int32(c.Parent),
 		Title:                  sql.NullString{String: c.Name, Valid: c.Name != ""},

--- a/cmd/goa4web/board_delete.go
+++ b/cmd/goa4web/board_delete.go
@@ -35,12 +35,12 @@ func (c *boardDeleteCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.DeleteImageBoard(ctx, int32(c.ID)); err != nil {
 		return fmt.Errorf("delete board: %w", err)
 	}

--- a/cmd/goa4web/board_list.go
+++ b/cmd/goa4web/board_list.go
@@ -29,12 +29,12 @@ func parseBoardListCmd(parent *boardCmd, args []string) (*boardListCmd, error) {
 }
 
 func (c *boardListCmd) Run() error {
-	sqldb, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(sqldb)
+	queries := db.New(conn)
 	rows, err := queries.AdminListBoards(ctx, db.AdminListBoardsParams{Limit: int32(c.limit), Offset: int32(c.offset)})
 	if err != nil {
 		return fmt.Errorf("list boards: %w", err)

--- a/cmd/goa4web/board_update.go
+++ b/cmd/goa4web/board_update.go
@@ -40,12 +40,12 @@ func (c *boardUpdateCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	err = queries.UpdateImageBoard(ctx, db.UpdateImageBoardParams{
 		Title:                  sql.NullString{String: c.Name, Valid: c.Name != ""},
 		Description:            sql.NullString{String: c.Description, Valid: c.Description != ""},

--- a/cmd/goa4web/config_test_cmd.go
+++ b/cmd/goa4web/config_test_cmd.go
@@ -97,8 +97,8 @@ func (c *configTestEmailCmd) Run() error {
 		return fmt.Errorf("email provider not configured")
 	}
 	var q db.Querier
-	if db, err := c.rootCmd.DB(); err == nil {
-		q = db.New(db)
+	if conn, err := c.rootCmd.DB(); err == nil {
+		q = db.New(conn)
 	}
 	ctx := context.Background()
 	emails := config.GetAdminEmails(ctx, q, c.rootCmd.cfg)
@@ -151,11 +151,11 @@ func parseConfigTestDBCmd(parent *configTestCmd, args []string) (*configTestDBCm
 }
 
 func (c *configTestDBCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
-	if err := db.Ping(); err != nil {
+	if err := conn.Ping(); err != nil {
 		return fmt.Errorf("ping: %w", err)
 	}
 	return nil
@@ -178,8 +178,8 @@ func parseConfigTestDLQCmd(parent *configTestCmd, args []string) (*configTestDLQ
 
 func (c *configTestDLQCmd) Run() error {
 	var q db.Querier
-	if db, err := c.rootCmd.DB(); err == nil {
-		q = db.New(db)
+	if conn, err := c.rootCmd.DB(); err == nil {
+		q = db.New(conn)
 	}
 	provider := c.rootCmd.dlqReg.ProviderFromConfig(c.rootCmd.cfg, q)
 	if provider == nil {

--- a/cmd/goa4web/email_queue_delete.go
+++ b/cmd/goa4web/email_queue_delete.go
@@ -30,12 +30,12 @@ func (c *emailQueueDeleteCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.AdminDeletePendingEmail(ctx, int32(c.ID)); err != nil {
 		return fmt.Errorf("delete email: %w", err)
 	}

--- a/cmd/goa4web/email_queue_list.go
+++ b/cmd/goa4web/email_queue_list.go
@@ -28,12 +28,12 @@ func parseEmailQueueListCmd(parent *emailQueueCmd, args []string) (*emailQueueLi
 }
 
 func (c *emailQueueListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.AdminListUnsentPendingEmails(ctx, db.AdminListUnsentPendingEmailsParams{})
 	if err != nil {
 		return fmt.Errorf("list emails: %w", err)

--- a/cmd/goa4web/email_queue_resend.go
+++ b/cmd/goa4web/email_queue_resend.go
@@ -31,12 +31,12 @@ func (c *emailQueueResendCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	e, err := queries.AdminGetPendingEmailByID(ctx, int32(c.ID))
 	if err != nil {
 		return fmt.Errorf("get email: %w", err)

--- a/cmd/goa4web/faq_read.go
+++ b/cmd/goa4web/faq_read.go
@@ -37,12 +37,12 @@ func (c *faqReadCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.GetAllFAQQuestions(ctx)
 	if err != nil {
 		return fmt.Errorf("get faq: %w", err)

--- a/cmd/goa4web/faq_tree.go
+++ b/cmd/goa4web/faq_tree.go
@@ -26,12 +26,12 @@ func parseFaqTreeCmd(parent *faqCmd, args []string) (*faqTreeCmd, error) {
 }
 
 func (c *faqTreeCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.GetAllAnsweredFAQWithFAQCategoriesForUser(ctx, db.GetAllAnsweredFAQWithFAQCategoriesForUserParams{ViewerID: 0, UserID: sql.NullInt32{}})
 	if err != nil {
 		return fmt.Errorf("tree: %w", err)

--- a/cmd/goa4web/grant_add.go
+++ b/cmd/goa4web/grant_add.go
@@ -41,12 +41,12 @@ func (c *grantAddCmd) Run() error {
 	if c.Section == "" || c.Action == "" {
 		return fmt.Errorf("section and action required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	q := db.New(db)
+	q := db.New(conn)
 	_, err = q.CreateGrant(ctx, db.CreateGrantParams{
 		UserID:   sql.NullInt32{Int32: int32(c.User), Valid: c.User != 0},
 		RoleID:   sql.NullInt32{},

--- a/cmd/goa4web/grant_delete.go
+++ b/cmd/goa4web/grant_delete.go
@@ -30,12 +30,12 @@ func (c *grantDeleteCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	q := db.New(db)
+	q := db.New(conn)
 	if err := q.DeleteGrant(ctx, int32(c.ID)); err != nil {
 		return fmt.Errorf("delete grant: %w", err)
 	}

--- a/cmd/goa4web/grant_list.go
+++ b/cmd/goa4web/grant_list.go
@@ -25,12 +25,12 @@ func parseGrantListCmd(parent *grantCmd, args []string) (*grantListCmd, error) {
 }
 
 func (c *grantListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	q := db.New(db)
+	q := db.New(conn)
 	rows, err := q.ListGrants(ctx)
 	if err != nil {
 		return fmt.Errorf("list grants: %w", err)

--- a/cmd/goa4web/ipban_add.go
+++ b/cmd/goa4web/ipban_add.go
@@ -37,12 +37,12 @@ func (c *ipBanAddCmd) Run() error {
 	if c.IP == "" {
 		return fmt.Errorf("ip required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	var expires sql.NullTime
 	if c.Expires != "" {
 		t, err := time.Parse("2006-01-02", c.Expires)

--- a/cmd/goa4web/ipban_delete.go
+++ b/cmd/goa4web/ipban_delete.go
@@ -31,12 +31,12 @@ func (c *ipBanDeleteCmd) Run() error {
 	if c.IP == "" {
 		return fmt.Errorf("ip required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.AdminCancelBannedIp(ctx, c.IP); err != nil {
 		return fmt.Errorf("cancel banned ip: %w", err)
 	}

--- a/cmd/goa4web/ipban_list.go
+++ b/cmd/goa4web/ipban_list.go
@@ -25,12 +25,12 @@ func parseIpBanListCmd(parent *ipBanCmd, args []string) (*ipBanListCmd, error) {
 }
 
 func (c *ipBanListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.ListBannedIps(ctx)
 	if err != nil {
 		return fmt.Errorf("list banned ips: %w", err)

--- a/cmd/goa4web/ipban_update.go
+++ b/cmd/goa4web/ipban_update.go
@@ -37,12 +37,12 @@ func (c *ipBanUpdateCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	var expires sql.NullTime
 	if c.Expires != "" {
 		t, err := time.Parse("2006-01-02", c.Expires)

--- a/cmd/goa4web/lang_add.go
+++ b/cmd/goa4web/lang_add.go
@@ -33,12 +33,12 @@ func (c *langAddCmd) Run() error {
 	if c.Code == "" || c.Name == "" {
 		return fmt.Errorf("code and name required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	c.rootCmd.Verbosef("adding language %s (%s)", c.Name, c.Code)
 	if _, err := queries.AdminInsertLanguage(ctx, sql.NullString{String: c.Name, Valid: true}); err != nil {
 		return fmt.Errorf("insert language: %w", err)

--- a/cmd/goa4web/lang_list.go
+++ b/cmd/goa4web/lang_list.go
@@ -25,12 +25,12 @@ func parseLangListCmd(parent *langCmd, args []string) (*langListCmd, error) {
 }
 
 func (c *langListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	langs, err := queries.SystemListLanguages(ctx)
 	if err != nil {
 		return fmt.Errorf("list languages: %w", err)

--- a/cmd/goa4web/lang_update.go
+++ b/cmd/goa4web/lang_update.go
@@ -33,12 +33,12 @@ func (c *langUpdateCmd) Run() error {
 	if c.ID == 0 || c.Name == "" {
 		return fmt.Errorf("id and name required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	err = queries.AdminRenameLanguage(ctx, db.AdminRenameLanguageParams{Nameof: sql.NullString{String: c.Name, Valid: true}, Idlanguage: int32(c.ID)})
 	if err != nil {
 		return fmt.Errorf("update language: %w", err)

--- a/cmd/goa4web/links_delete.go
+++ b/cmd/goa4web/links_delete.go
@@ -31,12 +31,12 @@ func (c *linksDeleteCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.AdminDeleteExternalLink(ctx, int32(c.ID)); err != nil {
 		return fmt.Errorf("delete link: %w", err)
 	}

--- a/cmd/goa4web/links_list.go
+++ b/cmd/goa4web/links_list.go
@@ -25,12 +25,12 @@ func parseLinksListCmd(parent *linksCmd, args []string) (*linksListCmd, error) {
 }
 
 func (c *linksListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.AdminListExternalLinks(ctx, db.AdminListExternalLinksParams{Limit: 200, Offset: 0})
 	if err != nil {
 		return fmt.Errorf("list links: %w", err)

--- a/cmd/goa4web/links_refresh.go
+++ b/cmd/goa4web/links_refresh.go
@@ -32,12 +32,12 @@ func (c *linksRefreshCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.AdminClearExternalLinkCache(ctx, db.AdminClearExternalLinkCacheParams{UpdatedBy: sql.NullInt32{}, ID: int32(c.ID)}); err != nil {
 		return fmt.Errorf("refresh link: %w", err)
 	}

--- a/cmd/goa4web/news_comments_list.go
+++ b/cmd/goa4web/news_comments_list.go
@@ -41,12 +41,12 @@ func (c *newsCommentsListCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	uid := int32(c.UserID)
 	n, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx, db.GetNewsPostByIdWithWriterIdAndThreadCommentCountParams{
 		ViewerID: uid,

--- a/cmd/goa4web/news_comments_read.go
+++ b/cmd/goa4web/news_comments_read.go
@@ -53,12 +53,12 @@ func (c *newsCommentsReadCmd) Run() error {
 	if c.NewsID == 0 {
 		return fmt.Errorf("news id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	uid := int32(c.UserID)
 	n, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx, db.GetNewsPostByIdWithWriterIdAndThreadCommentCountParams{
 		ViewerID: uid,

--- a/cmd/goa4web/news_list.go
+++ b/cmd/goa4web/news_list.go
@@ -30,12 +30,12 @@ func parseNewsListCmd(parent *newsCmd, args []string) (*newsListCmd, error) {
 }
 
 func (c *newsListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	cd := common.NewCoreData(ctx, queries, c.rootCmd.cfg)
 	posts, err := cd.LatestNewsList(int32(c.Offset), int32(c.Limit))
 	if err != nil {

--- a/cmd/goa4web/news_read.go
+++ b/cmd/goa4web/news_read.go
@@ -39,12 +39,12 @@ func (c *newsReadCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	row, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx, db.GetNewsPostByIdWithWriterIdAndThreadCommentCountParams{
 		ViewerID: 0,
 		ID:       int32(c.ID),

--- a/cmd/goa4web/perm_grant.go
+++ b/cmd/goa4web/perm_grant.go
@@ -34,12 +34,12 @@ func (c *permGrantCmd) Run() error {
 	if c.User == "" || c.Role == "" {
 		return fmt.Errorf("user and role required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	c.rootCmd.Verbosef("granting %s to %s", c.Role, c.User)
 	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.User, Valid: true})
 	if err != nil {

--- a/cmd/goa4web/perm_list.go
+++ b/cmd/goa4web/perm_list.go
@@ -28,12 +28,12 @@ func parsePermListCmd(parent *permCmd, args []string) (*permListCmd, error) {
 }
 
 func (c *permListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.GetPermissionsWithUsers(ctx,
 		db.GetPermissionsWithUsersParams{Username: sql.NullString{String: c.User, Valid: c.User != ""}},
 	)

--- a/cmd/goa4web/perm_revoke.go
+++ b/cmd/goa4web/perm_revoke.go
@@ -30,12 +30,12 @@ func (c *permRevokeCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.DeleteUserRole(ctx, int32(c.ID)); err != nil {
 		return fmt.Errorf("revoke: %w", err)
 	}

--- a/cmd/goa4web/perm_update.go
+++ b/cmd/goa4web/perm_update.go
@@ -32,12 +32,12 @@ func (c *permUpdateCmd) Run() error {
 	if c.ID == 0 || c.Role == "" {
 		return fmt.Errorf("id and role required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.UpdatePermission(ctx, db.UpdatePermissionParams{
 		IduserRoles: int32(c.ID),
 		Name:        c.Role,

--- a/cmd/goa4web/role_users.go
+++ b/cmd/goa4web/role_users.go
@@ -29,12 +29,12 @@ func parseRoleUsersCmd(parent *roleCmd, args []string) (*roleUsersCmd, error) {
 }
 
 func (c *roleUsersCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.AdminListRolesWithUsers(ctx)
 	if err != nil {
 		return fmt.Errorf("list roles with users: %w", err)

--- a/cmd/goa4web/user_activate.go
+++ b/cmd/goa4web/user_activate.go
@@ -35,12 +35,12 @@ func (c *userActivateCmd) Run() error {
 	if c.ID == 0 && c.Username == "" {
 		return fmt.Errorf("id or username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.ID == 0 {
 		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {
@@ -49,7 +49,7 @@ func (c *userActivateCmd) Run() error {
 		c.ID = int(u.Idusers)
 	}
 	c.rootCmd.Verbosef("restoring user %d", c.ID)
-	tx, err := db.BeginTx(ctx, nil)
+	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}

--- a/cmd/goa4web/user_add.go
+++ b/cmd/goa4web/user_add.go
@@ -54,12 +54,12 @@ func createUser(root *rootCmd, username, email, password string, admin bool) err
 	if username == "" || password == "" {
 		return fmt.Errorf("username and password required")
 	}
-	db, err := root.DB()
+	conn, err := root.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	hash, alg, err := auth.HashPassword(password)
 	if err != nil {
 		return fmt.Errorf("hash password: %w", err)

--- a/cmd/goa4web/user_add_role.go
+++ b/cmd/goa4web/user_add_role.go
@@ -35,12 +35,12 @@ func (c *userAddRoleCmd) Run() error {
 	if c.Username == "" || c.Role == "" {
 		return fmt.Errorf("username and role required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	c.rootCmd.Verbosef("adding role %s to %s", c.Role, c.Username)
 	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {

--- a/cmd/goa4web/user_approve.go
+++ b/cmd/goa4web/user_approve.go
@@ -34,12 +34,12 @@ func (c *userApproveCmd) Run() error {
 	if c.ID == 0 && c.Username == "" {
 		return fmt.Errorf("id or username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.ID == 0 {
 		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {

--- a/cmd/goa4web/user_comments_add.go
+++ b/cmd/goa4web/user_comments_add.go
@@ -40,12 +40,12 @@ func (c *userCommentsAddCmd) Run() error {
 	if strings.TrimSpace(c.Comment) == "" {
 		return fmt.Errorf("empty comment")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.ID == 0 {
 		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {

--- a/cmd/goa4web/user_comments_list.go
+++ b/cmd/goa4web/user_comments_list.go
@@ -34,12 +34,12 @@ func (c *userCommentsListCmd) Run() error {
 	if c.ID == 0 && c.Username == "" {
 		return fmt.Errorf("id or username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.ID == 0 {
 		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {

--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -40,18 +40,18 @@ func (c *userDeactivateCmd) Run() error {
 	if c.Username == "" {
 		return fmt.Errorf("username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}
 	c.rootCmd.Verbosef("deactivating user %s", c.Username)
-	tx, err := db.BeginTx(ctx, nil)
+	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}

--- a/cmd/goa4web/user_list.go
+++ b/cmd/goa4web/user_list.go
@@ -35,12 +35,12 @@ func parseUserListCmd(parent *userCmd, args []string) (*userListCmd, error) {
 }
 
 func (c *userListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 
 	var rows []*db.SystemListUserInfoRow
 	if c.showAdmin || c.showCreated || c.jsonOut {

--- a/cmd/goa4web/user_list_roles.go
+++ b/cmd/goa4web/user_list_roles.go
@@ -25,12 +25,12 @@ func parseUserListRolesCmd(parent *userCmd, args []string) (*userListRolesCmd, e
 }
 
 func (c *userListRolesCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	roles, err := queries.AdminListRoles(ctx)
 	if err != nil {
 		return fmt.Errorf("list roles: %w", err)

--- a/cmd/goa4web/user_make_admin.go
+++ b/cmd/goa4web/user_make_admin.go
@@ -33,12 +33,12 @@ func (c *userMakeAdminCmd) Run() error {
 	if c.Username == "" {
 		return fmt.Errorf("username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	c.rootCmd.Verbosef("granting administrator to %s", c.Username)
 	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {

--- a/cmd/goa4web/user_password_clear_expired.go
+++ b/cmd/goa4web/user_password_clear_expired.go
@@ -31,12 +31,12 @@ func parseUserPasswordClearExpiredCmd(parent *userPasswordCmd, args []string) (*
 }
 
 func (c *userPasswordClearExpiredCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	expiry := time.Now().Add(-time.Duration(c.Hours) * time.Hour)
 	res, err := queries.PurgePasswordResetsBefore(ctx, expiry)
 	if err != nil {

--- a/cmd/goa4web/user_password_clear_user.go
+++ b/cmd/goa4web/user_password_clear_user.go
@@ -34,12 +34,12 @@ func (c *userPasswordClearUserCmd) Run() error {
 	if c.Username == "" {
 		return fmt.Errorf("username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	user, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)

--- a/cmd/goa4web/user_profile.go
+++ b/cmd/goa4web/user_profile.go
@@ -36,12 +36,12 @@ func (c *userProfileCmd) Run() error {
 	if c.ID == 0 && c.Username == "" {
 		return fmt.Errorf("id or username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.ID == 0 {
 		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {

--- a/cmd/goa4web/user_reject.go
+++ b/cmd/goa4web/user_reject.go
@@ -37,12 +37,12 @@ func (c *userRejectCmd) Run() error {
 	if c.ID == 0 && c.Username == "" {
 		return fmt.Errorf("id or username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.ID == 0 {
 		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {

--- a/cmd/goa4web/user_remove_role.go
+++ b/cmd/goa4web/user_remove_role.go
@@ -34,12 +34,12 @@ func (c *userRemoveRoleCmd) Run() error {
 	if c.Username == "" || c.Role == "" {
 		return fmt.Errorf("username and role required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	c.rootCmd.Verbosef("removing role %s from %s", c.Role, c.Username)
 	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {

--- a/cmd/goa4web/user_roles.go
+++ b/cmd/goa4web/user_roles.go
@@ -26,12 +26,12 @@ func parseUserRolesCmd(parent *userCmd, args []string) (*userRolesCmd, error) {
 }
 
 func (c *userRolesCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.ListUsersWithRoles(ctx)
 	if err != nil {
 		return fmt.Errorf("list users with roles: %w", err)

--- a/cmd/goa4web/writing_comments_list.go
+++ b/cmd/goa4web/writing_comments_list.go
@@ -41,12 +41,12 @@ func (c *writingCommentsListCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	uid := int32(c.UserID)
 	w, err := queries.GetWritingForListerByID(ctx, db.GetWritingForListerByIDParams{ListerID: uid, Idwriting: int32(c.ID), ListerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0}})
 	if err != nil {

--- a/cmd/goa4web/writing_comments_read.go
+++ b/cmd/goa4web/writing_comments_read.go
@@ -53,12 +53,12 @@ func (c *writingCommentsReadCmd) Run() error {
 	if c.WritingID == 0 {
 		return fmt.Errorf("writing id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	uid := int32(c.UserID)
 	w, err := queries.GetWritingForListerByID(ctx, db.GetWritingForListerByIDParams{ListerID: uid, Idwriting: int32(c.WritingID), ListerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0}})
 	if err != nil {

--- a/cmd/goa4web/writing_list.go
+++ b/cmd/goa4web/writing_list.go
@@ -34,12 +34,12 @@ func parseWritingListCmd(parent *writingCmd, args []string) (*writingListCmd, er
 }
 
 func (c *writingListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.UserID != 0 {
 		rows, err := queries.SystemListPublicWritingsByAuthor(ctx, db.SystemListPublicWritingsByAuthorParams{
 			AuthorID: int32(c.UserID),

--- a/cmd/goa4web/writing_read.go
+++ b/cmd/goa4web/writing_read.go
@@ -38,12 +38,12 @@ func (c *writingReadCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	row, err := queries.GetWritingForListerByID(ctx, db.GetWritingForListerByIDParams{
 		ListerID:      0,
 		Idwriting:     int32(c.ID),

--- a/cmd/goa4web/writing_tree.go
+++ b/cmd/goa4web/writing_tree.go
@@ -26,12 +26,12 @@ func parseWritingTreeCmd(parent *writingCmd, args []string) (*writingTreeCmd, er
 }
 
 func (c *writingTreeCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.SystemListWritingCategories(ctx, db.SystemListWritingCategoriesParams{Limit: math.MaxInt32, Offset: 0})
 	if err != nil {
 		return fmt.Errorf("tree: %w", err)

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -263,8 +263,12 @@ func NewCoreData(ctx context.Context, q db.Querier, cfg *config.RuntimeConfig, o
 	cd := &CoreData{
 		ctx:               ctx,
 		queries:           q,
+		customQueries:     nil,
 		newsAnnouncements: map[int32]*lazy.Value[*db.SiteAnnouncement]{},
 		Config:            cfg,
+	}
+	if cq, ok := q.(db.CustomQueries); ok {
+		cd.customQueries = cq
 	}
 	for _, o := range opts {
 		o(cd)
@@ -274,6 +278,9 @@ func NewCoreData(ctx context.Context, q db.Querier, cfg *config.RuntimeConfig, o
 
 // Queries returns the db.Queries instance associated with this CoreData.
 func (cd *CoreData) Queries() db.Querier { return cd.queries }
+
+// CustomQueries returns the extended query helpers associated with this CoreData.
+func (cd *CoreData) CustomQueries() db.CustomQueries { return cd.customQueries }
 
 // ImageURLMapper maps image references like "image:" or "cache:" to full URLs.
 func (cd *CoreData) ImageURLMapper(tag, val string) string {

--- a/core/common/coredata_allroles_test.go
+++ b/core/common/coredata_allroles_test.go
@@ -6,15 +6,15 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/internal/db"
+	dbpkg "github.com/arran4/goa4web/internal/db"
 )
 
 func TestAllRolesLazy(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer sqldb.Close()
 
 	rows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).
 		AddRow(int32(1), "user", true, false, nil).
@@ -22,7 +22,7 @@ func TestAllRolesLazy(t *testing.T) {
 
 	mock.ExpectQuery("SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id").WillReturnRows(rows)
 
-	cd := NewCoreData(context.Background(), db.New(db), config.NewRuntimeConfig())
+	cd := NewCoreData(context.Background(), dbpkg.New(sqldb), config.NewRuntimeConfig())
 
 	if _, err := cd.AllRoles(); err != nil {
 		t.Fatalf("AllRoles: %v", err)

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func TestCoreDataLatestNewsLazy(t *testing.T) {
@@ -23,7 +23,7 @@ func TestCoreDataLatestNewsLazy(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
 		"writerName", "writerId", "idsitenews", "forumthread_id", "language_idlanguage",
@@ -62,7 +62,7 @@ func TestWritingCategoriesLazy(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
 		AddRow(1, 0, "a", "b")
 
@@ -94,7 +94,7 @@ func TestAnnouncementForNewsCaching(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	now := time.Now()
 	annRows := sqlmock.NewRows([]string{"id", "site_news_id", "active", "created_at"}).
 		AddRow(1, 1, true, now)
@@ -123,7 +123,7 @@ func TestAnnouncementForNewsError(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 
 	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnError(sql.ErrConnDone)
 
@@ -149,7 +149,7 @@ func TestPublicWritingsLazy(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "Username", "Comments"}).
 		AddRow(1, 1, 0, 1, 0, "t", now, "w", "a", false, now, now, "u", 0)
@@ -198,7 +198,7 @@ func TestCoreDataLatestWritingsLazy(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
 		"idwriting", "users_idusers", "forumthread_id", "language_idlanguage",
@@ -237,7 +237,7 @@ func TestBloggersLazy(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
 	mock.ExpectQuery("SELECT u.username").
 		WithArgs(int32(1), int32(1), int32(1), sqlmock.AnyArg(), int32(16), int32(0)).
@@ -271,7 +271,7 @@ func TestWritersLazy(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
 	mock.ExpectQuery("SELECT u.username").
 		WithArgs(int32(1), int32(1), int32(1), sqlmock.AnyArg(), int32(16), int32(0)).

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func TestTemplateFuncsFirstline(t *testing.T) {
@@ -57,7 +57,7 @@ func TestLatestNewsRespectsPermissions(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{

--- a/handlers/admin/adminHandler.go
+++ b/handlers/admin/adminHandler.go
@@ -34,21 +34,22 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 		CoreData:      cd,
 		AdminSections: cd.Nav.AdminSections(),
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).CustomQueries()
 	ctx := r.Context()
-	count := func(query string, dest *int64) {
-		if err := queries.DB().QueryRowContext(ctx, query).Scan(dest); err != nil && err != sql.ErrNoRows {
-			log.Printf("adminPage count query error: %v", err)
+	count := func(table string, dest *int64) {
+		if c, err := queries.AdminCountTable(ctx, table); err == nil {
+			*dest = c
+		} else if err != sql.ErrNoRows {
+			log.Printf("adminPage count %s error: %v", table, err)
 		}
 	}
-	count("SELECT COUNT(*) FROM users", &data.Stats.Users)
-	count("SELECT COUNT(*) FROM language", &data.Stats.Languages)
-	// site_news renamed from siteNews in schema version 24
-	count("SELECT COUNT(*) FROM site_news", &data.Stats.News)
-	count("SELECT COUNT(*) FROM blogs", &data.Stats.Blogs)
-	count("SELECT COUNT(*) FROM forumtopic", &data.Stats.ForumTopics)
-	count("SELECT COUNT(*) FROM forumthread", &data.Stats.ForumThreads)
-	count("SELECT COUNT(*) FROM writing", &data.Stats.Writings)
+	count("users", &data.Stats.Users)
+	count("language", &data.Stats.Languages)
+	count("site_news", &data.Stats.News)
+	count("blogs", &data.Stats.Blogs)
+	count("forumtopic", &data.Stats.ForumTopics)
+	count("forumthread", &data.Stats.ForumThreads)
+	count("writing", &data.Stats.Writings)
 
 	handlers.TemplateHandler(w, r, "adminPage", data)
 }

--- a/handlers/admin/adminRoleEditPage.go
+++ b/handlers/admin/adminRoleEditPage.go
@@ -15,8 +15,8 @@ import (
 
 // adminRoleEditFormPage shows a form to update a role.
 func adminRoleEditFormPage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
+       cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+       queries := cd.Queries()
 	idStr := mux.Vars(r)["id"]
 	id, _ := strconv.Atoi(idStr)
 
@@ -35,8 +35,8 @@ func adminRoleEditFormPage(w http.ResponseWriter, r *http.Request) {
 
 // adminRoleEditSavePage persists role updates.
 func adminRoleEditSavePage(w http.ResponseWriter, r *http.Request) {
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
+       cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+       queries := cd.CustomQueries()
 	idStr := mux.Vars(r)["id"]
 	id, _ := strconv.Atoi(idStr)
 	if err := r.ParseForm(); err != nil {
@@ -53,7 +53,7 @@ func adminRoleEditSavePage(w http.ResponseWriter, r *http.Request) {
 		Back   string
 	}{CoreData: cd, Back: fmt.Sprintf("/admin/role/%d", id)}
 
-	if _, err := queries.DB().ExecContext(r.Context(), "UPDATE roles SET name=?, can_login=?, is_admin=? WHERE id=?", name, canLogin, isAdmin, id); err != nil {
+	if err := queries.AdminUpdateRole(r.Context(), db.AdminUpdateRoleParams{Name: name, CanLogin: canLogin, IsAdmin: isAdmin, ID: int32(id)}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("update role: %w", err).Error())
 	}
 	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)

--- a/handlers/admin/adminUsageStatsPage.go
+++ b/handlers/admin/adminUsageStatsPage.go
@@ -38,6 +38,7 @@ func AdminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 	cd := data.CoreData
 	cd.PageTitle = "Usage Stats"
 	queries := cd.Queries()
+	cqueries := cd.CustomQueries()
 
 	ctx, cancel := context.WithTimeout(r.Context(), usageTimeout)
 	defer cancel()
@@ -155,7 +156,7 @@ func AdminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 			log.Print("stop monthly usage counts")
 			wg.Done()
 		}()
-		if rows, err := queries.MonthlyUsageCounts(ctx, int32(cd.Config.StatsStartYear)); err == nil {
+		if rows, err := cqueries.MonthlyUsageCounts(ctx, int32(cd.Config.StatsStartYear)); err == nil {
 			data.Monthly = rows
 		} else {
 			addErr("monthly usage counts", err)
@@ -169,7 +170,7 @@ func AdminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 			log.Print("stop user monthly usage counts")
 			wg.Done()
 		}()
-		if rows, err := queries.UserMonthlyUsageCounts(ctx, int32(cd.Config.StatsStartYear)); err == nil {
+		if rows, err := cqueries.UserMonthlyUsageCounts(ctx, int32(cd.Config.StatsStartYear)); err == nil {
 			data.UserMonthly = rows
 		} else {
 			addErr("user monthly usage counts", err)

--- a/handlers/auth/forgotPassword_event_test.go
+++ b/handlers/auth/forgotPassword_event_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 )
 
@@ -25,7 +25,7 @@ func TestForgotPasswordEventData(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, passwd")).WithArgs(int32(1), sqlmock.AnyArg()).WillReturnError(sql.ErrNoRows)

--- a/handlers/auth/forgotPassword_limit_test.go
+++ b/handlers/auth/forgotPassword_limit_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func TestForgotPasswordRateLimit(t *testing.T) {
@@ -24,7 +24,7 @@ func TestForgotPasswordRateLimit(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 
 	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
@@ -56,7 +56,7 @@ func TestForgotPasswordReplaceOld(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 
 	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))

--- a/handlers/auth/forgotPassword_no_email_test.go
+++ b/handlers/auth/forgotPassword_no_email_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func TestForgotPasswordNoEmail(t *testing.T) {
@@ -23,7 +23,7 @@ func TestForgotPasswordNoEmail(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 
@@ -51,7 +51,7 @@ func TestEmailAssociationRequestTask(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "", "u", nil))
 	mock.ExpectExec("INSERT INTO admin_request_queue").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO admin_request_comments").WillReturnResult(sqlmock.NewResult(1, 1))

--- a/handlers/auth/redirectBackPageHandler_test.go
+++ b/handlers/auth/redirectBackPageHandler_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func TestRedirectBackPageHandlerGETAlt(t *testing.T) {
@@ -20,7 +20,7 @@ func TestRedirectBackPageHandlerGETAlt(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 
 	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -77,11 +77,7 @@ func (RegisterTask) Action(w http.ResponseWriter, r *http.Request) any {
 		log.Printf("hashPassword Error: %s", err)
 		return fmt.Errorf("hash password %w", err)
 	}
-	// TODO make a system query
-	result, err := queries.DB().ExecContext(r.Context(),
-		"INSERT INTO users (username) VALUES (?)",
-		username,
-	)
+	result, err := queries.InsertUser(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		if strings.Contains(err.Error(), "Duplicate entry") || strings.Contains(err.Error(), "UNIQUE constraint failed") {
 			return handlers.ErrRedirectOnSamePageHandler(err)

--- a/handlers/auth/verify_password_task_test.go
+++ b/handlers/auth/verify_password_task_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func TestVerifyPasswordAction_Success(t *testing.T) {
@@ -25,7 +25,7 @@ func TestVerifyPasswordAction_Success(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 
 	pwHash, alg, _ := HashPassword("pw")
 	rows := sqlmock.NewRows([]string{"id", "user_id", "passwd", "passwd_algorithm", "verification_code", "created_at", "verified_at"}).
@@ -61,7 +61,7 @@ func TestVerifyPasswordAction_InvalidPassword(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 
 	pwHash, alg, _ := HashPassword("pw")
 	rows := sqlmock.NewRows([]string{"id", "user_id", "passwd", "passwd_algorithm", "verification_code", "created_at", "verified_at"}).

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -152,9 +152,9 @@ func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 			return fmt.Errorf("makeThread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		pthid = int32(pthidi)
-		if err := queries.AssignThreadIdToBlogEntry(r.Context(), db.AssignThreadIdToBlogEntryParams{
-			ForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
-			Idblogs:       int32(bid),
+		if err := queries.SystemAssignBlogThreadID(r.Context(), db.SystemAssignBlogThreadIDParams{
+			ThreadID: sql.NullInt32{Int32: pthid, Valid: true},
+			BlogID:   int32(bid),
 		}); err != nil {
 			return fmt.Errorf("assignThreadIdToBlogEntry fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/bookmarks/mine_test.go
+++ b/handlers/bookmarks/mine_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
-	"github.com/arran4/goa4web/internal/db"
+	dbpkg "github.com/arran4/goa4web/internal/db"
 )
 
 func Test_preprocessBookmarks(t *testing.T) {
@@ -72,13 +72,13 @@ func Test_preprocessBookmarks(t *testing.T) {
 }
 
 func TestMinePage_NoBookmarks(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer sqldb.Close()
 
-	queries := db.New(db)
+	queries := dbpkg.New(sqldb)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT Idbookmarks, list\nFROM bookmarks\nWHERE users_idusers = ?")).
 		WithArgs(int32(1)).WillReturnError(sql.ErrNoRows)
 

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -35,7 +35,10 @@ func AdminAddPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId: int(cd.PreferredLanguageID(cd.Config.DefaultLanguage)),
 	}
 
-	categoryRows, err := queries.GetAllLinkerCategories(r.Context())
+	categoryRows, err := queries.AdminListLinkerCategories(r.Context(), db.AdminListLinkerCategoriesParams{
+		Limit:  int32(cd.PageSize()),
+		Offset: 0,
+	})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/linker/linkerAdminLinkPage.go
+++ b/handlers/linker/linkerAdminLinkPage.go
@@ -33,7 +33,7 @@ func adminLinkPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cats, _ := queries.GetAllLinkerCategories(r.Context())
+	cats, _ := queries.AdminListLinkerCategories(r.Context(), db.AdminListLinkerCategoriesParams{Limit: int32(cd.PageSize()), Offset: 0})
 	langs, _ := cd.Languages()
 
 	cd.PageTitle = fmt.Sprintf("Edit Link %d", id)

--- a/handlers/linker/linkerCategoriesPage.go
+++ b/handlers/linker/linkerCategoriesPage.go
@@ -26,9 +26,11 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
 	cd := data.CoreData
-	categories, err := queries.GetAllLinkerCategoriesForUser(r.Context(), db.GetAllLinkerCategoriesForUserParams{
-		ViewerID:     cd.UserID,
-		ViewerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+	categories, err := queries.ListLinkerCategoriesForLister(r.Context(), db.ListLinkerCategoriesForListerParams{
+		ListerID:     cd.UserID,
+		ListerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		Limit:        int32(cd.PageSize()),
+		Offset:       0,
 	})
 	if err != nil {
 		switch {

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -279,9 +279,9 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			return fmt.Errorf("make thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		pthid = int32(pthidi)
-		if err := queries.AssignLinkerThisThreadId(r.Context(), db.AssignLinkerThisThreadIdParams{
-			ForumthreadID: pthid,
-			Idlinker:      int32(linkId),
+		if err := queries.SystemAssignLinkerThreadID(r.Context(), db.SystemAssignLinkerThreadIDParams{
+			ThreadID: pthid,
+			LinkerID: int32(linkId),
 		}); err != nil {
 			return fmt.Errorf("assign linker thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/linker/linkerPage.go
+++ b/handlers/linker/linkerPage.go
@@ -75,9 +75,11 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		data.Links = append(data.Links, row)
 	}
 
-	categories, err := queries.GetAllLinkerCategoriesForUser(r.Context(), db.GetAllLinkerCategoriesForUserParams{
-		ViewerID:     uid,
-		ViewerUserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
+	categories, err := queries.ListLinkerCategoriesForLister(r.Context(), db.ListLinkerCategoriesForListerParams{
+		ListerID:     uid,
+		ListerUserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
+		Limit:        int32(data.CoreData.PageSize()),
+		Offset:       0,
 	})
 	if err != nil {
 		switch {

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -148,9 +148,9 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		pthid = int32(pthidi)
-		if err := queries.AssignLinkerThisThreadId(r.Context(), db.AssignLinkerThisThreadIdParams{
-			ForumthreadID: pthid,
-			Idlinker:      int32(linkId),
+		if err := queries.SystemAssignLinkerThreadID(r.Context(), db.SystemAssignLinkerThreadIDParams{
+			ThreadID: pthid,
+			LinkerID: int32(linkId),
 		}); err != nil {
 			log.Printf("Error: assignThreadIdToBlogEntry: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -35,9 +35,11 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	uid := data.CoreData.UserID
-	categoryRows, err := queries.GetAllLinkerCategoriesForUser(r.Context(), db.GetAllLinkerCategoriesForUserParams{
-		ViewerID:     uid,
-		ViewerUserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
+	categoryRows, err := queries.ListLinkerCategoriesForLister(r.Context(), db.ListLinkerCategoriesForListerParams{
+		ListerID:     uid,
+		ListerUserID: sql.NullInt32{Int32: uid, Valid: uid != 0},
+		Limit:        int32(data.CoreData.PageSize()),
+		Offset:       0,
 	})
 	if err != nil {
 		switch {

--- a/handlers/news/newsIndexPermissions_test.go
+++ b/handlers/news/newsIndexPermissions_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func TestCustomNewsIndexRoles(t *testing.T) {
@@ -29,7 +29,7 @@ func TestCustomNewsIndexRoles(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	ctx := req.Context()
 	cd = common.NewCoreData(ctx, q, config.NewRuntimeConfig())
 	cd.SetRoles([]string{"content writer", "administrator"})

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -147,9 +147,9 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			return fmt.Errorf("make thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		pthid = int32(pthidi)
-		if err := queries.AssignNewsThisThreadId(r.Context(), db.AssignNewsThisThreadIdParams{
-			ForumthreadID: pthid,
-			Idsitenews:    int32(pid),
+		if err := queries.SystemAssignNewsThreadID(r.Context(), db.SystemAssignNewsThreadIDParams{
+			ThreadID: pthid,
+			NewsID:   int32(pid),
 		}); err != nil {
 			log.Printf("Error: assign_news_to_thread: %s", err)
 			return fmt.Errorf("assign news thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/search/admin.go
+++ b/handlers/search/admin.go
@@ -34,23 +34,24 @@ func adminSearchPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.CoreData.PageTitle = "Search Admin"
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).CustomQueries()
 	ctx := r.Context()
-	count := func(query string, dest *int64) {
-		if err := queries.DB().QueryRowContext(ctx, query).Scan(dest); err != nil && err != sql.ErrNoRows {
-			log.Printf("adminSearchPage count query error: %v", err)
+	count := func(table string, dest *int64) {
+		if c, err := queries.AdminCountTable(ctx, table); err == nil {
+			*dest = c
+		} else if err != sql.ErrNoRows {
+			log.Printf("adminSearchPage count %s error: %v", table, err)
 		}
 	}
 
-	// TODO make queries and find another way of making this DRY if really required
-	count("SELECT COUNT(*) FROM searchwordlist", &data.Stats.Words)
-	count("SELECT COUNT(*) FROM comments_search", &data.Stats.Comments)
-	count("SELECT COUNT(*) FROM site_news_search", &data.Stats.News)
-	count("SELECT COUNT(*) FROM blogs_search", &data.Stats.Blogs)
-	count("SELECT COUNT(*) FROM linker_search", &data.Stats.Linker)
-	count("SELECT COUNT(*) FROM writing_search", &data.Stats.Writing)
-	count("SELECT COUNT(*) FROM writing_search", &data.Stats.Writings)
-	count("SELECT COUNT(*) FROM imagepost_search", &data.Stats.Images)
+	count("searchwordlist", &data.Stats.Words)
+	count("comments_search", &data.Stats.Comments)
+	count("site_news_search", &data.Stats.News)
+	count("blogs_search", &data.Stats.Blogs)
+	count("linker_search", &data.Stats.Linker)
+	count("writing_search", &data.Stats.Writing)
+	count("writing_search", &data.Stats.Writings)
+	count("imagepost_search", &data.Stats.Images)
 
 	handlers.TemplateHandler(w, r, "adminSearchPage", data)
 }

--- a/handlers/search/permissions_test.go
+++ b/handlers/search/permissions_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func TestCanSearch(t *testing.T) {
@@ -18,7 +18,7 @@ func TestCanSearch(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	cd := common.NewCoreData(context.Background(), queries, config.NewRuntimeConfig())
 
 	// No grants

--- a/handlers/user/addEmailTask_invalid_test.go
+++ b/handlers/user/addEmailTask_invalid_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 )
 
@@ -26,7 +26,7 @@ func TestAddEmailTaskInvalid(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 
 	store := sessions.NewCookieStore([]byte("test"))
 	core.Store = store

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/middleware"
 	"github.com/arran4/goa4web/internal/notifications"
@@ -45,7 +45,7 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	queries := db.New(db)
+	queries := dbtest.New(db)
 
 	mock.ExpectQuery("SELECT idusers").
 		WithArgs(sqlmock.AnyArg()).

--- a/handlers/user/userEmailPage_event_test.go
+++ b/handlers/user/userEmailPage_event_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/gorilla/sessions"
 )
@@ -28,7 +28,7 @@ func TestAddEmailTaskEventData(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	mock.ExpectQuery("SELECT id, user_id, email").WillReturnError(sql.ErrNoRows)
 	mock.ExpectExec("INSERT INTO user_emails").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectQuery("SELECT u.idusers").WithArgs(int32(1)).
@@ -76,7 +76,7 @@ func TestVerifyRemovesDuplicates(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 
 	store = sessions.NewCookieStore([]byte("test"))
 	core.Store = store
@@ -130,7 +130,7 @@ func TestResendVerificationEmailTaskEventData(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	mock.ExpectQuery("SELECT id, user_id, email").WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "a@example.com", nil, nil, nil, 0))
 	mock.ExpectExec("UPDATE user_emails SET").WillReturnResult(sqlmock.NewResult(1, 1))
 

--- a/handlers/user/userEmailVerify_test.go
+++ b/handlers/user/userEmailVerify_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func TestUserEmailVerifyCodePage_Invalid(t *testing.T) {
@@ -25,7 +25,7 @@ func TestUserEmailVerifyCodePage_Invalid(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	code := "abc"
 	rows := sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).
 		AddRow(1, 1, "e@example.com", nil, code, nil, 0)
@@ -60,7 +60,7 @@ func TestUserEmailVerifyCodePage_Success(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	code := "xyz"
 	rows := sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).
 		AddRow(1, 1, "e@example.com", nil, code, nil, 0)

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
 	logProv "github.com/arran4/goa4web/internal/email/log"
 	"time"
@@ -56,7 +56,7 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	cfg.EmailProvider = ""
 	db, mock, _ := sqlmock.New()
 	defer db.Close()
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("POST", "/email", nil)
@@ -89,7 +89,7 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 
 	db, mock, _ := sqlmock.New()
 	defer db.Close()
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("POST", "/email", nil)
@@ -111,7 +111,7 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 func TestUserEmailPage_ShowError(t *testing.T) {
 	db, mock, _ := sqlmock.New()
 	defer db.Close()
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("GET", "/usr/email?error=missing", nil)
@@ -135,7 +135,7 @@ func TestUserEmailPage_ShowError(t *testing.T) {
 func TestUserEmailPage_NoUnverified(t *testing.T) {
 	db, mock, _ := sqlmock.New()
 	defer db.Close()
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", time.Now(), nil, nil, 100))
 
@@ -161,7 +161,7 @@ func TestUserEmailPage_NoUnverified(t *testing.T) {
 func TestUserEmailPage_NoVerified(t *testing.T) {
 	db, mock, _ := sqlmock.New()
 	defer db.Close()
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}))
 
@@ -191,7 +191,7 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	store = sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = sessionName
@@ -246,7 +246,7 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	store = sessions.NewCookieStore([]byte("test"))
 
 	form := url.Values{}
@@ -293,7 +293,7 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	store = sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = sessionName

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -121,7 +121,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			return fmt.Errorf("make thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		pthid = int32(pthidi)
-		if err := queries.AssignWritingThisThreadId(r.Context(), db.AssignWritingThisThreadIdParams{ForumthreadID: pthid, Idwriting: int32(aid)}); err != nil {
+		if err := queries.SystemAssignWritingThreadID(r.Context(), db.SystemAssignWritingThreadIDParams{ThreadID: pthid, WritingID: int32(aid)}); err != nil {
 			return fmt.Errorf("assign article thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	}

--- a/handlers/writings/writing_category_change_task_test.go
+++ b/handlers/writings/writing_category_change_task_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func TestWritingCategoryChangeTask(t *testing.T) {
@@ -21,7 +21,7 @@ func TestWritingCategoryChangeTask(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
 		AddRow(1, 0, "a", "")
@@ -53,7 +53,7 @@ func TestWritingCategoryWouldLoop(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
 		AddRow(1, 0, "a", "").
@@ -89,7 +89,7 @@ func TestWritingCategoryWouldLoopHeadToTail(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
 		AddRow(1, 0, "a", "").
@@ -117,7 +117,7 @@ func TestWritingCategoryWouldLoopAfterNode(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
 		AddRow(1, 0, "a", "").
@@ -144,7 +144,7 @@ func TestWritingCategoryChangeTaskLoop(t *testing.T) {
 	}
 	defer db.Close()
 
-	queries := db.New(db)
+	queries := dbtest.New(db)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
 		AddRow(1, 2, "a", "").

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -142,9 +142,9 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		pthid := int32(pthidi)
-		if err := queries.AssignWritingThisThreadId(r.Context(), db.AssignWritingThisThreadIdParams{
-			ForumthreadID: pthid,
-			Idwriting:     writing.Idwriting,
+		if err := queries.SystemAssignWritingThreadID(r.Context(), db.SystemAssignWritingThreadIDParams{
+			ThreadID:  pthid,
+			WritingID: writing.Idwriting,
 		}); err != nil {
 			log.Printf("Error: assign_article_to_thread: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -357,9 +357,9 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		pthid = int32(pthidi)
-		if err := queries.AssignWritingThisThreadId(r.Context(), db.AssignWritingThisThreadIdParams{
-			ForumthreadID: pthid,
-			Idwriting:     int32(aid),
+		if err := queries.SystemAssignWritingThreadID(r.Context(), db.SystemAssignWritingThreadIDParams{
+			ThreadID:  pthid,
+			WritingID: int32(aid),
 		}); err != nil {
 			log.Printf("Error: assign_article_to_thread: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/internal/db/customqueries.go
+++ b/internal/db/customqueries.go
@@ -7,4 +7,16 @@ type CustomQueries interface {
 	ListBloggers(ctx context.Context, arg ListBloggersParams) ([]*BloggerCountRow, error)
 	SearchWriters(ctx context.Context, arg SearchWritersParams) ([]*WriterCountRow, error)
 	ListWriters(ctx context.Context, arg ListWritersParams) ([]*WriterCountRow, error)
+	InsertFAQForWriter(ctx context.Context, arg InsertFAQForWriterParams) (int64, error)
+	ListUsersFiltered(ctx context.Context, arg ListUsersFilteredParams) ([]*UserFilteredRow, error)
+	SearchUsersFiltered(ctx context.Context, arg SearchUsersFilteredParams) ([]*UserFilteredRow, error)
+	AdminCountForumCategories(ctx context.Context) (int64, error)
+	AdminCountForumTopics(ctx context.Context) (int64, error)
+	AdminCountForumThreads(ctx context.Context) (int64, error)
+	AdminCountTable(ctx context.Context, table string) (int64, error)
+	AdminDeleteUser(ctx context.Context, id int32) error
+	AdminUpdateUserUsername(ctx context.Context, arg AdminUpdateUserUsernameParams) error
+	AdminUpdateRole(ctx context.Context, arg AdminUpdateRoleParams) error
+	MonthlyUsageCounts(ctx context.Context, startYear int32) ([]*MonthlyUsageRow, error)
+	UserMonthlyUsageCounts(ctx context.Context, startYear int32) ([]*UserMonthlyUsageRow, error)
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -80,6 +80,7 @@ type Querier interface {
 	AdminListFailedEmails(ctx context.Context, arg AdminListFailedEmailsParams) ([]*AdminListFailedEmailsRow, error)
 	// admin task
 	AdminListGrantsByRoleID(ctx context.Context, roleID sql.NullInt32) ([]*Grant, error)
+	AdminListLinkerCategories(ctx context.Context, arg AdminListLinkerCategoriesParams) ([]*LinkerCategory, error)
 	AdminListLoginAttempts(ctx context.Context) ([]*LoginAttempt, error)
 	AdminListPendingDeactivatedBlogs(ctx context.Context, arg AdminListPendingDeactivatedBlogsParams) ([]*AdminListPendingDeactivatedBlogsRow, error)
 	AdminListPendingDeactivatedComments(ctx context.Context, arg AdminListPendingDeactivatedCommentsParams) ([]*AdminListPendingDeactivatedCommentsRow, error)
@@ -144,10 +145,6 @@ type Querier interface {
 	AdminWordListWithCounts(ctx context.Context, arg AdminWordListWithCountsParams) ([]*AdminWordListWithCountsRow, error)
 	AdminWordListWithCountsByPrefix(ctx context.Context, arg AdminWordListWithCountsByPrefixParams) ([]*AdminWordListWithCountsByPrefixRow, error)
 	AdminWritingCategoryCounts(ctx context.Context) ([]*AdminWritingCategoryCountsRow, error)
-	AssignLinkerThisThreadId(ctx context.Context, arg AssignLinkerThisThreadIdParams) error
-	AssignNewsThisThreadId(ctx context.Context, arg AssignNewsThisThreadIdParams) error
-	AssignThreadIdToBlogEntry(ctx context.Context, arg AssignThreadIdToBlogEntryParams) error
-	AssignWritingThisThreadId(ctx context.Context, arg AssignWritingThisThreadIdParams) error
 	BlogsSearchFirst(ctx context.Context, arg BlogsSearchFirstParams) ([]int32, error)
 	BlogsSearchNext(ctx context.Context, arg BlogsSearchNextParams) ([]int32, error)
 	CheckGrant(ctx context.Context, arg CheckGrantParams) (int32, error)
@@ -217,8 +214,6 @@ type Querier interface {
 	GetAllForumTopicsByCategoryIdForUserWithLastPosterName(ctx context.Context, arg GetAllForumTopicsByCategoryIdForUserWithLastPosterNameParams) ([]*GetAllForumTopicsByCategoryIdForUserWithLastPosterNameRow, error)
 	GetAllForumTopicsForUser(ctx context.Context, arg GetAllForumTopicsForUserParams) ([]*GetAllForumTopicsForUserRow, error)
 	GetAllImagePostsForIndex(ctx context.Context) ([]*GetAllImagePostsForIndexRow, error)
-	GetAllLinkerCategories(ctx context.Context) ([]*LinkerCategory, error)
-	GetAllLinkerCategoriesForUser(ctx context.Context, arg GetAllLinkerCategoriesForUserParams) ([]*LinkerCategory, error)
 	GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow, error)
 	GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUser(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserRow, error)
 	GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginated(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow, error)
@@ -332,6 +327,7 @@ type Querier interface {
 	ListGrantsByUserID(ctx context.Context, userID sql.NullInt32) ([]*Grant, error)
 	ListImagePostsByBoardForLister(ctx context.Context, arg ListImagePostsByBoardForListerParams) ([]*ListImagePostsByBoardForListerRow, error)
 	ListImagePostsByPosterForLister(ctx context.Context, arg ListImagePostsByPosterForListerParams) ([]*ListImagePostsByPosterForListerRow, error)
+	ListLinkerCategoriesForLister(ctx context.Context, arg ListLinkerCategoriesForListerParams) ([]*LinkerCategory, error)
 	ListPublicWritingsByUserForLister(ctx context.Context, arg ListPublicWritingsByUserForListerParams) ([]*ListPublicWritingsByUserForListerRow, error)
 	ListPublicWritingsInCategoryForLister(ctx context.Context, arg ListPublicWritingsInCategoryForListerParams) ([]*ListPublicWritingsInCategoryForListerRow, error)
 	ListSubscribersForPattern(ctx context.Context, arg ListSubscribersForPatternParams) ([]int32, error)
@@ -377,6 +373,10 @@ type Querier interface {
 	SystemAddToImagePostSearch(ctx context.Context, arg SystemAddToImagePostSearchParams) error
 	SystemAddToLinkerSearch(ctx context.Context, arg SystemAddToLinkerSearchParams) error
 	SystemAddToSiteNewsSearch(ctx context.Context, arg SystemAddToSiteNewsSearchParams) error
+	SystemAssignBlogThreadID(ctx context.Context, arg SystemAssignBlogThreadIDParams) error
+	SystemAssignLinkerThreadID(ctx context.Context, arg SystemAssignLinkerThreadIDParams) error
+	SystemAssignNewsThreadID(ctx context.Context, arg SystemAssignNewsThreadIDParams) error
+	SystemAssignWritingThreadID(ctx context.Context, arg SystemAssignWritingThreadIDParams) error
 	SystemCountDeadLetters(ctx context.Context) (int64, error)
 	// SystemCountLanguages counts all languages.
 	SystemCountLanguages(ctx context.Context) (int64, error)

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -31,10 +31,10 @@ WHERE EXISTS (
       ))
 );
 
--- name: AssignThreadIdToBlogEntry :exec
+-- name: SystemAssignBlogThreadID :exec
 UPDATE blogs
-SET forumthread_id = ?
-WHERE idblogs = ?;
+SET forumthread_id = sqlc.arg(thread_id)
+WHERE idblogs = sqlc.arg(blog_id);
 
 -- name: ListBlogEntriesForLister :many
 WITH RECURSIVE role_ids(id) AS (

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -76,22 +76,6 @@ func (q *Queries) AdminGetAllBlogEntriesByUser(ctx context.Context, arg AdminGet
 	return items, nil
 }
 
-const assignThreadIdToBlogEntry = `-- name: AssignThreadIdToBlogEntry :exec
-UPDATE blogs
-SET forumthread_id = ?
-WHERE idblogs = ?
-`
-
-type AssignThreadIdToBlogEntryParams struct {
-	ForumthreadID sql.NullInt32
-	Idblogs       int32
-}
-
-func (q *Queries) AssignThreadIdToBlogEntry(ctx context.Context, arg AssignThreadIdToBlogEntryParams) error {
-	_, err := q.db.ExecContext(ctx, assignThreadIdToBlogEntry, arg.ForumthreadID, arg.Idblogs)
-	return err
-}
-
 const blogsSearchFirst = `-- name: BlogsSearchFirst :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
@@ -790,6 +774,22 @@ func (q *Queries) ListBloggersSearchForLister(ctx context.Context, arg ListBlogg
 		return nil, err
 	}
 	return items, nil
+}
+
+const systemAssignBlogThreadID = `-- name: SystemAssignBlogThreadID :exec
+UPDATE blogs
+SET forumthread_id = ?
+WHERE idblogs = ?
+`
+
+type SystemAssignBlogThreadIDParams struct {
+	ThreadID sql.NullInt32
+	BlogID   int32
+}
+
+func (q *Queries) SystemAssignBlogThreadID(ctx context.Context, arg SystemAssignBlogThreadIDParams) error {
+	_, err := q.db.ExecContext(ctx, systemAssignBlogThreadID, arg.ThreadID, arg.BlogID)
+	return err
 }
 
 const systemGetAllBlogsForIndex = `-- name: SystemGetAllBlogsForIndex :many

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -14,8 +14,10 @@ FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 WHERE s.idsiteNews = ?;
 
--- name: AssignNewsThisThreadId :exec
-UPDATE site_news SET forumthread_id = ? WHERE idsiteNews = ?;
+-- name: SystemAssignNewsThreadID :exec
+UPDATE site_news
+SET forumthread_id = sqlc.arg(thread_id)
+WHERE idsiteNews = sqlc.arg(news_id);
 
 -- name: GetNewsPostByIdWithWriterIdAndThreadCommentCount :one
 WITH RECURSIVE role_ids(id) AS (

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -11,20 +11,6 @@ import (
 	"strings"
 )
 
-const assignNewsThisThreadId = `-- name: AssignNewsThisThreadId :exec
-UPDATE site_news SET forumthread_id = ? WHERE idsiteNews = ?
-`
-
-type AssignNewsThisThreadIdParams struct {
-	ForumthreadID int32
-	Idsitenews    int32
-}
-
-func (q *Queries) AssignNewsThisThreadId(ctx context.Context, arg AssignNewsThisThreadIdParams) error {
-	_, err := q.db.ExecContext(ctx, assignNewsThisThreadId, arg.ForumthreadID, arg.Idsitenews)
-	return err
-}
-
 const createNewsPost = `-- name: CreateNewsPost :execlastid
 INSERT INTO site_news (news, users_idusers, occurred, language_idlanguage)
 VALUES (?, ?, NOW(), ?)
@@ -356,6 +342,22 @@ UPDATE site_news SET last_index = NOW() WHERE idsiteNews = ?
 
 func (q *Queries) SetSiteNewsLastIndex(ctx context.Context, idsitenews int32) error {
 	_, err := q.db.ExecContext(ctx, setSiteNewsLastIndex, idsitenews)
+	return err
+}
+
+const systemAssignNewsThreadID = `-- name: SystemAssignNewsThreadID :exec
+UPDATE site_news
+SET forumthread_id = ?
+WHERE idsiteNews = ?
+`
+
+type SystemAssignNewsThreadIDParams struct {
+	ThreadID int32
+	NewsID   int32
+}
+
+func (q *Queries) SystemAssignNewsThreadID(ctx context.Context, arg SystemAssignNewsThreadIDParams) error {
+	_, err := q.db.ExecContext(ctx, systemAssignNewsThreadID, arg.ThreadID, arg.NewsID)
 	return err
 }
 

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -177,8 +177,10 @@ WHERE EXISTS (
 );
 
 
--- name: AssignWritingThisThreadId :exec
-UPDATE writing SET forumthread_id = ? WHERE idwriting = ?;
+-- name: SystemAssignWritingThreadID :exec
+UPDATE writing
+SET forumthread_id = sqlc.arg(thread_id)
+WHERE idwriting = sqlc.arg(writing_id);
 
 
 -- name: GetAllWritingsByAuthorForLister :many

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -175,20 +175,6 @@ func (q *Queries) AdminUpdateWritingCategory(ctx context.Context, arg AdminUpdat
 	return err
 }
 
-const assignWritingThisThreadId = `-- name: AssignWritingThisThreadId :exec
-UPDATE writing SET forumthread_id = ? WHERE idwriting = ?
-`
-
-type AssignWritingThisThreadIdParams struct {
-	ForumthreadID int32
-	Idwriting     int32
-}
-
-func (q *Queries) AssignWritingThisThreadId(ctx context.Context, arg AssignWritingThisThreadIdParams) error {
-	_, err := q.db.ExecContext(ctx, assignWritingThisThreadId, arg.ForumthreadID, arg.Idwriting)
-	return err
-}
-
 const getAllWritingsByAuthorForLister = `-- name: GetAllWritingsByAuthorForLister :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
@@ -992,6 +978,22 @@ UPDATE writing SET last_index = NOW() WHERE idwriting = ?
 
 func (q *Queries) SetWritingLastIndex(ctx context.Context, idwriting int32) error {
 	_, err := q.db.ExecContext(ctx, setWritingLastIndex, idwriting)
+	return err
+}
+
+const systemAssignWritingThreadID = `-- name: SystemAssignWritingThreadID :exec
+UPDATE writing
+SET forumthread_id = ?
+WHERE idwriting = ?
+`
+
+type SystemAssignWritingThreadIDParams struct {
+	ThreadID  int32
+	WritingID int32
+}
+
+func (q *Queries) SystemAssignWritingThreadID(ctx context.Context, arg SystemAssignWritingThreadIDParams) error {
+	_, err := q.db.ExecContext(ctx, systemAssignWritingThreadID, arg.ThreadID, arg.WritingID)
 	return err
 }
 

--- a/internal/email/emaildefaults/email_test.go
+++ b/internal/email/emaildefaults/email_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 	mockdlq "github.com/arran4/goa4web/internal/dlq/mock"
 	"github.com/arran4/goa4web/internal/email"
 	jmapProv "github.com/arran4/goa4web/internal/email/jmap"
@@ -94,10 +94,10 @@ func TestInsertPendingEmail(t *testing.T) {
 	}
 	defer db.Close()
 
-	q := db.New(db)
+	q := dbtest.New(db)
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 1, Valid: true}, "body", false).WillReturnResult(sqlmock.NewResult(1, 1))
 
-	if err := q.InsertPendingEmail(context.Background(), db.InsertPendingEmailParams{ToUserID: sql.NullInt32{Int32: 1, Valid: true}, Body: "body", DirectEmail: false}); err != nil {
+	if err := q.InsertPendingEmail(context.Background(), dbtest.InsertPendingEmailParams{ToUserID: sql.NullInt32{Int32: 1, Valid: true}, Body: "body", DirectEmail: false}); err != nil {
 		t.Fatalf("insert: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -114,7 +114,7 @@ func TestEmailQueueWorker(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	rows := sqlmock.NewRows([]string{"id", "to_user_id", "body", "error_count", "direct_email"}).AddRow(1, 2, "b", 0, false)
 	mock.ExpectQuery("SELECT id, to_user_id, body, error_count, direct_email").WillReturnRows(rows)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
@@ -150,7 +150,7 @@ func TestProcessPendingEmailDLQ(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	rows := sqlmock.NewRows([]string{"id", "to_user_id", "body", "error_count", "direct_email"}).AddRow(1, 2, "b", 4, false)
 	mock.ExpectQuery("SELECT id, to_user_id, body, error_count, direct_email").WillReturnRows(rows)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -100,7 +100,6 @@ func CoreAdderMiddlewareWithDB(sdb *sql.DB, cfg *config.RuntimeConfig, verbosity
 			}
 			cd := common.NewCoreData(r.Context(), queries, cfg,
 				common.WithImageSigner(signer),
-				common.WithCustomQueries(sdb),
 				common.WithLinkSigner(linkSigner),
 				common.WithSession(session),
 				common.WithEmailProvider(provider),

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
 	imagesign "github.com/arran4/goa4web/internal/images"
 	linksign "github.com/arran4/goa4web/internal/linksign"
@@ -41,7 +41,7 @@ func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
 
 	session := &sessions.Session{ID: "sessid", Values: map[interface{}]interface{}{"UID": int32(1)}}
 	req := httptest.NewRequest("GET", "/", nil)
-	q := db.New(db)
+	q := dbtest.New(db)
 	cd := common.NewCoreData(req.Context(), q, cfg)
 	ctx := context.WithValue(req.Context(), core.ContextValues("session"), session)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -83,7 +83,7 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 
 	session := &sessions.Session{ID: "sessid"}
 	req := httptest.NewRequest("GET", "/", nil)
-	q := db.New(db)
+	q := dbtest.New(db)
 	cd := common.NewCoreData(req.Context(), q, cfg)
 	ctx := context.WithValue(req.Context(), core.ContextValues("session"), session)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func newCoreData(t *testing.T, cfg config.RuntimeConfig) (*common.CoreData, sqlmock.Sqlmock, func()) {
@@ -21,7 +21,7 @@ func newCoreData(t *testing.T, cfg config.RuntimeConfig) (*common.CoreData, sqlm
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	cleanup := func() { db.Close() }
-	queries := db.New(db)
+	queries := dbtest.New(db)
 	if cfg.HSTSHeaderValue == "" {
 		cfg.HSTSHeaderValue = "max-age=63072000; includeSubDomains"
 	}

--- a/internal/notifications/bus_worker_test.go
+++ b/internal/notifications/bus_worker_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/workers/postcountworker"
 )
@@ -86,7 +86,7 @@ func TestCollectSubscribersQuery(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 
 	patterns := []string{"post:/blog/1", "post:/blog/*"}
 	rows := sqlmock.NewRows([]string{"users_idusers"}).AddRow(1).AddRow(2)
@@ -136,7 +136,7 @@ func TestProcessEventDLQ(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	prov := &errProvider{}
 	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(cfg))
 	dlqRec := &recordDLQ{}
@@ -165,7 +165,7 @@ func TestProcessEventSubscribeSelf(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	n := New(WithQueries(q), WithConfig(cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/p", Task: TaskTest, UserID: 1}, nil); err != nil {
@@ -185,7 +185,7 @@ func TestProcessEventNoAutoSubscribe(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	n := New(WithQueries(q), WithConfig(cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/p", Task: TaskTest, UserID: 1}, nil); err != nil {
@@ -207,7 +207,7 @@ func TestProcessEventAdminNotify(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	prov := &busDummyProvider{}
 	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(cfg))
 
@@ -229,7 +229,7 @@ func TestProcessEventWritingSubscribers(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	n := New(WithQueries(q), WithConfig(cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/writings/article/1", Task: TaskTest, UserID: 2, Data: map[string]any{"target": Target{Type: "writing", ID: 1}}}, nil); err != nil {
@@ -263,7 +263,7 @@ func TestProcessEventTargetUsers(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	n := New(WithQueries(q), WithConfig(cfg))
 
 	for _, id := range []int32{2, 3} {
@@ -303,7 +303,7 @@ func TestBusWorker(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 
 	prov := &busDummyProvider{}
 	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(cfg))
@@ -348,7 +348,7 @@ func TestProcessEventAutoSubscribe(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	n := New(WithQueries(q), WithConfig(cfg))
 
 	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies"}).

--- a/internal/notifications/linker_queue_test.go
+++ b/internal/notifications/linker_queue_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func TestLinkerQueueNotifierMessages(t *testing.T) {
@@ -34,7 +34,7 @@ func TestLinkerQueueNotifierMessages(t *testing.T) {
 		WithArgs("linkerApprovedEmailSubject.gotxt").
 		WillReturnRows(sqlmock.NewRows([]string{"body"}).AddRow(""))
 
-	q := db.New(db)
+	q := dbtest.New(db)
 	n := New(WithQueries(q), WithConfig(cfg))
 	data := map[string]any{
 		"Title":     "Example",

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func TestNotificationsQueries(t *testing.T) {
@@ -18,9 +18,9 @@ func TestNotificationsQueries(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	mock.ExpectExec("INSERT INTO notifications").WithArgs(int32(1), sqlmock.AnyArg(), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-	if err := q.InsertNotification(context.Background(), db.InsertNotificationParams{UsersIdusers: 1, Link: sql.NullString{String: "/x", Valid: true}, Message: sql.NullString{String: "hi", Valid: true}}); err != nil {
+	if err := q.InsertNotification(context.Background(), dbtest.InsertNotificationParams{UsersIdusers: 1, Link: sql.NullString{String: "/x", Valid: true}, Message: sql.NullString{String: "hi", Valid: true}}); err != nil {
 		t.Fatalf("insert: %v", err)
 	}
 	rows := sqlmock.NewRows([]string{"cnt"}).AddRow(1)
@@ -58,7 +58,7 @@ func TestNotifierNotifyAdmins(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	cfg := config.NewRuntimeConfig()
 	cfg.EmailEnabled = true
 	cfg.AdminNotify = true
@@ -92,7 +92,7 @@ func TestNotifierInitialization(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	n = New(WithQueries(q), WithConfig(cfg))
 	if n.Queries != q {
 		t.Fatalf("queries not set via option")

--- a/internal/notifications/permission_tasks_test.go
+++ b/internal/notifications/permission_tasks_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers/user"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
@@ -44,7 +44,7 @@ func TestProcessEventPermissionTasks(t *testing.T) {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
-	q := db.New(db)
+	q := dbtest.New(db)
 	n := notif.New(notif.WithQueries(q), notif.WithConfig(cfg))
 
 	var wg sync.WaitGroup

--- a/workers/postcountworker/postupdate_test.go
+++ b/workers/postcountworker/postupdate_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/arran4/goa4web/internal/db"
+	dbtest "github.com/arran4/goa4web/internal/db"
 )
 
 func TestPostUpdate(t *testing.T) {
@@ -15,7 +15,7 @@ func TestPostUpdate(t *testing.T) {
 	}
 	defer db.Close()
 
-	q := db.New(db)
+	q := dbtest.New(db)
 	mock.ExpectExec("AdminRecalculateForumThreadByIdMetaData").
 		WithArgs(int32(1)).
 		WillReturnResult(sqlmock.NewResult(0, 0))


### PR DESCRIPTION
## Summary
- avoid exposing raw *sql.DB from Querier by adding explicit admin helpers
- support writer FAQ creation and admin forum statistics via new query helpers
- update handlers to rely on named queries instead of ExecContext

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688eb69ad22c832f9a751efc59b17911