### PR TITLE
refactor selection id mapping

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -2132,48 +2132,50 @@ func WithCustomQueries(cq db.CustomQueries) CoreOption {
 	return func(cd *CoreData) { cd.customQueries = cq }
 }
 
+// assignIDFromString converts v to int32 and stores it in the mapped CoreData
+// field identified by k.
+func assignIDFromString(m map[string]*int32, k, v string) {
+	dest, ok := m[k]
+	if !ok {
+		return
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return
+	}
+	*dest = int32(i)
+}
+
 // WithSelectionsFromRequest extracts integer identifiers from the request and
 // stores them on the CoreData instance. It searches path variables, query
 // parameters and finally form values.
 func WithSelectionsFromRequest(r *http.Request) CoreOption {
 	return func(cd *CoreData) {
-		setID := func(k, v string) {
-			i, err := strconv.Atoi(v)
-			if err != nil {
-				return
-			}
-			switch k {
-			case "boardno", "board":
-				cd.currentBoardID = int32(i)
-			case "thread", "replyTo":
-				cd.currentThreadID = int32(i)
-			case "topic":
-				cd.currentTopicID = int32(i)
-			case "comment":
-				cd.currentCommentID = int32(i)
-			case "news":
-				cd.currentNewsPostID = int32(i)
-			case "post":
-				cd.currentImagePostID = int32(i)
-			case "writing":
-				cd.currentWritingID = int32(i)
-			case "blog":
-				cd.currentBlogID = int32(i)
-			}
+		mapping := map[string]*int32{
+			"boardno": &cd.currentBoardID,
+			"board":   &cd.currentBoardID,
+			"thread":  &cd.currentThreadID,
+			"replyTo": &cd.currentThreadID,
+			"topic":   &cd.currentTopicID,
+			"comment": &cd.currentCommentID,
+			"news":    &cd.currentNewsPostID,
+			"post":    &cd.currentImagePostID,
+			"writing": &cd.currentWritingID,
+			"blog":    &cd.currentBlogID,
 		}
 		for k, v := range mux.Vars(r) {
-			setID(k, v)
+			assignIDFromString(mapping, k, v)
 		}
 		q := r.URL.Query()
 		for k, v := range q {
 			if len(v) > 0 {
-				setID(k, v[0])
+				assignIDFromString(mapping, k, v[0])
 			}
 		}
 		if err := r.ParseForm(); err == nil {
 			for k, v := range r.Form {
 				if len(v) > 0 {
-					setID(k, v[0])
+					assignIDFromString(mapping, k, v[0])
 				}
 			}
 		}

--- a/core/common/coredata_request_test.go
+++ b/core/common/coredata_request_test.go
@@ -1,0 +1,44 @@
+package common_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+)
+
+func TestWithSelectionsFromRequest(t *testing.T) {
+	cfg := config.NewRuntimeConfig()
+
+	t.Run("path variable", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req = mux.SetURLVars(req, map[string]string{"board": "1"})
+		cd := common.NewCoreData(context.Background(), nil, cfg, common.WithSelectionsFromRequest(req))
+		if got := cd.SelectedBoard(); got != 1 {
+			t.Fatalf("SelectedBoard = %d; want 1", got)
+		}
+	})
+
+	t.Run("query parameter", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/?thread=2", nil)
+		cd := common.NewCoreData(context.Background(), nil, cfg, common.WithSelectionsFromRequest(req))
+		if got := cd.SelectedThread(); got != 2 {
+			t.Fatalf("SelectedThread = %d; want 2", got)
+		}
+	})
+
+	t.Run("form value", func(t *testing.T) {
+		body := strings.NewReader("post=3")
+		req := httptest.NewRequest("POST", "/", body)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		cd := common.NewCoreData(context.Background(), nil, cfg, common.WithSelectionsFromRequest(req))
+		if got := cd.SelectedImagePost(); got != 3 {
+			t.Fatalf("SelectedImagePost = %d; want 3", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- centralize request ID parsing into a helper
- simplify WithSelectionsFromRequest using the helper
- cover path, query, and form ID extraction with tests

## Testing
- `go mod tidy`
- `go fmt ./core/common/...`
- `go vet ./core/common/...` *(fails: cd.queries.RegisterExternalLinkClick undefined; method CoreData.ThreadComments already declared)*
- `golangci-lint run` *(fails: multiple typecheck errors across repository)*
- `go test ./core/common/...` *(fails: cd.queries.RegisterExternalLinkClick undefined; method CoreData.ThreadComments already declared)*

------
https://chatgpt.com/codex/tasks/task_e_688feffc6ce8832faef46d5d125e6e49