### PR TITLE
Add pagination and permission checks to list queries

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -297,15 +297,6 @@ WITH RECURSIVE role_ids(id) AS (
 )
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written
 FROM blogs b
-JOIN grants g ON g.item_id = b.idblogs
-    AND g.section = 'blogs'
-    AND g.item = 'entry'
-    AND g.action = 'see'
-    AND g.active = 1
-    AND (g.user_id = ? OR g.user_id IS NULL)
-    AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
-LEFT JOIN users u ON b.users_idusers=u.idusers
-LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE b.idblogs IN (/*SLICE:blogids*/?)
   AND (
       b.language_idlanguage = 0
@@ -319,13 +310,26 @@ WHERE b.idblogs IN (/*SLICE:blogids*/?)
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
       )
   )
+  AND EXISTS (
+      SELECT 1 FROM grants g
+      WHERE g.section = 'blogs'
+        AND g.item = 'entry'
+        AND g.action = 'see'
+        AND g.active = 1
+        AND g.item_id = b.idblogs
+        AND (g.user_id = ? OR g.user_id IS NULL)
+        AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
+  )
 ORDER BY b.written DESC
+LIMIT ? OFFSET ?
 `
 
 type ListBlogEntriesByIDsForListerParams struct {
 	ListerID int32
-	UserID   sql.NullInt32
 	Blogids  []int32
+	UserID   sql.NullInt32
+	Limit    int32
+	Offset   int32
 }
 
 type ListBlogEntriesByIDsForListerRow struct {
@@ -341,7 +345,6 @@ func (q *Queries) ListBlogEntriesByIDsForLister(ctx context.Context, arg ListBlo
 	query := listBlogEntriesByIDsForLister
 	var queryParams []interface{}
 	queryParams = append(queryParams, arg.ListerID)
-	queryParams = append(queryParams, arg.UserID)
 	if len(arg.Blogids) > 0 {
 		for _, v := range arg.Blogids {
 			queryParams = append(queryParams, v)
@@ -352,6 +355,9 @@ func (q *Queries) ListBlogEntriesByIDsForLister(ctx context.Context, arg ListBlo
 	}
 	queryParams = append(queryParams, arg.ListerID)
 	queryParams = append(queryParams, arg.ListerID)
+	queryParams = append(queryParams, arg.UserID)
+	queryParams = append(queryParams, arg.Limit)
+	queryParams = append(queryParams, arg.Offset)
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- add grant checks and pagination to blog entry list by IDs
- enforce language filtering and pagination when listing writings by IDs
- thread search handlers now pass pagination settings
- fix missing strconv import in common helpers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method CoreData.ThreadComments already declared; RegisterExternalLinkClick undefined)*
- `golangci-lint run` *(fails: multiple typecheck errors)*
- `go test ./...` *(fails: build errors in core/common and various handlers)*

------
https://chatgpt.com/codex/tasks/task_e_688f628a1c34832fa37039783af7daf7