### PR TITLE
refactor faq data access

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -102,48 +102,57 @@ type CoreData struct {
 	customQueries db.CustomQueries
 	emailProvider lazy.Value[MailProvider]
 
-	allRoles                 lazy.Value[[]*db.Role]
-	announcement             lazy.Value[*db.GetActiveAnnouncementWithNewsForListerRow]
-	annMu                    sync.Mutex
-	bloggers                 lazy.Value[[]*db.BloggerCountRow]
-	bookmarks                lazy.Value[*db.GetBookmarksForUserRow]
-	event                    *eventbus.TaskEvent
-	forumCategories          lazy.Value[[]*db.Forumcategory]
-	forumThreads             map[int32]*lazy.Value[[]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow]
-	forumTopics              map[int32]*lazy.Value[*db.GetForumTopicByIdForUserRow]
-	forumThreadRows          map[int32]*lazy.Value[*db.GetThreadLastPosterAndPermsRow]
-	forumComments            map[int32]*lazy.Value[*db.GetCommentByIdForUserRow]
-	newsPosts                map[int32]*lazy.Value[*db.GetForumThreadIdByNewsPostIdRow]
-	currentThreadID          int32
-	currentTopicID           int32
-	currentCommentID         int32
-	currentNewsPostID        int32
-	imageBoardPosts          map[int32]*lazy.Value[[]*db.ListImagePostsByBoardForListerRow]
-	imageBoards              lazy.Value[[]*db.Imageboard]
-	languagesAll             lazy.Value[[]*db.Language]
-	langs                    lazy.Value[[]*db.Language]
-	latestNews               lazy.Value[[]*NewsPost]
-	latestWritings           lazy.Value[[]*db.Writing]
-	linkerCategories         lazy.Value[[]*db.GetLinkerCategoryLinkCountsRow]
-	newsAnnouncements        map[int32]*lazy.Value[*db.SiteAnnouncement]
-	notifCount               lazy.Value[int32]
-	perms                    lazy.Value[[]*db.GetPermissionsByUserIDRow]
-	pref                     lazy.Value[*db.Preference]
-	preferredLanguageID      lazy.Value[int32]
-	publicWritings           map[string]*lazy.Value[[]*db.ListPublicWritingsInCategoryForListerRow]
-	subImageBoards           map[int32]*lazy.Value[[]*db.Imageboard]
-	unreadCount              lazy.Value[int64]
-	subscriptions            lazy.Value[map[string]bool]
-	user                     lazy.Value[*db.User]
-	userRoles                lazy.Value[[]string]
-	visibleWritingCategories lazy.Value[[]*db.WritingCategory]
-	writerWritings           map[int32]*lazy.Value[[]*db.ListPublicWritingsByUserForListerRow]
-	writers                  lazy.Value[[]*db.WriterCountRow]
-	writingCategories        lazy.Value[[]*db.WritingCategory]
-	currentWritingID         int32
-	writingRows              map[int32]*lazy.Value[*db.GetWritingForListerByIDRow]
-	currentBlogID            int32
-	blogEntries              map[int32]*lazy.Value[*db.GetBlogEntryForListerByIDRow]
+	allRoles                  lazy.Value[[]*db.Role]
+	annMu                     sync.Mutex
+	announcement              lazy.Value[*db.GetActiveAnnouncementWithNewsForListerRow]
+	bloggers                  lazy.Value[[]*db.BloggerCountRow]
+	bookmarks                 lazy.Value[*db.GetBookmarksForUserRow]
+	event                     *eventbus.TaskEvent
+	faqAnswered               lazy.Value[[]*db.Faq]
+	faqAnsweredWithCategories lazy.Value[[]*db.GetAllAnsweredFAQWithFAQCategoriesForUserRow]
+	faqCategories             lazy.Value[[]*db.FaqCategory]
+	faqCategoriesCount        lazy.Value[[]*db.GetFAQCategoriesWithQuestionCountRow]
+	faqDismissed              lazy.Value[[]*db.Faq]
+	faqRevisions              map[int32]*lazy.Value[[]*db.FaqRevision]
+	faqRows                   map[int32]*lazy.Value[*db.Faq]
+	faqUnanswered             lazy.Value[[]*db.Faq]
+	forumCategories           lazy.Value[[]*db.Forumcategory]
+	forumComments             map[int32]*lazy.Value[*db.GetCommentByIdForUserRow]
+	forumThreadRows           map[int32]*lazy.Value[*db.GetThreadLastPosterAndPermsRow]
+	forumThreads              map[int32]*lazy.Value[[]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow]
+	forumTopics               map[int32]*lazy.Value[*db.GetForumTopicByIdForUserRow]
+	newsPosts                 map[int32]*lazy.Value[*db.GetForumThreadIdByNewsPostIdRow]
+	currentThreadID           int32
+	currentTopicID            int32
+	currentCommentID          int32
+	currentFAQID              int32
+	currentNewsPostID         int32
+	imageBoardPosts           map[int32]*lazy.Value[[]*db.ListImagePostsByBoardForListerRow]
+	imageBoards               lazy.Value[[]*db.Imageboard]
+	languagesAll              lazy.Value[[]*db.Language]
+	langs                     lazy.Value[[]*db.Language]
+	latestNews                lazy.Value[[]*NewsPost]
+	latestWritings            lazy.Value[[]*db.Writing]
+	linkerCategories          lazy.Value[[]*db.GetLinkerCategoryLinkCountsRow]
+	newsAnnouncements         map[int32]*lazy.Value[*db.SiteAnnouncement]
+	notifCount                lazy.Value[int32]
+	perms                     lazy.Value[[]*db.GetPermissionsByUserIDRow]
+	pref                      lazy.Value[*db.Preference]
+	preferredLanguageID       lazy.Value[int32]
+	publicWritings            map[string]*lazy.Value[[]*db.ListPublicWritingsInCategoryForListerRow]
+	subImageBoards            map[int32]*lazy.Value[[]*db.Imageboard]
+	unreadCount               lazy.Value[int64]
+	subscriptions             lazy.Value[map[string]bool]
+	user                      lazy.Value[*db.User]
+	userRoles                 lazy.Value[[]string]
+	visibleWritingCategories  lazy.Value[[]*db.WritingCategory]
+	writerWritings            map[int32]*lazy.Value[[]*db.ListPublicWritingsByUserForListerRow]
+	writers                   lazy.Value[[]*db.WriterCountRow]
+	writingCategories         lazy.Value[[]*db.WritingCategory]
+	currentWritingID          int32
+	writingRows               map[int32]*lazy.Value[*db.GetWritingForListerByIDRow]
+	currentBlogID             int32
+	blogEntries               map[int32]*lazy.Value[*db.GetBlogEntryForListerByIDRow]
 
 	absoluteURLBase lazy.Value[string]
 	dbRegistry      *dbdrivers.Registry
@@ -152,51 +161,12 @@ type CoreData struct {
 	marks map[string]struct{}
 }
 
-// SetRoles preloads the current user roles.
-func (cd *CoreData) SetRoles(r []string) { cd.userRoles.Set(r) }
-
-// Marked returns true the first time it is called with key. Subsequent
-// calls return false. It is used to avoid re-rendering template sections
-// when streaming pages after an error.
-func (cd *CoreData) Marked(key string) bool {
-	if cd.marks == nil {
-		cd.marks = map[string]struct{}{}
-	}
-	_, marked := cd.marks[key]
-	cd.marks[key] = struct{}{}
-	return !marked
-}
-
 // CoreOption configures a new CoreData instance.
 type CoreOption func(*CoreData)
 
 // WithImageURLMapper sets the a4code image mapper option.
 func WithImageURLMapper(fn func(tag, val string) string) CoreOption {
 	return func(cd *CoreData) { cd.a4codeMapper = fn }
-}
-
-func (cd *CoreData) composeMapper() {
-	var fns []func(tag, val string) string
-	if cd.ImageSigner != nil {
-		fns = append(fns, cd.ImageSigner.MapURL)
-	}
-	if cd.LinkSigner != nil {
-		fns = append(fns, cd.LinkSigner.MapURL)
-	}
-	if len(fns) == 0 {
-		cd.a4codeMapper = nil
-		return
-	}
-	cd.a4codeMapper = func(tag, val string) string {
-		for _, fn := range fns {
-			newVal := fn(tag, val)
-			if newVal != val {
-				return newVal
-			}
-			val = newVal
-		}
-		return val
-	}
 }
 
 // WithSession stores the gorilla session on the CoreData object.
@@ -280,67 +250,10 @@ func NewCoreData(ctx context.Context, q db.Querier, cfg *config.RuntimeConfig, o
 	return cd
 }
 
-// Queries returns the db.Queries instance associated with this CoreData.
-func (cd *CoreData) Queries() db.Querier { return cd.queries }
-
-// CustomQueries returns the db.CustomQueries instance associated with this CoreData.
-func (cd *CoreData) CustomQueries() db.CustomQueries { return cd.customQueries }
-
-// ImageURLMapper maps image references like "image:" or "cache:" to full URLs.
-func (cd *CoreData) ImageURLMapper(tag, val string) string {
-	if cd.a4codeMapper != nil {
-		return cd.a4codeMapper(tag, val)
-	}
-	return val
-}
-
 // EmailProvider lazily returns the configured email provider.
 // WithEmailProvider sets the email provider used by CoreData.
 func WithEmailProvider(p MailProvider) CoreOption {
 	return func(cd *CoreData) { cd.emailProvider.Set(p) }
-}
-
-// EmailProvider returns the configured email provider.
-func (cd *CoreData) EmailProvider() MailProvider {
-	p, err := cd.emailProvider.Load(func() (MailProvider, error) { return nil, nil })
-	if err != nil {
-		log.Printf("load email provider: %v", err)
-	}
-	return p
-}
-
-// HasRole reports whether the current user explicitly has the named role.
-func (cd *CoreData) HasRole(role string) bool {
-	for _, r := range cd.UserRoles() {
-		if r == role {
-			return true
-		}
-	}
-	if cd.queries != nil {
-		for _, r := range cd.UserRoles() {
-			if _, err := cd.queries.SystemCheckRoleGrant(cd.ctx, db.SystemCheckRoleGrantParams{Name: r, Action: role}); err == nil {
-				return true
-			}
-		}
-	} else {
-		for _, r := range cd.UserRoles() {
-			switch r {
-			case "administrator":
-				if role == "moderator" || role == "content writer" || role == "user" {
-					return true
-				}
-			case "moderator":
-				if role == "user" {
-					return true
-				}
-			case "content writer":
-				if role == "user" {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }
 
 // ContainsItem returns true if items includes an entry with the given name.
@@ -353,65 +266,17 @@ func ContainsItem(items []IndexItem, name string) bool {
 	return false
 }
 
-// UserRoles returns the user roles loaded lazily.
-func (cd *CoreData) UserRoles() []string {
-	roles, err := cd.userRoles.Load(func() ([]string, error) {
-		rs := []string{"anonymous"}
-		if cd.UserID == 0 || cd.queries == nil {
-			return rs, nil
-		}
-		rs = append(rs, "user")
-		perms, err := cd.queries.GetPermissionsByUserID(cd.ctx, cd.UserID)
-		if err != nil {
-			return rs, nil
-		}
-		for _, p := range perms {
-			if p.Name != "" {
-				rs = append(rs, p.Name)
-			}
-		}
-		return rs, nil
-	})
-	if err != nil {
-		log.Printf("load user roles: %v", err)
-	}
-	return roles
+// LatestWritings returns recent public writings with permission data.
+type LatestWritingsOption func(*db.GetPublicWritingsParams)
+
+// WithWritingsOffset sets the query offset.
+func WithWritingsOffset(o int32) LatestWritingsOption {
+	return func(p *db.GetPublicWritingsParams) { p.Offset = o }
 }
 
-// Role returns the first loaded role or "anonymous" when none.
-func (cd *CoreData) Role() string {
-	roles := cd.UserRoles()
-	if len(roles) == 0 {
-		return "anonymous"
-	}
-	return roles[0]
-}
-
-// SetSession stores s on cd for later retrieval.
-func (cd *CoreData) SetSession(s *sessions.Session) { cd.session = s }
-
-// Session returns the request session if available.
-func (cd *CoreData) Session() *sessions.Session { return cd.session }
-
-// SessionManager returns the configured session manager, if any.
-func (cd *CoreData) SessionManager() SessionManager { return cd.sessionManager }
-
-// DBRegistry returns the database driver registry associated with this request.
-func (cd *CoreData) DBRegistry() *dbdrivers.Registry { return cd.dbRegistry }
-
-// SetEvent stores evt on cd for handler access.
-func (cd *CoreData) SetEvent(evt *eventbus.TaskEvent) { cd.event = evt }
-
-// SetEventTask records the task associated with the current request event.
-func (cd *CoreData) SetEventTask(t tasks.Task) {
-	if cd.event != nil {
-		cd.event.Task = t
-	}
-}
-
-// SetPageTitle updates the Title field used by templates.
-func (cd *CoreData) SetPageTitle(title string) {
-	cd.Title = title
+// WithWritingsLimit sets the query limit.
+func WithWritingsLimit(l int32) LatestWritingsOption {
+	return func(p *db.GetPublicWritingsParams) { p.Limit = l }
 }
 
 // AbsoluteURL returns an absolute URL by combining the configured hostname or
@@ -424,39 +289,331 @@ func (cd *CoreData) AbsoluteURL(path string) string {
 	return base + path
 }
 
-// Event returns the event associated with the request, if any.
-func (cd *CoreData) Event() *eventbus.TaskEvent { return cd.event }
+// AdminCreateFAQCategory inserts a new FAQ category.
+func (cd *CoreData) AdminCreateFAQCategory(name string) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.AdminCreateFAQCategory(cd.ctx, sql.NullString{String: name, Valid: true})
+}
 
-// CurrentUser returns the logged in user's record loaded on demand.
-func (cd *CoreData) CurrentUser() (*db.User, error) {
-	return cd.user.Load(func() (*db.User, error) {
-		if cd.UserID == 0 || cd.queries == nil {
-			return nil, nil
-		}
-		row, err := cd.queries.SystemGetUserByID(cd.ctx, cd.UserID)
-		if err != nil {
-			if !errors.Is(err, sql.ErrNoRows) {
-				return nil, err
-			}
-			return nil, nil
-		}
-		return &db.User{Idusers: row.Idusers, Username: row.Username}, nil
+// AdminDeleteFAQ removes a FAQ entry.
+func (cd *CoreData) AdminDeleteFAQ(id int32) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.AdminDeleteFAQ(cd.ctx, id)
+}
+
+// AdminDeleteFAQCategory removes an FAQ category.
+func (cd *CoreData) AdminDeleteFAQCategory(id int32) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.AdminDeleteFAQCategory(cd.ctx, id)
+}
+
+// AdminUpdateFAQQuestion updates an existing FAQ entry.
+func (cd *CoreData) AdminUpdateFAQQuestion(faqID, categoryID int32, question, answer string) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.AdminUpdateFAQQuestionAnswer(cd.ctx, db.AdminUpdateFAQQuestionAnswerParams{
+		Answer:                       sql.NullString{String: answer, Valid: true},
+		Question:                     sql.NullString{String: question, Valid: true},
+		FaqcategoriesIdfaqcategories: categoryID,
+		Idfaq:                        faqID,
 	})
 }
 
-// CurrentUserLoaded returns the cached current user without triggering a database lookup.
-func (cd *CoreData) CurrentUserLoaded() *db.User {
-	u, ok := cd.user.Peek()
+// AllAnsweredFAQWithCategories returns all answered FAQs with category data.
+func (cd *CoreData) AllAnsweredFAQWithCategories() ([]*db.GetAllAnsweredFAQWithFAQCategoriesForUserRow, error) {
+	return cd.faqAnsweredWithCategories.Load(func() ([]*db.GetAllAnsweredFAQWithFAQCategoriesForUserRow, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetAllAnsweredFAQWithFAQCategoriesForUser(cd.ctx, db.GetAllAnsweredFAQWithFAQCategoriesForUserParams{
+			ViewerID: cd.UserID,
+			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		})
+	})
+}
+
+// AllLanguages returns all languages cached once.
+func (cd *CoreData) AllLanguages() ([]*db.Language, error) {
+	return cd.languagesAll.Load(func() ([]*db.Language, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.SystemListLanguages(cd.ctx)
+	})
+}
+
+// AllRoles returns every defined role loaded once from the database.
+func (cd *CoreData) AllRoles() ([]*db.Role, error) {
+	return cd.allRoles.Load(func() ([]*db.Role, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.AdminListRoles(cd.ctx)
+	})
+}
+
+// Announcement returns the active announcement row loaded lazily.
+func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsForListerRow {
+	ann, err := cd.announcement.Load(func() (*db.GetActiveAnnouncementWithNewsForListerRow, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		row, err := cd.queries.GetActiveAnnouncementWithNewsForLister(cd.ctx, db.GetActiveAnnouncementWithNewsForListerParams{
+			ListerID: cd.UserID,
+			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return row, nil
+	})
+	if err != nil {
+		log.Printf("load announcement: %v", err)
+	}
+	return ann
+}
+
+// AnnouncementForNews fetches the latest announcement for the given news post
+// only once.
+func (cd *CoreData) AnnouncementForNews(id int32) (*db.SiteAnnouncement, error) {
+	if cd.newsAnnouncements == nil {
+		cd.newsAnnouncements = map[int32]*lazy.Value[*db.SiteAnnouncement]{}
+	}
+	lv, ok := cd.newsAnnouncements[id]
+	if !ok {
+		lv = &lazy.Value[*db.SiteAnnouncement]{}
+		cd.newsAnnouncements[id] = lv
+	}
+	return lv.Load(func() (*db.SiteAnnouncement, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		ann, err := cd.queries.GetLatestAnnouncementByNewsID(cd.ctx, id)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return ann, err
+	})
+}
+
+// AnnouncementLoaded returns the cached active announcement without querying the database.
+func (cd *CoreData) AnnouncementLoaded() *db.GetActiveAnnouncementWithNewsForListerRow {
+	ann, ok := cd.announcement.Peek()
 	if !ok {
 		return nil
 	}
-	return u
+	return ann
 }
 
-// SetCurrentThreadAndTopic stores the requested thread and topic IDs.
-func (cd *CoreData) SetCurrentThreadAndTopic(threadID, topicID int32) {
-	cd.currentThreadID = threadID
-	cd.currentTopicID = topicID
+// BlogEntryByID returns a blog entry lazily loading it once per ID.
+func (cd *CoreData) BlogEntryByID(id int32, ops ...lazy.Option[*db.GetBlogEntryForListerByIDRow]) (*db.GetBlogEntryForListerByIDRow, error) {
+	fetch := func(i int32) (*db.GetBlogEntryForListerByIDRow, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetBlogEntryForListerByID(cd.ctx, db.GetBlogEntryForListerByIDParams{
+			ListerID: cd.UserID,
+			ID:       i,
+			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		})
+	}
+	return lazy.Map(&cd.blogEntries, &cd.mapMu, id, fetch, ops...)
+}
+
+// Bloggers returns bloggers ordered by username with post counts.
+func (cd *CoreData) Bloggers(r *http.Request) ([]*db.BloggerCountRow, error) {
+	return cd.bloggers.Load(func() ([]*db.BloggerCountRow, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		ps := cd.PageSize()
+		search := r.URL.Query().Get("search")
+		if search != "" {
+			return cd.customQueries.SearchBloggers(cd.ctx, db.SearchBloggersParams{
+				ListerID: cd.UserID,
+				Query:    search,
+				Limit:    int32(ps + 1),
+				Offset:   int32(offset),
+			})
+		}
+		return cd.customQueries.ListBloggers(cd.ctx, db.ListBloggersParams{
+			ListerID: cd.UserID,
+			Limit:    int32(ps + 1),
+			Offset:   int32(offset),
+		})
+	})
+}
+
+// Bookmarks returns the user's bookmark list loaded lazily.
+func (cd *CoreData) Bookmarks() (*db.GetBookmarksForUserRow, error) {
+	return cd.bookmarks.Load(func() (*db.GetBookmarksForUserRow, error) {
+		if cd.UserID == 0 || cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetBookmarksForUser(cd.ctx, cd.UserID)
+	})
+}
+
+// CanEditAny reports whether cd is in admin mode with administrator role.
+func (cd *CoreData) CanEditAny() bool {
+	return cd.HasRole("administrator") && cd.AdminMode
+}
+
+// CommentByID returns a forum comment lazily loading it once per ID.
+func (cd *CoreData) CommentByID(id int32, ops ...lazy.Option[*db.GetCommentByIdForUserRow]) (*db.GetCommentByIdForUserRow, error) {
+	fetch := func(i int32) (*db.GetCommentByIdForUserRow, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetCommentByIdForUser(cd.ctx, db.GetCommentByIdForUserParams{
+			ViewerID: cd.UserID,
+			ID:       i,
+			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		})
+	}
+	return lazy.Map(&cd.forumComments, &cd.mapMu, id, fetch, ops...)
+}
+
+func (cd *CoreData) composeMapper() {
+	var fns []func(tag, val string) string
+	if cd.ImageSigner != nil {
+		fns = append(fns, cd.ImageSigner.MapURL)
+	}
+	if cd.LinkSigner != nil {
+		fns = append(fns, cd.LinkSigner.MapURL)
+	}
+	if len(fns) == 0 {
+		cd.a4codeMapper = nil
+		return
+	}
+	cd.a4codeMapper = func(tag, val string) string {
+		for _, fn := range fns {
+			newVal := fn(tag, val)
+			if newVal != val {
+				return newVal
+			}
+			val = newVal
+		}
+		return val
+	}
+}
+
+// CreateFAQQuestion queues a question from a user.
+func (cd *CoreData) CreateFAQQuestion(question string, writerID, languageID, granteeID int32) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.CreateFAQQuestionForWriter(cd.ctx, db.CreateFAQQuestionForWriterParams{
+		Question:   sql.NullString{String: question, Valid: true},
+		WriterID:   writerID,
+		LanguageID: languageID,
+		GranteeID:  sql.NullInt32{Int32: granteeID, Valid: true},
+	})
+}
+
+// CurrentBlog returns the currently requested blog entry lazily loaded.
+func (cd *CoreData) CurrentBlog(ops ...lazy.Option[*db.GetBlogEntryForListerByIDRow]) (*db.GetBlogEntryForListerByIDRow, error) {
+	if cd.currentBlogID == 0 {
+		return nil, nil
+	}
+	return cd.BlogEntryByID(cd.currentBlogID, ops...)
+}
+
+// CurrentBlogLoaded returns the cached current blog entry without database access.
+func (cd *CoreData) CurrentBlogLoaded() *db.GetBlogEntryForListerByIDRow {
+	if cd.blogEntries == nil {
+		return nil
+	}
+	lv, ok := cd.blogEntries[cd.currentBlogID]
+	if !ok {
+		return nil
+	}
+	v, ok := lv.Peek()
+	if !ok {
+		return nil
+	}
+	return v
+}
+
+// CurrentComment returns the current comment lazily loaded.
+func (cd *CoreData) CurrentComment(r *http.Request, ops ...lazy.Option[*db.GetCommentByIdForUserRow]) (*db.GetCommentByIdForUserRow, error) {
+	if cd.currentCommentID == 0 {
+		if r != nil {
+			idStr := r.URL.Query().Get("comment")
+			if idStr == "" {
+				if vars := mux.Vars(r); vars != nil {
+					idStr = vars["comment"]
+				}
+			}
+			if idStr != "" {
+				id, err := strconv.Atoi(idStr)
+				if err != nil {
+					return nil, fmt.Errorf("invalid comment id: %w", err)
+				}
+				cd.currentCommentID = int32(id)
+			}
+		}
+		if cd.currentCommentID == 0 {
+			return nil, nil
+		}
+	}
+	return cd.CommentByID(cd.currentCommentID, ops...)
+}
+
+// CurrentCommentLoaded returns the cached current comment if available.
+func (cd *CoreData) CurrentCommentLoaded() *db.GetCommentByIdForUserRow {
+	if cd.forumComments == nil {
+		return nil
+	}
+	lv, ok := cd.forumComments[cd.currentCommentID]
+	if !ok {
+		return nil
+	}
+	v, ok := lv.Peek()
+	if !ok {
+		return nil
+	}
+	return v
+}
+
+// CurrentFAQ returns the FAQ for the stored current FAQ ID.
+func (cd *CoreData) CurrentFAQ(ops ...lazy.Option[*db.Faq]) (*db.Faq, error) {
+	if cd.currentFAQID == 0 {
+		return &db.Faq{Idfaq: 0}, nil
+	}
+	return cd.FAQByID(cd.currentFAQID, ops...)
+}
+
+// CurrentNewsPost returns the current news post lazily loaded.
+func (cd *CoreData) CurrentNewsPost(ops ...lazy.Option[*db.GetForumThreadIdByNewsPostIdRow]) (*db.GetForumThreadIdByNewsPostIdRow, error) {
+	if cd.currentNewsPostID == 0 {
+		return nil, nil
+	}
+	return cd.NewsPostByID(cd.currentNewsPostID, ops...)
+}
+
+// CurrentNewsPostLoaded returns the cached current news post if available.
+func (cd *CoreData) CurrentNewsPostLoaded() *db.GetForumThreadIdByNewsPostIdRow {
+	if cd.newsPosts == nil {
+		return nil
+	}
+	lv, ok := cd.newsPosts[cd.currentNewsPostID]
+	if !ok {
+		return nil
+	}
+	v, ok := lv.Peek()
+	if !ok {
+		return nil
+	}
+	return v
 }
 
 // CurrentThread returns the currently requested thread lazily loaded.
@@ -507,8 +664,31 @@ func (cd *CoreData) CurrentTopicLoaded() *db.GetForumTopicByIdForUserRow {
 	return v
 }
 
-// SetCurrentWriting stores the requested writing ID.
-func (cd *CoreData) SetCurrentWriting(id int32) { cd.currentWritingID = id }
+// CurrentUser returns the logged in user's record loaded on demand.
+func (cd *CoreData) CurrentUser() (*db.User, error) {
+	return cd.user.Load(func() (*db.User, error) {
+		if cd.UserID == 0 || cd.queries == nil {
+			return nil, nil
+		}
+		row, err := cd.queries.SystemGetUserByID(cd.ctx, cd.UserID)
+		if err != nil {
+			if !errors.Is(err, sql.ErrNoRows) {
+				return nil, err
+			}
+			return nil, nil
+		}
+		return &db.User{Idusers: row.Idusers, Username: row.Username}, nil
+	})
+}
+
+// CurrentUserLoaded returns the cached current user without triggering a database lookup.
+func (cd *CoreData) CurrentUserLoaded() *db.User {
+	u, ok := cd.user.Peek()
+	if !ok {
+		return nil
+	}
+	return u
+}
 
 // CurrentWriting returns the currently requested writing lazily loaded.
 func (cd *CoreData) CurrentWriting(ops ...lazy.Option[*db.GetWritingForListerByIDRow]) (*db.GetWritingForListerByIDRow, error) {
@@ -534,246 +714,101 @@ func (cd *CoreData) CurrentWritingLoaded() *db.GetWritingForListerByIDRow {
 	return v
 }
 
-// SetCurrentBlog stores the requested blog entry ID.
-func (cd *CoreData) SetCurrentBlog(id int32) { cd.currentBlogID = id }
+// CustomQueries returns the db.CustomQueries instance associated with this CoreData.
+func (cd *CoreData) CustomQueries() db.CustomQueries { return cd.customQueries }
 
-// CurrentBlog returns the currently requested blog entry lazily loaded.
-func (cd *CoreData) CurrentBlog(ops ...lazy.Option[*db.GetBlogEntryForListerByIDRow]) (*db.GetBlogEntryForListerByIDRow, error) {
-	if cd.currentBlogID == 0 {
-		return nil, nil
-	}
-	return cd.BlogEntryByID(cd.currentBlogID, ops...)
-}
+// DBRegistry returns the database driver registry associated with this request.
+func (cd *CoreData) DBRegistry() *dbdrivers.Registry { return cd.dbRegistry }
 
-// CurrentBlogLoaded returns the cached current blog entry without database access.
-func (cd *CoreData) CurrentBlogLoaded() *db.GetBlogEntryForListerByIDRow {
-	if cd.blogEntries == nil {
-		return nil
-	}
-	lv, ok := cd.blogEntries[cd.currentBlogID]
-	if !ok {
-		return nil
-	}
-	v, ok := lv.Peek()
-	if !ok {
-		return nil
-	}
-	return v
-}
-
-// Permissions returns the user's permissions loaded on demand.
-func (cd *CoreData) Permissions() ([]*db.GetPermissionsByUserIDRow, error) {
-	return cd.perms.Load(func() ([]*db.GetPermissionsByUserIDRow, error) {
-		if cd.UserID == 0 || cd.queries == nil {
-			return nil, nil
-		}
-		return cd.queries.GetPermissionsByUserID(cd.ctx, cd.UserID)
-	})
-}
-
-// Preference returns the user's preferences loaded on demand.
-func (cd *CoreData) Preference() (*db.Preference, error) {
-	return cd.pref.Load(func() (*db.Preference, error) {
-		if cd.UserID == 0 || cd.queries == nil {
-			return nil, nil
-		}
-		return cd.queries.GetPreferenceForLister(cd.ctx, cd.UserID)
-	})
-}
-
-// PageSize returns the preferred page size within configured limits.
-func (cd *CoreData) PageSize() int {
-	size := cd.Config.PageSizeDefault
-	if pref, err := cd.Preference(); err == nil && pref != nil && pref.PageSize != 0 {
-		size = int(pref.PageSize)
-	}
-	if size < cd.Config.PageSizeMin {
-		size = cd.Config.PageSizeMin
-	}
-	if size > cd.Config.PageSizeMax {
-		size = cd.Config.PageSizeMax
-	}
-	return size
-}
-
-// Languages returns the list of available languages loaded on demand.
-func (cd *CoreData) Languages() ([]*db.Language, error) {
-	return cd.langs.Load(func() ([]*db.Language, error) {
-		if cd.queries == nil {
-			return nil, nil
-		}
-		return cd.queries.SystemListLanguages(cd.ctx)
-	})
-}
-
-// AllLanguages returns all languages cached once.
-func (cd *CoreData) AllLanguages() ([]*db.Language, error) {
-	return cd.languagesAll.Load(func() ([]*db.Language, error) {
-		if cd.queries == nil {
-			return nil, nil
-		}
-		return cd.queries.SystemListLanguages(cd.ctx)
-	})
-}
-
-// PreferredLanguageID returns the user's preferred language ID if set,
-// otherwise it resolves the site's default language name to an ID.
-func (cd *CoreData) PreferredLanguageID(siteDefault string) int32 {
-	id, err := cd.preferredLanguageID.Load(func() (int32, error) {
-		if pref, err := cd.Preference(); err == nil && pref != nil {
-			if pref.LanguageIdlanguage != 0 {
-				return pref.LanguageIdlanguage, nil
-			}
-		}
-		if cd.queries == nil || siteDefault == "" {
-			return 0, nil
-		}
-		langID, err := cd.queries.SystemGetLanguageIDByName(cd.ctx, sql.NullString{String: siteDefault, Valid: true})
-		if err != nil {
-			return 0, nil
-		}
-		return langID, nil
-	})
+// EmailProvider returns the configured email provider.
+func (cd *CoreData) EmailProvider() MailProvider {
+	p, err := cd.emailProvider.Load(func() (MailProvider, error) { return nil, nil })
 	if err != nil {
-		log.Printf("load preferred language id: %v", err)
+		log.Printf("load email provider: %v", err)
 	}
-	return id
+	return p
 }
 
-// AllRoles returns every defined role loaded once from the database.
-func (cd *CoreData) AllRoles() ([]*db.Role, error) {
-	return cd.allRoles.Load(func() ([]*db.Role, error) {
+// Event returns the event associated with the request, if any.
+func (cd *CoreData) Event() *eventbus.TaskEvent { return cd.event }
+
+// ExecuteSiteTemplate renders the named site template using cd's helper
+// functions. It wraps templates.GetCompiledSiteTemplates(cd.Funcs(r)).
+func (cd *CoreData) ExecuteSiteTemplate(w io.Writer, r *http.Request, name string, data any) error {
+	return templates.GetCompiledSiteTemplates(cd.Funcs(r)).ExecuteTemplate(w, name, data)
+}
+
+// FAQAnsweredQuestions returns answered FAQ entries visible to the user.
+func (cd *CoreData) FAQAnsweredQuestions() ([]*db.Faq, error) {
+	return cd.faqAnswered.Load(func() ([]*db.Faq, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		return cd.queries.AdminListRoles(cd.ctx)
-	})
-}
-
-// Announcement returns the active announcement row loaded lazily.
-func (cd *CoreData) Announcement() *db.GetActiveAnnouncementWithNewsForListerRow {
-	ann, err := cd.announcement.Load(func() (*db.GetActiveAnnouncementWithNewsForListerRow, error) {
-		if cd.queries == nil {
-			return nil, nil
-		}
-		row, err := cd.queries.GetActiveAnnouncementWithNewsForLister(cd.ctx, db.GetActiveAnnouncementWithNewsForListerParams{
-			ListerID: cd.UserID,
+		return cd.queries.GetFAQAnsweredQuestions(cd.ctx, db.GetFAQAnsweredQuestionsParams{
+			ViewerID: cd.UserID,
 			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 		})
-		if err != nil {
-			return nil, err
-		}
-		return row, nil
 	})
-	if err != nil {
-		log.Printf("load announcement: %v", err)
-	}
-	return ann
 }
 
-// AnnouncementLoaded returns the cached active announcement without querying the database.
-func (cd *CoreData) AnnouncementLoaded() *db.GetActiveAnnouncementWithNewsForListerRow {
-	ann, ok := cd.announcement.Peek()
-	if !ok {
-		return nil
-	}
-	return ann
-}
-
-// AnnouncementForNews fetches the latest announcement for the given news post
-// only once.
-func (cd *CoreData) AnnouncementForNews(id int32) (*db.SiteAnnouncement, error) {
-	if cd.newsAnnouncements == nil {
-		cd.newsAnnouncements = map[int32]*lazy.Value[*db.SiteAnnouncement]{}
-	}
-	lv, ok := cd.newsAnnouncements[id]
-	if !ok {
-		lv = &lazy.Value[*db.SiteAnnouncement]{}
-		cd.newsAnnouncements[id] = lv
-	}
-	return lv.Load(func() (*db.SiteAnnouncement, error) {
+// FAQByID loads a FAQ entry once per ID.
+func (cd *CoreData) FAQByID(id int32, ops ...lazy.Option[*db.Faq]) (*db.Faq, error) {
+	return lazy.Map(&cd.faqRows, &cd.mapMu, id, func(i int32) (*db.Faq, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		ann, err := cd.queries.GetLatestAnnouncementByNewsID(cd.ctx, id)
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil
-		}
-		return ann, err
-	})
+		return cd.queries.GetFAQByID(cd.ctx, i)
+	}, ops...)
 }
 
-// NewsAnnouncement returns the latest announcement for the given news post. The
-// result is cached so repeated lookups for the same id hit the database only
-// once.
-func (cd *CoreData) NewsAnnouncement(id int32) (*db.SiteAnnouncement, error) {
-	cd.annMu.Lock()
-	lv, ok := cd.newsAnnouncements[id]
-	if !ok {
-		lv = &lazy.Value[*db.SiteAnnouncement]{}
-		cd.newsAnnouncements[id] = lv
-	}
-	cd.annMu.Unlock()
-
-	return lv.Load(func() (*db.SiteAnnouncement, error) {
+// FAQCategories returns all FAQ categories once.
+func (cd *CoreData) FAQCategories() ([]*db.FaqCategory, error) {
+	return cd.faqCategories.Load(func() ([]*db.FaqCategory, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		ann, err := cd.queries.GetLatestAnnouncementByNewsID(cd.ctx, id)
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return nil, nil
-			}
-			return nil, err
-		}
-		return ann, nil
+		return cd.queries.GetAllFAQCategories(cd.ctx)
 	})
 }
 
-// ForumCategories loads all forum categories once.
-func (cd *CoreData) ForumCategories() ([]*db.Forumcategory, error) {
-	return cd.forumCategories.Load(func() ([]*db.Forumcategory, error) {
+// FAQCategoriesWithQuestionCount returns categories with question totals.
+func (cd *CoreData) FAQCategoriesWithQuestionCount() ([]*db.GetFAQCategoriesWithQuestionCountRow, error) {
+	return cd.faqCategoriesCount.Load(func() ([]*db.GetFAQCategoriesWithQuestionCountRow, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		return cd.queries.GetAllForumCategories(cd.ctx)
+		return cd.queries.GetFAQCategoriesWithQuestionCount(cd.ctx)
 	})
 }
 
-// ForumThreads loads the threads for a forum topic once per topic.
-func (cd *CoreData) ForumThreads(topicID int32) ([]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow, error) {
-	if cd.forumThreads == nil {
-		cd.forumThreads = make(map[int32]*lazy.Value[[]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow])
-	}
-	lv, ok := cd.forumThreads[topicID]
-	if !ok {
-		lv = &lazy.Value[[]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow]{}
-		cd.forumThreads[topicID] = lv
-	}
-	return lv.Load(func() ([]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow, error) {
+// FAQDismissedQuestions returns dismissed FAQ entries.
+func (cd *CoreData) FAQDismissedQuestions() ([]*db.Faq, error) {
+	return cd.faqDismissed.Load(func() ([]*db.Faq, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		return cd.queries.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostText(cd.ctx, db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextParams{
-			ViewerID:      cd.UserID,
-			TopicID:       topicID,
-			ViewerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-		})
+		return cd.queries.GetFAQDismissedQuestions(cd.ctx)
 	})
 }
 
-// LatestNews returns recent news posts with permission data.
-func (cd *CoreData) LatestNews(r *http.Request) ([]*NewsPost, error) {
-	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-	replyID, _ := strconv.Atoi(r.URL.Query().Get("reply"))
-	return cd.latestNews.Load(func() ([]*NewsPost, error) {
-		return cd.fetchLatestNews(int32(offset), 15, replyID)
-	})
+// FAQRevisions returns revision history for a FAQ.
+func (cd *CoreData) FAQRevisions(id int32, ops ...lazy.Option[[]*db.FaqRevision]) ([]*db.FaqRevision, error) {
+	return lazy.Map(&cd.faqRevisions, &cd.mapMu, id, func(i int32) ([]*db.FaqRevision, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetFAQRevisionsForAdmin(cd.ctx, i)
+	}, ops...)
 }
 
-// LatestNewsList returns recent news posts without needing an HTTP request.
-func (cd *CoreData) LatestNewsList(offset, limit int32) ([]*NewsPost, error) {
-	return cd.fetchLatestNews(offset, limit, 0)
+// FAQUnansweredQuestions returns unanswered FAQ entries.
+func (cd *CoreData) FAQUnansweredQuestions() ([]*db.Faq, error) {
+	return cd.faqUnanswered.Load(func() ([]*db.Faq, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetFAQUnansweredQuestions(cd.ctx)
+	})
 }
 
 // fetchLatestNews loads news posts from the database with permission data.
@@ -813,17 +848,211 @@ func (cd *CoreData) fetchLatestNews(offset, limit int32, replyID int) ([]*NewsPo
 	return posts, nil
 }
 
-// LatestWritings returns recent public writings with permission data.
-type LatestWritingsOption func(*db.GetPublicWritingsParams)
-
-// WithWritingsOffset sets the query offset.
-func WithWritingsOffset(o int32) LatestWritingsOption {
-	return func(p *db.GetPublicWritingsParams) { p.Offset = o }
+// ForumCategories loads all forum categories once.
+func (cd *CoreData) ForumCategories() ([]*db.Forumcategory, error) {
+	return cd.forumCategories.Load(func() ([]*db.Forumcategory, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetAllForumCategories(cd.ctx)
+	})
 }
 
-// WithWritingsLimit sets the query limit.
-func WithWritingsLimit(l int32) LatestWritingsOption {
-	return func(p *db.GetPublicWritingsParams) { p.Limit = l }
+// ForumThreadByID returns a single forum thread lazily loading it once per ID.
+func (cd *CoreData) ForumThreadByID(id int32, ops ...lazy.Option[*db.GetThreadLastPosterAndPermsRow]) (*db.GetThreadLastPosterAndPermsRow, error) {
+	fetch := func(i int32) (*db.GetThreadLastPosterAndPermsRow, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetThreadLastPosterAndPerms(cd.ctx, db.GetThreadLastPosterAndPermsParams{
+			ViewerID:      cd.UserID,
+			ThreadID:      i,
+			ViewerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		})
+	}
+	return lazy.Map(&cd.forumThreadRows, &cd.mapMu, id, fetch, ops...)
+}
+
+// ForumThreads loads the threads for a forum topic once per topic.
+func (cd *CoreData) ForumThreads(topicID int32) ([]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow, error) {
+	if cd.forumThreads == nil {
+		cd.forumThreads = make(map[int32]*lazy.Value[[]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow])
+	}
+	lv, ok := cd.forumThreads[topicID]
+	if !ok {
+		lv = &lazy.Value[[]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow]{}
+		cd.forumThreads[topicID] = lv
+	}
+	return lv.Load(func() ([]*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostText(cd.ctx, db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextParams{
+			ViewerID:      cd.UserID,
+			TopicID:       topicID,
+			ViewerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		})
+	})
+}
+
+// ForumTopicByID loads a forum topic once per ID using caching.
+func (cd *CoreData) ForumTopicByID(id int32, ops ...lazy.Option[*db.GetForumTopicByIdForUserRow]) (*db.GetForumTopicByIdForUserRow, error) {
+	fetch := func(i int32) (*db.GetForumTopicByIdForUserRow, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetForumTopicByIdForUser(cd.ctx, db.GetForumTopicByIdForUserParams{
+			ViewerID:      cd.UserID,
+			Idforumtopic:  i,
+			ViewerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		})
+	}
+	return lazy.Map(&cd.forumTopics, &cd.mapMu, id, fetch, ops...)
+}
+
+// HasAdminRole reports whether the current user has the administrator role.
+func (cd *CoreData) HasAdminRole() bool {
+	return cd.HasRole("administrator")
+}
+
+// HasContentWriterRole reports whether the current user has the content writer role.
+func (cd *CoreData) HasContentWriterRole() bool {
+	return cd.HasRole("content writer")
+}
+
+// HasRole reports whether the current user explicitly has the named role.
+func (cd *CoreData) HasRole(role string) bool {
+	for _, r := range cd.UserRoles() {
+		if r == role {
+			return true
+		}
+	}
+	if cd.queries != nil {
+		for _, r := range cd.UserRoles() {
+			if _, err := cd.queries.SystemCheckRoleGrant(cd.ctx, db.SystemCheckRoleGrantParams{Name: r, Action: role}); err == nil {
+				return true
+			}
+		}
+	} else {
+		for _, r := range cd.UserRoles() {
+			switch r {
+			case "administrator":
+				if role == "moderator" || role == "content writer" || role == "user" {
+					return true
+				}
+			case "moderator":
+				if role == "user" {
+					return true
+				}
+			case "content writer":
+				if role == "user" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// ImageBoardPosts retrieves approved posts for the board lazily.
+func (cd *CoreData) ImageBoardPosts(boardID int32) ([]*db.ListImagePostsByBoardForListerRow, error) {
+	if cd.queries == nil {
+		return nil, nil
+	}
+	if cd.imageBoardPosts == nil {
+		cd.imageBoardPosts = make(map[int32]*lazy.Value[[]*db.ListImagePostsByBoardForListerRow])
+	}
+	lv, ok := cd.imageBoardPosts[boardID]
+	if !ok {
+		lv = &lazy.Value[[]*db.ListImagePostsByBoardForListerRow]{}
+		cd.imageBoardPosts[boardID] = lv
+	}
+	return lv.Load(func() ([]*db.ListImagePostsByBoardForListerRow, error) {
+		return cd.queries.ListImagePostsByBoardForLister(cd.ctx, db.ListImagePostsByBoardForListerParams{
+			ListerID:     cd.UserID,
+			BoardID:      boardID,
+			ListerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+			Limit:        200,
+			Offset:       0,
+		})
+	})
+}
+
+// ImageBoards returns all image boards cached once.
+func (cd *CoreData) ImageBoards() ([]*db.Imageboard, error) {
+	return cd.imageBoards.Load(func() ([]*db.Imageboard, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.AdminListBoards(cd.ctx, db.AdminListBoardsParams{Limit: 200, Offset: 0})
+	})
+}
+
+// ImageURLMapper maps image references like "image:" or "cache:" to full URLs.
+func (cd *CoreData) ImageURLMapper(tag, val string) string {
+	if cd.a4codeMapper != nil {
+		return cd.a4codeMapper(tag, val)
+	}
+	return val
+}
+
+// InsertFAQQuestion creates a new FAQ question for a writer.
+func (cd *CoreData) InsertFAQQuestion(question, answer string, categoryID, writerID int32) (int32, error) {
+	if cd.queries == nil {
+		return 0, nil
+	}
+	res, err := cd.queries.InsertFAQQuestionForWriter(cd.ctx, db.InsertFAQQuestionForWriterParams{
+		Question:   sql.NullString{String: question, Valid: true},
+		Answer:     sql.NullString{String: answer, Valid: true},
+		CategoryID: categoryID,
+		WriterID:   writerID,
+		LanguageID: 1,
+		GranteeID:  sql.NullInt32{Int32: writerID, Valid: true},
+	})
+	if err != nil {
+		return 0, err
+	}
+	id, _ := res.LastInsertId()
+	return int32(id), nil
+}
+
+// InsertFAQRevision records a revision for a FAQ entry.
+func (cd *CoreData) InsertFAQRevision(faqID, uid int32, question, answer string) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.InsertFAQRevisionForUser(cd.ctx, db.InsertFAQRevisionForUserParams{
+		FaqID:        faqID,
+		UsersIdusers: uid,
+		Question:     sql.NullString{String: question, Valid: true},
+		Answer:       sql.NullString{String: answer, Valid: true},
+		UserID:       sql.NullInt32{Int32: uid, Valid: true},
+		ViewerID:     uid,
+	})
+}
+
+// Languages returns the list of available languages loaded on demand.
+func (cd *CoreData) Languages() ([]*db.Language, error) {
+	return cd.langs.Load(func() ([]*db.Language, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.SystemListLanguages(cd.ctx)
+	})
+}
+
+// LatestNews returns recent news posts with permission data.
+func (cd *CoreData) LatestNews(r *http.Request) ([]*NewsPost, error) {
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	replyID, _ := strconv.Atoi(r.URL.Query().Get("reply"))
+	return cd.latestNews.Load(func() ([]*NewsPost, error) {
+		return cd.fetchLatestNews(int32(offset), 15, replyID)
+	})
+}
+
+// LatestNewsList returns recent news posts without needing an HTTP request.
+func (cd *CoreData) LatestNewsList(offset, limit int32) ([]*NewsPost, error) {
+	return cd.fetchLatestNews(offset, limit, 0)
 }
 
 func (cd *CoreData) LatestWritings(opts ...LatestWritingsOption) ([]*db.Writing, error) {
@@ -850,40 +1079,127 @@ func (cd *CoreData) LatestWritings(opts ...LatestWritingsOption) ([]*db.Writing,
 	})
 }
 
-// WritingCategories returns the visible writing categories for userID.
-func (cd *CoreData) VisibleWritingCategories(userID int32) ([]*db.WritingCategory, error) {
-	return cd.visibleWritingCategories.Load(func() ([]*db.WritingCategory, error) {
+// LinkerCategoryCounts lazily loads linker category statistics.
+func (cd *CoreData) LinkerCategoryCounts() ([]*db.GetLinkerCategoryLinkCountsRow, error) {
+	return cd.linkerCategories.Load(func() ([]*db.GetLinkerCategoryLinkCountsRow, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		rows, err := cd.queries.ListWritingCategoriesForLister(cd.ctx, db.ListWritingCategoriesForListerParams{
-			ListerID: cd.UserID,
-			UserID:   sql.NullInt32{Int32: userID, Valid: userID != 0},
-		})
+		rows, err := cd.queries.GetLinkerCategoryLinkCounts(cd.ctx)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+		return rows, nil
+	})
+}
+
+// Marked returns true the first time it is called with key. Subsequent
+// calls return false. It is used to avoid re-rendering template sections
+// when streaming pages after an error.
+func (cd *CoreData) Marked(key string) bool {
+	if cd.marks == nil {
+		cd.marks = map[string]struct{}{}
+	}
+	_, marked := cd.marks[key]
+	cd.marks[key] = struct{}{}
+	return !marked
+}
+
+// NewsAnnouncement returns the latest announcement for the given news post. The
+// result is cached so repeated lookups for the same id hit the database only
+// once.
+func (cd *CoreData) NewsAnnouncement(id int32) (*db.SiteAnnouncement, error) {
+	cd.annMu.Lock()
+	lv, ok := cd.newsAnnouncements[id]
+	if !ok {
+		lv = &lazy.Value[*db.SiteAnnouncement]{}
+		cd.newsAnnouncements[id] = lv
+	}
+	cd.annMu.Unlock()
+
+	return lv.Load(func() (*db.SiteAnnouncement, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		ann, err := cd.queries.GetLatestAnnouncementByNewsID(cd.ctx, id)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return nil, nil
 			}
 			return nil, err
 		}
-		var cats []*db.WritingCategory
-		for _, row := range rows {
-			if cd.HasGrant("writing", "category", "see", row.Idwritingcategory) {
-				cats = append(cats, row)
-			}
-		}
-		return cats, nil
+		return ann, nil
 	})
 }
 
-// WritingCategories returns all writing categories cached once.
-func (cd *CoreData) WritingCategories() ([]*db.WritingCategory, error) {
-	return cd.writingCategories.Load(func() ([]*db.WritingCategory, error) {
+// NewsPostByID returns the news post lazily loading it once per ID.
+func (cd *CoreData) NewsPostByID(id int32, ops ...lazy.Option[*db.GetForumThreadIdByNewsPostIdRow]) (*db.GetForumThreadIdByNewsPostIdRow, error) {
+	fetch := func(i int32) (*db.GetForumThreadIdByNewsPostIdRow, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		return cd.queries.SystemListWritingCategories(cd.ctx, db.SystemListWritingCategoriesParams{Limit: math.MaxInt32, Offset: 0})
+		return cd.queries.GetForumThreadIdByNewsPostId(cd.ctx, i)
+	}
+	return lazy.Map(&cd.newsPosts, &cd.mapMu, id, fetch, ops...)
+}
+
+// PageSize returns the preferred page size within configured limits.
+func (cd *CoreData) PageSize() int {
+	size := cd.Config.PageSizeDefault
+	if pref, err := cd.Preference(); err == nil && pref != nil && pref.PageSize != 0 {
+		size = int(pref.PageSize)
+	}
+	if size < cd.Config.PageSizeMin {
+		size = cd.Config.PageSizeMin
+	}
+	if size > cd.Config.PageSizeMax {
+		size = cd.Config.PageSizeMax
+	}
+	return size
+}
+
+// Permissions returns the user's permissions loaded on demand.
+func (cd *CoreData) Permissions() ([]*db.GetPermissionsByUserIDRow, error) {
+	return cd.perms.Load(func() ([]*db.GetPermissionsByUserIDRow, error) {
+		if cd.UserID == 0 || cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetPermissionsByUserID(cd.ctx, cd.UserID)
 	})
+}
+
+// Preference returns the user's preferences loaded on demand.
+func (cd *CoreData) Preference() (*db.Preference, error) {
+	return cd.pref.Load(func() (*db.Preference, error) {
+		if cd.UserID == 0 || cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.GetPreferenceForLister(cd.ctx, cd.UserID)
+	})
+}
+
+// PreferredLanguageID returns the user's preferred language ID if set,
+// otherwise it resolves the site's default language name to an ID.
+func (cd *CoreData) PreferredLanguageID(siteDefault string) int32 {
+	id, err := cd.preferredLanguageID.Load(func() (int32, error) {
+		if pref, err := cd.Preference(); err == nil && pref != nil {
+			if pref.LanguageIdlanguage != 0 {
+				return pref.LanguageIdlanguage, nil
+			}
+		}
+		if cd.queries == nil || siteDefault == "" {
+			return 0, nil
+		}
+		langID, err := cd.queries.SystemGetLanguageIDByName(cd.ctx, sql.NullString{String: siteDefault, Valid: true})
+		if err != nil {
+			return 0, nil
+		}
+		return langID, nil
+	})
+	if err != nil {
+		log.Printf("load preferred language id: %v", err)
+	}
+	return id
 }
 
 // PublicWritings returns public writings in a category, cached per category and offset.
@@ -925,28 +1241,189 @@ func (cd *CoreData) PublicWritings(categoryID int32, r *http.Request) ([]*db.Lis
 	})
 }
 
-// Bloggers returns bloggers ordered by username with post counts.
-func (cd *CoreData) Bloggers(r *http.Request) ([]*db.BloggerCountRow, error) {
-	return cd.bloggers.Load(func() ([]*db.BloggerCountRow, error) {
+// Queries returns the db.Queries instance associated with this CoreData.
+func (cd *CoreData) Queries() db.Querier { return cd.queries }
+
+// RenameFAQCategory changes a category name.
+func (cd *CoreData) RenameFAQCategory(id int32, name string) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.RenameFAQCategory(cd.ctx, db.RenameFAQCategoryParams{
+		Name:            sql.NullString{String: name, Valid: true},
+		Idfaqcategories: id,
+		ViewerID:        cd.UserID,
+	})
+}
+
+// Role returns the first loaded role or "anonymous" when none.
+func (cd *CoreData) Role() string {
+	roles := cd.UserRoles()
+	if len(roles) == 0 {
+		return "anonymous"
+	}
+	return roles[0]
+}
+
+// Session returns the request session if available.
+func (cd *CoreData) Session() *sessions.Session { return cd.session }
+
+// SessionManager returns the configured session manager, if any.
+func (cd *CoreData) SessionManager() SessionManager { return cd.sessionManager }
+
+// SetCurrentBlog stores the requested blog entry ID.
+func (cd *CoreData) SetCurrentBlog(id int32) { cd.currentBlogID = id }
+
+// SetCurrentFAQ stores the FAQ ID to be referenced by CurrentFAQ.
+func (cd *CoreData) SetCurrentFAQ(id int32) { cd.currentFAQID = id }
+
+// SetCurrentNewsPost stores the current news post ID.
+func (cd *CoreData) SetCurrentNewsPost(id int32) { cd.currentNewsPostID = id }
+
+// SetCurrentThreadAndTopic stores the requested thread and topic IDs.
+func (cd *CoreData) SetCurrentThreadAndTopic(threadID, topicID int32) {
+	cd.currentThreadID = threadID
+	cd.currentTopicID = topicID
+}
+
+// SetCurrentWriting stores the requested writing ID.
+func (cd *CoreData) SetCurrentWriting(id int32) { cd.currentWritingID = id }
+
+// SetEvent stores evt on cd for handler access.
+func (cd *CoreData) SetEvent(evt *eventbus.TaskEvent) { cd.event = evt }
+
+// SetEventTask records the task associated with the current request event.
+func (cd *CoreData) SetEventTask(t tasks.Task) {
+	if cd.event != nil {
+		cd.event.Task = t
+	}
+}
+
+// SetPageTitle updates the Title field used by templates.
+func (cd *CoreData) SetPageTitle(title string) {
+	cd.Title = title
+}
+
+// SetRoles preloads the current user roles.
+func (cd *CoreData) SetRoles(r []string) { cd.userRoles.Set(r) }
+
+// SetSession stores s on cd for later retrieval.
+func (cd *CoreData) SetSession(s *sessions.Session) { cd.session = s }
+
+// ImageBoards retrieves sub-boards under parentID lazily.
+func (cd *CoreData) SubImageBoards(parentID int32) ([]*db.Imageboard, error) {
+	if cd.queries == nil {
+		return nil, nil
+	}
+	if cd.subImageBoards == nil {
+		cd.subImageBoards = make(map[int32]*lazy.Value[[]*db.Imageboard])
+	}
+	lv, ok := cd.subImageBoards[parentID]
+	if !ok {
+		lv = &lazy.Value[[]*db.Imageboard]{}
+		cd.subImageBoards[parentID] = lv
+	}
+	return lv.Load(func() ([]*db.Imageboard, error) {
+		return cd.queries.ListBoardsByParentIDForLister(cd.ctx, db.ListBoardsByParentIDForListerParams{
+			ListerID:     cd.UserID,
+			ParentID:     parentID,
+			ListerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+			Limit:        200,
+			Offset:       0,
+		})
+	})
+}
+
+// Subscribed reports whether the user has a subscription matching pattern.
+func (cd *CoreData) Subscribed(pattern string) bool {
+	m, _ := cd.subscriptionMap()
+	return m[pattern]
+}
+
+// subscriptionMap loads the current user's subscriptions once.
+func (cd *CoreData) subscriptionMap() (map[string]bool, error) {
+	return cd.subscriptions.Load(func() (map[string]bool, error) {
+		if cd.queries == nil || cd.UserID == 0 {
+			return map[string]bool{}, nil
+		}
+		rows, err := cd.queries.ListSubscriptionsByUser(cd.ctx, cd.UserID)
+		if err != nil {
+			return nil, err
+		}
+		m := make(map[string]bool)
+		for _, row := range rows {
+			if row.Method == "internal" {
+				m[row.Pattern] = true
+			}
+		}
+		return m, nil
+	})
+}
+
+// UnreadNotificationCount returns the number of unread notifications for the
+// current user. The value is fetched lazily on the first call and cached for
+// subsequent calls.
+func (cd *CoreData) UnreadNotificationCount() int64 {
+	count, err := cd.unreadCount.Load(func() (int64, error) {
+		if cd.queries == nil || cd.UserID == 0 {
+			return 0, nil
+		}
+		return cd.queries.CountUnreadNotificationsForUser(cd.ctx, cd.UserID)
+	})
+	if err != nil {
+		log.Printf("load unread notification count: %v", err)
+	}
+	return count
+}
+
+// UserRoles returns the user roles loaded lazily.
+func (cd *CoreData) UserRoles() []string {
+	roles, err := cd.userRoles.Load(func() ([]string, error) {
+		rs := []string{"anonymous"}
+		if cd.UserID == 0 || cd.queries == nil {
+			return rs, nil
+		}
+		rs = append(rs, "user")
+		perms, err := cd.queries.GetPermissionsByUserID(cd.ctx, cd.UserID)
+		if err != nil {
+			return rs, nil
+		}
+		for _, p := range perms {
+			if p.Name != "" {
+				rs = append(rs, p.Name)
+			}
+		}
+		return rs, nil
+	})
+	if err != nil {
+		log.Printf("load user roles: %v", err)
+	}
+	return roles
+}
+
+// WritingCategories returns the visible writing categories for userID.
+func (cd *CoreData) VisibleWritingCategories(userID int32) ([]*db.WritingCategory, error) {
+	return cd.visibleWritingCategories.Load(func() ([]*db.WritingCategory, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-		ps := cd.PageSize()
-		search := r.URL.Query().Get("search")
-		if search != "" {
-			return cd.customQueries.SearchBloggers(cd.ctx, db.SearchBloggersParams{
-				ListerID: cd.UserID,
-				Query:    search,
-				Limit:    int32(ps + 1),
-				Offset:   int32(offset),
-			})
-		}
-		return cd.customQueries.ListBloggers(cd.ctx, db.ListBloggersParams{
+		rows, err := cd.queries.ListWritingCategoriesForLister(cd.ctx, db.ListWritingCategoriesForListerParams{
 			ListerID: cd.UserID,
-			Limit:    int32(ps + 1),
-			Offset:   int32(offset),
+			UserID:   sql.NullInt32{Int32: userID, Valid: userID != 0},
 		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		var cats []*db.WritingCategory
+		for _, row := range rows {
+			if cd.HasGrant("writing", "category", "see", row.Idwritingcategory) {
+				cats = append(cats, row)
+			}
+		}
+		return cats, nil
 	})
 }
 
@@ -973,160 +1450,6 @@ func (cd *CoreData) Writers(r *http.Request) ([]*db.WriterCountRow, error) {
 			Offset:   int32(offset),
 		})
 	})
-}
-
-// ForumTopicByID loads a forum topic once per ID using caching.
-func (cd *CoreData) ForumTopicByID(id int32, ops ...lazy.Option[*db.GetForumTopicByIdForUserRow]) (*db.GetForumTopicByIdForUserRow, error) {
-	fetch := func(i int32) (*db.GetForumTopicByIdForUserRow, error) {
-		if cd.queries == nil {
-			return nil, nil
-		}
-		return cd.queries.GetForumTopicByIdForUser(cd.ctx, db.GetForumTopicByIdForUserParams{
-			ViewerID:      cd.UserID,
-			Idforumtopic:  i,
-			ViewerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-		})
-	}
-	return lazy.Map(&cd.forumTopics, &cd.mapMu, id, fetch, ops...)
-}
-
-// ForumThreadByID returns a single forum thread lazily loading it once per ID.
-func (cd *CoreData) ForumThreadByID(id int32, ops ...lazy.Option[*db.GetThreadLastPosterAndPermsRow]) (*db.GetThreadLastPosterAndPermsRow, error) {
-	fetch := func(i int32) (*db.GetThreadLastPosterAndPermsRow, error) {
-		if cd.queries == nil {
-			return nil, nil
-		}
-		return cd.queries.GetThreadLastPosterAndPerms(cd.ctx, db.GetThreadLastPosterAndPermsParams{
-			ViewerID:      cd.UserID,
-			ThreadID:      i,
-			ViewerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-		})
-	}
-	return lazy.Map(&cd.forumThreadRows, &cd.mapMu, id, fetch, ops...)
-}
-
-// WritingByID returns a single writing lazily loading it once per ID.
-func (cd *CoreData) WritingByID(id int32, ops ...lazy.Option[*db.GetWritingForListerByIDRow]) (*db.GetWritingForListerByIDRow, error) {
-	fetch := func(i int32) (*db.GetWritingForListerByIDRow, error) {
-		if cd.queries == nil {
-			return nil, nil
-		}
-		return cd.queries.GetWritingForListerByID(cd.ctx, db.GetWritingForListerByIDParams{
-			ListerID:      cd.UserID,
-			Idwriting:     i,
-			ListerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-		})
-	}
-	return lazy.Map(&cd.writingRows, &cd.mapMu, id, fetch, ops...)
-}
-
-// BlogEntryByID returns a blog entry lazily loading it once per ID.
-func (cd *CoreData) BlogEntryByID(id int32, ops ...lazy.Option[*db.GetBlogEntryForListerByIDRow]) (*db.GetBlogEntryForListerByIDRow, error) {
-	fetch := func(i int32) (*db.GetBlogEntryForListerByIDRow, error) {
-		if cd.queries == nil {
-			return nil, nil
-		}
-		return cd.queries.GetBlogEntryForListerByID(cd.ctx, db.GetBlogEntryForListerByIDParams{
-			ListerID: cd.UserID,
-			ID:       i,
-			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-		})
-	}
-	return lazy.Map(&cd.blogEntries, &cd.mapMu, id, fetch, ops...)
-}
-
-// CommentByID returns a forum comment lazily loading it once per ID.
-func (cd *CoreData) CommentByID(id int32, ops ...lazy.Option[*db.GetCommentByIdForUserRow]) (*db.GetCommentByIdForUserRow, error) {
-	fetch := func(i int32) (*db.GetCommentByIdForUserRow, error) {
-		if cd.queries == nil {
-			return nil, nil
-		}
-		return cd.queries.GetCommentByIdForUser(cd.ctx, db.GetCommentByIdForUserParams{
-			ViewerID: cd.UserID,
-			ID:       i,
-			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-		})
-	}
-	return lazy.Map(&cd.forumComments, &cd.mapMu, id, fetch, ops...)
-}
-
-// CurrentComment returns the current comment lazily loaded.
-func (cd *CoreData) CurrentComment(r *http.Request, ops ...lazy.Option[*db.GetCommentByIdForUserRow]) (*db.GetCommentByIdForUserRow, error) {
-	if cd.currentCommentID == 0 {
-		if r != nil {
-			idStr := r.URL.Query().Get("comment")
-			if idStr == "" {
-				if vars := mux.Vars(r); vars != nil {
-					idStr = vars["comment"]
-				}
-			}
-			if idStr != "" {
-				id, err := strconv.Atoi(idStr)
-				if err != nil {
-					return nil, fmt.Errorf("invalid comment id: %w", err)
-				}
-				cd.currentCommentID = int32(id)
-			}
-		}
-		if cd.currentCommentID == 0 {
-			return nil, nil
-		}
-	}
-	return cd.CommentByID(cd.currentCommentID, ops...)
-}
-
-// CurrentCommentLoaded returns the cached current comment if available.
-func (cd *CoreData) CurrentCommentLoaded() *db.GetCommentByIdForUserRow {
-	if cd.forumComments == nil {
-		return nil
-	}
-	lv, ok := cd.forumComments[cd.currentCommentID]
-	if !ok {
-		return nil
-	}
-	v, ok := lv.Peek()
-	if !ok {
-		return nil
-	}
-	return v
-}
-
-// NewsPostByID returns the news post lazily loading it once per ID.
-func (cd *CoreData) NewsPostByID(id int32, ops ...lazy.Option[*db.GetForumThreadIdByNewsPostIdRow]) (*db.GetForumThreadIdByNewsPostIdRow, error) {
-	fetch := func(i int32) (*db.GetForumThreadIdByNewsPostIdRow, error) {
-		if cd.queries == nil {
-			return nil, nil
-		}
-		return cd.queries.GetForumThreadIdByNewsPostId(cd.ctx, i)
-	}
-	return lazy.Map(&cd.newsPosts, &cd.mapMu, id, fetch, ops...)
-}
-
-// SetCurrentNewsPost stores the current news post ID.
-func (cd *CoreData) SetCurrentNewsPost(id int32) { cd.currentNewsPostID = id }
-
-// CurrentNewsPost returns the current news post lazily loaded.
-func (cd *CoreData) CurrentNewsPost(ops ...lazy.Option[*db.GetForumThreadIdByNewsPostIdRow]) (*db.GetForumThreadIdByNewsPostIdRow, error) {
-	if cd.currentNewsPostID == 0 {
-		return nil, nil
-	}
-	return cd.NewsPostByID(cd.currentNewsPostID, ops...)
-}
-
-// CurrentNewsPostLoaded returns the cached current news post if available.
-func (cd *CoreData) CurrentNewsPostLoaded() *db.GetForumThreadIdByNewsPostIdRow {
-	if cd.newsPosts == nil {
-		return nil
-	}
-	lv, ok := cd.newsPosts[cd.currentNewsPostID]
-	if !ok {
-		return nil
-	}
-	v, ok := lv.Peek()
-	if !ok {
-		return nil
-	}
-	return v
 }
 
 // WriterWritings returns public writings for the specified author respecting cd's permissions.
@@ -1165,147 +1488,27 @@ func (cd *CoreData) WriterWritings(userID int32, r *http.Request) ([]*db.ListPub
 	})
 }
 
-// Bookmarks returns the user's bookmark list loaded lazily.
-func (cd *CoreData) Bookmarks() (*db.GetBookmarksForUserRow, error) {
-	return cd.bookmarks.Load(func() (*db.GetBookmarksForUserRow, error) {
-		if cd.UserID == 0 || cd.queries == nil {
-			return nil, nil
-		}
-		return cd.queries.GetBookmarksForUser(cd.ctx, cd.UserID)
-	})
-}
-
-// CanEditAny reports whether cd is in admin mode with administrator role.
-func (cd *CoreData) CanEditAny() bool {
-	return cd.HasRole("administrator") && cd.AdminMode
-}
-
-// ImageBoards retrieves sub-boards under parentID lazily.
-func (cd *CoreData) SubImageBoards(parentID int32) ([]*db.Imageboard, error) {
-	if cd.queries == nil {
-		return nil, nil
-	}
-	if cd.subImageBoards == nil {
-		cd.subImageBoards = make(map[int32]*lazy.Value[[]*db.Imageboard])
-	}
-	lv, ok := cd.subImageBoards[parentID]
-	if !ok {
-		lv = &lazy.Value[[]*db.Imageboard]{}
-		cd.subImageBoards[parentID] = lv
-	}
-	return lv.Load(func() ([]*db.Imageboard, error) {
-		return cd.queries.ListBoardsByParentIDForLister(cd.ctx, db.ListBoardsByParentIDForListerParams{
-			ListerID:     cd.UserID,
-			ParentID:     parentID,
-			ListerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-			Limit:        200,
-			Offset:       0,
-		})
-	})
-}
-
-// ImageBoards returns all image boards cached once.
-func (cd *CoreData) ImageBoards() ([]*db.Imageboard, error) {
-	return cd.imageBoards.Load(func() ([]*db.Imageboard, error) {
+// WritingByID returns a single writing lazily loading it once per ID.
+func (cd *CoreData) WritingByID(id int32, ops ...lazy.Option[*db.GetWritingForListerByIDRow]) (*db.GetWritingForListerByIDRow, error) {
+	fetch := func(i int32) (*db.GetWritingForListerByIDRow, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		return cd.queries.AdminListBoards(cd.ctx, db.AdminListBoardsParams{Limit: 200, Offset: 0})
-	})
-}
-
-// ImageBoardPosts retrieves approved posts for the board lazily.
-func (cd *CoreData) ImageBoardPosts(boardID int32) ([]*db.ListImagePostsByBoardForListerRow, error) {
-	if cd.queries == nil {
-		return nil, nil
-	}
-	if cd.imageBoardPosts == nil {
-		cd.imageBoardPosts = make(map[int32]*lazy.Value[[]*db.ListImagePostsByBoardForListerRow])
-	}
-	lv, ok := cd.imageBoardPosts[boardID]
-	if !ok {
-		lv = &lazy.Value[[]*db.ListImagePostsByBoardForListerRow]{}
-		cd.imageBoardPosts[boardID] = lv
-	}
-	return lv.Load(func() ([]*db.ListImagePostsByBoardForListerRow, error) {
-		return cd.queries.ListImagePostsByBoardForLister(cd.ctx, db.ListImagePostsByBoardForListerParams{
-			ListerID:     cd.UserID,
-			BoardID:      boardID,
-			ListerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-			Limit:        200,
-			Offset:       0,
+		return cd.queries.GetWritingForListerByID(cd.ctx, db.GetWritingForListerByIDParams{
+			ListerID:      cd.UserID,
+			Idwriting:     i,
+			ListerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 		})
-	})
-}
-
-// UnreadNotificationCount returns the number of unread notifications for the
-// current user. The value is fetched lazily on the first call and cached for
-// subsequent calls.
-func (cd *CoreData) UnreadNotificationCount() int64 {
-	count, err := cd.unreadCount.Load(func() (int64, error) {
-		if cd.queries == nil || cd.UserID == 0 {
-			return 0, nil
-		}
-		return cd.queries.CountUnreadNotificationsForUser(cd.ctx, cd.UserID)
-	})
-	if err != nil {
-		log.Printf("load unread notification count: %v", err)
 	}
-	return count
+	return lazy.Map(&cd.writingRows, &cd.mapMu, id, fetch, ops...)
 }
 
-// subscriptionMap loads the current user's subscriptions once.
-func (cd *CoreData) subscriptionMap() (map[string]bool, error) {
-	return cd.subscriptions.Load(func() (map[string]bool, error) {
-		if cd.queries == nil || cd.UserID == 0 {
-			return map[string]bool{}, nil
-		}
-		rows, err := cd.queries.ListSubscriptionsByUser(cd.ctx, cd.UserID)
-		if err != nil {
-			return nil, err
-		}
-		m := make(map[string]bool)
-		for _, row := range rows {
-			if row.Method == "internal" {
-				m[row.Pattern] = true
-			}
-		}
-		return m, nil
-	})
-}
-
-// Subscribed reports whether the user has a subscription matching pattern.
-func (cd *CoreData) Subscribed(pattern string) bool {
-	m, _ := cd.subscriptionMap()
-	return m[pattern]
-}
-
-// LinkerCategoryCounts lazily loads linker category statistics.
-func (cd *CoreData) LinkerCategoryCounts() ([]*db.GetLinkerCategoryLinkCountsRow, error) {
-	return cd.linkerCategories.Load(func() ([]*db.GetLinkerCategoryLinkCountsRow, error) {
+// WritingCategories returns all writing categories cached once.
+func (cd *CoreData) WritingCategories() ([]*db.WritingCategory, error) {
+	return cd.writingCategories.Load(func() ([]*db.WritingCategory, error) {
 		if cd.queries == nil {
 			return nil, nil
 		}
-		rows, err := cd.queries.GetLinkerCategoryLinkCounts(cd.ctx)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return nil, err
-		}
-		return rows, nil
+		return cd.queries.SystemListWritingCategories(cd.ctx, db.SystemListWritingCategoriesParams{Limit: math.MaxInt32, Offset: 0})
 	})
-}
-
-// HasAdminRole reports whether the current user has the administrator role.
-func (cd *CoreData) HasAdminRole() bool {
-	return cd.HasRole("administrator")
-}
-
-// HasContentWriterRole reports whether the current user has the content writer role.
-func (cd *CoreData) HasContentWriterRole() bool {
-	return cd.HasRole("content writer")
-}
-
-// ExecuteSiteTemplate renders the named site template using cd's helper
-// functions. It wraps templates.GetCompiledSiteTemplates(cd.Funcs(r)).
-func (cd *CoreData) ExecuteSiteTemplate(w io.Writer, r *http.Request, name string, data any) error {
-	return templates.GetCompiledSiteTemplates(cd.Funcs(r)).ExecuteTemplate(w, name, data)
 }

--- a/core/templates/site/faq/adminFaqRevisionPage.gohtml
+++ b/core/templates/site/faq/adminFaqRevisionPage.gohtml
@@ -9,6 +9,8 @@
   <td>{{ .Question.String }}</td>
   <td>{{ .Answer.String }}</td>
 </tr>
+{{- else }}
+<tr><td colspan="4">No Revisions</td></tr>
 {{- end }}
 </table>
 {{ template "tail" $ }}

--- a/core/templates/site/faq/adminQuestionEditPage.gohtml
+++ b/core/templates/site/faq/adminQuestionEditPage.gohtml
@@ -1,18 +1,21 @@
 {{ template "head" $ }}
-<h4>{{ if eq .Faq.Idfaq 0 }}Create FAQ Entry{{ else }}Edit FAQ Entry{{ end }}</h4>
+{{$faq := cd.CurrentFAQ}}
+<h4>{{ if eq $faq.Idfaq 0 }}Create FAQ Entry{{ else }}Edit FAQ Entry{{ end }}</h4>
 <form method="post" action="/admin/faq/questions">
 {{ csrfField }}
-<textarea name="question" cols="80" rows="15">{{ .Faq.Question.String }}</textarea><br>
-<textarea name="answer" cols="80" rows="15">{{ .Faq.Answer.String }}</textarea><br>
+<textarea name="question" cols="80" rows="15">{{ $faq.Question.String }}</textarea><br>
+<textarea name="answer" cols="80" rows="15">{{ $faq.Answer.String }}</textarea><br>
 <select name="category">
     <option value="0">Hidden</option>
-    {{$cat := .Faq.FaqcategoriesIdfaqcategories}}
-    {{- range .Categories }}
+    {{$cat := $faq.FaqcategoriesIdfaqcategories}}
+    {{- range cd.FAQCategories }}
     <option value="{{ .Idfaqcategories }}" {{if eq $cat .Idfaqcategories}}selected{{end}}>{{ .Name.String }}</option>
+    {{- else }}
+    <option disabled>No Categories</option>
     {{- end }}
 </select><br>
-<input type="hidden" name="faq" value="{{ .Faq.Idfaq }}">
-{{ if eq .Faq.Idfaq 0 }}
+<input type="hidden" name="faq" value="{{ $faq.Idfaq }}">
+{{ if eq $faq.Idfaq 0 }}
 <input type="submit" name="task" value="Create">
 {{ else }}
 <input type="submit" name="task" value="Edit">

--- a/core/templates/site/faq/adminQuestionPage.gohtml
+++ b/core/templates/site/faq/adminQuestionPage.gohtml
@@ -1,35 +1,14 @@
 {{ template "head" $ }}
 <h4>Unanswered Questions</h4>
-{{ template "adminQuestionTable" .UnansweredRows }}
+{{ template "adminQuestionTable" (cd.FAQUnansweredQuestions) }}
 
 <h4>FAQ Questions</h4>
 
-{{ template "adminQuestionTable" .AnsweredRows }}
+{{ template "adminQuestionTable" (cd.FAQAnsweredQuestions) }}
 
 <h4>Dismissed Questions</h4>
-{{ template "adminQuestionTable" .DismissedRows }}
+{{ template "adminQuestionTable" (cd.FAQDismissedQuestions) }}
 
 <p><a href="/admin/faq/question/0/edit">Create New Question</a></p>
-
-<table>
-<tr><th>Question</th><th>Category</th><th>Actions</th></tr>
-{{- range .Rows }}
-<tr>
-    <td>{{ .Question.String }}</td>
-    <td>{{ $cat := .FaqcategoriesIdfaqcategories }}{{ range $.Categories }}{{ if eq $cat .Idfaqcategories }}{{ .Name.String }}{{ end }}{{ end }}</td>
-    <td>
-        <a href="/admin/faq/question/{{ .Idfaq }}/edit">Edit</a> |
-        <a href="/admin/faq/revisions/{{ .Idfaq }}">History</a>
-        <form method="post" action="" style="display:inline;">
-            {{ csrfField }}
-            <input type="hidden" name="faq" value="{{ .Idfaq }}">
-            <input type="submit" name="task" value="Remove">
-        </form>
-    </td>
-</tr>
-{{- end }}
-</table>
-
-<p><a href="/admin/faq/question/create">Create New Question</a></p>
 
 {{ template "tail" $ }}

--- a/core/templates/site/faq/adminQuestionTable.gohtml
+++ b/core/templates/site/faq/adminQuestionTable.gohtml
@@ -4,7 +4,7 @@
 {{- range . }}
 <tr>
     <td>{{ .Question.String }}</td>
-    <td>{{ $cat := .FaqcategoriesIdfaqcategories }}{{ range $.Categories }}{{ if eq $cat .Idfaqcategories }}{{ .Name.String }}{{ end }}{{ end }}</td>
+    <td>{{ $cat := .FaqcategoriesIdfaqcategories }}{{ range (cd.FAQCategories) }}{{ if eq $cat .Idfaqcategories }}{{ .Name.String }}{{ end }}{{ end }}</td>
     <td>
         <a href="/admin/faq/question/{{ .Idfaq }}/edit">Edit</a> |
         <a href="/admin/faq/revisions/{{ .Idfaq }}">History</a>
@@ -15,6 +15,8 @@
         </form>
     </td>
 </tr>
+{{- else }}
+<tr><td colspan="3">No Questions</td></tr>
 {{- end }}
 </table>
 {{ end }}

--- a/core/templates/site/faq/faqAdminCategoriesPage.gohtml
+++ b/core/templates/site/faq/faqAdminCategoriesPage.gohtml
@@ -6,7 +6,7 @@
                                 <th>Question Count
                                 <th>Options
                         </tr>
-                        {{- range .Rows }}
+                        {{- range cd.FAQCategoriesWithQuestionCount }}
                         <tr>
                                 <td>{{ .Idfaqcategories }}</td>
                                 <td>
@@ -22,6 +22,8 @@
                                         </form>
                                 </td>
                         </tr>
+                        {{- else }}
+                        <tr><td colspan="4">No Categories</td></tr>
                         {{- end }}
                         <tr>
                                 <td>NEW</td>

--- a/core/templates/site/faq/page.gohtml
+++ b/core/templates/site/faq/page.gohtml
@@ -10,8 +10,12 @@
             <tr>
                 <td>A: {{ $faq.Answer | a4code2html }}</td>
             </tr>
+        {{ else }}
+            <tr><td colspan="1">No Questions</td></tr>
         {{ end }}
         </table>
+    {{ else }}
+        <p>No FAQs available</p>
     {{ end }}
     {{ template "tail" $ }}
 {{ end }}

--- a/handlers/faq/admin_categories.go
+++ b/handlers/faq/admin_categories.go
@@ -8,25 +8,13 @@ import (
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 )
 
 func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
-	type Data struct {
-		*common.CoreData
-		Rows []*db.GetFAQCategoriesWithQuestionCountRow
-	}
-
-	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-	}
-	cd := data.CoreData
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "FAQ Categories"
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-
-	rows, err := queries.GetFAQCategoriesWithQuestionCount(r.Context())
-	if err != nil {
+	if _, err := cd.FAQCategoriesWithQuestionCount(); err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
@@ -34,7 +22,5 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	data.Rows = rows
-
-	handlers.TemplateHandler(w, r, "faqAdminCategoriesPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "faqAdminCategoriesPage.gohtml", struct{}{})
 }

--- a/handlers/faq/admin_edit_question_page.go
+++ b/handlers/faq/admin_edit_question_page.go
@@ -10,7 +10,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/mux"
 )
 
@@ -23,12 +22,10 @@ func AdminEditQuestionPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	var faq *db.Faq
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.SetCurrentFAQ(int32(id))
 	if id != 0 {
-		var err error
-		faq, err = queries.GetFAQByID(r.Context(), int32(id))
-		if err != nil {
+		if _, err := cd.FAQByID(int32(id)); err != nil {
 			switch {
 			case errors.Is(err, sql.ErrNoRows):
 				http.Error(w, "Not Found", http.StatusNotFound)
@@ -38,27 +35,21 @@ func AdminEditQuestionPage(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-	} else {
-		faq = &db.Faq{Idfaq: 0}
 	}
-	cats, _ := queries.GetAllFAQCategories(r.Context())
-	type Data struct {
-		*common.CoreData
-		Faq        *db.Faq
-		Categories []*db.FaqCategory
+	if _, err := cd.FAQCategories(); err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+		default:
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
 	}
-	data := Data{
-		CoreData:   r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		Faq:        faq,
-		Categories: cats,
-	}
-	cd := data.CoreData
 	if id != 0 {
 		cd.PageTitle = fmt.Sprintf("Edit FAQ %d", id)
 	} else {
 		cd.PageTitle = "New FAQ"
 	}
-	handlers.TemplateHandler(w, r, "adminQuestionEditPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminQuestionEditPage.gohtml", struct{}{})
 }
 
 // AdminCreateQuestionPage redirects to AdminEditQuestionPage with id zero to

--- a/handlers/faq/admin_revision_page.go
+++ b/handlers/faq/admin_revision_page.go
@@ -23,8 +23,8 @@ func AdminRevisionHistoryPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	faq, err := queries.GetFAQByID(r.Context(), int32(id))
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	faq, err := cd.FAQByID(int32(id))
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -35,18 +35,11 @@ func AdminRevisionHistoryPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	revs, _ := queries.GetFAQRevisionsForAdmin(r.Context(), int32(id))
-	type Data struct {
-		*common.CoreData
+	revs, _ := cd.FAQRevisions(int32(id))
+	data := struct {
 		Faq       *db.Faq
 		Revisions []*db.FaqRevision
-	}
-	data := Data{
-		CoreData:  r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		Faq:       faq,
-		Revisions: revs,
-	}
-	cd := data.CoreData
+	}{faq, revs}
 	cd.PageTitle = fmt.Sprintf("FAQ %d History", id)
 	handlers.TemplateHandler(w, r, "adminFaqRevisionPage.gohtml", data)
 }

--- a/handlers/faq/create_category_task.go
+++ b/handlers/faq/create_category_task.go
@@ -1,7 +1,6 @@
 package faq
 
 import (
-	"database/sql"
 	"fmt"
 	"net/http"
 
@@ -25,9 +24,8 @@ func (CreateCategoryTask) Match(r *http.Request, m *mux.RouteMatch) bool {
 func (CreateCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	text := r.PostFormValue("cname")
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
 
-	if err := queries.AdminCreateFAQCategory(r.Context(), sql.NullString{String: text, Valid: true}); err != nil {
+	if err := cd.AdminCreateFAQCategory(text); err != nil {
 		return fmt.Errorf("create category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 

--- a/handlers/faq/create_question_task.go
+++ b/handlers/faq/create_question_task.go
@@ -1,7 +1,6 @@
 package faq
 
 import (
-	"database/sql"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -11,7 +10,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 )
@@ -34,7 +32,6 @@ func (CreateQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("category parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
 	if !cd.HasGrant("faq", "question", "post", 0) {
 		r.URL.RawQuery = "error=" + url.QueryEscape("Forbidden")
 		handlers.TaskErrorAcknowledgementPage(w, r)
@@ -45,26 +42,11 @@ func (CreateQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
-	res, err := queries.InsertFAQQuestionForWriter(r.Context(), db.InsertFAQQuestionForWriterParams{
-		Question:   sql.NullString{String: question, Valid: true},
-		Answer:     sql.NullString{String: answer, Valid: true},
-		CategoryID: int32(category),
-		WriterID:   uid,
-		LanguageID: 1,
-		GranteeID:  sql.NullInt32{Int32: uid, Valid: true},
-	})
+	id, err := cd.InsertFAQQuestion(question, answer, int32(category), uid)
 	if err != nil {
 		return fmt.Errorf("insert faq fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	id, _ := res.LastInsertId()
-	_ = queries.InsertFAQRevisionForUser(r.Context(), db.InsertFAQRevisionForUserParams{
-		FaqID:        int32(id),
-		UsersIdusers: uid,
-		Question:     sql.NullString{String: question, Valid: true},
-		Answer:       sql.NullString{String: answer, Valid: true},
-		UserID:       sql.NullInt32{Int32: uid, Valid: true},
-		ViewerID:     uid,
-	})
+	_ = cd.InsertFAQRevision(id, uid, question, answer)
 
 	return nil
 }

--- a/handlers/faq/delete_category_task.go
+++ b/handlers/faq/delete_category_task.go
@@ -28,9 +28,8 @@ func (DeleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("cid parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
 
-	if err := queries.AdminDeleteFAQCategory(r.Context(), int32(cid)); err != nil {
+	if err := cd.AdminDeleteFAQCategory(int32(cid)); err != nil {
 		return fmt.Errorf("delete category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 

--- a/handlers/faq/delete_question_task.go
+++ b/handlers/faq/delete_question_task.go
@@ -28,9 +28,8 @@ func (DeleteQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("faq id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
 
-	if err := queries.AdminDeleteFAQ(r.Context(), int32(faq)); err != nil {
+	if err := cd.AdminDeleteFAQ(int32(faq)); err != nil {
 		return fmt.Errorf("delete faq fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 

--- a/handlers/faq/edit_question_task.go
+++ b/handlers/faq/edit_question_task.go
@@ -1,7 +1,6 @@
 package faq
 
 import (
-	"database/sql"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -11,7 +10,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 )
@@ -38,30 +36,17 @@ func (EditQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("faq id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	if err := queries.AdminUpdateFAQQuestionAnswer(r.Context(), db.AdminUpdateFAQQuestionAnswerParams{
-		Answer:                       sql.NullString{Valid: true, String: answer},
-		Question:                     sql.NullString{Valid: true, String: question},
-		FaqcategoriesIdfaqcategories: int32(category),
-		Idfaq:                        int32(faq),
-	}); err != nil {
+	if err := cd.AdminUpdateFAQQuestion(int32(faq), int32(category), question, answer); err != nil {
 		return fmt.Errorf("update faq question fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	_ = queries.InsertFAQRevisionForUser(r.Context(), db.InsertFAQRevisionForUserParams{
-		FaqID:        int32(faq),
-		UsersIdusers: uid,
-		Question:     sql.NullString{String: question, Valid: true},
-		Answer:       sql.NullString{String: answer, Valid: true},
-		UserID:       sql.NullInt32{Int32: uid, Valid: true},
-		ViewerID:     uid,
-	})
+	_ = cd.InsertFAQRevision(int32(faq), uid, question, answer)
 
 	return nil
 }

--- a/handlers/faq/page.go
+++ b/handlers/faq/page.go
@@ -28,18 +28,13 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		FAQ []*CategoryFAQs
 	}
 
-	data := Data{}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	data := Data{}
 	cd.PageTitle = "FAQ"
-
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 
 	var currentCategoryFAQs CategoryFAQs
 
-	faqRows, err := queries.GetAllAnsweredFAQWithFAQCategoriesForUser(r.Context(), db.GetAllAnsweredFAQWithFAQCategoriesForUserParams{
-		ViewerID: cd.UserID,
-		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-	})
+	faqRows, err := cd.AllAnsweredFAQWithCategories()
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):

--- a/handlers/faq/remove_question_task.go
+++ b/handlers/faq/remove_question_task.go
@@ -29,9 +29,8 @@ func (RemoveQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("faq id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
 
-	if err := queries.AdminDeleteFAQ(r.Context(), int32(faq)); err != nil {
+	if err := cd.AdminDeleteFAQ(int32(faq)); err != nil {
 		return fmt.Errorf("delete faq fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 

--- a/handlers/faq/rename_category_task.go
+++ b/handlers/faq/rename_category_task.go
@@ -1,7 +1,6 @@
 package faq
 
 import (
-	"database/sql"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -9,7 +8,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
 )
@@ -30,17 +28,8 @@ func (RenameCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("cid parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	if err := queries.RenameFAQCategory(r.Context(), db.RenameFAQCategoryParams{
-		Name: sql.NullString{
-			String: text,
-			Valid:  true,
-		},
-		Idfaqcategories: int32(cid),
-		ViewerID:        cd.UserID,
-	}); err != nil {
+	if err := cd.RenameFAQCategory(int32(cid), text); err != nil {
 		return fmt.Errorf("rename faq category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 

--- a/handlers/template.go
+++ b/handlers/template.go
@@ -11,10 +11,11 @@ import (
 // TemplateHandler renders the template and handles any template error.
 // Example usage:
 //
-//	type Data struct{ *CoreData }
-//	TemplateHandler(w, r, "page.gohtml", Data{cd})
+//	type Data struct{}
+//	TemplateHandler(w, r, "page.gohtml", Data{})
 //
-// Template helpers are provided via data.CoreData.Funcs(r).
+// CoreData helpers are available through the "cd" template function.
+// Pass a dedicated data struct if the template needs additional fields.
 func TemplateHandler(w http.ResponseWriter, r *http.Request, tmpl string, data any) {
 	cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if err := cd.ExecuteSiteTemplate(w, r, tmpl, data); err != nil {


### PR DESCRIPTION
## Summary
- expose FAQ categories and questions through CoreData lazy helpers
- use CoreData in FAQ handlers and templates to fetch data on demand without passing CoreData as template data
- show fallback rows when FAQ lists are empty

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f19683f50832f87a0245b765c8bce