### PR TITLE
Hide admin links when user lacks admin mode

### DIFF
--- a/core/templates/site/admin/noAccessPage.gohtml
+++ b/core/templates/site/admin/noAccessPage.gohtml
@@ -1,4 +1,4 @@
 {{ template "head" $ }}
-    [<a href="/admin">Admin</a>]<br />
+    {{ if and cd.HasAdminRole cd.AdminMode }}[<a href="/admin">Admin</a>]<br />{{ end }}
 The requested content may not exist or you may not have permission to access it.
 {{ template "tail" $ }}

--- a/core/templates/site/listWritingCategories.gohtml
+++ b/core/templates/site/listWritingCategories.gohtml
@@ -10,7 +10,7 @@
                 {{ $description := .Description.String }}
                 {{ $id := .Idwritingcategory }}
                 <tr>
-                    <th><a href="/writings/category/{{ $id }}">{{ $title }}</a>{{ if cd.HasAdminRole }} [<a href="/admin/writings/categories?category={{ $id }}">Admin</a>]{{ end }}</th>
+                    <th><a href="/writings/category/{{ $id }}">{{ $title }}</a>{{ if and cd.HasAdminRole cd.AdminMode }} [<a href="/admin/writings/categories?category={{ $id }}">Admin</a>]{{ end }}</th>
                     <td>{{ $description }}</td>
                 </tr>
             {{ end }}

--- a/core/templates/site/news/post.gohtml
+++ b/core/templates/site/news/post.gohtml
@@ -14,7 +14,7 @@
             {{ if .ShowEdit }}
                 [<a href="/news/news/{{ .Idsitenews }}/edit">EDIT</a>]
             {{ end }}
-            {{ if cd.HasAdminRole }}
+            {{ if and cd.HasAdminRole cd.AdminMode }}
                 [<a href="/admin/announcements?news_id={{ .Idsitenews }}">
                     {{ if and .Announcement (eq .Announcement.Active true) }}
                         MANAGE ANNOUNCEMENT


### PR DESCRIPTION
## Summary
- require admin role and admin mode before showing admin links in public templates
- hide admin link on no-access page unless user is an active admin

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68904d947ecc832f82693594b8f04069