### PR TITLE
Use CurrentProfileUser for admin user pages

### DIFF
--- a/handlers/admin/adminUserBlogsPage.go
+++ b/handlers/admin/adminUserBlogsPage.go
@@ -3,27 +3,23 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserBlogsPage lists all blog posts authored by a user.
 func adminUserBlogsPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.AdminGetAllBlogEntriesByUser(r.Context(), int32(id))
+	queries := cd.Queries()
+	rows, err := queries.AdminGetAllBlogEntriesByUser(r.Context(), user.Idusers)
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/admin/adminUserCommentsPage.go
+++ b/handlers/admin/adminUserCommentsPage.go
@@ -3,27 +3,23 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserCommentsPage lists all comments posted by a user.
 func adminUserCommentsPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.AdminGetAllCommentsByUser(r.Context(), int32(id))
+	queries := cd.Queries()
+	rows, err := queries.AdminGetAllCommentsByUser(r.Context(), user.Idusers)
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/admin/adminUserForumPage.go
+++ b/handlers/admin/adminUserForumPage.go
@@ -3,27 +3,23 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserForumPage lists forum threads started by a user.
 func adminUserForumPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.AdminGetThreadsStartedByUserWithTopic(r.Context(), int32(id))
+	queries := cd.Queries()
+	rows, err := queries.AdminGetThreadsStartedByUserWithTopic(r.Context(), user.Idusers)
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/admin/adminUserImagebbsPage.go
+++ b/handlers/admin/adminUserImagebbsPage.go
@@ -3,28 +3,24 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserImagebbsPage lists image board posts by a user.
 func adminUserImagebbsPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
+	queries := cd.Queries()
 	rows, err := queries.GetImagePostsByUserDescendingAll(r.Context(), db.GetImagePostsByUserDescendingAllParams{
-		UsersIdusers: int32(id),
+		UsersIdusers: user.Idusers,
 		Limit:        100,
 		Offset:       0,
 	})

--- a/handlers/admin/adminUserLinkerPage.go
+++ b/handlers/admin/adminUserLinkerPage.go
@@ -3,28 +3,24 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserLinkerPage lists linker posts created by a user.
 func adminUserLinkerPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
+	queries := cd.Queries()
 	rows, err := queries.GetLinkerItemsByUserDescending(r.Context(), db.GetLinkerItemsByUserDescendingParams{
-		UsersIdusers: int32(id),
+		UsersIdusers: user.Idusers,
 		Limit:        100,
 		Offset:       0,
 	})

--- a/handlers/admin/adminUserProfilePage.go
+++ b/handlers/admin/adminUserProfilePage.go
@@ -3,10 +3,7 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
-
-	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
@@ -26,25 +23,28 @@ func adminUserProfilePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func adminUserAddCommentPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	user := cd.CurrentProfileUser()
+	back := "/admin/user"
+	if user != nil {
+		back = fmt.Sprintf("/admin/user/%d", user.Idusers)
+	}
 	data := struct {
 		*common.CoreData
 		Errors   []string
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-		Back:     "/admin/user/" + idStr,
+		CoreData: cd,
+		Back:     back,
 	}
 	comment := r.PostFormValue("comment")
-	if id == 0 {
+	if user == nil {
 		data.Errors = append(data.Errors, "invalid user id")
 	} else if strings.TrimSpace(comment) == "" {
 		data.Errors = append(data.Errors, "empty comment")
 	} else {
-		queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-		if err := queries.InsertAdminUserComment(r.Context(), db.InsertAdminUserCommentParams{UsersIdusers: int32(id), Comment: comment}); err != nil {
+		if err := cd.Queries().InsertAdminUserComment(r.Context(), db.InsertAdminUserCommentParams{UsersIdusers: user.Idusers, Comment: comment}); err != nil {
 			data.Errors = append(data.Errors, err.Error())
 		} else {
 			data.Messages = append(data.Messages, "comment added")

--- a/handlers/admin/adminUserSubscriptionsPage.go
+++ b/handlers/admin/adminUserSubscriptionsPage.go
@@ -3,27 +3,23 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserSubscriptionsPage lists subscription patterns of a user.
 func adminUserSubscriptionsPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.ListSubscriptionsByUser(r.Context(), int32(id))
+	queries := cd.Queries()
+	rows, err := queries.ListSubscriptionsByUser(r.Context(), user.Idusers)
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/admin/adminUserWritingsPage.go
+++ b/handlers/admin/adminUserWritingsPage.go
@@ -3,27 +3,23 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserWritingsPage lists all writings authored by a user.
 func adminUserWritingsPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.AdminGetAllWritingsByAuthor(r.Context(), int32(id))
+	queries := cd.Queries()
+	rows, err := queries.AdminGetAllWritingsByAuthor(r.Context(), user.Idusers)
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Summary
- resolve current user in admin pages via CoreData.CurrentProfileUser
- simplify admin user password reset handling
- streamline admin user comment addition

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68905a014588832fb77689f7b824e26a