### PR TITLE
Replace SetNewsOffset with option

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1704,9 +1704,6 @@ func (cd *CoreData) SetEventTask(t tasks.Task) {
 	}
 }
 
-// SetNewsOffset records the current news listing offset.
-func (cd *CoreData) SetNewsOffset(o int) { cd.currentNewsOffset = o } // TODO this should be done from the constructing middleware via options and this function removed once obsolete
-
 // SetPageTitle updates the Title field used by templates.
 func (cd *CoreData) SetPageTitle(title string) {
 	cd.Title = title
@@ -2130,6 +2127,11 @@ func WithNavRegistry(r NavigationProvider) CoreOption {
 // WithCustomQueries sets the db.CustomQueries dependency.
 func WithCustomQueries(cq db.CustomQueries) CoreOption {
 	return func(cd *CoreData) { cd.customQueries = cq }
+}
+
+// WithNewsOffset records the current news listing offset.
+func WithNewsOffset(o int) CoreOption {
+	return func(cd *CoreData) { cd.currentNewsOffset = o }
 }
 
 // WithSelectionsFromRequest extracts integer identifiers from the request and

--- a/handlers/news/admin_customindex.go
+++ b/handlers/news/admin_customindex.go
@@ -11,7 +11,6 @@ import (
 // CustomAdminNewsIndex injects pagination links for the admin news pages.
 func CustomAdminNewsIndex(cd *common.CoreData, r *http.Request) {
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-	cd.SetNewsOffset(offset)
 	ps := cd.PageSize()
 	if offset != 0 {
 		cd.CustomIndexItems = append(cd.CustomIndexItems, common.IndexItem{

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -98,6 +99,7 @@ func CoreAdderMiddlewareWithDB(sdb *sql.DB, cfg *config.RuntimeConfig, verbosity
 			if emailReg != nil && cfg != nil {
 				provider = emailReg.ProviderFromConfig(cfg)
 			}
+			offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 			cd := common.NewCoreData(r.Context(), queries, cfg,
 				common.WithImageSigner(signer),
 				common.WithCustomQueries(queries),
@@ -106,7 +108,8 @@ func CoreAdderMiddlewareWithDB(sdb *sql.DB, cfg *config.RuntimeConfig, verbosity
 				common.WithEmailProvider(provider),
 				common.WithAbsoluteURLBase(base),
 				common.WithSessionManager(sm),
-				common.WithSelectionsFromRequest(r))
+				common.WithSelectionsFromRequest(r),
+				common.WithNewsOffset(offset))
 			cd.UserID = uid
 
 			if navReg != nil {


### PR DESCRIPTION
## Summary
- remove SetNewsOffset
- support news offset via WithNewsOffset option
- set news offset via middleware option instead of mutating CoreData in CustomAdminNewsIndex

## Testing
- `go mod tidy`
- `go fmt core/common/coredata.go`
- `go fmt handlers/news/admin_customindex.go`
- `go fmt internal/middleware/middleware.go`
- `go fmt ./...`
- `go vet ./...` *(fails: cd.queries.RegisterExternalLinkClick undefined; method CoreData.ThreadComments already declared)*
- `golangci-lint run` *(fails: multiple typecheck errors such as undefined methods and duplicate declarations)*
- `go test ./...` *(fails: cd.queries.RegisterExternalLinkClick undefined; method CoreData.ThreadComments already declared)*

------
https://chatgpt.com/codex/tasks/task_e_688fefc0fffc832f86c6fcec0d59c186