### PR TITLE
refactor: prefix user lookup queries with system

### DIFF
--- a/cmd/goa4web/email_queue_list.go
+++ b/cmd/goa4web/email_queue_list.go
@@ -44,9 +44,9 @@ func (c *emailQueueListCmd) Run() error {
 			ids = append(ids, e.ToUserID.Int32)
 		}
 	}
-	users := make(map[int32]*db.GetUserByIdRow)
+	users := make(map[int32]*db.SystemGetUserByIDRow)
 	for _, id := range ids {
-		if u, err := queries.GetUserById(ctx, id); err == nil {
+		if u, err := queries.SystemGetUserByID(ctx, id); err == nil {
 			users[id] = u
 		}
 	}

--- a/cmd/goa4web/perm_grant.go
+++ b/cmd/goa4web/perm_grant.go
@@ -41,7 +41,7 @@ func (c *permGrantCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(db)
 	c.rootCmd.Verbosef("granting %s to %s", c.Role, c.User)
-	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.User, Valid: true})
+	u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.User, Valid: true})
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}

--- a/cmd/goa4web/user_activate.go
+++ b/cmd/goa4web/user_activate.go
@@ -42,7 +42,7 @@ func (c *userActivateCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(db)
 	if c.ID == 0 {
-		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+		u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {
 			return fmt.Errorf("get user: %w", err)
 		}

--- a/cmd/goa4web/user_add_role.go
+++ b/cmd/goa4web/user_add_role.go
@@ -42,7 +42,7 @@ func (c *userAddRoleCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(db)
 	c.rootCmd.Verbosef("adding role %s to %s", c.Role, c.Username)
-	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+	u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}

--- a/cmd/goa4web/user_approve.go
+++ b/cmd/goa4web/user_approve.go
@@ -41,7 +41,7 @@ func (c *userApproveCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(db)
 	if c.ID == 0 {
-		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+		u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {
 			return fmt.Errorf("get user: %w", err)
 		}

--- a/cmd/goa4web/user_comments_add.go
+++ b/cmd/goa4web/user_comments_add.go
@@ -47,7 +47,7 @@ func (c *userCommentsAddCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(db)
 	if c.ID == 0 {
-		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+		u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {
 			return fmt.Errorf("get user: %w", err)
 		}

--- a/cmd/goa4web/user_comments_list.go
+++ b/cmd/goa4web/user_comments_list.go
@@ -41,7 +41,7 @@ func (c *userCommentsListCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(db)
 	if c.ID == 0 {
-		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+		u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {
 			return fmt.Errorf("get user: %w", err)
 		}

--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -46,7 +46,7 @@ func (c *userDeactivateCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := db.New(db)
-	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+	u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}

--- a/cmd/goa4web/user_make_admin.go
+++ b/cmd/goa4web/user_make_admin.go
@@ -40,7 +40,7 @@ func (c *userMakeAdminCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(db)
 	c.rootCmd.Verbosef("granting administrator to %s", c.Username)
-	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+	u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}

--- a/cmd/goa4web/user_password_clear_user.go
+++ b/cmd/goa4web/user_password_clear_user.go
@@ -40,7 +40,7 @@ func (c *userPasswordClearUserCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := db.New(db)
-	user, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+	user, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}

--- a/cmd/goa4web/user_profile.go
+++ b/cmd/goa4web/user_profile.go
@@ -43,13 +43,13 @@ func (c *userProfileCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(db)
 	if c.ID == 0 {
-		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+		u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {
 			return fmt.Errorf("get user: %w", err)
 		}
 		c.ID = int(u.Idusers)
 	}
-	u, err := queries.GetUserById(ctx, int32(c.ID))
+	u, err := queries.SystemGetUserByID(ctx, int32(c.ID))
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}

--- a/cmd/goa4web/user_reject.go
+++ b/cmd/goa4web/user_reject.go
@@ -44,7 +44,7 @@ func (c *userRejectCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(db)
 	if c.ID == 0 {
-		u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+		u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {
 			return fmt.Errorf("get user: %w", err)
 		}

--- a/cmd/goa4web/user_remove_role.go
+++ b/cmd/goa4web/user_remove_role.go
@@ -41,7 +41,7 @@ func (c *userRemoveRoleCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(db)
 	c.rootCmd.Verbosef("removing role %s from %s", c.Role, c.Username)
-	u, err := queries.GetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
+	u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -433,7 +433,7 @@ func (cd *CoreData) CurrentUser() (*db.User, error) {
 		if cd.UserID == 0 || cd.queries == nil {
 			return nil, nil
 		}
-		row, err := cd.queries.GetUserById(cd.ctx, cd.UserID)
+		row, err := cd.queries.SystemGetUserByID(cd.ctx, cd.UserID)
 		if err != nil {
 			if !errors.Is(err, sql.ErrNoRows) {
 				return nil, err

--- a/handlers/admin/adminAnnouncementsPage.go
+++ b/handlers/admin/adminAnnouncementsPage.go
@@ -15,14 +15,14 @@ import (
 func AdminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		*common.CoreData
-               Announcements []*db.AdminListAnnouncementsWithNewsRow
+		Announcements []*db.AdminListAnnouncementsWithNewsRow
 		NewsID        string
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Admin Announcements"
 	data := Data{CoreData: cd}
 	queries := cd.Queries()
-       rows, err := queries.AdminListAnnouncementsWithNews(r.Context())
+	rows, err := queries.AdminListAnnouncementsWithNews(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list announcements: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -46,9 +46,9 @@ func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 			ids = append(ids, e.ToUserID.Int32)
 		}
 	}
-	users := make(map[int32]*db.GetUserByIdRow)
+	users := make(map[int32]*db.SystemGetUserByIDRow)
 	for _, id := range ids {
-		if u, err := queries.GetUserById(r.Context(), id); err == nil {
+		if u, err := queries.SystemGetUserByID(r.Context(), id); err == nil {
 			users[id] = u
 		}
 	}

--- a/handlers/admin/adminFailedEmailsPage.go
+++ b/handlers/admin/adminFailedEmailsPage.go
@@ -60,9 +60,9 @@ func AdminFailedEmailsPage(w http.ResponseWriter, r *http.Request) {
 			ids = append(ids, e.ToUserID.Int32)
 		}
 	}
-	users := make(map[int32]*db.GetUserByIdRow)
+	users := make(map[int32]*db.SystemGetUserByIDRow)
 	for _, id := range ids {
-		if u, err := queries.GetUserById(r.Context(), id); err == nil {
+		if u, err := queries.SystemGetUserByID(r.Context(), id); err == nil {
 			users[id] = u
 		}
 	}

--- a/handlers/admin/adminRequestQueuePage.go
+++ b/handlers/admin/adminRequestQueuePage.go
@@ -31,7 +31,7 @@ func AdminRequestQueuePage(w http.ResponseWriter, r *http.Request) {
 		Rows []Row
 	}{CoreData: cd}
 	for _, row := range rows {
-		user, err := queries.GetUserById(r.Context(), row.UsersIdusers)
+		user, err := queries.SystemGetUserByID(r.Context(), row.UsersIdusers)
 		if err != nil {
 			continue
 		}
@@ -58,7 +58,7 @@ func AdminRequestArchivePage(w http.ResponseWriter, r *http.Request) {
 		Rows []Row
 	}{CoreData: cd}
 	for _, row := range rows {
-		user, err := queries.GetUserById(r.Context(), row.UsersIdusers)
+		user, err := queries.SystemGetUserByID(r.Context(), row.UsersIdusers)
 		if err != nil {
 			continue
 		}
@@ -78,11 +78,11 @@ func adminRequestPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	comments, _ := queries.AdminListRequestComments(r.Context(), int32(id))
-	user, _ := queries.GetUserById(r.Context(), req.UsersIdusers)
+	user, _ := queries.SystemGetUserByID(r.Context(), req.UsersIdusers)
 	data := struct {
 		*common.CoreData
 		Req      *db.AdminRequestQueue
-		User     *db.GetUserByIdRow
+		User     *db.SystemGetUserByIDRow
 		Comments []*db.AdminRequestComment
 	}{
 		CoreData: cd,

--- a/handlers/admin/adminSentEmailsPage.go
+++ b/handlers/admin/adminSentEmailsPage.go
@@ -60,9 +60,9 @@ func AdminSentEmailsPage(w http.ResponseWriter, r *http.Request) {
 			ids = append(ids, e.ToUserID.Int32)
 		}
 	}
-	users := make(map[int32]*db.GetUserByIdRow)
+	users := make(map[int32]*db.SystemGetUserByIDRow)
 	for _, id := range ids {
-		if u, err := queries.GetUserById(r.Context(), id); err == nil {
+		if u, err := queries.SystemGetUserByID(r.Context(), id); err == nil {
 			users[id] = u
 		}
 	}

--- a/handlers/admin/adminUserBlogsPage.go
+++ b/handlers/admin/adminUserBlogsPage.go
@@ -18,7 +18,7 @@ func adminUserBlogsPage(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
-	user, err := queries.GetUserById(r.Context(), int32(id))
+	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return

--- a/handlers/admin/adminUserCommentsPage.go
+++ b/handlers/admin/adminUserCommentsPage.go
@@ -18,7 +18,7 @@ func adminUserCommentsPage(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
-	user, err := queries.GetUserById(r.Context(), int32(id))
+	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return

--- a/handlers/admin/adminUserForumPage.go
+++ b/handlers/admin/adminUserForumPage.go
@@ -18,7 +18,7 @@ func adminUserForumPage(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
-	user, err := queries.GetUserById(r.Context(), int32(id))
+	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return

--- a/handlers/admin/adminUserImagebbsPage.go
+++ b/handlers/admin/adminUserImagebbsPage.go
@@ -18,7 +18,7 @@ func adminUserImagebbsPage(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
-	user, err := queries.GetUserById(r.Context(), int32(id))
+	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return

--- a/handlers/admin/adminUserLinkerPage.go
+++ b/handlers/admin/adminUserLinkerPage.go
@@ -18,7 +18,7 @@ func adminUserLinkerPage(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
-	user, err := queries.GetUserById(r.Context(), int32(id))
+	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return

--- a/handlers/admin/adminUserPasswordReset.go
+++ b/handlers/admin/adminUserPasswordReset.go
@@ -43,7 +43,7 @@ func (UserPasswordResetTask) Action(w http.ResponseWriter, r *http.Request) any 
 		CoreData: cd,
 		Back:     "/admin/user/" + idStr,
 	}
-	userRow, err := queries.GetUserById(r.Context(), int32(id))
+	userRow, err := queries.SystemGetUserByID(r.Context(), int32(id))
 	if err != nil {
 		data.Errors = append(data.Errors, "user not found")
 		return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)
@@ -109,7 +109,7 @@ func adminUserResetPasswordConfirmPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Reset Password"
 	queries := cd.Queries()
-	userRow, err := queries.GetUserById(r.Context(), int32(id))
+	userRow, err := queries.SystemGetUserByID(r.Context(), int32(id))
 	if err != nil {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return

--- a/handlers/admin/adminUserProfilePage.go
+++ b/handlers/admin/adminUserProfilePage.go
@@ -20,7 +20,7 @@ func adminUserProfilePage(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
-	user, err := queries.GetUserById(r.Context(), int32(id))
+	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return

--- a/handlers/admin/adminUserSubscriptionsPage.go
+++ b/handlers/admin/adminUserSubscriptionsPage.go
@@ -18,7 +18,7 @@ func adminUserSubscriptionsPage(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
-	user, err := queries.GetUserById(r.Context(), int32(id))
+	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return

--- a/handlers/admin/adminUserWritingsPage.go
+++ b/handlers/admin/adminUserWritingsPage.go
@@ -18,7 +18,7 @@ func adminUserWritingsPage(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
-	user, err := queries.GetUserById(r.Context(), int32(id))
+	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -139,7 +139,7 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	var q db.Querier
 	emails := []string{"a@test.com", "b@test.com"}
 	for _, e := range emails {
-		mock.ExpectQuery("UserByEmail").
+		mock.ExpectQuery("SystemGetUserByEmail").
 			WithArgs(sql.NullString{String: e, Valid: true}).
 			WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, e, "u"))
 		mock.ExpectExec("INSERT INTO pending_emails").

--- a/handlers/admin/news_user_allow_task.go
+++ b/handlers/admin/news_user_allow_task.go
@@ -30,7 +30,7 @@ func (NewsUserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	username := r.PostFormValue("username")
 	role := r.PostFormValue("role")
-	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
+	u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
 	if err != nil {
 		return fmt.Errorf("get user by username fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/admin/resend_queue_task.go
+++ b/handlers/admin/resend_queue_task.go
@@ -51,9 +51,9 @@ func (ResendQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 		}
 	}
-	users := make(map[int32]*db.GetUserByIdRow)
+	users := make(map[int32]*db.SystemGetUserByIDRow)
 	for _, id := range ids {
-		if u, err := queries.GetUserById(r.Context(), id); err == nil {
+		if u, err := queries.SystemGetUserByID(r.Context(), id); err == nil {
 			users[id] = u
 		}
 	}

--- a/handlers/admin/send_notification_task.go
+++ b/handlers/admin/send_notification_task.go
@@ -36,7 +36,7 @@ func (SendNotificationTask) Action(w http.ResponseWriter, r *http.Request) any {
 			if name == "" {
 				continue
 			}
-			u, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: name, Valid: true})
+			u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{String: name, Valid: true})
 			if err != nil {
 				return fmt.Errorf("get user %s fail %w", name, handlers.ErrRedirectOnSamePageHandler(err))
 			}

--- a/handlers/admin/test_template_task.go
+++ b/handlers/admin/test_template_task.go
@@ -37,7 +37,7 @@ func (TestTemplateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	queries := cd.Queries()
-	urow, err := queries.GetUserById(r.Context(), cd.UserID)
+	urow, err := queries.SystemGetUserByID(r.Context(), cd.UserID)
 	if err != nil {
 		return fmt.Errorf("get user fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/auth/email_association_request_task.go
+++ b/handlers/auth/email_association_request_task.go
@@ -33,7 +33,7 @@ func (EmailAssociationRequestTask) Action(w http.ResponseWriter, r *http.Request
 	email := r.PostFormValue("email")
 	reason := r.PostFormValue("reason")
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	row, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
+	row, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		return fmt.Errorf("user not found %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/auth/forgotPassword_event_test.go
+++ b/handlers/auth/forgotPassword_event_test.go
@@ -26,7 +26,7 @@ func TestForgotPasswordEventData(t *testing.T) {
 	}
 	defer db.Close()
 	q := db.New(db)
-	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
+	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, passwd")).WithArgs(int32(1), sqlmock.AnyArg()).WillReturnError(sql.ErrNoRows)
 	mock.ExpectExec("INSERT INTO pending_passwords").WillReturnResult(sqlmock.NewResult(1, 1))

--- a/handlers/auth/forgotPassword_limit_test.go
+++ b/handlers/auth/forgotPassword_limit_test.go
@@ -26,7 +26,7 @@ func TestForgotPasswordRateLimit(t *testing.T) {
 	defer db.Close()
 	q := db.New(db)
 
-	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
+	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 	resetRows := sqlmock.NewRows([]string{"id", "user_id", "passwd", "passwd_algorithm", "verification_code", "created_at", "verified_at"}).
 		AddRow(1, 1, "hash", "alg", "code", time.Now(), nil)
@@ -58,7 +58,7 @@ func TestForgotPasswordReplaceOld(t *testing.T) {
 	defer db.Close()
 	q := db.New(db)
 
-	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
+	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 	oldRows := sqlmock.NewRows([]string{"id", "user_id", "passwd", "passwd_algorithm", "verification_code", "created_at", "verified_at"}).
 		AddRow(1, 1, "hash", "alg", "code", time.Now().Add(-25*time.Hour), nil)

--- a/handlers/auth/forgotPassword_no_email_test.go
+++ b/handlers/auth/forgotPassword_no_email_test.go
@@ -24,7 +24,7 @@ func TestForgotPasswordNoEmail(t *testing.T) {
 	}
 	defer db.Close()
 	q := db.New(db)
-	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "", "u", nil))
+	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 
 	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
@@ -52,7 +52,7 @@ func TestEmailAssociationRequestTask(t *testing.T) {
 	}
 	defer db.Close()
 	q := db.New(db)
-	mock.ExpectQuery("GetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "", "u", nil))
+	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "", "u", nil))
 	mock.ExpectExec("INSERT INTO admin_request_queue").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO admin_request_comments").WillReturnResult(sqlmock.NewResult(1, 1))
 

--- a/handlers/auth/forgot_password_task.go
+++ b/handlers/auth/forgot_password_task.go
@@ -41,7 +41,7 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 	pw := r.PostFormValue("password")
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
-	row, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
+	row, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		return fmt.Errorf("user not found %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/auth/login_task.go
+++ b/handlers/auth/login_task.go
@@ -61,7 +61,7 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 
-	row, err := queries.Login(r.Context(), sql.NullString{String: username, Valid: true})
+	row, err := queries.SystemGetLogin(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			if err := queries.SystemInsertLoginAttempt(r.Context(), db.SystemInsertLoginAttemptParams{Username: username, IpAddress: strings.Split(r.RemoteAddr, ":")[0]}); err != nil {

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -53,7 +53,7 @@ func (RegisterTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	queries := cd.Queries()
 
-	if _, err := queries.GetUserByUsername(r.Context(), sql.NullString{
+	if _, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{
 		String: username,
 		Valid:  true,
 	}); errors.Is(err, sql.ErrNoRows) {
@@ -64,7 +64,7 @@ func (RegisterTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return handlers.ErrRedirectOnSamePageHandler(errors.New("user exists"))
 	}
 
-	if _, err := queries.UserByEmail(r.Context(), email); errors.Is(err, sql.ErrNoRows) {
+	if _, err := queries.SystemGetUserByEmail(r.Context(), email); errors.Is(err, sql.ErrNoRows) {
 	} else if err != nil {
 		log.Printf("UserByUsername Error: %s", err)
 		return fmt.Errorf("user by email %w", err)

--- a/handlers/blogs/bloggerPostsPage.go
+++ b/handlers/blogs/bloggerPostsPage.go
@@ -45,7 +45,7 @@ func BloggerPostsPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
-	bu, err := queries.GetUserByUsername(r.Context(), sql.NullString{
+	bu, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{
 		String: username,
 		Valid:  true,
 	})
@@ -54,7 +54,7 @@ func BloggerPostsPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 			http.NotFound(w, r)
 		default:
-			log.Printf("GetUserByUsername Error: %s", err)
+			log.Printf("SystemGetUserByUsername Error: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		}
 		return

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -151,7 +151,7 @@ func CustomBlogIndex(data *common.CoreData, r *http.Request) {
 func RssPage(w http.ResponseWriter, r *http.Request) {
 	username := r.URL.Query().Get("rss")
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{
+	u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{
 		String: username,
 		Valid:  true,
 	})
@@ -176,7 +176,7 @@ func RssPage(w http.ResponseWriter, r *http.Request) {
 func AtomPage(w http.ResponseWriter, r *http.Request) {
 	username := r.URL.Query().Get("rss")
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{
+	u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{
 		String: username,
 		Valid:  true,
 	})

--- a/handlers/blogs/blogsUserPermissionsPage.go
+++ b/handlers/blogs/blogsUserPermissionsPage.go
@@ -80,8 +80,8 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/blogs/bloggers",
 	}
-	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("GetUserByUsername: %w", err).Error())
+	if u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("SystemGetUserByUsername: %w", err).Error())
 	} else if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
 		UsersIdusers: u.Idusers,
 		Name:         role,

--- a/handlers/forum/category_grant_create_task.go
+++ b/handlers/forum/category_grant_create_task.go
@@ -40,9 +40,9 @@ func (CategoryGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) an
 	}
 	var uid sql.NullInt32
 	if username != "" {
-		u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
+		u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
 		if err != nil {
-			log.Printf("GetUserByUsername: %v", err)
+			log.Printf("SystemGetUserByUsername: %v", err)
 			return fmt.Errorf("get user by username %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		uid = sql.NullInt32{Int32: u.Idusers, Valid: true}

--- a/handlers/forum/forumAdminCategoryGrantsPage.go
+++ b/handlers/forum/forumAdminCategoryGrantsPage.go
@@ -49,7 +49,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 		if g.Section == "forum" && g.Item.Valid && g.Item.String == "category" && g.ItemID.Valid && g.ItemID.Int32 == int32(cid) {
 			gi := GrantInfo{Grant: g}
 			if g.UserID.Valid {
-				if u, err := queries.GetUserById(r.Context(), g.UserID.Int32); err == nil {
+				if u, err := queries.SystemGetUserByID(r.Context(), g.UserID.Int32); err == nil {
 					gi.Username = sql.NullString{String: u.Username.String, Valid: true}
 				}
 			}

--- a/handlers/forum/forumAdminTopicGrantsPage.go
+++ b/handlers/forum/forumAdminTopicGrantsPage.go
@@ -48,7 +48,7 @@ func AdminTopicGrantsPage(w http.ResponseWriter, r *http.Request) {
 		if g.Section == "forum" && g.Item.Valid && g.Item.String == "topic" && g.ItemID.Valid && g.ItemID.Int32 == int32(tid) {
 			gi := GrantInfo{Grant: g}
 			if g.UserID.Valid {
-				if u, err := queries.GetUserById(r.Context(), g.UserID.Int32); err == nil {
+				if u, err := queries.SystemGetUserByID(r.Context(), g.UserID.Int32); err == nil {
 					gi.Username = sql.NullString{String: u.Username.String, Valid: true}
 				}
 			}

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -142,7 +142,7 @@ func (CreateThreadTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if trow, err := queries.GetForumTopicByIdForUser(r.Context(), db.GetForumTopicByIdForUserParams{ViewerID: uid, Idforumtopic: int32(topicId), ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0}}); err == nil {
 		topicTitle = trow.Title.String
 	}
-	if u, err := queries.GetUserById(r.Context(), uid); err == nil {
+	if u, err := queries.SystemGetUserByID(r.Context(), uid); err == nil {
 		author = u.Username.String
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/forum/topic_grant_create_task.go
+++ b/handlers/forum/topic_grant_create_task.go
@@ -40,9 +40,9 @@ func (TopicGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	var uid sql.NullInt32
 	if username != "" {
-		u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
+		u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
 		if err != nil {
-			log.Printf("GetUserByUsername: %v", err)
+			log.Printf("SystemGetUserByUsername: %v", err)
 			return fmt.Errorf("get user by username %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		uid = sql.NullInt32{Int32: u.Idusers, Valid: true}

--- a/handlers/imagebbs/imagebbsPosterPage.go
+++ b/handlers/imagebbs/imagebbsPosterPage.go
@@ -31,13 +31,13 @@ func PosterPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = fmt.Sprintf("Images by %s", username)
 	queries := cd.Queries()
-	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
+	u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 			http.NotFound(w, r)
 		default:
-			log.Printf("GetUserByUsername Error: %s", err)
+			log.Printf("SystemGetUserByUsername Error: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		}
 		return

--- a/handlers/linker/category_grant_create_task.go
+++ b/handlers/linker/category_grant_create_task.go
@@ -40,9 +40,9 @@ func (CategoryGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) an
 	}
 	var uid sql.NullInt32
 	if username != "" {
-		u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
+		u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
 		if err != nil {
-			log.Printf("GetUserByUsername: %v", err)
+			log.Printf("SystemGetUserByUsername: %v", err)
 			return fmt.Errorf("get user by username %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		uid = sql.NullInt32{Int32: u.Idusers, Valid: true}

--- a/handlers/linker/linkerAdminCategoryGrantsPage.go
+++ b/handlers/linker/linkerAdminCategoryGrantsPage.go
@@ -49,7 +49,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 		if g.Section == "linker" && g.Item.Valid && g.Item.String == "category" && g.ItemID.Valid && g.ItemID.Int32 == int32(cid) {
 			gi := GrantInfo{Grant: g}
 			if g.UserID.Valid {
-				if u, err := queries.GetUserById(r.Context(), g.UserID.Int32); err == nil {
+				if u, err := queries.SystemGetUserByID(r.Context(), g.UserID.Int32); err == nil {
 					gi.Username = sql.NullString{String: u.Username.String, Valid: true}
 				}
 			}

--- a/handlers/linker/linkerUserPage.go
+++ b/handlers/linker/linkerUserPage.go
@@ -29,13 +29,13 @@ func UserPage(w http.ResponseWriter, r *http.Request) {
 	username := vars["username"]
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
+	u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 			http.NotFound(w, r)
 		default:
-			log.Printf("GetUserByUsername Error: %s", err)
+			log.Printf("SystemGetUserByUsername Error: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		}
 		return

--- a/handlers/linker/user_allow_task.go
+++ b/handlers/linker/user_allow_task.go
@@ -35,9 +35,9 @@ func (userAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
 		if username == "" {
 			continue
 		}
-		u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
+		u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
 		if err != nil {
-			log.Printf("GetUserByUsername Error: %s", err)
+			log.Printf("SystemGetUserByUsername Error: %s", err)
 			continue
 		}
 		if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{

--- a/handlers/news/announcement_add_task.go
+++ b/handlers/news/announcement_add_task.go
@@ -36,9 +36,9 @@ func (AnnouncementAddTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	if ann == nil {
-               if err := queries.AdminPromoteAnnouncement(r.Context(), int32(pid)); err != nil {
-                       return fmt.Errorf("promote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-               }
+		if err := queries.AdminPromoteAnnouncement(r.Context(), int32(pid)); err != nil {
+			return fmt.Errorf("promote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
 	} else if !ann.Active {
 		if err := queries.SetAnnouncementActive(r.Context(), db.SetAnnouncementActiveParams{Active: true, ID: ann.ID}); err != nil {
 			return fmt.Errorf("activate announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/news/newsNewPostTask.go
+++ b/handlers/news/newsNewPostTask.go
@@ -108,7 +108,7 @@ func (NewPostTask) Action(w http.ResponseWriter, r *http.Request) any {
 		log.Printf("create grant: %v", err)
 	}
 
-	if u, err := queries.GetUserById(r.Context(), uid); err == nil {
+	if u, err := queries.SystemGetUserByID(r.Context(), uid); err == nil {
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 			if evt := cd.Event(); evt != nil {
 				if evt.Data == nil {

--- a/handlers/news/user_allow_task.go
+++ b/handlers/news/user_allow_task.go
@@ -43,8 +43,8 @@ func (UserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     "/news",
 	}
-	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("GetUserByUsername: %w", err).Error())
+	if u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("SystemGetUserByUsername: %w", err).Error())
 	} else if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
 		UsersIdusers: u.Idusers,
 		Name:         role,

--- a/handlers/user/admin_permissions.go
+++ b/handlers/user/admin_permissions.go
@@ -32,7 +32,7 @@ func adminUserPermissionsPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := data.Queries()
 
-	if u, err := queries.GetUserById(r.Context(), int32(id)); err == nil {
+	if u, err := queries.SystemGetUserByID(r.Context(), int32(id)); err == nil {
 		data.User = &db.User{Idusers: u.Idusers, Username: u.Username}
 	} else {
 		http.Error(w, "user not found", http.StatusNotFound)

--- a/handlers/user/admin_users.go
+++ b/handlers/user/admin_users.go
@@ -136,7 +136,7 @@ func adminUserDisableConfirmPage(w http.ResponseWriter, r *http.Request) {
 	idStr := mux.Vars(r)["id"]
 	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	u, err := cd.Queries().GetUserById(r.Context(), int32(id))
+	u, err := cd.Queries().SystemGetUserByID(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
@@ -178,14 +178,14 @@ func adminUserEditFormPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	idStr := mux.Vars(r)["id"]
 	uid, _ := strconv.Atoi(idStr)
-	urow, err := queries.GetUserById(r.Context(), int32(uid))
+	urow, err := queries.SystemGetUserByID(r.Context(), int32(uid))
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 	data := struct {
 		*common.CoreData
-		User *db.GetUserByIdRow
+		User *db.SystemGetUserByIDRow
 	}{
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		User:     urow,

--- a/handlers/user/permissionUserAllowTask.go
+++ b/handlers/user/permissionUserAllowTask.go
@@ -52,8 +52,8 @@ func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) an
 		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
 		Back:     back,
 	}
-	if u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("GetUserByUsername: %w", err).Error())
+	if u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
+		data.Errors = append(data.Errors, fmt.Errorf("SystemGetUserByUsername: %w", err).Error())
 	} else if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
 		UsersIdusers: u.Idusers,
 		Name:         role,

--- a/handlers/user/permissionUserDisallowTask.go
+++ b/handlers/user/permissionUserDisallowTask.go
@@ -64,7 +64,7 @@ func (PermissionUserDisallowTask) Action(w http.ResponseWriter, r *http.Request)
 				if row.IduserRoles == int32(permidi) {
 					role = row.Role
 					userID = row.UsersIdusers
-					if u, err := queries.GetUserById(r.Context(), row.UsersIdusers); err == nil && u.Username.Valid {
+					if u, err := queries.SystemGetUserByID(r.Context(), row.UsersIdusers); err == nil && u.Username.Valid {
 						uname = u.Username.String
 					}
 					break

--- a/handlers/user/publicProfilePage.go
+++ b/handlers/user/publicProfilePage.go
@@ -18,7 +18,7 @@ func userPublicProfilePage(w http.ResponseWriter, r *http.Request) {
 	username := mux.Vars(r)["username"]
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
-	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
+	u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		http.NotFound(w, r)
 		return

--- a/handlers/writings/category_grant_create_task.go
+++ b/handlers/writings/category_grant_create_task.go
@@ -40,9 +40,9 @@ func (CategoryGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) an
 	}
 	var uid sql.NullInt32
 	if username != "" {
-		u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
+		u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
 		if err != nil {
-			log.Printf("GetUserByUsername: %v", err)
+			log.Printf("SystemGetUserByUsername: %v", err)
 			return fmt.Errorf("get user by username %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		uid = sql.NullInt32{Int32: u.Idusers, Valid: true}

--- a/handlers/writings/submit_writing_task.go
+++ b/handlers/writings/submit_writing_task.go
@@ -71,7 +71,7 @@ func (SubmitWritingTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	var author string
-	if u, err := queries.GetUserById(r.Context(), uid); err == nil {
+	if u, err := queries.SystemGetUserByID(r.Context(), uid); err == nil {
 		author = u.Username.String
 	} else {
 		return fmt.Errorf("get user fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/writings/user_allow_task.go
+++ b/handlers/writings/user_allow_task.go
@@ -26,7 +26,7 @@ func (UserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	username := r.PostFormValue("username")
 	role := r.PostFormValue("role")
-	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
+	u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
 	if err != nil {
 		return fmt.Errorf("get user by username fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/writings/writing_category_grant_create_task.go
+++ b/handlers/writings/writing_category_grant_create_task.go
@@ -40,9 +40,9 @@ func (WritingCategoryGrantCreateTask) Action(w http.ResponseWriter, r *http.Requ
 	}
 	var uid sql.NullInt32
 	if username != "" {
-		u, err := queries.GetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
+		u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username})
 		if err != nil {
-			log.Printf("GetUserByUsername: %v", err)
+			log.Printf("SystemGetUserByUsername: %v", err)
 			return fmt.Errorf("get user by username %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		uid = sql.NullInt32{Int32: u.Idusers, Valid: true}

--- a/handlers/writings/writingsAdminCategoryGrantsPage.go
+++ b/handlers/writings/writingsAdminCategoryGrantsPage.go
@@ -51,7 +51,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 		if g.Section == "writing" && g.Item.Valid && g.Item.String == "category" && g.ItemID.Valid && g.ItemID.Int32 == int32(cid) {
 			gi := GrantInfo{Grant: g}
 			if g.UserID.Valid {
-				if u, err := queries.GetUserById(r.Context(), g.UserID.Int32); err == nil {
+				if u, err := queries.SystemGetUserByID(r.Context(), g.UserID.Int32); err == nil {
 					gi.Username = sql.NullString{String: u.Username.String, Valid: true}
 				}
 			}

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -70,7 +70,7 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var author string
-	if u, err := queries.GetUserById(r.Context(), uid); err == nil {
+	if u, err := queries.SystemGetUserByID(r.Context(), uid); err == nil {
 		author = u.Username.String
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/writings/writingsWriterPage.go
+++ b/handlers/writings/writingsWriterPage.go
@@ -31,13 +31,13 @@ func WriterPage(w http.ResponseWriter, r *http.Request) {
 	cd.PageTitle = fmt.Sprintf("Writer: %s", username)
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	u, err := queries.GetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
+	u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{String: username, Valid: true})
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 			http.NotFound(w, r)
 		default:
-			log.Printf("GetUserByUsername Error: %s", err)
+			log.Printf("SystemGetUserByUsername Error: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		}
 		return

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -286,8 +286,6 @@ type Querier interface {
 	GetPublicWritings(ctx context.Context, arg GetPublicWritingsParams) ([]*Writing, error)
 	GetThreadLastPosterAndPerms(ctx context.Context, arg GetThreadLastPosterAndPermsParams) (*GetThreadLastPosterAndPermsRow, error)
 	GetUnreadNotifications(ctx context.Context, usersIdusers int32) ([]*Notification, error)
-	GetUserById(ctx context.Context, idusers int32) (*GetUserByIdRow, error)
-	GetUserByUsername(ctx context.Context, username sql.NullString) (*GetUserByUsernameRow, error)
 	GetUserEmailByCode(ctx context.Context, lastVerificationCode sql.NullString) (*UserEmail, error)
 	GetUserEmailByEmail(ctx context.Context, email string) (*UserEmail, error)
 	GetUserEmailByID(ctx context.Context, id int32) (*UserEmail, error)
@@ -351,7 +349,6 @@ type Querier interface {
 	ListWritersSearchForLister(ctx context.Context, arg ListWritersSearchForListerParams) ([]*ListWritersSearchForListerRow, error)
 	ListWritingCategoriesForLister(ctx context.Context, arg ListWritingCategoriesForListerParams) ([]*WritingCategory, error)
 	ListWritingsByIDsForLister(ctx context.Context, arg ListWritingsByIDsForListerParams) ([]*ListWritingsByIDsForListerRow, error)
-	Login(ctx context.Context, username sql.NullString) (*LoginRow, error)
 	MakeThread(ctx context.Context, forumtopicIdforumtopic int32) (int64, error)
 	MarkEmailSent(ctx context.Context, id int32) error
 	MarkNotificationRead(ctx context.Context, id int32) error
@@ -407,8 +404,12 @@ type Querier interface {
 	SystemGetAllBlogsForIndex(ctx context.Context) ([]*SystemGetAllBlogsForIndexRow, error)
 	// SystemGetLanguageIDByName resolves a language ID by name.
 	SystemGetLanguageIDByName(ctx context.Context, nameof sql.NullString) (int32, error)
+	SystemGetLogin(ctx context.Context, username sql.NullString) (*SystemGetLoginRow, error)
 	SystemGetSearchWordByWordLowercased(ctx context.Context, lcase string) (*Searchwordlist, error)
 	SystemGetTemplateOverride(ctx context.Context, name string) (string, error)
+	SystemGetUserByEmail(ctx context.Context, email string) (*SystemGetUserByEmailRow, error)
+	SystemGetUserByID(ctx context.Context, idusers int32) (*SystemGetUserByIDRow, error)
+	SystemGetUserByUsername(ctx context.Context, username sql.NullString) (*SystemGetUserByUsernameRow, error)
 	// System query only used internally
 	SystemInsertDeadLetter(ctx context.Context, message string) error
 	SystemInsertLoginAttempt(ctx context.Context, arg SystemInsertLoginAttemptParams) error
@@ -448,7 +449,6 @@ type Querier interface {
 	UpdateUserEmail(ctx context.Context, arg UpdateUserEmailParams) error
 	UpdateUserEmailVerification(ctx context.Context, arg UpdateUserEmailVerificationParams) error
 	UpdateWriting(ctx context.Context, arg UpdateWritingParams) error
-	UserByEmail(ctx context.Context, email string) (*UserByEmailRow, error)
 	UserHasLoginRole(ctx context.Context, usersIdusers int32) (int32, error)
 	UserHasPublicProfileRole(ctx context.Context, usersIdusers int32) (int32, error)
 	UserHasRole(ctx context.Context, arg UserHasRoleParams) (int32, error)

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -10,7 +10,7 @@ JOIN user_roles ur ON ur.users_idusers = u.idusers
 JOIN roles r ON ur.role_id = r.id
 WHERE r.is_admin = 1;
 
--- name: GetUserByUsername :one
+-- name: SystemGetUserByUsername :one
 SELECT idusers,
        (SELECT email FROM user_emails ue WHERE ue.user_id = users.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
        username,
@@ -18,7 +18,7 @@ SELECT idusers,
 FROM users
 WHERE username = ?;
 
--- name: Login :one
+-- name: SystemGetLogin :one
 SELECT u.idusers,
        (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
        p.passwd, p.passwd_algorithm, u.username
@@ -27,7 +27,7 @@ WHERE u.username = ?
 ORDER BY p.created_at DESC
 LIMIT 1;
 
--- name: GetUserById :one
+-- name: SystemGetUserByID :one
 SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at
 FROM users u
 LEFT JOIN user_emails ue ON ue.id = (
@@ -37,7 +37,7 @@ LEFT JOIN user_emails ue ON ue.id = (
 )
 WHERE u.idusers = ?;
 
--- name: UserByEmail :one
+-- name: SystemGetUserByEmail :one
 SELECT u.idusers, ue.email, u.username
 FROM users u JOIN user_emails ue ON ue.user_id = u.idusers
 WHERE ue.email = ?

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -211,7 +211,7 @@ func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.TaskEvent
 		return err
 	}
 	for _, id := range ids {
-		user, err := n.Queries.GetUserById(ctx, id)
+		user, err := n.Queries.SystemGetUserByID(ctx, id)
 		if err != nil || !user.Email.Valid || user.Email.String == "" {
 			if nmErr := notifyMissingEmail(ctx, n.Queries, id); nmErr != nil {
 				log.Printf("notify missing email: %v", nmErr)

--- a/internal/notifications/dlq.go
+++ b/internal/notifications/dlq.go
@@ -37,7 +37,7 @@ func (n *Notifier) dlqRecordAndNotify(ctx context.Context, q dlq.DLQ, msg string
 				nt, err := n.renderNotification(ctx, NotificationTemplateFilenameGenerator("dlqMultiFailure"), data)
 				if err == nil {
 					for _, addr := range n.adminEmails(ctx) {
-						u, err := n.Queries.UserByEmail(ctx, addr)
+						u, err := n.Queries.SystemGetUserByEmail(ctx, addr)
 						if err != nil {
 							continue
 						}

--- a/internal/notifications/email.go
+++ b/internal/notifications/email.go
@@ -145,7 +145,7 @@ func (n *Notifier) queueEmail(ctx context.Context, userID *int32, direct bool, m
 
 // sendSubscriberEmail queues an email notification for a subscriber.
 func (n *Notifier) sendSubscriberEmail(ctx context.Context, userID int32, evt eventbus.TaskEvent, et *EmailTemplates) error {
-	user, err := n.Queries.GetUserById(ctx, userID)
+	user, err := n.Queries.SystemGetUserByID(ctx, userID)
 	if err != nil || !user.Email.Valid || user.Email.String == "" {
 		if nmErr := notifyMissingEmail(ctx, n.Queries, userID); nmErr != nil {
 			log.Printf("notify missing email: %v", nmErr)

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -66,7 +66,7 @@ func TestNotifierNotifyAdmins(t *testing.T) {
 	cfg.EmailFrom = "from@example.com"
 	cfg.NotificationsEnabled = true
 
-	mock.ExpectQuery("UserByEmail").
+	mock.ExpectQuery("SystemGetUserByEmail").
 		WithArgs(sql.NullString{String: "a@test", Valid: true}).
 		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test", "a"))
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 1, Valid: true}, sqlmock.AnyArg(), false).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -134,7 +134,7 @@ func (n *Notifier) notifyAdmins(ctx context.Context, et *EmailTemplates, nt *str
 	}
 	for _, addr := range n.adminEmails(ctx) {
 		var uid *int32
-		if u, err := n.Queries.UserByEmail(ctx, addr); err == nil {
+		if u, err := n.Queries.SystemGetUserByEmail(ctx, addr); err == nil {
 			id := u.Idusers
 			uid = &id
 		} else {

--- a/workers/emailqueue/email_queue.go
+++ b/workers/emailqueue/email_queue.go
@@ -98,7 +98,7 @@ func hasVerificationRecord(ctx context.Context, q db.Querier, addr string) bool 
 // email logic is applied.
 func ResolveQueuedEmailAddress(ctx context.Context, q db.Querier, cfg *config.RuntimeConfig, e *db.SystemListPendingEmailsRow) (mail.Address, error) {
 	if e.ToUserID.Valid && e.ToUserID.Int32 != 0 {
-		user, err := q.GetUserById(ctx, e.ToUserID.Int32)
+		user, err := q.SystemGetUserByID(ctx, e.ToUserID.Int32)
 		if err == nil && user.Email.Valid && user.Email.String != "" {
 			return mail.Address{Name: user.Username.String, Address: user.Email.String}, nil
 		}


### PR DESCRIPTION
## Summary
- rename user lookup SQL queries with `System` prefix and regenerate
- update handlers and tasks to call `SystemGetLogin`, `SystemGetUserByUsername`, `SystemGetUserByID`, and `SystemGetUserByEmail`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: db.New undefined, etc.)*
- `golangci-lint run` *(fails: db.New undefined, typecheck errors)*
- `go test ./...` *(fails: db.New undefined, build errors)*

------
https://chatgpt.com/codex/tasks/task_e_688ee25f6ad8832fa86b8faa0503d1e9