### PR TITLE
core: accept runtime config via option

### DIFF
--- a/cmd/goa4web/news_list.go
+++ b/cmd/goa4web/news_list.go
@@ -36,7 +36,7 @@ func (c *newsListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := db.New(conn)
-	cd := common.NewCoreData(ctx, queries, c.rootCmd.cfg)
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(c.rootCmd.cfg))
 	posts, err := cd.LatestNewsList(int32(c.Offset), int32(c.Limit))
 	if err != nil {
 		return fmt.Errorf("list news: %w", err)

--- a/cmd/goa4web/writing_list.go
+++ b/cmd/goa4web/writing_list.go
@@ -68,7 +68,7 @@ func (c *writingListCmd) Run() error {
 		}
 		return nil
 	}
-	cd := common.NewCoreData(ctx, queries, c.rootCmd.cfg)
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(c.rootCmd.cfg))
 	rows, err := cd.LatestWritings(common.WithWritingsOffset(int32(c.Offset)), common.WithWritingsLimit(int32(c.Limit)))
 	if err != nil {
 		return fmt.Errorf("list writings: %w", err)

--- a/core/common/coredata_allroles_test.go
+++ b/core/common/coredata_allroles_test.go
@@ -22,7 +22,7 @@ func TestAllRolesLazy(t *testing.T) {
 
 	mock.ExpectQuery("SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id").WillReturnRows(rows)
 
-	cd := NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
+	cd := NewCoreData(context.Background(), db.New(conn), WithConfig(config.NewRuntimeConfig()))
 
 	if _, err := cd.AllRoles(); err != nil {
 		t.Fatalf("AllRoles: %v", err)

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -37,7 +37,7 @@ func TestCoreDataLatestNewsLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -71,7 +71,7 @@ func TestWritingCategoriesLazy(t *testing.T) {
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "category", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 
@@ -102,7 +102,7 @@ func TestAnnouncementForNewsCaching(t *testing.T) {
 	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnRows(annRows)
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()))
 
 	if _, err := cd.AnnouncementForNews(1); err != nil {
 		t.Fatalf("AnnouncementForNews: %v", err)
@@ -128,7 +128,7 @@ func TestAnnouncementForNewsError(t *testing.T) {
 	mock.ExpectQuery("SELECT id, site_news_id, active, created_at").WithArgs(int32(1)).WillReturnError(sql.ErrConnDone)
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()))
 
 	if _, err := cd.AnnouncementForNews(1); !errors.Is(err, sql.ErrConnDone) {
 		t.Fatalf("AnnouncementForNews error=%v", err)
@@ -167,7 +167,7 @@ func TestPublicWritingsLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -211,7 +211,7 @@ func TestCoreDataLatestWritingsLazy(t *testing.T) {
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "article", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 
@@ -245,7 +245,7 @@ func TestBloggersLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, cfg)
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(cfg))
 	cd.UserID = 1
 	req = req.WithContext(ctx)
 
@@ -279,7 +279,7 @@ func TestWritersLazy(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, cfg)
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(cfg))
 	cd.UserID = 1
 	req = req.WithContext(ctx)
 

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -77,7 +77,7 @@ func TestLatestNewsRespectsPermissions(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 	cd.SetRoles([]string{"user"})
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)

--- a/handlers/access_test.go
+++ b/handlers/access_test.go
@@ -17,7 +17,7 @@ func TestVerifyAccess(t *testing.T) {
 	}, "administrator")
 
 	req := httptest.NewRequest("GET", "/", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"anonymous"})
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
 
@@ -27,7 +27,7 @@ func TestVerifyAccess(t *testing.T) {
 		t.Fatalf("expected %d got %d", http.StatusForbidden, rr.Code)
 	}
 
-	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd = common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"administrator"})
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
 	rr = httptest.NewRecorder()

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -34,7 +34,7 @@ func TestAdminEmailTemplateTestAction_NoProvider(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
 	reg := newEmailReg()
-	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithEmailProvider(reg.ProviderFromConfig(cfg)))
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(cfg), common.WithEmailProvider(reg.ProviderFromConfig(cfg)))
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -67,7 +67,7 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
 	q := db.New(conn)
 	reg := newEmailReg()
