### PR TITLE
refactor: apply query naming conventions

### DIFF
--- a/cmd/goa4web/email_queue_resend.go
+++ b/cmd/goa4web/email_queue_resend.go
@@ -51,7 +51,7 @@ func (c *emailQueueResendCmd) Run() error {
 			return fmt.Errorf("send email: %w", err)
 		}
 	}
-	if err := queries.MarkEmailSent(ctx, e.ID); err != nil {
+	if err := queries.SystemMarkPendingEmailSent(ctx, e.ID); err != nil {
 		return fmt.Errorf("mark sent: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/user_add_role.go
+++ b/cmd/goa4web/user_add_role.go
@@ -46,7 +46,7 @@ func (c *userAddRoleCmd) Run() error {
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}
-	if _, err := queries.UserHasRole(ctx, db.UserHasRoleParams{UsersIdusers: u.Idusers, Name: c.Role}); err == nil {
+	if _, err := queries.AdminGetRoleByNameForUser(ctx, db.AdminGetRoleByNameForUserParams{UsersIdusers: u.Idusers, Name: c.Role}); err == nil {
 		c.rootCmd.Verbosef("%s already has role %s", c.Username, c.Role)
 		return nil
 	} else if !errors.Is(err, sql.ErrNoRows) {

--- a/cmd/goa4web/user_password_clear_expired.go
+++ b/cmd/goa4web/user_password_clear_expired.go
@@ -38,7 +38,7 @@ func (c *userPasswordClearExpiredCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(conn)
 	expiry := time.Now().Add(-time.Duration(c.Hours) * time.Hour)
-	res, err := queries.PurgePasswordResetsBefore(ctx, expiry)
+	res, err := queries.SystemPurgePasswordResetsBefore(ctx, expiry)
 	if err != nil {
 		return fmt.Errorf("clear expired: %w", err)
 	}

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1246,7 +1246,7 @@ func (cd *CoreData) UnreadNotificationCount() int64 {
 		if cd.queries == nil || cd.UserID == 0 {
 			return 0, nil
 		}
-		return cd.queries.CountUnreadNotificationsForUser(cd.ctx, cd.UserID)
+		return cd.queries.GetUnreadNotificationCountForLister(cd.ctx, cd.UserID)
 	})
 	if err != nil {
 		log.Printf("load unread notification count: %v", err)

--- a/handlers/admin/resend_queue_task.go
+++ b/handlers/admin/resend_queue_task.go
@@ -67,7 +67,7 @@ func (ResendQueueTask) Action(w http.ResponseWriter, r *http.Request) any {
 				return fmt.Errorf("send email fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 			}
 		}
-		if err := queries.MarkEmailSent(r.Context(), e.ID); err != nil {
+		if err := queries.SystemMarkPendingEmailSent(r.Context(), e.ID); err != nil {
 			return fmt.Errorf("mark sent fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	}

--- a/handlers/auth/forgot_password_task.go
+++ b/handlers/auth/forgot_password_task.go
@@ -45,7 +45,7 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("user not found %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if _, err := queries.UserHasLoginRole(r.Context(), row.Idusers); err != nil {
+	if _, err := queries.GetLoginRoleForUser(r.Context(), row.Idusers); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return handlers.ErrRedirectOnSamePageHandler(errors.New("approval is pending"))
 		}

--- a/handlers/auth/login_task.go
+++ b/handlers/auth/login_task.go
@@ -78,7 +78,7 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 		code := r.FormValue("code")
 		if err == nil && VerifyPassword(password, reset.Passwd, reset.PasswdAlgorithm) {
 			if code != "" && code == reset.VerificationCode {
-				_ = queries.MarkPasswordResetVerified(r.Context(), reset.ID)
+				_ = queries.SystemMarkPasswordResetVerified(r.Context(), reset.ID)
 				_ = queries.InsertPassword(r.Context(), db.InsertPasswordParams{UsersIdusers: reset.UserID, Passwd: reset.Passwd, PasswdAlgorithm: sql.NullString{String: reset.PasswdAlgorithm, Valid: true}})
 			} else {
 				type Data struct {
@@ -101,7 +101,7 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 
-	if _, err := queries.UserHasLoginRole(r.Context(), row.Idusers); err != nil {
+	if _, err := queries.GetLoginRoleForUser(r.Context(), row.Idusers); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return loginFormHandler{msg: "approval is pending"}
 		}

--- a/handlers/auth/verify_password_task.go
+++ b/handlers/auth/verify_password_task.go
@@ -48,7 +48,7 @@ func (VerifyPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil || reset.ID != id {
 		return handlers.ErrRedirectOnSamePageHandler(errors.New("invalid code"))
 	}
-	if _, err := queries.UserHasLoginRole(r.Context(), reset.UserID); err != nil {
+	if _, err := queries.GetLoginRoleForUser(r.Context(), reset.UserID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return handlers.ErrRedirectOnSamePageHandler(errors.New("approval is pending"))
 		}
@@ -57,7 +57,7 @@ func (VerifyPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if !VerifyPassword(pw, reset.Passwd, reset.PasswdAlgorithm) {
 		return handlers.ErrRedirectOnSamePageHandler(errors.New("invalid password"))
 	}
-	if err := queries.MarkPasswordResetVerified(r.Context(), reset.ID); err != nil {
+	if err := queries.SystemMarkPasswordResetVerified(r.Context(), reset.ID); err != nil {
 		log.Printf("mark reset verified: %v", err)
 	}
 	if err := queries.InsertPassword(r.Context(), db.InsertPasswordParams{UsersIdusers: reset.UserID, Passwd: reset.Passwd, PasswdAlgorithm: sql.NullString{String: reset.PasswdAlgorithm, Valid: true}}); err != nil {

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -120,7 +120,7 @@ func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if blog.ForumthreadID.Valid {
 		pthid = blog.ForumthreadID.Int32
 	}
-	pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{
+	pt, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{
 		String: BloggerTopicName,
 		Valid:  true,
 	})
@@ -147,7 +147,7 @@ func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 		ptid = pt.Idforumtopic
 	}
 	if pthid == 0 {
-		pthidi, err := queries.MakeThread(r.Context(), ptid)
+		pthidi, err := queries.SystemCreateThread(r.Context(), ptid)
 		if err != nil {
 			return fmt.Errorf("makeThread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/externallink/redirect.go
+++ b/handlers/externallink/redirect.go
@@ -25,7 +25,7 @@ func RedirectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.URL.Query().Get("go") != "" {
-		if err := cd.Queries().RegisterExternalLinkClick(r.Context(), raw); err != nil {
+		if err := cd.Queries().SystemRegisterExternalLinkClick(r.Context(), raw); err != nil {
 			log.Printf("record external link click: %v", err)
 		}
 		http.Redirect(w, r, raw, http.StatusTemporaryRedirect)

--- a/handlers/faq/rename_category_task.go
+++ b/handlers/faq/rename_category_task.go
@@ -33,7 +33,7 @@ func (RenameCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	if err := queries.RenameFAQCategory(r.Context(), db.RenameFAQCategoryParams{
+	if err := queries.AdminRenameFAQCategory(r.Context(), db.AdminRenameFAQCategoryParams{
 		Name: sql.NullString{
 			String: text,
 			Valid:  true,

--- a/handlers/forum/adminForumHandler.go
+++ b/handlers/forum/adminForumHandler.go
@@ -148,7 +148,7 @@ func AdminForumRemakeForumTopicPage(w http.ResponseWriter, r *http.Request) {
 		data.Messages = append(data.Messages, fmt.Sprintf("Processing %d topics...", c))
 	}
 
-	if err := queries.RebuildAllForumTopicMetaColumns(r.Context()); err != nil {
+	if err := queries.AdminRebuildAllForumTopicMetaColumns(r.Context()); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("rebuildForumTopicByIdMetaColumns_lastaddition_lastposter: %w", err).Error())
 	} else {
 		data.Messages = append(data.Messages, "Topic metadata rebuild complete.")

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -132,7 +132,7 @@ func (CreateThreadTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return nil
 	}
 
-	threadId, err := queries.MakeThread(r.Context(), int32(topicId))
+	threadId, err := queries.SystemCreateThread(r.Context(), int32(topicId))
 	if err != nil {
 		log.Printf("Error: makeThread: %s", err)
 		return fmt.Errorf("make thread %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/forum/thread_delete.go
+++ b/handlers/forum/thread_delete.go
@@ -10,5 +10,5 @@ func ThreadDelete(ctx context.Context, q db.Querier, threadID, topicID int32) er
 	if err := q.AdminDeleteForumThread(ctx, threadID); err != nil {
 		return err
 	}
-	return q.RebuildForumTopicByIdMetaColumns(ctx, topicID)
+	return q.SystemRebuildForumTopicMetaByID(ctx, topicID)
 }

--- a/handlers/forum/thread_delete_test.go
+++ b/handlers/forum/thread_delete_test.go
@@ -19,7 +19,7 @@ func TestThreadDelete(t *testing.T) {
 	mock.ExpectExec("AdminDeleteForumThread").
 		WithArgs(int32(1)).
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec("RebuildForumTopicByIdMetaColumns").
+	mock.ExpectExec("SystemRebuildForumTopicMetaByID").
 		WithArgs(int32(2)).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -244,7 +244,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	var pthid int32 = post.ForumthreadID
-	pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{
+	pt, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{
 		String: ImageBBSTopicName,
 		Valid:  true,
 	})
@@ -271,7 +271,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		ptid = pt.Idforumtopic
 	}
 	if pthid == 0 {
-		pthidi, err := queries.MakeThread(r.Context(), ptid)
+		pthidi, err := queries.SystemCreateThread(r.Context(), ptid)
 		if err != nil {
 			return fmt.Errorf("make thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/linker/approve_task.go
+++ b/handlers/linker/approve_task.go
@@ -42,7 +42,7 @@ func (approveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	qid, _ := strconv.Atoi(r.URL.Query().Get("qid"))
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	lid, err := queries.SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId(r.Context(), db.SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueIdParams{
+	lid, err := queries.AdminInsertQueuedLinkFromQueue(r.Context(), db.AdminInsertQueuedLinkFromQueueParams{
 		Idlinkerqueue: int32(qid),
 		AdminID:       cd.UserID,
 	})

--- a/handlers/linker/bulk_approve_task.go
+++ b/handlers/linker/bulk_approve_task.go
@@ -46,7 +46,7 @@ func (bulkApproveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	for _, q := range r.Form["qid"] {
 		id, _ := strconv.Atoi(q)
 		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-		lid, err := queries.SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId(r.Context(), db.SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueIdParams{
+		lid, err := queries.AdminInsertQueuedLinkFromQueue(r.Context(), db.AdminInsertQueuedLinkFromQueueParams{
 			Idlinkerqueue: int32(id),
 			AdminID:       cd.UserID,
 		})

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -247,7 +247,7 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	var pthid int32 = link.ForumthreadID
-	pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{
+	pt, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{
 		String: LinkerTopicName,
 		Valid:  true,
 	})
@@ -274,7 +274,7 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		ptid = pt.Idforumtopic
 	}
 	if pthid == 0 {
-		pthidi, err := queries.MakeThread(r.Context(), ptid)
+		pthidi, err := queries.SystemCreateThread(r.Context(), ptid)
 		if err != nil {
 			return fmt.Errorf("make thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -110,7 +110,7 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var pthid int32 = link.ForumthreadID
-	pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{
+	pt, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{
 		String: LinkerTopicName,
 		Valid:  true,
 	})
@@ -141,7 +141,7 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		ptid = pt.Idforumtopic
 	}
 	if pthid == 0 {
-		pthidi, err := queries.MakeThread(r.Context(), ptid)
+		pthidi, err := queries.SystemCreateThread(r.Context(), ptid)
 		if err != nil {
 			log.Printf("Error: makeThread: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/handlers/linker/rename_category_task.go
+++ b/handlers/linker/rename_category_task.go
@@ -23,7 +23,7 @@ func (renameCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
 	title := r.PostFormValue("title")
 	pos, _ := strconv.Atoi(r.PostFormValue("position"))
-	if err := queries.RenameLinkerCategory(r.Context(), db.RenameLinkerCategoryParams{
+	if err := queries.AdminRenameLinkerCategory(r.Context(), db.AdminRenameLinkerCategoryParams{
 		Title:            sql.NullString{Valid: true, String: title},
 		Position:         int32(pos),
 		Idlinkercategory: int32(cid),

--- a/handlers/linker/update_category_task.go
+++ b/handlers/linker/update_category_task.go
@@ -23,7 +23,7 @@ func (updateCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cid, _ := strconv.Atoi(r.PostFormValue("cid"))
 	title := r.PostFormValue("title")
 	pos, _ := strconv.Atoi(r.PostFormValue("position"))
-	if err := queries.RenameLinkerCategory(r.Context(), db.RenameLinkerCategoryParams{
+	if err := queries.AdminRenameLinkerCategory(r.Context(), db.AdminRenameLinkerCategoryParams{
 		Title:            sql.NullString{Valid: true, String: title},
 		Position:         int32(pos),
 		Idlinkercategory: int32(cid),

--- a/handlers/news/announcement_add_task.go
+++ b/handlers/news/announcement_add_task.go
@@ -40,7 +40,7 @@ func (AnnouncementAddTask) Action(w http.ResponseWriter, r *http.Request) any {
 			return fmt.Errorf("promote announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	} else if !ann.Active {
-		if err := queries.SetAnnouncementActive(r.Context(), db.SetAnnouncementActiveParams{Active: true, ID: ann.ID}); err != nil {
+		if err := queries.AdminSetAnnouncementActive(r.Context(), db.AdminSetAnnouncementActiveParams{Active: true, ID: ann.ID}); err != nil {
 			return fmt.Errorf("activate announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	}

--- a/handlers/news/announcement_delete_task.go
+++ b/handlers/news/announcement_delete_task.go
@@ -37,7 +37,7 @@ func (AnnouncementDeleteTask) Action(w http.ResponseWriter, r *http.Request) any
 		return nil
 	}
 	if ann != nil && ann.Active {
-		if err := queries.SetAnnouncementActive(r.Context(), db.SetAnnouncementActiveParams{Active: false, ID: ann.ID}); err != nil {
+		if err := queries.AdminSetAnnouncementActive(r.Context(), db.AdminSetAnnouncementActiveParams{Active: false, ID: ann.ID}); err != nil {
 			return fmt.Errorf("deactivate announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	}

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -112,7 +112,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	var pthid = post.ForumthreadID
-	pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{
+	pt, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{
 		String: NewsTopicName,
 		Valid:  true,
 	})
@@ -141,7 +141,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		ptid = pt.Idforumtopic
 	}
 	if pthid == 0 {
-		pthidi, err := queries.MakeThread(r.Context(), ptid)
+		pthidi, err := queries.SystemCreateThread(r.Context(), ptid)
 		if err != nil {
 			log.Printf("Error: makeThread: %s", err)
 			return fmt.Errorf("make thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/news/searchResultNewsActionPage.go
+++ b/handlers/news/searchResultNewsActionPage.go
@@ -42,7 +42,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	ftbn, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: NewsTopicName})
+	ftbn, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: NewsTopicName})
 	if err != nil {
 		log.Printf("findForumTopicByTitle Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -78,7 +78,7 @@ func NewsSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, uid 
 
 	for i, word := range searchWords {
 		if i == 0 {
-			ids, err := queries.SiteNewsSearchFirst(r.Context(), db.SiteNewsSearchFirstParams{
+			ids, err := queries.ListSiteNewsSearchFirstForLister(r.Context(), db.ListSiteNewsSearchFirstForListerParams{
 				ListerID: uid,
 				Word: sql.NullString{
 					String: word,
@@ -97,7 +97,7 @@ func NewsSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, uid 
 			}
 			newsIds = ids
 		} else {
-			ids, err := queries.SiteNewsSearchNext(r.Context(), db.SiteNewsSearchNextParams{
+			ids, err := queries.ListSiteNewsSearchNextForLister(r.Context(), db.ListSiteNewsSearchNextForListerParams{
 				ListerID: uid,
 				Word: sql.NullString{
 					String: word,

--- a/handlers/search/remakeCommentsTask.go
+++ b/handlers/search/remakeCommentsTask.go
@@ -58,7 +58,7 @@ func (RemakeCommentsTask) BackgroundTask(ctx context.Context, q db.Querier) (tas
 		}); err != nil {
 			return nil, err
 		}
-		if err := q.SetCommentLastIndex(ctx, row.Idcomments); err != nil {
+		if err := q.SystemSetCommentLastIndex(ctx, row.Idcomments); err != nil {
 			return nil, err
 		}
 	}

--- a/handlers/search/remakeImageTask.go
+++ b/handlers/search/remakeImageTask.go
@@ -58,7 +58,7 @@ func (RemakeImageTask) BackgroundTask(ctx context.Context, q db.Querier) (tasks.
 		}); err != nil {
 			return nil, err
 		}
-		if err := q.SetImagePostLastIndex(ctx, row.Idimagepost); err != nil {
+		if err := q.SystemSetImagePostLastIndex(ctx, row.Idimagepost); err != nil {
 			return nil, err
 		}
 	}

--- a/handlers/search/remakeLinkerTask.go
+++ b/handlers/search/remakeLinkerTask.go
@@ -58,7 +58,7 @@ func (RemakeLinkerTask) BackgroundTask(ctx context.Context, q db.Querier) (tasks
 		}); err != nil {
 			return nil, err
 		}
-		if err := q.SetLinkerLastIndex(ctx, row.Idlinker); err != nil {
+		if err := q.SystemSetLinkerLastIndex(ctx, row.Idlinker); err != nil {
 			return nil, err
 		}
 	}

--- a/handlers/search/remakeNewsTask.go
+++ b/handlers/search/remakeNewsTask.go
@@ -58,7 +58,7 @@ func (RemakeNewsTask) BackgroundTask(ctx context.Context, q db.Querier) (tasks.T
 		}); err != nil {
 			return nil, err
 		}
-		if err := q.SetSiteNewsLastIndex(ctx, row.Idsitenews); err != nil {
+		if err := q.SystemSetSiteNewsLastIndex(ctx, row.Idsitenews); err != nil {
 			return nil, err
 		}
 	}

--- a/handlers/search/remakeWritingTask.go
+++ b/handlers/search/remakeWritingTask.go
@@ -58,7 +58,7 @@ func (RemakeWritingTask) BackgroundTask(ctx context.Context, q db.Querier) (task
 		}); err != nil {
 			return nil, err
 		}
-		if err := q.SetWritingLastIndex(ctx, row.Idwriting); err != nil {
+		if err := q.SystemSetWritingLastIndex(ctx, row.Idwriting); err != nil {
 			return nil, err
 		}
 	}

--- a/handlers/search/searchResultBlogsActionPage.go
+++ b/handlers/search/searchResultBlogsActionPage.go
@@ -48,7 +48,7 @@ func (SearchBlogsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	ftbn, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: hblogs.BloggerTopicName})
+	ftbn, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: hblogs.BloggerTopicName})
 	if err != nil {
 		log.Printf("findForumTopicByTitle Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/search/searchResultLinkerActionPage.go
+++ b/handlers/search/searchResultLinkerActionPage.go
@@ -50,7 +50,7 @@ func (SearchLinkerTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	ftbn, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: hlinker.LinkerTopicName})
+	ftbn, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: hlinker.LinkerTopicName})
 	if err != nil {
 		log.Printf("findForumTopicByTitle Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/search/searchResultWritingsActionPage.go
+++ b/handlers/search/searchResultWritingsActionPage.go
@@ -49,7 +49,7 @@ func (SearchWritingsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	ftbn, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: hwritings.WritingTopicName})
+	ftbn, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: hwritings.WritingTopicName})
 	if err != nil {
 		log.Printf("findForumTopicByTitle Error: %s", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -85,7 +85,7 @@ func WritingSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, u
 
 	for i, word := range searchWords {
 		if i == 0 {
-			ids, err := queries.WritingSearchFirst(r.Context(), db.WritingSearchFirstParams{
+			ids, err := queries.ListWritingSearchFirstForLister(r.Context(), db.ListWritingSearchFirstForListerParams{
 				ListerID: uid,
 				Word: sql.NullString{
 					String: word,
@@ -104,7 +104,7 @@ func WritingSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, u
 			}
 			writingsIds = ids
 		} else {
-			ids, err := queries.WritingSearchNext(r.Context(), db.WritingSearchNextParams{
+			ids, err := queries.ListWritingSearchNextForLister(r.Context(), db.ListWritingSearchNextForListerParams{
 				ListerID: uid,
 				Word: sql.NullString{
 					String: word,

--- a/handlers/user/addEmailTask.go
+++ b/handlers/user/addEmailTask.go
@@ -99,7 +99,7 @@ func (AddEmailTask) Resend(w http.ResponseWriter, r *http.Request) any {
 	}
 	code := hex.EncodeToString(buf[:])
 	expire := time.Now().Add(24 * time.Hour)
-	if err := queries.SetVerificationCode(r.Context(), db.SetVerificationCodeParams{LastVerificationCode: sql.NullString{String: code, Valid: true}, VerificationExpiresAt: sql.NullTime{Time: expire, Valid: true}, ID: int32(id)}); err != nil {
+	if err := queries.SetVerificationCodeForLister(r.Context(), db.SetVerificationCodeForListerParams{ListerID: uid, LastVerificationCode: sql.NullString{String: code, Valid: true}, VerificationExpiresAt: sql.NullTime{Time: expire, Valid: true}, ID: int32(id)}); err != nil {
 		log.Printf("set verification code: %v", err)
 	}
 	path := "/usr/email/verify?code=" + code
@@ -139,7 +139,7 @@ func (AddEmailTask) Notify(w http.ResponseWriter, r *http.Request) {
 	case int32:
 		maxPr = v
 	}
-	if err := queries.SetNotificationPriority(r.Context(), db.SetNotificationPriorityParams{NotificationPriority: maxPr + 1, ID: int32(id)}); err != nil {
+	if err := queries.SetNotificationPriorityForLister(r.Context(), db.SetNotificationPriorityForListerParams{ListerID: uid, NotificationPriority: maxPr + 1, ID: int32(id)}); err != nil {
 		log.Printf("set notification priority: %v", err)
 	}
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)

--- a/handlers/user/publicProfilePage.go
+++ b/handlers/user/publicProfilePage.go
@@ -27,7 +27,7 @@ func userPublicProfilePage(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	if _, err := queries.UserHasPublicProfileRole(r.Context(), u.Idusers); err != nil {
+	if _, err := queries.GetPublicProfileRoleForUser(r.Context(), u.Idusers); err != nil {
 		http.NotFound(w, r)
 		return
 	}

--- a/handlers/user/userNotificationsPage.go
+++ b/handlers/user/userNotificationsPage.go
@@ -100,7 +100,7 @@ func (DismissTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	n, err := queries.GetNotificationForLister(r.Context(), db.GetNotificationForListerParams{ID: int32(id), ListerID: uid})
 	if err == nil && !n.ReadAt.Valid {
-		if err := queries.MarkNotificationReadForLister(r.Context(), db.MarkNotificationReadForListerParams{ID: n.ID, ListerID: uid}); err != nil {
+		if err := queries.SetNotificationReadForLister(r.Context(), db.SetNotificationReadForListerParams{ID: n.ID, ListerID: uid}); err != nil {
 			log.Printf("mark notification read: %v", err)
 		}
 	}
@@ -156,7 +156,7 @@ func userNotificationEmailActionPage(w http.ResponseWriter, r *http.Request) {
 		maxPr = v
 	}
 	if id != 0 {
-		if err := queries.SetNotificationPriority(r.Context(), db.SetNotificationPriorityParams{NotificationPriority: maxPr + 1, ID: int32(id)}); err != nil {
+		if err := queries.SetNotificationPriorityForLister(r.Context(), db.SetNotificationPriorityForListerParams{ListerID: uid, NotificationPriority: maxPr + 1, ID: int32(id)}); err != nil {
 			log.Printf("set notification priority: %v", err)
 		}
 	}

--- a/handlers/user/userPublicSettingPage.go
+++ b/handlers/user/userPublicSettingPage.go
@@ -18,7 +18,7 @@ import (
 func userPublicProfileSettingPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Public Profile"
-	if _, err := cd.Queries().UserHasPublicProfileRole(r.Context(), cd.UserID); err != nil {
+	if _, err := cd.Queries().GetPublicProfileRoleForUser(r.Context(), cd.UserID); err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -48,7 +48,7 @@ func (PublicProfileSaveTask) Action(w http.ResponseWriter, r *http.Request) any 
 	}
 	uid, _ := session.Values["UID"].(int32)
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	if _, err := queries.UserHasPublicProfileRole(r.Context(), uid); err != nil {
+	if _, err := queries.GetPublicProfileRoleForUser(r.Context(), uid); err != nil {
 		return common.UserError{ErrorMessage: "forbidden"}
 	}
 	enable := r.PostFormValue("enable") != ""

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -97,7 +97,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	pthid := post.ForumthreadID
-	pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{String: WritingTopicName, Valid: true})
+	pt, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{String: WritingTopicName, Valid: true})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
 		ptidi, err := queries.SystemCreateForumTopic(r.Context(), db.SystemCreateForumTopicParams{
@@ -116,7 +116,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if pthid == 0 {
-		pthidi, err := queries.MakeThread(r.Context(), ptid)
+		pthidi, err := queries.SystemCreateThread(r.Context(), ptid)
 		if err != nil {
 			return fmt.Errorf("make thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -110,7 +110,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if writing.ForumthreadID == 0 && uid != 0 {
-		pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{
+		pt, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{
 			String: WritingTopicName,
 			Valid:  true,
 		})
@@ -135,7 +135,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 			ptid = pt.Idforumtopic
 		}
 
-		pthidi, err := queries.MakeThread(r.Context(), ptid)
+		pthidi, err := queries.SystemCreateThread(r.Context(), ptid)
 		if err != nil {
 			log.Printf("Error: makeThread: %s", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -319,7 +319,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var pthid int32 = post.ForumthreadID
-	pt, err := queries.FindForumTopicByTitle(r.Context(), sql.NullString{
+	pt, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{
 		String: WritingTopicName,
 		Valid:  true,
 	})
@@ -350,7 +350,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		ptid = pt.Idforumtopic
 	}
 	if pthid == 0 {
-		pthidi, err := queries.MakeThread(r.Context(), ptid)
+		pthidi, err := queries.SystemCreateThread(r.Context(), ptid)
 		if err != nil {
 			log.Printf("Error: makeThread: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -80,6 +80,7 @@ type Querier interface {
 	AdminGetRequestByID(ctx context.Context, id int32) (*AdminRequestQueue, error)
 	// admin task
 	AdminGetRoleByID(ctx context.Context, id int32) (*Role, error)
+	AdminGetRoleByNameForUser(ctx context.Context, arg AdminGetRoleByNameForUserParams) (int32, error)
 	AdminGetSearchStats(ctx context.Context) (*AdminGetSearchStatsRow, error)
 	AdminGetThreadsStartedByUser(ctx context.Context, usersIdusers int32) ([]*Forumthread, error)
 	AdminGetThreadsStartedByUserWithTopic(ctx context.Context, usersIdusers int32) ([]*AdminGetThreadsStartedByUserWithTopicRow, error)
@@ -88,6 +89,7 @@ type Querier interface {
 	AdminInsertBannedIp(ctx context.Context, arg AdminInsertBannedIpParams) error
 	// AdminInsertLanguage adds a new language returning a result.
 	AdminInsertLanguage(ctx context.Context, nameof sql.NullString) (sql.Result, error)
+	AdminInsertQueuedLinkFromQueue(ctx context.Context, arg AdminInsertQueuedLinkFromQueueParams) (int64, error)
 	AdminInsertRequestComment(ctx context.Context, arg AdminInsertRequestCommentParams) error
 	AdminInsertRequestQueue(ctx context.Context, arg AdminInsertRequestQueueParams) (sql.Result, error)
 	AdminInsertWritingCategory(ctx context.Context, arg AdminInsertWritingCategoryParams) error
@@ -145,13 +147,16 @@ type Querier interface {
 	// admin task
 	AdminPromoteAnnouncement(ctx context.Context, siteNewsID int32) error
 	AdminPurgeReadNotifications(ctx context.Context) error
+	AdminRebuildAllForumTopicMetaColumns(ctx context.Context) error
 	AdminRecalculateAllForumThreadMetaData(ctx context.Context) error
 	AdminRecalculateForumThreadByIdMetaData(ctx context.Context, idforumthread int32) error
+	AdminRenameFAQCategory(ctx context.Context, arg AdminRenameFAQCategoryParams) error
 	// AdminRenameLanguage updates the language name.
 	// Parameters:
 	//   ? - New name for the language (string)
 	//   ? - Language ID to be updated (int)
 	AdminRenameLanguage(ctx context.Context, arg AdminRenameLanguageParams) error
+	AdminRenameLinkerCategory(ctx context.Context, arg AdminRenameLinkerCategoryParams) error
 	AdminRestoreBlog(ctx context.Context, arg AdminRestoreBlogParams) error
 	AdminRestoreComment(ctx context.Context, arg AdminRestoreCommentParams) error
 	AdminRestoreImagepost(ctx context.Context, arg AdminRestoreImagepostParams) error
@@ -164,6 +169,7 @@ type Querier interface {
 	AdminScrubLink(ctx context.Context, arg AdminScrubLinkParams) error
 	AdminScrubUser(ctx context.Context, arg AdminScrubUserParams) error
 	AdminScrubWriting(ctx context.Context, arg AdminScrubWritingParams) error
+	AdminSetAnnouncementActive(ctx context.Context, arg AdminSetAnnouncementActiveParams) error
 	AdminSetTemplateOverride(ctx context.Context, arg AdminSetTemplateOverrideParams) error
 	AdminUpdateBannedIp(ctx context.Context, arg AdminUpdateBannedIpParams) error
 	AdminUpdateFAQQuestionAnswer(ctx context.Context, arg AdminUpdateFAQQuestionAnswerParams) error
@@ -188,12 +194,6 @@ type Querier interface {
 	AdminWordListWithCounts(ctx context.Context, arg AdminWordListWithCountsParams) ([]*AdminWordListWithCountsRow, error)
 	AdminWordListWithCountsByPrefix(ctx context.Context, arg AdminWordListWithCountsByPrefixParams) ([]*AdminWordListWithCountsByPrefixRow, error)
 	AdminWritingCategoryCounts(ctx context.Context) ([]*AdminWritingCategoryCountsRow, error)
-	// CountUnreadNotificationsForUser returns the number of unread notifications for a user.
-	// Parameters:
-	//   user_id - ID of the user to count notifications for
-	// A clearer name for the role is "User" as it is the user's own data.
-	// See specs/query_naming.md for naming conventions.
-	CountUnreadNotificationsForUser(ctx context.Context, userID int32) (int64, error)
 	CreateBlogEntryForWriter(ctx context.Context, arg CreateBlogEntryForWriterParams) (int64, error)
 	// This query adds a new entry to the "bookmarks" table for a lister.
 	CreateBookmarksForLister(ctx context.Context, arg CreateBookmarksForListerParams) error
@@ -210,7 +210,6 @@ type Querier interface {
 	DeleteSubscriptionForSubscriber(ctx context.Context, arg DeleteSubscriptionForSubscriberParams) error
 	DeleteUserEmailForOwner(ctx context.Context, arg DeleteUserEmailForOwnerParams) error
 	DeleteUserLanguagesForUser(ctx context.Context, userID int32) error
-	FindForumTopicByTitle(ctx context.Context, title sql.NullString) (*Forumtopic, error)
 	GetActiveAnnouncementWithNewsForLister(ctx context.Context, arg GetActiveAnnouncementWithNewsForListerParams) (*GetActiveAnnouncementWithNewsForListerRow, error)
 	GetAdministratorUserRole(ctx context.Context, usersIdusers int32) (*UserRole, error)
 	GetAllAnsweredFAQWithFAQCategoriesForUser(ctx context.Context, arg GetAllAnsweredFAQWithFAQCategoriesForUserParams) ([]*GetAllAnsweredFAQWithFAQCategoriesForUserRow, error)
@@ -272,6 +271,7 @@ type Querier interface {
 	GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUser(ctx context.Context, arg GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserParams) ([]*GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserRow, error)
 	GetLinkerItemsByUserDescending(ctx context.Context, arg GetLinkerItemsByUserDescendingParams) ([]*GetLinkerItemsByUserDescendingRow, error)
 	GetLinkerItemsByUserDescendingForUser(ctx context.Context, arg GetLinkerItemsByUserDescendingForUserParams) ([]*GetLinkerItemsByUserDescendingForUserRow, error)
+	GetLoginRoleForUser(ctx context.Context, usersIdusers int32) (int32, error)
 	GetMaxNotificationPriority(ctx context.Context, userID int32) (interface{}, error)
 	GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx context.Context, arg GetNewsPostByIdWithWriterIdAndThreadCommentCountParams) (*GetNewsPostByIdWithWriterIdAndThreadCommentCountRow, error)
 	GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount(ctx context.Context, arg GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountParams) ([]*GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow, error)
@@ -285,8 +285,14 @@ type Querier interface {
 	GetPermissionsByUserID(ctx context.Context, usersIdusers int32) ([]*GetPermissionsByUserIDRow, error)
 	GetPermissionsWithUsers(ctx context.Context, arg GetPermissionsWithUsersParams) ([]*GetPermissionsWithUsersRow, error)
 	GetPreferenceForLister(ctx context.Context, listerID int32) (*Preference, error)
+	GetPublicProfileRoleForUser(ctx context.Context, usersIdusers int32) (int32, error)
 	GetPublicWritings(ctx context.Context, arg GetPublicWritingsParams) ([]*Writing, error)
 	GetThreadLastPosterAndPerms(ctx context.Context, arg GetThreadLastPosterAndPermsParams) (*GetThreadLastPosterAndPermsRow, error)
+	// GetUnreadNotificationCountForLister returns the number of unread notifications for a
+	// lister.
+	// Parameters:
+	//   lister_id - ID of the lister to count notifications for
+	GetUnreadNotificationCountForLister(ctx context.Context, listerID int32) (int64, error)
 	GetUserEmailByCode(ctx context.Context, lastVerificationCode sql.NullString) (*UserEmail, error)
 	GetUserEmailByEmail(ctx context.Context, email string) (*UserEmail, error)
 	GetUserEmailByID(ctx context.Context, id int32) (*UserEmail, error)
@@ -303,7 +309,6 @@ type Querier interface {
 	GetUserRoles(ctx context.Context) ([]*GetUserRolesRow, error)
 	GetWritingCategoryById(ctx context.Context, idwritingcategory int32) (*WritingCategory, error)
 	GetWritingForListerByID(ctx context.Context, arg GetWritingForListerByIDParams) (*GetWritingForListerByIDRow, error)
-	IncrementEmailError(ctx context.Context, id int32) error
 	InsertAdminUserComment(ctx context.Context, arg InsertAdminUserCommentParams) error
 	InsertAuditLog(ctx context.Context, arg InsertAuditLogParams) error
 	InsertEmailPreferenceForLister(ctx context.Context, arg InsertEmailPreferenceForListerParams) error
@@ -343,6 +348,8 @@ type Querier interface {
 	ListNotificationsForLister(ctx context.Context, arg ListNotificationsForListerParams) ([]*Notification, error)
 	ListPublicWritingsByUserForLister(ctx context.Context, arg ListPublicWritingsByUserForListerParams) ([]*ListPublicWritingsByUserForListerRow, error)
 	ListPublicWritingsInCategoryForLister(ctx context.Context, arg ListPublicWritingsInCategoryForListerParams) ([]*ListPublicWritingsInCategoryForListerRow, error)
+	ListSiteNewsSearchFirstForLister(ctx context.Context, arg ListSiteNewsSearchFirstForListerParams) ([]int32, error)
+	ListSiteNewsSearchNextForLister(ctx context.Context, arg ListSiteNewsSearchNextForListerParams) ([]int32, error)
 	ListSubscribersForPattern(ctx context.Context, arg ListSubscribersForPatternParams) ([]int32, error)
 	ListSubscribersForPatterns(ctx context.Context, arg ListSubscribersForPatternsParams) ([]int32, error)
 	ListSubscriptionsByUser(ctx context.Context, usersIdusers int32) ([]*ListSubscriptionsByUserRow, error)
@@ -353,30 +360,13 @@ type Querier interface {
 	ListWritersForLister(ctx context.Context, arg ListWritersForListerParams) ([]*ListWritersForListerRow, error)
 	ListWritersSearchForLister(ctx context.Context, arg ListWritersSearchForListerParams) ([]*ListWritersSearchForListerRow, error)
 	ListWritingCategoriesForLister(ctx context.Context, arg ListWritingCategoriesForListerParams) ([]*WritingCategory, error)
+	ListWritingSearchFirstForLister(ctx context.Context, arg ListWritingSearchFirstForListerParams) ([]int32, error)
+	ListWritingSearchNextForLister(ctx context.Context, arg ListWritingSearchNextForListerParams) ([]int32, error)
 	ListWritingsByIDsForLister(ctx context.Context, arg ListWritingsByIDsForListerParams) ([]*ListWritingsByIDsForListerRow, error)
-	MakeThread(ctx context.Context, forumtopicIdforumtopic int32) (int64, error)
-	MarkEmailSent(ctx context.Context, id int32) error
-	MarkNotificationReadForLister(ctx context.Context, arg MarkNotificationReadForListerParams) error
-	MarkNotificationUnreadForLister(ctx context.Context, arg MarkNotificationUnreadForListerParams) error
-	MarkPasswordResetVerified(ctx context.Context, id int32) error
-	// Remove password reset entries that have expired or were already verified
-	PurgePasswordResetsBefore(ctx context.Context, createdAt time.Time) (sql.Result, error)
-	RebuildAllForumTopicMetaColumns(ctx context.Context) error
-	RebuildForumTopicByIdMetaColumns(ctx context.Context, idforumtopic int32) error
-	RegisterExternalLinkClick(ctx context.Context, url string) error
-	RenameFAQCategory(ctx context.Context, arg RenameFAQCategoryParams) error
-	RenameLinkerCategory(ctx context.Context, arg RenameLinkerCategoryParams) error
-	SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId(ctx context.Context, arg SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueIdParams) (int64, error)
-	SetAnnouncementActive(ctx context.Context, arg SetAnnouncementActiveParams) error
-	SetCommentLastIndex(ctx context.Context, idcomments int32) error
-	SetImagePostLastIndex(ctx context.Context, idimagepost int32) error
-	SetLinkerLastIndex(ctx context.Context, idlinker int32) error
-	SetNotificationPriority(ctx context.Context, arg SetNotificationPriorityParams) error
-	SetSiteNewsLastIndex(ctx context.Context, idsitenews int32) error
-	SetVerificationCode(ctx context.Context, arg SetVerificationCodeParams) error
-	SetWritingLastIndex(ctx context.Context, idwriting int32) error
-	SiteNewsSearchFirst(ctx context.Context, arg SiteNewsSearchFirstParams) ([]int32, error)
-	SiteNewsSearchNext(ctx context.Context, arg SiteNewsSearchNextParams) ([]int32, error)
+	SetNotificationPriorityForLister(ctx context.Context, arg SetNotificationPriorityForListerParams) error
+	SetNotificationReadForLister(ctx context.Context, arg SetNotificationReadForListerParams) error
+	SetNotificationUnreadForLister(ctx context.Context, arg SetNotificationUnreadForListerParams) error
+	SetVerificationCodeForLister(ctx context.Context, arg SetVerificationCodeForListerParams) error
 	SystemAddToBlogsSearch(ctx context.Context, arg SystemAddToBlogsSearchParams) error
 	SystemAddToForumCommentSearch(ctx context.Context, arg SystemAddToForumCommentSearchParams) error
 	SystemAddToForumWritingSearch(ctx context.Context, arg SystemAddToForumWritingSearchParams) error
@@ -397,6 +387,7 @@ type Querier interface {
 	SystemCreateForumTopic(ctx context.Context, arg SystemCreateForumTopicParams) (int64, error)
 	SystemCreateNotification(ctx context.Context, arg SystemCreateNotificationParams) error
 	SystemCreateSearchWord(ctx context.Context, word string) (int64, error)
+	SystemCreateThread(ctx context.Context, forumtopicIdforumtopic int32) (int64, error)
 	// This query inserts a new permission into the "permissions" table.
 	// Parameters:
 	//   ? - User ID to be associated with the permission (int)
@@ -421,6 +412,7 @@ type Querier interface {
 	SystemDeleteWritingSearch(ctx context.Context) error
 	SystemDeleteWritingSearchByWritingID(ctx context.Context, writingID int32) error
 	SystemGetAllBlogsForIndex(ctx context.Context) ([]*SystemGetAllBlogsForIndexRow, error)
+	SystemGetForumTopicByTitle(ctx context.Context, title sql.NullString) (*Forumtopic, error)
 	// SystemGetLanguageIDByName resolves a language ID by name.
 	SystemGetLanguageIDByName(ctx context.Context, nameof sql.NullString) (int32, error)
 	SystemGetLastNotificationForRecipientByMessage(ctx context.Context, arg SystemGetLastNotificationForRecipientByMessageParams) (*Notification, error)
@@ -430,6 +422,7 @@ type Querier interface {
 	SystemGetUserByEmail(ctx context.Context, email string) (*SystemGetUserByEmailRow, error)
 	SystemGetUserByID(ctx context.Context, idusers int32) (*SystemGetUserByIDRow, error)
 	SystemGetUserByUsername(ctx context.Context, username sql.NullString) (*SystemGetUserByUsernameRow, error)
+	SystemIncrementPendingEmailError(ctx context.Context, id int32) error
 	// System query only used internally
 	SystemInsertDeadLetter(ctx context.Context, message string) error
 	SystemInsertLoginAttempt(ctx context.Context, arg SystemInsertLoginAttemptParams) error
@@ -446,9 +439,20 @@ type Querier interface {
 	SystemListUserInfo(ctx context.Context) ([]*SystemListUserInfoRow, error)
 	SystemListVerifiedEmailsByUserID(ctx context.Context, userID int32) ([]*UserEmail, error)
 	SystemListWritingCategories(ctx context.Context, arg SystemListWritingCategoriesParams) ([]*WritingCategory, error)
+	SystemMarkPasswordResetVerified(ctx context.Context, id int32) error
+	SystemMarkPendingEmailSent(ctx context.Context, id int32) error
 	SystemMarkUserEmailVerified(ctx context.Context, arg SystemMarkUserEmailVerifiedParams) error
 	SystemPurgeDeadLettersBefore(ctx context.Context, createdAt time.Time) error
+	// Remove password reset entries that have expired or were already verified
+	SystemPurgePasswordResetsBefore(ctx context.Context, createdAt time.Time) (sql.Result, error)
+	SystemRebuildForumTopicMetaByID(ctx context.Context, idforumtopic int32) error
+	SystemRegisterExternalLinkClick(ctx context.Context, url string) error
 	SystemSetBlogLastIndex(ctx context.Context, id int32) error
+	SystemSetCommentLastIndex(ctx context.Context, idcomments int32) error
+	SystemSetImagePostLastIndex(ctx context.Context, idimagepost int32) error
+	SystemSetLinkerLastIndex(ctx context.Context, idlinker int32) error
+	SystemSetSiteNewsLastIndex(ctx context.Context, idsitenews int32) error
+	SystemSetWritingLastIndex(ctx context.Context, idwriting int32) error
 	UpdateAutoSubscribeRepliesForLister(ctx context.Context, arg UpdateAutoSubscribeRepliesForListerParams) error
 	UpdateBlogEntryForWriter(ctx context.Context, arg UpdateBlogEntryForWriterParams) error
 	// This query updates the "list" column in the "bookmarks" table for a specific lister.
@@ -459,11 +463,6 @@ type Querier interface {
 	UpdatePreferenceForLister(ctx context.Context, arg UpdatePreferenceForListerParams) error
 	UpdatePublicProfileEnabledAtForUser(ctx context.Context, arg UpdatePublicProfileEnabledAtForUserParams) error
 	UpdateWritingForWriter(ctx context.Context, arg UpdateWritingForWriterParams) error
-	UserHasLoginRole(ctx context.Context, usersIdusers int32) (int32, error)
-	UserHasPublicProfileRole(ctx context.Context, usersIdusers int32) (int32, error)
-	UserHasRole(ctx context.Context, arg UserHasRoleParams) (int32, error)
-	WritingSearchFirst(ctx context.Context, arg WritingSearchFirstParams) ([]int32, error)
-	WritingSearchNext(ctx context.Context, arg WritingSearchNextParams) ([]int32, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -14,7 +14,7 @@ WHERE site_news_id = ?
 ORDER BY created_at DESC
 LIMIT 1;
 
--- name: SetAnnouncementActive :exec
+-- name: AdminSetAnnouncementActive :exec
 UPDATE site_announcements SET active = ? WHERE id = ?;
 
 -- name: GetActiveAnnouncementWithNewsForLister :one

--- a/internal/db/queries-announcements.sql.go
+++ b/internal/db/queries-announcements.sql.go
@@ -77,6 +77,20 @@ func (q *Queries) AdminPromoteAnnouncement(ctx context.Context, siteNewsID int32
 	return err
 }
 
+const adminSetAnnouncementActive = `-- name: AdminSetAnnouncementActive :exec
+UPDATE site_announcements SET active = ? WHERE id = ?
+`
+
+type AdminSetAnnouncementActiveParams struct {
+	Active bool
+	ID     int32
+}
+
+func (q *Queries) AdminSetAnnouncementActive(ctx context.Context, arg AdminSetAnnouncementActiveParams) error {
+	_, err := q.db.ExecContext(ctx, adminSetAnnouncementActive, arg.Active, arg.ID)
+	return err
+}
+
 const getActiveAnnouncementWithNewsForLister = `-- name: GetActiveAnnouncementWithNewsForLister :one
 WITH RECURSIVE role_ids(id) AS (
     SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
@@ -152,18 +166,4 @@ func (q *Queries) GetLatestAnnouncementByNewsID(ctx context.Context, siteNewsID 
 		&i.CreatedAt,
 	)
 	return &i, err
-}
-
-const setAnnouncementActive = `-- name: SetAnnouncementActive :exec
-UPDATE site_announcements SET active = ? WHERE id = ?
-`
-
-type SetAnnouncementActiveParams struct {
-	Active bool
-	ID     int32
-}
-
-func (q *Queries) SetAnnouncementActive(ctx context.Context, arg SetAnnouncementActiveParams) error {
-	_, err := q.db.ExecContext(ctx, setAnnouncementActive, arg.Active, arg.ID)
-	return err
 }

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -155,7 +155,7 @@ LEFT JOIN forumthread th ON c.forumthread_id = th.idforumthread
 WHERE c.users_idusers = sqlc.arg('user_id')
 ORDER BY c.written;
 
--- name: SetCommentLastIndex :exec
+-- name: SystemSetCommentLastIndex :exec
 UPDATE comments SET last_index = NOW() WHERE idcomments = ?;
 
 

--- a/internal/db/queries-comments.sql.go
+++ b/internal/db/queries-comments.sql.go
@@ -521,12 +521,12 @@ func (q *Queries) GetCommentsByThreadIdForUser(ctx context.Context, arg GetComme
 	return items, nil
 }
 
-const setCommentLastIndex = `-- name: SetCommentLastIndex :exec
+const systemSetCommentLastIndex = `-- name: SystemSetCommentLastIndex :exec
 UPDATE comments SET last_index = NOW() WHERE idcomments = ?
 `
 
-func (q *Queries) SetCommentLastIndex(ctx context.Context, idcomments int32) error {
-	_, err := q.db.ExecContext(ctx, setCommentLastIndex, idcomments)
+func (q *Queries) SystemSetCommentLastIndex(ctx context.Context, idcomments int32) error {
+	_, err := q.db.ExecContext(ctx, systemSetCommentLastIndex, idcomments)
 	return err
 }
 

--- a/internal/db/queries-externallinks.sql
+++ b/internal/db/queries-externallinks.sql
@@ -1,4 +1,4 @@
--- name: RegisterExternalLinkClick :exec
+-- name: SystemRegisterExternalLinkClick :exec
 INSERT INTO external_links (url, clicks)
 VALUES (?, 1)
 ON DUPLICATE KEY UPDATE clicks = clicks + 1;

--- a/internal/db/queries-externallinks.sql.go
+++ b/internal/db/queries-externallinks.sql.go
@@ -102,13 +102,13 @@ func (q *Queries) GetExternalLink(ctx context.Context, url string) (*ExternalLin
 	return &i, err
 }
 
-const registerExternalLinkClick = `-- name: RegisterExternalLinkClick :exec
+const systemRegisterExternalLinkClick = `-- name: SystemRegisterExternalLinkClick :exec
 INSERT INTO external_links (url, clicks)
 VALUES (?, 1)
 ON DUPLICATE KEY UPDATE clicks = clicks + 1
 `
 
-func (q *Queries) RegisterExternalLinkClick(ctx context.Context, url string) error {
-	_, err := q.db.ExecContext(ctx, registerExternalLinkClick, url)
+func (q *Queries) SystemRegisterExternalLinkClick(ctx context.Context, url string) error {
+	_, err := q.db.ExecContext(ctx, systemRegisterExternalLinkClick, url)
 	return err
 }

--- a/internal/db/queries-faq.sql
+++ b/internal/db/queries-faq.sql
@@ -43,7 +43,7 @@ WHERE deleted_at IS NOT NULL;
 SELECT *
 FROM faq;
 
--- name: RenameFAQCategory :exec
+-- name: AdminRenameFAQCategory :exec
 UPDATE faq_categories
 SET name = ?
 WHERE idfaqCategories = ?

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -99,7 +99,7 @@ INSERT INTO forumcategory (forumcategory_idforumcategory, title, description) VA
 -- name: SystemCreateForumTopic :execlastid
 INSERT INTO forumtopic (forumcategory_idforumcategory, title, description) VALUES (?, ?, ?);
 
--- name: FindForumTopicByTitle :one
+-- name: SystemGetForumTopicByTitle :one
 SELECT *
 FROM forumtopic
 WHERE title=?;
@@ -136,7 +136,7 @@ WHERE th.forumtopic_idforumtopic=sqlc.arg(topic_id)
   )
 ORDER BY th.lastaddition DESC;
 
--- name: RebuildAllForumTopicMetaColumns :exec
+-- name: AdminRebuildAllForumTopicMetaColumns :exec
 UPDATE forumtopic
 SET threads = (
     SELECT COUNT(idforumthread)
@@ -160,7 +160,7 @@ SET threads = (
     LIMIT 1
 );
 
--- name: RebuildForumTopicByIdMetaColumns :exec
+-- name: SystemRebuildForumTopicMetaByID :exec
 UPDATE forumtopic
 SET threads = (
     SELECT COUNT(idforumthread)

--- a/internal/db/queries-imagebbs.sql
+++ b/internal/db/queries-imagebbs.sql
@@ -180,7 +180,7 @@ WHERE i.idimagepost = sqlc.arg(id)
   )
 LIMIT 1;
 
--- name: SetImagePostLastIndex :exec
+-- name: SystemSetImagePostLastIndex :exec
 UPDATE imagepost SET last_index = NOW() WHERE idimagepost = ?;
 
 

--- a/internal/db/queries-imagebbs.sql.go
+++ b/internal/db/queries-imagebbs.sql.go
@@ -777,15 +777,6 @@ func (q *Queries) ListImagePostsByPosterForLister(ctx context.Context, arg ListI
 	return items, nil
 }
 
-const setImagePostLastIndex = `-- name: SetImagePostLastIndex :exec
-UPDATE imagepost SET last_index = NOW() WHERE idimagepost = ?
-`
-
-func (q *Queries) SetImagePostLastIndex(ctx context.Context, idimagepost int32) error {
-	_, err := q.db.ExecContext(ctx, setImagePostLastIndex, idimagepost)
-	return err
-}
-
 const systemAssignImagePostThreadID = `-- name: SystemAssignImagePostThreadID :exec
 UPDATE imagepost SET forumthread_id = ? WHERE idimagepost = ?
 `
@@ -840,4 +831,13 @@ func (q *Queries) SystemListBoardsByParentID(ctx context.Context, arg SystemList
 		return nil, err
 	}
 	return items, nil
+}
+
+const systemSetImagePostLastIndex = `-- name: SystemSetImagePostLastIndex :exec
+UPDATE imagepost SET last_index = NOW() WHERE idimagepost = ?
+`
+
+func (q *Queries) SystemSetImagePostLastIndex(ctx context.Context, idimagepost int32) error {
+	_, err := q.db.ExecContext(ctx, systemSetImagePostLastIndex, idimagepost)
+	return err
 }

--- a/internal/db/queries-linker.sql
+++ b/internal/db/queries-linker.sql
@@ -3,7 +3,7 @@
 DELETE FROM linker_category
 WHERE idlinkerCategory = ?;
 
--- name: RenameLinkerCategory :exec
+-- name: AdminRenameLinkerCategory :exec
 UPDATE linker_category SET title = ?, position = ?
 WHERE idlinkerCategory = ?
   AND EXISTS (
@@ -93,7 +93,7 @@ FROM linker_queue l
 JOIN users u ON l.users_idusers = u.idusers
 JOIN linker_category c ON l.linker_category_id = c.idlinkerCategory
 ;
--- name: SelectInsertLInkerQueuedItemIntoLinkerByLinkerQueueId :execlastid
+-- name: AdminInsertQueuedLinkFromQueue :execlastid
 INSERT INTO linker (users_idusers, linker_category_id, language_idlanguage, title, `url`, description)
 SELECT l.users_idusers, l.linker_category_id, l.language_idlanguage, l.title, l.url, l.description
 FROM linker_queue l
@@ -284,7 +284,7 @@ WHERE idlinkerCategory = ?;
 SELECT COUNT(*) FROM linker WHERE linker_category_id = ?;
 
 
--- name: SetLinkerLastIndex :exec
+-- name: SystemSetLinkerLastIndex :exec
 UPDATE linker SET last_index = NOW() WHERE idlinker = ?;
 
 

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -130,7 +130,7 @@ ORDER BY s.occurred DESC
 LIMIT ? OFFSET ?;
 
 
--- name: SetSiteNewsLastIndex :exec
+-- name: SystemSetSiteNewsLastIndex :exec
 UPDATE site_news SET last_index = NOW() WHERE idsiteNews = ?;
 
 

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -355,15 +355,6 @@ func (q *Queries) GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(
 	return items, nil
 }
 
-const setSiteNewsLastIndex = `-- name: SetSiteNewsLastIndex :exec
-UPDATE site_news SET last_index = NOW() WHERE idsiteNews = ?
-`
-
-func (q *Queries) SetSiteNewsLastIndex(ctx context.Context, idsitenews int32) error {
-	_, err := q.db.ExecContext(ctx, setSiteNewsLastIndex, idsitenews)
-	return err
-}
-
 const systemAssignNewsThreadID = `-- name: SystemAssignNewsThreadID :exec
 UPDATE site_news SET forumthread_id = ? WHERE idsiteNews = ?
 `
@@ -375,6 +366,15 @@ type SystemAssignNewsThreadIDParams struct {
 
 func (q *Queries) SystemAssignNewsThreadID(ctx context.Context, arg SystemAssignNewsThreadIDParams) error {
 	_, err := q.db.ExecContext(ctx, systemAssignNewsThreadID, arg.ForumthreadID, arg.Idsitenews)
+	return err
+}
+
+const systemSetSiteNewsLastIndex = `-- name: SystemSetSiteNewsLastIndex :exec
+UPDATE site_news SET last_index = NOW() WHERE idsiteNews = ?
+`
+
+func (q *Queries) SystemSetSiteNewsLastIndex(ctx context.Context, idsitenews int32) error {
+	_, err := q.db.ExecContext(ctx, systemSetSiteNewsLastIndex, idsitenews)
 	return err
 }
 

--- a/internal/db/queries-notifications.sql
+++ b/internal/db/queries-notifications.sql
@@ -2,14 +2,13 @@
 INSERT INTO notifications (users_idusers, link, message)
 VALUES (sqlc.arg(recipient_id), sqlc.arg(link), sqlc.arg(message));
 
--- CountUnreadNotificationsForUser returns the number of unread notifications for a user.
+-- GetUnreadNotificationCountForLister returns the number of unread notifications for a
+-- lister.
 -- Parameters:
---   user_id - ID of the user to count notifications for
--- A clearer name for the role is "User" as it is the user's own data.
--- See specs/query_naming.md for naming conventions.
--- name: CountUnreadNotificationsForUser :one
+--   lister_id - ID of the lister to count notifications for
+-- name: GetUnreadNotificationCountForLister :one
 SELECT COUNT(*) FROM notifications
-WHERE users_idusers = sqlc.arg(user_id) AND read_at IS NULL;
+WHERE users_idusers = sqlc.arg(lister_id) AND read_at IS NULL;
 
 -- name: ListNotificationsForLister :many
 SELECT id, users_idusers, link, message, created_at, read_at
@@ -25,12 +24,12 @@ WHERE users_idusers = sqlc.arg(lister_id) AND read_at IS NULL
 ORDER BY id DESC
 LIMIT ? OFFSET ?;
 
--- name: MarkNotificationReadForLister :exec
+-- name: SetNotificationReadForLister :exec
 UPDATE notifications
 SET read_at = NOW()
 WHERE id = sqlc.arg(id) AND users_idusers = sqlc.arg(lister_id);
 
--- name: MarkNotificationUnreadForLister :exec
+-- name: SetNotificationUnreadForLister :exec
 UPDATE notifications
 SET read_at = NULL
 WHERE id = sqlc.arg(id) AND users_idusers = sqlc.arg(lister_id);

--- a/internal/db/queries-password_resets.sql
+++ b/internal/db/queries-password_resets.sql
@@ -14,7 +14,7 @@ SELECT id, user_id, passwd, passwd_algorithm, verification_code, created_at, ver
 FROM pending_passwords
 WHERE verification_code = ? AND verified_at IS NULL AND created_at > ?;
 
--- name: MarkPasswordResetVerified :exec
+-- name: SystemMarkPasswordResetVerified :exec
 UPDATE pending_passwords SET verified_at = NOW() WHERE id = ?;
 
 -- name: SystemDeletePasswordReset :exec
@@ -24,7 +24,7 @@ DELETE FROM pending_passwords WHERE id = ?;
 -- Delete all password reset entries for the given user and return the result
 DELETE FROM pending_passwords WHERE user_id = ?;
 
--- name: PurgePasswordResetsBefore :execresult
+-- name: SystemPurgePasswordResetsBefore :execresult
 -- Remove password reset entries that have expired or were already verified
 DELETE FROM pending_passwords
 WHERE created_at < ? OR verified_at IS NOT NULL;

--- a/internal/db/queries-password_resets.sql.go
+++ b/internal/db/queries-password_resets.sql.go
@@ -87,25 +87,6 @@ func (q *Queries) GetPasswordResetByUser(ctx context.Context, arg GetPasswordRes
 	return &i, err
 }
 
-const markPasswordResetVerified = `-- name: MarkPasswordResetVerified :exec
-UPDATE pending_passwords SET verified_at = NOW() WHERE id = ?
-`
-
-func (q *Queries) MarkPasswordResetVerified(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, markPasswordResetVerified, id)
-	return err
-}
-
-const purgePasswordResetsBefore = `-- name: PurgePasswordResetsBefore :execresult
-DELETE FROM pending_passwords
-WHERE created_at < ? OR verified_at IS NOT NULL
-`
-
-// Remove password reset entries that have expired or were already verified
-func (q *Queries) PurgePasswordResetsBefore(ctx context.Context, createdAt time.Time) (sql.Result, error) {
-	return q.db.ExecContext(ctx, purgePasswordResetsBefore, createdAt)
-}
-
 const systemDeletePasswordReset = `-- name: SystemDeletePasswordReset :exec
 DELETE FROM pending_passwords WHERE id = ?
 `
@@ -122,4 +103,23 @@ DELETE FROM pending_passwords WHERE user_id = ?
 // Delete all password reset entries for the given user and return the result
 func (q *Queries) SystemDeletePasswordResetsByUser(ctx context.Context, userID int32) (sql.Result, error) {
 	return q.db.ExecContext(ctx, systemDeletePasswordResetsByUser, userID)
+}
+
+const systemMarkPasswordResetVerified = `-- name: SystemMarkPasswordResetVerified :exec
+UPDATE pending_passwords SET verified_at = NOW() WHERE id = ?
+`
+
+func (q *Queries) SystemMarkPasswordResetVerified(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, systemMarkPasswordResetVerified, id)
+	return err
+}
+
+const systemPurgePasswordResetsBefore = `-- name: SystemPurgePasswordResetsBefore :execresult
+DELETE FROM pending_passwords
+WHERE created_at < ? OR verified_at IS NOT NULL
+`
+
+// Remove password reset entries that have expired or were already verified
+func (q *Queries) SystemPurgePasswordResetsBefore(ctx context.Context, createdAt time.Time) (sql.Result, error) {
+	return q.db.ExecContext(ctx, systemPurgePasswordResetsBefore, createdAt)
 }

--- a/internal/db/queries-pending_emails.sql
+++ b/internal/db/queries-pending_emails.sql
@@ -9,7 +9,7 @@ WHERE sent_at IS NULL
 ORDER BY id
 LIMIT ? OFFSET ?;
 
--- name: MarkEmailSent :exec
+-- name: SystemMarkPendingEmailSent :exec
 UPDATE pending_emails SET sent_at = NOW() WHERE id = ?;
 
 -- name: AdminListUnsentPendingEmails :many
@@ -34,7 +34,7 @@ WHERE id = ?;
 -- admin task
 DELETE FROM pending_emails WHERE id = ?;
 
--- name: IncrementEmailError :exec
+-- name: SystemIncrementPendingEmailError :exec
 UPDATE pending_emails SET error_count = error_count + 1 WHERE id = ?;
 
 -- name: GetPendingEmailErrorCount :one

--- a/internal/db/queries-pending_emails.sql.go
+++ b/internal/db/queries-pending_emails.sql.go
@@ -258,15 +258,6 @@ func (q *Queries) GetPendingEmailErrorCount(ctx context.Context, id int32) (int3
 	return error_count, err
 }
 
-const incrementEmailError = `-- name: IncrementEmailError :exec
-UPDATE pending_emails SET error_count = error_count + 1 WHERE id = ?
-`
-
-func (q *Queries) IncrementEmailError(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, incrementEmailError, id)
-	return err
-}
-
 const insertPendingEmail = `-- name: InsertPendingEmail :exec
 INSERT INTO pending_emails (to_user_id, body, direct_email)
 VALUES (?, ?, ?)
@@ -283,12 +274,12 @@ func (q *Queries) InsertPendingEmail(ctx context.Context, arg InsertPendingEmail
 	return err
 }
 
-const markEmailSent = `-- name: MarkEmailSent :exec
-UPDATE pending_emails SET sent_at = NOW() WHERE id = ?
+const systemIncrementPendingEmailError = `-- name: SystemIncrementPendingEmailError :exec
+UPDATE pending_emails SET error_count = error_count + 1 WHERE id = ?
 `
 
-func (q *Queries) MarkEmailSent(ctx context.Context, id int32) error {
-	_, err := q.db.ExecContext(ctx, markEmailSent, id)
+func (q *Queries) SystemIncrementPendingEmailError(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, systemIncrementPendingEmailError, id)
 	return err
 }
 
@@ -340,4 +331,13 @@ func (q *Queries) SystemListPendingEmails(ctx context.Context, arg SystemListPen
 		return nil, err
 	}
 	return items, nil
+}
+
+const systemMarkPendingEmailSent = `-- name: SystemMarkPendingEmailSent :exec
+UPDATE pending_emails SET sent_at = NOW() WHERE id = ?
+`
+
+func (q *Queries) SystemMarkPendingEmailSent(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, systemMarkPendingEmailSent, id)
+	return err
 }

--- a/internal/db/queries-permissions.sql
+++ b/internal/db/queries-permissions.sql
@@ -90,21 +90,21 @@ SELECT * FROM grants ORDER BY id;
 -- name: ListGrantsByUserID :many
 SELECT * FROM grants WHERE user_id = ? ORDER BY id;
 
--- name: UserHasRole :one
+-- name: AdminGetRoleByNameForUser :one
 SELECT 1
 FROM user_roles ur
 JOIN roles r ON ur.role_id = r.id
 WHERE ur.users_idusers = ? AND r.name = ?
 LIMIT 1;
 
--- name: UserHasLoginRole :one
+-- name: GetLoginRoleForUser :one
 SELECT 1
 FROM user_roles ur
 JOIN roles r ON ur.role_id = r.id
 WHERE ur.users_idusers = ? AND r.can_login = 1
 LIMIT 1;
 
--- name: UserHasPublicProfileRole :one
+-- name: GetPublicProfileRoleForUser :one
 SELECT 1
 FROM user_roles ur
 JOIN roles r ON ur.role_id = r.id

--- a/internal/db/queries-permissions.sql.go
+++ b/internal/db/queries-permissions.sql.go
@@ -69,6 +69,26 @@ func (q *Queries) AdminDeleteUserRole(ctx context.Context, iduserRoles int32) er
 	return err
 }
 
+const adminGetRoleByNameForUser = `-- name: AdminGetRoleByNameForUser :one
+SELECT 1
+FROM user_roles ur
+JOIN roles r ON ur.role_id = r.id
+WHERE ur.users_idusers = ? AND r.name = ?
+LIMIT 1
+`
+
+type AdminGetRoleByNameForUserParams struct {
+	UsersIdusers int32
+	Name         string
+}
+
+func (q *Queries) AdminGetRoleByNameForUser(ctx context.Context, arg AdminGetRoleByNameForUserParams) (int32, error) {
+	row := q.db.QueryRowContext(ctx, adminGetRoleByNameForUser, arg.UsersIdusers, arg.Name)
+	var column_1 int32
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const adminUpdateUserRole = `-- name: AdminUpdateUserRole :exec
 UPDATE user_roles SET role_id = (SELECT id FROM roles WHERE name = ?) WHERE iduser_roles = ?
 `
@@ -95,6 +115,21 @@ func (q *Queries) GetAdministratorUserRole(ctx context.Context, usersIdusers int
 	var i UserRole
 	err := row.Scan(&i.IduserRoles, &i.UsersIdusers, &i.RoleID)
 	return &i, err
+}
+
+const getLoginRoleForUser = `-- name: GetLoginRoleForUser :one
+SELECT 1
+FROM user_roles ur
+JOIN roles r ON ur.role_id = r.id
+WHERE ur.users_idusers = ? AND r.can_login = 1
+LIMIT 1
+`
+
+func (q *Queries) GetLoginRoleForUser(ctx context.Context, usersIdusers int32) (int32, error) {
+	row := q.db.QueryRowContext(ctx, getLoginRoleForUser, usersIdusers)
+	var column_1 int32
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const getPermissionsByUserID = `-- name: GetPermissionsByUserID :many
@@ -188,6 +223,21 @@ func (q *Queries) GetPermissionsWithUsers(ctx context.Context, arg GetPermission
 		return nil, err
 	}
 	return items, nil
+}
+
+const getPublicProfileRoleForUser = `-- name: GetPublicProfileRoleForUser :one
+SELECT 1
+FROM user_roles ur
+JOIN roles r ON ur.role_id = r.id
+WHERE ur.users_idusers = ? AND r.public_profile_allowed_at IS NOT NULL
+LIMIT 1
+`
+
+func (q *Queries) GetPublicProfileRoleForUser(ctx context.Context, usersIdusers int32) (int32, error) {
+	row := q.db.QueryRowContext(ctx, getPublicProfileRoleForUser, usersIdusers)
+	var column_1 int32
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const getUserRole = `-- name: GetUserRole :one
@@ -489,54 +539,4 @@ type SystemCreateUserRoleParams struct {
 func (q *Queries) SystemCreateUserRole(ctx context.Context, arg SystemCreateUserRoleParams) error {
 	_, err := q.db.ExecContext(ctx, systemCreateUserRole, arg.UsersIdusers, arg.Name)
 	return err
-}
-
-const userHasLoginRole = `-- name: UserHasLoginRole :one
-SELECT 1
-FROM user_roles ur
-JOIN roles r ON ur.role_id = r.id
-WHERE ur.users_idusers = ? AND r.can_login = 1
-LIMIT 1
-`
-
-func (q *Queries) UserHasLoginRole(ctx context.Context, usersIdusers int32) (int32, error) {
-	row := q.db.QueryRowContext(ctx, userHasLoginRole, usersIdusers)
-	var column_1 int32
-	err := row.Scan(&column_1)
-	return column_1, err
-}
-
-const userHasPublicProfileRole = `-- name: UserHasPublicProfileRole :one
-SELECT 1
-FROM user_roles ur
-JOIN roles r ON ur.role_id = r.id
-WHERE ur.users_idusers = ? AND r.public_profile_allowed_at IS NOT NULL
-LIMIT 1
-`
-
-func (q *Queries) UserHasPublicProfileRole(ctx context.Context, usersIdusers int32) (int32, error) {
-	row := q.db.QueryRowContext(ctx, userHasPublicProfileRole, usersIdusers)
-	var column_1 int32
-	err := row.Scan(&column_1)
-	return column_1, err
-}
-
-const userHasRole = `-- name: UserHasRole :one
-SELECT 1
-FROM user_roles ur
-JOIN roles r ON ur.role_id = r.id
-WHERE ur.users_idusers = ? AND r.name = ?
-LIMIT 1
-`
-
-type UserHasRoleParams struct {
-	UsersIdusers int32
-	Name         string
-}
-
-func (q *Queries) UserHasRole(ctx context.Context, arg UserHasRoleParams) (int32, error) {
-	row := q.db.QueryRowContext(ctx, userHasRole, arg.UsersIdusers, arg.Name)
-	var column_1 int32
-	err := row.Scan(&column_1)
-	return column_1, err
 }

--- a/internal/db/queries-search.sql
+++ b/internal/db/queries-search.sql
@@ -254,7 +254,7 @@ ON DUPLICATE KEY UPDATE word_count=VALUES(word_count);
 -- name: SystemDeleteWritingSearchByWritingID :exec
 DELETE FROM writing_search
 WHERE writing_id = sqlc.arg(writing_id);
--- name: WritingSearchFirst :many
+-- name: ListWritingSearchFirstForLister :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
@@ -286,7 +286,7 @@ WHERE swl.word = sqlc.arg(word)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
 
--- name: WritingSearchNext :many
+-- name: ListWritingSearchNextForLister :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
@@ -319,7 +319,7 @@ WHERE swl.word = sqlc.arg(word)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
 
--- name: SiteNewsSearchFirst :many
+-- name: ListSiteNewsSearchFirstForLister :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
@@ -351,7 +351,7 @@ WHERE swl.word = sqlc.arg(word)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
 
--- name: SiteNewsSearchNext :many
+-- name: ListSiteNewsSearchNextForLister :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )

--- a/internal/db/queries-threads.sql
+++ b/internal/db/queries-threads.sql
@@ -87,7 +87,7 @@ WHERE th.idforumthread=sqlc.arg(thread_id)
   )
 ORDER BY t.lastaddition DESC;
 
--- name: MakeThread :execlastid
+-- name: SystemCreateThread :execlastid
 INSERT INTO forumthread (forumtopic_idforumtopic) VALUES (?);
 
 

--- a/internal/db/queries-threads.sql.go
+++ b/internal/db/queries-threads.sql.go
@@ -267,12 +267,12 @@ func (q *Queries) GetThreadLastPosterAndPerms(ctx context.Context, arg GetThread
 	return &i, err
 }
 
-const makeThread = `-- name: MakeThread :execlastid
+const systemCreateThread = `-- name: SystemCreateThread :execlastid
 INSERT INTO forumthread (forumtopic_idforumtopic) VALUES (?)
 `
 
-func (q *Queries) MakeThread(ctx context.Context, forumtopicIdforumtopic int32) (int64, error) {
-	result, err := q.db.ExecContext(ctx, makeThread, forumtopicIdforumtopic)
+func (q *Queries) SystemCreateThread(ctx context.Context, forumtopicIdforumtopic int32) (int64, error) {
+	result, err := q.db.ExecContext(ctx, systemCreateThread, forumtopicIdforumtopic)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/queries-user_emails.sql
+++ b/internal/db/queries-user_emails.sql
@@ -48,8 +48,9 @@ SET verified_at = ?, last_verification_code = NULL, verification_expires_at = NU
 WHERE id = ?;
 
 
--- name: SetNotificationPriority :exec
-UPDATE user_emails SET notification_priority = ? WHERE id = ?;
+-- name: SetNotificationPriorityForLister :exec
+UPDATE user_emails SET notification_priority = sqlc.arg(notification_priority)
+WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(lister_id);
 
 -- name: GetNotificationEmailByUserID :one
 SELECT id, user_id, email, verified_at, last_verification_code, verification_expires_at, notification_priority
@@ -61,8 +62,11 @@ LIMIT 1;
 -- name: DeleteUserEmailForOwner :exec
 DELETE FROM user_emails WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(owner_id);
 
--- name: SetVerificationCode :exec
-UPDATE user_emails SET last_verification_code = ?, verification_expires_at = ? WHERE id = ?;
+-- name: SetVerificationCodeForLister :exec
+UPDATE user_emails
+SET last_verification_code = sqlc.arg(last_verification_code),
+    verification_expires_at = sqlc.arg(verification_expires_at)
+WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(lister_id);
 
 -- name: GetUserEmailByCode :one
 SELECT id, user_id, email, verified_at, last_verification_code, verification_expires_at, notification_priority

--- a/internal/db/queries-user_emails.sql.go
+++ b/internal/db/queries-user_emails.sql.go
@@ -239,32 +239,43 @@ func (q *Queries) ListUserEmailsForLister(ctx context.Context, arg ListUserEmail
 	return items, nil
 }
 
-const setNotificationPriority = `-- name: SetNotificationPriority :exec
-UPDATE user_emails SET notification_priority = ? WHERE id = ?
+const setNotificationPriorityForLister = `-- name: SetNotificationPriorityForLister :exec
+UPDATE user_emails SET notification_priority = ?
+WHERE id = ? AND user_id = ?
 `
 
-type SetNotificationPriorityParams struct {
+type SetNotificationPriorityForListerParams struct {
 	NotificationPriority int32
 	ID                   int32
+	ListerID             int32
 }
 
-func (q *Queries) SetNotificationPriority(ctx context.Context, arg SetNotificationPriorityParams) error {
-	_, err := q.db.ExecContext(ctx, setNotificationPriority, arg.NotificationPriority, arg.ID)
+func (q *Queries) SetNotificationPriorityForLister(ctx context.Context, arg SetNotificationPriorityForListerParams) error {
+	_, err := q.db.ExecContext(ctx, setNotificationPriorityForLister, arg.NotificationPriority, arg.ID, arg.ListerID)
 	return err
 }
 
-const setVerificationCode = `-- name: SetVerificationCode :exec
-UPDATE user_emails SET last_verification_code = ?, verification_expires_at = ? WHERE id = ?
+const setVerificationCodeForLister = `-- name: SetVerificationCodeForLister :exec
+UPDATE user_emails
+SET last_verification_code = ?,
+    verification_expires_at = ?
+WHERE id = ? AND user_id = ?
 `
 
-type SetVerificationCodeParams struct {
+type SetVerificationCodeForListerParams struct {
 	LastVerificationCode  sql.NullString
 	VerificationExpiresAt sql.NullTime
 	ID                    int32
+	ListerID              int32
 }
 
-func (q *Queries) SetVerificationCode(ctx context.Context, arg SetVerificationCodeParams) error {
-	_, err := q.db.ExecContext(ctx, setVerificationCode, arg.LastVerificationCode, arg.VerificationExpiresAt, arg.ID)
+func (q *Queries) SetVerificationCodeForLister(ctx context.Context, arg SetVerificationCodeForListerParams) error {
+	_, err := q.db.ExecContext(ctx, setVerificationCodeForLister,
+		arg.LastVerificationCode,
+		arg.VerificationExpiresAt,
+		arg.ID,
+		arg.ListerID,
+	)
 	return err
 }
 

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -293,7 +293,7 @@ GROUP BY u.idusers
 ORDER BY u.username
 LIMIT ? OFFSET ?;
 
--- name: SetWritingLastIndex :exec
+-- name: SystemSetWritingLastIndex :exec
 UPDATE writing SET last_index = NOW() WHERE idwriting = ?;
 
 

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -972,15 +972,6 @@ func (q *Queries) ListWritingsByIDsForLister(ctx context.Context, arg ListWritin
 	return items, nil
 }
 
-const setWritingLastIndex = `-- name: SetWritingLastIndex :exec
-UPDATE writing SET last_index = NOW() WHERE idwriting = ?
-`
-
-func (q *Queries) SetWritingLastIndex(ctx context.Context, idwriting int32) error {
-	_, err := q.db.ExecContext(ctx, setWritingLastIndex, idwriting)
-	return err
-}
-
 const systemAssignWritingThreadID = `-- name: SystemAssignWritingThreadID :exec
 UPDATE writing SET forumthread_id = ? WHERE idwriting = ?
 `
@@ -1175,6 +1166,15 @@ func (q *Queries) SystemListWritingCategories(ctx context.Context, arg SystemLis
 		return nil, err
 	}
 	return items, nil
+}
+
+const systemSetWritingLastIndex = `-- name: SystemSetWritingLastIndex :exec
+UPDATE writing SET last_index = NOW() WHERE idwriting = ?
+`
+
+func (q *Queries) SystemSetWritingLastIndex(ctx context.Context, idwriting int32) error {
+	_, err := q.db.ExecContext(ctx, systemSetWritingLastIndex, idwriting)
+	return err
 }
 
 const updateWritingForWriter = `-- name: UpdateWritingForWriter :exec

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -25,7 +25,7 @@ func TestNotificationsQueries(t *testing.T) {
 	}
 	rows := sqlmock.NewRows([]string{"cnt"}).AddRow(1)
 	mock.ExpectQuery("SELECT COUNT\\(\\*\\)").WillReturnRows(rows)
-	if c, err := q.CountUnreadNotificationsForUser(context.Background(), 1); err != nil || c != 1 {
+	if c, err := q.GetUnreadNotificationCountForLister(context.Background(), 1); err != nil || c != 1 {
 		t.Fatalf("count=%d err=%v", c, err)
 	}
 	mock.ExpectQuery("SELECT id, users_idusers").WillReturnRows(sqlmock.NewRows([]string{"id", "users_idusers", "link", "message", "created_at", "read_at"}).AddRow(1, 1, "/x", "hi", time.Now(), nil))
@@ -33,7 +33,7 @@ func TestNotificationsQueries(t *testing.T) {
 		t.Fatalf("get: %v", err)
 	}
 	mock.ExpectExec("UPDATE notifications SET read_at").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
-	if err := q.MarkNotificationReadForLister(context.Background(), db.MarkNotificationReadForListerParams{ID: 1, ListerID: 1}); err != nil {
+	if err := q.SetNotificationReadForLister(context.Background(), db.SetNotificationReadForListerParams{ID: 1, ListerID: 1}); err != nil {
 		t.Fatalf("mark: %v", err)
 	}
 	mock.ExpectExec("DELETE FROM notifications").WillReturnResult(sqlmock.NewResult(1, 1))

--- a/workers/emailqueue/email_queue.go
+++ b/workers/emailqueue/email_queue.go
@@ -158,14 +158,14 @@ func ProcessPendingEmail(ctx context.Context, q db.Querier, provider email.Provi
 	addr, err := ResolveQueuedEmailAddress(ctx, q, cfg, e)
 	if err != nil {
 		log.Printf("ResolveQueuedEmailAddress: %v", err)
-		if err := q.IncrementEmailError(ctx, e.ID); err != nil {
+		if err := q.SystemIncrementPendingEmailError(ctx, e.ID); err != nil {
 			log.Printf("increment email error: %v", err)
 		}
 		return false
 	}
 	if err := provider.Send(ctx, addr, []byte(e.Body)); err != nil {
 		log.Printf("send queued mail: %v", err)
-		if err := q.IncrementEmailError(ctx, e.ID); err != nil {
+		if err := q.SystemIncrementPendingEmailError(ctx, e.ID); err != nil {
 			log.Printf("increment email error: %v", err)
 			return true
 		}
@@ -181,7 +181,7 @@ func ProcessPendingEmail(ctx context.Context, q db.Querier, provider email.Provi
 		}
 		return true
 	}
-	if err := q.MarkEmailSent(ctx, e.ID); err != nil {
+	if err := q.SystemMarkPendingEmailSent(ctx, e.ID); err != nil {
 		log.Printf("mark sent: %v", err)
 	}
 	return true

--- a/workers/postcountworker/postupdate.go
+++ b/workers/postcountworker/postupdate.go
@@ -13,7 +13,7 @@ func PostUpdate(ctx context.Context, q db.Querier, threadID, topicID int32) erro
 	if err := q.AdminRecalculateForumThreadByIdMetaData(ctx, threadID); err != nil {
 		return fmt.Errorf("recalc thread metadata: %w", err)
 	}
-	if err := q.RebuildForumTopicByIdMetaColumns(ctx, topicID); err != nil {
+	if err := q.SystemRebuildForumTopicMetaByID(ctx, topicID); err != nil {
 		return fmt.Errorf("rebuild topic metadata: %w", err)
 	}
 	return nil

--- a/workers/postcountworker/postupdate_test.go
+++ b/workers/postcountworker/postupdate_test.go
@@ -19,7 +19,7 @@ func TestPostUpdate(t *testing.T) {
 	mock.ExpectExec("AdminRecalculateForumThreadByIdMetaData").
 		WithArgs(int32(1)).
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec("RebuildForumTopicByIdMetaColumns").
+	mock.ExpectExec("SystemRebuildForumTopicMetaByID").
 		WithArgs(int32(2)).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 

--- a/workers/searchworker/worker.go
+++ b/workers/searchworker/worker.go
@@ -89,13 +89,13 @@ func index(ctx context.Context, q db.Querier, data IndexEventData) error {
 	}
 	switch data.Type {
 	case TypeComment:
-		return q.SetCommentLastIndex(ctx, data.ID)
+		return q.SystemSetCommentLastIndex(ctx, data.ID)
 	case TypeWriting:
-		return q.SetWritingLastIndex(ctx, data.ID)
+		return q.SystemSetWritingLastIndex(ctx, data.ID)
 	case TypeLinker:
-		return q.SetLinkerLastIndex(ctx, data.ID)
+		return q.SystemSetLinkerLastIndex(ctx, data.ID)
 	case TypeImage:
-		return q.SetImagePostLastIndex(ctx, data.ID)
+		return q.SystemSetImagePostLastIndex(ctx, data.ID)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- enforce naming conventions for notifications queries and other sqlc outputs
- align forum and password reset helpers with System/Admin prefixes
- secure email updates by requiring lister ID

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f152b6000832fa151443adc6161d8