### PR TITLE
Remove unused role inheritance query

### DIFF
--- a/internal/db/queries-permissions.sql
+++ b/internal/db/queries-permissions.sql
@@ -58,15 +58,9 @@ WHERE g.section = 'role'
 LIMIT 1;
 
 -- name: ListEffectiveRoleIDsByUserID :many
-WITH RECURSIVE role_ids(id) AS (
-    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
-    UNION
-    SELECT r2.id
-    FROM role_ids ri
-    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
-    JOIN roles r2 ON r2.name = g.action
-)
-SELECT DISTINCT id FROM role_ids;
+SELECT DISTINCT ur.role_id AS id
+FROM user_roles ur
+WHERE ur.users_idusers = ?;
 
 -- name: CheckGrant :one
 WITH RECURSIVE role_ids(id) AS (

--- a/internal/db/queries-permissions.sql.go
+++ b/internal/db/queries-permissions.sql.go
@@ -329,15 +329,9 @@ func (q *Queries) GetUserRoles(ctx context.Context) ([]*GetUserRolesRow, error) 
 }
 
 const listEffectiveRoleIDsByUserID = `-- name: ListEffectiveRoleIDsByUserID :many
-WITH RECURSIVE role_ids(id) AS (
-    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
-    UNION
-    SELECT r2.id
-    FROM role_ids ri
-    JOIN grants g ON g.role_id = ri.id AND g.section = 'role' AND g.active = 1
-    JOIN roles r2 ON r2.name = g.action
-)
-SELECT DISTINCT id FROM role_ids
+SELECT DISTINCT ur.role_id AS id
+FROM user_roles ur
+WHERE ur.users_idusers = ?
 `
 
 func (q *Queries) ListEffectiveRoleIDsByUserID(ctx context.Context, usersIdusers int32) ([]int32, error) {

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -18,10 +18,8 @@ Each role includes the following flags:
 - **is_admin** – marks administrator roles that bypass permission checks
 - **public_profile_allowed_at** – when set, users with this role may expose a public profile
 
-Users can hold multiple roles through the `user_roles` table. Role inheritance is
-modelled via entries in the `grants` table with `section = 'role'`. For example,
-`administrator` inherits `moderator` and `content writer` which in turn inherit
-`user`.
+Users can hold multiple roles through the `user_roles` table. Roles are assigned
+explicitly without inheritance.
 
 The `user` role does not need to be explicitly assigned. Any authenticated
 account automatically gains the `user` role while the `anonymous` role applies
@@ -81,8 +79,8 @@ Each section may define additional actions, but these are the core verbs used by
 ## Permission Resolution
 
 When checking access for a user, the application resolves the user's effective
-roles using the `ListEffectiveRoleIDsByUserID` query. This query recursively
-expands role inheritance defined in `grants`.
+roles using the `ListEffectiveRoleIDsByUserID` query which returns the roles
+directly assigned to the user.
 
 A permission check searches the `grants` table for an active row matching the
 requested `section`, `item` and `action`. A grant is considered applicable if


### PR DESCRIPTION
## Summary
- simplify ListEffectiveRoleIDsByUserID to only fetch direct user roles
- document that roles are assigned explicitly without inheritance

## Testing
- `go mod tidy`
- `go vet ./...` *(fails: queries.MonthlyUsageCounts undefined, db.New undefined, etc.)*
- `golangci-lint run` *(fails: typecheck errors e.g. db.New undefined)*
- `go test ./...` *(fails: queries.MonthlyUsageCounts undefined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688edafb690c832f96462d47f55bfbb2