### PR TITLE
refactor: tighten DB access and standardise queries

### DIFF
--- a/cmd/goa4web/user_add.go
+++ b/cmd/goa4web/user_add.go
@@ -64,10 +64,7 @@ func createUser(root *rootCmd, username, email, password string, admin bool) err
 	if err != nil {
 		return fmt.Errorf("hash password: %w", err)
 	}
-	res, err := queries.DB().ExecContext(ctx,
-		"INSERT INTO users (username) VALUES (?)",
-		username,
-	)
+	res, err := queries.InsertUser(ctx, sql.NullString{String: username, Valid: true})
 	if err != nil {
 		if strings.Contains(err.Error(), "Duplicate entry") || strings.Contains(err.Error(), "UNIQUE constraint failed") {
 			return fmt.Errorf("user already exists")

--- a/handlers/admin/adminHandler.go
+++ b/handlers/admin/adminHandler.go
@@ -1,15 +1,12 @@
 package admin
 
 import (
-	"database/sql"
 	_ "embed"
 	"github.com/arran4/goa4web/core/consts"
-	"log"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 )
 
 func AdminPage(w http.ResponseWriter, r *http.Request) {
@@ -36,25 +33,18 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 		AdminSections: cd.Nav.AdminSections(),
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	ctx := r.Context()
-	dber, ok := queries.(interface{ DB() db.DBTX })
-	if !ok {
+	counts, err := queries.AdminSiteCounts(r.Context())
+	if err != nil {
 		http.Error(w, "database not available", http.StatusInternalServerError)
 		return
 	}
-	count := func(query string, dest *int64) {
-		if err := dber.DB().QueryRowContext(ctx, query).Scan(dest); err != nil && err != sql.ErrNoRows {
-			log.Printf("adminPage count query error: %v", err)
-		}
-	}
-	count("SELECT COUNT(*) FROM users", &data.Stats.Users)
-	count("SELECT COUNT(*) FROM language", &data.Stats.Languages)
-	// site_news renamed from siteNews in schema version 24
-	count("SELECT COUNT(*) FROM site_news", &data.Stats.News)
-	count("SELECT COUNT(*) FROM blogs", &data.Stats.Blogs)
-	count("SELECT COUNT(*) FROM forumtopic", &data.Stats.ForumTopics)
-	count("SELECT COUNT(*) FROM forumthread", &data.Stats.ForumThreads)
-	count("SELECT COUNT(*) FROM writing", &data.Stats.Writings)
+	data.Stats.Users = counts.Users
+	data.Stats.Languages = counts.Languages
+	data.Stats.News = counts.News
+	data.Stats.Blogs = counts.Blogs
+	data.Stats.ForumTopics = counts.ForumTopics
+	data.Stats.ForumThreads = counts.ForumThreads
+	data.Stats.Writings = counts.Writings
 
 	handlers.TemplateHandler(w, r, "adminPage", data)
 }

--- a/handlers/admin/adminRoleEditPage.go
+++ b/handlers/admin/adminRoleEditPage.go
@@ -53,12 +53,13 @@ func adminRoleEditSavePage(w http.ResponseWriter, r *http.Request) {
 		Back   string
 	}{CoreData: cd, Back: fmt.Sprintf("/admin/role/%d", id)}
 
-	if dber, ok := queries.(interface{ DB() db.DBTX }); ok {
-		if _, err := dber.DB().ExecContext(r.Context(), "UPDATE roles SET name=?, can_login=?, is_admin=? WHERE id=?", name, canLogin, isAdmin, id); err != nil {
-			data.Errors = append(data.Errors, fmt.Errorf("update role: %w", err).Error())
-		}
-	} else {
-		data.Errors = append(data.Errors, "database not available")
+	if err := queries.AdminUpdateRole(r.Context(), db.AdminUpdateRoleParams{
+		Name:     name,
+		CanLogin: canLogin,
+		IsAdmin:  isAdmin,
+		ID:       int32(id),
+	}); err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("update role: %w", err).Error())
 	}
 	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/handlers/faq/create_question_task.go
+++ b/handlers/faq/create_question_task.go
@@ -39,16 +39,14 @@ func (CreateQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	dbq, ok := queries.(interface{ DB() db.DBTX })
-	if !ok {
-		return fmt.Errorf("querier missing DB method")
-	}
-	res, err := dbq.DB().ExecContext(r.Context(),
-		"INSERT INTO faq (question, answer, faqCategories_idfaqCategories, users_idusers, language_idlanguage) VALUES (?, ?, ?, ?, ?)",
-		sql.NullString{String: question, Valid: true},
-		sql.NullString{String: answer, Valid: true},
-		int32(category), uid, 1,
-	)
+	res, err := queries.CreateFAQEntryForWriter(r.Context(), db.CreateFAQEntryForWriterParams{
+		Question:   sql.NullString{String: question, Valid: true},
+		Answer:     sql.NullString{String: answer, Valid: true},
+		CategoryID: int32(category),
+		WriterID:   uid,
+		LanguageID: 1,
+		ViewerID:   uid,
+	})
 	if err != nil {
 		return fmt.Errorf("insert faq fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/forum/adminForumHandler.go
+++ b/handlers/forum/adminForumHandler.go
@@ -91,20 +91,14 @@ func AdminForumPage(w http.ResponseWriter, r *http.Request) {
 	categoryTree := NewCategoryTree(categoryRows, topicRows)
 	data.Categories = categoryTree.CategoryChildrenLookup[0]
 
-	ctx := r.Context()
-	dber, ok := queries.(interface{ DB() db.DBTX })
-	if !ok {
+	counts, err := queries.AdminForumCounts(r.Context())
+	if err != nil {
 		http.Error(w, "database not available", http.StatusInternalServerError)
 		return
 	}
-	count := func(q string, dest *int64) {
-		if err := dber.DB().QueryRowContext(ctx, q).Scan(dest); err != nil && err != sql.ErrNoRows {
-			log.Printf("forumAdminPage count query error: %v", err)
-		}
-	}
-	count("SELECT COUNT(*) FROM forumcategory", &data.Stats.Categories)
-	count("SELECT COUNT(*) FROM forumtopic", &data.Stats.Topics)
-	count("SELECT COUNT(*) FROM forumthread", &data.Stats.Threads)
+	data.Stats.Categories = counts.Categories
+	data.Stats.Topics = counts.Topics
+	data.Stats.Threads = counts.Threads
 
 	handlers.TemplateHandler(w, r, "forumAdminPage", data)
 }
@@ -163,21 +157,17 @@ func AdminForumRemakeForumTopicPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func countForumThreads(ctx context.Context, q db.Querier) (int64, error) {
-	var c int64
-	dber, ok := q.(interface{ DB() db.DBTX })
-	if !ok {
-		return 0, fmt.Errorf("querier missing DB method")
+	counts, err := q.AdminForumCounts(ctx)
+	if err != nil {
+		return 0, err
 	}
-	err := dber.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM forumthread").Scan(&c)
-	return c, err
+	return counts.Threads, nil
 }
 
 func countForumTopics(ctx context.Context, q db.Querier) (int64, error) {
-	var c int64
-	dber, ok := q.(interface{ DB() db.DBTX })
-	if !ok {
-		return 0, fmt.Errorf("querier missing DB method")
+	counts, err := q.AdminForumCounts(ctx)
+	if err != nil {
+		return 0, err
 	}
-	err := dber.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM forumtopic").Scan(&c)
-	return c, err
+	return counts.Topics, nil
 }

--- a/internal/db/db_custom.go
+++ b/internal/db/db_custom.go
@@ -1,4 +1,0 @@
-package db
-
-// DB exposes the underlying database handle.
-func (q *Queries) DB() DBTX { return q.db }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -39,9 +39,11 @@ type Querier interface {
 	// admin task
 	AdminDeletePendingEmail(ctx context.Context, id int32) error
 	AdminDeleteTemplateOverride(ctx context.Context, name string) error
+	AdminDeleteUser(ctx context.Context, userID int32) error
 	// admin task
 	AdminDemoteAnnouncement(ctx context.Context, id int32) error
 	AdminForumCategoryThreadCounts(ctx context.Context) ([]*AdminForumCategoryThreadCountsRow, error)
+	AdminForumCounts(ctx context.Context) (*AdminForumCountsRow, error)
 	AdminForumTopicThreadCounts(ctx context.Context) ([]*AdminForumTopicThreadCountsRow, error)
 	AdminGetAllBlogEntriesByUser(ctx context.Context, arg AdminGetAllBlogEntriesByUserParams) ([]*AdminGetAllBlogEntriesByUserRow, error)
 	AdminGetAllCommentsByUser(ctx context.Context, userID int32) ([]*AdminGetAllCommentsByUserRow, error)
@@ -132,11 +134,15 @@ type Querier interface {
 	AdminScrubLink(ctx context.Context, arg AdminScrubLinkParams) error
 	AdminScrubUser(ctx context.Context, arg AdminScrubUserParams) error
 	AdminScrubWriting(ctx context.Context, arg AdminScrubWritingParams) error
+	AdminSearchIndexCounts(ctx context.Context) (*AdminSearchIndexCountsRow, error)
 	AdminSetTemplateOverride(ctx context.Context, arg AdminSetTemplateOverrideParams) error
+	AdminSiteCounts(ctx context.Context) (*AdminSiteCountsRow, error)
 	AdminUpdateBannedIp(ctx context.Context, arg AdminUpdateBannedIpParams) error
 	AdminUpdateRequestStatus(ctx context.Context, arg AdminUpdateRequestStatusParams) error
+	AdminUpdateRole(ctx context.Context, arg AdminUpdateRoleParams) error
 	// admin task
 	AdminUpdateRolePublicProfileAllowed(ctx context.Context, arg AdminUpdateRolePublicProfileAllowedParams) error
+	AdminUpdateUserUsername(ctx context.Context, arg AdminUpdateUserUsernameParams) error
 	AdminUpdateWritingCategory(ctx context.Context, arg AdminUpdateWritingCategoryParams) error
 	AdminUserPostCounts(ctx context.Context) ([]*AdminUserPostCountsRow, error)
 	AdminUserPostCountsByID(ctx context.Context, idusers int32) (*AdminUserPostCountsByIDRow, error)
@@ -159,6 +165,7 @@ type Querier interface {
 	CreateBookmarks(ctx context.Context, arg CreateBookmarksParams) error
 	CreateComment(ctx context.Context, arg CreateCommentParams) (int64, error)
 	CreateFAQCategory(ctx context.Context, arg CreateFAQCategoryParams) error
+	CreateFAQEntryForWriter(ctx context.Context, arg CreateFAQEntryForWriterParams) (sql.Result, error)
 	CreateFAQQuestion(ctx context.Context, arg CreateFAQQuestionParams) error
 	CreateForumCategory(ctx context.Context, arg CreateForumCategoryParams) error
 	CreateForumTopic(ctx context.Context, arg CreateForumTopicParams) (int64, error)

--- a/internal/db/queries-roles.sql
+++ b/internal/db/queries-roles.sql
@@ -30,3 +30,6 @@ ORDER BY u.username;
 -- name: AdminListGrantsByRoleID :many
 -- admin task
 SELECT * FROM grants WHERE role_id = ? ORDER BY id;
+
+-- name: AdminUpdateRole :exec
+UPDATE roles SET name = ?, can_login = ?, is_admin = ? WHERE id = ?;

--- a/internal/db/queries-roles.sql.go
+++ b/internal/db/queries-roles.sql.go
@@ -181,6 +181,27 @@ func (q *Queries) AdminListUsersByRoleID(ctx context.Context, roleID int32) ([]*
 	return items, nil
 }
 
+const adminUpdateRole = `-- name: AdminUpdateRole :exec
+UPDATE roles SET name = ?, can_login = ?, is_admin = ? WHERE id = ?
+`
+
+type AdminUpdateRoleParams struct {
+	Name     string
+	CanLogin bool
+	IsAdmin  bool
+	ID       int32
+}
+
+func (q *Queries) AdminUpdateRole(ctx context.Context, arg AdminUpdateRoleParams) error {
+	_, err := q.db.ExecContext(ctx, adminUpdateRole,
+		arg.Name,
+		arg.CanLogin,
+		arg.IsAdmin,
+		arg.ID,
+	)
+	return err
+}
+
 const adminUpdateRolePublicProfileAllowed = `-- name: AdminUpdateRolePublicProfileAllowed :exec
 UPDATE roles SET public_profile_allowed_at = ? WHERE id = ?
 `

--- a/internal/db/queries-stats.sql
+++ b/internal/db/queries-stats.sql
@@ -87,3 +87,31 @@ ORDER BY u.idusers;
 SELECT a.id, a.users_idusers, u.username, a.action, a.path, a.details, a.data, a.created_at
 FROM audit_log a LEFT JOIN users u ON a.users_idusers = u.idusers
 ORDER BY a.id DESC LIMIT ?;
+
+-- name: AdminSiteCounts :one
+SELECT
+    (SELECT COUNT(*) FROM users) AS users,
+    (SELECT COUNT(*) FROM language) AS languages,
+    (SELECT COUNT(*) FROM site_news) AS news,
+    (SELECT COUNT(*) FROM blogs) AS blogs,
+    (SELECT COUNT(*) FROM forumtopic) AS forum_topics,
+    (SELECT COUNT(*) FROM forumthread) AS forum_threads,
+    (SELECT COUNT(*) FROM writing) AS writings;
+
+-- name: AdminForumCounts :one
+SELECT
+    (SELECT COUNT(*) FROM forumcategory) AS categories,
+    (SELECT COUNT(*) FROM forumtopic) AS topics,
+    (SELECT COUNT(*) FROM forumthread) AS threads;
+
+-- name: AdminSearchIndexCounts :one
+SELECT
+    (SELECT COUNT(*) FROM searchwordlist) AS words,
+    (SELECT COUNT(*) FROM searchwordlist) AS word_list,
+    (SELECT COUNT(*) FROM comments_search) AS comments,
+    (SELECT COUNT(*) FROM site_news_search) AS news,
+    (SELECT COUNT(*) FROM blogs_search) AS blogs,
+    (SELECT COUNT(*) FROM linker_search) AS linker,
+    (SELECT COUNT(*) FROM writing_search) AS writing,
+    (SELECT COUNT(*) FROM writing_search) AS writings,
+    (SELECT COUNT(*) FROM imagepost_search) AS images;

--- a/internal/db/queries-stats.sql.go
+++ b/internal/db/queries-stats.sql.go
@@ -71,6 +71,26 @@ func (q *Queries) AdminForumCategoryThreadCounts(ctx context.Context) ([]*AdminF
 	return items, nil
 }
 
+const adminForumCounts = `-- name: AdminForumCounts :one
+SELECT
+    (SELECT COUNT(*) FROM forumcategory) AS categories,
+    (SELECT COUNT(*) FROM forumtopic) AS topics,
+    (SELECT COUNT(*) FROM forumthread) AS threads
+`
+
+type AdminForumCountsRow struct {
+	Categories int64
+	Topics     int64
+	Threads    int64
+}
+
+func (q *Queries) AdminForumCounts(ctx context.Context) (*AdminForumCountsRow, error) {
+	row := q.db.QueryRowContext(ctx, adminForumCounts)
+	var i AdminForumCountsRow
+	err := row.Scan(&i.Categories, &i.Topics, &i.Threads)
+	return &i, err
+}
+
 const adminForumTopicThreadCounts = `-- name: AdminForumTopicThreadCounts :many
 SELECT t.idforumtopic, t.title, COUNT(th.idforumthread) AS count
 FROM forumtopic t
@@ -194,6 +214,48 @@ func (q *Queries) AdminImageboardPostCounts(ctx context.Context) ([]*AdminImageb
 	return items, nil
 }
 
+const adminSearchIndexCounts = `-- name: AdminSearchIndexCounts :one
+SELECT
+    (SELECT COUNT(*) FROM searchwordlist) AS words,
+    (SELECT COUNT(*) FROM searchwordlist) AS word_list,
+    (SELECT COUNT(*) FROM comments_search) AS comments,
+    (SELECT COUNT(*) FROM site_news_search) AS news,
+    (SELECT COUNT(*) FROM blogs_search) AS blogs,
+    (SELECT COUNT(*) FROM linker_search) AS linker,
+    (SELECT COUNT(*) FROM writing_search) AS writing,
+    (SELECT COUNT(*) FROM writing_search) AS writings,
+    (SELECT COUNT(*) FROM imagepost_search) AS images
+`
+
+type AdminSearchIndexCountsRow struct {
+	Words    int64
+	WordList int64
+	Comments int64
+	News     int64
+	Blogs    int64
+	Linker   int64
+	Writing  int64
+	Writings int64
+	Images   int64
+}
+
+func (q *Queries) AdminSearchIndexCounts(ctx context.Context) (*AdminSearchIndexCountsRow, error) {
+	row := q.db.QueryRowContext(ctx, adminSearchIndexCounts)
+	var i AdminSearchIndexCountsRow
+	err := row.Scan(
+		&i.Words,
+		&i.WordList,
+		&i.Comments,
+		&i.News,
+		&i.Blogs,
+		&i.Linker,
+		&i.Writing,
+		&i.Writings,
+		&i.Images,
+	)
+	return &i, err
+}
+
 const adminSetTemplateOverride = `-- name: AdminSetTemplateOverride :exec
 INSERT INTO template_overrides (name, body)
 VALUES (?, ?)
@@ -208,6 +270,42 @@ type AdminSetTemplateOverrideParams struct {
 func (q *Queries) AdminSetTemplateOverride(ctx context.Context, arg AdminSetTemplateOverrideParams) error {
 	_, err := q.db.ExecContext(ctx, adminSetTemplateOverride, arg.Name, arg.Body)
 	return err
+}
+
+const adminSiteCounts = `-- name: AdminSiteCounts :one
+SELECT
+    (SELECT COUNT(*) FROM users) AS users,
+    (SELECT COUNT(*) FROM language) AS languages,
+    (SELECT COUNT(*) FROM site_news) AS news,
+    (SELECT COUNT(*) FROM blogs) AS blogs,
+    (SELECT COUNT(*) FROM forumtopic) AS forum_topics,
+    (SELECT COUNT(*) FROM forumthread) AS forum_threads,
+    (SELECT COUNT(*) FROM writing) AS writings
+`
+
+type AdminSiteCountsRow struct {
+	Users        int64
+	Languages    int64
+	News         int64
+	Blogs        int64
+	ForumTopics  int64
+	ForumThreads int64
+	Writings     int64
+}
+
+func (q *Queries) AdminSiteCounts(ctx context.Context) (*AdminSiteCountsRow, error) {
+	row := q.db.QueryRowContext(ctx, adminSiteCounts)
+	var i AdminSiteCountsRow
+	err := row.Scan(
+		&i.Users,
+		&i.Languages,
+		&i.News,
+		&i.Blogs,
+		&i.ForumTopics,
+		&i.ForumThreads,
+		&i.Writings,
+	)
+	return &i, err
 }
 
 const adminUserPostCounts = `-- name: AdminUserPostCounts :many

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -88,3 +88,9 @@ WHERE idusers IN (sqlc.slice('ids'));
 
 -- name: UpdatePublicProfileEnabledAtByUserID :exec
 UPDATE users SET public_profile_enabled_at = ? WHERE idusers = ?;
+
+-- name: AdminDeleteUser :exec
+DELETE FROM users WHERE idusers = sqlc.arg(user_id);
+
+-- name: AdminUpdateUserUsername :exec
+UPDATE users SET username = sqlc.arg(username) WHERE idusers = sqlc.arg(user_id);

--- a/internal/db/queries-users.sql.go
+++ b/internal/db/queries-users.sql.go
@@ -11,6 +11,15 @@ import (
 	"strings"
 )
 
+const adminDeleteUser = `-- name: AdminDeleteUser :exec
+DELETE FROM users WHERE idusers = ?
+`
+
+func (q *Queries) AdminDeleteUser(ctx context.Context, userID int32) error {
+	_, err := q.db.ExecContext(ctx, adminDeleteUser, userID)
+	return err
+}
+
 const adminListAdministratorEmails = `-- name: AdminListAdministratorEmails :many
 SELECT (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
 FROM users u
@@ -227,6 +236,20 @@ func (q *Queries) AdminListUsersByID(ctx context.Context, ids []int32) ([]*Admin
 		return nil, err
 	}
 	return items, nil
+}
+
+const adminUpdateUserUsername = `-- name: AdminUpdateUserUsername :exec
+UPDATE users SET username = ? WHERE idusers = ?
+`
+
+type AdminUpdateUserUsernameParams struct {
+	Username sql.NullString
+	UserID   int32
+}
+
+func (q *Queries) AdminUpdateUserUsername(ctx context.Context, arg AdminUpdateUserUsernameParams) error {
+	_, err := q.db.ExecContext(ctx, adminUpdateUserUsername, arg.Username, arg.UserID)
+	return err
 }
 
 const getUserById = `-- name: GetUserById :one


### PR DESCRIPTION
## Summary
- avoid exposing raw DB handles by removing `DB()` and replacing ad-hoc SQL with generated queries
- add admin and writer query helpers and site/forum/search count queries
- rewrite handlers and CLI to use the new typed queries

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: db.New undefined in many tests)*
- `golangci-lint run ./...` *(fails: typecheck errors such as db.New undefined)*
- `go test ./...` *(fails: missing MonthlyUsageCounts, other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_688ed9ee9adc832f94970c59e63b3476