### PR TITLE
feat: pin pagination bar to bottom

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -7,7 +7,7 @@ body {
 }
 
 #bottom {
-        flex: 1 1 auto;
+        flex: none;
 }
 
 .navbar {
@@ -47,6 +47,8 @@ body {
 
 .content {
         flex: 1;
+        display: flex;
+        flex-direction: column;
 }
 
 .site-footer {
@@ -149,6 +151,7 @@ div.title {
 .pagination-bar {
         position: sticky;
         bottom: 0;
+        margin-top: auto;
         background-color: #FFF6E0;
         padding: 0.5em;
         text-align: center;


### PR DESCRIPTION
## Summary
- keep pagination bar anchored to the bottom of short pages while remaining sticky during scroll

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(no output; process hung and was interrupted)*
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689058fbf454832f87361ee8c60c3ad2