### PR TITLE
Fix comment queries and template

### DIFF
--- a/core/templates/site/user/subscriptions.gohtml
+++ b/core/templates/site/user/subscriptions.gohtml
@@ -25,8 +25,8 @@
     {{ range .Options }}
     <div>
         {{ .Name }}
-        <label><input type="checkbox" name="{{ .Path }}_internal" {{ if (call $cd.HasSubscription .Pattern "internal") }}checked{{ end }}>Internal</label>
-        <label><input type="checkbox" name="{{ .Path }}_email" {{ if (call $cd.HasSubscription .Pattern "email") }}checked{{ end }}>Email</label>
+        <label><input type="checkbox" name="{{ .Path }}_internal" {{ if (call cd.HasSubscription .Pattern "internal") }}checked{{ end }}>Internal</label>
+        <label><input type="checkbox" name="{{ .Path }}_email" {{ if (call cd.HasSubscription .Pattern "email") }}checked{{ end }}>Email</label>
     </div>
     {{ end }}
     <input type="submit" name="task" value="Update">

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -413,16 +413,19 @@ type Querier interface {
 	SystemDeleteWritingSearch(ctx context.Context) error
 	SystemDeleteWritingSearchByWritingID(ctx context.Context, writingID int32) error
 	SystemGetAllBlogsForIndex(ctx context.Context) ([]*SystemGetAllBlogsForIndexRow, error)
+	SystemGetBlogEntryByID(ctx context.Context, idblogs int32) (*SystemGetBlogEntryByIDRow, error)
 	SystemGetForumTopicByTitle(ctx context.Context, title sql.NullString) (*Forumtopic, error)
 	// SystemGetLanguageIDByName resolves a language ID by name.
 	SystemGetLanguageIDByName(ctx context.Context, nameof sql.NullString) (int32, error)
 	SystemGetLastNotificationForRecipientByMessage(ctx context.Context, arg SystemGetLastNotificationForRecipientByMessageParams) (*Notification, error)
 	SystemGetLogin(ctx context.Context, username sql.NullString) (*SystemGetLoginRow, error)
+	SystemGetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx context.Context, idsitenews int32) (*SystemGetNewsPostByIdWithWriterIdAndThreadCommentCountRow, error)
 	SystemGetSearchWordByWordLowercased(ctx context.Context, lcase string) (*Searchwordlist, error)
 	SystemGetTemplateOverride(ctx context.Context, name string) (string, error)
 	SystemGetUserByEmail(ctx context.Context, email string) (*SystemGetUserByEmailRow, error)
 	SystemGetUserByID(ctx context.Context, idusers int32) (*SystemGetUserByIDRow, error)
 	SystemGetUserByUsername(ctx context.Context, username sql.NullString) (*SystemGetUserByUsernameRow, error)
+	SystemGetWritingByID(ctx context.Context, idwriting int32) (*SystemGetWritingByIDRow, error)
 	SystemIncrementPendingEmailError(ctx context.Context, id int32) error
 	// System query only used internally
 	SystemInsertDeadLetter(ctx context.Context, message string) error