-	cd := common.NewCoreData(req.Context(), q, cfg, common.WithEmailProvider(reg.ProviderFromConfig(cfg)))
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(cfg), common.WithEmailProvider(reg.ProviderFromConfig(cfg)))
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/admin/reload_shutdown_test.go
+++ b/handlers/admin/reload_shutdown_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestAdminReloadConfigPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -43,7 +43,7 @@ func TestAdminReloadRoute_Unauthorized(t *testing.T) {
 	h.RegisterRoutes(ar, cfg, navReg)
 
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
-	cd := common.NewCoreData(req.Context(), nil, cfg)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(cfg))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -65,7 +65,7 @@ func TestAdminReloadRoute_Authorized(t *testing.T) {
 	h.RegisterRoutes(ar, cfg, navReg)
 
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
-	cd := common.NewCoreData(req.Context(), nil, cfg)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(cfg))
 	cd.SetRoles([]string{"administrator"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -87,7 +87,7 @@ func TestAdminShutdownRoute_Unauthorized(t *testing.T) {
 	h.RegisterRoutes(ar, cfg, navReg)
 
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
-	cd := common.NewCoreData(req.Context(), nil, cfg)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(cfg))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -112,7 +112,7 @@ func TestAdminShutdownRoute_Authorized(t *testing.T) {
 	form.Set("task", string(TaskServerShutdown))
 	req := httptest.NewRequest("POST", "/admin/shutdown", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	cd := common.NewCoreData(req.Context(), nil, cfg)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(cfg))
 	cd.SetRoles([]string{"administrator"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -128,7 +128,7 @@ func TestAdminShutdownRoute_Authorized(t *testing.T) {
 func TestServerShutdownTask_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
 	cfg := config.NewRuntimeConfig()
-	cd := common.NewCoreData(req.Context(), nil, cfg)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(cfg))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -145,7 +145,7 @@ func TestServerShutdownTask_Unauthorized(t *testing.T) {
 func TestServerShutdownMatcher_Denied(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
 	cfg := config.NewRuntimeConfig()
-	cd := common.NewCoreData(req.Context(), nil, cfg)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(cfg))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -160,7 +160,7 @@ func TestServerShutdownMatcher_Allowed(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/admin/shutdown", body)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	cfg := config.NewRuntimeConfig()
-	cd := common.NewCoreData(req.Context(), nil, cfg)
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(cfg))
 	cd.SetRoles([]string{"administrator"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/admin/server_shutdown_task_test.go
+++ b/handlers/admin/server_shutdown_task_test.go
@@ -19,7 +19,7 @@ func TestServerShutdownTask_EventPublished(t *testing.T) {
 	h := New(WithServer(&server.Server{Bus: bus}))
 	ch := bus.Subscribe(eventbus.TaskMessageType)
 
-	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 	cd.SetRoles([]string{"administrator"})
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)

--- a/handlers/auth/forgotPassword_event_test.go
+++ b/handlers/auth/forgotPassword_event_test.go
@@ -32,7 +32,7 @@ func TestForgotPasswordEventData(t *testing.T) {
 	mock.ExpectExec("INSERT INTO pending_passwords").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig(), common.WithEvent(evt))
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.NewRuntimeConfig()), common.WithEvent(evt))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 
 	form := url.Values{"username": {"u"}, "password": {"pw"}}

--- a/handlers/auth/forgotPassword_limit_test.go
+++ b/handlers/auth/forgotPassword_limit_test.go
@@ -35,7 +35,7 @@ func TestForgotPasswordRateLimit(t *testing.T) {
 	form := url.Values{"username": {"u"}, "password": {"pw"}}
 	req := httptest.NewRequest(http.MethodPost, "/forgot", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -69,7 +69,7 @@ func TestForgotPasswordReplaceOld(t *testing.T) {
 	form := url.Values{"username": {"u"}, "password": {"pw"}}
 	req := httptest.NewRequest(http.MethodPost, "/forgot", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/handlers/auth/forgotPassword_no_email_test.go
+++ b/handlers/auth/forgotPassword_no_email_test.go
@@ -27,7 +27,7 @@ func TestForgotPasswordNoEmail(t *testing.T) {
 	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 
 	form := url.Values{"username": {"u"}, "password": {"pw"}}
@@ -56,7 +56,7 @@ func TestEmailAssociationRequestTask(t *testing.T) {
 	mock.ExpectExec("INSERT INTO admin_request_queue").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO admin_request_comments").WillReturnResult(sqlmock.NewResult(1, 1))
 
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 
 	form := url.Values{"username": {"u"}, "email": {"a@test.com"}, "reason": {"help"}}

--- a/handlers/auth/redirectBackPageHandler_test.go
+++ b/handlers/auth/redirectBackPageHandler_test.go
@@ -22,7 +22,7 @@ func TestRedirectBackPageHandlerGETAlt(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
 	req = req.WithContext(ctx)

--- a/handlers/auth/registerPage_test.go
+++ b/handlers/auth/registerPage_test.go
@@ -26,7 +26,7 @@ func TestRegisterActionPageValidation(t *testing.T) {
 	for _, c := range cases {
 		req := httptest.NewRequest("POST", "/register", strings.NewReader(c.form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+		cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 		ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 		req = req.WithContext(ctx)
 		rr := httptest.NewRecorder()

--- a/handlers/auth/verify_password_task_test.go
+++ b/handlers/auth/verify_password_task_test.go
@@ -37,7 +37,7 @@ func TestVerifyPasswordAction_Success(t *testing.T) {
 		WithArgs(int32(1), pwHash, sql.NullString{String: alg, Valid: true}).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 	form := url.Values{"id": {"1"}, "code": {"code"}, "password": {"pw"}}
 	req := httptest.NewRequest(http.MethodPost, "/login/verify", strings.NewReader(form.Encode()))
@@ -69,7 +69,7 @@ func TestVerifyPasswordAction_InvalidPassword(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, passwd")).WithArgs("code", sqlmock.AnyArg()).WillReturnRows(rows)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), q, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 	form := url.Values{"id": {"1"}, "code": {"code"}, "password": {"wrong"}}
 	req := httptest.NewRequest(http.MethodPost, "/login/verify", strings.NewReader(form.Encode()))

--- a/handlers/blogs/blogsBloggersBloggerPage_test.go
+++ b/handlers/blogs/blogsBloggersBloggerPage_test.go
@@ -28,7 +28,7 @@ func TestBloggersBloggerPage(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/blogs/bloggers/blogger", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/handlers/blogs/blogsCommentPage_replyable_test.go
+++ b/handlers/blogs/blogsCommentPage_replyable_test.go
@@ -32,7 +32,7 @@ func setupCommentRequest(t *testing.T, queries db.Querier, store *sessions.Cooki
 		req.AddCookie(c)
 	}
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithSession(sess))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()), common.WithSession(sess))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	return req, sess

--- a/handlers/blogs/blogsIndexPermissions_test.go
+++ b/handlers/blogs/blogsIndexPermissions_test.go
@@ -11,7 +11,7 @@ import (
 func TestCustomBlogIndexRoles(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs", nil)
 
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"administrator"})
 	cd.AdminMode = true
 	CustomBlogIndex(cd, req)
@@ -22,7 +22,7 @@ func TestCustomBlogIndexRoles(t *testing.T) {
 		t.Errorf("admin should see write blog")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd = common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"content writer"})
 	CustomBlogIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "User Roles") {
@@ -32,7 +32,7 @@ func TestCustomBlogIndexRoles(t *testing.T) {
 		t.Errorf("content writer should see write blog")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd = common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"anonymous"})
 	CustomBlogIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "User Roles") || common.ContainsItem(cd.CustomIndexItems, "Write blog") {

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -54,7 +54,7 @@ func TestBlogsBloggerPostsPage(t *testing.T) {
 	}
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess))
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()), common.WithSession(sess))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -102,7 +102,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "http://example.com/blogs/rss?rss=bob", nil)
 	q := db.New(conn)
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -127,7 +127,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 
 func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -140,7 +140,7 @@ func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
 
 func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/1/edit", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -153,7 +153,7 @@ func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 
 func TestGetPermissionsByUserIdAndSectionBlogsPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin/blogs/users/roles", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/bookmarks/mine_test.go
+++ b/handlers/bookmarks/mine_test.go
@@ -96,7 +96,7 @@ func TestMinePage_NoBookmarks(t *testing.T) {
 	}
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithSession(sess))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()), common.WithSession(sess))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/faq/ask_test.go
+++ b/handlers/faq/ask_test.go
@@ -99,7 +99,7 @@ func TestAskActionPage_AdminEvent(t *testing.T) {
 		WithArgs(sql.NullString{String: "hi", Valid: true}, int32(1), int32(1), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	evt := &eventbus.TaskEvent{Path: "/faq/ask", Task: tasks.TaskString(TaskAsk), UserID: 1}
-	cd := common.NewCoreData(req.Context(), q, cfg)
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(cfg))
 	cd.UserID = 1
 	cd.SetEvent(evt)
 

--- a/handlers/faq/faqIndexPermissions_test.go
+++ b/handlers/faq/faqIndexPermissions_test.go
@@ -21,7 +21,7 @@ func TestCustomFAQIndexAsk(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "faq", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -46,7 +46,7 @@ func TestCustomFAQIndexAskDenied(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "faq", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).

--- a/handlers/faq/page_test.go
+++ b/handlers/faq/page_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCustomFAQIndexRoles(t *testing.T) {
-	cd := common.NewCoreData(nil, nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(nil, nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"administrator"})
 	cd.AdminMode = true
 	CustomFAQIndex(cd, nil)
@@ -16,7 +16,7 @@ func TestCustomFAQIndexRoles(t *testing.T) {
 		t.Errorf("admin should see question controls")
 	}
 
-	cd = common.NewCoreData(nil, nil, config.NewRuntimeConfig())
+	cd = common.NewCoreData(nil, nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"anonymous"})
 	CustomFAQIndex(cd, nil)
 	if common.ContainsItem(cd.CustomIndexItems, "Question Qontrols") {

--- a/handlers/forum/forumIndexPermissions_test.go
+++ b/handlers/forum/forumIndexPermissions_test.go
@@ -23,7 +23,7 @@ func TestCustomForumIndexWriteReply(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "reply", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -49,7 +49,7 @@ func TestCustomForumIndexWriteReplyDenied(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "reply", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -75,7 +75,7 @@ func TestCustomForumIndexCreateThread(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -101,7 +101,7 @@ func TestCustomForumIndexCreateThreadDenied(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()))
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
 		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -127,7 +127,7 @@ func TestCustomForumIndexSubscribeLink(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 
 	mock.ExpectQuery("SELECT id, pattern, method FROM subscriptions").
@@ -154,7 +154,7 @@ func TestCustomForumIndexUnsubscribeLink(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 
 	pattern := topicSubscriptionPattern(2)

--- a/handlers/forum/matchers_test.go
+++ b/handlers/forum/matchers_test.go
@@ -45,7 +45,7 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
 	q := db.New(conn)
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -96,7 +96,7 @@ func TestRequireThreadAndTopicFalse(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
 	q := db.New(conn)
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -133,7 +133,7 @@ func TestRequireThreadAndTopicError(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
 	q := db.New(conn)
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -75,7 +75,7 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/admin/queue?qid=1", nil)
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
-	cd := common.NewCoreData(req.Context(), queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), queries, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetEvent(evt)
 	cd.SetEventTask(AdminApproveTask)
 	ctxreq := context.WithValue(req.Context(), consts.KeyCoreData, cd)

--- a/handlers/matchers_test.go
+++ b/handlers/matchers_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestRequiredAccessAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 	cd.SetRoles([]string{"content writer"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
@@ -27,7 +27,7 @@ func TestRequiredAccessAllowed(t *testing.T) {
 
 func TestRequiredAccessDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)

--- a/handlers/news/newsIndexPermissions_test.go
+++ b/handlers/news/newsIndexPermissions_test.go
@@ -13,7 +13,7 @@ import (
 func TestCustomNewsIndexRoles(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"administrator"})
 	cd.AdminMode = true
 	CustomNewsIndex(cd, req)
@@ -31,7 +31,7 @@ func TestCustomNewsIndexRoles(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 	ctx := req.Context()
-	cd = common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd = common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"content writer", "administrator"})
 	CustomNewsIndex(cd, req.WithContext(ctx))
 	if common.ContainsItem(cd.CustomIndexItems, "User Roles") {
@@ -41,7 +41,7 @@ func TestCustomNewsIndexRoles(t *testing.T) {
 		t.Errorf("content writer should see add news")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd = common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"anonymous"})
 	CustomNewsIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "User Roles") || common.ContainsItem(cd.CustomIndexItems, "Add News") {

--- a/handlers/search/permissions_test.go
+++ b/handlers/search/permissions_test.go
@@ -19,7 +19,7 @@ func TestCanSearch(t *testing.T) {
 	defer conn.Close()
 
 	queries := db.New(conn)
-	cd := common.NewCoreData(context.Background(), queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), queries, common.WithConfig(config.NewRuntimeConfig()))
 
 	// No grants
 	mock.ExpectQuery("SELECT 1 FROM grants").WillReturnError(sql.ErrNoRows)

--- a/handlers/user/addEmailTask_invalid_test.go
+++ b/handlers/user/addEmailTask_invalid_test.go
@@ -38,7 +38,7 @@ func TestAddEmailTaskInvalid(t *testing.T) {
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess), common.WithEvent(evt))
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()), common.WithSession(sess), common.WithEvent(evt))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)

--- a/handlers/user/admin_export.go
+++ b/handlers/user/admin_export.go
@@ -30,7 +30,7 @@ func adminUsersExportPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cd := common.NewCoreData(r.Context(), queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(r.Context(), queries, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = int32(uid)
 
 	user, err := cd.CurrentUser()

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -62,7 +62,7 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 	form.Set("task", string(TaskUserAllow))
 	req := httptest.NewRequest("POST", "/admin/user/2/permissions", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	cd := common.NewCoreData(req.Context(), queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), queries, common.WithConfig(config.NewRuntimeConfig()))
 	evt := &eventbus.TaskEvent{}
 	cd.SetEvent(evt)
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)

--- a/handlers/user/userEmailPage_event_test.go
+++ b/handlers/user/userEmailPage_event_test.go
@@ -45,7 +45,7 @@ func TestAddEmailTaskEventData(t *testing.T) {
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess), common.WithEvent(evt))
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()), common.WithSession(sess), common.WithEvent(evt))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -88,7 +88,7 @@ func TestVerifyRemovesDuplicates(t *testing.T) {
 
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess), common.WithEvent(evt))
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()), common.WithSession(sess), common.WithEvent(evt))
 	cd.UserID = 1
 
 	rows := sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).
@@ -151,7 +151,7 @@ func TestResendVerificationEmailTaskEventData(t *testing.T) {
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess), common.WithEvent(evt))
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()), common.WithSession(sess), common.WithEvent(evt))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	req = req.WithContext(ctx)

--- a/handlers/user/userEmailVerify_test.go
+++ b/handlers/user/userEmailVerify_test.go
@@ -39,7 +39,7 @@ func TestUserEmailVerifyCodePage_Invalid(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess))
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()), common.WithSession(sess))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	req := httptest.NewRequest(http.MethodGet, "/usr/email/verify?code="+code, nil).WithContext(ctx)
@@ -75,7 +75,7 @@ func TestUserEmailVerifyCodePage_Success(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess))
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()), common.WithSession(sess))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 
 	form := url.Values{"code": {code}}

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -62,7 +62,7 @@ func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := req.Context()
 	reg := newEmailReg()
