### PR TITLE
Add blogger search results and redirect

### DIFF
--- a/core/templates/site/blogs/bloggerListPage.gohtml
+++ b/core/templates/site/blogs/bloggerListPage.gohtml
@@ -3,12 +3,23 @@
         <input name="search" value="{{$.Search}}">
         <input type="submit" value="Search">
     </form>
-    {{if .Rows}}
-        <font size="5">All bloggers.</font><br>
-        {{range .Rows}}
-            Blogger: <a href="/blogs/blogger/{{.Username.String}}">{{.Username.String}}</a> has {{.Count}} blogs.<br>
+    {{if .Search}}
+        {{if .Rows}}
+            <font size="5">Search results for "{{.Search}}".</font><br>
+            {{range .Rows}}
+                Blogger: <a href="/blogs/blogger/{{.Username.String}}">{{.Username.String}}</a> has {{.Count}} blogs.<br>
+            {{end}}
+        {{else}}
+            No bloggers found for "{{.Search}}".
         {{end}}
     {{else}}
-        No bloggers here.
+        {{if .Rows}}
+            <font size="5">All bloggers.</font><br>
+            {{range .Rows}}
+                Blogger: <a href="/blogs/blogger/{{.Username.String}}">{{.Username.String}}</a> has {{.Count}} blogs.<br>
+            {{end}}
+        {{else}}
+            No bloggers here.
+        {{end}}
     {{end}}
 {{ template "tail" $ }}

--- a/handlers/blogs/bloggerListPage.go
+++ b/handlers/blogs/bloggerListPage.go
@@ -53,6 +53,18 @@ func BloggerListPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Rows = rows
 
+	if data.Search != "" {
+		if len(rows) == 1 {
+			http.Redirect(w, r, "/blogs/blogger/"+rows[0].Username.String, http.StatusFound)
+			return
+		}
+		if len(rows) == 0 {
+			cd.PageTitle = fmt.Sprintf("No bloggers found for %q", data.Search)
+		} else {
+			cd.PageTitle = fmt.Sprintf("Bloggers matching %q", data.Search)
+		}
+	}
+
 	base := "/blogs/bloggers"
 	if data.Search != "" {
 		base += "?search=" + url.QueryEscape(data.Search)

--- a/handlers/blogs/bloggerListPage_search_test.go
+++ b/handlers/blogs/bloggerListPage_search_test.go
@@ -1,0 +1,48 @@
+package blogs
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestBloggerListPageSearchRedirect(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+	q := db.New(conn)
+
+	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("arran4", 2)
+	mock.ExpectQuery(regexp.QuoteMeta("WITH RECURSIVE role_ids")).
+		WithArgs(int32(0), "%arran4%", "%arran4%", int32(0), int32(0), nil, int32(16), int32(0)).
+		WillReturnRows(rows)
+
+	req := httptest.NewRequest("GET", "/blogs/bloggers?search=arran4", nil)
+	ctx := req.Context()
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	BloggerListPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Result().StatusCode != http.StatusFound {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+	if loc := rr.Result().Header.Get("Location"); loc != "/blogs/blogger/arran4" {
+		t.Fatalf("location=%s", loc)
+	}
+}


### PR DESCRIPTION
## Summary
- Improve blogger list search handling and redirect to single blogger when search yields one match
- Show search results message in blogger list template
- Cover redirect behaviour with new test

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68905a95cb20832fba6fbc967bb7b14c