### PR TITLE
Use RenderErrorPage in auth login page

### DIFF
--- a/handlers/auth/loginPage.go
+++ b/handlers/auth/loginPage.go
@@ -47,7 +47,7 @@ func (h redirectBackPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 	if err := cd.ExecuteSiteTemplate(w, r, "redirectBackPage.gohtml", data); err != nil {
 		log.Printf("Template Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- show a standard error page when redirect-back template execution fails in auth login handler

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method CoreData.CurrentProfileUserID already declared at core/common/coredata.go:795:21)*
- `golangci-lint run ./...` *(fails: typecheck errors including method CoreData.CurrentProfileUserID already declared)*
- `go test ./...` *(fails: method CoreData.CurrentProfileUserID already declared at core/common/coredata.go:795:21)*

------
https://chatgpt.com/codex/tasks/task_e_68909566793c832f9719c7273a11051b