-	cd := common.NewCoreData(ctx, queries, cfg, common.WithEmailProvider(reg.ProviderFromConfig(cfg)))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(cfg), common.WithEmailProvider(reg.ProviderFromConfig(cfg)))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -95,7 +95,7 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := req.Context()
 	reg := newEmailReg()
-	cd := common.NewCoreData(ctx, queries, cfg, common.WithEmailProvider(reg.ProviderFromConfig(cfg)))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(cfg), common.WithEmailProvider(reg.ProviderFromConfig(cfg)))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -116,7 +116,7 @@ func TestUserEmailPage_ShowError(t *testing.T) {
 	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
 	req := httptest.NewRequest("GET", "/usr/email?error=missing", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -141,7 +141,7 @@ func TestUserEmailPage_NoUnverified(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/usr/email", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -167,7 +167,7 @@ func TestUserEmailPage_NoVerified(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/usr/email", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -218,7 +218,7 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 	ctx := req.Context()
 	cfg := config.NewRuntimeConfig()
 	cfg.PageSizeDefault = 15
-	cd := common.NewCoreData(ctx, queries, cfg, common.WithSession(sess))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(cfg), common.WithSession(sess))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -266,7 +266,7 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithSession(sess))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()), common.WithSession(sess))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -317,7 +317,7 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	cfg.PageSizeDefault = 15
 
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, cfg, common.WithSession(sess))
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(cfg), common.WithSession(sess))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/writings/matchers_test.go
+++ b/handlers/writings/matchers_test.go
@@ -37,7 +37,7 @@ func TestRequireWritingAuthorArticleVar(t *testing.T) {
 	sess, _ := store.Get(req, core.SessionName)
 	sess.Values["UID"] = int32(1)
 
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithSession(sess))
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.NewRuntimeConfig()), common.WithSession(sess))
 	cd.SetRoles([]string{"content writer"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/writings/writing_category_change_task_test.go
+++ b/handlers/writings/writing_category_change_task_test.go
@@ -34,7 +34,7 @@ func TestWritingCategoryChangeTask(t *testing.T) {
 	form := url.Values{"name": {"A"}, "desc": {"B"}, "pcid": {"0"}, "cid": {"1"}}
 	req := httptest.NewRequest("POST", "/admin/writings/categories", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	cd := common.NewCoreData(req.Context(), queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), queries, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -154,7 +154,7 @@ func TestWritingCategoryChangeTaskLoop(t *testing.T) {
 	form := url.Values{"name": {"A"}, "desc": {"B"}, "pcid": {"2"}, "cid": {"1"}}
 	req := httptest.NewRequest("POST", "/admin/writings/categories", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	cd := common.NewCoreData(req.Context(), queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), queries, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/writings/writingsAdminCategoriesPage_test.go
+++ b/handlers/writings/writingsAdminCategoriesPage_test.go
@@ -29,7 +29,7 @@ func TestWritingsAdminCategoriesPage(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/admin/writings/categories", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/handlers/writings/writingsAdminCategoryGrantsPage_test.go
+++ b/handlers/writings/writingsAdminCategoryGrantsPage_test.go
@@ -37,7 +37,7 @@ func TestAdminCategoryGrantsPage(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/admin/writings/category/1/permissions", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, common.WithConfig(config.NewRuntimeConfig()))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	req = mux.SetURLVars(req, map[string]string{"category": "1"})

--- a/handlers/writings/writingsArticlePage_test.go
+++ b/handlers/writings/writingsArticlePage_test.go
@@ -52,7 +52,7 @@ func TestArticleReplyActionPage_UsesArticleParam(t *testing.T) {
 	}
 
 	q := db.New(dbconn)
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(config.NewRuntimeConfig()))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/writings/writingsWriterListPage_test.go
+++ b/handlers/writings/writingsWriterListPage_test.go
@@ -26,7 +26,7 @@ func TestWriterListPage_List(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/writings/writers", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -56,7 +56,7 @@ func TestWriterListPage_Search(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/writings/writers?search=bob", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, common.WithConfig(config.NewRuntimeConfig()))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -225,7 +225,7 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 				base = strings.TrimRight(s.Config.HTTPHostname, "/")
 			}
 			provider := s.EmailReg.ProviderFromConfig(s.Config)
-			cd := common.NewCoreData(r.Context(), queries, s.Config,
+			cd := common.NewCoreData(r.Context(), queries, common.WithConfig(s.Config),
 				common.WithImageSigner(s.ImageSigner),
 				common.WithLinkSigner(s.LinkSigner),
 				common.WithSession(session),

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -98,7 +98,7 @@ func CoreAdderMiddlewareWithDB(sdb *sql.DB, cfg *config.RuntimeConfig, verbosity
 			if emailReg != nil && cfg != nil {
 				provider = emailReg.ProviderFromConfig(cfg)
 			}
-			cd := common.NewCoreData(r.Context(), queries, cfg,
+			cd := common.NewCoreData(r.Context(), queries, common.WithConfig(cfg),
 				common.WithImageSigner(signer),
 				common.WithCustomQueries(queries),
 				common.WithLinkSigner(linkSigner),

--- a/internal/middleware/middleware_role_test.go
+++ b/internal/middleware/middleware_role_test.go
@@ -42,7 +42,7 @@ func TestCoreAdderMiddlewareUserRoles(t *testing.T) {
 	session := &sessions.Session{ID: "sessid", Values: map[interface{}]interface{}{"UID": int32(1)}}
 	req := httptest.NewRequest("GET", "/", nil)
 	q := db.New(conn)
-	cd := common.NewCoreData(req.Context(), q, cfg)
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(cfg))
 	ctx := context.WithValue(req.Context(), core.ContextValues("session"), session)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -84,7 +84,7 @@ func TestCoreAdderMiddlewareAnonymous(t *testing.T) {
 	session := &sessions.Session{ID: "sessid"}
 	req := httptest.NewRequest("GET", "/", nil)
 	q := db.New(conn)
-	cd := common.NewCoreData(req.Context(), q, cfg)
+	cd := common.NewCoreData(req.Context(), q, common.WithConfig(cfg))
 	ctx := context.WithValue(req.Context(), core.ContextValues("session"), session)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -25,7 +25,7 @@ func newCoreData(t *testing.T, cfg config.RuntimeConfig) (*common.CoreData, sqlm
 	if cfg.HSTSHeaderValue == "" {
 		cfg.HSTSHeaderValue = "max-age=63072000; includeSubDomains"
 	}
-	cd := common.NewCoreData(context.Background(), queries, &cfg)
+	cd := common.NewCoreData(context.Background(), queries, common.WithConfig(&cfg))
 	return cd, mock, cleanup
 }
 

--- a/internal/router/roles_test.go
+++ b/internal/router/roles_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"administrator"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -39,7 +39,7 @@ func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 
 func TestRoleCheckerMiddlewareDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), nil, common.WithConfig(config.NewRuntimeConfig()))
 	cd.SetRoles([]string{"anonymous"})
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)


### PR DESCRIPTION
## Summary
- pass runtime configuration to `NewCoreData` via `WithConfig`
- default to a fresh runtime config when none supplied
- update handlers, server setup and tests for the new option

## Testing
- `go mod tidy && go fmt ./... && go vet ./... && golangci-lint run && go test ./...` *(fails: handlers/user/userSubscriptionsPage.go:6:2: "github.com/arran4/goa4web/core" imported and not used)*
- `golangci-lint run` *(fails: typecheck errors such as SystemGetBlogEntryByID undefined and unused import in userSubscriptionsPage.go)*
- `go test ./...` *(fails: template variable $cd undefined in subscriptions.gohtml and build failures in handlers/user)*


------
https://chatgpt.com/codex/tasks/task_e_688fefb4b394832faa7377043cd510d3