### PR TITLE
fix: remove duplicate CurrentProfileUserID

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -815,9 +815,6 @@ func (cd *CoreData) CurrentProfileStats() *db.AdminUserPostCountsByIDRow {
 	return row
 }
 
-// CurrentProfileUserID returns the user ID being viewed.
-func (cd *CoreData) CurrentProfileUserID() int32 { return cd.currentProfileUserID }
-
 // CurrentProfileUser returns the user being viewed.
 func (cd *CoreData) CurrentProfileUser() *db.SystemGetUserByIDRow {
 	return cd.UserByID(cd.currentProfileUserID)


### PR DESCRIPTION
## Summary
- remove duplicate `CurrentProfileUserID` method

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689097536a14832fad364aaf1a937504