### PR TITLE
news: use lazy CoreData access

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -18,9 +17,6 @@ import (
 
 // Funcs returns template helpers configured with cd's ImageURLMapper.
 func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
-	// newsCache memoizes LatestNews results for a single template execution.
-	var newsCache any
-	var LatestWritings any
 	mapper := cd.ImageURLMapper
 	return map[string]any{
 		"cd":        func() *CoreData { return cd },
@@ -75,27 +71,11 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 			return u + "?mode=admin"
 		},
 		"LatestNews": func() (any, error) {
-			if newsCache != nil {
-				return newsCache, nil
-			}
 			posts, err := cd.LatestNews(r)
 			if err != nil {
 				return nil, fmt.Errorf("latestNews: %w", err)
 			}
-			newsCache = posts
 			return posts, nil
-		},
-		"LatestWritings": func() (any, error) {
-			if LatestWritings != nil {
-				return LatestWritings, nil
-			}
-			offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-			wrs, err := cd.LatestWritings(WithWritingsOffset(int32(offset)))
-			if err != nil {
-				return nil, fmt.Errorf("latestWritings: %w", err)
-			}
-			LatestWritings = wrs
-			return wrs, nil
 		},
 	}
 }

--- a/core/templates/site/news/adminNewsListPage.gohtml
+++ b/core/templates/site/news/adminNewsListPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 <table border="1">
     <tr><th>ID<th>Date<th>Writer<th>Comments<th>View</tr>
-    {{ range .Posts }}
+    {{ range cd.AdminLatestNews }}
         <tr>
             <td><a href="/admin/news/{{ .Idsitenews }}">{{ .Idsitenews }}</a></td>
             <td><a href="/admin/news/{{ .Idsitenews }}">{{ .Occurred.Time }}</a></td>
@@ -9,6 +9,8 @@
             <td><a href="/admin/news/{{ .Idsitenews }}#comments">{{ .Comments.Int32 }}</a></td>
             <td><a href="/news/news/{{ .Idsitenews }}">Public</a></td>
         </tr>
+    {{ else }}
+        <tr><td colspan="5">No news.</td></tr>
     {{ end }}
 </table>
 {{ template "tail" $ }}

--- a/handlers/news/admin_customindex.go
+++ b/handlers/news/admin_customindex.go
@@ -1,0 +1,32 @@
+package news
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+)
+
+// CustomAdminNewsIndex injects pagination links for the admin news pages.
+func CustomAdminNewsIndex(cd *common.CoreData, r *http.Request) {
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	cd.SetNewsOffset(offset)
+	ps := cd.PageSize()
+	if offset != 0 {
+		cd.CustomIndexItems = append(cd.CustomIndexItems, common.IndexItem{
+			Name: "The start",
+			Link: "/admin/news?offset=0",
+		})
+	}
+	cd.CustomIndexItems = append(cd.CustomIndexItems, common.IndexItem{
+		Name: fmt.Sprintf("Next %d", ps),
+		Link: fmt.Sprintf("/admin/news?offset=%d", offset+ps),
+	})
+	if offset > 0 {
+		cd.CustomIndexItems = append(cd.CustomIndexItems, common.IndexItem{
+			Name: fmt.Sprintf("Previous %d", ps),
+			Link: fmt.Sprintf("/admin/news?offset=%d", offset-ps),
+		})
+	}
+}

