### PR TITLE
refactor: rename notification queries with role-specific prefixes

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1246,7 +1246,7 @@ func (cd *CoreData) UnreadNotificationCount() int64 {
 		if cd.queries == nil || cd.UserID == 0 {
 			return 0, nil
 		}
-		return cd.queries.CountUnreadNotifications(cd.ctx, cd.UserID)
+		return cd.queries.CountUnreadNotificationsForLister(cd.ctx, cd.UserID)
 	})
 	if err != nil {
 		log.Printf("load unread notification count: %v", err)

--- a/handlers/admin/adminNotificationsPage.go
+++ b/handlers/admin/adminNotificationsPage.go
@@ -31,7 +31,7 @@ func AdminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		log.Printf("load roles: %v", err)
 	}
 	data.Roles = roles
-	items, err := queries.RecentNotifications(r.Context(), 50)
+	items, err := queries.AdminListRecentNotifications(r.Context(), 50)
 	if err != nil {
 		log.Printf("recent notifications: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -109,7 +109,7 @@ func TestRecentNotifications(t *testing.T) {
 	q := db.New(sqldb)
 	rows := sqlmock.NewRows([]string{"id", "users_idusers", "link", "message", "created_at", "read_at"}).AddRow(1, 1, "/l", "m", time.Now(), nil)
 	mock.ExpectQuery("SELECT id, users_idusers, link, message, created_at, read_at FROM notifications ORDER BY id DESC LIMIT ?").WithArgs(int32(5)).WillReturnRows(rows)
-	if _, err := q.RecentNotifications(context.Background(), 5); err != nil {
+	if _, err := q.AdminListRecentNotifications(context.Background(), 5); err != nil {
 		t.Fatalf("recent: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/handlers/admin/delete_notification_task.go
+++ b/handlers/admin/delete_notification_task.go
@@ -26,7 +26,7 @@ func (DeleteNotificationTask) Action(w http.ResponseWriter, r *http.Request) any
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.DeleteNotification(r.Context(), int32(id)); err != nil {
+		if err := queries.AdminDeleteNotification(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("delete notification fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/mark_read_task.go
+++ b/handlers/admin/mark_read_task.go
@@ -27,7 +27,7 @@ func (MarkReadTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.MarkNotificationRead(r.Context(), int32(id)); err != nil {
+		if err := queries.AdminMarkNotificationRead(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("mark read fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/mark_unread_task.go
+++ b/handlers/admin/mark_unread_task.go
@@ -26,7 +26,7 @@ func (MarkUnreadTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.MarkNotificationUnread(r.Context(), int32(id)); err != nil {
+		if err := queries.AdminMarkNotificationUnread(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("mark unread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/purge_selected_notifications_task.go
+++ b/handlers/admin/purge_selected_notifications_task.go
@@ -26,7 +26,7 @@ func (PurgeSelectedNotificationsTask) Action(w http.ResponseWriter, r *http.Requ
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.DeleteNotification(r.Context(), int32(id)); err != nil {
+		if err := queries.AdminDeleteNotification(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("delete notification fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/toggle_notification_read_task.go
+++ b/handlers/admin/toggle_notification_read_task.go
@@ -26,16 +26,16 @@ func (ToggleNotificationReadTask) Action(w http.ResponseWriter, r *http.Request)
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		n, err := queries.GetNotification(r.Context(), int32(id))
+		n, err := queries.AdminGetNotification(r.Context(), int32(id))
 		if err != nil {
 			return fmt.Errorf("get notification fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if n.ReadAt.Valid {
-			if err := queries.MarkNotificationUnread(r.Context(), int32(id)); err != nil {
+			if err := queries.AdminMarkNotificationUnread(r.Context(), int32(id)); err != nil {
 				return fmt.Errorf("mark unread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 			}
 		} else {
-			if err := queries.MarkNotificationRead(r.Context(), int32(id)); err != nil {
+			if err := queries.AdminMarkNotificationRead(r.Context(), int32(id)); err != nil {
 				return fmt.Errorf("mark read fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 			}
 		}

--- a/handlers/user/userNotificationsPage.go
+++ b/handlers/user/userNotificationsPage.go
@@ -40,16 +40,16 @@ func userNotificationsPage(w http.ResponseWriter, r *http.Request) {
 	var err error
 	limit := int32(cd.Config.PageSizeDefault)
 	if showAll {
-		notifs, err = queries.ListUserNotifications(r.Context(), db.ListUserNotificationsParams{
-			UsersIdusers: uid,
-			Limit:        limit,
-			Offset:       int32(offset),
+		notifs, err = queries.ListNotificationsForLister(r.Context(), db.ListNotificationsForListerParams{
+			ListerID: uid,
+			Limit:    limit,
+			Offset:   int32(offset),
 		})
 	} else {
-		notifs, err = queries.ListUserUnreadNotifications(r.Context(), db.ListUserUnreadNotificationsParams{
-			UsersIdusers: uid,
-			Limit:        limit,
-			Offset:       int32(offset),
+		notifs, err = queries.ListUnreadNotificationsForLister(r.Context(), db.ListUnreadNotificationsForListerParams{
+			ListerID: uid,
+			Limit:    limit,
+			Offset:   int32(offset),
 		})
 	}
 	if err != nil {
@@ -98,11 +98,11 @@ func (DismissTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	id, _ := strconv.Atoi(r.FormValue("id"))
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	n, err := queries.GetUnreadNotifications(r.Context(), uid)
+	n, err := queries.ListUnreadNotificationsForLister(r.Context(), db.ListUnreadNotificationsForListerParams{ListerID: uid, Limit: 50, Offset: 0})
 	if err == nil {
 		for _, no := range n {
 			if int(no.ID) == id {
-				if err := queries.MarkNotificationRead(r.Context(), no.ID); err != nil {
+				if err := queries.MarkNotificationReadForReader(r.Context(), db.MarkNotificationReadForReaderParams{ID: no.ID, ReaderID: uid}); err != nil {
 					log.Printf("mark notification read: %v", err)
 				}
 				break
@@ -124,7 +124,7 @@ func notificationsRssPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	notifs, err := queries.GetUnreadNotifications(r.Context(), uid)
+	notifs, err := queries.ListUnreadNotificationsForLister(r.Context(), db.ListUnreadNotificationsForListerParams{ListerID: uid, Limit: 50, Offset: 0})
 	if err != nil {
 		log.Printf("notify feed: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -38,6 +38,7 @@ type Querier interface {
 	// Parameters:
 	//   ? - Language ID to be deleted (int)
 	AdminDeleteLanguage(ctx context.Context, idlanguage int32) error
+	AdminDeleteNotification(ctx context.Context, id int32) error
 	// admin task
 	AdminDeletePendingEmail(ctx context.Context, id int32) error
 	AdminDeleteTemplateOverride(ctx context.Context, name string) error
@@ -51,6 +52,7 @@ type Querier interface {
 	AdminGetAllWritingsByAuthor(ctx context.Context, authorID int32) ([]*AdminGetAllWritingsByAuthorRow, error)
 	AdminGetDashboardStats(ctx context.Context) (*AdminGetDashboardStatsRow, error)
 	AdminGetForumStats(ctx context.Context) (*AdminGetForumStatsRow, error)
+	AdminGetNotification(ctx context.Context, id int32) (*Notification, error)
 	// admin task
 	AdminGetPendingEmailByID(ctx context.Context, id int32) (*AdminGetPendingEmailByIDRow, error)
 	AdminGetRecentAuditLogs(ctx context.Context, limit int32) ([]*AdminGetRecentAuditLogsRow, error)
@@ -94,6 +96,7 @@ type Querier interface {
 	AdminListPendingDeactivatedWritings(ctx context.Context, arg AdminListPendingDeactivatedWritingsParams) ([]*AdminListPendingDeactivatedWritingsRow, error)
 	AdminListPendingRequests(ctx context.Context) ([]*AdminRequestQueue, error)
 	AdminListPendingUsers(ctx context.Context) ([]*AdminListPendingUsersRow, error)
+	AdminListRecentNotifications(ctx context.Context, limit int32) ([]*Notification, error)
 	AdminListRequestComments(ctx context.Context, requestID int32) ([]*AdminRequestComment, error)
 	// admin task
 	AdminListRoles(ctx context.Context) ([]*Role, error)
@@ -115,6 +118,8 @@ type Querier interface {
 	AdminMarkCommentRestored(ctx context.Context, idcomments int32) error
 	AdminMarkImagepostRestored(ctx context.Context, idimagepost int32) error
 	AdminMarkLinkRestored(ctx context.Context, idlinker int32) error
+	AdminMarkNotificationRead(ctx context.Context, id int32) error
+	AdminMarkNotificationUnread(ctx context.Context, id int32) error
 	AdminMarkWritingRestored(ctx context.Context, idwriting int32) error
 	// admin task
 	AdminPromoteAnnouncement(ctx context.Context, siteNewsID int32) error
@@ -162,7 +167,7 @@ type Querier interface {
 	CommentsSearchNextInRestrictedTopic(ctx context.Context, arg CommentsSearchNextInRestrictedTopicParams) ([]int32, error)
 	CommentsSearchNextNotInRestrictedTopic(ctx context.Context, arg CommentsSearchNextNotInRestrictedTopicParams) ([]int32, error)
 	CountLinksByCategory(ctx context.Context, linkerCategoryID int32) (int64, error)
-	CountUnreadNotifications(ctx context.Context, usersIdusers int32) (int64, error)
+	CountUnreadNotificationsForLister(ctx context.Context, listerID int32) (int64, error)
 	CreateBlogEntry(ctx context.Context, arg CreateBlogEntryParams) (int64, error)
 	// This query adds a new entry to the "bookmarks" table for a user.
 	CreateBookmarks(ctx context.Context, arg CreateBookmarksParams) error
@@ -195,7 +200,6 @@ type Querier interface {
 	DeleteImageBoard(ctx context.Context, idimageboard int32) error
 	DeleteLinkerCategory(ctx context.Context, arg DeleteLinkerCategoryParams) error
 	DeleteLinkerQueuedItem(ctx context.Context, arg DeleteLinkerQueuedItemParams) error
-	DeleteNotification(ctx context.Context, id int32) error
 	DeletePasswordReset(ctx context.Context, id int32) error
 	// Delete all password reset entries for the given user and return the result
 	DeletePasswordResetsByUser(ctx context.Context, userID int32) (sql.Result, error)
@@ -274,7 +278,6 @@ type Querier interface {
 	GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx context.Context, arg GetNewsPostByIdWithWriterIdAndThreadCommentCountParams) (*GetNewsPostByIdWithWriterIdAndThreadCommentCountRow, error)
 	GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount(ctx context.Context, arg GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountParams) ([]*GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow, error)
 	GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(ctx context.Context, arg GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams) ([]*GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow, error)
-	GetNotification(ctx context.Context, id int32) (*Notification, error)
 	GetNotificationEmailByUserID(ctx context.Context, userID int32) (*UserEmail, error)
 	GetPasswordResetByCode(ctx context.Context, arg GetPasswordResetByCodeParams) (*PendingPassword, error)
 	GetPasswordResetByUser(ctx context.Context, arg GetPasswordResetByUserParams) (*PendingPassword, error)
@@ -285,7 +288,6 @@ type Querier interface {
 	GetPreferenceForLister(ctx context.Context, listerID int32) (*Preference, error)
 	GetPublicWritings(ctx context.Context, arg GetPublicWritingsParams) ([]*Writing, error)
 	GetThreadLastPosterAndPerms(ctx context.Context, arg GetThreadLastPosterAndPermsParams) (*GetThreadLastPosterAndPermsRow, error)
-	GetUnreadNotifications(ctx context.Context, usersIdusers int32) ([]*Notification, error)
 	GetUserById(ctx context.Context, idusers int32) (*GetUserByIdRow, error)
 	GetUserByUsername(ctx context.Context, username sql.NullString) (*GetUserByUsernameRow, error)
 	GetUserEmailByCode(ctx context.Context, lastVerificationCode sql.NullString) (*UserEmail, error)
@@ -310,7 +312,6 @@ type Querier interface {
 	InsertEmailPreferenceForLister(ctx context.Context, arg InsertEmailPreferenceForListerParams) error
 	InsertFAQQuestionForWriter(ctx context.Context, arg InsertFAQQuestionForWriterParams) (sql.Result, error)
 	InsertFAQRevisionForUser(ctx context.Context, arg InsertFAQRevisionForUserParams) error
-	InsertNotification(ctx context.Context, arg InsertNotificationParams) error
 	InsertPassword(ctx context.Context, arg InsertPasswordParams) error
 	InsertPendingEmail(ctx context.Context, arg InsertPendingEmailParams) error
 	InsertPreferenceForLister(ctx context.Context, arg InsertPreferenceForListerParams) error
@@ -318,7 +319,6 @@ type Querier interface {
 	InsertUserEmail(ctx context.Context, arg InsertUserEmailParams) error
 	InsertUserLang(ctx context.Context, arg InsertUserLangParams) error
 	InsertWriting(ctx context.Context, arg InsertWritingParams) (int64, error)
-	LastNotificationByMessage(ctx context.Context, arg LastNotificationByMessageParams) (*Notification, error)
 	LatestAdminUserComment(ctx context.Context, usersIdusers int32) (*AdminUserComment, error)
 	LinkerSearchFirst(ctx context.Context, arg LinkerSearchFirstParams) ([]int32, error)
 	LinkerSearchNext(ctx context.Context, arg LinkerSearchNextParams) ([]int32, error)
@@ -337,15 +337,15 @@ type Querier interface {
 	ListGrantsByUserID(ctx context.Context, userID sql.NullInt32) ([]*Grant, error)
 	ListImagePostsByBoardForLister(ctx context.Context, arg ListImagePostsByBoardForListerParams) ([]*ListImagePostsByBoardForListerRow, error)
 	ListImagePostsByPosterForLister(ctx context.Context, arg ListImagePostsByPosterForListerParams) ([]*ListImagePostsByPosterForListerRow, error)
+	ListNotificationsForLister(ctx context.Context, arg ListNotificationsForListerParams) ([]*Notification, error)
 	ListPublicWritingsByUserForLister(ctx context.Context, arg ListPublicWritingsByUserForListerParams) ([]*ListPublicWritingsByUserForListerRow, error)
 	ListPublicWritingsInCategoryForLister(ctx context.Context, arg ListPublicWritingsInCategoryForListerParams) ([]*ListPublicWritingsInCategoryForListerRow, error)
 	ListSubscribersForPattern(ctx context.Context, arg ListSubscribersForPatternParams) ([]int32, error)
 	ListSubscribersForPatterns(ctx context.Context, arg ListSubscribersForPatternsParams) ([]int32, error)
 	ListSubscriptionsByUser(ctx context.Context, usersIdusers int32) ([]*ListSubscriptionsByUserRow, error)
+	ListUnreadNotificationsForLister(ctx context.Context, arg ListUnreadNotificationsForListerParams) ([]*Notification, error)
 	ListUploadedImagesByUserForLister(ctx context.Context, arg ListUploadedImagesByUserForListerParams) ([]*UploadedImage, error)
 	ListUserEmailsForLister(ctx context.Context, arg ListUserEmailsForListerParams) ([]*UserEmail, error)
-	ListUserNotifications(ctx context.Context, arg ListUserNotificationsParams) ([]*Notification, error)
-	ListUserUnreadNotifications(ctx context.Context, arg ListUserUnreadNotificationsParams) ([]*Notification, error)
 	ListUsersWithRoles(ctx context.Context) ([]*ListUsersWithRolesRow, error)
 	ListWritersForLister(ctx context.Context, arg ListWritersForListerParams) ([]*ListWritersForListerRow, error)
 	ListWritersSearchForLister(ctx context.Context, arg ListWritersSearchForListerParams) ([]*ListWritersSearchForListerRow, error)
@@ -354,14 +354,13 @@ type Querier interface {
 	Login(ctx context.Context, username sql.NullString) (*LoginRow, error)
 	MakeThread(ctx context.Context, forumtopicIdforumtopic int32) (int64, error)
 	MarkEmailSent(ctx context.Context, id int32) error
-	MarkNotificationRead(ctx context.Context, id int32) error
-	MarkNotificationUnread(ctx context.Context, id int32) error
+	MarkNotificationReadForReader(ctx context.Context, arg MarkNotificationReadForReaderParams) error
+	MarkNotificationUnreadForReader(ctx context.Context, arg MarkNotificationUnreadForReaderParams) error
 	MarkPasswordResetVerified(ctx context.Context, id int32) error
 	// Remove password reset entries that have expired or were already verified
 	PurgePasswordResetsBefore(ctx context.Context, createdAt time.Time) (sql.Result, error)
 	RebuildAllForumTopicMetaColumns(ctx context.Context) error
 	RebuildForumTopicByIdMetaColumns(ctx context.Context, idforumtopic int32) error
-	RecentNotifications(ctx context.Context, limit int32) ([]*Notification, error)
 	RegisterExternalLinkClick(ctx context.Context, url string) error
 	RenameFAQCategory(ctx context.Context, arg RenameFAQCategoryParams) error
 	RenameLinkerCategory(ctx context.Context, arg RenameLinkerCategoryParams) error
@@ -407,11 +406,18 @@ type Querier interface {
 	SystemGetAllBlogsForIndex(ctx context.Context) ([]*SystemGetAllBlogsForIndexRow, error)
 	// SystemGetLanguageIDByName resolves a language ID by name.
 	SystemGetLanguageIDByName(ctx context.Context, nameof sql.NullString) (int32, error)
+	SystemGetLastNotificationByMessage(ctx context.Context, arg SystemGetLastNotificationByMessageParams) (*Notification, error)
 	SystemGetSearchWordByWordLowercased(ctx context.Context, lcase string) (*Searchwordlist, error)
 	SystemGetTemplateOverride(ctx context.Context, name string) (string, error)
 	// System query only used internally
 	SystemInsertDeadLetter(ctx context.Context, message string) error
 	SystemInsertLoginAttempt(ctx context.Context, arg SystemInsertLoginAttemptParams) error
+	// SystemInsertNotification stores an internal notification for a user.
+	// Parameters:
+	//   UserID
+	//   Link
+	//   Message
+	SystemInsertNotification(ctx context.Context, arg SystemInsertNotificationParams) error
 	SystemInsertSession(ctx context.Context, arg SystemInsertSessionParams) error
 	SystemInsertUser(ctx context.Context, username sql.NullString) (sql.Result, error)
 	SystemLatestDeadLetter(ctx context.Context) (interface{}, error)

--- a/internal/db/queries-notifications.sql.go
+++ b/internal/db/queries-notifications.sql.go
@@ -10,6 +10,89 @@ import (
 	"database/sql"
 )
 
+const adminDeleteNotification = `-- name: AdminDeleteNotification :exec
+DELETE FROM notifications WHERE id = ?
+`
+
+func (q *Queries) AdminDeleteNotification(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, adminDeleteNotification, id)
+	return err
+}
+
+const adminGetNotification = `-- name: AdminGetNotification :one
+SELECT id, users_idusers, link, message, created_at, read_at
+FROM notifications
+WHERE id = ?
+`
+
+func (q *Queries) AdminGetNotification(ctx context.Context, id int32) (*Notification, error) {
+	row := q.db.QueryRowContext(ctx, adminGetNotification, id)
+	var i Notification
+	err := row.Scan(
+		&i.ID,
+		&i.UsersIdusers,
+		&i.Link,
+		&i.Message,
+		&i.CreatedAt,
+		&i.ReadAt,
+	)
+	return &i, err
+}
+
+const adminListRecentNotifications = `-- name: AdminListRecentNotifications :many
+SELECT id, users_idusers, link, message, created_at, read_at
+FROM notifications
+ORDER BY id DESC LIMIT ?
+`
+
+func (q *Queries) AdminListRecentNotifications(ctx context.Context, limit int32) ([]*Notification, error) {
+	rows, err := q.db.QueryContext(ctx, adminListRecentNotifications, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*Notification
+	for rows.Next() {
+		var i Notification
+		if err := rows.Scan(
+			&i.ID,
+			&i.UsersIdusers,
+			&i.Link,
+			&i.Message,
+			&i.CreatedAt,
+			&i.ReadAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const adminMarkNotificationRead = `-- name: AdminMarkNotificationRead :exec
+UPDATE notifications SET read_at = NOW() WHERE id = ?
+`
+
+func (q *Queries) AdminMarkNotificationRead(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, adminMarkNotificationRead, id)
+	return err
+}
+
+const adminMarkNotificationUnread = `-- name: AdminMarkNotificationUnread :exec
+UPDATE notifications SET read_at = NULL WHERE id = ?
+`
+
+func (q *Queries) AdminMarkNotificationUnread(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, adminMarkNotificationUnread, id)
+	return err
+}
+
 const adminPurgeReadNotifications = `-- name: AdminPurgeReadNotifications :exec
 DELETE FROM notifications
 WHERE read_at IS NOT NULL AND read_at < (NOW() - INTERVAL 24 HOUR)
@@ -20,127 +103,19 @@ func (q *Queries) AdminPurgeReadNotifications(ctx context.Context) error {
 	return err
 }
 
-const countUnreadNotifications = `-- name: CountUnreadNotifications :one
+const countUnreadNotificationsForLister = `-- name: CountUnreadNotificationsForLister :one
 SELECT COUNT(*) FROM notifications
 WHERE users_idusers = ? AND read_at IS NULL
 `
 
-func (q *Queries) CountUnreadNotifications(ctx context.Context, usersIdusers int32) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countUnreadNotifications, usersIdusers)
+func (q *Queries) CountUnreadNotificationsForLister(ctx context.Context, listerID int32) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countUnreadNotificationsForLister, listerID)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
 }
 
-const deleteNotification = `-- name: DeleteNotification :exec
-DELETE FROM notifications WHERE id = ?
-`
-
-func (q *Queries) DeleteNotification(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, deleteNotification, id)
-	return err
-}
-
-const getNotification = `-- name: GetNotification :one
-SELECT id, users_idusers, link, message, created_at, read_at
-FROM notifications
-WHERE id = ?
-`
-
-func (q *Queries) GetNotification(ctx context.Context, id int32) (*Notification, error) {
-	row := q.db.QueryRowContext(ctx, getNotification, id)
-	var i Notification
-	err := row.Scan(
-		&i.ID,
-		&i.UsersIdusers,
-		&i.Link,
-		&i.Message,
-		&i.CreatedAt,
-		&i.ReadAt,
-	)
-	return &i, err
-}
-
-const getUnreadNotifications = `-- name: GetUnreadNotifications :many
-SELECT id, users_idusers, link, message, created_at, read_at
-FROM notifications
-WHERE users_idusers = ? AND read_at IS NULL
-ORDER BY id DESC
-`
-
-func (q *Queries) GetUnreadNotifications(ctx context.Context, usersIdusers int32) ([]*Notification, error) {
-	rows, err := q.db.QueryContext(ctx, getUnreadNotifications, usersIdusers)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*Notification
-	for rows.Next() {
-		var i Notification
-		if err := rows.Scan(
-			&i.ID,
-			&i.UsersIdusers,
-			&i.Link,
-			&i.Message,
-			&i.CreatedAt,
-			&i.ReadAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const insertNotification = `-- name: InsertNotification :exec
-INSERT INTO notifications (users_idusers, link, message)
-VALUES (?, ?, ?)
-`
-
-type InsertNotificationParams struct {
-	UsersIdusers int32
-	Link         sql.NullString
-	Message      sql.NullString
-}
-
-func (q *Queries) InsertNotification(ctx context.Context, arg InsertNotificationParams) error {
-	_, err := q.db.ExecContext(ctx, insertNotification, arg.UsersIdusers, arg.Link, arg.Message)
-	return err
-}
-
-const lastNotificationByMessage = `-- name: LastNotificationByMessage :one
-SELECT id, users_idusers, link, message, created_at, read_at
-FROM notifications
-WHERE users_idusers = ? AND message = ?
-ORDER BY id DESC LIMIT 1
-`
-
-type LastNotificationByMessageParams struct {
-	UsersIdusers int32
-	Message      sql.NullString
-}
-
-func (q *Queries) LastNotificationByMessage(ctx context.Context, arg LastNotificationByMessageParams) (*Notification, error) {
-	row := q.db.QueryRowContext(ctx, lastNotificationByMessage, arg.UsersIdusers, arg.Message)
-	var i Notification
-	err := row.Scan(
-		&i.ID,
-		&i.UsersIdusers,
-		&i.Link,
-		&i.Message,
-		&i.CreatedAt,
-		&i.ReadAt,
-	)
-	return &i, err
-}
-
-const listUserNotifications = `-- name: ListUserNotifications :many
+const listNotificationsForLister = `-- name: ListNotificationsForLister :many
 SELECT id, users_idusers, link, message, created_at, read_at
 FROM notifications
 WHERE users_idusers = ?
@@ -148,14 +123,14 @@ ORDER BY id DESC
 LIMIT ? OFFSET ?
 `
 
-type ListUserNotificationsParams struct {
-	UsersIdusers int32
-	Limit        int32
-	Offset       int32
+type ListNotificationsForListerParams struct {
+	ListerID int32
+	Limit    int32
+	Offset   int32
 }
 
-func (q *Queries) ListUserNotifications(ctx context.Context, arg ListUserNotificationsParams) ([]*Notification, error) {
-	rows, err := q.db.QueryContext(ctx, listUserNotifications, arg.UsersIdusers, arg.Limit, arg.Offset)
+func (q *Queries) ListNotificationsForLister(ctx context.Context, arg ListNotificationsForListerParams) ([]*Notification, error) {
+	rows, err := q.db.QueryContext(ctx, listNotificationsForLister, arg.ListerID, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +159,7 @@ func (q *Queries) ListUserNotifications(ctx context.Context, arg ListUserNotific
 	return items, nil
 }
 
-const listUserUnreadNotifications = `-- name: ListUserUnreadNotifications :many
+const listUnreadNotificationsForLister = `-- name: ListUnreadNotificationsForLister :many
 SELECT id, users_idusers, link, message, created_at, read_at
 FROM notifications
 WHERE users_idusers = ? AND read_at IS NULL
@@ -192,14 +167,14 @@ ORDER BY id DESC
 LIMIT ? OFFSET ?
 `
 
-type ListUserUnreadNotificationsParams struct {
-	UsersIdusers int32
-	Limit        int32
-	Offset       int32
+type ListUnreadNotificationsForListerParams struct {
+	ListerID int32
+	Limit    int32
+	Offset   int32
 }
 
-func (q *Queries) ListUserUnreadNotifications(ctx context.Context, arg ListUserUnreadNotificationsParams) ([]*Notification, error) {
-	rows, err := q.db.QueryContext(ctx, listUserUnreadNotifications, arg.UsersIdusers, arg.Limit, arg.Offset)
+func (q *Queries) ListUnreadNotificationsForLister(ctx context.Context, arg ListUnreadNotificationsForListerParams) ([]*Notification, error) {
+	rows, err := q.db.QueryContext(ctx, listUnreadNotificationsForLister, arg.ListerID, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
@@ -228,56 +203,80 @@ func (q *Queries) ListUserUnreadNotifications(ctx context.Context, arg ListUserU
 	return items, nil
 }
 
-const markNotificationRead = `-- name: MarkNotificationRead :exec
-UPDATE notifications SET read_at = NOW() WHERE id = ?
+const markNotificationReadForReader = `-- name: MarkNotificationReadForReader :exec
+UPDATE notifications SET read_at = NOW()
+WHERE id = ? AND users_idusers = ?
 `
 
-func (q *Queries) MarkNotificationRead(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, markNotificationRead, id)
+type MarkNotificationReadForReaderParams struct {
+	ID       int32
+	ReaderID int32
+}
+
+func (q *Queries) MarkNotificationReadForReader(ctx context.Context, arg MarkNotificationReadForReaderParams) error {
+	_, err := q.db.ExecContext(ctx, markNotificationReadForReader, arg.ID, arg.ReaderID)
 	return err
 }
 
-const markNotificationUnread = `-- name: MarkNotificationUnread :exec
-UPDATE notifications SET read_at = NULL WHERE id = ?
+const markNotificationUnreadForReader = `-- name: MarkNotificationUnreadForReader :exec
+UPDATE notifications SET read_at = NULL
+WHERE id = ? AND users_idusers = ?
 `
 
-func (q *Queries) MarkNotificationUnread(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, markNotificationUnread, id)
+type MarkNotificationUnreadForReaderParams struct {
+	ID       int32
+	ReaderID int32
+}
+
+func (q *Queries) MarkNotificationUnreadForReader(ctx context.Context, arg MarkNotificationUnreadForReaderParams) error {
+	_, err := q.db.ExecContext(ctx, markNotificationUnreadForReader, arg.ID, arg.ReaderID)
 	return err
 }
 
-const recentNotifications = `-- name: RecentNotifications :many
+const systemGetLastNotificationByMessage = `-- name: SystemGetLastNotificationByMessage :one
 SELECT id, users_idusers, link, message, created_at, read_at
 FROM notifications
-ORDER BY id DESC LIMIT ?
+WHERE users_idusers = ? AND message = ?
+ORDER BY id DESC LIMIT 1
 `
 
-func (q *Queries) RecentNotifications(ctx context.Context, limit int32) ([]*Notification, error) {
-	rows, err := q.db.QueryContext(ctx, recentNotifications, limit)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*Notification
-	for rows.Next() {
-		var i Notification
-		if err := rows.Scan(
-			&i.ID,
-			&i.UsersIdusers,
-			&i.Link,
-			&i.Message,
-			&i.CreatedAt,
-			&i.ReadAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
+type SystemGetLastNotificationByMessageParams struct {
+	UserID  int32
+	Message sql.NullString
+}
+
+func (q *Queries) SystemGetLastNotificationByMessage(ctx context.Context, arg SystemGetLastNotificationByMessageParams) (*Notification, error) {
+	row := q.db.QueryRowContext(ctx, systemGetLastNotificationByMessage, arg.UserID, arg.Message)
+	var i Notification
+	err := row.Scan(
+		&i.ID,
+		&i.UsersIdusers,
+		&i.Link,
+		&i.Message,
+		&i.CreatedAt,
+		&i.ReadAt,
+	)
+	return &i, err
+}
+
+const systemInsertNotification = `-- name: SystemInsertNotification :exec
+INSERT INTO notifications (users_idusers, link, message)
+VALUES (?, ?, ?)
+`
+
+type SystemInsertNotificationParams struct {
+	UserID  int32
+	Link    sql.NullString
+	Message sql.NullString
+}
+
+// SystemInsertNotification stores an internal notification for a user.
+// Parameters:
+//
+//	UserID
+//	Link
+//	Message
+func (q *Queries) SystemInsertNotification(ctx context.Context, arg SystemInsertNotificationParams) error {
+	_, err := q.db.ExecContext(ctx, systemInsertNotification, arg.UserID, arg.Link, arg.Message)
+	return err
 }

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -177,10 +177,10 @@ func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, tp Se
 			return err
 		}
 		if len(msg) > 0 {
-			if err := n.Queries.InsertNotification(ctx, db.InsertNotificationParams{
-				UsersIdusers: evt.UserID,
-				Link:         sql.NullString{String: evt.Path, Valid: true},
-				Message:      sql.NullString{String: string(msg), Valid: true},
+			if err := n.Queries.SystemInsertNotification(ctx, db.SystemInsertNotificationParams{
+				UserID:  evt.UserID,
+				Link:    sql.NullString{String: evt.Path, Valid: true},
+				Message: sql.NullString{String: string(msg), Valid: true},
 			}); err != nil {
 				return err
 			}
@@ -230,10 +230,10 @@ func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.TaskEvent
 				return err
 			}
 			if len(msg) > 0 {
-				if err := n.Queries.InsertNotification(ctx, db.InsertNotificationParams{
-					UsersIdusers: id,
-					Link:         sql.NullString{String: evt.Path, Valid: true},
-					Message:      sql.NullString{String: string(msg), Valid: true},
+				if err := n.Queries.SystemInsertNotification(ctx, db.SystemInsertNotificationParams{
+					UserID:  id,
+					Link:    sql.NullString{String: evt.Path, Valid: true},
+					Message: sql.NullString{String: string(msg), Valid: true},
 				}); err != nil {
 					return err
 				}
@@ -368,14 +368,14 @@ func notifyMissingEmail(ctx context.Context, q db.Querier, userID int32) error {
 	if q == nil || userID == 0 {
 		return nil
 	}
-	last, err := q.LastNotificationByMessage(ctx, db.LastNotificationByMessageParams{UsersIdusers: userID, Message: sql.NullString{String: "missing email address", Valid: true}})
+	last, err := q.SystemGetLastNotificationByMessage(ctx, db.SystemGetLastNotificationByMessageParams{UserID: userID, Message: sql.NullString{String: "missing email address", Valid: true}})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("last notification: %w", err)
 	}
 	if err == nil && time.Since(last.CreatedAt) < 7*24*time.Hour {
 		return nil
 	}
-	if err := q.InsertNotification(ctx, db.InsertNotificationParams{UsersIdusers: userID, Message: sql.NullString{String: "missing email address", Valid: true}}); err != nil {
+	if err := q.SystemInsertNotification(ctx, db.SystemInsertNotificationParams{UserID: userID, Message: sql.NullString{String: "missing email address", Valid: true}}); err != nil {
 		return fmt.Errorf("insert notification: %w", err)
 	}
 	return nil

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -151,10 +151,10 @@ func (n *Notifier) notifyAdmins(ctx context.Context, et *EmailTemplates, nt *str
 				return err
 			}
 			if uid != nil {
-				if err := n.Queries.InsertNotification(ctx, db.InsertNotificationParams{
-					UsersIdusers: *uid,
-					Link:         sql.NullString{String: link, Valid: link != ""},
-					Message:      sql.NullString{String: string(msg), Valid: len(msg) > 0},
+				if err := n.Queries.SystemInsertNotification(ctx, db.SystemInsertNotificationParams{
+					UserID:  *uid,
+					Link:    sql.NullString{String: link, Valid: link != ""},
+					Message: sql.NullString{String: string(msg), Valid: len(msg) > 0},
 				}); err != nil {
 					return err
 				}
@@ -187,9 +187,9 @@ func (n *Notifier) NotificationPurgeWorker(ctx context.Context, interval time.Du
 
 // sendInternalNotification stores an internal notification for the user.
 func (n *Notifier) sendInternalNotification(ctx context.Context, userID int32, path, msg string) error {
-	return n.Queries.InsertNotification(ctx, db.InsertNotificationParams{
-		UsersIdusers: userID,
-		Link:         sql.NullString{String: path, Valid: path != ""},
-		Message:      sql.NullString{String: msg, Valid: msg != ""},
+	return n.Queries.SystemInsertNotification(ctx, db.SystemInsertNotificationParams{
+		UserID:  userID,
+		Link:    sql.NullString{String: path, Valid: path != ""},
+		Message: sql.NullString{String: msg, Valid: msg != ""},
 	})
 }

--- a/internal/notifications/permission_tasks_test.go
+++ b/internal/notifications/permission_tasks_test.go
@@ -69,7 +69,7 @@ func TestProcessEventPermissionTasks(t *testing.T) {
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
 			WithArgs(int32(2)).
 			WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(2, "u@test", "bob", nil))
-		mock.ExpectQuery("LastNotificationByMessage").
+		mock.ExpectQuery("SystemGetLastNotificationByMessage").
 			WithArgs(int32(2), "missing email address").
 			WillReturnError(sql.ErrNoRows)
 		mock.ExpectExec(regexp.QuoteMeta("INSERT INTO notifications (users_idusers, link, message) VALUES (?, ?, ?)")).


### PR DESCRIPTION
## Summary
- refactor notification SQL queries to use role-prefixed names and enforce reader IDs
- update admin and user handlers to use new query names
- adjust notifier and bus worker to call SystemInsertNotification

## Testing
- `go vet ./...`
- `golangci-lint run ./...` *(fails: db.New undefined and other typecheck errors)*
- `go test ./...` *(fails: multiple build failures such as db.New undefined)*

------
https://chatgpt.com/codex/tasks/task_e_688ee25f6ad8832fa86b8faa0503d1e9