### PR TITLE
refactor: generalize pagination offset

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -114,32 +114,31 @@ type CoreData struct {
 	queries       db.Querier
 
 	// Keep this sorted
-	adminLatestNews       lazy.Value[[]*db.AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow]
-	adminLinkerItemRows   map[int32]*lazy.Value[*db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow]
-	adminRequest          map[int32]*lazy.Value[*db.AdminRequestQueue]
-	adminRequestComments  map[int32]*lazy.Value[[]*db.AdminRequestComment]
-	adminRequests         map[string]*lazy.Value[[]*db.AdminRequestQueue]
-	adminUserBookmarkSize map[int32]*lazy.Value[int]
-	adminUserComments     map[int32]*lazy.Value[[]*db.AdminUserComment]
-	adminUserEmails       map[int32]*lazy.Value[[]*db.UserEmail]
-	adminUserGrants       map[int32]*lazy.Value[[]*db.Grant]
-	adminUserRoles        map[int32]*lazy.Value[[]*db.GetPermissionsByUserIDRow]
-	adminUserStats        map[int32]*lazy.Value[*db.AdminUserPostCountsByIDRow]
-	allRoles              lazy.Value[[]*db.Role]
-	annMu                 sync.Mutex
-	announcement          lazy.Value[*db.GetActiveAnnouncementWithNewsForListerRow]
-	blogEntries           map[int32]*lazy.Value[*db.GetBlogEntryForListerByIDRow]
-	bloggers              lazy.Value[[]*db.ListBloggersForListerRow]
-	blogListOffset        int
-	blogListRows          lazy.Value[[]*db.ListBlogEntriesByAuthorForListerRow]
-	blogListUID           int32
-	bookmarks             lazy.Value[*db.GetBookmarksForUserRow]
-	currentBlogID         int32
-	currentBoardID        int32
-	currentCommentID      int32
-	currentImagePostID    int32
-	// TODO offset is not specific to news
-	currentNewsOffset        int
+	adminLatestNews          lazy.Value[[]*db.AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow]
+	adminLinkerItemRows      map[int32]*lazy.Value[*db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow]
+	adminRequest             map[int32]*lazy.Value[*db.AdminRequestQueue]
+	adminRequestComments     map[int32]*lazy.Value[[]*db.AdminRequestComment]
+	adminRequests            map[string]*lazy.Value[[]*db.AdminRequestQueue]
+	adminUserBookmarkSize    map[int32]*lazy.Value[int]
+	adminUserComments        map[int32]*lazy.Value[[]*db.AdminUserComment]
+	adminUserEmails          map[int32]*lazy.Value[[]*db.UserEmail]
+	adminUserGrants          map[int32]*lazy.Value[[]*db.Grant]
+	adminUserRoles           map[int32]*lazy.Value[[]*db.GetPermissionsByUserIDRow]
+	adminUserStats           map[int32]*lazy.Value[*db.AdminUserPostCountsByIDRow]
+	allRoles                 lazy.Value[[]*db.Role]
+	annMu                    sync.Mutex
+	announcement             lazy.Value[*db.GetActiveAnnouncementWithNewsForListerRow]
+	blogEntries              map[int32]*lazy.Value[*db.GetBlogEntryForListerByIDRow]
+	bloggers                 lazy.Value[[]*db.ListBloggersForListerRow]
+	blogListOffset           int
+	blogListRows             lazy.Value[[]*db.ListBlogEntriesByAuthorForListerRow]
+	blogListUID              int32
+	bookmarks                lazy.Value[*db.GetBookmarksForUserRow]
+	currentBlogID            int32
+	currentBoardID           int32
+	currentCommentID         int32
+	currentImagePostID       int32
+	currentOffset            int
 	currentNewsPostID        int32
 	currentProfileUserID     int32
 	currentRequestID         int32
@@ -217,7 +216,7 @@ func (cd *CoreData) AdminForumTopics() ([]*db.Forumtopic, error) {
 func (cd *CoreData) AdminLatestNews() ([]*db.AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow, error) {
 	ps := cd.PageSize()
 	return cd.adminLatestNews.Load(func() ([]*db.AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow, error) {
-		return cd.AdminLatestNewsList(int32(cd.currentNewsOffset), int32(ps))
+		return cd.AdminLatestNewsList(int32(cd.currentOffset), int32(ps))
 	})
 }
 
@@ -2115,9 +2114,9 @@ func WithCustomQueries(cq db.CustomQueries) CoreOption {
 	return func(cd *CoreData) { cd.customQueries = cq }
 }
 
-// WithNewsOffset records the current news listing offset.
-func WithNewsOffset(o int) CoreOption {
-	return func(cd *CoreData) { cd.currentNewsOffset = o }
+// WithOffset records the current pagination offset.
+func WithOffset(o int) CoreOption {
+	return func(cd *CoreData) { cd.currentOffset = o }
 }
 
 // assignIDFromString converts v to int32 and stores it in the mapped CoreData

--- a/core/common/coredata_request_test.go
+++ b/core/common/coredata_request_test.go
@@ -1,4 +1,4 @@
-package common_test
+package common
 
 import (
 	"context"
@@ -9,7 +9,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core/common"
 )
 
 func TestWithSelectionsFromRequest(t *testing.T) {
@@ -18,17 +17,17 @@ func TestWithSelectionsFromRequest(t *testing.T) {
 	t.Run("path variable", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/", nil)
 		req = mux.SetURLVars(req, map[string]string{"board": "1"})
-		cd := common.NewCoreData(context.Background(), nil, cfg, common.WithSelectionsFromRequest(req))
-		if got := cd.SelectedBoard(); got != 1 {
-			t.Fatalf("SelectedBoard = %d; want 1", got)
+		cd := NewCoreData(context.Background(), nil, cfg, WithSelectionsFromRequest(req))
+		if got := cd.currentBoardID; got != 1 {
+			t.Fatalf("currentBoardID = %d; want 1", got)
 		}
 	})
 
 	t.Run("query parameter", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/?thread=2", nil)
-		cd := common.NewCoreData(context.Background(), nil, cfg, common.WithSelectionsFromRequest(req))
-		if got := cd.SelectedThread(); got != 2 {
-			t.Fatalf("SelectedThread = %d; want 2", got)
+		cd := NewCoreData(context.Background(), nil, cfg, WithSelectionsFromRequest(req))
+		if got := cd.currentThreadID; got != 2 {
+			t.Fatalf("currentThreadID = %d; want 2", got)
 		}
 	})
 
@@ -36,9 +35,9 @@ func TestWithSelectionsFromRequest(t *testing.T) {
 		body := strings.NewReader("post=3")
 		req := httptest.NewRequest("POST", "/", body)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		cd := common.NewCoreData(context.Background(), nil, cfg, common.WithSelectionsFromRequest(req))
-		if got := cd.SelectedImagePost(); got != 3 {
-			t.Fatalf("SelectedImagePost = %d; want 3", got)
+		cd := NewCoreData(context.Background(), nil, cfg, WithSelectionsFromRequest(req))
+		if got := cd.currentImagePostID; got != 3 {
+			t.Fatalf("currentImagePostID = %d; want 3", got)
 		}
 	})
 }

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -109,7 +109,7 @@ func CoreAdderMiddlewareWithDB(sdb *sql.DB, cfg *config.RuntimeConfig, verbosity
 				common.WithAbsoluteURLBase(base),
 				common.WithSessionManager(sm),
 				common.WithSelectionsFromRequest(r),
-				common.WithNewsOffset(offset))
+				common.WithOffset(offset))
 			cd.UserID = uid
 
 			if navReg != nil {


### PR DESCRIPTION
## Summary
- rename currentNewsOffset to a generic currentOffset in CoreData
- update CoreData option and middleware to use WithOffset
- update selection request test to use internal IDs and remove obsolete comment

## Testing
- `go vet ./core/common/...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68903677f764832f882f25efb2ad4e0a