### PR TITLE
refactor: use writing id in routes and handlers

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -2164,7 +2164,6 @@ func WithSelectionsFromRequest(r *http.Request) CoreOption {
 			"blog":    &cd.currentBlogID,
 			"request": &cd.currentRequestID,
 			"user":    &cd.currentProfileUserID,
-			"request": &cd.currentRequestID,
 		}
 		for k, v := range mux.Vars(r) {
 			assignIDFromString(mapping, k, v)

--- a/core/templates/pagination_template_test.go
+++ b/core/templates/pagination_template_test.go
@@ -6,12 +6,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 )
 
 func TestPaginationTemplateWithoutPageSize(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
-	cd := &common.CoreData{}
+	cd := &common.CoreData{Config: config.NewRuntimeConfig()}
 	cd.PrevLink = "/prev"
 	tmpl := template.Must(template.New("").Funcs(cd.Funcs(r)).ParseFS(testTemplates,
 		"site/*.gohtml", "site/*/*.gohtml", "email/*.gohtml"))

--- a/handlers/admin/adminRequestQueuePage.go
+++ b/handlers/admin/adminRequestQueuePage.go
@@ -93,11 +93,11 @@ func handleRequestAction(w http.ResponseWriter, r *http.Request, status string) 
 	} else {
 		auto = fmt.Sprintf("status changed to %s", status)
 		data.Messages = append(data.Messages, auto)
-		if err := queries.AdminInsertRequestComment(r.Context(), db.AdminInsertRequestCommentParams{RequestID: id, Comment: auto}); err != nil {
+		if err := queries.AdminInsertRequestComment(r.Context(), db.AdminInsertRequestCommentParams{RequestID: req.ID, Comment: auto}); err != nil {
 			data.Errors = append(data.Errors, err.Error())
 		}
 		if comment != "" {
-			if err := queries.AdminInsertRequestComment(r.Context(), db.AdminInsertRequestCommentParams{RequestID: id, Comment: comment}); err != nil {
+			if err := queries.AdminInsertRequestComment(r.Context(), db.AdminInsertRequestCommentParams{RequestID: req.ID, Comment: comment}); err != nil {
 				data.Errors = append(data.Errors, err.Error())
 			}
 		}

--- a/handlers/writings/cancel_task.go
+++ b/handlers/writings/cancel_task.go
@@ -1,11 +1,10 @@
 package writings
 
 import (
-	"fmt"
 	"net/http"
 
-	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/core/consts"
+	"github.com/gorilla/mux"
+
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -19,10 +18,5 @@ var cancelTask = &CancelTask{TaskString: TaskCancel}
 var _ tasks.Task = (*CancelTask)(nil)
 
 func (CancelTask) Action(w http.ResponseWriter, r *http.Request) any {
-	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	writing, err := cd.CurrentWriting()
-	if err != nil || writing == nil {
-		return fmt.Errorf("load writing fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-	}
-	return handlers.RedirectHandler(fmt.Sprintf("/writings/article/%d", writing.Idwriting))
+	return handlers.RedirectHandler("/writings/article/" + mux.Vars(r)["writing"])
 }

--- a/handlers/writings/edit_reply_task.go
+++ b/handlers/writings/edit_reply_task.go
@@ -35,8 +35,11 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
 	writing, err := cd.CurrentWriting()
-	if err != nil || writing == nil {
+	if err != nil {
 		return fmt.Errorf("load writing fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	if writing == nil {
+		return fmt.Errorf("load writing fail %w", handlers.ErrRedirectOnSamePageHandler(sql.ErrNoRows))
 	}
 	comment, err := cd.CurrentComment(r)
 	if err != nil || comment == nil {

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -73,7 +73,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := cd.Queries()
 	uid, _ := session.Values["UID"].(int32)
 
-	post, err := cd.CurrentWriting()
+	writing, err := cd.CurrentWriting()
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd); err != nil {
@@ -83,11 +83,11 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 		return fmt.Errorf("get writing fail %w", err)
 	}
-	if post == nil {
+	if writing == nil {
 		return fmt.Errorf("get writing fail %w", handlers.ErrRedirectOnSamePageHandler(sql.ErrNoRows))
 	}
 
-	pthid := post.ForumthreadID
+	pthid := writing.ForumthreadID
 	pt, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{String: WritingTopicName, Valid: true})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
@@ -112,7 +112,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			return fmt.Errorf("make thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 		pthid = int32(pthidi)
-		if err := queries.SystemAssignWritingThreadID(r.Context(), db.SystemAssignWritingThreadIDParams{ForumthreadID: pthid, Idwriting: post.Idwriting}); err != nil {
+		if err := queries.SystemAssignWritingThreadID(r.Context(), db.SystemAssignWritingThreadIDParams{ForumthreadID: pthid, Idwriting: writing.Idwriting}); err != nil {
 			return fmt.Errorf("assign writing thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	}
@@ -122,7 +122,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data["target"] = notif.Target{Type: "writing", ID: post.Idwriting}
+			evt.Data["target"] = notif.Target{Type: "writing", ID: writing.Idwriting}
 		}
 	}
 

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -27,6 +27,7 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Regis
 	wr.HandleFunc("/writer/{username}", WriterPage).Methods("GET")
 	wr.HandleFunc("/writer/{username}/", WriterPage).Methods("GET")
 	wr.HandleFunc("/writers", WriterListPage).Methods("GET")
+	// Writing routes use {writing} to identify the requested writing.
 	wr.HandleFunc("/article/{writing}", ArticlePage).Methods("GET")
 	wr.HandleFunc("/article/{writing}", handlers.TaskHandler(replyTask)).Methods("POST").MatcherFunc(replyTask.Matcher())
 	wr.Handle("/article/{writing}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(handlers.TaskHandler(editReplyTask)))).Methods("POST").MatcherFunc(editReplyTask.Matcher())
@@ -34,7 +35,7 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Regis
 	wr.Handle("/article/{writing}/edit", RequireWritingAuthor(http.HandlerFunc(updateWritingTask.Page))).Methods("GET").MatcherFunc(handlers.RequiredAccess("content writer", "administrator"))
 	wr.Handle("/article/{writing}/edit", RequireWritingAuthor(http.HandlerFunc(handlers.TaskHandler(updateWritingTask)))).Methods("POST").MatcherFunc(handlers.RequiredAccess("content writer", "administrator")).MatcherFunc(updateWritingTask.Matcher())
 	wr.HandleFunc("/categories", CategoriesPage).Methods("GET")
-	wr.HandleFunc("/categories", CategoriesPage).Methods("GET")
+	wr.HandleFunc("/categories/", CategoriesPage).Methods("GET")
 	wr.HandleFunc("/category/{category}", CategoryPage).Methods("GET")
 	wr.HandleFunc("/category/{category}/add", submitWritingTask.Page).Methods("GET").MatcherFunc(handlers.RequiredAccess("content writer", "administrator"))
 	wr.HandleFunc("/category/{category}/add", handlers.TaskHandler(submitWritingTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("content writer", "administrator")).MatcherFunc(submitWritingTask.Matcher())

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -107,7 +107,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	uid, _ := session.Values["UID"].(int32)
 
-	post, err := cd.CurrentWriting()
+	writing, err := cd.CurrentWriting()
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
@@ -121,12 +121,12 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if post == nil {
+	if writing == nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 
-	var pthid int32 = post.ForumthreadID
+	var pthid int32 = writing.ForumthreadID
 	pt, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{
 		String: WritingTopicName,
 		Valid:  true,
@@ -167,7 +167,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		pthid = int32(pthidi)
 		if err := queries.SystemAssignWritingThreadID(r.Context(), db.SystemAssignWritingThreadIDParams{
 			ForumthreadID: pthid,
-			Idwriting:     post.Idwriting,
+			Idwriting:     writing.Idwriting,
 		}); err != nil {
 			log.Printf("Error: assign_writing_to_thread: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
@@ -180,7 +180,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data["target"] = notifications.Target{Type: "writing", ID: post.Idwriting}
+			evt.Data["target"] = notifications.Target{Type: "writing", ID: writing.Idwriting}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- clarify writing route paths and ensure writing routes use {writing}
- load current writing in reply handlers via CoreData and simplify cancel task
- fix vet/test failures by deduping selection keys and initialising config in template test

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68908c56eb0c832fb76e194d8a64180d