@@ -431,6 +434,7 @@ type Querier interface {
 	SystemInsertUser(ctx context.Context, username sql.NullString) (sql.Result, error)
 	SystemLatestDeadLetter(ctx context.Context) (interface{}, error)
 	SystemListBoardsByParentID(ctx context.Context, arg SystemListBoardsByParentIDParams) ([]*Imageboard, error)
+	SystemListCommentsByThreadID(ctx context.Context, forumthreadID int32) ([]*SystemListCommentsByThreadIDRow, error)
 	SystemListDeadLetters(ctx context.Context, limit int32) ([]*DeadLetter, error)
 	// SystemListLanguages lists all languages.
 	SystemListLanguages(ctx context.Context) ([]*Language, error)

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -37,6 +37,12 @@ UPDATE blogs
 SET forumthread_id = ?
 WHERE idblogs = ?;
 
+-- name: SystemGetBlogEntryByID :one
+SELECT idblogs, forumthread_id
+FROM blogs
+WHERE idblogs = ?
+LIMIT 1;
+
 -- name: ListBlogEntriesForLister :many
 WITH RECURSIVE role_ids(id) AS (
     SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -818,6 +818,25 @@ func (q *Queries) SystemGetAllBlogsForIndex(ctx context.Context) ([]*SystemGetAl
 	return items, nil
 }
 
+const systemGetBlogEntryByID = `-- name: SystemGetBlogEntryByID :one
+SELECT idblogs, forumthread_id
+FROM blogs
+WHERE idblogs = ?
+LIMIT 1
+`
+
+type SystemGetBlogEntryByIDRow struct {
+	Idblogs       int32
+	ForumthreadID sql.NullInt32
+}
+
+func (q *Queries) SystemGetBlogEntryByID(ctx context.Context, idblogs int32) (*SystemGetBlogEntryByIDRow, error) {
+	row := q.db.QueryRowContext(ctx, systemGetBlogEntryByID, idblogs)
+	var i SystemGetBlogEntryByIDRow
+	err := row.Scan(&i.Idblogs, &i.ForumthreadID)
+	return &i, err
+}
+
 const systemSetBlogLastIndex = `-- name: SystemSetBlogLastIndex :exec
 UPDATE blogs SET last_index = NOW() WHERE idblogs = ?
 `

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -155,6 +155,12 @@ LEFT JOIN forumthread th ON c.forumthread_id = th.idforumthread
 WHERE c.users_idusers = sqlc.arg('user_id')
 ORDER BY c.written;
 
+-- name: SystemListCommentsByThreadID :many
+SELECT idcomments, text
+FROM comments
+WHERE forumthread_id = ?
+ORDER BY idcomments;
+
 -- name: SystemSetCommentLastIndex :exec
 UPDATE comments SET last_index = NOW() WHERE idcomments = ?;
 

--- a/internal/db/queries-comments.sql.go
+++ b/internal/db/queries-comments.sql.go
@@ -515,6 +515,41 @@ func (q *Queries) GetCommentsByThreadIdForUser(ctx context.Context, arg GetComme
 	return items, nil
 }
 
+const systemListCommentsByThreadID = `-- name: SystemListCommentsByThreadID :many
+SELECT idcomments, text
+FROM comments
+WHERE forumthread_id = ?
+ORDER BY idcomments
+`
+
+type SystemListCommentsByThreadIDRow struct {
+	Idcomments int32
+	Text       sql.NullString
+}
+
+func (q *Queries) SystemListCommentsByThreadID(ctx context.Context, forumthreadID int32) ([]*SystemListCommentsByThreadIDRow, error) {
+	rows, err := q.db.QueryContext(ctx, systemListCommentsByThreadID, forumthreadID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*SystemListCommentsByThreadIDRow
+	for rows.Next() {
+		var i SystemListCommentsByThreadIDRow
+		if err := rows.Scan(&i.Idcomments, &i.Text); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const systemSetCommentLastIndex = `-- name: SystemSetCommentLastIndex :exec
 UPDATE comments SET last_index = NOW() WHERE idcomments = ?
 `

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -44,6 +44,13 @@ WHERE s.idsiteNews = ?;
 -- name: SystemAssignNewsThreadID :exec
 UPDATE site_news SET forumthread_id = ? WHERE idsiteNews = ?;
 
+-- name: SystemGetNewsPostByIdWithWriterIdAndThreadCommentCount :one
+SELECT s.idsiteNews, s.forumthread_id, s.users_idusers AS writer_id,
+       (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id = s.forumthread_id) AS comments
+FROM site_news s
+WHERE s.idsiteNews = ?
+LIMIT 1;
+
 -- name: GetNewsPostByIdWithWriterIdAndThreadCommentCount :one
 WITH RECURSIVE role_ids(id) AS (
     SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -429,6 +429,33 @@ func (q *Queries) SystemAssignNewsThreadID(ctx context.Context, arg SystemAssign
 	return err
 }
 
+const systemGetNewsPostByIdWithWriterIdAndThreadCommentCount = `-- name: SystemGetNewsPostByIdWithWriterIdAndThreadCommentCount :one
+SELECT s.idsiteNews, s.forumthread_id, s.users_idusers AS writer_id,
+       (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id = s.forumthread_id) AS comments
+FROM site_news s
+WHERE s.idsiteNews = ?
+LIMIT 1
+`
+
+type SystemGetNewsPostByIdWithWriterIdAndThreadCommentCountRow struct {
+	Idsitenews    int32
+	ForumthreadID int32
+	WriterID      int32
+	Comments      int64
+}
+
+func (q *Queries) SystemGetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx context.Context, idsitenews int32) (*SystemGetNewsPostByIdWithWriterIdAndThreadCommentCountRow, error) {
+	row := q.db.QueryRowContext(ctx, systemGetNewsPostByIdWithWriterIdAndThreadCommentCount, idsitenews)
+	var i SystemGetNewsPostByIdWithWriterIdAndThreadCommentCountRow
+	err := row.Scan(
+		&i.Idsitenews,
+		&i.ForumthreadID,
+		&i.WriterID,
+		&i.Comments,
+	)
+	return &i, err
+}
+
 const systemSetSiteNewsLastIndex = `-- name: SystemSetSiteNewsLastIndex :exec
 UPDATE site_news SET last_index = NOW() WHERE idsiteNews = ?
 `

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -205,6 +205,11 @@ WHERE EXISTS (
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 );
 
+-- name: SystemGetWritingByID :one
+SELECT idwriting, forumthread_id
+FROM writing
+WHERE idwriting = ?
+LIMIT 1;
 
 -- name: SystemAssignWritingThreadID :exec
 UPDATE writing SET forumthread_id = ? WHERE idwriting = ?;

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -1005,6 +1005,25 @@ func (q *Queries) SystemAssignWritingThreadID(ctx context.Context, arg SystemAss
 	return err
 }
 
+const systemGetWritingByID = `-- name: SystemGetWritingByID :one
+SELECT idwriting, forumthread_id
+FROM writing
+WHERE idwriting = ?
+LIMIT 1
+`
+
+type SystemGetWritingByIDRow struct {
+	Idwriting     int32
+	ForumthreadID int32
+}
+
+func (q *Queries) SystemGetWritingByID(ctx context.Context, idwriting int32) (*SystemGetWritingByIDRow, error) {
+	row := q.db.QueryRowContext(ctx, systemGetWritingByID, idwriting)
+	var i SystemGetWritingByIDRow
+	err := row.Scan(&i.Idwriting, &i.ForumthreadID)
+	return &i, err
+}
+
 const systemListPublicWritingsByAuthor = `-- name: SystemListPublicWritingsByAuthor :many
 SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments


### PR DESCRIPTION
## Summary
- add sqlc-generated system queries for blog entries, news posts, writings, and thread comments
- call `cd.HasSubscription` directly in user subscription template

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68901641aa3c832fa87c8d1c6e219100