### PR TITLE
refactor: centralize language enumeration

### DIFF
--- a/cmd/goa4web/lang_list.go
+++ b/cmd/goa4web/lang_list.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 )
 
@@ -31,7 +32,8 @@ func (c *langListCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := db.New(conn)
-	langs, err := queries.SystemListLanguages(ctx)
+	cd := common.NewCoreData(ctx, queries, nil)
+	langs, err := cd.Languages()
 	if err != nil {
 		return fmt.Errorf("list languages: %w", err)
 	}

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -151,7 +151,6 @@ type CoreData struct {
 	imageBoards              lazy.Value[[]*db.Imageboard]
 	imagePostRows            map[int32]*lazy.Value[*db.GetImagePostByIDForListerRow]
 	langs                    lazy.Value[[]*db.Language]
-	languagesAll             lazy.Value[[]*db.Language]
 	latestNews               lazy.Value[[]*NewsPost]
 	latestWritings           lazy.Value[[]*db.Writing]
 	linkerCategories         lazy.Value[[]*db.GetLinkerCategoryLinkCountsRow]
@@ -264,16 +263,6 @@ func (cd *CoreData) adminRequestList(kind string) ([]*db.AdminRequestQueue, erro
 		default:
 			return nil, nil
 		}
-	})
-}
-
-// AllLanguages returns all languages cached once.
-func (cd *CoreData) AllLanguages() ([]*db.Language, error) {
-	return cd.languagesAll.Load(func() ([]*db.Language, error) {
-		if cd.queries == nil {
-			return nil, nil
-		}
-		return cd.queries.SystemListLanguages(cd.ctx)
 	})
 }
 

--- a/handlers/admin/adminRolePage.go
+++ b/handlers/admin/adminRolePage.go
@@ -49,7 +49,7 @@ func adminRolePage(w http.ResponseWriter, r *http.Request) {
 	for _, c := range forumCats {
 		catMap[c.Idforumcategory] = c
 	}
-	langs, _ := queries.SystemListLanguages(r.Context())
+	langs, _ := cd.Languages()
 	langMap := map[int32]string{}
 	for _, l := range langs {
 		if l.Nameof.Valid {

--- a/handlers/languages/admin.go
+++ b/handlers/languages/admin.go
@@ -55,7 +55,8 @@ func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {
 	handlers.TemplateHandler(w, r, "runTaskPage.gohtml", data)
 }
 func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	cid := r.PostFormValue("cid")
 	data := struct {
 		*common.CoreData
@@ -63,14 +64,14 @@ func adminLanguagesDeletePage(w http.ResponseWriter, r *http.Request) {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Back:     "/admin/languages",
 	}
 	if cidi, err := strconv.Atoi(cid); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("strconv.Atoi: %w", err).Error())
 	} else {
 		var name string
-		if rows, err := queries.SystemListLanguages(r.Context()); err == nil {
+		if rows, err := cd.Languages(); err == nil {
 			for _, l := range rows {
 				if l.Idlanguage == int32(cidi) {
 					name = l.Nameof.String

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -63,7 +63,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 
 	languages, err := cd.Languages()
 	if err != nil {
-		log.Printf("SystemListLanguages error: %s", err)
+		log.Printf("languages: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary
- remove `AllLanguages` and its cache from core data
- enumerate languages via `Languages()` throughout CLI and admin handlers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: RegisterExternalLinkClick undefined; duplicate ThreadComments)*
- `golangci-lint run` *(fails: multiple typecheck errors)*
- `go test ./...` *(fails: multiple build failures)*

------
https://chatgpt.com/codex/tasks/task_e_688feeeeb120832fbaf22e8b592020e8