### PR TITLE
Use CoreData profile user ID for admin handlers

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -770,6 +770,9 @@ func (cd *CoreData) CurrentProfileStats() *db.AdminUserPostCountsByIDRow {
 	return row
 }
 
+// CurrentProfileUserID returns the user ID being viewed.
+func (cd *CoreData) CurrentProfileUserID() int32 { return cd.currentProfileUserID }
+
 // CurrentProfileUser returns the user being viewed.
 func (cd *CoreData) CurrentProfileUser() *db.SystemGetUserByIDRow {
 	return cd.UserByID(cd.currentProfileUserID)

--- a/handlers/forum/forumAdminUsersRedirect.go
+++ b/handlers/forum/forumAdminUsersRedirect.go
@@ -2,8 +2,10 @@ package forum
 
 import (
 	"net/http"
+	"strconv"
 
-	"github.com/gorilla/mux"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 )
 
 // AdminUsersRedirect redirects forum user management to the global user admin page.
@@ -13,6 +15,7 @@ func AdminUsersRedirect(w http.ResponseWriter, r *http.Request) {
 
 // AdminUserLevelsRedirect redirects to the global user profile page.
 func AdminUserLevelsRedirect(w http.ResponseWriter, r *http.Request) {
-	id := mux.Vars(r)["user"]
-	http.Redirect(w, r, "/admin/user/"+id, http.StatusTemporaryRedirect)
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	id := cd.CurrentProfileUserID()
+	http.Redirect(w, r, "/admin/user/"+strconv.Itoa(int(id)), http.StatusTemporaryRedirect)
 }

--- a/handlers/user/permissionUpdateTask.go
+++ b/handlers/user/permissionUpdateTask.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/gorilla/mux"
-
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -28,14 +26,15 @@ var _ tasks.Task = (*PermissionUpdateTask)(nil)
 var _ notif.TargetUsersNotificationProvider = (*PermissionUpdateTask)(nil)
 
 func (PermissionUpdateTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	permid := r.PostFormValue("permid")
 	role := r.PostFormValue("role")
 
-	idStr := mux.Vars(r)["user"]
+	id := cd.CurrentProfileUserID()
 	back := "/admin/users/permissions"
-	if idStr != "" {
-		back = "/admin/user/" + idStr + "/permissions"
+	if id != 0 {
+		back = fmt.Sprintf("/admin/user/%d/permissions", id)
 	}
 	data := struct {
 		*common.CoreData
@@ -43,7 +42,7 @@ func (PermissionUpdateTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Back:     back,
 	}
 

--- a/handlers/user/permissionUserAllowTask.go
+++ b/handlers/user/permissionUserAllowTask.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gorilla/mux"
-
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -35,13 +33,14 @@ func (PermissionUserAllowTask) AdminInternalNotificationTemplate() *string {
 }
 
 func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	username := r.PostFormValue("username")
 	role := r.PostFormValue("role")
-	idStr := mux.Vars(r)["user"]
+	id := cd.CurrentProfileUserID()
 	back := "/admin/users/permissions"
-	if idStr != "" {
-		back = "/admin/user/" + idStr + "/permissions"
+	if id != 0 {
+		back = fmt.Sprintf("/admin/user/%d/permissions", id)
 	}
 	data := struct {
 		*common.CoreData
@@ -49,7 +48,7 @@ func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) an
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Back:     back,
 	}
 	if u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {

--- a/handlers/user/permissionUserDisallowTask.go
+++ b/handlers/user/permissionUserDisallowTask.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/gorilla/mux"
-
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -35,12 +33,13 @@ func (PermissionUserDisallowTask) AdminInternalNotificationTemplate() *string {
 }
 
 func (PermissionUserDisallowTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	permid := r.PostFormValue("permid")
-	idStr := mux.Vars(r)["user"]
+	id := cd.CurrentProfileUserID()
 	back := "/admin/users/permissions"
-	if idStr != "" {
-		back = "/admin/user/" + idStr + "/permissions"
+	if id != 0 {
+		back = fmt.Sprintf("/admin/user/%d/permissions", id)
 	}
 	data := struct {
 		*common.CoreData
@@ -48,7 +47,7 @@ func (PermissionUserDisallowTask) Action(w http.ResponseWriter, r *http.Request)
 		Messages []string
 		Back     string
 	}{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
+		CoreData: cd,
 		Back:     back,
 	}
 	if permidi, err := strconv.Atoi(permid); err != nil {


### PR DESCRIPTION
## Summary
- expose `CurrentProfileUserID` on CoreData
- use `CurrentProfileUserID` in admin forum redirect
- use `CurrentProfileUserID` in user permission tasks instead of mux vars

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689088985f50832f8ffe78b3b64e1d99