### PR TITLE
Add system-level query for unbounded user listing

### DIFF
--- a/cmd/goa4web/user_list.go
+++ b/cmd/goa4web/user_list.go
@@ -47,7 +47,7 @@ func (c *userListCmd) Run() error {
 		rows, err = queries.SystemListUserInfo(ctx)
 	} else {
 		// fall back to basic user list when no extra columns requested
-		basic, err2 := queries.AdminListAllUsers(ctx)
+		basic, err2 := queries.SystemListAllUsers(ctx)
 		if err2 != nil {
 			return fmt.Errorf("list users: %w", err2)
 		}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -430,6 +430,11 @@ type Querier interface {
 	SystemInsertSession(ctx context.Context, arg SystemInsertSessionParams) error
 	SystemInsertUser(ctx context.Context, username sql.NullString) (sql.Result, error)
 	SystemLatestDeadLetter(ctx context.Context) (interface{}, error)
+	// Result:
+	//   idusers (int)
+	//   username (string)
+	//   email (string)
+	SystemListAllUsers(ctx context.Context) ([]*SystemListAllUsersRow, error)
 	SystemListBoardsByParentID(ctx context.Context, arg SystemListBoardsByParentIDParams) ([]*Imageboard, error)
 	SystemListDeadLetters(ctx context.Context, limit int32) ([]*DeadLetter, error)
 	// SystemListLanguages lists all languages.

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -10,6 +10,16 @@ JOIN user_roles ur ON ur.users_idusers = u.idusers
 JOIN roles r ON ur.role_id = r.id
 WHERE r.is_admin = 1;
 
+-- name: SystemListAllUsers :many
+-- Result:
+--   idusers (int)
+--   username (string)
+--   email (string)
+SELECT u.idusers, u.username,
+       (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email
+FROM users u
+ORDER BY u.idusers;
+
 -- name: SystemGetUserByUsername :one
 SELECT idusers,
        (SELECT email FROM user_emails ue WHERE ue.user_id = users.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,

--- a/internal/db/queries_users_system_test.go
+++ b/internal/db/queries_users_system_test.go
@@ -1,0 +1,35 @@
+package db
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestQueries_SystemListAllUsers(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+	q := New(conn)
+
+	rows := sqlmock.NewRows([]string{"idusers", "username", "email"}).
+		AddRow(1, "bob", "bob@example.com")
+	mock.ExpectQuery(regexp.QuoteMeta(systemListAllUsers)).
+		WillReturnRows(rows)
+
+	res, err := q.SystemListAllUsers(context.Background())
+	if err != nil {
+		t.Fatalf("SystemListAllUsers: %v", err)
+	}
+	if len(res) != 1 || res[0].Idusers != 1 || res[0].Username.String != "bob" || res[0].Email != "bob@example.com" {
+		t.Fatalf("unexpected result %+v", res)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- introduce `SystemListAllUsers` query to return every user with email
- switch CLI `user list` to use the system-level query
- add a test covering `SystemListAllUsers`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cd.queries.RegisterExternalLinkClick undefined, method CoreData.ThreadComments already declared)*
- `golangci-lint run` *(fails: typecheck errors such as SystemGetBlogEntryByID undefined)*
- `go test ./...` *(fails: cd.queries.RegisterExternalLinkClick undefined, method CoreData.ThreadComments already declared)*

------
https://chatgpt.com/codex/tasks/task_e_688feeecb218832fbebe4008174e08e6