### PR TITLE
refactor: tighten db query naming

### DIFF
--- a/cmd/goa4web/user_add.go
+++ b/cmd/goa4web/user_add.go
@@ -64,10 +64,7 @@ func createUser(root *rootCmd, username, email, password string, admin bool) err
 	if err != nil {
 		return fmt.Errorf("hash password: %w", err)
 	}
-	res, err := queries.DB().ExecContext(ctx,
-		"INSERT INTO users (username) VALUES (?)",
-		username,
-	)
+	res, err := queries.SystemInsertUser(ctx, sql.NullString{String: username, Valid: true})
 	if err != nil {
 		if strings.Contains(err.Error(), "Duplicate entry") || strings.Contains(err.Error(), "UNIQUE constraint failed") {
 			return fmt.Errorf("user already exists")

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -283,6 +283,9 @@ func NewCoreData(ctx context.Context, q db.Querier, cfg *config.RuntimeConfig, o
 // Queries returns the db.Queries instance associated with this CoreData.
 func (cd *CoreData) Queries() db.Querier { return cd.queries }
 
+// CustomQueries returns the db.CustomQueries instance associated with this CoreData.
+func (cd *CoreData) CustomQueries() db.CustomQueries { return cd.customQueries }
+
 // ImageURLMapper maps image references like "image:" or "cache:" to full URLs.
 func (cd *CoreData) ImageURLMapper(tag, val string) string {
 	if cd.a4codeMapper != nil {

--- a/handlers/admin/adminHandler.go
+++ b/handlers/admin/adminHandler.go
@@ -1,15 +1,12 @@
 package admin
 
 import (
-	"database/sql"
 	_ "embed"
-	"github.com/arran4/goa4web/core/consts"
-	"log"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 )
 
 func AdminPage(w http.ResponseWriter, r *http.Request) {
@@ -36,25 +33,18 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 		AdminSections: cd.Nav.AdminSections(),
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	ctx := r.Context()
-	dber, ok := queries.(interface{ DB() db.DBTX })
-	if !ok {
+	stats, err := queries.AdminGetDashboardStats(r.Context())
+	if err != nil {
 		http.Error(w, "database not available", http.StatusInternalServerError)
 		return
 	}
-	count := func(query string, dest *int64) {
-		if err := dber.DB().QueryRowContext(ctx, query).Scan(dest); err != nil && err != sql.ErrNoRows {
-			log.Printf("adminPage count query error: %v", err)
-		}
-	}
-	count("SELECT COUNT(*) FROM users", &data.Stats.Users)
-	count("SELECT COUNT(*) FROM language", &data.Stats.Languages)
-	// site_news renamed from siteNews in schema version 24
-	count("SELECT COUNT(*) FROM site_news", &data.Stats.News)
-	count("SELECT COUNT(*) FROM blogs", &data.Stats.Blogs)
-	count("SELECT COUNT(*) FROM forumtopic", &data.Stats.ForumTopics)
-	count("SELECT COUNT(*) FROM forumthread", &data.Stats.ForumThreads)
-	count("SELECT COUNT(*) FROM writing", &data.Stats.Writings)
+	data.Stats.Users = stats.Users
+	data.Stats.Languages = stats.Languages
+	data.Stats.News = stats.News
+	data.Stats.Blogs = stats.Blogs
+	data.Stats.ForumTopics = stats.ForumTopics
+	data.Stats.ForumThreads = stats.ForumThreads
+	data.Stats.Writings = stats.Writings
 
 	handlers.TemplateHandler(w, r, "adminPage", data)
 }

--- a/handlers/admin/adminRoleEditPage.go
+++ b/handlers/admin/adminRoleEditPage.go
@@ -53,12 +53,13 @@ func adminRoleEditSavePage(w http.ResponseWriter, r *http.Request) {
 		Back   string
 	}{CoreData: cd, Back: fmt.Sprintf("/admin/role/%d", id)}
 
-	if dber, ok := queries.(interface{ DB() db.DBTX }); ok {
-		if _, err := dber.DB().ExecContext(r.Context(), "UPDATE roles SET name=?, can_login=?, is_admin=? WHERE id=?", name, canLogin, isAdmin, id); err != nil {
-			data.Errors = append(data.Errors, fmt.Errorf("update role: %w", err).Error())
-		}
-	} else {
-		data.Errors = append(data.Errors, "database not available")
+	if err := queries.AdminUpdateRole(r.Context(), db.AdminUpdateRoleParams{
+		Name:     name,
+		CanLogin: canLogin,
+		IsAdmin:  isAdmin,
+		ID:       int32(id),
+	}); err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("update role: %w", err).Error())
 	}
 	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/handlers/admin/adminUsageStatsPage.go
+++ b/handlers/admin/adminUsageStatsPage.go
@@ -148,6 +148,8 @@ func AdminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
+	cq := cd.CustomQueries()
+
 	log.Print("start monthly usage counts")
 	wg.Add(1)
 	go func() {
@@ -155,7 +157,7 @@ func AdminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 			log.Print("stop monthly usage counts")
 			wg.Done()
 		}()
-		if rows, err := queries.MonthlyUsageCounts(ctx, int32(cd.Config.StatsStartYear)); err == nil {
+		if rows, err := cq.MonthlyUsageCounts(ctx, int32(cd.Config.StatsStartYear)); err == nil {
 			data.Monthly = rows
 		} else {
 			addErr("monthly usage counts", err)
@@ -169,7 +171,7 @@ func AdminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 			log.Print("stop user monthly usage counts")
 			wg.Done()
 		}()
-		if rows, err := queries.UserMonthlyUsageCounts(ctx, int32(cd.Config.StatsStartYear)); err == nil {
+		if rows, err := cq.UserMonthlyUsageCounts(ctx, int32(cd.Config.StatsStartYear)); err == nil {
 			data.UserMonthly = rows
 		} else {
 			addErr("user monthly usage counts", err)

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -77,12 +77,12 @@ func (RegisterTask) Action(w http.ResponseWriter, r *http.Request) any {
 		log.Printf("hashPassword Error: %s", err)
 		return fmt.Errorf("hash password %w", err)
 	}
-	result, err := queries.InsertUser(r.Context(), sql.NullString{String: username, Valid: true})
+	result, err := queries.SystemInsertUser(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		if strings.Contains(err.Error(), "Duplicate entry") || strings.Contains(err.Error(), "UNIQUE constraint failed") {
 			return handlers.ErrRedirectOnSamePageHandler(err)
 		}
-		log.Printf("InsertUser Error: %s", err)
+		log.Printf("SystemInsertUser Error: %s", err)
 		return fmt.Errorf("insert user %w", err)
 	}
 

--- a/handlers/search/admin.go
+++ b/handlers/search/admin.go
@@ -1,14 +1,10 @@
 package search
 
 import (
-	"database/sql"
-	"github.com/arran4/goa4web/core/consts"
-	"log"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/internal/db"
-
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 )
 
@@ -36,27 +32,19 @@ func adminSearchPage(w http.ResponseWriter, r *http.Request) {
 	data.CoreData.PageTitle = "Search Admin"
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	ctx := r.Context()
-	dber, ok := queries.(interface{ DB() db.DBTX })
-	if !ok {
+	stats, err := queries.AdminGetSearchStats(r.Context())
+	if err != nil {
 		http.Error(w, "database not available", http.StatusInternalServerError)
 		return
 	}
-	count := func(query string, dest *int64) {
-		if err := dber.DB().QueryRowContext(ctx, query).Scan(dest); err != nil && err != sql.ErrNoRows {
-			log.Printf("adminSearchPage count query error: %v", err)
-		}
-	}
-
-	// TODO make queries and find another way of making this DRY if really required
-	count("SELECT COUNT(*) FROM searchwordlist", &data.Stats.Words)
-	count("SELECT COUNT(*) FROM comments_search", &data.Stats.Comments)
-	count("SELECT COUNT(*) FROM site_news_search", &data.Stats.News)
-	count("SELECT COUNT(*) FROM blogs_search", &data.Stats.Blogs)
-	count("SELECT COUNT(*) FROM linker_search", &data.Stats.Linker)
-	count("SELECT COUNT(*) FROM writing_search", &data.Stats.Writing)
-	count("SELECT COUNT(*) FROM writing_search", &data.Stats.Writings)
-	count("SELECT COUNT(*) FROM imagepost_search", &data.Stats.Images)
+	data.Stats.Words = stats.Words
+	data.Stats.Comments = stats.Comments
+	data.Stats.News = stats.News
+	data.Stats.Blogs = stats.Blogs
+	data.Stats.Linker = stats.Linker
+	data.Stats.Writing = stats.Writings // maintain existing struct fields
+	data.Stats.Writings = stats.Writings
+	data.Stats.Images = stats.Images
 
 	handlers.TemplateHandler(w, r, "adminSearchPage", data)
 }

--- a/handlers/user/admin_users.go
+++ b/handlers/user/admin_users.go
@@ -168,12 +168,8 @@ func adminUserDisablePage(w http.ResponseWriter, r *http.Request) {
 	}
 	if uidi, err := strconv.Atoi(uid); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("strconv.Atoi: %w", err).Error())
-	} else if dber, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries().(interface{ DB() db.DBTX }); ok {
-		if _, err := dber.DB().ExecContext(r.Context(), "DELETE FROM users WHERE idusers = ?", uidi); err != nil {
-			data.Errors = append(data.Errors, fmt.Errorf("delete user: %w", err).Error())
-		}
-	} else {
-		data.Errors = append(data.Errors, "database not available")
+	} else if err := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries().AdminDeleteUserByID(r.Context(), int32(uidi)); err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("delete user: %w", err).Error())
 	}
 	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
@@ -217,14 +213,12 @@ func adminUserEditSavePage(w http.ResponseWriter, r *http.Request) {
 	}
 	if uidi, err := strconv.Atoi(uid); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("strconv.Atoi: %w", err).Error())
-	} else if dber, ok := queries.(interface{ DB() db.DBTX }); ok {
-		if _, err := dber.DB().ExecContext(r.Context(), "UPDATE users SET username=? WHERE idusers=?", username, uidi); err != nil {
+	} else {
+		if err := queries.AdminUpdateUsernameByID(r.Context(), db.AdminUpdateUsernameByIDParams{Username: sql.NullString{String: username, Valid: username != ""}, Idusers: int32(uidi)}); err != nil {
 			data.Errors = append(data.Errors, fmt.Errorf("update user: %w", err).Error())
 		} else if err := queries.UpdateUserEmail(r.Context(), db.UpdateUserEmailParams{Email: email, UserID: int32(uidi)}); err != nil {
 			data.Errors = append(data.Errors, fmt.Errorf("update user email: %w", err).Error())
 		}
-	} else {
-		data.Errors = append(data.Errors, "database not available")
 	}
 	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }

--- a/internal/db/customqueries.go
+++ b/internal/db/customqueries.go
@@ -7,4 +7,6 @@ type CustomQueries interface {
 	ListBloggers(ctx context.Context, arg ListBloggersParams) ([]*BloggerCountRow, error)
 	SearchWriters(ctx context.Context, arg SearchWritersParams) ([]*WriterCountRow, error)
 	ListWriters(ctx context.Context, arg ListWritersParams) ([]*WriterCountRow, error)
+	MonthlyUsageCounts(ctx context.Context, startYear int32) ([]*MonthlyUsageRow, error)
+	UserMonthlyUsageCounts(ctx context.Context, startYear int32) ([]*UserMonthlyUsageRow, error)
 }

--- a/internal/db/db_custom.go
+++ b/internal/db/db_custom.go
@@ -1,4 +1,0 @@
-package db
-
-// DB exposes the underlying database handle.
-func (q *Queries) DB() DBTX { return q.db }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -23,6 +23,8 @@ type Querier interface {
 	AdminClearExternalLinkCache(ctx context.Context, arg AdminClearExternalLinkCacheParams) error
 	// This query selects all words from the "searchwordlist" table and prints them.
 	AdminCompleteWordList(ctx context.Context) ([]sql.NullString, error)
+	AdminCountForumThreads(ctx context.Context) (int64, error)
+	AdminCountForumTopics(ctx context.Context) (int64, error)
 	AdminCountThreadsByBoard(ctx context.Context, imageboardIdimageboard int32) (int64, error)
 	AdminCountWordList(ctx context.Context) (int64, error)
 	AdminCountWordListByPrefix(ctx context.Context, prefix interface{}) (int64, error)
@@ -39,6 +41,7 @@ type Querier interface {
 	// admin task
 	AdminDeletePendingEmail(ctx context.Context, id int32) error
 	AdminDeleteTemplateOverride(ctx context.Context, name string) error
+	AdminDeleteUserByID(ctx context.Context, idusers int32) error
 	// admin task
 	AdminDemoteAnnouncement(ctx context.Context, id int32) error
 	AdminForumCategoryThreadCounts(ctx context.Context) ([]*AdminForumCategoryThreadCountsRow, error)
@@ -46,12 +49,15 @@ type Querier interface {
 	AdminGetAllBlogEntriesByUser(ctx context.Context, arg AdminGetAllBlogEntriesByUserParams) ([]*AdminGetAllBlogEntriesByUserRow, error)
 	AdminGetAllCommentsByUser(ctx context.Context, userID int32) ([]*AdminGetAllCommentsByUserRow, error)
 	AdminGetAllWritingsByAuthor(ctx context.Context, authorID int32) ([]*AdminGetAllWritingsByAuthorRow, error)
+	AdminGetDashboardStats(ctx context.Context) (*AdminGetDashboardStatsRow, error)
+	AdminGetForumStats(ctx context.Context) (*AdminGetForumStatsRow, error)
 	// admin task
 	AdminGetPendingEmailByID(ctx context.Context, id int32) (*AdminGetPendingEmailByIDRow, error)
 	AdminGetRecentAuditLogs(ctx context.Context, limit int32) ([]*AdminGetRecentAuditLogsRow, error)
 	AdminGetRequestByID(ctx context.Context, id int32) (*AdminRequestQueue, error)
 	// admin task
 	AdminGetRoleByID(ctx context.Context, id int32) (*Role, error)
+	AdminGetSearchStats(ctx context.Context) (*AdminGetSearchStatsRow, error)
 	AdminGetThreadsStartedByUser(ctx context.Context, usersIdusers int32) ([]*Forumthread, error)
 	AdminGetThreadsStartedByUserWithTopic(ctx context.Context, usersIdusers int32) ([]*AdminGetThreadsStartedByUserWithTopicRow, error)
 	AdminGetWritingsByCategoryId(ctx context.Context, writingCategoryID int32) ([]*AdminGetWritingsByCategoryIdRow, error)
@@ -136,7 +142,10 @@ type Querier interface {
 	AdminUpdateBannedIp(ctx context.Context, arg AdminUpdateBannedIpParams) error
 	AdminUpdateRequestStatus(ctx context.Context, arg AdminUpdateRequestStatusParams) error
 	// admin task
+	AdminUpdateRole(ctx context.Context, arg AdminUpdateRoleParams) error
+	// admin task
 	AdminUpdateRolePublicProfileAllowed(ctx context.Context, arg AdminUpdateRolePublicProfileAllowedParams) error
+	AdminUpdateUsernameByID(ctx context.Context, arg AdminUpdateUsernameByIDParams) error
 	AdminUpdateWritingCategory(ctx context.Context, arg AdminUpdateWritingCategoryParams) error
 	AdminUserPostCounts(ctx context.Context) ([]*AdminUserPostCountsRow, error)
 	AdminUserPostCountsByID(ctx context.Context, idusers int32) (*AdminUserPostCountsByIDRow, error)
@@ -299,13 +308,13 @@ type Querier interface {
 	InsertAdminUserComment(ctx context.Context, arg InsertAdminUserCommentParams) error
 	InsertAuditLog(ctx context.Context, arg InsertAuditLogParams) error
 	InsertEmailPreferenceForLister(ctx context.Context, arg InsertEmailPreferenceForListerParams) error
+	InsertFAQQuestionForWriter(ctx context.Context, arg InsertFAQQuestionForWriterParams) (sql.Result, error)
 	InsertFAQRevisionForUser(ctx context.Context, arg InsertFAQRevisionForUserParams) error
 	InsertNotification(ctx context.Context, arg InsertNotificationParams) error
 	InsertPassword(ctx context.Context, arg InsertPasswordParams) error
 	InsertPendingEmail(ctx context.Context, arg InsertPendingEmailParams) error
 	InsertPreferenceForLister(ctx context.Context, arg InsertPreferenceForListerParams) error
 	InsertSubscription(ctx context.Context, arg InsertSubscriptionParams) error
-	InsertUser(ctx context.Context, username sql.NullString) (sql.Result, error)
 	InsertUserEmail(ctx context.Context, arg InsertUserEmailParams) error
 	InsertUserLang(ctx context.Context, arg InsertUserLangParams) error
 	InsertWriting(ctx context.Context, arg InsertWritingParams) (int64, error)
@@ -404,6 +413,7 @@ type Querier interface {
 	SystemInsertDeadLetter(ctx context.Context, message string) error
 	SystemInsertLoginAttempt(ctx context.Context, arg SystemInsertLoginAttemptParams) error
 	SystemInsertSession(ctx context.Context, arg SystemInsertSessionParams) error
+	SystemInsertUser(ctx context.Context, username sql.NullString) (sql.Result, error)
 	SystemLatestDeadLetter(ctx context.Context) (interface{}, error)
 	SystemListBoardsByParentID(ctx context.Context, arg SystemListBoardsByParentIDParams) ([]*Imageboard, error)
 	SystemListDeadLetters(ctx context.Context, limit int32) ([]*DeadLetter, error)

--- a/internal/db/queries-faq.sql
+++ b/internal/db/queries-faq.sql
@@ -78,6 +78,21 @@ WHERE EXISTS (
 INSERT INTO faq (question, users_idusers, language_idlanguage)
 VALUES (?, ?, ?);
 
+-- name: InsertFAQQuestionForWriter :execresult
+INSERT INTO faq (question, answer, faqCategories_idfaqCategories, users_idusers, language_idlanguage)
+SELECT sqlc.arg(question), sqlc.arg(answer), sqlc.arg(category_id), sqlc.arg(writer_id), sqlc.arg(language_id)
+WHERE EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section = 'faq'
+      AND g.item = 'question'
+      AND g.action = 'post'
+      AND g.active = 1
+      AND (g.user_id = sqlc.arg(grantee_id) OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (
+          SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(writer_id)
+      ))
+);
+
 -- name: UpdateFAQQuestionAnswer :exec
 UPDATE faq
 SET answer = ?, question = ?, faqCategories_idfaqCategories = ?

--- a/internal/db/queries-faq.sql.go
+++ b/internal/db/queries-faq.sql.go
@@ -471,6 +471,43 @@ func (q *Queries) GetFAQUnansweredQuestions(ctx context.Context) ([]*Faq, error)
 	return items, nil
 }
 
+const insertFAQQuestionForWriter = `-- name: InsertFAQQuestionForWriter :execresult
+INSERT INTO faq (question, answer, faqCategories_idfaqCategories, users_idusers, language_idlanguage)
+SELECT ?, ?, ?, ?, ?
+WHERE EXISTS (
+    SELECT 1 FROM grants g
+    WHERE g.section = 'faq'
+      AND g.item = 'question'
+      AND g.action = 'post'
+      AND g.active = 1
+      AND (g.user_id = ? OR g.user_id IS NULL)
+      AND (g.role_id IS NULL OR g.role_id IN (
+          SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+      ))
+)
+`
+
+type InsertFAQQuestionForWriterParams struct {
+	Question   sql.NullString
+	Answer     sql.NullString
+	CategoryID int32
+	WriterID   int32
+	LanguageID int32
+	GranteeID  sql.NullInt32
+}
+
+func (q *Queries) InsertFAQQuestionForWriter(ctx context.Context, arg InsertFAQQuestionForWriterParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, insertFAQQuestionForWriter,
+		arg.Question,
+		arg.Answer,
+		arg.CategoryID,
+		arg.WriterID,
+		arg.LanguageID,
+		arg.GranteeID,
+		arg.WriterID,
+	)
+}
+
 const insertFAQRevisionForUser = `-- name: InsertFAQRevisionForUser :exec
 INSERT INTO faq_revisions (faq_id, users_idusers, question, answer)
 SELECT ?, ?, ?, ?

--- a/internal/db/queries-roles.sql
+++ b/internal/db/queries-roles.sql
@@ -30,3 +30,7 @@ ORDER BY u.username;
 -- name: AdminListGrantsByRoleID :many
 -- admin task
 SELECT * FROM grants WHERE role_id = ? ORDER BY id;
+
+-- name: AdminUpdateRole :exec
+-- admin task
+UPDATE roles SET name = ?, can_login = ?, is_admin = ? WHERE id = ?;

--- a/internal/db/queries-roles.sql.go
+++ b/internal/db/queries-roles.sql.go
@@ -181,6 +181,28 @@ func (q *Queries) AdminListUsersByRoleID(ctx context.Context, roleID int32) ([]*
 	return items, nil
 }
 
+const adminUpdateRole = `-- name: AdminUpdateRole :exec
+UPDATE roles SET name = ?, can_login = ?, is_admin = ? WHERE id = ?
+`
+
+type AdminUpdateRoleParams struct {
+	Name     string
+	CanLogin bool
+	IsAdmin  bool
+	ID       int32
+}
+
+// admin task
+func (q *Queries) AdminUpdateRole(ctx context.Context, arg AdminUpdateRoleParams) error {
+	_, err := q.db.ExecContext(ctx, adminUpdateRole,
+		arg.Name,
+		arg.CanLogin,
+		arg.IsAdmin,
+		arg.ID,
+	)
+	return err
+}
+
 const adminUpdateRolePublicProfileAllowed = `-- name: AdminUpdateRolePublicProfileAllowed :exec
 UPDATE roles SET public_profile_allowed_at = ? WHERE id = ?
 `

--- a/internal/db/queries-stats.sql
+++ b/internal/db/queries-stats.sql
@@ -87,3 +87,35 @@ ORDER BY u.idusers;
 SELECT a.id, a.users_idusers, u.username, a.action, a.path, a.details, a.data, a.created_at
 FROM audit_log a LEFT JOIN users u ON a.users_idusers = u.idusers
 ORDER BY a.id DESC LIMIT ?;
+
+-- name: AdminGetDashboardStats :one
+SELECT
+    (SELECT COUNT(*) FROM users) AS users,
+    (SELECT COUNT(*) FROM language) AS languages,
+    (SELECT COUNT(*) FROM site_news) AS news,
+    (SELECT COUNT(*) FROM blogs) AS blogs,
+    (SELECT COUNT(*) FROM forumtopic) AS forum_topics,
+    (SELECT COUNT(*) FROM forumthread) AS forum_threads,
+    (SELECT COUNT(*) FROM writing) AS writings;
+
+-- name: AdminGetSearchStats :one
+SELECT
+    (SELECT COUNT(*) FROM searchwordlist) AS words,
+    (SELECT COUNT(*) FROM comments_search) AS comments,
+    (SELECT COUNT(*) FROM site_news_search) AS news,
+    (SELECT COUNT(*) FROM blogs_search) AS blogs,
+    (SELECT COUNT(*) FROM linker_search) AS linker,
+    (SELECT COUNT(*) FROM writing_search) AS writings,
+    (SELECT COUNT(*) FROM imagepost_search) AS images;
+
+-- name: AdminGetForumStats :one
+SELECT
+    (SELECT COUNT(*) FROM forumcategory) AS categories,
+    (SELECT COUNT(*) FROM forumtopic) AS topics,
+    (SELECT COUNT(*) FROM forumthread) AS threads;
+
+-- name: AdminCountForumThreads :one
+SELECT COUNT(*) FROM forumthread;
+
+-- name: AdminCountForumTopics :one
+SELECT COUNT(*) FROM forumtopic;

--- a/internal/db/queries-stats.sql.go
+++ b/internal/db/queries-stats.sql.go
@@ -11,6 +11,28 @@ import (
 	"time"
 )
 
+const adminCountForumThreads = `-- name: AdminCountForumThreads :one
+SELECT COUNT(*) FROM forumthread
+`
+
+func (q *Queries) AdminCountForumThreads(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, adminCountForumThreads)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const adminCountForumTopics = `-- name: AdminCountForumTopics :one
+SELECT COUNT(*) FROM forumtopic
+`
+
+func (q *Queries) AdminCountForumTopics(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, adminCountForumTopics)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const adminCountThreadsByBoard = `-- name: AdminCountThreadsByBoard :one
 SELECT COUNT(DISTINCT forumthread_id)
 FROM imagepost
@@ -108,6 +130,62 @@ func (q *Queries) AdminForumTopicThreadCounts(ctx context.Context) ([]*AdminForu
 	return items, nil
 }
 
+const adminGetDashboardStats = `-- name: AdminGetDashboardStats :one
+SELECT
+    (SELECT COUNT(*) FROM users) AS users,
+    (SELECT COUNT(*) FROM language) AS languages,
+    (SELECT COUNT(*) FROM site_news) AS news,
+    (SELECT COUNT(*) FROM blogs) AS blogs,
+    (SELECT COUNT(*) FROM forumtopic) AS forum_topics,
+    (SELECT COUNT(*) FROM forumthread) AS forum_threads,
+    (SELECT COUNT(*) FROM writing) AS writings
+`
+
+type AdminGetDashboardStatsRow struct {
+	Users        int64
+	Languages    int64
+	News         int64
+	Blogs        int64
+	ForumTopics  int64
+	ForumThreads int64
+	Writings     int64
+}
+
+func (q *Queries) AdminGetDashboardStats(ctx context.Context) (*AdminGetDashboardStatsRow, error) {
+	row := q.db.QueryRowContext(ctx, adminGetDashboardStats)
+	var i AdminGetDashboardStatsRow
+	err := row.Scan(
+		&i.Users,
+		&i.Languages,
+		&i.News,
+		&i.Blogs,
+		&i.ForumTopics,
+		&i.ForumThreads,
+		&i.Writings,
+	)
+	return &i, err
+}
+
+const adminGetForumStats = `-- name: AdminGetForumStats :one
+SELECT
+    (SELECT COUNT(*) FROM forumcategory) AS categories,
+    (SELECT COUNT(*) FROM forumtopic) AS topics,
+    (SELECT COUNT(*) FROM forumthread) AS threads
+`
+
+type AdminGetForumStatsRow struct {
+	Categories int64
+	Topics     int64
+	Threads    int64
+}
+
+func (q *Queries) AdminGetForumStats(ctx context.Context) (*AdminGetForumStatsRow, error) {
+	row := q.db.QueryRowContext(ctx, adminGetForumStats)
+	var i AdminGetForumStatsRow
+	err := row.Scan(&i.Categories, &i.Topics, &i.Threads)
+	return &i, err
+}
+
 const adminGetRecentAuditLogs = `-- name: AdminGetRecentAuditLogs :many
 SELECT a.id, a.users_idusers, u.username, a.action, a.path, a.details, a.data, a.created_at
 FROM audit_log a LEFT JOIN users u ON a.users_idusers = u.idusers
@@ -155,6 +233,42 @@ func (q *Queries) AdminGetRecentAuditLogs(ctx context.Context, limit int32) ([]*
 		return nil, err
 	}
 	return items, nil
+}
+
+const adminGetSearchStats = `-- name: AdminGetSearchStats :one
+SELECT
+    (SELECT COUNT(*) FROM searchwordlist) AS words,
+    (SELECT COUNT(*) FROM comments_search) AS comments,
+    (SELECT COUNT(*) FROM site_news_search) AS news,
+    (SELECT COUNT(*) FROM blogs_search) AS blogs,
+    (SELECT COUNT(*) FROM linker_search) AS linker,
+    (SELECT COUNT(*) FROM writing_search) AS writings,
+    (SELECT COUNT(*) FROM imagepost_search) AS images
+`
+
+type AdminGetSearchStatsRow struct {
+	Words    int64
+	Comments int64
+	News     int64
+	Blogs    int64
+	Linker   int64
+	Writings int64
+	Images   int64
+}
+
+func (q *Queries) AdminGetSearchStats(ctx context.Context) (*AdminGetSearchStatsRow, error) {
+	row := q.db.QueryRowContext(ctx, adminGetSearchStats)
+	var i AdminGetSearchStatsRow
+	err := row.Scan(
+		&i.Words,
+		&i.Comments,
+		&i.News,
+		&i.Blogs,
+		&i.Linker,
+		&i.Writings,
+		&i.Images,
+	)
+	return &i, err
 }
 
 const adminImageboardPostCounts = `-- name: AdminImageboardPostCounts :many

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -43,7 +43,7 @@ FROM users u JOIN user_emails ue ON ue.user_id = u.idusers
 WHERE ue.email = ?
 LIMIT 1;
 
--- name: InsertUser :execresult
+-- name: SystemInsertUser :execresult
 INSERT INTO users (username)
 VALUES (?)
 ;
@@ -88,3 +88,9 @@ WHERE idusers IN (sqlc.slice('ids'));
 
 -- name: UpdatePublicProfileEnabledAtByUserID :exec
 UPDATE users SET public_profile_enabled_at = ? WHERE idusers = ?;
+
+-- name: AdminDeleteUserByID :exec
+DELETE FROM users WHERE idusers = ?;
+
+-- name: AdminUpdateUsernameByID :exec
+UPDATE users SET username = ? WHERE idusers = ?;

--- a/internal/db/queries-users.sql.go
+++ b/internal/db/queries-users.sql.go
@@ -11,6 +11,15 @@ import (
 	"strings"
 )
 
+const adminDeleteUserByID = `-- name: AdminDeleteUserByID :exec
+DELETE FROM users WHERE idusers = ?
+`
+
+func (q *Queries) AdminDeleteUserByID(ctx context.Context, idusers int32) error {
+	_, err := q.db.ExecContext(ctx, adminDeleteUserByID, idusers)
+	return err
+}
+
 const adminListAdministratorEmails = `-- name: AdminListAdministratorEmails :many
 SELECT (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
 FROM users u
@@ -229,6 +238,20 @@ func (q *Queries) AdminListUsersByID(ctx context.Context, ids []int32) ([]*Admin
 	return items, nil
 }
 
+const adminUpdateUsernameByID = `-- name: AdminUpdateUsernameByID :exec
+UPDATE users SET username = ? WHERE idusers = ?
+`
+
+type AdminUpdateUsernameByIDParams struct {
+	Username sql.NullString
+	Idusers  int32
+}
+
+func (q *Queries) AdminUpdateUsernameByID(ctx context.Context, arg AdminUpdateUsernameByIDParams) error {
+	_, err := q.db.ExecContext(ctx, adminUpdateUsernameByID, arg.Username, arg.Idusers)
+	return err
+}
+
 const getUserById = `-- name: GetUserById :one
 SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at
 FROM users u
@@ -287,15 +310,6 @@ func (q *Queries) GetUserByUsername(ctx context.Context, username sql.NullString
 	return &i, err
 }
 
-const insertUser = `-- name: InsertUser :execresult
-INSERT INTO users (username)
-VALUES (?)
-`
-
-func (q *Queries) InsertUser(ctx context.Context, username sql.NullString) (sql.Result, error) {
-	return q.db.ExecContext(ctx, insertUser, username)
-}
-
 const login = `-- name: Login :one
 SELECT u.idusers,
        (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
@@ -325,6 +339,15 @@ func (q *Queries) Login(ctx context.Context, username sql.NullString) (*LoginRow
 		&i.Username,
 	)
 	return &i, err
+}
+
+const systemInsertUser = `-- name: SystemInsertUser :execresult
+INSERT INTO users (username)
+VALUES (?)
+`
+
+func (q *Queries) SystemInsertUser(ctx context.Context, username sql.NullString) (sql.Result, error) {
+	return q.db.ExecContext(ctx, systemInsertUser, username)
 }
 
 const updatePublicProfileEnabledAtByUserID = `-- name: UpdatePublicProfileEnabledAtByUserID :exec

--- a/internal/db/queries_faq_test.go
+++ b/internal/db/queries_faq_test.go
@@ -1,0 +1,38 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"regexp"
+)
+
+func TestQueries_InsertFAQQuestionForWriter(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := New(db)
+
+	mock.ExpectExec(regexp.QuoteMeta(insertFAQQuestionForWriter)).
+		WithArgs(sql.NullString{String: "q", Valid: true}, sql.NullString{String: "a", Valid: true}, int32(1), int32(2), int32(1), sql.NullInt32{Int32: 2, Valid: true}).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if _, err := q.InsertFAQQuestionForWriter(context.Background(), InsertFAQQuestionForWriterParams{
+		Question:   sql.NullString{String: "q", Valid: true},
+		Answer:     sql.NullString{String: "a", Valid: true},
+		CategoryID: 1,
+		WriterID:   2,
+		LanguageID: 1,
+		GranteeID:  sql.NullInt32{Int32: 2, Valid: true},
+	}); err != nil {
+		t.Fatalf("InsertFAQQuestionForWriter: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/internal/db/queries_roles_test.go
+++ b/internal/db/queries_roles_test.go
@@ -1,0 +1,30 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"regexp"
+)
+
+func TestQueries_AdminUpdateRole(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := New(db)
+
+	mock.ExpectExec(regexp.QuoteMeta(adminUpdateRole)).
+		WithArgs("name", true, false, int32(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := q.AdminUpdateRole(context.Background(), AdminUpdateRoleParams{Name: "name", CanLogin: true, IsAdmin: false, ID: 1}); err != nil {
+		t.Fatalf("AdminUpdateRole: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/internal/db/queries_users_admin_test.go
+++ b/internal/db/queries_users_admin_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"regexp"
 	"testing"
 
@@ -52,6 +53,48 @@ func TestQueries_AdminListAllUsers(t *testing.T) {
 	}
 	if len(res) != 1 || res[0].Idusers != 1 || res[0].Username.String != "bob" || res[0].Email != "bob@example.com" {
 		t.Fatalf("unexpected result %+v", res)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestQueries_AdminDeleteUserByID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := New(db)
+
+	mock.ExpectExec(regexp.QuoteMeta(adminDeleteUserByID)).
+		WithArgs(int32(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := q.AdminDeleteUserByID(context.Background(), 1); err != nil {
+		t.Fatalf("AdminDeleteUserByID: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestQueries_AdminUpdateUsernameByID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := New(db)
+
+	mock.ExpectExec(regexp.QuoteMeta(adminUpdateUsernameByID)).
+		WithArgs(sql.NullString{String: "bob", Valid: true}, int32(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := q.AdminUpdateUsernameByID(context.Background(), AdminUpdateUsernameByIDParams{Username: sql.NullString{String: "bob", Valid: true}, Idusers: 1}); err != nil {
+		t.Fatalf("AdminUpdateUsernameByID: %v", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/specs/query_naming.md
+++ b/specs/query_naming.md
@@ -54,3 +54,11 @@ queries.
   must apply the caller's pagination and language settings.
 - User queries should validate grants in SQL and again in Go code for defence in
   depth.
+
+## Custom queries
+
+Queries that cannot be represented as static SQL should be defined on the
+`CustomQueries` interface. The generated `Queries` type must not expose the
+underlying database handle (previously available via `DB()`). If a custom
+query can be implemented as a normal query without significant runtime cost,
+prefer adding it as a standard query instead of using `CustomQueries`.


### PR DESCRIPTION
## Summary
- document custom query rules and forbid exposing raw DB handles
- add admin and system queries for user, role, FAQ and stats operations
- remove direct database access from handlers in favour of named queries

## Testing
- `go vet ./...` (fails: db.New undefined in several tests)
- `golangci-lint run` (failed: process interrupted)
- `go test ./...` (fails: db.New undefined in tests)


------
https://chatgpt.com/codex/tasks/task_e_688ed9ee9adc832f94970c59e63b3476