### PR TITLE
Align pagination controls

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -151,6 +151,19 @@ div.title {
         bottom: 0;
         background-color: #FFF6E0;
         padding: 0.5em;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+}
+.pagination-left,
+.pagination-right {
+        flex: 1;
+}
+.pagination-right {
+        text-align: right;
+}
+.pagination-center {
+        flex: 1;
         text-align: center;
 }
 .pagination-bar a, .pagination-bar strong {

--- a/core/templates/site/pagination.gohtml
+++ b/core/templates/site/pagination.gohtml
@@ -1,12 +1,18 @@
 {{define "pagination"}}
     {{ if or cd.StartLink cd.PrevLink cd.NextLink cd.PageLinks }}
         <div class="pagination-bar">
-            {{ if cd.StartLink }}<a href="{{ cd.StartLink }}">The start</a>{{ end }}
-            {{ if cd.PrevLink }}<a href="{{ cd.PrevLink }}">Previous{{ if .PageSize }} {{ .PageSize }}{{ end }}</a>{{ end }}
-            {{ range cd.PageLinks }}
-                {{ if .Active }}<strong>{{ .Num }}</strong>{{ else }}<a href="{{ .Link }}">{{ .Num }}</a>{{ end }}
-            {{ end }}
-            {{ if cd.NextLink }}<a href="{{ cd.NextLink }}">Next{{ if .PageSize }} {{ .PageSize }}{{ end }}</a>{{ end }}
+            <div class="pagination-left">
+                {{ if cd.StartLink }}<a href="{{ cd.StartLink }}">The start</a>{{ end }}
+                {{ if cd.PrevLink }}<a href="{{ cd.PrevLink }}">Previous{{ if .PageSize }} {{ .PageSize }}{{ end }}</a>{{ end }}
+            </div>
+            <div class="pagination-center">
+                {{ range cd.PageLinks }}
+                    {{ if .Active }}<strong>{{ .Num }}</strong>{{ else }}<a href="{{ .Link }}">{{ .Num }}</a>{{ end }}
+                {{ end }}
+            </div>
+            <div class="pagination-right">
+                {{ if cd.NextLink }}<a href="{{ cd.NextLink }}">Next{{ if .PageSize }} {{ .PageSize }}{{ end }}</a>{{ end }}
+            </div>
         </div>
     {{ end }}
 {{end}}


### PR DESCRIPTION
## Summary
- align pagination previous/next links to opposite sides

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_689059126340832fb83da87cd86aae36