### PR TITLE
Fix subscriptions template variable and handler data

### DIFF
--- a/core/templates/site/user/subscriptions.gohtml
+++ b/core/templates/site/user/subscriptions.gohtml
@@ -2,7 +2,7 @@
 <h2>Your Subscriptions</h2>
 <table>
 <tr><th>Pattern</th><th>Method</th><th></th></tr>
-{{ range .UserSubscriptions }}
+{{ range (call cd.UserSubscriptions) }}
 <tr>
 <td>{{ .Pattern }}</td>
 <td>{{ .Method }}</td>
@@ -25,8 +25,8 @@
     {{ range .Options }}
     <div>
         {{ .Name }}
-        <label><input type="checkbox" name="{{ .Path }}_internal" {{ if (call $cd.HasSubscription .Pattern "internal") }}checked{{ end }}>Internal</label>
-        <label><input type="checkbox" name="{{ .Path }}_email" {{ if (call $cd.HasSubscription .Pattern "email") }}checked{{ end }}>Email</label>
+        <label><input type="checkbox" name="{{ .Path }}_internal" {{ if (call cd.HasSubscription .Pattern "internal") }}checked{{ end }}>Internal</label>
+        <label><input type="checkbox" name="{{ .Path }}_email" {{ if (call cd.HasSubscription .Pattern "email") }}checked{{ end }}>Email</label>
     </div>
     {{ end }}
     <input type="submit" name="task" value="Update">

--- a/handlers/user/userSubscriptionsPage.go
+++ b/handlers/user/userSubscriptionsPage.go
@@ -3,7 +3,6 @@ package user
 import (
 	"net/http"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"


### PR DESCRIPTION
## Summary
- load subscription rows in template via CoreData and drop handler query
- simplify handler to provide only subscription options

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cd.queries.RegisterExternalLinkClick undefined)*
- `golangci-lint run` *(fails: queries.SystemGetBlogEntryByID undefined)*
- `go test ./...` *(fails: cd.queries.RegisterExternalLinkClick undefined, method CoreData.ThreadComments already declared)*

------
https://chatgpt.com/codex/tasks/task_e_6890130c264c832f94333eac77d6acec