### PR TITLE
Fix admin blogs link

### DIFF
--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -150,7 +150,7 @@ func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 }
 
 func TestGetPermissionsByUserIdAndSectionBlogsPage_Unauthorized(t *testing.T) {
-	req := httptest.NewRequest("GET", "/admin/blogs/users/roles", nil)
+	req := httptest.NewRequest("GET", "/admin/blogs", nil)
 	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/blogs/routes.go
+++ b/handlers/blogs/routes.go
@@ -15,7 +15,7 @@ import (
 // RegisterRoutes attaches the public blog endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
 	navReg.RegisterIndexLink("Blogs", "/blogs", SectionWeight)
-	navReg.RegisterAdminControlCenter("Blogs", "Blogs", "/admin/blogs/users/roles", SectionWeight)
+	navReg.RegisterAdminControlCenter("Blogs", "Blogs", "/admin/blogs", SectionWeight)
 	br := r.PathPrefix("/blogs").Subrouter()
 	br.Use(handlers.IndexMiddleware(CustomBlogIndex))
 	br.HandleFunc("/rss", RssPage).Methods("GET")

--- a/handlers/blogs/routes_admin.go
+++ b/handlers/blogs/routes_admin.go
@@ -8,6 +8,8 @@ import (
 // RegisterAdminRoutes attaches blog admin endpoints to ar.
 func RegisterAdminRoutes(ar *mux.Router) {
 	br := ar.PathPrefix("/blogs").Subrouter()
+	br.HandleFunc("", GetPermissionsByUserIdAndSectionBlogsPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
+	br.HandleFunc("/", GetPermissionsByUserIdAndSectionBlogsPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 	br.HandleFunc("/users/roles", GetPermissionsByUserIdAndSectionBlogsPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 	br.HandleFunc("/users/roles", UsersPermissionsPermissionUserAllowPage).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(userAllowTask.Matcher())
 	br.HandleFunc("/users/roles", UsersPermissionsDisallowPage).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(userDisallowTask.Matcher())

--- a/handlers/blogs/routes_test.go
+++ b/handlers/blogs/routes_test.go
@@ -1,0 +1,26 @@
+package blogs
+
+import (
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/config"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
+)
+
+func TestRegisterRoutesRegistersAdminLink(t *testing.T) {
+	r := mux.NewRouter()
+	navReg := navpkg.NewRegistry()
+	RegisterRoutes(r, config.NewRuntimeConfig(), navReg)
+	links := navReg.AdminLinks()
+	for _, l := range links {
+		if l.Name == "Blogs" {
+			if l.Link != "/admin/blogs" {
+				t.Fatalf("expected /admin/blogs got %s", l.Link)
+			}
+			return
+		}
+	}
+	t.Fatalf("Blogs link not registered")
+}


### PR DESCRIPTION
## Summary
- fix admin blogs navigation link to `/admin/blogs`
- expose `/admin/blogs` route for blog admin page
- add tests for blog admin navigation and permissions

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68904df5252c832f8adaf7eac23481b7