### PR TITLE
Remove viewer IDs from admin queries

### DIFF
--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -119,10 +119,7 @@ func (c *userDeactivateCmd) Run() error {
 			return fmt.Errorf("scrub writing: %w", err)
 		}
 	}
-	blogs, err := qtx.AdminGetAllBlogEntriesByUser(ctx, db.AdminGetAllBlogEntriesByUserParams{
-		AuthorID: u.Idusers,
-		ListerID: 0,
-	})
+	blogs, err := qtx.AdminGetAllBlogEntriesByUser(ctx, u.Idusers)
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("list blogs: %w", err)

--- a/handlers/admin/adminCommentsPage.go
+++ b/handlers/admin/adminCommentsPage.go
@@ -15,9 +15,8 @@ func AdminCommentsPage(w http.ResponseWriter, r *http.Request) {
 	cd.PageTitle = "Comments"
 	queries := cd.Queries()
 	rows, err := queries.AdminListAllCommentsWithThreadInfo(r.Context(), db.AdminListAllCommentsWithThreadInfoParams{
-		ViewerID: cd.UserID,
-		Limit:    50,
-		Offset:   0,
+		Limit:  50,
+		Offset: 0,
 	})
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/handlers/admin/adminUserBlogsPage.go
+++ b/handlers/admin/adminUserBlogsPage.go
@@ -23,10 +23,7 @@ func adminUserBlogsPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.AdminGetAllBlogEntriesByUser(r.Context(), db.AdminGetAllBlogEntriesByUserParams{
-		AuthorID: int32(id),
-		ListerID: cd.UserID,
-	})
+	rows, err := queries.AdminGetAllBlogEntriesByUser(r.Context(), int32(id))
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/faq/rename_category_task.go
+++ b/handlers/faq/rename_category_task.go
@@ -31,15 +31,12 @@ func (RenameCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("cid parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if err := queries.AdminRenameFAQCategory(r.Context(), db.AdminRenameFAQCategoryParams{
 		Name: sql.NullString{
 			String: text,
 			Valid:  true,
 		},
 		Idfaqcategories: int32(cid),
-		ViewerID:        cd.UserID,
 	}); err != nil {
 		return fmt.Errorf("rename faq category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/linker/approve_task.go
+++ b/handlers/linker/approve_task.go
@@ -42,10 +42,7 @@ func (approveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	qid, _ := strconv.Atoi(r.URL.Query().Get("qid"))
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	lid, err := queries.AdminInsertQueuedLinkFromQueue(r.Context(), db.AdminInsertQueuedLinkFromQueueParams{
-		Idlinkerqueue: int32(qid),
-		AdminID:       cd.UserID,
-	})
+	lid, err := queries.AdminInsertQueuedLinkFromQueue(r.Context(), int32(qid))
 	if err != nil {
 		return fmt.Errorf("approve linker item fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/linker/bulk_approve_task.go
+++ b/handlers/linker/bulk_approve_task.go
@@ -46,10 +46,7 @@ func (bulkApproveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	for _, q := range r.Form["qid"] {
 		id, _ := strconv.Atoi(q)
 		cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-		lid, err := queries.AdminInsertQueuedLinkFromQueue(r.Context(), db.AdminInsertQueuedLinkFromQueueParams{
-			Idlinkerqueue: int32(id),
-			AdminID:       cd.UserID,
-		})
+		lid, err := queries.AdminInsertQueuedLinkFromQueue(r.Context(), int32(id))
 		if err != nil {
 			log.Printf("selectInsert Error: %s", err)
 			continue

--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -103,10 +103,7 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 		ws = append(ws, writingExport{wrow, catMap[wrow.WritingCategoryID]})
 	}
 
-	blogs, err := queries.AdminGetAllBlogEntriesByUser(r.Context(), db.AdminGetAllBlogEntriesByUserParams{
-		AuthorID: int32(uid),
-		ListerID: cd.UserID,
-	})
+	blogs, err := queries.AdminGetAllBlogEntriesByUser(r.Context(), int32(uid))
 	if err != nil {
 		log.Printf("fetch blogs: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -68,7 +68,7 @@ type Querier interface {
 	AdminDemoteAnnouncement(ctx context.Context, id int32) error
 	AdminForumCategoryThreadCounts(ctx context.Context) ([]*AdminForumCategoryThreadCountsRow, error)
 	AdminForumTopicThreadCounts(ctx context.Context) ([]*AdminForumTopicThreadCountsRow, error)
-	AdminGetAllBlogEntriesByUser(ctx context.Context, arg AdminGetAllBlogEntriesByUserParams) ([]*AdminGetAllBlogEntriesByUserRow, error)
+	AdminGetAllBlogEntriesByUser(ctx context.Context, authorID int32) ([]*AdminGetAllBlogEntriesByUserRow, error)
 	AdminGetAllCommentsByUser(ctx context.Context, userID int32) ([]*AdminGetAllCommentsByUserRow, error)
 	AdminGetAllWritingsByAuthor(ctx context.Context, authorID int32) ([]*AdminGetAllWritingsByAuthorRow, error)
 	AdminGetDashboardStats(ctx context.Context) (*AdminGetDashboardStatsRow, error)
@@ -89,7 +89,7 @@ type Querier interface {
 	AdminInsertBannedIp(ctx context.Context, arg AdminInsertBannedIpParams) error
 	// AdminInsertLanguage adds a new language returning a result.
 	AdminInsertLanguage(ctx context.Context, nameof sql.NullString) (sql.Result, error)
-	AdminInsertQueuedLinkFromQueue(ctx context.Context, arg AdminInsertQueuedLinkFromQueueParams) (int64, error)
+	AdminInsertQueuedLinkFromQueue(ctx context.Context, idlinkerqueue int32) (int64, error)
 	AdminInsertRequestComment(ctx context.Context, arg AdminInsertRequestCommentParams) error
 	AdminInsertRequestQueue(ctx context.Context, arg AdminInsertRequestQueueParams) (sql.Result, error)
 	AdminInsertWritingCategory(ctx context.Context, arg AdminInsertWritingCategoryParams) error

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -307,13 +307,6 @@ FROM blogs b
 LEFT JOIN users u ON b.users_idusers = u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE b.users_idusers = sqlc.arg(author_id)
-  AND EXISTS (
-      SELECT 1
-      FROM user_roles ur
-      JOIN roles r ON ur.role_id = r.id
-      WHERE ur.users_idusers = sqlc.arg(lister_id)
-        AND r.is_admin = 1
-  )
 ORDER BY b.written DESC;
 
 -- name: SystemSetBlogLastIndex :exec

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -18,20 +18,8 @@ FROM blogs b
 LEFT JOIN users u ON b.users_idusers = u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE b.users_idusers = ?
-  AND EXISTS (
-      SELECT 1
-      FROM user_roles ur
-      JOIN roles r ON ur.role_id = r.id
-      WHERE ur.users_idusers = ?
-        AND r.is_admin = 1
-  )
 ORDER BY b.written DESC
 `
-
-type AdminGetAllBlogEntriesByUserParams struct {
-	AuthorID int32
-	ListerID int32
-}
 
 type AdminGetAllBlogEntriesByUserRow struct {
 	Idblogs            int32
@@ -44,8 +32,8 @@ type AdminGetAllBlogEntriesByUserRow struct {
 	Comments           int32
 }
 
-func (q *Queries) AdminGetAllBlogEntriesByUser(ctx context.Context, arg AdminGetAllBlogEntriesByUserParams) ([]*AdminGetAllBlogEntriesByUserRow, error) {
-	rows, err := q.db.QueryContext(ctx, adminGetAllBlogEntriesByUser, arg.AuthorID, arg.ListerID)
+func (q *Queries) AdminGetAllBlogEntriesByUser(ctx context.Context, authorID int32) ([]*AdminGetAllBlogEntriesByUserRow, error) {
+	rows, err := q.db.QueryContext(ctx, adminGetAllBlogEntriesByUser, authorID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -170,10 +170,5 @@ FROM comments c
 LEFT JOIN forumthread th ON c.forumthread_id = th.idforumthread
 LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic = t.idforumtopic
 LEFT JOIN users u ON u.idusers = c.users_idusers
-WHERE EXISTS (
-    SELECT 1 FROM user_roles ur
-    JOIN roles r ON ur.role_id = r.id
-    WHERE ur.users_idusers = sqlc.arg('viewer_id') AND r.is_admin = 1
-)
 ORDER BY c.written DESC
 LIMIT ? OFFSET ?;

--- a/internal/db/queries-comments.sql.go
+++ b/internal/db/queries-comments.sql.go
@@ -72,19 +72,13 @@ FROM comments c
 LEFT JOIN forumthread th ON c.forumthread_id = th.idforumthread
 LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic = t.idforumtopic
 LEFT JOIN users u ON u.idusers = c.users_idusers
-WHERE EXISTS (
-    SELECT 1 FROM user_roles ur
-    JOIN roles r ON ur.role_id = r.id
-    WHERE ur.users_idusers = ? AND r.is_admin = 1
-)
 ORDER BY c.written DESC
 LIMIT ? OFFSET ?
 `
 
 type AdminListAllCommentsWithThreadInfoParams struct {
-	ViewerID int32
-	Limit    int32
-	Offset   int32
+	Limit  int32
+	Offset int32
 }
 
 type AdminListAllCommentsWithThreadInfoRow struct {
@@ -100,7 +94,7 @@ type AdminListAllCommentsWithThreadInfoRow struct {
 }
 
 func (q *Queries) AdminListAllCommentsWithThreadInfo(ctx context.Context, arg AdminListAllCommentsWithThreadInfoParams) ([]*AdminListAllCommentsWithThreadInfoRow, error) {
-	rows, err := q.db.QueryContext(ctx, adminListAllCommentsWithThreadInfo, arg.ViewerID, arg.Limit, arg.Offset)
+	rows, err := q.db.QueryContext(ctx, adminListAllCommentsWithThreadInfo, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/queries-faq.sql
+++ b/internal/db/queries-faq.sql
@@ -46,13 +46,7 @@ FROM faq;
 -- name: AdminRenameFAQCategory :exec
 UPDATE faq_categories
 SET name = ?
-WHERE idfaqCategories = ?
-  AND EXISTS (
-      SELECT 1 FROM user_roles ur
-      JOIN roles r ON ur.role_id = r.id
-      WHERE ur.users_idusers = sqlc.arg(viewer_id)
-        AND r.is_admin = 1
-  );
+WHERE idfaqCategories = ?;
 
 -- name: AdminDeleteFAQCategory :exec
 UPDATE faq_categories SET deleted_at = NOW()

--- a/internal/db/queries-faq.sql.go
+++ b/internal/db/queries-faq.sql.go
@@ -43,22 +43,15 @@ const adminRenameFAQCategory = `-- name: AdminRenameFAQCategory :exec
 UPDATE faq_categories
 SET name = ?
 WHERE idfaqCategories = ?
-  AND EXISTS (
-      SELECT 1 FROM user_roles ur
-      JOIN roles r ON ur.role_id = r.id
-      WHERE ur.users_idusers = ?
-        AND r.is_admin = 1
-  )
 `
 
 type AdminRenameFAQCategoryParams struct {
 	Name            sql.NullString
 	Idfaqcategories int32
-	ViewerID        int32
 }
 
 func (q *Queries) AdminRenameFAQCategory(ctx context.Context, arg AdminRenameFAQCategoryParams) error {
-	_, err := q.db.ExecContext(ctx, adminRenameFAQCategory, arg.Name, arg.Idfaqcategories, arg.ViewerID)
+	_, err := q.db.ExecContext(ctx, adminRenameFAQCategory, arg.Name, arg.Idfaqcategories)
 	return err
 }
 

--- a/internal/db/queries-linker.sql
+++ b/internal/db/queries-linker.sql
@@ -5,12 +5,7 @@ WHERE idlinkerCategory = ?;
 
 -- name: AdminRenameLinkerCategory :exec
 UPDATE linker_category SET title = ?, position = ?
-WHERE idlinkerCategory = ?
-  AND EXISTS (
-    SELECT 1 FROM user_roles ur
-    JOIN roles r ON ur.role_id = r.id
-    WHERE ur.users_idusers = sqlc.arg(admin_id) AND r.is_admin = 1
-  );
+WHERE idlinkerCategory = ?;
 
 -- name: AdminCreateLinkerCategory :exec
 INSERT INTO linker_category (title, position) VALUES (sqlc.arg(title), sqlc.arg(position));
@@ -97,12 +92,7 @@ JOIN linker_category c ON l.linker_category_id = c.idlinkerCategory
 INSERT INTO linker (users_idusers, linker_category_id, language_idlanguage, title, `url`, description)
 SELECT l.users_idusers, l.linker_category_id, l.language_idlanguage, l.title, l.url, l.description
 FROM linker_queue l
-WHERE l.idlinkerQueue = ?
-  AND EXISTS (
-    SELECT 1 FROM user_roles ur
-    JOIN roles r ON ur.role_id = r.id
-    WHERE ur.users_idusers = sqlc.arg(admin_id) AND r.is_admin = 1
-  );
+WHERE l.idlinkerQueue = ?;
 
 -- name: AdminCreateLinkerItem :exec
 INSERT INTO linker (users_idusers, linker_category_id, title, url, description, listed)

--- a/internal/db/queries-linker.sql.go
+++ b/internal/db/queries-linker.sql.go
@@ -86,20 +86,10 @@ INSERT INTO linker (users_idusers, linker_category_id, language_idlanguage, titl
 SELECT l.users_idusers, l.linker_category_id, l.language_idlanguage, l.title, l.url, l.description
 FROM linker_queue l
 WHERE l.idlinkerQueue = ?
-  AND EXISTS (
-    SELECT 1 FROM user_roles ur
-    JOIN roles r ON ur.role_id = r.id
-    WHERE ur.users_idusers = ? AND r.is_admin = 1
-  )
 `
 
-type AdminInsertQueuedLinkFromQueueParams struct {
-	Idlinkerqueue int32
-	AdminID       int32
-}
-
-func (q *Queries) AdminInsertQueuedLinkFromQueue(ctx context.Context, arg AdminInsertQueuedLinkFromQueueParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, adminInsertQueuedLinkFromQueue, arg.Idlinkerqueue, arg.AdminID)
+func (q *Queries) AdminInsertQueuedLinkFromQueue(ctx context.Context, idlinkerqueue int32) (int64, error) {
+	result, err := q.db.ExecContext(ctx, adminInsertQueuedLinkFromQueue, idlinkerqueue)
 	if err != nil {
 		return 0, err
 	}
@@ -109,27 +99,16 @@ func (q *Queries) AdminInsertQueuedLinkFromQueue(ctx context.Context, arg AdminI
 const adminRenameLinkerCategory = `-- name: AdminRenameLinkerCategory :exec
 UPDATE linker_category SET title = ?, position = ?
 WHERE idlinkerCategory = ?
-  AND EXISTS (
-    SELECT 1 FROM user_roles ur
-    JOIN roles r ON ur.role_id = r.id
-    WHERE ur.users_idusers = ? AND r.is_admin = 1
-  )
 `
 
 type AdminRenameLinkerCategoryParams struct {
 	Title            sql.NullString
 	Position         int32
 	Idlinkercategory int32
-	AdminID          int32
 }
 
 func (q *Queries) AdminRenameLinkerCategory(ctx context.Context, arg AdminRenameLinkerCategoryParams) error {
-	_, err := q.db.ExecContext(ctx, adminRenameLinkerCategory,
-		arg.Title,
-		arg.Position,
-		arg.Idlinkercategory,
-		arg.AdminID,
-	)
+	_, err := q.db.ExecContext(ctx, adminRenameLinkerCategory, arg.Title, arg.Position, arg.Idlinkercategory)
 	return err
 }
 


### PR DESCRIPTION
## Summary
- drop user checks from admin SQL queries for comments, blogs, FAQ categories, and linker queues
- regenerate sqlc models and update handlers for new query signatures

## Testing
- `sqlc generate`
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method CoreData.ThreadComments already declared; cd.queries.RegisterExternalLinkClick undefined; undefined: strconv)*
- `go test ./...` *(fails: build failures in core/common and many handlers)*
- `golangci-lint run` *(fails: typecheck errors in core/common and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_688f625a0650832f9a78e37758c2f857