### PR TITLE
Refactor forum admin pages to use lazy data

### DIFF
--- a/core/templates/site/forum/adminThreadsPage.gohtml
+++ b/core/templates/site/forum/adminThreadsPage.gohtml
@@ -1,17 +1,20 @@
 {{ template "head" $ }}
-{{ range $idx, $tid := .Order }}
-    {{ $grp := index $.Groups $tid }}
-    <h2>{{ $grp.TopicTitle }}</h2>
+{{ range $topic := call cd.AdminForumTopics }}
+    <h2>{{ $topic.Title.String }}</h2>
     <table border="1">
         <tr><th>ID<th>Posts<th>Last Addition<th>View public</tr>
-        {{ range $grp.Threads }}
+        {{ range call cd.ForumThreads $topic.Idforumtopic }}
             <tr>
                 <td><a href="/admin/forum/thread/{{ .Idforumthread }}">{{ .Idforumthread }}</a></td>
                 <td>{{ .Comments.Int32 }}</td>
                 <td>{{ .Lastaddition.Time }}</td>
                 <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic }}/thread/{{ .Idforumthread }}">View</a></td>
             </tr>
+        {{ else }}
+            <tr><td colspan="4">No threads</td></tr>
         {{ end }}
     </table>
+{{ else }}
+    <p>No topics</p>
 {{ end }}
 {{ template "tail" $ }}

--- a/core/templates/site/forum/adminTopicsPage.gohtml
+++ b/core/templates/site/forum/adminTopicsPage.gohtml
@@ -11,7 +11,7 @@
             <th>Restrictions
             <th>Options?
         </tr>
-        {{ range .Topics }}
+        {{ range call cd.AdminForumTopics }}
             <tr>
                 <td>{{ .Idforumtopic }}</td>
                 <td>
@@ -20,7 +20,7 @@
                         <input name="name" value="{{ .Title.String }}">
                 </td>
                 <td><textarea name="desc">{{ .Description.String }}</textarea></td>
-                <td>{{ $fcid := .ForumcategoryIdforumcategory }} <select name="cid" value="{{ .ForumcategoryIdforumcategory }}"><option value="0">None</option>{{ range $.Categories }}<option value="{{.Idforumcategory}}" {{if eq $fcid .Idforumcategory}}selected{{end}}>{{.Title.String}}</option>  {{ end }}</select></td>
+                <td>{{ $fcid := .ForumcategoryIdforumcategory }} <select name="cid" value="{{ .ForumcategoryIdforumcategory }}"><option value="0">None</option>{{ range call cd.ForumCategories }}<option value="{{.Idforumcategory}}" {{if eq $fcid .Idforumcategory}}selected{{end}}>{{.Title.String}}</option>  {{ end }}</select></td>
                 <td align="center">{{ .Threads.Int32 }}</td>
                 <td align="center">{{ .Comments.Int32 }}</td>
                 <td><a href="/forum/topic/{{ .Idforumtopic }}">View</a></td>
@@ -35,6 +35,8 @@
                     </form>
                 </td>
             </tr>
+        {{ else }}
+            <tr><td colspan="9">No topics</td></tr>
         {{ end }}
         <tr>
             <td>New</td>
@@ -44,7 +46,7 @@
                     <input name="name" value="">
             </td>
             <td><textarea name="desc"></textarea></td>
-            <td><select name="pcid" value=""><option value="0">None</option>{{ range $.Categories }}<option value="{{.Idforumcategory}}">{{.Title.String}}</option>{{ end }}</select></td>
+            <td><select name="pcid" value=""><option value="0">None</option>{{ range call cd.ForumCategories }}<option value="{{.Idforumcategory}}">{{.Title.String}}</option>{{ end }}</select></td>
             <td>0</td>
             <td>0</td>
             <td></td>


### PR DESCRIPTION
## Summary
- add CoreData.ForumTopics lazy helper
- simplify forum admin pages to pass CoreData directly
- move thread/topic rendering to templates using range/else constructs
- provide AdminForumTopics helper to avoid magic category IDs

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f19655c08832faa29522eb4a21f32