### PR TITLE
refactor: prefix user queries with roles

### DIFF
--- a/cmd/goa4web/user_add_role.go
+++ b/cmd/goa4web/user_add_role.go
@@ -46,7 +46,7 @@ func (c *userAddRoleCmd) Run() error {
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}
-	if _, err := queries.UserHasRole(ctx, db.UserHasRoleParams{UsersIdusers: u.Idusers, Name: c.Role}); err == nil {
+	if _, err := queries.GetHasRoleForUser(ctx, db.GetHasRoleForUserParams{Userid: u.Idusers, Role: c.Role}); err == nil {
 		c.rootCmd.Verbosef("%s already has role %s", c.Username, c.Role)
 		return nil
 	} else if !errors.Is(err, sql.ErrNoRows) {

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -139,8 +139,8 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	var q db.Querier
 	emails := []string{"a@test.com", "b@test.com"}
 	for _, e := range emails {
-		mock.ExpectQuery("UserByEmail").
-			WithArgs(sql.NullString{String: e, Valid: true}).
+		mock.ExpectQuery("SystemGetUserByEmail").
+			WithArgs(e).
 			WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, e, "u"))
 		mock.ExpectExec("INSERT INTO pending_emails").
 			WithArgs(sql.NullInt32{Int32: 1, Valid: true}, sqlmock.AnyArg(), false).

--- a/handlers/auth/forgot_password_task.go
+++ b/handlers/auth/forgot_password_task.go
@@ -45,7 +45,7 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("user not found %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if _, err := queries.UserHasLoginRole(r.Context(), row.Idusers); err != nil {
+	if _, err := queries.GetHasLoginRoleForUser(r.Context(), row.Idusers); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return handlers.ErrRedirectOnSamePageHandler(errors.New("approval is pending"))
 		}

--- a/handlers/auth/login_task.go
+++ b/handlers/auth/login_task.go
@@ -101,7 +101,7 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 
-	if _, err := queries.UserHasLoginRole(r.Context(), row.Idusers); err != nil {
+	if _, err := queries.GetHasLoginRoleForUser(r.Context(), row.Idusers); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return loginFormHandler{msg: "approval is pending"}
 		}

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -64,7 +64,7 @@ func (RegisterTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return handlers.ErrRedirectOnSamePageHandler(errors.New("user exists"))
 	}
 
-	if _, err := queries.UserByEmail(r.Context(), email); errors.Is(err, sql.ErrNoRows) {
+	if _, err := queries.SystemGetUserByEmail(r.Context(), email); errors.Is(err, sql.ErrNoRows) {
 	} else if err != nil {
 		log.Printf("UserByUsername Error: %s", err)
 		return fmt.Errorf("user by email %w", err)

--- a/handlers/auth/verify_password_task.go
+++ b/handlers/auth/verify_password_task.go
@@ -48,7 +48,7 @@ func (VerifyPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil || reset.ID != id {
 		return handlers.ErrRedirectOnSamePageHandler(errors.New("invalid code"))
 	}
-	if _, err := queries.UserHasLoginRole(r.Context(), reset.UserID); err != nil {
+	if _, err := queries.GetHasLoginRoleForUser(r.Context(), reset.UserID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return handlers.ErrRedirectOnSamePageHandler(errors.New("approval is pending"))
 		}

--- a/handlers/user/publicProfilePage.go
+++ b/handlers/user/publicProfilePage.go
@@ -27,7 +27,7 @@ func userPublicProfilePage(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	if _, err := queries.UserHasPublicProfileRole(r.Context(), u.Idusers); err != nil {
+	if _, err := queries.GetHasPublicProfileRoleForUser(r.Context(), u.Idusers); err != nil {
 		http.NotFound(w, r)
 		return
 	}

--- a/handlers/user/userPublicSettingPage.go
+++ b/handlers/user/userPublicSettingPage.go
@@ -18,7 +18,7 @@ import (
 func userPublicProfileSettingPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Public Profile"
-	if _, err := cd.Queries().UserHasPublicProfileRole(r.Context(), cd.UserID); err != nil {
+	if _, err := cd.Queries().GetHasPublicProfileRoleForUser(r.Context(), cd.UserID); err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -48,7 +48,7 @@ func (PublicProfileSaveTask) Action(w http.ResponseWriter, r *http.Request) any 
 	}
 	uid, _ := session.Values["UID"].(int32)
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	if _, err := queries.UserHasPublicProfileRole(r.Context(), uid); err != nil {
+	if _, err := queries.GetHasPublicProfileRoleForUser(r.Context(), uid); err != nil {
 		return common.UserError{ErrorMessage: "forbidden"}
 	}
 	enable := r.PostFormValue("enable") != ""

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -255,6 +255,12 @@ type Querier interface {
 	GetForumTopicByIdForUser(ctx context.Context, arg GetForumTopicByIdForUserParams) (*GetForumTopicByIdForUserRow, error)
 	GetForumTopicIdByThreadId(ctx context.Context, idforumthread int32) (int32, error)
 	GetForumTopicsByCategoryId(ctx context.Context, forumcategoryIdforumcategory int32) ([]*Forumtopic, error)
+	// Check whether a user is permitted to log in.
+	GetHasLoginRoleForUser(ctx context.Context, userid int32) (int32, error)
+	// Check whether a user can enable a public profile.
+	GetHasPublicProfileRoleForUser(ctx context.Context, userid int32) (int32, error)
+	// Check whether a user possesses the specified role.
+	GetHasRoleForUser(ctx context.Context, arg GetHasRoleForUserParams) (int32, error)
 	GetImageBoardById(ctx context.Context, idimageboard int32) (*Imageboard, error)
 	GetImagePostByIDForLister(ctx context.Context, arg GetImagePostByIDForListerParams) (*GetImagePostByIDForListerRow, error)
 	GetImagePostInfoByPath(ctx context.Context, arg GetImagePostInfoByPathParams) (*GetImagePostInfoByPathRow, error)
@@ -409,6 +415,9 @@ type Querier interface {
 	SystemGetLanguageIDByName(ctx context.Context, nameof sql.NullString) (int32, error)
 	SystemGetSearchWordByWordLowercased(ctx context.Context, lcase string) (*Searchwordlist, error)
 	SystemGetTemplateOverride(ctx context.Context, name string) (string, error)
+	// Fetch a user record by email for system operations.
+	// This query must not require an acting user ID.
+	SystemGetUserByEmail(ctx context.Context, email string) (*SystemGetUserByEmailRow, error)
 	// System query only used internally
 	SystemInsertDeadLetter(ctx context.Context, message string) error
 	SystemInsertLoginAttempt(ctx context.Context, arg SystemInsertLoginAttemptParams) error
@@ -448,10 +457,6 @@ type Querier interface {
 	UpdateUserEmail(ctx context.Context, arg UpdateUserEmailParams) error
 	UpdateUserEmailVerification(ctx context.Context, arg UpdateUserEmailVerificationParams) error
 	UpdateWriting(ctx context.Context, arg UpdateWritingParams) error
-	UserByEmail(ctx context.Context, email string) (*UserByEmailRow, error)
-	UserHasLoginRole(ctx context.Context, usersIdusers int32) (int32, error)
-	UserHasPublicProfileRole(ctx context.Context, usersIdusers int32) (int32, error)
-	UserHasRole(ctx context.Context, arg UserHasRoleParams) (int32, error)
 	WritingSearchDelete(ctx context.Context, writingID int32) error
 	WritingSearchFirst(ctx context.Context, arg WritingSearchFirstParams) ([]int32, error)
 	WritingSearchNext(ctx context.Context, arg WritingSearchNextParams) ([]int32, error)

--- a/internal/db/queries-permissions.sql
+++ b/internal/db/queries-permissions.sql
@@ -96,25 +96,28 @@ SELECT * FROM grants ORDER BY id;
 -- name: ListGrantsByUserID :many
 SELECT * FROM grants WHERE user_id = ? ORDER BY id;
 
--- name: UserHasRole :one
+-- Check whether a user possesses the specified role.
+-- name: GetHasRoleForUser :one
 SELECT 1
 FROM user_roles ur
 JOIN roles r ON ur.role_id = r.id
-WHERE ur.users_idusers = ? AND r.name = ?
+WHERE ur.users_idusers = sqlc.arg(UserID) AND r.name = sqlc.arg(Role)
 LIMIT 1;
 
--- name: UserHasLoginRole :one
+-- Check whether a user is permitted to log in.
+-- name: GetHasLoginRoleForUser :one
 SELECT 1
 FROM user_roles ur
 JOIN roles r ON ur.role_id = r.id
-WHERE ur.users_idusers = ? AND r.can_login = 1
+WHERE ur.users_idusers = sqlc.arg(UserID) AND r.can_login = 1
 LIMIT 1;
 
--- name: UserHasPublicProfileRole :one
+-- Check whether a user can enable a public profile.
+-- name: GetHasPublicProfileRoleForUser :one
 SELECT 1
 FROM user_roles ur
 JOIN roles r ON ur.role_id = r.id
-WHERE ur.users_idusers = ? AND r.public_profile_allowed_at IS NOT NULL
+WHERE ur.users_idusers = sqlc.arg(UserID) AND r.public_profile_allowed_at IS NOT NULL
 LIMIT 1;
 
 -- name: GetPermissionsByUserID :many

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -37,10 +37,13 @@ LEFT JOIN user_emails ue ON ue.id = (
 )
 WHERE u.idusers = ?;
 
--- name: UserByEmail :one
+-- Fetch a user record by email for system operations.
+-- This query must not require an acting user ID.
+-- name: SystemGetUserByEmail :one
 SELECT u.idusers, ue.email, u.username
-FROM users u JOIN user_emails ue ON ue.user_id = u.idusers
-WHERE ue.email = ?
+FROM users u
+JOIN user_emails ue ON ue.user_id = u.idusers
+WHERE ue.email = sqlc.arg(email)
 LIMIT 1;
 
 -- name: SystemInsertUser :execresult

--- a/internal/notifications/dlq.go
+++ b/internal/notifications/dlq.go
@@ -37,7 +37,7 @@ func (n *Notifier) dlqRecordAndNotify(ctx context.Context, q dlq.DLQ, msg string
 				nt, err := n.renderNotification(ctx, NotificationTemplateFilenameGenerator("dlqMultiFailure"), data)
 				if err == nil {
 					for _, addr := range n.adminEmails(ctx) {
-						u, err := n.Queries.UserByEmail(ctx, addr)
+						u, err := n.Queries.SystemGetUserByEmail(ctx, addr)
 						if err != nil {
 							continue
 						}

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -66,8 +66,8 @@ func TestNotifierNotifyAdmins(t *testing.T) {
 	cfg.EmailFrom = "from@example.com"
 	cfg.NotificationsEnabled = true
 
-	mock.ExpectQuery("UserByEmail").
-		WithArgs(sql.NullString{String: "a@test", Valid: true}).
+	mock.ExpectQuery("SystemGetUserByEmail").
+		WithArgs("a@test").
 		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test", "a"))
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 1, Valid: true}, sqlmock.AnyArg(), false).WillReturnResult(sqlmock.NewResult(1, 1))
 	rec := &dummyProvider{}

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -134,7 +134,7 @@ func (n *Notifier) notifyAdmins(ctx context.Context, et *EmailTemplates, nt *str
 	}
 	for _, addr := range n.adminEmails(ctx) {
 		var uid *int32
-		if u, err := n.Queries.UserByEmail(ctx, addr); err == nil {
+		if u, err := n.Queries.SystemGetUserByEmail(ctx, addr); err == nil {
 			id := u.Idusers
 			uid = &id
 		} else {


### PR DESCRIPTION
## Summary
- ensure user queries carry role prefixes and `For<User>` suffixes
- rename `UserByEmail` to `SystemGetUserByEmail` and update callers
- rename role checks to `GetHasRoleForUser`, `GetHasLoginRoleForUser`, `GetHasPublicProfileRoleForUser`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: db.New undefined in tests)*
- `go test ./...` *(fails: db.New undefined in tests)*
- `golangci-lint run` *(fails: db.New undefined in tests)*


------
https://chatgpt.com/codex/tasks/task_e_688ee25f6ad8832fa86b8faa0503d1e9