### PR TITLE
refactor: prefix admin user list queries

### DIFF
--- a/handlers/user/admin_users.go
+++ b/handlers/user/admin_users.go
@@ -54,8 +54,8 @@ func adminUsersPage(w http.ResponseWriter, r *http.Request) {
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cqueries, ok := queries.(interface {
-		SearchUsersFiltered(context.Context, db.SearchUsersFilteredParams) ([]*db.UserFilteredRow, error)
-		ListUsersFiltered(context.Context, db.ListUsersFilteredParams) ([]*db.UserFilteredRow, error)
+		AdminSearchUsersFiltered(context.Context, db.AdminSearchUsersFilteredParams) ([]*db.UserFilteredRow, error)
+		AdminListUsersFiltered(context.Context, db.AdminListUsersFilteredParams) ([]*db.UserFilteredRow, error)
 	})
 	if !ok {
 		http.Error(w, "database not available", http.StatusInternalServerError)
@@ -69,7 +69,7 @@ func adminUsersPage(w http.ResponseWriter, r *http.Request) {
 	var rows []*db.UserFilteredRow
 	var err error
 	if data.Search != "" {
-		rows, err = cqueries.SearchUsersFiltered(r.Context(), db.SearchUsersFilteredParams{
+		rows, err = cqueries.AdminSearchUsersFiltered(r.Context(), db.AdminSearchUsersFilteredParams{
 			Query:  data.Search,
 			Role:   data.Role,
 			Status: data.Status,
@@ -77,7 +77,7 @@ func adminUsersPage(w http.ResponseWriter, r *http.Request) {
 			Offset: int32(offset),
 		})
 	} else {
-		rows, err = cqueries.ListUsersFiltered(r.Context(), db.ListUsersFilteredParams{
+		rows, err = cqueries.AdminListUsersFiltered(r.Context(), db.AdminListUsersFilteredParams{
 			Role:   data.Role,
 			Status: data.Status,
 			Limit:  int32(pageSize + 1),

--- a/internal/db/customqueries.go
+++ b/internal/db/customqueries.go
@@ -7,6 +7,8 @@ type CustomQueries interface {
 	ListBloggers(ctx context.Context, arg ListBloggersParams) ([]*BloggerCountRow, error)
 	SearchWriters(ctx context.Context, arg SearchWritersParams) ([]*WriterCountRow, error)
 	ListWriters(ctx context.Context, arg ListWritersParams) ([]*WriterCountRow, error)
+	AdminListUsersFiltered(ctx context.Context, arg AdminListUsersFilteredParams) ([]*UserFilteredRow, error)
+	AdminSearchUsersFiltered(ctx context.Context, arg AdminSearchUsersFilteredParams) ([]*UserFilteredRow, error)
 	MonthlyUsageCounts(ctx context.Context, startYear int32) ([]*MonthlyUsageRow, error)
 	UserMonthlyUsageCounts(ctx context.Context, startYear int32) ([]*UserMonthlyUsageRow, error)
 }

--- a/internal/db/queries_admin_users_test.go
+++ b/internal/db/queries_admin_users_test.go
@@ -1,0 +1,63 @@
+package db
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestQueries_AdminListUsersFiltered(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := New(db)
+
+	query := "SELECT u.idusers, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email, u.username FROM users u ORDER BY u.idusers LIMIT ? OFFSET ?"
+	rows := sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "bob@example.com", "bob")
+	mock.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(int32(5), int32(0)).
+		WillReturnRows(rows)
+
+	res, err := q.AdminListUsersFiltered(context.Background(), AdminListUsersFilteredParams{Limit: 5, Offset: 0})
+	if err != nil {
+		t.Fatalf("AdminListUsersFiltered: %v", err)
+	}
+	if len(res) != 1 || res[0].Idusers != 1 || res[0].Email.String != "bob@example.com" || res[0].Username.String != "bob" {
+		t.Fatalf("unexpected result %+v", res)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestQueries_AdminSearchUsersFiltered(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	q := New(db)
+
+	query := "SELECT u.idusers, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email, u.username FROM users u WHERE (LOWER(u.username) LIKE LOWER(?) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(?)) ORDER BY u.idusers LIMIT ? OFFSET ?"
+	rows := sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "bob@example.com", "bob")
+	mock.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs("%bob%", "%bob%", int32(5), int32(0)).
+		WillReturnRows(rows)
+
+	res, err := q.AdminSearchUsersFiltered(context.Background(), AdminSearchUsersFilteredParams{Query: "bob", Limit: 5, Offset: 0})
+	if err != nil {
+		t.Fatalf("AdminSearchUsersFiltered: %v", err)
+	}
+	if len(res) != 1 || res[0].Idusers != 1 || res[0].Email.String != "bob@example.com" || res[0].Username.String != "bob" {
+		t.Fatalf("unexpected result %+v", res)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/internal/db/queries_dynamic.go
+++ b/internal/db/queries_dynamic.go
@@ -122,8 +122,8 @@ func (q *Queries) SearchWriters(ctx context.Context, arg SearchWritersParams) ([
 	return items, nil
 }
 
-// ListUsersFiltered returns users filtered by role and status with pagination.
-type ListUsersFilteredParams struct {
+// AdminListUsersFiltered returns users filtered by role and status with pagination.
+type AdminListUsersFilteredParams struct {
 	Role   string
 	Status string
 	Limit  int32
@@ -137,7 +137,7 @@ type UserFilteredRow struct {
 	Username sql.NullString
 }
 
-func (q *Queries) ListUsersFiltered(ctx context.Context, arg ListUsersFilteredParams) ([]*UserFilteredRow, error) {
+func (q *Queries) AdminListUsersFiltered(ctx context.Context, arg AdminListUsersFilteredParams) ([]*UserFilteredRow, error) {
 	query := "SELECT u.idusers, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email, u.username FROM users u"
 	var args []interface{}
 	var cond []string
@@ -177,8 +177,8 @@ func (q *Queries) ListUsersFiltered(ctx context.Context, arg ListUsersFilteredPa
 	return items, rows.Err()
 }
 
-// SearchUsersFiltered finds users by username or email with role and status filters.
-type SearchUsersFilteredParams struct {
+// AdminSearchUsersFiltered finds users by username or email with role and status filters.
+type AdminSearchUsersFilteredParams struct {
 	Query  string
 	Role   string
 	Status string
@@ -186,7 +186,7 @@ type SearchUsersFilteredParams struct {
 	Offset int32
 }
 
-func (q *Queries) SearchUsersFiltered(ctx context.Context, arg SearchUsersFilteredParams) ([]*UserFilteredRow, error) {
+func (q *Queries) AdminSearchUsersFiltered(ctx context.Context, arg AdminSearchUsersFilteredParams) ([]*UserFilteredRow, error) {
 	like := "%" + arg.Query + "%"
 	query := "SELECT u.idusers, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email, u.username FROM users u"
 	var args []interface{}


### PR DESCRIPTION
## Summary
- prefix admin user list/search queries with Admin
- expose new admin user list helpers via CustomQueries
- test admin user list and search query builders

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: db.New undefined in multiple tests)*
- `golangci-lint run` *(fails: typecheck errors such as db.New undefined)*
- `go test ./...` *(fails: db.New undefined and parameter mismatch in InsertFAQQuestionForWriter)*
- `go test ./internal/db -run AdminListUsersFiltered -count=1`
- `go test ./internal/db -run AdminSearchUsersFiltered -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688ee75f13e4832f81831d331af2fae9