### PR TITLE
Rename feed URL fields

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -77,7 +77,7 @@ type CoreData struct {
 	a4codeMapper func(tag, val string) string
 	// AdminMode indicates whether admin-only UI elements should be displayed.
 	AdminMode         bool
-	AtomFeedUrl       string
+	AtomFeedURL       string
 	AutoRefresh       string
 	Config            *config.RuntimeConfig
 	CustomIndexItems  []IndexItem
@@ -90,7 +90,7 @@ type CoreData struct {
 	NotificationCount int32
 	// PageTitle holds the title of the current page.
 	PageTitle  string
-	RSSFeedUrl string
+	RSSFeedURL string
 	TasksReg   *tasks.Registry
 	Title      string
 	UserID     int32

--- a/core/templates/site/headdata.gohtml
+++ b/core/templates/site/headdata.gohtml
@@ -1,10 +1,10 @@
 {{- define "headdata"}}
     {{ if $.FeedsEnabled }}
-        {{ if $.RSSFeedUrl }}
-            <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="{{$.RSSFeedUrl}}">
+        {{ if $.RSSFeedURL }}
+            <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="{{$.RSSFeedURL}}">
         {{ end }}
-        {{ if $.AtomFeedUrl }}
-            <link rel="alternate" type="application/atom+xml" title="Atom Feed" href="{{$.AtomFeedUrl}}">
+        {{ if $.AtomFeedURL }}
+            <link rel="alternate" type="application/atom+xml" title="Atom Feed" href="{{$.AtomFeedURL}}">
         {{ end }}
     {{ end }}
 {{- end}}

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -41,11 +41,11 @@ func CustomBlogIndex(data *common.CoreData, r *http.Request) {
 		if user != "" {
 			suffix = "?user=" + url.QueryEscape(user)
 		}
-		data.RSSFeedUrl = "/blogs/rss" + suffix
-		data.AtomFeedUrl = "/blogs/atom" + suffix
+		data.RSSFeedURL = "/blogs/rss" + suffix
+		data.AtomFeedURL = "/blogs/atom" + suffix
 		data.CustomIndexItems = append(data.CustomIndexItems,
-			common.IndexItem{Name: "Atom Feed", Link: data.AtomFeedUrl},
-			common.IndexItem{Name: "RSS Feed", Link: data.RSSFeedUrl},
+			common.IndexItem{Name: "Atom Feed", Link: data.AtomFeedURL},
+			common.IndexItem{Name: "RSS Feed", Link: data.RSSFeedURL},
 		)
 	}
 

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -137,11 +137,11 @@ func CustomForumIndex(data *common.CoreData, r *http.Request) {
 	categoryId := vars["category"]
 	data.CustomIndexItems = []common.IndexItem{}
 	if data.FeedsEnabled && topicId != "" && threadId == "" {
-		data.RSSFeedUrl = fmt.Sprintf("/forum/topic/%s.rss", topicId)
-		data.AtomFeedUrl = fmt.Sprintf("/forum/topic/%s.atom", topicId)
+		data.RSSFeedURL = fmt.Sprintf("/forum/topic/%s.rss", topicId)
+		data.AtomFeedURL = fmt.Sprintf("/forum/topic/%s.atom", topicId)
 		data.CustomIndexItems = append(data.CustomIndexItems,
-			common.IndexItem{Name: "Atom Feed", Link: data.AtomFeedUrl},
-			common.IndexItem{Name: "RSS Feed", Link: data.RSSFeedUrl},
+			common.IndexItem{Name: "Atom Feed", Link: data.AtomFeedURL},
+			common.IndexItem{Name: "RSS Feed", Link: data.RSSFeedURL},
 		)
 	}
 	userHasAdmin := data.HasRole("administrator") && data.AdminMode

--- a/handlers/imagebbs/imagebbsPage.go
+++ b/handlers/imagebbs/imagebbsPage.go
@@ -42,8 +42,8 @@ func CustomImageBBSIndex(data *common.CoreData, r *http.Request) {
 	data.CustomIndexItems = []common.IndexItem{}
 
 	if data.FeedsEnabled {
-		data.RSSFeedUrl = "/imagebbs/rss"
-		data.AtomFeedUrl = "/imagebbs/atom"
+		data.RSSFeedURL = "/imagebbs/rss"
+		data.AtomFeedURL = "/imagebbs/atom"
 	}
 
 	userHasAdmin := data.HasRole("administrator") && data.AdminMode

--- a/handlers/linker/linkerPage.go
+++ b/handlers/linker/linkerPage.go
@@ -45,8 +45,8 @@ func Page(w http.ResponseWriter, r *http.Request) {
 func CustomLinkerIndex(data *common.CoreData, r *http.Request) {
 	data.CustomIndexItems = []common.IndexItem{}
 	if r.URL.Path == "/linker" || strings.HasPrefix(r.URL.Path, "/linker/category/") {
-		data.RSSFeedUrl = "/linker/rss"
-		data.AtomFeedUrl = "/linker/atom"
+		data.RSSFeedURL = "/linker/rss"
+		data.AtomFeedURL = "/linker/atom"
 	}
 
 	userHasAdmin := data.HasRole("administrator") && data.AdminMode

--- a/handlers/news/newsPage.go
+++ b/handlers/news/newsPage.go
@@ -11,7 +11,7 @@ import (
 )
 
 func CustomNewsIndex(data *common.CoreData, r *http.Request) {
-	data.RSSFeedUrl = "/news.rss"
+	data.RSSFeedURL = "/news.rss"
 	data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
 		Name: "RSS Feed",
 		Link: "/news.rss",

--- a/handlers/writings/writingsPage.go
+++ b/handlers/writings/writingsPage.go
@@ -31,8 +31,8 @@ func CustomWritingsIndex(data *common.CoreData, r *http.Request) {
 		common.IndexItem{Name: "Atom Feed", Link: "/writings/atom"},
 		common.IndexItem{Name: "RSS Feed", Link: "/writings/rss"},
 	)
-	data.RSSFeedUrl = "/writings/rss"
-	data.AtomFeedUrl = "/writings/atom"
+	data.RSSFeedURL = "/writings/rss"
+	data.AtomFeedURL = "/writings/atom"
 
 	userHasAdmin := data.HasAdminRole() && data.AdminMode
 	if userHasAdmin {


### PR DESCRIPTION
## Summary
- Rename CoreData fields to `AtomFeedURL` and `RSSFeedURL`
- Update handlers and templates to use new feed URL names

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cd.queries.RegisterExternalLinkClick undefined; method CoreData.ThreadComments already declared; undefined: strconv)*
- `golangci-lint run` *(fails: typecheck errors such as RegisterExternalLinkClick undefined, undefined: strconv, missing fields)*
- `go test ./...` *(fails: RegisterExternalLinkClick undefined; method CoreData.ThreadComments already declared; undefined: strconv)*

------
https://chatgpt.com/codex/tasks/task_e_688fe6aa2120832fbf35ed7d17d37f58