### PR TITLE
admin: reuse profile user from CoreData

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1690,6 +1690,9 @@ func (cd *CoreData) SetCurrentNewsPost(id int32) { cd.currentNewsPostID = id }
 // SetCurrentProfileUserID records the user ID for profile lookups.
 func (cd *CoreData) SetCurrentProfileUserID(id int32) { cd.currentProfileUserID = id }
 
+// CurrentProfileUserID returns the user ID for profile lookups.
+func (cd *CoreData) CurrentProfileUserID() int32 { return cd.currentProfileUserID }
+
 // SetCurrentRequestID stores the request ID for subsequent lookups.
 func (cd *CoreData) SetCurrentRequestID(id int32) { cd.currentRequestID = id }
 

--- a/handlers/admin/adminUserBlogsPage.go
+++ b/handlers/admin/adminUserBlogsPage.go
@@ -3,27 +3,23 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserBlogsPage lists all blog posts authored by a user.
 func adminUserBlogsPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.AdminGetAllBlogEntriesByUser(r.Context(), int32(id))
+	queries := cd.Queries()
+	rows, err := queries.AdminGetAllBlogEntriesByUser(r.Context(), cd.CurrentProfileUserID())
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/admin/adminUserCommentsPage.go
+++ b/handlers/admin/adminUserCommentsPage.go
@@ -3,27 +3,23 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserCommentsPage lists all comments posted by a user.
 func adminUserCommentsPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.AdminGetAllCommentsByUser(r.Context(), int32(id))
+	queries := cd.Queries()
+	rows, err := queries.AdminGetAllCommentsByUser(r.Context(), cd.CurrentProfileUserID())
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/admin/adminUserForumPage.go
+++ b/handlers/admin/adminUserForumPage.go
@@ -3,27 +3,23 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserForumPage lists forum threads started by a user.
 func adminUserForumPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.AdminGetThreadsStartedByUserWithTopic(r.Context(), int32(id))
+	queries := cd.Queries()
+	rows, err := queries.AdminGetThreadsStartedByUserWithTopic(r.Context(), cd.CurrentProfileUserID())
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/admin/adminUserImagebbsPage.go
+++ b/handlers/admin/adminUserImagebbsPage.go
@@ -3,28 +3,24 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserImagebbsPage lists image board posts by a user.
 func adminUserImagebbsPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
+	queries := cd.Queries()
 	rows, err := queries.GetImagePostsByUserDescendingAll(r.Context(), db.GetImagePostsByUserDescendingAllParams{
-		UsersIdusers: int32(id),
+		UsersIdusers: cd.CurrentProfileUserID(),
 		Limit:        100,
 		Offset:       0,
 	})

--- a/handlers/admin/adminUserLinkerPage.go
+++ b/handlers/admin/adminUserLinkerPage.go
@@ -3,28 +3,24 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserLinkerPage lists linker posts created by a user.
 func adminUserLinkerPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
+	queries := cd.Queries()
 	rows, err := queries.GetLinkerItemsByUserDescending(r.Context(), db.GetLinkerItemsByUserDescendingParams{
-		UsersIdusers: int32(id),
+		UsersIdusers: cd.CurrentProfileUserID(),
 		Limit:        100,
 		Offset:       0,
 	})

--- a/handlers/admin/adminUserSubscriptionsPage.go
+++ b/handlers/admin/adminUserSubscriptionsPage.go
@@ -3,27 +3,23 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserSubscriptionsPage lists subscription patterns of a user.
 func adminUserSubscriptionsPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.ListSubscriptionsByUser(r.Context(), int32(id))
+	queries := cd.Queries()
+	rows, err := queries.ListSubscriptionsByUser(r.Context(), cd.CurrentProfileUserID())
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/admin/adminUserWritingsPage.go
+++ b/handlers/admin/adminUserWritingsPage.go
@@ -3,27 +3,23 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/gorilla/mux"
 )
 
 // adminUserWritingsPage lists all writings authored by a user.
 func adminUserWritingsPage(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["user"]
-	id, _ := strconv.Atoi(idStr)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
-	user, err := queries.SystemGetUserByID(r.Context(), int32(id))
-	if err != nil {
+	user := cd.CurrentProfileUser()
+	if user == nil {
 		http.Error(w, "user not found", http.StatusNotFound)
 		return
 	}
-	rows, err := queries.AdminGetAllWritingsByAuthor(r.Context(), int32(id))
+	queries := cd.Queries()
+	rows, err := queries.AdminGetAllWritingsByAuthor(r.Context(), cd.CurrentProfileUserID())
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Summary
- use CoreData's profile user helpers in admin user pages
- avoid redundant queries for already loaded users
- expose `CurrentProfileUserID` from CoreData

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68905ab423a8832f8418e44286cea92c