### PR TITLE
Use CoreData for languages page templates

### DIFF
--- a/core/templates/site/admin/languagesPage.gohtml
+++ b/core/templates/site/admin/languagesPage.gohtml
@@ -6,7 +6,7 @@
                 <th>Name</th>
                 <th>Options</th>
             </tr>
-            {{range $.Rows}}
+            {{range cd.Languages}}
                 <tr>
                     <td>{{.Idlanguage}}</td>
                     <td>

--- a/handlers/languages/admin.go
+++ b/handlers/languages/admin.go
@@ -2,7 +2,6 @@ package languages
 
 import (
 	"database/sql"
-	_ "embed"
 	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"net/http"
@@ -19,25 +18,9 @@ func adminLanguageRedirect(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminLanguagesPage(w http.ResponseWriter, r *http.Request) {
-	type Data struct {
-		*common.CoreData
-		Rows []*db.Language
-	}
-
-	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-	}
-
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-
-	rows, err := cd.Languages()
-	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-	data.Rows = rows
-
-	handlers.TemplateHandler(w, r, "languagesPage.gohtml", data)
+	cd.PageTitle = "Languages"
+	handlers.TemplateHandler(w, r, "languagesPage.gohtml", cd)
 }
 
 func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/languages/delete_language_task.go
+++ b/handlers/languages/delete_language_task.go
@@ -33,7 +33,7 @@ func (DeleteLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("cid parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	var name string
-	if rows, err := queries.SystemListLanguages(r.Context()); err == nil {
+	if rows, err := cd.Languages(); err == nil {
 		for _, l := range rows {
 			if l.Idlanguage == int32(cid) {
 				name = l.Nameof.String


### PR DESCRIPTION
## Summary
- load language list lazily in templates via CoreData
- remove direct language queries from admin handler and tasks

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f19706780832fa62a36302e7d8712