### PR TITLE
fix: correct admin linker link

### DIFF
--- a/handlers/linker/linkerPage.go
+++ b/handlers/linker/linkerPage.go
@@ -57,7 +57,7 @@ func CustomLinkerIndex(data *common.CoreData, r *http.Request) {
 		})
 		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
 			Name: "Category Controls",
-			Link: "/admin/linker/categories",
+			Link: "/admin/linker",
 		})
 		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
 			Name: "Approve links",

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -17,7 +17,7 @@ var legacyRedirectsEnabled = true
 // RegisterRoutes attaches the public linker endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
 	navReg.RegisterIndexLink("Linker", "/linker", SectionWeight)
-	navReg.RegisterAdminControlCenter("Linker", "Linker", "/admin/linker/categories", SectionWeight)
+	navReg.RegisterAdminControlCenter("Linker", "Linker", "/admin/linker", SectionWeight)
 	lr := r.PathPrefix("/linker").Subrouter()
 	lr.Use(handlers.IndexMiddleware(CustomLinkerIndex))
 	lr.HandleFunc("/rss", RssPage).Methods("GET")

--- a/handlers/linker/routes_admin.go
+++ b/handlers/linker/routes_admin.go
@@ -8,6 +8,8 @@ import (
 // RegisterAdminRoutes attaches linker admin endpoints to ar.
 func RegisterAdminRoutes(ar *mux.Router) {
 	lar := ar.PathPrefix("/linker").Subrouter()
+	lar.HandleFunc("", AdminCategoriesPage).Methods("GET")
+	lar.HandleFunc("/", AdminCategoriesPage).Methods("GET")
 	lar.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")
 	lar.HandleFunc("/category/{category}", AdminCategoryPage).Methods("GET")
 	lar.HandleFunc("/categories", handlers.TaskHandler(UpdateCategoryTask)).Methods("POST").MatcherFunc(UpdateCategoryTask.Matcher())


### PR DESCRIPTION
## Summary
- fix admin linker control center link path
- support `/admin/linker` route in linker admin router
- update category controls link on linker page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68904e0dcaf0832fab84970725f7e6bc