### PR TITLE
Use template error pages for websocket notifications

### DIFF
--- a/internal/websocket/notifications.go
+++ b/internal/websocket/notifications.go
@@ -15,6 +15,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	coreconsts "github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/navigation"
@@ -106,18 +107,21 @@ func (h *NotificationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	sess, err := core.GetSession(r)
 	if err != nil {
 		core.SessionError(w, r, err)
-		http.Error(w, "invalid session", http.StatusUnauthorized)
+		w.WriteHeader(http.StatusUnauthorized)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("invalid session"))
 		return
 	}
 	uid, _ := sess.Values["UID"].(int32)
 	if uid == 0 {
-		http.Error(w, "authentication required", http.StatusUnauthorized)
+		w.WriteHeader(http.StatusUnauthorized)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("authentication required"))
 		return
 	}
 
 	queries := r.Context().Value(coreconsts.KeyCoreData).(*corecommon.CoreData).Queries()
 	if queries == nil {
-		http.Error(w, "db unavailable", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("db unavailable"))
 		return
 	}
 
@@ -140,7 +144,8 @@ func (h *NotificationsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	subsRows, patterns, err := loadSubs()
 	if err != nil {
 		log.Printf("list subscriptions: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	log.Printf("subscriptions loaded: %d entries", len(subsRows))

--- a/internal/websocket/notifications_test.go
+++ b/internal/websocket/notifications_test.go
@@ -1,13 +1,17 @@
 package websocket
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
 	nav "github.com/arran4/goa4web/internal/navigation"
 	routerpkg "github.com/arran4/goa4web/internal/router"
 )
@@ -73,5 +77,44 @@ func TestNotificationsJSRoute(t *testing.T) {
 	}
 	if rec.Body.Len() == 0 {
 		t.Fatal("empty body")
+	}
+}
+
+func TestNotificationsHandlerInvalidSession(t *testing.T) {
+	core.Store = sessions.NewCookieStore([]byte("test"))
+	core.SessionName = "test"
+
+	h := NewNotificationsHandler(nil, &config.RuntimeConfig{})
+	req := httptest.NewRequest("GET", "http://example.com/ws/notifications", nil)
+	req.AddCookie(&http.Cookie{Name: core.SessionName, Value: "bad"})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "invalid session") {
+		t.Fatalf("body=%q", rec.Body.String())
+	}
+}
+
+func TestNotificationsHandlerAuthenticationRequired(t *testing.T) {
+	core.Store = sessions.NewCookieStore([]byte("test"))
+	core.SessionName = "test"
+	sess := sessions.NewSession(core.Store, core.SessionName)
+	sess.Values = map[interface{}]interface{}{}
+
+	h := NewNotificationsHandler(nil, &config.RuntimeConfig{})
+	req := httptest.NewRequest("GET", "http://example.com/ws/notifications", nil)
+	ctx := context.WithValue(req.Context(), core.ContextValues("session"), sess)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "authentication required") {
+		t.Fatalf("body=%q", rec.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary
- render notifications handler errors using templated error page
- ensure unauthorized and internal server errors preserve HTTP status codes
- cover invalid session and auth required responses in tests

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method CoreData.CurrentProfileUserID already declared)*
- `golangci-lint run` *(fails: typecheck errors including duplicate method)*
- `go test ./...` *(fails: method CoreData.CurrentProfileUserID already declared)*


------
https://chatgpt.com/codex/tasks/task_e_689095449838832f9db9016313ff1949