--- a/handlers/news/admin_pages.go
+++ b/handlers/news/admin_pages.go
@@ -20,21 +20,7 @@ import (
 func AdminNewsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "News Admin"
-
-	posts, err := cd.LatestNewsList(0, 50)
-	if err != nil {
-		log.Printf("LatestNewsList: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-	data := struct {
-		*common.CoreData
-		Posts []*common.NewsPost
-	}{
-		CoreData: cd,
-		Posts:    posts,
-	}
-	handlers.TemplateHandler(w, r, "adminNewsListPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "adminNewsListPage.gohtml", cd)
 }
 
 type CommentPlus struct {

--- a/handlers/news/routes_admin.go
+++ b/handlers/news/routes_admin.go
@@ -8,6 +8,7 @@ import (
 // RegisterAdminRoutes attaches news admin endpoints to ar.
 func RegisterAdminRoutes(ar *mux.Router) {
 	nr := ar.PathPrefix("/news").Subrouter()
+	nr.Use(handlers.IndexMiddleware(CustomAdminNewsIndex))
 	nr.HandleFunc("", handlers.VerifyAccess(AdminNewsPage, "administrator")).Methods("GET")
 	nr.HandleFunc("/{post}", handlers.VerifyAccess(AdminNewsPostPage, "administrator")).Methods("GET")
 	nr.HandleFunc("/{post}/edit", handlers.VerifyAccess(adminNewsEditFormPage, "administrator")).Methods("GET")

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -110,6 +110,7 @@ type Querier interface {
 	// admin task
 	AdminListGrantsByRoleID(ctx context.Context, roleID sql.NullInt32) ([]*Grant, error)
 	AdminListLoginAttempts(ctx context.Context) ([]*LoginAttempt, error)
+	AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescending(ctx context.Context, arg AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams) ([]*AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow, error)
 	AdminListPendingDeactivatedBlogs(ctx context.Context, arg AdminListPendingDeactivatedBlogsParams) ([]*AdminListPendingDeactivatedBlogsRow, error)
 	AdminListPendingDeactivatedComments(ctx context.Context, arg AdminListPendingDeactivatedCommentsParams) ([]*AdminListPendingDeactivatedCommentsRow, error)
 	AdminListPendingDeactivatedImageposts(ctx context.Context, arg AdminListPendingDeactivatedImagepostsParams) ([]*AdminListPendingDeactivatedImagepostsRow, error)

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -130,6 +130,16 @@ ORDER BY s.occurred DESC
 LIMIT ? OFFSET ?;
 
 
+-- name: AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescending :many
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers,
+s.news, s.occurred, th.comments as Comments
+FROM site_news s
+LEFT JOIN users u ON s.users_idusers = u.idusers
+LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+ORDER BY s.occurred DESC
+LIMIT ? OFFSET ?;
+
+
 -- name: SetSiteNewsLastIndex :exec
 UPDATE site_news SET last_index = NOW() WHERE idsiteNews = ?;
 

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -11,6 +11,66 @@ import (
 	"strings"
 )
 
+const adminListNewsPostsWithWriterUsernameAndThreadCommentCountDescending = `-- name: AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescending :many
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers,
+s.news, s.occurred, th.comments as Comments
+FROM site_news s
+LEFT JOIN users u ON s.users_idusers = u.idusers
+LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+ORDER BY s.occurred DESC
+LIMIT ? OFFSET ?
+`
+
+type AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams struct {
+	Limit  int32
+	Offset int32
+}
+
+type AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow struct {
+	Writername         sql.NullString
+	Writerid           sql.NullInt32
+	Idsitenews         int32
+	ForumthreadID      int32
+	LanguageIdlanguage int32
+	UsersIdusers       int32
+	News               sql.NullString
+	Occurred           sql.NullTime
+	Comments           sql.NullInt32
+}
+
+func (q *Queries) AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescending(ctx context.Context, arg AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams) ([]*AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminListNewsPostsWithWriterUsernameAndThreadCommentCountDescending, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow
+	for rows.Next() {
+		var i AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow
+		if err := rows.Scan(
+			&i.Writername,
+			&i.Writerid,
+			&i.Idsitenews,
+			&i.ForumthreadID,
+			&i.LanguageIdlanguage,
+			&i.UsersIdusers,
+			&i.News,
+			&i.Occurred,
+			&i.Comments,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const createNewsPostForWriter = `-- name: CreateNewsPostForWriter :execlastid
 INSERT INTO site_news (news, users_idusers, occurred, language_idlanguage)
 SELECT ?, ?, NOW(), ?


### PR DESCRIPTION
## Summary
- move news author matcher to CoreData-backed lookup
- drop admin news query in favor of template-side CoreData iteration
- load single news post via CoreData LatestNewsList
- render admin news list via cd.AdminLatestNews with a "No news" fallback
- introduce admin-specific news listing query and CoreData accessor
- add built-in pagination for admin news pages through CoreData and index middleware
- drop redundant cache wrappers from template helpers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f19681f28832f8cc1bd435a52fcf4