### PR TITLE
refactor subscriptions to lazy coredata

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -134,6 +134,7 @@ type CoreData struct {
 	subImageBoards           map[int32]*lazy.Value[[]*db.Imageboard]
 	unreadCount              lazy.Value[int64]
 	subscriptions            lazy.Value[map[string]bool]
+	userSubscriptions        lazy.Value[[]*db.ListSubscriptionsByUserRow]
 	user                     lazy.Value[*db.User]
 	userRoles                lazy.Value[[]string]
 	visibleWritingCategories lazy.Value[[]*db.WritingCategory]
@@ -1260,24 +1261,33 @@ func (cd *CoreData) subscriptionMap() (map[string]bool, error) {
 		if cd.queries == nil || cd.UserID == 0 {
 			return map[string]bool{}, nil
 		}
-		rows, err := cd.queries.ListSubscriptionsByUser(cd.ctx, cd.UserID)
+		rows, err := cd.UserSubscriptions()
 		if err != nil {
 			return nil, err
 		}
 		m := make(map[string]bool)
 		for _, row := range rows {
-			if row.Method == "internal" {
-				m[row.Pattern] = true
-			}
+			key := row.Pattern + "|" + row.Method
+			m[key] = true
 		}
 		return m, nil
 	})
 }
 
-// Subscribed reports whether the user has a subscription matching pattern.
-func (cd *CoreData) Subscribed(pattern string) bool {
+// Subscribed reports whether the user has a subscription matching pattern and method.
+func (cd *CoreData) Subscribed(pattern, method string) bool {
 	m, _ := cd.subscriptionMap()
-	return m[pattern]
+	return m[pattern+"|"+method]
+}
+
+// UserSubscriptions returns the current user's subscriptions loaded lazily.
+func (cd *CoreData) UserSubscriptions() ([]*db.ListSubscriptionsByUserRow, error) {
+	return cd.userSubscriptions.Load(func() ([]*db.ListSubscriptionsByUserRow, error) {
+		if cd.queries == nil || cd.UserID == 0 {
+			return nil, nil
+		}
+		return cd.queries.ListSubscriptionsByUser(cd.ctx, cd.UserID)
+	})
 }
 
 // LinkerCategoryCounts lazily loads linker category statistics.

--- a/core/templates/site/user/subscriptions.gohtml
+++ b/core/templates/site/user/subscriptions.gohtml
@@ -1,9 +1,8 @@
 {{ template "head" $ }}
 <h2>Your Subscriptions</h2>
-{{ if .Subs }}
 <table>
 <tr><th>Pattern</th><th>Method</th><th></th></tr>
-{{ range .Subs }}
+{{ range .UserSubscriptions }}
 <tr>
 <td>{{ .Pattern }}</td>
 <td>{{ .Method }}</td>
@@ -12,14 +11,13 @@
     {{ csrfField }}
     <input type="hidden" name="id" value="{{ .ID }}">
     <input type="submit" name="task" value="Delete">
-</form>
+    </form>
 </td>
 </tr>
+{{ else }}
+<tr><td colspan="3">No subscriptions</td></tr>
 {{ end }}
 </table>
-{{ else }}
-<p>No subscriptions</p>
-{{ end }}
 
 <h3>Update Subscriptions</h3>
 <form method="post" action="/usr/subscriptions/update">
@@ -27,8 +25,8 @@
     {{ range .Options }}
     <div>
         {{ .Name }}
-        <label><input type="checkbox" name="{{ .Path }}_internal" {{ if index $.SubMap (printf "%s|internal" .Pattern) }}checked{{ end }}>Internal</label>
-        <label><input type="checkbox" name="{{ .Path }}_email" {{ if index $.SubMap (printf "%s|email" .Pattern) }}checked{{ end }}>Email</label>
+        <label><input type="checkbox" name="{{ .Path }}_internal" {{ if $.Subscribed .Pattern "internal" }}checked{{ end }}>Internal</label>
+        <label><input type="checkbox" name="{{ .Path }}_email" {{ if $.Subscribed .Pattern "email" }}checked{{ end }}>Email</label>
     </div>
     {{ end }}
     <input type="submit" name="task" value="Update">

--- a/handlers/forum/forumSubscriptions.go
+++ b/handlers/forum/forumSubscriptions.go
@@ -17,5 +17,5 @@ func subscribedToTopic(cd *common.CoreData, topicID int32) bool {
 	if cd == nil || cd.UserID == 0 {
 		return false
 	}
-	return cd.Subscribed(topicSubscriptionPattern(topicID))
+	return cd.Subscribed(topicSubscriptionPattern(topicID), "internal")
 }

--- a/handlers/user/subscriptionOptions.go
+++ b/handlers/user/subscriptionOptions.go
@@ -1,0 +1,16 @@
+package user
+
+// subscriptionOption describes a subscription choice presented to the user.
+type subscriptionOption struct {
+	Name    string
+	Pattern string
+	Path    string
+}
+
+// userSubscriptionOptions lists the available subscription options.
+var userSubscriptionOptions = []subscriptionOption{
+	{Name: "New blog posts", Pattern: "post:/blog/*", Path: "blogs"},
+	{Name: "New articles", Pattern: "post:/writing/*", Path: "writings"},
+	{Name: "New news posts", Pattern: "post:/news/*", Path: "news"},
+	{Name: "New image board posts", Pattern: "post:/image/*", Path: "images"},
+}

--- a/handlers/user/userSubscriptionsPage.go
+++ b/handlers/user/userSubscriptionsPage.go
@@ -1,63 +1,19 @@
 package user
 
 import (
-	"github.com/arran4/goa4web/core/consts"
-	"log"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
-
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-
-	"github.com/arran4/goa4web/core"
-	"github.com/arran4/goa4web/internal/db"
 )
-
-type subscriptionOption struct {
-	Name    string
-	Pattern string
-	Path    string
-}
-
-var userSubscriptionOptions = []subscriptionOption{
-	{Name: "New blog posts", Pattern: "post:/blog/*", Path: "blogs"},
-	{Name: "New articles", Pattern: "post:/writing/*", Path: "writings"},
-	{Name: "New news posts", Pattern: "post:/news/*", Path: "news"},
-	{Name: "New image board posts", Pattern: "post:/image/*", Path: "images"},
-}
 
 func userSubscriptionsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Subscriptions"
-	session, ok := core.GetSessionOrFail(w, r)
-	if !ok {
-		return
-	}
-	uid, _ := session.Values["UID"].(int32)
-	queries := cd.Queries()
-	rows, err := queries.ListSubscriptionsByUser(r.Context(), uid)
-	if err != nil {
-		log.Printf("list subs: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-	subMap := make(map[string]bool)
-	for _, s := range rows {
-		key := s.Pattern + "|" + s.Method
-		subMap[key] = true
-	}
 	data := struct {
 		*common.CoreData
-		Subs    []*db.ListSubscriptionsByUserRow
 		Options []subscriptionOption
-		SubMap  map[string]bool
-		Error   string
-	}{
-		CoreData: cd,
-		Subs:     rows,
-		Options:  userSubscriptionOptions,
-		SubMap:   subMap,
-		Error:    r.URL.Query().Get("error"),
-	}
+	}{cd, userSubscriptionOptions}
 	handlers.TemplateHandler(w, r, "subscriptions.gohtml", data)
 }


### PR DESCRIPTION
## Summary
- keep subscription options in user handlers package for shared use
- trim redundant subscription helpers from template Funcs and rely on CoreData methods
- update subscriptions handler and template to call lazy helpers with range/else

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f19814870832f80b2f83a4d9a1e06