### PR TITLE
fix: avoid db package shadowing

### DIFF
--- a/cmd/goa4web/blog_comments_list.go
+++ b/cmd/goa4web/blog_comments_list.go
@@ -41,12 +41,12 @@ func (c *blogCommentsListCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	listerID := int32(c.UserID)
 	b, err := queries.GetBlogEntryForListerByID(ctx, db.GetBlogEntryForListerByIDParams{
 		ListerID: listerID,

--- a/cmd/goa4web/blog_comments_read.go
+++ b/cmd/goa4web/blog_comments_read.go
@@ -53,12 +53,12 @@ func (c *blogCommentsReadCmd) Run() error {
 	if c.BlogID == 0 {
 		return fmt.Errorf("blog id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	uid := int32(c.UserID)
 	b, err := queries.GetBlogEntryForListerByID(ctx, db.GetBlogEntryForListerByIDParams{
 		ListerID: uid,

--- a/cmd/goa4web/blog_create.go
+++ b/cmd/goa4web/blog_create.go
@@ -35,12 +35,12 @@ func (c *blogCreateCmd) Run() error {
 	if c.UserID == 0 || c.LangID == 0 || c.Text == "" {
 		return fmt.Errorf("user, lang and text required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	_, err = queries.CreateBlogEntry(ctx, db.CreateBlogEntryParams{
 		UsersIdusers:       int32(c.UserID),
 		LanguageIdlanguage: int32(c.LangID),

--- a/cmd/goa4web/blog_deactivate.go
+++ b/cmd/goa4web/blog_deactivate.go
@@ -31,12 +31,12 @@ func (c *blogDeactivateCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	b, err := queries.GetBlogEntryForListerByID(ctx, db.GetBlogEntryForListerByIDParams{
 		ListerID: 0,
 		ID:       int32(c.ID),

--- a/cmd/goa4web/blog_list.go
+++ b/cmd/goa4web/blog_list.go
@@ -32,12 +32,12 @@ func parseBlogListCmd(parent *blogCmd, args []string) (*blogListCmd, error) {
 }
 
 func (c *blogListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	uid := int32(c.UserID)
 	rows, err := queries.ListBlogEntriesForLister(ctx, db.ListBlogEntriesForListerParams{
 		ListerID: uid,

--- a/cmd/goa4web/blog_read.go
+++ b/cmd/goa4web/blog_read.go
@@ -39,12 +39,12 @@ func (c *blogReadCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	row, err := queries.GetBlogEntryForListerByID(ctx, db.GetBlogEntryForListerByIDParams{
 		ListerID: 0,
 		ID:       int32(c.ID),

--- a/cmd/goa4web/blog_update.go
+++ b/cmd/goa4web/blog_update.go
@@ -35,12 +35,12 @@ func (c *blogUpdateCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	err = queries.UpdateBlogEntry(ctx, db.UpdateBlogEntryParams{
 		LanguageIdlanguage: int32(c.LangID),
 		Blog:               sql.NullString{String: c.Text, Valid: c.Text != ""},

--- a/cmd/goa4web/board_create.go
+++ b/cmd/goa4web/board_create.go
@@ -32,12 +32,12 @@ func parseBoardCreateCmd(parent *boardCmd, args []string) (*boardCreateCmd, erro
 }
 
 func (c *boardCreateCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	err = queries.CreateImageBoard(ctx, db.CreateImageBoardParams{
 		ImageboardIdimageboard: int32(c.Parent),
 		Title:                  sql.NullString{String: c.Name, Valid: c.Name != ""},

--- a/cmd/goa4web/board_delete.go
+++ b/cmd/goa4web/board_delete.go
@@ -35,12 +35,12 @@ func (c *boardDeleteCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.DeleteImageBoard(ctx, int32(c.ID)); err != nil {
 		return fmt.Errorf("delete board: %w", err)
 	}

--- a/cmd/goa4web/board_list.go
+++ b/cmd/goa4web/board_list.go
@@ -29,12 +29,12 @@ func parseBoardListCmd(parent *boardCmd, args []string) (*boardListCmd, error) {
 }
 
 func (c *boardListCmd) Run() error {
-	sqldb, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(sqldb)
+	queries := db.New(conn)
 	rows, err := queries.AdminListBoards(ctx, db.AdminListBoardsParams{Limit: int32(c.limit), Offset: int32(c.offset)})
 	if err != nil {
 		return fmt.Errorf("list boards: %w", err)

--- a/cmd/goa4web/board_update.go
+++ b/cmd/goa4web/board_update.go
@@ -40,12 +40,12 @@ func (c *boardUpdateCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	err = queries.UpdateImageBoard(ctx, db.UpdateImageBoardParams{
 		Title:                  sql.NullString{String: c.Name, Valid: c.Name != ""},
 		Description:            sql.NullString{String: c.Description, Valid: c.Description != ""},

--- a/cmd/goa4web/config_test_cmd.go
+++ b/cmd/goa4web/config_test_cmd.go
@@ -97,8 +97,8 @@ func (c *configTestEmailCmd) Run() error {
 		return fmt.Errorf("email provider not configured")
 	}
 	var q db.Querier
-	if db, err := c.rootCmd.DB(); err == nil {
-		q = db.New(db)
+	if conn, err := c.rootCmd.DB(); err == nil {
+		q = db.New(conn)
 	}
 	ctx := context.Background()
 	emails := config.GetAdminEmails(ctx, q, c.rootCmd.cfg)
@@ -151,11 +151,11 @@ func parseConfigTestDBCmd(parent *configTestCmd, args []string) (*configTestDBCm
 }
 
 func (c *configTestDBCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
-	if err := db.Ping(); err != nil {
+	if err := conn.Ping(); err != nil {
 		return fmt.Errorf("ping: %w", err)
 	}
 	return nil
@@ -178,8 +178,8 @@ func parseConfigTestDLQCmd(parent *configTestCmd, args []string) (*configTestDLQ
 
 func (c *configTestDLQCmd) Run() error {
 	var q db.Querier
-	if db, err := c.rootCmd.DB(); err == nil {
-		q = db.New(db)
+	if conn, err := c.rootCmd.DB(); err == nil {
+		q = db.New(conn)
 	}
 	provider := c.rootCmd.dlqReg.ProviderFromConfig(c.rootCmd.cfg, q)
 	if provider == nil {

--- a/cmd/goa4web/email_queue_delete.go
+++ b/cmd/goa4web/email_queue_delete.go
@@ -30,12 +30,12 @@ func (c *emailQueueDeleteCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.AdminDeletePendingEmail(ctx, int32(c.ID)); err != nil {
 		return fmt.Errorf("delete email: %w", err)
 	}

--- a/cmd/goa4web/email_queue_list.go
+++ b/cmd/goa4web/email_queue_list.go
@@ -28,12 +28,12 @@ func parseEmailQueueListCmd(parent *emailQueueCmd, args []string) (*emailQueueLi
 }
 
 func (c *emailQueueListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.AdminListUnsentPendingEmails(ctx, db.AdminListUnsentPendingEmailsParams{})
 	if err != nil {
 		return fmt.Errorf("list emails: %w", err)

--- a/cmd/goa4web/email_queue_resend.go
+++ b/cmd/goa4web/email_queue_resend.go
@@ -31,12 +31,12 @@ func (c *emailQueueResendCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	e, err := queries.AdminGetPendingEmailByID(ctx, int32(c.ID))
 	if err != nil {
 		return fmt.Errorf("get email: %w", err)

--- a/cmd/goa4web/faq_read.go
+++ b/cmd/goa4web/faq_read.go
@@ -37,12 +37,12 @@ func (c *faqReadCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.GetAllFAQQuestions(ctx)
 	if err != nil {
 		return fmt.Errorf("get faq: %w", err)

--- a/cmd/goa4web/faq_tree.go
+++ b/cmd/goa4web/faq_tree.go
@@ -26,12 +26,12 @@ func parseFaqTreeCmd(parent *faqCmd, args []string) (*faqTreeCmd, error) {
 }
 
 func (c *faqTreeCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.GetAllAnsweredFAQWithFAQCategoriesForUser(ctx, db.GetAllAnsweredFAQWithFAQCategoriesForUserParams{ViewerID: 0, UserID: sql.NullInt32{}})
 	if err != nil {
 		return fmt.Errorf("tree: %w", err)

--- a/cmd/goa4web/grant_add.go
+++ b/cmd/goa4web/grant_add.go
@@ -41,12 +41,12 @@ func (c *grantAddCmd) Run() error {
 	if c.Section == "" || c.Action == "" {
 		return fmt.Errorf("section and action required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	q := db.New(db)
+	q := db.New(conn)
 	_, err = q.CreateGrant(ctx, db.CreateGrantParams{
 		UserID:   sql.NullInt32{Int32: int32(c.User), Valid: c.User != 0},
 		RoleID:   sql.NullInt32{},

--- a/cmd/goa4web/grant_delete.go
+++ b/cmd/goa4web/grant_delete.go
@@ -30,12 +30,12 @@ func (c *grantDeleteCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	q := db.New(db)
+	q := db.New(conn)
 	if err := q.DeleteGrant(ctx, int32(c.ID)); err != nil {
 		return fmt.Errorf("delete grant: %w", err)
 	}

--- a/cmd/goa4web/grant_list.go
+++ b/cmd/goa4web/grant_list.go
@@ -25,12 +25,12 @@ func parseGrantListCmd(parent *grantCmd, args []string) (*grantListCmd, error) {
 }
 
 func (c *grantListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	q := db.New(db)
+	q := db.New(conn)
 	rows, err := q.ListGrants(ctx)
 	if err != nil {
 		return fmt.Errorf("list grants: %w", err)

--- a/cmd/goa4web/ipban_add.go
+++ b/cmd/goa4web/ipban_add.go
@@ -37,12 +37,12 @@ func (c *ipBanAddCmd) Run() error {
 	if c.IP == "" {
 		return fmt.Errorf("ip required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	var expires sql.NullTime
 	if c.Expires != "" {
 		t, err := time.Parse("2006-01-02", c.Expires)

--- a/cmd/goa4web/ipban_delete.go
+++ b/cmd/goa4web/ipban_delete.go
@@ -31,12 +31,12 @@ func (c *ipBanDeleteCmd) Run() error {
 	if c.IP == "" {
 		return fmt.Errorf("ip required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.AdminCancelBannedIp(ctx, c.IP); err != nil {
 		return fmt.Errorf("cancel banned ip: %w", err)
 	}

--- a/cmd/goa4web/ipban_list.go
+++ b/cmd/goa4web/ipban_list.go
@@ -25,12 +25,12 @@ func parseIpBanListCmd(parent *ipBanCmd, args []string) (*ipBanListCmd, error) {
 }
 
 func (c *ipBanListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.ListBannedIps(ctx)
 	if err != nil {
 		return fmt.Errorf("list banned ips: %w", err)

--- a/cmd/goa4web/ipban_update.go
+++ b/cmd/goa4web/ipban_update.go
@@ -37,12 +37,12 @@ func (c *ipBanUpdateCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	var expires sql.NullTime
 	if c.Expires != "" {
 		t, err := time.Parse("2006-01-02", c.Expires)

--- a/cmd/goa4web/lang_add.go
+++ b/cmd/goa4web/lang_add.go
@@ -33,12 +33,12 @@ func (c *langAddCmd) Run() error {
 	if c.Code == "" || c.Name == "" {
 		return fmt.Errorf("code and name required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	c.rootCmd.Verbosef("adding language %s (%s)", c.Name, c.Code)
 	if _, err := queries.AdminInsertLanguage(ctx, sql.NullString{String: c.Name, Valid: true}); err != nil {
 		return fmt.Errorf("insert language: %w", err)

--- a/cmd/goa4web/lang_list.go
+++ b/cmd/goa4web/lang_list.go
@@ -25,12 +25,12 @@ func parseLangListCmd(parent *langCmd, args []string) (*langListCmd, error) {
 }
 
 func (c *langListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	langs, err := queries.SystemListLanguages(ctx)
 	if err != nil {
 		return fmt.Errorf("list languages: %w", err)

--- a/cmd/goa4web/lang_update.go
+++ b/cmd/goa4web/lang_update.go
@@ -33,12 +33,12 @@ func (c *langUpdateCmd) Run() error {
 	if c.ID == 0 || c.Name == "" {
 		return fmt.Errorf("id and name required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	err = queries.AdminRenameLanguage(ctx, db.AdminRenameLanguageParams{Nameof: sql.NullString{String: c.Name, Valid: true}, Idlanguage: int32(c.ID)})
 	if err != nil {
 		return fmt.Errorf("update language: %w", err)

--- a/cmd/goa4web/links_delete.go
+++ b/cmd/goa4web/links_delete.go
@@ -31,12 +31,12 @@ func (c *linksDeleteCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.AdminDeleteExternalLink(ctx, int32(c.ID)); err != nil {
 		return fmt.Errorf("delete link: %w", err)
 	}

--- a/cmd/goa4web/links_list.go
+++ b/cmd/goa4web/links_list.go
@@ -25,12 +25,12 @@ func parseLinksListCmd(parent *linksCmd, args []string) (*linksListCmd, error) {
 }
 
 func (c *linksListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.AdminListExternalLinks(ctx, db.AdminListExternalLinksParams{Limit: 200, Offset: 0})
 	if err != nil {
 		return fmt.Errorf("list links: %w", err)

--- a/cmd/goa4web/links_refresh.go
+++ b/cmd/goa4web/links_refresh.go
@@ -32,12 +32,12 @@ func (c *linksRefreshCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.AdminClearExternalLinkCache(ctx, db.AdminClearExternalLinkCacheParams{UpdatedBy: sql.NullInt32{}, ID: int32(c.ID)}); err != nil {
 		return fmt.Errorf("refresh link: %w", err)
 	}

--- a/cmd/goa4web/news_comments_list.go
+++ b/cmd/goa4web/news_comments_list.go
@@ -41,12 +41,12 @@ func (c *newsCommentsListCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	uid := int32(c.UserID)
 	n, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx, db.GetNewsPostByIdWithWriterIdAndThreadCommentCountParams{
 		ViewerID: uid,

--- a/cmd/goa4web/news_comments_read.go
+++ b/cmd/goa4web/news_comments_read.go
@@ -53,12 +53,12 @@ func (c *newsCommentsReadCmd) Run() error {
 	if c.NewsID == 0 {
 		return fmt.Errorf("news id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	uid := int32(c.UserID)
 	n, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx, db.GetNewsPostByIdWithWriterIdAndThreadCommentCountParams{
 		ViewerID: uid,

--- a/cmd/goa4web/news_list.go
+++ b/cmd/goa4web/news_list.go
@@ -30,12 +30,12 @@ func parseNewsListCmd(parent *newsCmd, args []string) (*newsListCmd, error) {
 }
 
 func (c *newsListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	cd := common.NewCoreData(ctx, queries, c.rootCmd.cfg)
 	posts, err := cd.LatestNewsList(int32(c.Offset), int32(c.Limit))
 	if err != nil {

--- a/cmd/goa4web/news_read.go
+++ b/cmd/goa4web/news_read.go
@@ -39,12 +39,12 @@ func (c *newsReadCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	row, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx, db.GetNewsPostByIdWithWriterIdAndThreadCommentCountParams{
 		ViewerID: 0,
 		ID:       int32(c.ID),

--- a/cmd/goa4web/perm_grant.go
+++ b/cmd/goa4web/perm_grant.go
@@ -34,12 +34,12 @@ func (c *permGrantCmd) Run() error {
 	if c.User == "" || c.Role == "" {
 		return fmt.Errorf("user and role required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	c.rootCmd.Verbosef("granting %s to %s", c.Role, c.User)
 	u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.User, Valid: true})
 	if err != nil {

--- a/cmd/goa4web/perm_list.go
+++ b/cmd/goa4web/perm_list.go
@@ -28,12 +28,12 @@ func parsePermListCmd(parent *permCmd, args []string) (*permListCmd, error) {
 }
 
 func (c *permListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.GetPermissionsWithUsers(ctx,
 		db.GetPermissionsWithUsersParams{Username: sql.NullString{String: c.User, Valid: c.User != ""}},
 	)

--- a/cmd/goa4web/perm_revoke.go
+++ b/cmd/goa4web/perm_revoke.go
@@ -30,12 +30,12 @@ func (c *permRevokeCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.DeleteUserRole(ctx, int32(c.ID)); err != nil {
 		return fmt.Errorf("revoke: %w", err)
 	}

--- a/cmd/goa4web/perm_update.go
+++ b/cmd/goa4web/perm_update.go
@@ -32,12 +32,12 @@ func (c *permUpdateCmd) Run() error {
 	if c.ID == 0 || c.Role == "" {
 		return fmt.Errorf("id and role required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if err := queries.UpdatePermission(ctx, db.UpdatePermissionParams{
 		IduserRoles: int32(c.ID),
 		Name:        c.Role,

--- a/cmd/goa4web/role_users.go
+++ b/cmd/goa4web/role_users.go
@@ -29,12 +29,12 @@ func parseRoleUsersCmd(parent *roleCmd, args []string) (*roleUsersCmd, error) {
 }
 
 func (c *roleUsersCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.AdminListRolesWithUsers(ctx)
 	if err != nil {
 		return fmt.Errorf("list roles with users: %w", err)

--- a/cmd/goa4web/user_activate.go
+++ b/cmd/goa4web/user_activate.go
@@ -35,12 +35,12 @@ func (c *userActivateCmd) Run() error {
 	if c.ID == 0 && c.Username == "" {
 		return fmt.Errorf("id or username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.ID == 0 {
 		u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {
@@ -49,7 +49,7 @@ func (c *userActivateCmd) Run() error {
 		c.ID = int(u.Idusers)
 	}
 	c.rootCmd.Verbosef("restoring user %d", c.ID)
-	tx, err := db.BeginTx(ctx, nil)
+	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}

--- a/cmd/goa4web/user_add.go
+++ b/cmd/goa4web/user_add.go
@@ -54,12 +54,12 @@ func createUser(root *rootCmd, username, email, password string, admin bool) err
 	if username == "" || password == "" {
 		return fmt.Errorf("username and password required")
 	}
-	db, err := root.DB()
+	conn, err := root.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	hash, alg, err := auth.HashPassword(password)
 	if err != nil {
 		return fmt.Errorf("hash password: %w", err)

--- a/cmd/goa4web/user_add_role.go
+++ b/cmd/goa4web/user_add_role.go
@@ -35,12 +35,12 @@ func (c *userAddRoleCmd) Run() error {
 	if c.Username == "" || c.Role == "" {
 		return fmt.Errorf("username and role required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	c.rootCmd.Verbosef("adding role %s to %s", c.Role, c.Username)
 	u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {

--- a/cmd/goa4web/user_approve.go
+++ b/cmd/goa4web/user_approve.go
@@ -34,12 +34,12 @@ func (c *userApproveCmd) Run() error {
 	if c.ID == 0 && c.Username == "" {
 		return fmt.Errorf("id or username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.ID == 0 {
 		u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {

--- a/cmd/goa4web/user_comments_add.go
+++ b/cmd/goa4web/user_comments_add.go
@@ -40,12 +40,12 @@ func (c *userCommentsAddCmd) Run() error {
 	if strings.TrimSpace(c.Comment) == "" {
 		return fmt.Errorf("empty comment")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.ID == 0 {
 		u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {

--- a/cmd/goa4web/user_comments_list.go
+++ b/cmd/goa4web/user_comments_list.go
@@ -34,12 +34,12 @@ func (c *userCommentsListCmd) Run() error {
 	if c.ID == 0 && c.Username == "" {
 		return fmt.Errorf("id or username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.ID == 0 {
 		u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {

--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -40,18 +40,18 @@ func (c *userDeactivateCmd) Run() error {
 	if c.Username == "" {
 		return fmt.Errorf("username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}
 	c.rootCmd.Verbosef("deactivating user %s", c.Username)
-	tx, err := db.BeginTx(ctx, nil)
+	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}

--- a/cmd/goa4web/user_list.go
+++ b/cmd/goa4web/user_list.go
@@ -35,12 +35,12 @@ func parseUserListCmd(parent *userCmd, args []string) (*userListCmd, error) {
 }
 
 func (c *userListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 
 	var rows []*db.SystemListUserInfoRow
 	if c.showAdmin || c.showCreated || c.jsonOut {

--- a/cmd/goa4web/user_list_roles.go
+++ b/cmd/goa4web/user_list_roles.go
@@ -25,12 +25,12 @@ func parseUserListRolesCmd(parent *userCmd, args []string) (*userListRolesCmd, e
 }
 
 func (c *userListRolesCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	roles, err := queries.AdminListRoles(ctx)
 	if err != nil {
 		return fmt.Errorf("list roles: %w", err)

--- a/cmd/goa4web/user_make_admin.go
+++ b/cmd/goa4web/user_make_admin.go
@@ -33,12 +33,12 @@ func (c *userMakeAdminCmd) Run() error {
 	if c.Username == "" {
 		return fmt.Errorf("username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	c.rootCmd.Verbosef("granting administrator to %s", c.Username)
 	u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {

--- a/cmd/goa4web/user_password_clear_expired.go
+++ b/cmd/goa4web/user_password_clear_expired.go
@@ -31,12 +31,12 @@ func parseUserPasswordClearExpiredCmd(parent *userPasswordCmd, args []string) (*
 }
 
 func (c *userPasswordClearExpiredCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	expiry := time.Now().Add(-time.Duration(c.Hours) * time.Hour)
 	res, err := queries.PurgePasswordResetsBefore(ctx, expiry)
 	if err != nil {

--- a/cmd/goa4web/user_password_clear_user.go
+++ b/cmd/goa4web/user_password_clear_user.go
@@ -34,12 +34,12 @@ func (c *userPasswordClearUserCmd) Run() error {
 	if c.Username == "" {
 		return fmt.Errorf("username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	user, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)

--- a/cmd/goa4web/user_profile.go
+++ b/cmd/goa4web/user_profile.go
@@ -36,12 +36,12 @@ func (c *userProfileCmd) Run() error {
 	if c.ID == 0 && c.Username == "" {
 		return fmt.Errorf("id or username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.ID == 0 {
 		u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {

--- a/cmd/goa4web/user_reject.go
+++ b/cmd/goa4web/user_reject.go
@@ -37,12 +37,12 @@ func (c *userRejectCmd) Run() error {
 	if c.ID == 0 && c.Username == "" {
 		return fmt.Errorf("id or username required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.ID == 0 {
 		u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 		if err != nil {

--- a/cmd/goa4web/user_remove_role.go
+++ b/cmd/goa4web/user_remove_role.go
@@ -34,12 +34,12 @@ func (c *userRemoveRoleCmd) Run() error {
 	if c.Username == "" || c.Role == "" {
 		return fmt.Errorf("username and role required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	c.rootCmd.Verbosef("removing role %s from %s", c.Role, c.Username)
 	u, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.Username, Valid: true})
 	if err != nil {

--- a/cmd/goa4web/user_roles.go
+++ b/cmd/goa4web/user_roles.go
@@ -26,12 +26,12 @@ func parseUserRolesCmd(parent *userCmd, args []string) (*userRolesCmd, error) {
 }
 
 func (c *userRolesCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.ListUsersWithRoles(ctx)
 	if err != nil {
 		return fmt.Errorf("list users with roles: %w", err)

--- a/cmd/goa4web/writing_comments_list.go
+++ b/cmd/goa4web/writing_comments_list.go
@@ -41,12 +41,12 @@ func (c *writingCommentsListCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	uid := int32(c.UserID)
 	w, err := queries.GetWritingForListerByID(ctx, db.GetWritingForListerByIDParams{ListerID: uid, Idwriting: int32(c.ID), ListerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0}})
 	if err != nil {

--- a/cmd/goa4web/writing_comments_read.go
+++ b/cmd/goa4web/writing_comments_read.go
@@ -53,12 +53,12 @@ func (c *writingCommentsReadCmd) Run() error {
 	if c.WritingID == 0 {
 		return fmt.Errorf("writing id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	uid := int32(c.UserID)
 	w, err := queries.GetWritingForListerByID(ctx, db.GetWritingForListerByIDParams{ListerID: uid, Idwriting: int32(c.WritingID), ListerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0}})
 	if err != nil {

--- a/cmd/goa4web/writing_list.go
+++ b/cmd/goa4web/writing_list.go
@@ -34,12 +34,12 @@ func parseWritingListCmd(parent *writingCmd, args []string) (*writingListCmd, er
 }
 
 func (c *writingListCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	if c.UserID != 0 {
 		rows, err := queries.SystemListPublicWritingsByAuthor(ctx, db.SystemListPublicWritingsByAuthorParams{
 			AuthorID: int32(c.UserID),

--- a/cmd/goa4web/writing_read.go
+++ b/cmd/goa4web/writing_read.go
@@ -38,12 +38,12 @@ func (c *writingReadCmd) Run() error {
 	if c.ID == 0 {
 		return fmt.Errorf("id required")
 	}
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	row, err := queries.GetWritingForListerByID(ctx, db.GetWritingForListerByIDParams{
 		ListerID:      0,
 		Idwriting:     int32(c.ID),

--- a/cmd/goa4web/writing_tree.go
+++ b/cmd/goa4web/writing_tree.go
@@ -26,12 +26,12 @@ func parseWritingTreeCmd(parent *writingCmd, args []string) (*writingTreeCmd, er
 }
 
 func (c *writingTreeCmd) Run() error {
-	db, err := c.rootCmd.DB()
+	conn, err := c.rootCmd.DB()
 	if err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
 	ctx := context.Background()
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows, err := queries.SystemListWritingCategories(ctx, db.SystemListWritingCategoriesParams{Limit: math.MaxInt32, Offset: 0})
 	if err != nil {
 		return fmt.Errorf("tree: %w", err)

--- a/core/common/coredata_allroles_test.go
+++ b/core/common/coredata_allroles_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestAllRolesLazy(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
+	defer conn.Close()
 
 	rows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).
 		AddRow(int32(1), "user", true, false, nil).
@@ -22,7 +22,7 @@ func TestAllRolesLazy(t *testing.T) {
 
 	mock.ExpectQuery("SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id").WillReturnRows(rows)
 
-	cd := NewCoreData(context.Background(), db.New(sqldb), config.NewRuntimeConfig())
+	cd := NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
 
 	if _, err := cd.AllRoles(); err != nil {
 		t.Fatalf("AllRoles: %v", err)

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -17,13 +17,13 @@ import (
 )
 
 func TestCoreDataLatestNewsLazy(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
 		"writerName", "writerId", "idsitenews", "forumthread_id", "language_idlanguage",
@@ -56,13 +56,13 @@ func TestCoreDataLatestNewsLazy(t *testing.T) {
 }
 
 func TestWritingCategoriesLazy(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
 		AddRow(1, 0, "a", "b")
 
@@ -88,13 +88,13 @@ func TestWritingCategoriesLazy(t *testing.T) {
 }
 
 func TestAnnouncementForNewsCaching(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 	now := time.Now()
 	annRows := sqlmock.NewRows([]string{"id", "site_news_id", "active", "created_at"}).
 		AddRow(1, 1, true, now)
@@ -117,13 +117,13 @@ func TestAnnouncementForNewsCaching(t *testing.T) {
 }
 
 func TestAnnouncementForNewsError(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 
 	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnError(sql.ErrConnDone)
 
@@ -143,13 +143,13 @@ func TestAnnouncementForNewsError(t *testing.T) {
 }
 
 func TestPublicWritingsLazy(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "Username", "Comments"}).
 		AddRow(1, 1, 0, 1, 0, "t", now, "w", "a", false, now, now, "u", 0)
@@ -192,13 +192,13 @@ func TestPublicWritingsLazy(t *testing.T) {
 }
 
 func TestCoreDataLatestWritingsLazy(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
 		"idwriting", "users_idusers", "forumthread_id", "language_idlanguage",
@@ -231,13 +231,13 @@ func TestCoreDataLatestWritingsLazy(t *testing.T) {
 
 func TestBloggersLazy(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
 	mock.ExpectQuery("SELECT u.username").
 		WithArgs(int32(1), int32(1), int32(1), sqlmock.AnyArg(), int32(16), int32(0)).
@@ -265,13 +265,13 @@ func TestWritersLazy(t *testing.T) {
 
 	cfg := config.NewRuntimeConfig()
 
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
 	mock.ExpectQuery("SELECT u.username").
 		WithArgs(int32(1), int32(1), int32(1), sqlmock.AnyArg(), int32(16), int32(0)).

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -51,13 +51,13 @@ func TestTemplateFuncsCSRFToken(t *testing.T) {
 }
 
 func TestLatestNewsRespectsPermissions(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{

--- a/examples/config.env
+++ b/examples/config.env
@@ -42,8 +42,8 @@ EMAIL_SUBJECT_PREFIX=goa4web
 EMAIL_WORKER_INTERVAL=60
 # enable or disable feeds (default: true)
 FEEDS_ENABLED=true
-# server base URL (default: http://localhost:8080)
-HOSTNAME=http://localhost:8080
+# server base URL (default: a44598274634)
+HOSTNAME=a44598274634
 # Strict-Transport-Security header value (default: max-age=63072000; includeSubDomains)
 HSTS_HEADER=max-age=63072000; includeSubDomains
 # directory for cached thumbnails when using the local provider (default: uploads/cache)

--- a/handlers/auth/forgotPassword_event_test.go
+++ b/handlers/auth/forgotPassword_event_test.go
@@ -20,12 +20,12 @@ import (
 )
 
 func TestForgotPasswordEventData(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, passwd")).WithArgs(int32(1), sqlmock.AnyArg()).WillReturnError(sql.ErrNoRows)

--- a/handlers/auth/forgotPassword_limit_test.go
+++ b/handlers/auth/forgotPassword_limit_test.go
@@ -19,12 +19,12 @@ import (
 )
 
 func TestForgotPasswordRateLimit(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 
 	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
@@ -51,12 +51,12 @@ func TestForgotPasswordRateLimit(t *testing.T) {
 }
 
 func TestForgotPasswordReplaceOld(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 
 	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))

--- a/handlers/auth/forgotPassword_no_email_test.go
+++ b/handlers/auth/forgotPassword_no_email_test.go
@@ -18,12 +18,12 @@ import (
 )
 
 func TestForgotPasswordNoEmail(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 
@@ -46,12 +46,12 @@ func TestForgotPasswordNoEmail(t *testing.T) {
 }
 
 func TestEmailAssociationRequestTask(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "", "u", nil))
 	mock.ExpectExec("INSERT INTO admin_request_queue").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO admin_request_comments").WillReturnResult(sqlmock.NewResult(1, 1))

--- a/handlers/auth/redirectBackPageHandler_test.go
+++ b/handlers/auth/redirectBackPageHandler_test.go
@@ -15,12 +15,12 @@ import (
 )
 
 func TestRedirectBackPageHandlerGETAlt(t *testing.T) {
-	db, _, err := sqlmock.New()
+	conn, _, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 
 	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)

--- a/handlers/auth/verify_password_task_test.go
+++ b/handlers/auth/verify_password_task_test.go
@@ -20,12 +20,12 @@ import (
 )
 
 func TestVerifyPasswordAction_Success(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 
 	pwHash, alg, _ := HashPassword("pw")
 	rows := sqlmock.NewRows([]string{"id", "user_id", "passwd", "passwd_algorithm", "verification_code", "created_at", "verified_at"}).
@@ -56,12 +56,12 @@ func TestVerifyPasswordAction_Success(t *testing.T) {
 }
 
 func TestVerifyPasswordAction_InvalidPassword(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 
 	pwHash, alg, _ := HashPassword("pw")
 	rows := sqlmock.NewRows([]string{"id", "user_id", "passwd", "passwd_algorithm", "verification_code", "created_at", "verified_at"}).

--- a/handlers/blogs/blogsBloggersBloggerPage_test.go
+++ b/handlers/blogs/blogsBloggersBloggerPage_test.go
@@ -14,12 +14,12 @@ import (
 )
 
 func TestBloggersBloggerPage(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 
 	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
 	mock.ExpectQuery(regexp.QuoteMeta("WITH RECURSIVE role_ids")).

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -27,13 +27,13 @@ var (
 )
 
 func TestBlogsBloggerPostsPage(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
+	defer conn.Close()
 
-	q := db.New(sqldb)
+	q := db.New(conn)
 	store = sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = sessionName
@@ -84,11 +84,11 @@ func TestBlogsBloggerPostsPage(t *testing.T) {
 }
 
 func TestBlogsRssPageWritesRSS(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
+	defer conn.Close()
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT idusers, (SELECT email FROM user_emails ue WHERE ue.user_id = users.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email, username, public_profile_enabled_at\nFROM users\nWHERE username = ?")).
 		WithArgs("bob").
@@ -101,7 +101,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 			AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), "bob", 0, true))
 
 	req := httptest.NewRequest("GET", "http://example.com/blogs/rss?rss=bob", nil)
-	q := db.New(sqldb)
+	q := db.New(conn)
 	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/bookmarks/mine_test.go
+++ b/handlers/bookmarks/mine_test.go
@@ -72,13 +72,13 @@ func Test_preprocessBookmarks(t *testing.T) {
 }
 
 func TestMinePage_NoBookmarks(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT Idbookmarks, list\nFROM bookmarks\nWHERE users_idusers = ?")).
 		WithArgs(int32(1)).WillReturnError(sql.ErrNoRows)
 

--- a/handlers/faq/faqIndexPermissions_test.go
+++ b/handlers/faq/faqIndexPermissions_test.go
@@ -14,12 +14,12 @@ import (
 func TestCustomFAQIndexAsk(t *testing.T) {
 	req := httptest.NewRequest("GET", "/faq", nil)
 
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
 
@@ -39,12 +39,12 @@ func TestCustomFAQIndexAsk(t *testing.T) {
 func TestCustomFAQIndexAskDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/faq", nil)
 
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
 

--- a/handlers/forum/forumIndexPermissions_test.go
+++ b/handlers/forum/forumIndexPermissions_test.go
@@ -16,12 +16,12 @@ func TestCustomForumIndexWriteReply(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2/thread/3", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "thread": "3"})
 
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
 
@@ -42,12 +42,12 @@ func TestCustomForumIndexWriteReplyDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2/thread/3", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "thread": "3"})
 
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
 
@@ -68,12 +68,12 @@ func TestCustomForumIndexCreateThread(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "category": "1"})
 
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
 
@@ -94,12 +94,12 @@ func TestCustomForumIndexCreateThreadDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "category": "1"})
 
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
 
@@ -120,12 +120,12 @@ func TestCustomForumIndexSubscribeLink(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "category": "1"})
 
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
 	cd.UserID = 1
@@ -147,12 +147,12 @@ func TestCustomForumIndexUnsubscribeLink(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "category": "1"})
 
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
 	cd.UserID = 1

--- a/handlers/forum/matchers_test.go
+++ b/handlers/forum/matchers_test.go
@@ -17,11 +17,11 @@ import (
 )
 
 func TestRequireThreadAndTopicTrue(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
+	defer conn.Close()
 
 	mock.ExpectQuery("SELECT th.idforumthread").
 		WithArgs(int32(0), int32(2), int32(0), int32(0), sql.NullInt32{Int32: 0, Valid: false}).
@@ -44,7 +44,7 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
-	q := db.New(sqldb)
+	q := db.New(conn)
 	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -75,11 +75,11 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 }
 
 func TestRequireThreadAndTopicFalse(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
+	defer conn.Close()
 
 	mock.ExpectQuery("SELECT th.idforumthread").
 		WithArgs(int32(0), int32(2), int32(0), int32(0), sql.NullInt32{Int32: 0, Valid: false}).
@@ -95,7 +95,7 @@ func TestRequireThreadAndTopicFalse(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
-	q := db.New(sqldb)
+	q := db.New(conn)
 	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -120,11 +120,11 @@ func TestRequireThreadAndTopicFalse(t *testing.T) {
 }
 
 func TestRequireThreadAndTopicError(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
+	defer conn.Close()
 
 	mock.ExpectQuery("SELECT th.idforumthread").
 		WithArgs(int32(0), int32(2), int32(0), int32(0), sql.NullInt32{Int32: 0, Valid: false}).
@@ -132,7 +132,7 @@ func TestRequireThreadAndTopicError(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
-	q := db.New(sqldb)
+	q := db.New(conn)
 	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/forum/permissions_test.go
+++ b/handlers/forum/permissions_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func TestUserCanCreateThread_Allowed(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
+	defer conn.Close()
 
-	q := db.New(sqldb)
+	q := db.New(conn)
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
@@ -34,13 +34,13 @@ func TestUserCanCreateThread_Allowed(t *testing.T) {
 }
 
 func TestUserCanCreateThread_Denied(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
+	defer conn.Close()
 
-	q := db.New(sqldb)
+	q := db.New(conn)
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnError(sql.ErrNoRows)

--- a/handlers/forum/thread_delete_test.go
+++ b/handlers/forum/thread_delete_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestThreadDelete(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
+	defer conn.Close()
 
-	q := db.New(sqldb)
+	q := db.New(conn)
 	mock.ExpectExec("AdminDeleteForumThread").
 		WithArgs(int32(1)).
 		WillReturnResult(sqlmock.NewResult(0, 0))

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -45,14 +45,14 @@ func TestLinkerFeed(t *testing.T) {
 func TestLinkerApproveAddsToSearch(t *testing.T) {
 	t.Skip("event bus worker requires long wait; skipping")
 
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	mock.MatchExpectationsInOrder(false)
-	defer sqldb.Close()
+	defer conn.Close()
 
-	queries := db.New(sqldb)
+	queries := db.New(conn)
 
 	mock.ExpectExec("INSERT INTO linker").
 		WithArgs(int32(1)).

--- a/handlers/news/newsIndexPermissions_test.go
+++ b/handlers/news/newsIndexPermissions_test.go
@@ -24,12 +24,12 @@ func TestCustomNewsIndexRoles(t *testing.T) {
 		t.Errorf("admin should see add news")
 	}
 
-	db, _, err := sqlmock.New()
+	conn, _, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	ctx := req.Context()
 	cd = common.NewCoreData(ctx, q, config.NewRuntimeConfig())
 	cd.SetRoles([]string{"content writer", "administrator"})

--- a/handlers/news/search_test.go
+++ b/handlers/news/search_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 func TestNewsSearchFiltersUnauthorized(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
+	defer conn.Close()
 
-	queries := db.New(sqldb)
+	queries := db.New(conn)
 
 	firstRows := sqlmock.NewRows([]string{"site_news_id"}).AddRow(1).AddRow(2)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT DISTINCT cs.site_news_id")).

--- a/handlers/search/permissions_test.go
+++ b/handlers/search/permissions_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 func TestCanSearch(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 	cd := common.NewCoreData(context.Background(), queries, config.NewRuntimeConfig())
 
 	// No grants

--- a/handlers/user/addEmailTask_invalid_test.go
+++ b/handlers/user/addEmailTask_invalid_test.go
@@ -21,12 +21,12 @@ import (
 )
 
 func TestAddEmailTaskInvalid(t *testing.T) {
-	db, _, err := sqlmock.New()
+	conn, _, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 
 	store := sessions.NewCookieStore([]byte("test"))
 	core.Store = store

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -40,12 +40,12 @@ func TestPermissionUserTasksTemplates(t *testing.T) {
 func TestPermissionUserAllowEventData(t *testing.T) {
 	bus := eventbus.NewBus()
 
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	queries := db.New(db)
+	defer conn.Close()
+	queries := db.New(conn)
 
 	mock.ExpectQuery("SELECT idusers").
 		WithArgs(sqlmock.AnyArg()).

--- a/handlers/user/userEmailPage_event_test.go
+++ b/handlers/user/userEmailPage_event_test.go
@@ -23,12 +23,12 @@ import (
 )
 
 func TestAddEmailTaskEventData(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	mock.ExpectQuery("SELECT id, user_id, email").WillReturnError(sql.ErrNoRows)
 	mock.ExpectExec("INSERT INTO user_emails").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectQuery("SELECT u.idusers").WithArgs(int32(1)).
@@ -71,12 +71,12 @@ func TestAddEmailTaskEventData(t *testing.T) {
 }
 
 func TestVerifyRemovesDuplicates(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 
 	store = sessions.NewCookieStore([]byte("test"))
 	core.Store = store
@@ -125,12 +125,12 @@ func TestVerifyRemovesDuplicates(t *testing.T) {
 }
 
 func TestResendVerificationEmailTaskEventData(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	mock.ExpectQuery("SELECT id, user_id, email").WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "a@example.com", nil, nil, nil, 0))
 	mock.ExpectExec("UPDATE user_emails SET").WillReturnResult(sqlmock.NewResult(1, 1))
 

--- a/handlers/user/userEmailVerify_test.go
+++ b/handlers/user/userEmailVerify_test.go
@@ -20,12 +20,12 @@ import (
 )
 
 func TestUserEmailVerifyCodePage_Invalid(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	code := "abc"
 	rows := sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).
 		AddRow(1, 1, "e@example.com", nil, code, nil, 0)
@@ -55,12 +55,12 @@ func TestUserEmailVerifyCodePage_Invalid(t *testing.T) {
 }
 
 func TestUserEmailVerifyCodePage_Success(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	code := "xyz"
 	rows := sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).
 		AddRow(1, 1, "e@example.com", nil, code, nil, 0)

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -54,9 +54,9 @@ func newRequestWithSession(method, target string, values map[string]interface{})
 func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
 	cfg.EmailProvider = ""
-	db, mock, _ := sqlmock.New()
-	defer db.Close()
-	queries := db.New(db)
+	conn, mock, _ := sqlmock.New()
+	defer conn.Close()
+	queries := db.New(conn)
 	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("POST", "/email", nil)
@@ -87,9 +87,9 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
 	cfg.EmailProvider = "log"
 
-	db, mock, _ := sqlmock.New()
-	defer db.Close()
-	queries := db.New(db)
+	conn, mock, _ := sqlmock.New()
+	defer conn.Close()
+	queries := db.New(conn)
 	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("POST", "/email", nil)
@@ -109,9 +109,9 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 }
 
 func TestUserEmailPage_ShowError(t *testing.T) {
-	db, mock, _ := sqlmock.New()
-	defer db.Close()
-	queries := db.New(db)
+	conn, mock, _ := sqlmock.New()
+	defer conn.Close()
+	queries := db.New(conn)
 	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("GET", "/usr/email?error=missing", nil)
@@ -133,9 +133,9 @@ func TestUserEmailPage_ShowError(t *testing.T) {
 }
 
 func TestUserEmailPage_NoUnverified(t *testing.T) {
-	db, mock, _ := sqlmock.New()
-	defer db.Close()
-	queries := db.New(db)
+	conn, mock, _ := sqlmock.New()
+	defer conn.Close()
+	queries := db.New(conn)
 	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", time.Now(), nil, nil, 100))
 
@@ -159,9 +159,9 @@ func TestUserEmailPage_NoUnverified(t *testing.T) {
 }
 
 func TestUserEmailPage_NoVerified(t *testing.T) {
-	db, mock, _ := sqlmock.New()
-	defer db.Close()
-	queries := db.New(db)
+	conn, mock, _ := sqlmock.New()
+	defer conn.Close()
+	queries := db.New(conn)
 	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}))
 
@@ -185,13 +185,13 @@ func TestUserEmailPage_NoVerified(t *testing.T) {
 }
 
 func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 	store = sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = sessionName
@@ -240,13 +240,13 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 }
 
 func TestUserLangSaveLanguagesActionPage(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 	store = sessions.NewCookieStore([]byte("test"))
 
 	form := url.Values{}
@@ -287,13 +287,13 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 }
 
 func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 	store = sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = sessionName

--- a/handlers/writings/matchers_test.go
+++ b/handlers/writings/matchers_test.go
@@ -20,13 +20,13 @@ import (
 )
 
 func TestRequireWritingAuthorArticleVar(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
+	defer conn.Close()
 
-	q := db.New(sqldb)
+	q := db.New(conn)
 	store := sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = "test-session"

--- a/handlers/writings/writing_category_change_task_test.go
+++ b/handlers/writings/writing_category_change_task_test.go
@@ -15,13 +15,13 @@ import (
 )
 
 func TestWritingCategoryChangeTask(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
 		AddRow(1, 0, "a", "")
@@ -47,13 +47,13 @@ func TestWritingCategoryChangeTask(t *testing.T) {
 }
 
 func TestWritingCategoryWouldLoop(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
 		AddRow(1, 0, "a", "").
@@ -83,13 +83,13 @@ func TestWritingCategoryWouldLoopSelfRef(t *testing.T) {
 }
 
 func TestWritingCategoryWouldLoopHeadToTail(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
 		AddRow(1, 0, "a", "").
@@ -111,13 +111,13 @@ func TestWritingCategoryWouldLoopHeadToTail(t *testing.T) {
 }
 
 func TestWritingCategoryWouldLoopAfterNode(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
 		AddRow(1, 0, "a", "").
@@ -138,13 +138,13 @@ func TestWritingCategoryWouldLoopAfterNode(t *testing.T) {
 }
 
 func TestWritingCategoryChangeTaskLoop(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	queries := db.New(db)
+	queries := db.New(conn)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
 		AddRow(1, 2, "a", "").

--- a/handlers/writings/writingsWriterListPage_test.go
+++ b/handlers/writings/writingsWriterListPage_test.go
@@ -14,12 +14,12 @@ import (
 
 func TestWriterListPage_List(t *testing.T) {
 	t.Skip("environment not fully configured")
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 
 	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
 	mock.ExpectQuery(".*").WillReturnRows(rows)
@@ -44,12 +44,12 @@ func TestWriterListPage_List(t *testing.T) {
 
 func TestWriterListPage_Search(t *testing.T) {
 	t.Skip("environment not fully configured")
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 
 	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
 	mock.ExpectQuery(".*").WillReturnRows(rows)

--- a/internal/app/dbstart/ensure_schema_test.go
+++ b/internal/app/dbstart/ensure_schema_test.go
@@ -10,18 +10,18 @@ import (
 )
 
 func TestEnsureSchemaVersionMatch(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
 	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)")).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
 		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(handlers.ExpectedSchemaVersion))
 
-	if err := EnsureSchema(context.Background(), db); err != nil {
+	if err := EnsureSchema(context.Background(), conn); err != nil {
 		t.Fatalf("ensureSchema: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -30,18 +30,18 @@ func TestEnsureSchemaVersionMatch(t *testing.T) {
 }
 
 func TestEnsureSchemaVersionMismatch(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
 	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)")).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
 		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(handlers.ExpectedSchemaVersion - 1))
 
-	err = EnsureSchema(context.Background(), db)
+	err = EnsureSchema(context.Background(), conn)
 	if err == nil {
 		t.Fatalf("expected error")
 	}

--- a/internal/app/dbstart/migrate_test.go
+++ b/internal/app/dbstart/migrate_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestApply(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
 	mfs := fstest.MapFS{
 		"0002.mysql.sql": {Data: []byte("CREATE TABLE t (id int);")},
@@ -31,7 +31,7 @@ func TestApply(t *testing.T) {
 	mock.ExpectExec("UPDATE schema_version SET version = ?").WithArgs(2).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	if err := Apply(context.Background(), db, mfs, false, "mysql"); err != nil {
+	if err := Apply(context.Background(), conn, mfs, false, "mysql"); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/db/queries_admin_users_test.go
+++ b/internal/db/queries_admin_users_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func TestQueries_AdminListUsersFiltered(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer conn.Close()
+	q := New(conn)
 
 	query := "SELECT u.idusers, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email, u.username FROM users u ORDER BY u.idusers LIMIT ? OFFSET ?"
 	rows := sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "bob@example.com", "bob")
@@ -36,12 +36,12 @@ func TestQueries_AdminListUsersFiltered(t *testing.T) {
 }
 
 func TestQueries_AdminSearchUsersFiltered(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer conn.Close()
+	q := New(conn)
 
 	query := "SELECT u.idusers, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email, u.username FROM users u WHERE (LOWER(u.username) LIKE LOWER(?) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(?)) ORDER BY u.idusers LIMIT ? OFFSET ?"
 	rows := sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "bob@example.com", "bob")

--- a/internal/db/queries_faq_test.go
+++ b/internal/db/queries_faq_test.go
@@ -10,15 +10,15 @@ import (
 )
 
 func TestQueries_InsertFAQQuestionForWriter(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer conn.Close()
+	q := New(conn)
 
 	mock.ExpectExec(regexp.QuoteMeta(insertFAQQuestionForWriter)).
-		WithArgs(sql.NullString{String: "q", Valid: true}, sql.NullString{String: "a", Valid: true}, int32(1), int32(2), int32(1), sql.NullInt32{Int32: 2, Valid: true}).
+		WithArgs(sql.NullString{String: "q", Valid: true}, sql.NullString{String: "a", Valid: true}, int32(1), int32(2), int32(1), sql.NullInt32{Int32: 2, Valid: true}, int32(2)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	if _, err := q.InsertFAQQuestionForWriter(context.Background(), InsertFAQQuestionForWriterParams{

--- a/internal/db/queries_imagebbs_test.go
+++ b/internal/db/queries_imagebbs_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func TestQueries_ListBoardsByParentIDForLister(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer conn.Close()
+	q := New(conn)
 
 	rows := sqlmock.NewRows([]string{"idimageboard", "imageboard_idimageboard", "title", "description", "approval_required"}).AddRow(1, 0, nil, nil, 0)
 	viewer := sql.NullInt32{}

--- a/internal/db/queries_roles_test.go
+++ b/internal/db/queries_roles_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func TestQueries_AdminUpdateRole(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer conn.Close()
+	q := New(conn)
 
 	mock.ExpectExec(regexp.QuoteMeta(adminUpdateRole)).
 		WithArgs("name", true, false, int32(1)).

--- a/internal/db/queries_users_admin_test.go
+++ b/internal/db/queries_users_admin_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func TestQueries_AdminListAllUserIDs(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer conn.Close()
+	q := New(conn)
 
 	rows := sqlmock.NewRows([]string{"idusers"}).AddRow(1).AddRow(2)
 	mock.ExpectQuery(regexp.QuoteMeta(adminListAllUserIDs)).
@@ -35,12 +35,12 @@ func TestQueries_AdminListAllUserIDs(t *testing.T) {
 }
 
 func TestQueries_AdminListAllUsers(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer conn.Close()
+	q := New(conn)
 
 	rows := sqlmock.NewRows([]string{"idusers", "username", "email"}).
 		AddRow(1, "bob", "bob@example.com")
@@ -61,12 +61,12 @@ func TestQueries_AdminListAllUsers(t *testing.T) {
 }
 
 func TestQueries_AdminDeleteUserByID(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer conn.Close()
+	q := New(conn)
 
 	mock.ExpectExec(regexp.QuoteMeta(adminDeleteUserByID)).
 		WithArgs(int32(1)).
@@ -82,12 +82,12 @@ func TestQueries_AdminDeleteUserByID(t *testing.T) {
 }
 
 func TestQueries_AdminUpdateUsernameByID(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer conn.Close()
+	q := New(conn)
 
 	mock.ExpectExec(regexp.QuoteMeta(adminUpdateUsernameByID)).
 		WithArgs(sql.NullString{String: "bob", Valid: true}, int32(1)).

--- a/internal/db/queries_writers_test.go
+++ b/internal/db/queries_writers_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func TestQueries_ListWriters(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer conn.Close()
+	q := New(conn)
 
 	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
 	mock.ExpectQuery(regexp.QuoteMeta(listWritersForLister)).
@@ -35,12 +35,12 @@ func TestQueries_ListWriters(t *testing.T) {
 }
 
 func TestQueries_SearchWriters(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer conn.Close()
+	q := New(conn)
 
 	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
 	mock.ExpectQuery(regexp.QuoteMeta(listWritersSearchForLister)).

--- a/internal/db/template_override_test.go
+++ b/internal/db/template_override_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 func TestTemplateOverride(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := New(db)
+	defer conn.Close()
+	q := New(conn)
 
 	mock.ExpectExec("INSERT INTO template_overrides").WithArgs("t", "body").WillReturnResult(sqlmock.NewResult(1, 1))
 	if err := q.AdminSetTemplateOverride(context.Background(), AdminSetTemplateOverrideParams{Name: "t", Body: "body"}); err != nil {

--- a/internal/email/emaildefaults/email_test.go
+++ b/internal/email/emaildefaults/email_test.go
@@ -88,13 +88,13 @@ func TestLoadEmailConfigFromFileValues(t *testing.T) {
 	}
 }
 func TestInsertPendingEmail(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	q := db.New(db)
+	q := db.New(conn)
 	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 1, Valid: true}, "body", false).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	if err := q.InsertPendingEmail(context.Background(), db.InsertPendingEmailParams{ToUserID: sql.NullInt32{Int32: 1, Valid: true}, Body: "body", DirectEmail: false}); err != nil {
@@ -109,12 +109,12 @@ func TestEmailQueueWorker(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
 	cfg.EmailEnabled = true
 
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	rows := sqlmock.NewRows([]string{"id", "to_user_id", "body", "error_count", "direct_email"}).AddRow(1, 2, "b", 0, false)
 	mock.ExpectQuery("SELECT id, to_user_id, body, error_count, direct_email").WillReturnRows(rows)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
@@ -145,12 +145,12 @@ func TestProcessPendingEmailDLQ(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
 	cfg.EmailEnabled = true
 
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	rows := sqlmock.NewRows([]string{"id", "to_user_id", "body", "error_count", "direct_email"}).AddRow(1, 2, "b", 4, false)
 	mock.ExpectQuery("SELECT id, to_user_id, body, error_count, direct_email").WillReturnRows(rows)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -16,12 +16,12 @@ import (
 
 func newCoreData(t *testing.T, cfg config.RuntimeConfig) (*common.CoreData, sqlmock.Sqlmock, func()) {
 	t.Helper()
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	cleanup := func() { db.Close() }
-	queries := db.New(db)
+	cleanup := func() { conn.Close() }
+	queries := db.New(conn)
 	if cfg.HSTSHeaderValue == "" {
 		cfg.HSTSHeaderValue = "max-age=63072000; includeSubDomains"
 	}

--- a/internal/notifications/bus_worker_test.go
+++ b/internal/notifications/bus_worker_test.go
@@ -81,12 +81,12 @@ func TestBuildPatternsAdditional(t *testing.T) {
 
 func TestCollectSubscribersQuery(t *testing.T) {
 	ctx := context.Background()
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 
 	patterns := []string{"post:/blog/1", "post:/blog/*"}
 	rows := sqlmock.NewRows([]string{"users_idusers"}).AddRow(1).AddRow(2)
@@ -131,12 +131,12 @@ func TestProcessEventDLQ(t *testing.T) {
 	cfg.NotificationsEnabled = true
 	cfg.EmailFrom = "from@example.com"
 
-	db, _, err := sqlmock.New()
+	conn, _, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	prov := &errProvider{}
 	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(cfg))
 	dlqRec := &recordDLQ{}
@@ -160,12 +160,12 @@ func TestProcessEventSubscribeSelf(t *testing.T) {
 	cfg.NotificationsEnabled = true
 	cfg.EmailFrom = "from@example.com"
 
-	db, _, err := sqlmock.New()
+	conn, _, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	n := New(WithQueries(q), WithConfig(cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/p", Task: TaskTest, UserID: 1}, nil); err != nil {
@@ -180,12 +180,12 @@ func TestProcessEventNoAutoSubscribe(t *testing.T) {
 	cfg.AdminNotify = true
 	cfg.NotificationsEnabled = true
 
-	db, _, err := sqlmock.New()
+	conn, _, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	n := New(WithQueries(q), WithConfig(cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/p", Task: TaskTest, UserID: 1}, nil); err != nil {
@@ -202,12 +202,12 @@ func TestProcessEventAdminNotify(t *testing.T) {
 	cfg.EmailFrom = "from@example.com"
 	cfg.NotificationsEnabled = true
 
-	db, _, err := sqlmock.New()
+	conn, _, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	prov := &busDummyProvider{}
 	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(cfg))
 
@@ -224,12 +224,12 @@ func TestProcessEventWritingSubscribers(t *testing.T) {
 	cfg.NotificationsEnabled = true
 	cfg.EmailFrom = "from@example.com"
 
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	n := New(WithQueries(q), WithConfig(cfg))
 
 	if err := n.processEvent(ctx, eventbus.TaskEvent{Path: "/writings/article/1", Task: TaskTest, UserID: 2, Data: map[string]any{"target": Target{Type: "writing", ID: 1}}}, nil); err != nil {
@@ -258,12 +258,12 @@ func TestProcessEventTargetUsers(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
 	cfg.NotificationsEnabled = true
 
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	n := New(WithQueries(q), WithConfig(cfg))
 
 	for _, id := range []int32{2, 3} {
@@ -298,12 +298,12 @@ func TestBusWorker(t *testing.T) {
 
 	bus := eventbus.NewBus()
 
-	db, _, err := sqlmock.New()
+	conn, _, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 
 	prov := &busDummyProvider{}
 	n := New(WithQueries(q), WithEmailProvider(prov), WithConfig(cfg))
@@ -343,12 +343,12 @@ func TestProcessEventAutoSubscribe(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
 	cfg.NotificationsEnabled = true
 
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	n := New(WithQueries(q), WithConfig(cfg))
 
 	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies"}).

--- a/internal/notifications/linker_queue_test.go
+++ b/internal/notifications/linker_queue_test.go
@@ -16,11 +16,11 @@ func TestLinkerQueueNotifierMessages(t *testing.T) {
 	cfg.EmailFrom = "from@example.com"
 	ntName := NotificationTemplateFilenameGenerator("linker_approved")
 
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 	mock.ExpectQuery("SELECT body FROM template_overrides WHERE name = ?").
 		WithArgs(ntName).
 		WillReturnRows(sqlmock.NewRows([]string{"body"}).AddRow(""))
@@ -34,7 +34,7 @@ func TestLinkerQueueNotifierMessages(t *testing.T) {
 		WithArgs("linkerApprovedEmailSubject.gotxt").
 		WillReturnRows(sqlmock.NewRows([]string{"body"}).AddRow(""))
 
-	q := db.New(db)
+	q := db.New(conn)
 	n := New(WithQueries(q), WithConfig(cfg))
 	data := map[string]any{
 		"Title":     "Example",

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestNotificationsQueries(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 	mock.ExpectExec("INSERT INTO notifications").WithArgs(int32(1), sqlmock.AnyArg(), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 	if err := q.SystemCreateNotification(context.Background(), db.SystemCreateNotificationParams{RecipientID: 1, Link: sql.NullString{String: "/x", Valid: true}, Message: sql.NullString{String: "hi", Valid: true}}); err != nil {
 		t.Fatalf("insert: %v", err)
@@ -53,12 +53,12 @@ func (r *dummyProvider) Send(ctx context.Context, to mail.Address, rawEmailMessa
 }
 
 func TestNotifierNotifyAdmins(t *testing.T) {
-	sqldb, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 	cfg := config.NewRuntimeConfig()
 	cfg.EmailEnabled = true
 	cfg.AdminNotify = true
@@ -87,12 +87,12 @@ func TestNotifierInitialization(t *testing.T) {
 	if n.Queries != nil {
 		t.Fatalf("expected nil Queries")
 	}
-	sqldb, _, err := sqlmock.New()
+	conn, _, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer sqldb.Close()
-	q := db.New(sqldb)
+	defer conn.Close()
+	q := db.New(conn)
 	n = New(WithQueries(q), WithConfig(cfg))
 	if n.Queries != q {
 		t.Fatalf("queries not set via option")

--- a/internal/notifications/permission_tasks_test.go
+++ b/internal/notifications/permission_tasks_test.go
@@ -39,12 +39,12 @@ func TestProcessEventPermissionTasks(t *testing.T) {
 	cfg.EmailFrom = "from@example.com"
 
 	bus := eventbus.NewBus()
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
-	q := db.New(db)
+	defer conn.Close()
+	q := db.New(conn)
 	n := notif.New(notif.WithQueries(q), notif.WithConfig(cfg))
 
 	var wg sync.WaitGroup

--- a/workers/postcountworker/postupdate_test.go
+++ b/workers/postcountworker/postupdate_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestPostUpdate(t *testing.T) {
-	db, mock, err := sqlmock.New()
+	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer conn.Close()
 
-	q := db.New(db)
+	q := db.New(conn)
 	mock.ExpectExec("AdminRecalculateForumThreadByIdMetaData").
 		WithArgs(int32(1)).
 		WillReturnResult(sqlmock.NewResult(0, 0))


### PR DESCRIPTION
## Summary
- avoid shadowing internal db package by using conn for local *sql.DB variables
- adjust tests to use conn and correct expected SQL args
- regenerate example config env file

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `go run ./cmd/goa4web config as-env-file > examples/config.env`


------
https://chatgpt.com/codex/tasks/task_e_688ef59cf2ec832f8b1814c9a0b5ca3f