### PR TITLE
refactor: pass roles via option

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -171,7 +171,6 @@ type CoreData struct {
 	subscriptionRows         lazy.Value[[]*db.ListSubscriptionsByUserRow]
 	subscriptions            lazy.Value[map[string]bool]
 	templateOverrides        map[string]*lazy.Value[string]
-	threadComments           map[int32]*lazy.Value[[]*db.GetCommentsByThreadIdForUserRow]
 	unreadCount              lazy.Value[int64]
 	user                     lazy.Value[*db.User]
 	userRoles                lazy.Value[[]string]
@@ -1581,7 +1580,7 @@ func (cd *CoreData) RegisterExternalLinkClick(url string) {
 	if cd.queries == nil {
 		return
 	}
-	if err := cd.queries.RegisterExternalLinkClick(cd.ctx, url); err != nil {
+	if err := cd.queries.SystemRegisterExternalLinkClick(cd.ctx, url); err != nil {
 		log.Printf("record external link click: %v", err)
 	}
 }
@@ -1712,9 +1711,6 @@ func (cd *CoreData) SetPageTitle(title string) {
 	cd.Title = title
 }
 
-// SetRoles preloads the current user roles.
-func (cd *CoreData) SetRoles(r []string) { cd.userRoles.Set(r) } // TODO this should be done from the constructing middleware via options and this function removed once obsolete
-
 // SetSession stores s on cd for later retrieval.
 func (cd *CoreData) SetSession(s *sessions.Session) { cd.session = s }
 
@@ -1825,35 +1821,6 @@ func (cd *CoreData) ThreadComments(id int32, ops ...lazy.Option[[]*db.GetComment
 		})
 	}
 	return lazy.Map(&cd.forumThreadComments, &cd.mapMu, id, fetch, ops...)
-}
-
-// ThreadComments returns comments for a thread lazily loading them once per thread ID.
-func (cd *CoreData) ThreadComments(threadID int32) ([]*db.GetCommentsByThreadIdForUserRow, error) {
-	if cd.threadComments == nil {
-		cd.threadComments = make(map[int32]*lazy.Value[[]*db.GetCommentsByThreadIdForUserRow])
-	}
-	lv, ok := cd.threadComments[threadID]
-	if !ok {
-		lv = &lazy.Value[[]*db.GetCommentsByThreadIdForUserRow]{}
-		cd.threadComments[threadID] = lv
-	}
-	return lv.Load(func() ([]*db.GetCommentsByThreadIdForUserRow, error) {
-		if cd.queries == nil {
-			return nil, nil
-		}
-		rows, err := cd.queries.GetCommentsByThreadIdForUser(cd.ctx, db.GetCommentsByThreadIdForUserParams{
-			ViewerID: cd.UserID,
-			ThreadID: threadID,
-			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-		})
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return nil, nil
-			}
-			return nil, err
-		}
-		return rows, nil
-	})
 }
 
 // UnreadNotificationCount returns the number of unread notifications for the
@@ -2130,6 +2097,11 @@ func WithNavRegistry(r NavigationProvider) CoreOption {
 // WithCustomQueries sets the db.CustomQueries dependency.
 func WithCustomQueries(cq db.CustomQueries) CoreOption {
 	return func(cd *CoreData) { cd.customQueries = cq }
+}
+
+// WithUserRoles preloads the current user roles.
+func WithUserRoles(r []string) CoreOption {
+	return func(cd *CoreData) { cd.userRoles.Set(r) }
 }
 
 // WithSelectionsFromRequest extracts integer identifiers from the request and

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -37,9 +37,8 @@ func TestCoreDataLatestNewsLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{"user"}))
 	cd.UserID = 1
-	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -71,9 +70,8 @@ func TestWritingCategoriesLazy(t *testing.T) {
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "category", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{"user"}))
 	cd.UserID = 1
-	cd.SetRoles([]string{"user"})
 
 	if _, err := cd.VisibleWritingCategories(cd.UserID); err != nil {
 		t.Fatalf("WritingCategories: %v", err)
@@ -167,9 +165,8 @@ func TestPublicWritingsLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{"user"}))
 	cd.UserID = 1
-	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -211,9 +208,8 @@ func TestCoreDataLatestWritingsLazy(t *testing.T) {
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "article", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{"user"}))
 	cd.UserID = 1
-	cd.SetRoles([]string{"user"})
 
 	req := httptest.NewRequest("GET", "/", nil).WithContext(context.WithValue(ctx, consts.KeyCoreData, cd))
 	offset, _ := strconv.Atoi(req.URL.Query().Get("offset"))

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -77,9 +77,8 @@ func TestLatestNewsRespectsPermissions(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{"user"}))
 	cd.UserID = 1
-	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/access_test.go
+++ b/handlers/access_test.go
@@ -17,8 +17,7 @@ func TestVerifyAccess(t *testing.T) {
 	}, "administrator")
 
 	req := httptest.NewRequest("GET", "/", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"anonymous"})
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
 
 	rr := httptest.NewRecorder()
@@ -27,8 +26,7 @@ func TestVerifyAccess(t *testing.T) {
 		t.Fatalf("expected %d got %d", http.StatusForbidden, rr.Code)
 	}
 
