### PR TITLE
refactor: apply role-based naming to notification queries

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1246,7 +1246,7 @@ func (cd *CoreData) UnreadNotificationCount() int64 {
 		if cd.queries == nil || cd.UserID == 0 {
 			return 0, nil
 		}
-		return cd.queries.CountUnreadNotifications(cd.ctx, cd.UserID)
+		return cd.queries.CountUnreadNotificationsForUser(cd.ctx, cd.UserID)
 	})
 	if err != nil {
 		log.Printf("load unread notification count: %v", err)

--- a/handlers/admin/adminNotificationsPage.go
+++ b/handlers/admin/adminNotificationsPage.go
@@ -31,7 +31,7 @@ func AdminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 		log.Printf("load roles: %v", err)
 	}
 	data.Roles = roles
-	items, err := queries.RecentNotifications(r.Context(), 50)
+	items, err := queries.AdminListRecentNotifications(r.Context(), 50)
 	if err != nil {
 		log.Printf("recent notifications: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -109,7 +109,7 @@ func TestRecentNotifications(t *testing.T) {
 	q := db.New(sqldb)
 	rows := sqlmock.NewRows([]string{"id", "users_idusers", "link", "message", "created_at", "read_at"}).AddRow(1, 1, "/l", "m", time.Now(), nil)
 	mock.ExpectQuery("SELECT id, users_idusers, link, message, created_at, read_at FROM notifications ORDER BY id DESC LIMIT ?").WithArgs(int32(5)).WillReturnRows(rows)
-	if _, err := q.RecentNotifications(context.Background(), 5); err != nil {
+	if _, err := q.AdminListRecentNotifications(context.Background(), 5); err != nil {
 		t.Fatalf("recent: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/handlers/admin/delete_notification_task.go
+++ b/handlers/admin/delete_notification_task.go
@@ -26,7 +26,7 @@ func (DeleteNotificationTask) Action(w http.ResponseWriter, r *http.Request) any
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.DeleteNotification(r.Context(), int32(id)); err != nil {
+		if err := queries.AdminDeleteNotification(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("delete notification fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/mark_read_task.go
+++ b/handlers/admin/mark_read_task.go
@@ -27,7 +27,7 @@ func (MarkReadTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.MarkNotificationRead(r.Context(), int32(id)); err != nil {
+		if err := queries.AdminMarkNotificationRead(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("mark read fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/mark_unread_task.go
+++ b/handlers/admin/mark_unread_task.go
@@ -26,7 +26,7 @@ func (MarkUnreadTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.MarkNotificationUnread(r.Context(), int32(id)); err != nil {
+		if err := queries.AdminMarkNotificationUnread(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("mark unread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/purge_selected_notifications_task.go
+++ b/handlers/admin/purge_selected_notifications_task.go
@@ -26,7 +26,7 @@ func (PurgeSelectedNotificationsTask) Action(w http.ResponseWriter, r *http.Requ
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		if err := queries.DeleteNotification(r.Context(), int32(id)); err != nil {
+		if err := queries.AdminDeleteNotification(r.Context(), int32(id)); err != nil {
 			return fmt.Errorf("delete notification fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {

--- a/handlers/admin/send_notification_task.go
+++ b/handlers/admin/send_notification_task.go
@@ -56,10 +56,10 @@ func (SendNotificationTask) Action(w http.ResponseWriter, r *http.Request) any {
 		ids = append(ids, rows...)
 	}
 	for _, id := range ids {
-		err := queries.InsertNotification(r.Context(), db.InsertNotificationParams{
-			UsersIdusers: id,
-			Link:         sql.NullString{String: link, Valid: link != ""},
-			Message:      sql.NullString{String: message, Valid: message != ""},
+		err := queries.SystemCreateNotification(r.Context(), db.SystemCreateNotificationParams{
+			RecipientID: id,
+			Link:        sql.NullString{String: link, Valid: link != ""},
+			Message:     sql.NullString{String: message, Valid: message != ""},
 		})
 		if err != nil {
 			return fmt.Errorf("insert notification fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/admin/toggle_notification_read_task.go
+++ b/handlers/admin/toggle_notification_read_task.go
@@ -26,16 +26,16 @@ func (ToggleNotificationReadTask) Action(w http.ResponseWriter, r *http.Request)
 	}
 	for _, idStr := range r.Form["id"] {
 		id, _ := strconv.Atoi(idStr)
-		n, err := queries.GetNotification(r.Context(), int32(id))
+		n, err := queries.AdminGetNotification(r.Context(), int32(id))
 		if err != nil {
 			return fmt.Errorf("get notification fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		if n.ReadAt.Valid {
-			if err := queries.MarkNotificationUnread(r.Context(), int32(id)); err != nil {
+			if err := queries.AdminMarkNotificationUnread(r.Context(), int32(id)); err != nil {
 				return fmt.Errorf("mark unread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 			}
 		} else {
-			if err := queries.MarkNotificationRead(r.Context(), int32(id)); err != nil {
+			if err := queries.AdminMarkNotificationRead(r.Context(), int32(id)); err != nil {
 				return fmt.Errorf("mark read fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 			}
 		}

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -177,10 +177,10 @@ func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, tp Se
 			return err
 		}
 		if len(msg) > 0 {
-			if err := n.Queries.InsertNotification(ctx, db.InsertNotificationParams{
-				UsersIdusers: evt.UserID,
-				Link:         sql.NullString{String: evt.Path, Valid: true},
-				Message:      sql.NullString{String: string(msg), Valid: true},
+			if err := n.Queries.SystemCreateNotification(ctx, db.SystemCreateNotificationParams{
+				RecipientID: evt.UserID,
+				Link:        sql.NullString{String: evt.Path, Valid: true},
+				Message:     sql.NullString{String: string(msg), Valid: true},
 			}); err != nil {
 				return err
 			}
@@ -230,10 +230,10 @@ func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.TaskEvent
 				return err
 			}
 			if len(msg) > 0 {
-				if err := n.Queries.InsertNotification(ctx, db.InsertNotificationParams{
-					UsersIdusers: id,
-					Link:         sql.NullString{String: evt.Path, Valid: true},
-					Message:      sql.NullString{String: string(msg), Valid: true},
+				if err := n.Queries.SystemCreateNotification(ctx, db.SystemCreateNotificationParams{
+					RecipientID: id,
+					Link:        sql.NullString{String: evt.Path, Valid: true},
+					Message:     sql.NullString{String: string(msg), Valid: true},
 				}); err != nil {
 					return err
 				}
@@ -368,14 +368,14 @@ func notifyMissingEmail(ctx context.Context, q db.Querier, userID int32) error {
 	if q == nil || userID == 0 {
 		return nil
 	}
-	last, err := q.LastNotificationByMessage(ctx, db.LastNotificationByMessageParams{UsersIdusers: userID, Message: sql.NullString{String: "missing email address", Valid: true}})
+	last, err := q.SystemGetLastNotificationForRecipientByMessage(ctx, db.SystemGetLastNotificationForRecipientByMessageParams{RecipientID: userID, Message: sql.NullString{String: "missing email address", Valid: true}})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("last notification: %w", err)
 	}
 	if err == nil && time.Since(last.CreatedAt) < 7*24*time.Hour {
 		return nil
 	}
-	if err := q.InsertNotification(ctx, db.InsertNotificationParams{UsersIdusers: userID, Message: sql.NullString{String: "missing email address", Valid: true}}); err != nil {
+	if err := q.SystemCreateNotification(ctx, db.SystemCreateNotificationParams{RecipientID: userID, Message: sql.NullString{String: "missing email address", Valid: true}}); err != nil {
 		return fmt.Errorf("insert notification: %w", err)
 	}
 	return nil

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -13,27 +13,27 @@ import (
 )
 
 func TestNotificationsQueries(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer sqldb.Close()
+	q := db.New(sqldb)
 	mock.ExpectExec("INSERT INTO notifications").WithArgs(int32(1), sqlmock.AnyArg(), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-	if err := q.InsertNotification(context.Background(), db.InsertNotificationParams{UsersIdusers: 1, Link: sql.NullString{String: "/x", Valid: true}, Message: sql.NullString{String: "hi", Valid: true}}); err != nil {
+	if err := q.SystemCreateNotification(context.Background(), db.SystemCreateNotificationParams{RecipientID: 1, Link: sql.NullString{String: "/x", Valid: true}, Message: sql.NullString{String: "hi", Valid: true}}); err != nil {
 		t.Fatalf("insert: %v", err)
 	}
 	rows := sqlmock.NewRows([]string{"cnt"}).AddRow(1)
 	mock.ExpectQuery("SELECT COUNT\\(\\*\\)").WillReturnRows(rows)
-	if c, err := q.CountUnreadNotifications(context.Background(), 1); err != nil || c != 1 {
+	if c, err := q.CountUnreadNotificationsForUser(context.Background(), 1); err != nil || c != 1 {
 		t.Fatalf("count=%d err=%v", c, err)
 	}
 	mock.ExpectQuery("SELECT id, users_idusers").WillReturnRows(sqlmock.NewRows([]string{"id", "users_idusers", "link", "message", "created_at", "read_at"}).AddRow(1, 1, "/x", "hi", time.Now(), nil))
-	if _, err := q.GetUnreadNotifications(context.Background(), 1); err != nil {
+	if _, err := q.ListUnreadNotificationsForLister(context.Background(), db.ListUnreadNotificationsForListerParams{ListerID: 1, Limit: 10, Offset: 0}); err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	mock.ExpectExec("UPDATE notifications SET read_at").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
-	if err := q.MarkNotificationRead(context.Background(), 1); err != nil {
+	mock.ExpectExec("UPDATE notifications SET read_at").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
+	if err := q.MarkNotificationReadForLister(context.Background(), db.MarkNotificationReadForListerParams{ID: 1, ListerID: 1}); err != nil {
 		t.Fatalf("mark: %v", err)
 	}
 	mock.ExpectExec("DELETE FROM notifications").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -53,12 +53,12 @@ func (r *dummyProvider) Send(ctx context.Context, to mail.Address, rawEmailMessa
 }
 
 func TestNotifierNotifyAdmins(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer sqldb.Close()
+	q := db.New(sqldb)
 	cfg := config.NewRuntimeConfig()
 	cfg.EmailEnabled = true
 	cfg.AdminNotify = true
@@ -87,12 +87,12 @@ func TestNotifierInitialization(t *testing.T) {
 	if n.Queries != nil {
 		t.Fatalf("expected nil Queries")
 	}
-	db, _, err := sqlmock.New()
+	sqldb, _, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer sqldb.Close()
+	q := db.New(sqldb)
 	n = New(WithQueries(q), WithConfig(cfg))
 	if n.Queries != q {
 		t.Fatalf("queries not set via option")

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -151,10 +151,10 @@ func (n *Notifier) notifyAdmins(ctx context.Context, et *EmailTemplates, nt *str
 				return err
 			}
 			if uid != nil {
-				if err := n.Queries.InsertNotification(ctx, db.InsertNotificationParams{
-					UsersIdusers: *uid,
-					Link:         sql.NullString{String: link, Valid: link != ""},
-					Message:      sql.NullString{String: string(msg), Valid: len(msg) > 0},
+				if err := n.Queries.SystemCreateNotification(ctx, db.SystemCreateNotificationParams{
+					RecipientID: *uid,
+					Link:        sql.NullString{String: link, Valid: link != ""},
+					Message:     sql.NullString{String: string(msg), Valid: len(msg) > 0},
 				}); err != nil {
 					return err
 				}
@@ -187,9 +187,9 @@ func (n *Notifier) NotificationPurgeWorker(ctx context.Context, interval time.Du
 
 // sendInternalNotification stores an internal notification for the user.
 func (n *Notifier) sendInternalNotification(ctx context.Context, userID int32, path, msg string) error {
-	return n.Queries.InsertNotification(ctx, db.InsertNotificationParams{
-		UsersIdusers: userID,
-		Link:         sql.NullString{String: path, Valid: path != ""},
-		Message:      sql.NullString{String: msg, Valid: msg != ""},
+	return n.Queries.SystemCreateNotification(ctx, db.SystemCreateNotificationParams{
+		RecipientID: userID,
+		Link:        sql.NullString{String: path, Valid: path != ""},
+		Message:     sql.NullString{String: msg, Valid: msg != ""},
 	})
 }

--- a/internal/notifications/permission_tasks_test.go
+++ b/internal/notifications/permission_tasks_test.go
@@ -69,7 +69,7 @@ func TestProcessEventPermissionTasks(t *testing.T) {
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
 			WithArgs(int32(2)).
 			WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(2, "u@test", "bob", nil))
-		mock.ExpectQuery("LastNotificationByMessage").
+		mock.ExpectQuery("SystemGetLastNotificationForRecipientByMessage").
 			WithArgs(int32(2), "missing email address").
 			WillReturnError(sql.ErrNoRows)
 		mock.ExpectExec(regexp.QuoteMeta("INSERT INTO notifications (users_idusers, link, message) VALUES (?, ?, ?)")).


### PR DESCRIPTION
## Summary
- rename unread notifications count query to use `ForUser`
- update core data helper to call `CountUnreadNotificationsForUser`
- fix notifications tests to avoid package shadowing

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(terminated: command did not complete)*
- `go test ./...` *(fails: db.New undefined in multiple files)*
- `golangci-lint run` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_688ee75f13e4832f81831d331af2fae9