### PR TITLE
refactor: consolidate auth templates into core

### DIFF
--- a/handlers/auth/templates/adminNotificationUserRequestPasswordResetEmail.gohtml
+++ b/handlers/auth/templates/adminNotificationUserRequestPasswordResetEmail.gohtml
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html>
-<body>
-<p>Hi the user {{.Item.Username}},</p>
-<p>Is attempting a password reset.</p>
-</body>
-</html>

--- a/handlers/auth/templates/adminNotificationUserRequestPasswordResetEmail.gotxt
+++ b/handlers/auth/templates/adminNotificationUserRequestPasswordResetEmail.gotxt
@@ -1,2 +1,0 @@
-Hi the user {{.Item.Username}},
-Is attempting a password reset.

--- a/handlers/auth/templates/adminNotificationUserRequestPasswordResetEmailSubject.gotxt
+++ b/handlers/auth/templates/adminNotificationUserRequestPasswordResetEmailSubject.gotxt
@@ -1,1 +1,0 @@
-[{{.SubjectPrefix}}] User Password Reset Requested

--- a/handlers/auth/templates/passwordResetEmail.gohtml
+++ b/handlers/auth/templates/passwordResetEmail.gohtml
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html>
-<body>
-<p>Hi {{.Item.Username}},</p>
-<p>Use code <b>{{.Item.Code}}</b> when logging in with your new password.</p>
-<p>If you didn't request this change, you can ignore this email.</p>
-</body>
-</html>

--- a/handlers/auth/templates/passwordResetEmail.gotxt
+++ b/handlers/auth/templates/passwordResetEmail.gotxt
@@ -1,3 +1,0 @@
-Hi {{.Item.Username}},
-Use code {{.Item.Code}} when logging in with your new password.
-If you didn't request this change, you can ignore this email.

--- a/handlers/auth/templates/passwordResetEmailSubject.gotxt
+++ b/handlers/auth/templates/passwordResetEmailSubject.gotxt
@@ -1,1 +1,0 @@
-[{{.SubjectPrefix}}] Password reset request


### PR DESCRIPTION
## Summary
- remove redundant auth email templates

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` (fails: duplicate key "request" in map literal)
- `golangci-lint run` (fails: duplicate key "request" and other type-check errors)
- `go test ./...` (fails: duplicate key "request" in map literal)


------
https://chatgpt.com/codex/tasks/task_e_68908e6dac5c832f9f8ef97576c42c17