-	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"administrator"})
+	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
 	rr = httptest.NewRecorder()
 	h(rr, req)

--- a/handlers/admin/reload_shutdown_test.go
+++ b/handlers/admin/reload_shutdown_test.go
@@ -20,8 +20,7 @@ import (
 
 func TestAdminReloadConfigPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"anonymous"})
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	h := New()
@@ -43,8 +42,7 @@ func TestAdminReloadRoute_Unauthorized(t *testing.T) {
 	h.RegisterRoutes(ar, cfg, navReg)
 
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
-	cd := common.NewCoreData(req.Context(), nil, cfg)
-	cd.SetRoles([]string{"anonymous"})
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"anonymous"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -65,8 +63,7 @@ func TestAdminReloadRoute_Authorized(t *testing.T) {
 	h.RegisterRoutes(ar, cfg, navReg)
 
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
-	cd := common.NewCoreData(req.Context(), nil, cfg)
-	cd.SetRoles([]string{"administrator"})
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"administrator"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -87,8 +84,7 @@ func TestAdminShutdownRoute_Unauthorized(t *testing.T) {
 	h.RegisterRoutes(ar, cfg, navReg)
 
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
-	cd := common.NewCoreData(req.Context(), nil, cfg)
-	cd.SetRoles([]string{"anonymous"})
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"anonymous"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -112,8 +108,7 @@ func TestAdminShutdownRoute_Authorized(t *testing.T) {
 	form.Set("task", string(TaskServerShutdown))
 	req := httptest.NewRequest("POST", "/admin/shutdown", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	cd := common.NewCoreData(req.Context(), nil, cfg)
-	cd.SetRoles([]string{"administrator"})
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"administrator"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -128,8 +123,7 @@ func TestAdminShutdownRoute_Authorized(t *testing.T) {
 func TestServerShutdownTask_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
 	cfg := config.NewRuntimeConfig()
-	cd := common.NewCoreData(req.Context(), nil, cfg)
-	cd.SetRoles([]string{"anonymous"})
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"anonymous"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	h := New()
@@ -145,8 +139,7 @@ func TestServerShutdownTask_Unauthorized(t *testing.T) {
 func TestServerShutdownMatcher_Denied(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
 	cfg := config.NewRuntimeConfig()
-	cd := common.NewCoreData(req.Context(), nil, cfg)
-	cd.SetRoles([]string{"anonymous"})
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"anonymous"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	h := New()
@@ -160,8 +153,7 @@ func TestServerShutdownMatcher_Allowed(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/admin/shutdown", body)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	cfg := config.NewRuntimeConfig()
-	cd := common.NewCoreData(req.Context(), nil, cfg)
-	cd.SetRoles([]string{"administrator"})
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"administrator"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	h := New()

--- a/handlers/admin/server_shutdown_task_test.go
+++ b/handlers/admin/server_shutdown_task_test.go
@@ -19,9 +19,8 @@ func TestServerShutdownTask_EventPublished(t *testing.T) {
 	h := New(WithServer(&server.Server{Bus: bus}))
 	ch := bus.Subscribe(eventbus.TaskMessageType)
 
-	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
 	cd.UserID = 1
-	cd.SetRoles([]string{"administrator"})
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)

--- a/handlers/auth/loginPage_test.go
+++ b/handlers/auth/loginPage_test.go
@@ -108,8 +108,7 @@ func TestLoginAction_InvalidPassword(t *testing.T) {
 
 func TestLoginPageHiddenFields(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/login?code=abc&back=%2Ffoo&method=POST&data=x", nil)
-	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"anonymous"})
+	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -402,8 +401,7 @@ func TestLoginAction_Throttle(t *testing.T) {
 func TestRedirectBackPageHandlerGET(t *testing.T) {
 	t.Skip("skip due to template environment")
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"anonymous"})
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -422,8 +420,7 @@ func TestRedirectBackPageHandlerGET(t *testing.T) {
 func TestRedirectBackPageHandlerEmptyMethod(t *testing.T) {
 	t.Skip("skip due to template environment")
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"anonymous"})
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -443,8 +440,7 @@ func TestRedirectBackPageHandler(t *testing.T) {
 	cases := map[string]string{"empty": "", "get": http.MethodGet}
 	for name, method := range cases {
 		t.Run(name, func(t *testing.T) {
-			cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
-			cd.SetRoles([]string{"anonymous"})
+			cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 			req = req.WithContext(ctx)
@@ -466,8 +462,7 @@ func TestRedirectBackPageHandler(t *testing.T) {
 	}
 
 	t.Run("post", func(t *testing.T) {
-		cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
-		cd.SetRoles([]string{"anonymous"})
+		cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 		req = req.WithContext(ctx)

--- a/handlers/blogs/blogsIndexPermissions_test.go
+++ b/handlers/blogs/blogsIndexPermissions_test.go
@@ -11,8 +11,7 @@ import (
 func TestCustomBlogIndexRoles(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs", nil)
 
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"administrator"})
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
 	cd.AdminMode = true
 	CustomBlogIndex(cd, req)
 	if !common.ContainsItem(cd.CustomIndexItems, "User Roles") {
@@ -22,8 +21,7 @@ func TestCustomBlogIndexRoles(t *testing.T) {
 		t.Errorf("admin should see write blog")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"content writer"})
+	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"content writer"}))
 	CustomBlogIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "User Roles") {
 		t.Errorf("content writer should not see user roles")
@@ -32,8 +30,7 @@ func TestCustomBlogIndexRoles(t *testing.T) {
 		t.Errorf("content writer should see write blog")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"anonymous"})
+	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	CustomBlogIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "User Roles") || common.ContainsItem(cd.CustomIndexItems, "Write blog") {
 		t.Errorf("anonymous should not see writer/admin items")

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -127,8 +127,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 
 func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"anonymous"})
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -140,8 +139,7 @@ func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
 
 func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/1/edit", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"anonymous"})
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -153,8 +151,7 @@ func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 
 func TestGetPermissionsByUserIdAndSectionBlogsPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin/blogs/users/roles", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"anonymous"})
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/handlers/faq/page_test.go
+++ b/handlers/faq/page_test.go
@@ -8,16 +8,14 @@ import (
 )
 
 func TestCustomFAQIndexRoles(t *testing.T) {
-	cd := common.NewCoreData(nil, nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"administrator"})
+	cd := common.NewCoreData(nil, nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
 	cd.AdminMode = true
 	CustomFAQIndex(cd, nil)
 	if !common.ContainsItem(cd.CustomIndexItems, "Question Qontrols") {
 		t.Errorf("admin should see question controls")
 	}
 
-	cd = common.NewCoreData(nil, nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"anonymous"})
+	cd = common.NewCoreData(nil, nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	CustomFAQIndex(cd, nil)
 	if common.ContainsItem(cd.CustomIndexItems, "Question Qontrols") {
 		t.Errorf("anonymous should not see admin items")

--- a/handlers/matchers_test.go
+++ b/handlers/matchers_test.go
@@ -14,9 +14,8 @@ import (
 
 func TestRequiredAccessAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"content writer"}))
 	cd.UserID = 1
-	cd.SetRoles([]string{"content writer"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -27,9 +26,8 @@ func TestRequiredAccessAllowed(t *testing.T) {
 
 func TestRequiredAccessDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	cd.UserID = 1
-	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/news/newsIndexPermissions_test.go
+++ b/handlers/news/newsIndexPermissions_test.go
@@ -13,8 +13,7 @@ import (
 func TestCustomNewsIndexRoles(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"administrator"})
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
 	cd.AdminMode = true
 	CustomNewsIndex(cd, req)
 	if !common.ContainsItem(cd.CustomIndexItems, "User Roles") {
@@ -31,8 +30,7 @@ func TestCustomNewsIndexRoles(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 	ctx := req.Context()
-	cd = common.NewCoreData(ctx, q, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"content writer", "administrator"})
+	cd = common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithUserRoles([]string{"content writer", "administrator"}))
 	CustomNewsIndex(cd, req.WithContext(ctx))
 	if common.ContainsItem(cd.CustomIndexItems, "User Roles") {
 		t.Errorf("content writer should not see user roles")
@@ -41,8 +39,7 @@ func TestCustomNewsIndexRoles(t *testing.T) {
 		t.Errorf("content writer should see add news")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"anonymous"})
+	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	CustomNewsIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "User Roles") || common.ContainsItem(cd.CustomIndexItems, "Add News") {
 		t.Errorf("anonymous should not see admin items")

--- a/handlers/user/userSubscriptionsPage.go
+++ b/handlers/user/userSubscriptionsPage.go
@@ -3,7 +3,6 @@ package user
 import (
 	"net/http"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"

--- a/handlers/writings/matchers_test.go
+++ b/handlers/writings/matchers_test.go
@@ -37,8 +37,7 @@ func TestRequireWritingAuthorArticleVar(t *testing.T) {
 	sess, _ := store.Get(req, core.SessionName)
 	sess.Values["UID"] = int32(1)
 
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithSession(sess))
-	cd.SetRoles([]string{"content writer"})
+	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithSession(sess), common.WithUserRoles([]string{"content writer"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/internal/router/roles_test.go
+++ b/internal/router/roles_test.go
@@ -14,8 +14,7 @@ import (
 
 func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"administrator"})
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -39,8 +38,7 @@ func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 
 func TestRoleCheckerMiddlewareDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
-	cd.SetRoles([]string{"anonymous"})
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 


### PR DESCRIPTION
## Summary
- remove `SetRoles` and support injecting roles through `WithUserRoles` option
- update CoreData creations to pass roles via `WithUserRoles`
- clean up unused import in user subscription page

## Testing
- `go mod tidy`
- `go vet ./...` *(fails: queries.SystemGetBlogEntryByID undefined, etc.)*
- `golangci-lint run` *(fails: typecheck errors for missing db query methods)*
- `go test ./...` *(fails: missing db query methods and template variable `$cd`)*

------
https://chatgpt.com/codex/tasks/task_e_688fefa6937c832f96e40a2cdba09c8a