### PR TITLE
Refactor blogs page to use CoreData lazy loading

### DIFF
--- a/core/templates/site/blogs/page.gohtml
+++ b/core/templates/site/blogs/page.gohtml
@@ -1,38 +1,38 @@
 {{ define "blogsPage" }}
     {{ template "head" $ }}
-        {{if .Rows}}
-                        {{if .UID}}
-                                <font size="5"><a href="/blogs/blogger/{{(index $.Blogs 0).Username.String}}">{{(index $.Blogs 0).Username.String}}</a>'s blogs.</font><br>
-            {{else}}
-                <font size="5"><a href="/blogs/bloggers">All bloggers</a>' blogs.</font><br>
-            {{end}}
-            <table width="100%">
-                {{range .Rows}}
-                    <tr>
-                        <th bgcolor="lightgrey">{{.Written}}</th>
-                    </tr>
-                    <tr>
-                        <td>
-                            {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]
-                                                        {{if .EditUrl}} - [<a href="{{.EditUrl}}">EDIT</a>]{{end}}
-                        </td>
-                    </tr>
-                {{end}}
-            </table><br>
-        {{else}}
-            {{if .IsOffset}}
-                {{if .UID}}
+    {{ $rows := cd.BlogList }}
+    {{ if $rows }}
+        {{ if cd.BlogListUID }}
+            <font size="5"><a href="/blogs/blogger/{{ (index $rows 0).Username.String }}">{{ (index $rows 0).Username.String }}</a>'s blogs.</font><br>
+        {{ else }}
+            <font size="5"><a href="/blogs/bloggers">All bloggers</a>' blogs.</font><br>
+        {{ end }}
+    {{ end }}
+    <table width="100%">
+        {{ range $rows }}
+            <tr>
+                <th bgcolor="lightgrey">{{ .Written }}</th>
+            </tr>
+            <tr>
+                <td>
+                    {{ .Blog.String | a4code2html}}<br><br>{{ .Username.String }} - [<a href="/blogs/blog/{{ .Idblogs }}/comments">{{ .Comments }} COMMENTS</a>]{{ if or cd.CanEditAny .IsOwner }} - [<a href="/blogs/blog/{{ .Idblogs }}/edit">EDIT</a>]{{ end }}
+                </td>
+            </tr>
+        {{ else }}
+            {{ if gt (cd.BlogListOffset) 0 }}
+                {{ if cd.BlogListUID }}
                     There are no more blogs under this user.<br>
-                {{else}}
+                {{ else }}
                     There are no more blogs.<br>
-                {{end}}
-            {{else}}
-                {{if .UID}}
+                {{ end }}
+            {{ else }}
+                {{ if cd.BlogListUID }}
                     Nothing under this blog.<br>
-                {{else}}
+                {{ else }}
                     There are no blogs here.<br>
-                {{end}}
-            {{end}}
-        {{end}}
+                {{ end }}
+            {{ end }}
+        {{ end }}
+    </table><br>
     {{ template "tail" $ }}
 {{ end }}

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -19,72 +19,18 @@ import (
 	"github.com/arran4/goa4web/handlers"
 
 	"github.com/arran4/goa4web/a4code/a4code2html"
-	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/feeds"
 )
 
 func Page(w http.ResponseWriter, r *http.Request) {
-	type BlogRow struct {
-		*db.ListBlogEntriesByAuthorForListerRow
-		EditUrl string
-	}
-	type Data struct {
-		*common.CoreData
-		Rows     []*BlogRow
-		IsOffset bool
-		UID      string
-	}
-
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	buid := r.URL.Query().Get("uid")
-	userId, _ := strconv.Atoi(buid)
-	session, ok := core.GetSessionOrFail(w, r)
-	if !ok {
-		return
-	}
-	uid, _ := session.Values["UID"].(int32)
+	userID, _ := strconv.Atoi(buid)
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Blogs"
-	queries := cd.Queries()
-	rows, err := queries.ListBlogEntriesByAuthorForLister(r.Context(), db.ListBlogEntriesByAuthorForListerParams{
-		AuthorID: int32(userId),
-		ListerID: uid,
-		UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
-		Limit:    15,
-		Offset:   int32(offset),
-	})
-	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-		default:
-			log.Printf("Query Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
-	}
-
-	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		IsOffset: offset != 0,
-		UID:      buid,
-	}
-
-	for _, row := range rows {
-		if !data.CoreData.HasGrant("blogs", "entry", "see", row.Idblogs) {
-			continue
-		}
-		editUrl := ""
-		if data.CoreData.CanEditAny() || row.IsOwner {
-			editUrl = fmt.Sprintf("/blogs/blog/%d/edit", row.Idblogs)
-		}
-		data.Rows = append(data.Rows, &BlogRow{
-			ListBlogEntriesByAuthorForListerRow: row,
-			EditUrl:                             editUrl,
-		})
-	}
-
-	handlers.TemplateHandler(w, r, "blogsPage", data)
+	cd.SetBlogListParams(int32(userID), offset)
+	handlers.TemplateHandler(w, r, "blogsPage", cd)
 }
 
 func CustomBlogIndex(data *common.CoreData, r *http.Request) {

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -63,13 +63,7 @@ func TestPageTemplatesRender(t *testing.T) {
 			*common.CoreData
 			Boards any
 		}{&common.CoreData{}, nil}},
-		{"blogsPage", struct {
-			*common.CoreData
-			Rows     any
-			IsOffset bool
-			UID      string
-			Blogs    []struct{ Username string }
-		}{&common.CoreData{}, nil, false, "", []struct{ Username string }{{"test"}}}},
+		{"blogsPage", &common.CoreData{}},
 		{"writingsPage", struct {
 			*common.CoreData
 			Categories        []*db.WritingCategory


### PR DESCRIPTION
## Summary
- move blog listing queries into `CoreData` with lazy `BlogList` getter returning DB rows
- render blogs page directly from `CoreData`, computing edit links in template via `cd` helpers
- sort `CoreData` blog list fields alphabetically

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f19426900832fb3699c7da3a809c9