### PR TITLE
Defer request selection parsing

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -2197,40 +2197,38 @@ func assignIDFromString(m map[string]*int32, k, v string) {
 	*dest = int32(i)
 }
 
-// WithSelectionsFromRequest extracts integer identifiers from the request and
+// LoadSelectionsFromRequest extracts integer identifiers from the request and
 // stores them on the CoreData instance. It searches path variables, query
 // parameters and finally form values.
-func WithSelectionsFromRequest(r *http.Request) CoreOption {
-	return func(cd *CoreData) {
-		mapping := map[string]*int32{
-			"boardno": &cd.currentBoardID,
-			"board":   &cd.currentBoardID,
-			"thread":  &cd.currentThreadID,
-			"replyTo": &cd.currentThreadID,
-			"topic":   &cd.currentTopicID,
-			"comment": &cd.currentCommentID,
-			"news":    &cd.currentNewsPostID,
-			"post":    &cd.currentImagePostID,
-			"writing": &cd.currentWritingID,
-			"blog":    &cd.currentBlogID,
-			"request": &cd.currentRequestID,
-			"role":    &cd.currentRoleID,
-			"user":    &cd.currentProfileUserID,
+func (cd *CoreData) LoadSelectionsFromRequest(r *http.Request) {
+	mapping := map[string]*int32{
+		"boardno": &cd.currentBoardID,
+		"board":   &cd.currentBoardID,
+		"thread":  &cd.currentThreadID,
+		"replyTo": &cd.currentThreadID,
+		"topic":   &cd.currentTopicID,
+		"comment": &cd.currentCommentID,
+		"news":    &cd.currentNewsPostID,
+		"post":    &cd.currentImagePostID,
+		"writing": &cd.currentWritingID,
+		"blog":    &cd.currentBlogID,
+		"request": &cd.currentRequestID,
+		"role":    &cd.currentRoleID,
+		"user":    &cd.currentProfileUserID,
+	}
+	for k, v := range mux.Vars(r) {
+		assignIDFromString(mapping, k, v)
+	}
+	q := r.URL.Query()
+	for k, v := range q {
+		if len(v) > 0 {
+			assignIDFromString(mapping, k, v[0])
 		}
-		for k, v := range mux.Vars(r) {
-			assignIDFromString(mapping, k, v)
-		}
-		q := r.URL.Query()
-		for k, v := range q {
+	}
+	if err := r.ParseForm(); err == nil {
+		for k, v := range r.Form {
 			if len(v) > 0 {
 				assignIDFromString(mapping, k, v[0])
-			}
-		}
-		if err := r.ParseForm(); err == nil {
-			for k, v := range r.Form {
-				if len(v) > 0 {
-					assignIDFromString(mapping, k, v[0])
-				}
 			}
 		}
 	}

--- a/core/common/coredata_request_test.go
+++ b/core/common/coredata_request_test.go
@@ -11,13 +11,14 @@ import (
 	"github.com/arran4/goa4web/config"
 )
 
-func TestWithSelectionsFromRequest(t *testing.T) {
+func TestLoadSelectionsFromRequest(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
 
 	t.Run("path variable", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/", nil)
 		req = mux.SetURLVars(req, map[string]string{"board": "1"})
-		cd := NewCoreData(context.Background(), nil, cfg, WithSelectionsFromRequest(req))
+		cd := NewCoreData(context.Background(), nil, cfg)
+		cd.LoadSelectionsFromRequest(req)
 		if cd.currentBoardID != 1 {
 			t.Fatalf("currentBoardID = %d; want 1", cd.currentBoardID)
 		}
@@ -26,7 +27,8 @@ func TestWithSelectionsFromRequest(t *testing.T) {
 	t.Run("request variable", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/", nil)
 		req = mux.SetURLVars(req, map[string]string{"request": "4"})
-		cd := NewCoreData(context.Background(), nil, cfg, WithSelectionsFromRequest(req))
+		cd := NewCoreData(context.Background(), nil, cfg)
+		cd.LoadSelectionsFromRequest(req)
 		if cd.currentRequestID != 4 {
 			t.Fatalf("currentRequestID = %d; want 4", cd.currentRequestID)
 		}
@@ -35,7 +37,8 @@ func TestWithSelectionsFromRequest(t *testing.T) {
 	t.Run("request path variable", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/", nil)
 		req = mux.SetURLVars(req, map[string]string{"request": "4"})
-		cd := NewCoreData(context.Background(), nil, cfg, WithSelectionsFromRequest(req))
+		cd := NewCoreData(context.Background(), nil, cfg)
+		cd.LoadSelectionsFromRequest(req)
 		if cd.CurrentRequestID() != 4 {
 			t.Fatalf("currentRequestID = %d; want 4", cd.CurrentRequestID())
 		}
@@ -43,7 +46,8 @@ func TestWithSelectionsFromRequest(t *testing.T) {
 
 	t.Run("query parameter", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/?thread=2", nil)
-		cd := NewCoreData(context.Background(), nil, cfg, WithSelectionsFromRequest(req))
+		cd := NewCoreData(context.Background(), nil, cfg)
+		cd.LoadSelectionsFromRequest(req)
 		if cd.currentThreadID != 2 {
 			t.Fatalf("currentThreadID = %d; want 2", cd.currentThreadID)
 		}
@@ -53,7 +57,8 @@ func TestWithSelectionsFromRequest(t *testing.T) {
 		body := strings.NewReader("post=3")
 		req := httptest.NewRequest("POST", "/", body)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		cd := NewCoreData(context.Background(), nil, cfg, WithSelectionsFromRequest(req))
+		cd := NewCoreData(context.Background(), nil, cfg)
+		cd.LoadSelectionsFromRequest(req)
 		if cd.currentImagePostID != 3 {
 			t.Fatalf("currentImagePostID = %d; want 3", cd.currentImagePostID)
 		}

--- a/handlers/admin/adminCommentPage_test.go
+++ b/handlers/admin/adminCommentPage_test.go
@@ -45,7 +45,8 @@ func TestAdminCommentPage_UsesURLParam(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{"comment": strconv.Itoa(commentID)})
 	cfg := config.NewRuntimeConfig()
 	q := db.New(conn)
-	cd := common.NewCoreData(req.Context(), q, cfg, common.WithSelectionsFromRequest(req))
+	cd := common.NewCoreData(req.Context(), q, cfg)
+	cd.LoadSelectionsFromRequest(req)
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/admin/adminCommentTasks_test.go
+++ b/handlers/admin/adminCommentTasks_test.go
@@ -40,7 +40,8 @@ func setupCommentTest(t *testing.T, commentID int, body url.Values) (*httptest.R
 	req = mux.SetURLVars(req, map[string]string{"comment": strconv.Itoa(commentID)})
 	cfg := config.NewRuntimeConfig()
 	q := db.New(conn)
-	cd := common.NewCoreData(req.Context(), q, cfg, common.WithSelectionsFromRequest(req))
+	cd := common.NewCoreData(req.Context(), q, cfg)
+	cd.LoadSelectionsFromRequest(req)
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	return httptest.NewRecorder(), req, conn, mock

--- a/handlers/admin/adminRequestQueuePage.go
+++ b/handlers/admin/adminRequestQueuePage.go
@@ -24,6 +24,7 @@ func AdminRequestArchivePage(w http.ResponseWriter, r *http.Request) {
 
 func adminRequestPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	id := cd.CurrentRequestID()
 	if id == 0 {
 		http.Error(w, "not found", http.StatusNotFound)
@@ -35,6 +36,7 @@ func adminRequestPage(w http.ResponseWriter, r *http.Request) {
 
 func adminRequestAddCommentPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	req := cd.CurrentRequest()
 	var id int32
 	if req != nil {
@@ -65,6 +67,7 @@ func adminRequestAddCommentPage(w http.ResponseWriter, r *http.Request) {
 func handleRequestAction(w http.ResponseWriter, r *http.Request, status string) {
 	comment := r.PostFormValue("comment")
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	if cd == nil || !cd.HasRole("administrator") {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return

--- a/handlers/admin/adminRequestQueuePage_test.go
+++ b/handlers/admin/adminRequestQueuePage_test.go
@@ -40,7 +40,8 @@ func TestAdminRequestPage_RequestFound(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{"request": strconv.Itoa(requestID)})
 	cfg := config.NewRuntimeConfig()
 	q := db.New(conn)
-	cd := common.NewCoreData(req.Context(), q, cfg, common.WithSelectionsFromRequest(req))
+	cd := common.NewCoreData(req.Context(), q, cfg)
+	cd.LoadSelectionsFromRequest(req)
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/admin/adminUserProfilePage_test.go
+++ b/handlers/admin/adminUserProfilePage_test.go
@@ -38,7 +38,8 @@ func TestAdminUserProfilePage_UserFound(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{"user": strconv.Itoa(userID)})
 	cfg := config.NewRuntimeConfig()
 	q := db.New(conn)
-	cd := common.NewCoreData(req.Context(), q, cfg, common.WithSelectionsFromRequest(req))
+	cd := common.NewCoreData(req.Context(), q, cfg)
+	cd.LoadSelectionsFromRequest(req)
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/handlers/forum/comment_edit_action_cancel_task.go
+++ b/handlers/forum/comment_edit_action_cancel_task.go
@@ -19,6 +19,7 @@ var _ tasks.Task = (*topicThreadCommentEditActionCancelTask)(nil)
 
 func (topicThreadCommentEditActionCancelTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	threadRow, err := cd.SelectedThread()
 	if err != nil || threadRow == nil {
 		return fmt.Errorf("thread fetch %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/forum/comment_edit_action_task.go
+++ b/handlers/forum/comment_edit_action_task.go
@@ -30,6 +30,7 @@ func (topicThreadCommentEditActionTask) Action(w http.ResponseWriter, r *http.Re
 	text := r.PostFormValue("replytext")
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	queries := cd.Queries()
 	threadRow, err := cd.SelectedThread()
 	if err != nil || threadRow == nil {

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -48,6 +48,7 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	data := Data{
 		CoreData:           cd,
 		Offset:             offset,

--- a/handlers/forum/forumTopicThreadCommentEditPage.go
+++ b/handlers/forum/forumTopicThreadCommentEditPage.go
@@ -22,6 +22,7 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("replytext")
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	cd.PageTitle = "Forum - Edit Comment"
 	queries := cd.Queries()
 	threadRow, err := cd.SelectedThread()
@@ -67,6 +68,7 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 
 func TopicThreadCommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	cd.PageTitle = "Forum - Edit Comment"
 	threadRow, err := cd.SelectedThread()
 	if err != nil || threadRow == nil {

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -81,6 +81,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	cd.PageTitle = "Forum - Reply"
 	threadRow, err := cd.SelectedThread()
 	if err != nil || threadRow == nil {

--- a/handlers/forum/topic_thread_reply_cancel_task.go
+++ b/handlers/forum/topic_thread_reply_cancel_task.go
@@ -19,6 +19,7 @@ var _ tasks.Task = (*topicThreadReplyCancelTask)(nil)
 
 func (topicThreadReplyCancelTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	threadRow, err := cd.SelectedThread()
 	if err != nil || threadRow == nil {
 		return fmt.Errorf("thread fetch %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -86,6 +86,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	vars := mux.Vars(r)
 	bidStr := vars["board"]
 	if bidStr == "" {

--- a/handlers/user/admin_user_routes_test.go
+++ b/handlers/user/admin_user_routes_test.go
@@ -29,7 +29,8 @@ func setupRequest(t *testing.T, path string, userID int) (*http.Request, sqlmock
 	req = mux.SetURLVars(req, map[string]string{"user": strconv.Itoa(userID)})
 	cfg := config.NewRuntimeConfig()
 	q := db.New(conn)
-	cd := common.NewCoreData(req.Context(), q, cfg, common.WithSelectionsFromRequest(req))
+	cd := common.NewCoreData(req.Context(), q, cfg)
+	cd.LoadSelectionsFromRequest(req)
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	return req, mock, cd

--- a/handlers/user/permissionUserAllowTask.go
+++ b/handlers/user/permissionUserAllowTask.go
@@ -34,6 +34,7 @@ func (PermissionUserAllowTask) AdminInternalNotificationTemplate() *string {
 
 func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	queries := cd.Queries()
 	username := r.PostFormValue("username")
 	role := r.PostFormValue("role")

--- a/handlers/user/permissionUserDisallowTask.go
+++ b/handlers/user/permissionUserDisallowTask.go
@@ -34,6 +34,7 @@ func (PermissionUserDisallowTask) AdminInternalNotificationTemplate() *string {
 
 func (PermissionUserDisallowTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	queries := cd.Queries()
 	permid := r.PostFormValue("permid")
 	cpu := cd.CurrentProfileUser()

--- a/handlers/writings/matchers_test.go
+++ b/handlers/writings/matchers_test.go
@@ -37,7 +37,8 @@ func TestRequireWritingAuthorWritingVar(t *testing.T) {
 	sess, _ := store.Get(req, core.SessionName)
 	sess.Values["UID"] = int32(1)
 
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithSession(sess), common.WithUserRoles([]string{"content writer"}), common.WithSelectionsFromRequest(req))
+	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithSession(sess), common.WithUserRoles([]string{"content writer"}))
+	cd.LoadSelectionsFromRequest(req)
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/writings/writingsArticlePage_test.go
+++ b/handlers/writings/writingsArticlePage_test.go
@@ -52,7 +52,8 @@ func TestArticleReplyActionPage_UsesWritingParam(t *testing.T) {
 	}
 
 	q := db.New(dbconn)
-	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithSession(sess), common.WithSelectionsFromRequest(req))
+	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithSession(sess))
+	cd.LoadSelectionsFromRequest(req)
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -236,7 +236,6 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 				common.WithTasksRegistry(s.TasksReg),
 				common.WithDBRegistry(s.DBReg),
 				common.WithSiteTitle("Arran's Site"),
-				common.WithSelectionsFromRequest(r),
 			)
 			cd.UserID = uid
 			_ = cd.UserRoles()

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -108,10 +108,9 @@ func CoreAdderMiddlewareWithDB(sdb *sql.DB, cfg *config.RuntimeConfig, verbosity
 				common.WithEmailProvider(provider),
 				common.WithAbsoluteURLBase(base),
 				common.WithSessionManager(sm),
-				common.WithSelectionsFromRequest(r),
 				common.WithOffset(offset),
 				common.WithSiteTitle("Arran's Site"),
-      )
+			)
 			cd.UserID = uid
 
 			if navReg != nil {


### PR DESCRIPTION
## Summary
- load selection IDs lazily via `CoreData.LoadSelectionsFromRequest`
- remove eager selection parsing from server middleware
- update handlers, tasks, and tests to call the loader when needed

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890a1ffc064832f80aa76b41b5c0c12