### PR TITLE
refactor: clarify create query roles

### DIFF
--- a/cmd/goa4web/blog_create.go
+++ b/cmd/goa4web/blog_create.go
@@ -41,7 +41,7 @@ func (c *blogCreateCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := db.New(db)
-	_, err = queries.CreateBlogEntry(ctx, db.CreateBlogEntryParams{
+	_, err = queries.CreateBlogEntryForWriter(ctx, db.CreateBlogEntryForWriterParams{
 		UsersIdusers:       int32(c.UserID),
 		LanguageIdlanguage: int32(c.LangID),
 		Blog:               sql.NullString{String: c.Text, Valid: true},

--- a/cmd/goa4web/board_create.go
+++ b/cmd/goa4web/board_create.go
@@ -38,7 +38,7 @@ func (c *boardCreateCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := db.New(db)
-	err = queries.CreateImageBoard(ctx, db.CreateImageBoardParams{
+	err = queries.AdminCreateImageBoard(ctx, db.AdminCreateImageBoardParams{
 		ImageboardIdimageboard: int32(c.Parent),
 		Title:                  sql.NullString{String: c.Name, Valid: c.Name != ""},
 		Description:            sql.NullString{String: c.Description, Valid: c.Description != ""},

--- a/cmd/goa4web/grant_add.go
+++ b/cmd/goa4web/grant_add.go
@@ -47,7 +47,7 @@ func (c *grantAddCmd) Run() error {
 	}
 	ctx := context.Background()
 	q := db.New(db)
-	_, err = q.CreateGrant(ctx, db.CreateGrantParams{
+	_, err = q.AdminCreateGrant(ctx, db.AdminCreateGrantParams{
 		UserID:   sql.NullInt32{Int32: int32(c.User), Valid: c.User != 0},
 		RoleID:   sql.NullInt32{},
 		Section:  c.Section,

--- a/cmd/goa4web/perm_grant.go
+++ b/cmd/goa4web/perm_grant.go
@@ -53,7 +53,7 @@ func (c *permGrantCmd) Run() error {
 			return fmt.Errorf("check admin: %w", err)
 		}
 	}
-	if err := queries.CreateUserRole(ctx, db.CreateUserRoleParams{
+	if err := queries.SystemCreateUserRole(ctx, db.SystemCreateUserRoleParams{
 		UsersIdusers: u.Idusers,
 		Name:         c.Role,
 	}); err != nil {

--- a/cmd/goa4web/user_add.go
+++ b/cmd/goa4web/user_add.go
@@ -84,7 +84,7 @@ func createUser(root *rootCmd, username, email, password string, admin bool) err
 		return fmt.Errorf("insert password: %w", err)
 	}
 	if !admin {
-		if err := queries.CreateUserRole(ctx, db.CreateUserRoleParams{
+		if err := queries.SystemCreateUserRole(ctx, db.SystemCreateUserRoleParams{
 			UsersIdusers: int32(id),
 			Name:         "user",
 		}); err != nil {
@@ -97,7 +97,7 @@ func createUser(root *rootCmd, username, email, password string, admin bool) err
 			}
 		} else if !errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("check admin: %w", err)
-		} else if err := queries.CreateUserRole(ctx, db.CreateUserRoleParams{
+		} else if err := queries.SystemCreateUserRole(ctx, db.SystemCreateUserRoleParams{
 			UsersIdusers: int32(id),
 			Name:         "administrator",
 		}); err != nil {

--- a/cmd/goa4web/user_add_role.go
+++ b/cmd/goa4web/user_add_role.go
@@ -52,7 +52,7 @@ func (c *userAddRoleCmd) Run() error {
 	} else if !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("check role: %w", err)
 	}
-	if err := queries.CreateUserRole(ctx, db.CreateUserRoleParams{
+	if err := queries.SystemCreateUserRole(ctx, db.SystemCreateUserRoleParams{
 		UsersIdusers: u.Idusers,
 		Name:         c.Role,
 	}); err != nil {

--- a/cmd/goa4web/user_approve.go
+++ b/cmd/goa4web/user_approve.go
@@ -48,7 +48,7 @@ func (c *userApproveCmd) Run() error {
 		c.ID = int(u.Idusers)
 	}
 	c.rootCmd.Verbosef("approving user %d", c.ID)
-	if err := queries.CreateUserRole(ctx, db.CreateUserRoleParams{UsersIdusers: int32(c.ID), Name: "user"}); err != nil {
+	if err := queries.SystemCreateUserRole(ctx, db.SystemCreateUserRoleParams{UsersIdusers: int32(c.ID), Name: "user"}); err != nil {
 		return fmt.Errorf("add role: %w", err)
 	}
 	c.rootCmd.Infof("approved user %d", c.ID)

--- a/cmd/goa4web/user_make_admin.go
+++ b/cmd/goa4web/user_make_admin.go
@@ -50,7 +50,7 @@ func (c *userMakeAdminCmd) Run() error {
 	} else if !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("check admin: %w", err)
 	}
-	if err := queries.CreateUserRole(ctx, db.CreateUserRoleParams{
+	if err := queries.SystemCreateUserRole(ctx, db.SystemCreateUserRoleParams{
 		UsersIdusers: u.Idusers,
 		Name:         "administrator",
 	}); err != nil {

--- a/cmd/goa4web/user_reject.go
+++ b/cmd/goa4web/user_reject.go
@@ -51,7 +51,7 @@ func (c *userRejectCmd) Run() error {
 		c.ID = int(u.Idusers)
 	}
 	c.rootCmd.Verbosef("rejecting user %d", c.ID)
-	if err := queries.CreateUserRole(ctx, db.CreateUserRoleParams{UsersIdusers: int32(c.ID), Name: "rejected"}); err != nil {
+	if err := queries.SystemCreateUserRole(ctx, db.SystemCreateUserRoleParams{UsersIdusers: int32(c.ID), Name: "rejected"}); err != nil {
 		return fmt.Errorf("add role: %w", err)
 	}
 	if c.Reason != "" {

--- a/handlers/admin/news_user_allow_task.go
+++ b/handlers/admin/news_user_allow_task.go
@@ -35,7 +35,7 @@ func (NewsUserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("get user by username fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
+	if err := queries.SystemCreateUserRole(r.Context(), db.SystemCreateUserRoleParams{
 		UsersIdusers: u.Idusers,
 		Name:         role,
 	}); err != nil {

--- a/handlers/admin/role_grant_create_task.go
+++ b/handlers/admin/role_grant_create_task.go
@@ -46,7 +46,7 @@ func (RoleGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if section == "" || action == "" {
 		return fmt.Errorf("missing section or action %w", handlers.ErrRedirectOnSamePageHandler(fmt.Errorf("")))
 	}
-	if _, err = queries.CreateGrant(r.Context(), db.CreateGrantParams{
+	if _, err = queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
 		UserID:   sql.NullInt32{},
 		RoleID:   sql.NullInt32{Int32: int32(roleID), Valid: true},
 		Section:  section,

--- a/handlers/admin/role_grant_update_task.go
+++ b/handlers/admin/role_grant_update_task.go
@@ -65,7 +65,7 @@ func (RoleGrantUpdateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	for a := range desired {
 		if _, ok := existing[a]; !ok {
-			if _, err := queries.CreateGrant(r.Context(), db.CreateGrantParams{
+			if _, err := queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
 				RoleID:   sql.NullInt32{Int32: int32(roleID), Valid: true},
 				Section:  section,
 				Item:     sql.NullString{String: item, Valid: item != ""},

--- a/handlers/auth/forgot_password_task.go
+++ b/handlers/auth/forgot_password_task.go
@@ -90,7 +90,7 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("rand %w", err)
 	}
 	code := hex.EncodeToString(buf[:])
-	if err := queries.CreatePasswordReset(r.Context(), db.CreatePasswordResetParams{UserID: row.Idusers, Passwd: hash, PasswdAlgorithm: alg, VerificationCode: code}); err != nil {
+	if err := queries.CreatePasswordResetForUser(r.Context(), db.CreatePasswordResetForUserParams{UserID: row.Idusers, Passwd: hash, PasswdAlgorithm: alg, VerificationCode: code}); err != nil {
 		log.Printf("create reset: %v", err)
 		return fmt.Errorf("create reset %w", err)
 	}

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -72,7 +72,7 @@ func (AddBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	id, err := queries.CreateBlogEntry(r.Context(), db.CreateBlogEntryParams{
+	id, err := queries.CreateBlogEntryForWriter(r.Context(), db.CreateBlogEntryForWriterParams{
 		UsersIdusers:       uid,
 		LanguageIdlanguage: int32(languageId),
 		Blog: sql.NullString{

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -126,7 +126,7 @@ func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 	})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
-		ptidi, err := queries.CreateForumTopic(r.Context(), db.CreateForumTopicParams{
+		ptidi, err := queries.SystemCreateForumTopic(r.Context(), db.SystemCreateForumTopicParams{
 			ForumcategoryIdforumcategory: 0,
 			Title: sql.NullString{
 				String: BloggerTopicName,
@@ -165,14 +165,13 @@ func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	endUrl := fmt.Sprintf("/blogs/blog/%d/comments", bid)
 
-	cid, err := queries.CreateComment(r.Context(), db.CreateCommentParams{
-		LanguageIdlanguage: int32(languageId),
-		UsersIdusers:       uid,
+	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
+		LanguageID:         int32(languageId),
+		CommenterID:        uid,
 		ForumthreadID:      pthid,
-		Text: sql.NullString{
-			String: text,
-			Valid:  true,
-		},
+		Text:               sql.NullString{String: text, Valid: true},
+		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
+		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
 	})
 	if err != nil {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/blogs/blogsUserPermissionsPage.go
+++ b/handlers/blogs/blogsUserPermissionsPage.go
@@ -82,7 +82,7 @@ func UsersPermissionsPermissionUserAllowPage(w http.ResponseWriter, r *http.Requ
 	}
 	if u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("SystemGetUserByUsername: %w", err).Error())
-	} else if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
+	} else if err := queries.SystemCreateUserRole(r.Context(), db.SystemCreateUserRoleParams{
 		UsersIdusers: u.Idusers,
 		Name:         role,
 	}); err != nil {
@@ -165,7 +165,7 @@ func UsersPermissionsBulkAllowPage(w http.ResponseWriter, r *http.Request) {
 			data.Errors = append(data.Errors, fmt.Errorf("lookup role %s: %w", id, err2).Error())
 			continue
 		}
-		if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
+		if err := queries.SystemCreateUserRole(r.Context(), db.SystemCreateUserRoleParams{
 			UsersIdusers: uid,
 			Name:         role,
 		}); err != nil {

--- a/handlers/bookmarks/createTask.go
+++ b/handlers/bookmarks/createTask.go
@@ -30,7 +30,7 @@ func (CreateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	if err := queries.CreateBookmarks(r.Context(), db.CreateBookmarksParams{
+	if err := queries.CreateBookmarksForLister(r.Context(), db.CreateBookmarksForListerParams{
 		List: sql.NullString{
 			String: text,
 			Valid:  true,

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -84,13 +84,11 @@ func (AskTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return nil
 	}
 
-	if err := queries.CreateFAQQuestion(r.Context(), db.CreateFAQQuestionParams{
-		Question: sql.NullString{
-			String: text,
-			Valid:  true,
-		},
-		UsersIdusers:       uid,
-		LanguageIdlanguage: int32(languageId),
+	if err := queries.CreateFAQQuestionForWriter(r.Context(), db.CreateFAQQuestionForWriterParams{
+		Question:   sql.NullString{String: text, Valid: true},
+		WriterID:   uid,
+		LanguageID: int32(languageId),
+		GranteeID:  sql.NullInt32{Int32: uid, Valid: true},
 	}); err != nil {
 		return fmt.Errorf("faq fetch fail: %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/faq/create_category_task.go
+++ b/handlers/faq/create_category_task.go
@@ -8,7 +8,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 )
@@ -28,10 +27,7 @@ func (CreateCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
 
-	if err := queries.CreateFAQCategory(r.Context(), db.CreateFAQCategoryParams{
-		Name:     sql.NullString{String: text, Valid: true},
-		ViewerID: cd.UserID,
-	}); err != nil {
+	if err := queries.AdminCreateFAQCategory(r.Context(), sql.NullString{String: text, Valid: true}); err != nil {
 		return fmt.Errorf("create category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 

--- a/handlers/forum/category_grant_create_task.go
+++ b/handlers/forum/category_grant_create_task.go
@@ -65,7 +65,7 @@ func (CategoryGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) an
 		if action == "" {
 			action = "see"
 		}
-		if _, err = queries.CreateGrant(r.Context(), db.CreateGrantParams{
+		if _, err = queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
 			UserID:   uid,
 			RoleID:   rid,
 			Section:  "forum",

--- a/handlers/forum/forumAdminCategoriesPage.go
+++ b/handlers/forum/forumAdminCategoriesPage.go
@@ -141,16 +141,10 @@ func AdminCategoryCreatePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := queries.CreateForumCategory(r.Context(), db.CreateForumCategoryParams{
+	if err := queries.AdminCreateForumCategory(r.Context(), db.AdminCreateForumCategoryParams{
 		ForumcategoryIdforumcategory: int32(pcid),
-		Title: sql.NullString{
-			Valid:  true,
-			String: name,
-		},
-		Description: sql.NullString{
-			Valid:  true,
-			String: desc,
-		},
+		Title:                        sql.NullString{Valid: true, String: name},
+		Description:                  sql.NullString{Valid: true, String: desc},
 	}); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return

--- a/handlers/forum/forumAdminTopicsPage.go
+++ b/handlers/forum/forumAdminTopicsPage.go
@@ -83,7 +83,7 @@ func AdminTopicCreatePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	if _, err := queries.CreateForumTopic(r.Context(), db.CreateForumTopicParams{
+	if _, err := queries.SystemCreateForumTopic(r.Context(), db.SystemCreateForumTopicParams{
 		ForumcategoryIdforumcategory: int32(pcid),
 		Title:                        sql.NullString{String: name, Valid: true},
 		Description:                  sql.NullString{String: desc, Valid: true},

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -160,14 +160,13 @@ func (CreateThreadTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d", topicId, threadId)
 
-	cid, err := queries.CreateComment(r.Context(), db.CreateCommentParams{
-		LanguageIdlanguage: int32(languageId),
-		UsersIdusers:       uid,
+	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
+		LanguageID:         int32(languageId),
+		CommenterID:        uid,
 		ForumthreadID:      int32(threadId),
-		Text: sql.NullString{
-			String: text,
-			Valid:  true,
-		},
+		Text:               sql.NullString{String: text, Valid: true},
+		GrantForumthreadID: sql.NullInt32{Int32: int32(threadId), Valid: true},
+		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
 	})
 	if err != nil {
 		log.Printf("Error: makeThread: %s", err)

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -110,14 +110,13 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
 
-	cid, err := queries.CreateComment(r.Context(), db.CreateCommentParams{
-		LanguageIdlanguage: int32(languageId),
-		UsersIdusers:       uid,
+	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
+		LanguageID:         int32(languageId),
+		CommenterID:        uid,
 		ForumthreadID:      threadRow.Idforumthread,
-		Text: sql.NullString{
-			String: text,
-			Valid:  true,
-		},
+		Text:               sql.NullString{String: text, Valid: true},
+		GrantForumthreadID: sql.NullInt32{Int32: threadRow.Idforumthread, Valid: true},
+		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
 	})
 	if err != nil {
 		log.Printf("Error: CreateComment: %s", err)

--- a/handlers/forum/topic_grant_create_task.go
+++ b/handlers/forum/topic_grant_create_task.go
@@ -65,7 +65,7 @@ func (TopicGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) any {
 		if action == "" {
 			action = "see"
 		}
-		if _, err = queries.CreateGrant(r.Context(), db.CreateGrantParams{
+		if _, err = queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
 			UserID:   uid,
 			RoleID:   rid,
 			Section:  "forum",

--- a/handlers/imagebbs/imagebbsAdminNewBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminNewBoardPage.go
@@ -57,7 +57,7 @@ func (NewBoardTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return common.UserError{ErrorMessage: fmt.Sprintf("invalid parent board: loop %v", path)}
 	}
 
-	err = queries.CreateImageBoard(r.Context(), db.CreateImageBoardParams{
+	err = queries.AdminCreateImageBoard(r.Context(), db.AdminCreateImageBoardParams{
 		ImageboardIdimageboard: int32(parentBoardId),
 		Title:                  sql.NullString{Valid: true, String: name},
 		Description:            sql.NullString{Valid: true, String: desc},

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -192,14 +192,16 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	approved := !board.ApprovalRequired
 
-	pid, err := queries.CreateImagePost(r.Context(), db.CreateImagePostParams{
-		ImageboardIdimageboard: int32(bid),
-		Thumbnail:              sql.NullString{Valid: true, String: relThumb},
-		Fullimage:              sql.NullString{Valid: true, String: relFull},
-		UsersIdusers:           uid,
-		Description:            sql.NullString{Valid: true, String: text},
-		Approved:               approved,
-		FileSize:               int32(size),
+	pid, err := queries.CreateImagePostForPoster(r.Context(), db.CreateImagePostForPosterParams{
+		ImageboardID: int32(bid),
+		Thumbnail:    sql.NullString{Valid: true, String: relThumb},
+		Fullimage:    sql.NullString{Valid: true, String: relFull},
+		PosterID:     uid,
+		Description:  sql.NullString{Valid: true, String: text},
+		Approved:     approved,
+		FileSize:     int32(size),
+		GrantBoardID: sql.NullInt32{Int32: int32(bid), Valid: true},
+		GranteeID:    sql.NullInt32{Int32: uid, Valid: true},
 	})
 	if err != nil {
 		return fmt.Errorf("create image post fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -250,7 +250,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
-		ptidi, err := queries.CreateForumTopic(r.Context(), db.CreateForumTopicParams{
+		ptidi, err := queries.SystemCreateForumTopic(r.Context(), db.SystemCreateForumTopicParams{
 			ForumcategoryIdforumcategory: 0,
 			Title: sql.NullString{
 				String: ImageBBSTopicName,
@@ -290,14 +290,13 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	endUrl := fmt.Sprintf("/imagebbss/imagebbs/%d/comments", bid)
 
-	cid, err := queries.CreateComment(r.Context(), db.CreateCommentParams{
-		LanguageIdlanguage: int32(languageId),
-		UsersIdusers:       uid,
+	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
+		LanguageID:         int32(languageId),
+		CommenterID:        uid,
 		ForumthreadID:      pthid,
-		Text: sql.NullString{
-			String: text,
-			Valid:  true,
-		},
+		Text:               sql.NullString{String: text, Valid: true},
+		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
+		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
 	})
 	if err != nil {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/images/upload_task.go
+++ b/handlers/images/upload_task.go
@@ -116,12 +116,13 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok && cd != nil {
 		uid = cd.UserID
 	}
-	_, err = queries.CreateUploadedImage(r.Context(), db.CreateUploadedImageParams{
-		UsersIdusers: uid,
-		Path:         sql.NullString{String: url, Valid: true},
-		Width:        sql.NullInt32{Int32: int32(width), Valid: true},
-		Height:       sql.NullInt32{Int32: int32(height), Valid: true},
-		FileSize:     int32(size),
+	_, err = queries.CreateUploadedImageForUploader(r.Context(), db.CreateUploadedImageForUploaderParams{
+		UploaderID: uid,
+		Path:       sql.NullString{String: url, Valid: true},
+		Width:      sql.NullInt32{Int32: int32(width), Valid: true},
+		Height:     sql.NullInt32{Int32: int32(height), Valid: true},
+		FileSize:   int32(size),
+		GranteeID:  sql.NullInt32{Int32: uid, Valid: true},
 	})
 	if err != nil {
 		return fmt.Errorf("create uploaded image %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/linker/category_grant_create_task.go
+++ b/handlers/linker/category_grant_create_task.go
@@ -65,7 +65,7 @@ func (CategoryGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) an
 		if action == "" {
 			action = "see"
 		}
-		if _, err = queries.CreateGrant(r.Context(), db.CreateGrantParams{
+		if _, err = queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
 			UserID:   uid,
 			RoleID:   rid,
 			Section:  "linker",

--- a/handlers/linker/create_category_task.go
+++ b/handlers/linker/create_category_task.go
@@ -23,7 +23,7 @@ func (createCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	rows, _ := cd.LinkerCategoryCounts()
 	pos := len(rows) + 1
-	if err := queries.CreateLinkerCategory(r.Context(), db.CreateLinkerCategoryParams{
+	if err := queries.AdminCreateLinkerCategory(r.Context(), db.AdminCreateLinkerCategoryParams{
 		Title:    sql.NullString{Valid: true, String: title},
 		Position: int32(pos),
 	}); err != nil {

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -85,13 +85,12 @@ func (addTask) Action(w http.ResponseWriter, r *http.Request) any {
 	description := r.PostFormValue("description")
 	category, _ := strconv.Atoi(r.PostFormValue("category"))
 
-	if err := queries.CreateLinkerItem(r.Context(), db.CreateLinkerItemParams{
+	if err := queries.AdminCreateLinkerItem(r.Context(), db.AdminCreateLinkerItemParams{
 		UsersIdusers:     uid,
 		LinkerCategoryID: int32(category),
 		Title:            sql.NullString{Valid: true, String: title},
 		Url:              sql.NullString{Valid: true, String: url},
 		Description:      sql.NullString{Valid: true, String: description},
-		AdminID:          cd.UserID,
 	}); err != nil {
 		return fmt.Errorf("create linker item fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -253,7 +253,7 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
-		ptidi, err := queries.CreateForumTopic(r.Context(), db.CreateForumTopicParams{
+		ptidi, err := queries.SystemCreateForumTopic(r.Context(), db.SystemCreateForumTopicParams{
 			ForumcategoryIdforumcategory: 0,
 			Title: sql.NullString{
 				String: LinkerTopicName,
@@ -296,14 +296,13 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	endUrl := fmt.Sprintf("/linker/comments/%d", linkId)
 
-	cid, err := queries.CreateComment(r.Context(), db.CreateCommentParams{
-		LanguageIdlanguage: int32(languageId),
-		UsersIdusers:       uid,
+	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
+		LanguageID:         int32(languageId),
+		CommenterID:        uid,
 		ForumthreadID:      pthid,
-		Text: sql.NullString{
-			String: text,
-			Valid:  true,
-		},
+		Text:               sql.NullString{String: text, Valid: true},
+		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
+		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
 	})
 	if err != nil {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -116,7 +116,7 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 	})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
-		ptidi, err := queries.CreateForumTopic(r.Context(), db.CreateForumTopicParams{
+		ptidi, err := queries.SystemCreateForumTopic(r.Context(), db.SystemCreateForumTopicParams{
 			ForumcategoryIdforumcategory: 0,
 			Title: sql.NullString{
 				String: LinkerTopicName,
@@ -164,14 +164,13 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 
 	endUrl := fmt.Sprintf("/linker/show/%d", linkId)
 
-	cid, err := queries.CreateComment(r.Context(), db.CreateCommentParams{
-		LanguageIdlanguage: int32(languageId),
-		UsersIdusers:       uid,
+	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
+		LanguageID:         int32(languageId),
+		CommenterID:        uid,
 		ForumthreadID:      pthid,
-		Text: sql.NullString{
-			String: text,
-			Valid:  true,
-		},
+		Text:               sql.NullString{String: text, Valid: true},
+		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
+		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
 	})
 	if err != nil {
 		log.Printf("Error: createComment: %s", err)

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -81,12 +81,14 @@ func (SuggestTask) Action(w http.ResponseWriter, r *http.Request) any {
 	description := r.PostFormValue("description")
 	category, _ := strconv.Atoi(r.PostFormValue("category"))
 
-	if err := queries.CreateLinkerQueuedItem(r.Context(), db.CreateLinkerQueuedItemParams{
-		UsersIdusers:     uid,
+	if err := queries.CreateLinkerQueuedItemForWriter(r.Context(), db.CreateLinkerQueuedItemForWriterParams{
+		WriterID:         uid,
 		LinkerCategoryID: int32(category),
 		Title:            sql.NullString{Valid: true, String: title},
 		Url:              sql.NullString{Valid: true, String: url},
 		Description:      sql.NullString{Valid: true, String: description},
+		GrantCategoryID:  sql.NullInt32{Int32: int32(category), Valid: true},
+		GranteeID:        sql.NullInt32{Int32: uid, Valid: true},
 	}); err != nil {
 		return fmt.Errorf("create linker queued item fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/linker/user_allow_task.go
+++ b/handlers/linker/user_allow_task.go
@@ -40,7 +40,7 @@ func (userAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
 			log.Printf("SystemGetUserByUsername Error: %s", err)
 			continue
 		}
-		if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
+		if err := queries.SystemCreateUserRole(r.Context(), db.SystemCreateUserRoleParams{
 			UsersIdusers: u.Idusers,
 			Name:         role,
 		}); err != nil {

--- a/handlers/news/newsNewPostTask.go
+++ b/handlers/news/newsNewPostTask.go
@@ -81,20 +81,18 @@ func (NewPostTask) Action(w http.ResponseWriter, r *http.Request) any {
 		handlers.TaskErrorAcknowledgementPage(w, r)
 		return nil
 	}
-	id, err := queries.CreateNewsPost(r.Context(), db.CreateNewsPostParams{
-		LanguageIdlanguage: int32(languageId),
-		News: sql.NullString{
-			String: text,
-			Valid:  true,
-		},
-		UsersIdusers: uid,
+	id, err := queries.CreateNewsPostForWriter(r.Context(), db.CreateNewsPostForWriterParams{
+		LanguageID: int32(languageId),
+		News:       sql.NullString{String: text, Valid: true},
+		WriterID:   uid,
+		GranteeID:  sql.NullInt32{Int32: uid, Valid: true},
 	})
 	if err != nil {
 		return fmt.Errorf("create news post fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
 	// give the author edit rights on the new post
-	if _, err := queries.CreateGrant(r.Context(), db.CreateGrantParams{
+	if _, err := queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
 		UserID:   sql.NullInt32{Int32: uid, Valid: true},
 		RoleID:   sql.NullInt32{},
 		Section:  "news",

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -118,7 +118,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
-		ptidi, err := queries.CreateForumTopic(r.Context(), db.CreateForumTopicParams{
+		ptidi, err := queries.SystemCreateForumTopic(r.Context(), db.SystemCreateForumTopicParams{
 			ForumcategoryIdforumcategory: 0,
 			Title: sql.NullString{
 				String: NewsTopicName,
@@ -167,14 +167,13 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	evt.Data["CommentURL"] = endUrl
 
-	cid, err := queries.CreateComment(r.Context(), db.CreateCommentParams{
-		LanguageIdlanguage: int32(languageId),
-		UsersIdusers:       uid,
+	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
+		LanguageID:         int32(languageId),
+		CommenterID:        uid,
 		ForumthreadID:      pthid,
-		Text: sql.NullString{
-			String: text,
-			Valid:  true,
-		},
+		Text:               sql.NullString{String: text, Valid: true},
+		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
+		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
 	})
 	if err != nil {
 		log.Printf("Error: createComment: %s", err)

--- a/handlers/news/user_allow_task.go
+++ b/handlers/news/user_allow_task.go
@@ -45,7 +45,7 @@ func (UserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	if u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("SystemGetUserByUsername: %w", err).Error())
-	} else if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
+	} else if err := queries.SystemCreateUserRole(r.Context(), db.SystemCreateUserRoleParams{
 		UsersIdusers: u.Idusers,
 		Name:         role,
 	}); err != nil {

--- a/handlers/user/admin_pending.go
+++ b/handlers/user/admin_pending.go
@@ -47,7 +47,7 @@ func adminPendingUsersApprove(w http.ResponseWriter, r *http.Request) {
 	if id == 0 {
 		data.Errors = append(data.Errors, "invalid id")
 	} else {
-		if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{UsersIdusers: id, Name: "user"}); err != nil {
+		if err := queries.SystemCreateUserRole(r.Context(), db.SystemCreateUserRoleParams{UsersIdusers: id, Name: "user"}); err != nil {
 			data.Errors = append(data.Errors, fmt.Errorf("add role: %w", err).Error())
 		} else {
 			data.Messages = append(data.Messages, "User approved")
@@ -75,7 +75,7 @@ func adminPendingUsersReject(w http.ResponseWriter, r *http.Request) {
 	if id == 0 {
 		data.Errors = append(data.Errors, "invalid id")
 	} else {
-		if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{UsersIdusers: id, Name: "rejected"}); err != nil {
+		if err := queries.SystemCreateUserRole(r.Context(), db.SystemCreateUserRoleParams{UsersIdusers: id, Name: "rejected"}); err != nil {
 			data.Errors = append(data.Errors, fmt.Errorf("add role:%w", err).Error())
 		} else {
 			data.Messages = append(data.Messages, "user rejected")

--- a/handlers/user/permissionUserAllowTask.go
+++ b/handlers/user/permissionUserAllowTask.go
@@ -54,7 +54,7 @@ func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) an
 	}
 	if u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("SystemGetUserByUsername: %w", err).Error())
-	} else if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
+	} else if err := queries.SystemCreateUserRole(r.Context(), db.SystemCreateUserRoleParams{
 		UsersIdusers: u.Idusers,
 		Name:         role,
 	}); err != nil {

--- a/handlers/writings/category_grant_create_task.go
+++ b/handlers/writings/category_grant_create_task.go
@@ -65,7 +65,7 @@ func (CategoryGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) an
 		if action == "" {
 			action = "see"
 		}
-		if _, err = queries.CreateGrant(r.Context(), db.CreateGrantParams{
+		if _, err = queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
 			UserID:   uid,
 			RoleID:   rid,
 			Section:  "writing",

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -100,7 +100,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{String: WritingTopicName, Valid: true})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
-		ptidi, err := queries.CreateForumTopic(r.Context(), db.CreateForumTopicParams{
+		ptidi, err := queries.SystemCreateForumTopic(r.Context(), db.SystemCreateForumTopicParams{
 			ForumcategoryIdforumcategory: 0,
 			Title:                        sql.NullString{String: WritingTopicName, Valid: true},
 			Description:                  sql.NullString{String: WritingTopicDescription, Valid: true},
@@ -141,11 +141,13 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("language parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if _, err := queries.CreateComment(r.Context(), db.CreateCommentParams{
-		LanguageIdlanguage: int32(languageID),
-		UsersIdusers:       uid,
+	if _, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
+		LanguageID:         int32(languageID),
+		CommenterID:        uid,
 		ForumthreadID:      pthid,
 		Text:               sql.NullString{String: text, Valid: true},
+		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
+		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
 	}); err != nil {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/writings/user_allow_task.go
+++ b/handlers/writings/user_allow_task.go
@@ -31,7 +31,7 @@ func (UserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("get user by username fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if err := queries.CreateUserRole(r.Context(), db.CreateUserRoleParams{
+	if err := queries.SystemCreateUserRole(r.Context(), db.SystemCreateUserRoleParams{
 		UsersIdusers: u.Idusers,
 		Name:         role,
 	}); err != nil {

--- a/handlers/writings/writing_category_grant_create_task.go
+++ b/handlers/writings/writing_category_grant_create_task.go
@@ -65,7 +65,7 @@ func (WritingCategoryGrantCreateTask) Action(w http.ResponseWriter, r *http.Requ
 		if action == "" {
 			action = "see"
 		}
-		if _, err = queries.CreateGrant(r.Context(), db.CreateGrantParams{
+		if _, err = queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
 			UserID:   uid,
 			RoleID:   rid,
 			Section:  "writing",

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -116,7 +116,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		})
 		var ptid int32
 		if errors.Is(err, sql.ErrNoRows) {
-			ptidi, err := queries.CreateForumTopic(r.Context(), db.CreateForumTopicParams{
+			ptidi, err := queries.SystemCreateForumTopic(r.Context(), db.SystemCreateForumTopicParams{
 				ForumcategoryIdforumcategory: 0,
 				Title:                        sql.NullString{String: WritingTopicName, Valid: true},
 				Description:                  sql.NullString{String: WritingTopicDescription, Valid: true},
@@ -325,7 +325,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
-		ptidi, err := queries.CreateForumTopic(r.Context(), db.CreateForumTopicParams{
+		ptidi, err := queries.SystemCreateForumTopic(r.Context(), db.SystemCreateForumTopicParams{
 			ForumcategoryIdforumcategory: 0,
 			Title: sql.NullString{
 				String: WritingTopicName,
@@ -379,14 +379,13 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("replytext")
 	languageId, _ := strconv.Atoi(r.PostFormValue("language"))
 
-	if _, err := queries.CreateComment(r.Context(), db.CreateCommentParams{
-		LanguageIdlanguage: int32(languageId),
-		UsersIdusers:       uid,
+	if _, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
+		LanguageID:         int32(languageId),
+		CommenterID:        uid,
 		ForumthreadID:      pthid,
-		Text: sql.NullString{
-			String: text,
-			Valid:  true,
-		},
+		Text:               sql.NullString{String: text, Valid: true},
+		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
+		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
 	}); err != nil {
 		log.Printf("Error: createComment: %s", err)
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -29,10 +29,16 @@ type Querier interface {
 	AdminCountThreadsByBoard(ctx context.Context, imageboardIdimageboard int32) (int64, error)
 	AdminCountWordList(ctx context.Context) (int64, error)
 	AdminCountWordListByPrefix(ctx context.Context, prefix interface{}) (int64, error)
+	AdminCreateFAQCategory(ctx context.Context, name sql.NullString) error
+	AdminCreateForumCategory(ctx context.Context, arg AdminCreateForumCategoryParams) error
+	AdminCreateGrant(ctx context.Context, arg AdminCreateGrantParams) (int64, error)
+	AdminCreateImageBoard(ctx context.Context, arg AdminCreateImageBoardParams) error
 	// AdminCreateLanguage adds a new language.
 	// Parameters:
 	//   ? - Name of the new language (string)
 	AdminCreateLanguage(ctx context.Context, nameof sql.NullString) error
+	AdminCreateLinkerCategory(ctx context.Context, arg AdminCreateLinkerCategoryParams) error
+	AdminCreateLinkerItem(ctx context.Context, arg AdminCreateLinkerItemParams) error
 	AdminDeleteExternalLink(ctx context.Context, id int32) error
 	AdminDeleteFAQ(ctx context.Context, idfaq int32) error
 	AdminDeleteFAQCategory(ctx context.Context, idfaqcategories int32) error
@@ -179,28 +185,16 @@ type Querier interface {
 	// A clearer name for the role is "User" as it is the user's own data.
 	// See specs/query_naming.md for naming conventions.
 	CountUnreadNotificationsForUser(ctx context.Context, userID int32) (int64, error)
-	CreateBlogEntry(ctx context.Context, arg CreateBlogEntryParams) (int64, error)
-	// This query adds a new entry to the "bookmarks" table for a user.
-	CreateBookmarks(ctx context.Context, arg CreateBookmarksParams) error
-	CreateComment(ctx context.Context, arg CreateCommentParams) (int64, error)
-	CreateFAQCategory(ctx context.Context, arg CreateFAQCategoryParams) error
-	CreateFAQQuestion(ctx context.Context, arg CreateFAQQuestionParams) error
-	CreateForumCategory(ctx context.Context, arg CreateForumCategoryParams) error
-	CreateForumTopic(ctx context.Context, arg CreateForumTopicParams) (int64, error)
-	CreateGrant(ctx context.Context, arg CreateGrantParams) (int64, error)
-	CreateImageBoard(ctx context.Context, arg CreateImageBoardParams) error
-	CreateImagePost(ctx context.Context, arg CreateImagePostParams) (int64, error)
-	CreateLinkerCategory(ctx context.Context, arg CreateLinkerCategoryParams) error
-	CreateLinkerItem(ctx context.Context, arg CreateLinkerItemParams) error
-	CreateLinkerQueuedItem(ctx context.Context, arg CreateLinkerQueuedItemParams) error
-	CreateNewsPost(ctx context.Context, arg CreateNewsPostParams) (int64, error)
-	CreatePasswordReset(ctx context.Context, arg CreatePasswordResetParams) error
-	CreateUploadedImage(ctx context.Context, arg CreateUploadedImageParams) (int64, error)
-	// This query inserts a new permission into the "permissions" table.
-	// Parameters:
-	//   ? - User ID to be associated with the permission (int)
-	//   ? - Role of the permission (string)
-	CreateUserRole(ctx context.Context, arg CreateUserRoleParams) error
+	CreateBlogEntryForWriter(ctx context.Context, arg CreateBlogEntryForWriterParams) (int64, error)
+	// This query adds a new entry to the "bookmarks" table for a lister.
+	CreateBookmarksForLister(ctx context.Context, arg CreateBookmarksForListerParams) error
+	CreateCommentForCommenter(ctx context.Context, arg CreateCommentForCommenterParams) (int64, error)
+	CreateFAQQuestionForWriter(ctx context.Context, arg CreateFAQQuestionForWriterParams) error
+	CreateImagePostForPoster(ctx context.Context, arg CreateImagePostForPosterParams) (int64, error)
+	CreateLinkerQueuedItemForWriter(ctx context.Context, arg CreateLinkerQueuedItemForWriterParams) error
+	CreateNewsPostForWriter(ctx context.Context, arg CreateNewsPostForWriterParams) (int64, error)
+	CreatePasswordResetForUser(ctx context.Context, arg CreatePasswordResetForUserParams) error
+	CreateUploadedImageForUploader(ctx context.Context, arg CreateUploadedImageForUploaderParams) (int64, error)
 	DeactivateNewsPost(ctx context.Context, idsitenews int32) error
 	DeleteNotificationForLister(ctx context.Context, arg DeleteNotificationForListerParams) error
 	DeleteSubscriptionByIDForSubscriber(ctx context.Context, arg DeleteSubscriptionByIDForSubscriberParams) error
@@ -390,8 +384,14 @@ type Querier interface {
 	// SystemCountLanguages counts all languages.
 	SystemCountLanguages(ctx context.Context) (int64, error)
 	SystemCountRecentLoginAttempts(ctx context.Context, arg SystemCountRecentLoginAttemptsParams) (int64, error)
+	SystemCreateForumTopic(ctx context.Context, arg SystemCreateForumTopicParams) (int64, error)
 	SystemCreateNotification(ctx context.Context, arg SystemCreateNotificationParams) error
 	SystemCreateSearchWord(ctx context.Context, word string) (int64, error)
+	// This query inserts a new permission into the "permissions" table.
+	// Parameters:
+	//   ? - User ID to be associated with the permission (int)
+	//   ? - Role of the permission (string)
+	SystemCreateUserRole(ctx context.Context, arg SystemCreateUserRoleParams) error
 	// This query deletes all data from the "blogs_search" table.
 	SystemDeleteBlogsSearch(ctx context.Context) error
 	// This query deletes all data from the "comments_search" table.

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -15,7 +15,7 @@ WHERE idblogs = sqlc.arg(blog_id)
         ))
   );
 
--- name: CreateBlogEntry :execlastid
+-- name: CreateBlogEntryForWriter :execlastid
 INSERT INTO blogs (users_idusers, language_idlanguage, blog, written)
 SELECT sqlc.arg(users_idusers), sqlc.arg(language_idlanguage), sqlc.arg(blog), CURRENT_TIMESTAMP
 WHERE EXISTS (

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -76,7 +76,7 @@ func (q *Queries) AdminGetAllBlogEntriesByUser(ctx context.Context, arg AdminGet
 	return items, nil
 }
 
-const createBlogEntry = `-- name: CreateBlogEntry :execlastid
+const createBlogEntryForWriter = `-- name: CreateBlogEntryForWriter :execlastid
 INSERT INTO blogs (users_idusers, language_idlanguage, blog, written)
 SELECT ?, ?, ?, CURRENT_TIMESTAMP
 WHERE EXISTS (
@@ -93,7 +93,7 @@ WHERE EXISTS (
 )
 `
 
-type CreateBlogEntryParams struct {
+type CreateBlogEntryForWriterParams struct {
 	UsersIdusers       int32
 	LanguageIdlanguage int32
 	Blog               sql.NullString
@@ -101,8 +101,8 @@ type CreateBlogEntryParams struct {
 	ListerID           int32
 }
 
-func (q *Queries) CreateBlogEntry(ctx context.Context, arg CreateBlogEntryParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, createBlogEntry,
+func (q *Queries) CreateBlogEntryForWriter(ctx context.Context, arg CreateBlogEntryForWriterParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, createBlogEntryForWriter,
 		arg.UsersIdusers,
 		arg.LanguageIdlanguage,
 		arg.Blog,

--- a/internal/db/queries-bookmarks.sql
+++ b/internal/db/queries-bookmarks.sql
@@ -1,5 +1,5 @@
--- name: CreateBookmarks :exec
--- This query adds a new entry to the "bookmarks" table for a user.
+-- name: CreateBookmarksForLister :exec
+-- This query adds a new entry to the "bookmarks" table for a lister.
 INSERT INTO bookmarks (users_idusers, list)
 VALUES (?, ?);
 

--- a/internal/db/queries-bookmarks.sql.go
+++ b/internal/db/queries-bookmarks.sql.go
@@ -10,19 +10,19 @@ import (
 	"database/sql"
 )
 
-const createBookmarks = `-- name: CreateBookmarks :exec
+const createBookmarksForLister = `-- name: CreateBookmarksForLister :exec
 INSERT INTO bookmarks (users_idusers, list)
 VALUES (?, ?)
 `
 
-type CreateBookmarksParams struct {
+type CreateBookmarksForListerParams struct {
 	UsersIdusers int32
 	List         sql.NullString
 }
 
-// This query adds a new entry to the "bookmarks" table for a user.
-func (q *Queries) CreateBookmarks(ctx context.Context, arg CreateBookmarksParams) error {
-	_, err := q.db.ExecContext(ctx, createBookmarks, arg.UsersIdusers, arg.List)
+// This query adds a new entry to the "bookmarks" table for a lister.
+func (q *Queries) CreateBookmarksForLister(ctx context.Context, arg CreateBookmarksForListerParams) error {
+	_, err := q.db.ExecContext(ctx, createBookmarksForLister, arg.UsersIdusers, arg.List)
 	return err
 }
 

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -93,10 +93,10 @@ ORDER BY t.lastaddition DESC;
 SELECT f.*
 FROM forumcategory f;
 
--- name: CreateForumCategory :exec
+-- name: AdminCreateForumCategory :exec
 INSERT INTO forumcategory (forumcategory_idforumcategory, title, description) VALUES (?, ?, ?);
 
--- name: CreateForumTopic :execlastid
+-- name: SystemCreateForumTopic :execlastid
 INSERT INTO forumtopic (forumcategory_idforumcategory, title, description) VALUES (?, ?, ?);
 
 -- name: FindForumTopicByTitle :one

--- a/internal/db/queries-forum.sql.go
+++ b/internal/db/queries-forum.sql.go
@@ -10,6 +10,21 @@ import (
 	"database/sql"
 )
 
+const adminCreateForumCategory = `-- name: AdminCreateForumCategory :exec
+INSERT INTO forumcategory (forumcategory_idforumcategory, title, description) VALUES (?, ?, ?)
+`
+
+type AdminCreateForumCategoryParams struct {
+	ForumcategoryIdforumcategory int32
+	Title                        sql.NullString
+	Description                  sql.NullString
+}
+
+func (q *Queries) AdminCreateForumCategory(ctx context.Context, arg AdminCreateForumCategoryParams) error {
+	_, err := q.db.ExecContext(ctx, adminCreateForumCategory, arg.ForumcategoryIdforumcategory, arg.Title, arg.Description)
+	return err
+}
+
 const adminDeleteForumCategory = `-- name: AdminDeleteForumCategory :exec
 UPDATE forumcategory SET deleted_at = NOW() WHERE idforumcategory = ?
 `
@@ -27,39 +42,6 @@ UPDATE forumtopic SET deleted_at = NOW() WHERE idforumtopic = ?
 func (q *Queries) AdminDeleteForumTopic(ctx context.Context, idforumtopic int32) error {
 	_, err := q.db.ExecContext(ctx, adminDeleteForumTopic, idforumtopic)
 	return err
-}
-
-const createForumCategory = `-- name: CreateForumCategory :exec
-INSERT INTO forumcategory (forumcategory_idforumcategory, title, description) VALUES (?, ?, ?)
-`
-
-type CreateForumCategoryParams struct {
-	ForumcategoryIdforumcategory int32
-	Title                        sql.NullString
-	Description                  sql.NullString
-}
-
-func (q *Queries) CreateForumCategory(ctx context.Context, arg CreateForumCategoryParams) error {
-	_, err := q.db.ExecContext(ctx, createForumCategory, arg.ForumcategoryIdforumcategory, arg.Title, arg.Description)
-	return err
-}
-
-const createForumTopic = `-- name: CreateForumTopic :execlastid
-INSERT INTO forumtopic (forumcategory_idforumcategory, title, description) VALUES (?, ?, ?)
-`
-
-type CreateForumTopicParams struct {
-	ForumcategoryIdforumcategory int32
-	Title                        sql.NullString
-	Description                  sql.NullString
-}
-
-func (q *Queries) CreateForumTopic(ctx context.Context, arg CreateForumTopicParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, createForumTopic, arg.ForumcategoryIdforumcategory, arg.Title, arg.Description)
-	if err != nil {
-		return 0, err
-	}
-	return result.LastInsertId()
 }
 
 const findForumTopicByTitle = `-- name: FindForumTopicByTitle :one
@@ -681,6 +663,24 @@ WHERE idforumtopic = ?
 func (q *Queries) RebuildForumTopicByIdMetaColumns(ctx context.Context, idforumtopic int32) error {
 	_, err := q.db.ExecContext(ctx, rebuildForumTopicByIdMetaColumns, idforumtopic)
 	return err
+}
+
+const systemCreateForumTopic = `-- name: SystemCreateForumTopic :execlastid
+INSERT INTO forumtopic (forumcategory_idforumcategory, title, description) VALUES (?, ?, ?)
+`
+
+type SystemCreateForumTopicParams struct {
+	ForumcategoryIdforumcategory int32
+	Title                        sql.NullString
+	Description                  sql.NullString
+}
+
+func (q *Queries) SystemCreateForumTopic(ctx context.Context, arg SystemCreateForumTopicParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, systemCreateForumTopic, arg.ForumcategoryIdforumcategory, arg.Title, arg.Description)
+	if err != nil {
+		return 0, err
+	}
+	return result.LastInsertId()
 }
 
 const updateForumCategory = `-- name: UpdateForumCategory :exec

--- a/internal/db/queries-password_resets.sql
+++ b/internal/db/queries-password_resets.sql
@@ -1,4 +1,4 @@
--- name: CreatePasswordReset :exec
+-- name: CreatePasswordResetForUser :exec
 INSERT INTO pending_passwords (user_id, passwd, passwd_algorithm, verification_code)
 VALUES (?, ?, ?, ?);
 

--- a/internal/db/queries-password_resets.sql.go
+++ b/internal/db/queries-password_resets.sql.go
@@ -11,20 +11,20 @@ import (
 	"time"
 )
 
-const createPasswordReset = `-- name: CreatePasswordReset :exec
+const createPasswordResetForUser = `-- name: CreatePasswordResetForUser :exec
 INSERT INTO pending_passwords (user_id, passwd, passwd_algorithm, verification_code)
 VALUES (?, ?, ?, ?)
 `
 
-type CreatePasswordResetParams struct {
+type CreatePasswordResetForUserParams struct {
 	UserID           int32
 	Passwd           string
 	PasswdAlgorithm  string
 	VerificationCode string
 }
 
-func (q *Queries) CreatePasswordReset(ctx context.Context, arg CreatePasswordResetParams) error {
-	_, err := q.db.ExecContext(ctx, createPasswordReset,
+func (q *Queries) CreatePasswordResetForUser(ctx context.Context, arg CreatePasswordResetForUserParams) error {
+	_, err := q.db.ExecContext(ctx, createPasswordResetForUser,
 		arg.UserID,
 		arg.Passwd,
 		arg.PasswdAlgorithm,

--- a/internal/db/queries-permissions.sql
+++ b/internal/db/queries-permissions.sql
@@ -22,7 +22,7 @@ JOIN users u ON u.idusers = ur.users_idusers
 JOIN roles r ON ur.role_id = r.id
 ;
 
--- name: CreateUserRole :exec
+-- name: SystemCreateUserRole :exec
 -- This query inserts a new permission into the "permissions" table.
 -- Parameters:
 --   ? - User ID to be associated with the permission (int)
@@ -76,7 +76,7 @@ WHERE g.section = sqlc.arg(section)
   AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 LIMIT 1;
 
--- name: CreateGrant :execlastid
+-- name: AdminCreateGrant :execlastid
 INSERT INTO grants (
     created_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active
 ) VALUES (NOW(), ?, ?, ?, ?, ?, ?, ?, ?, ?, 1);


### PR DESCRIPTION
## Summary
- align create queries with role-based naming
- enforce grants on user-facing creates
- update handlers to use new create helpers

## Testing
- `go vet ./...` *(fails: db.New undefined in tests)*
- `golangci-lint run`
- `go test ./...` *(fails: db.New undefined in cmd package tests)*

------
https://chatgpt.com/codex/tasks/task_e_688ef9b9dc04832f80562adc6b0cf018