### PR TITLE
Use RenderErrorPage for FAQ handlers

### DIFF
--- a/handlers/faq/admin_categories.go
+++ b/handlers/faq/admin_categories.go
@@ -3,6 +3,7 @@ package faq
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 
@@ -30,7 +31,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}

--- a/handlers/faq/admin_edit_question_page.go
+++ b/handlers/faq/admin_edit_question_page.go
@@ -20,7 +20,7 @@ func AdminEditQuestionPage(w http.ResponseWriter, r *http.Request) {
 	idStr := vars["id"]
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Bad Request"))
 		return
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
@@ -31,10 +31,10 @@ func AdminEditQuestionPage(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			switch {
 			case errors.Is(err, sql.ErrNoRows):
-				http.Error(w, "Not Found", http.StatusNotFound)
+				handlers.RenderErrorPage(w, r, fmt.Errorf("Not Found"))
 				return
 			default:
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 				return
 			}
 		}

--- a/handlers/faq/admin_question.go
+++ b/handlers/faq/admin_question.go
@@ -3,6 +3,7 @@ package faq
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 
@@ -32,7 +33,7 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}
@@ -45,7 +46,7 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}
@@ -59,7 +60,7 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}
@@ -70,7 +71,7 @@ func AdminQuestionsPage(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}

--- a/handlers/faq/admin_revision_page.go
+++ b/handlers/faq/admin_revision_page.go
@@ -20,7 +20,7 @@ func AdminRevisionHistoryPage(w http.ResponseWriter, r *http.Request) {
 	idStr := vars["id"]
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Bad Request"))
 		return
 	}
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
@@ -28,10 +28,10 @@ func AdminRevisionHistoryPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			http.Error(w, "Not Found", http.StatusNotFound)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Not Found"))
 			return
 		default:
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -53,7 +53,7 @@ func (AskTask) Page(w http.ResponseWriter, r *http.Request) {
 
 	languageRows, err := cd.Languages()
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data.Languages = languageRows

--- a/handlers/faq/page.go
+++ b/handlers/faq/page.go
@@ -3,6 +3,7 @@ package faq
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -45,7 +46,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getAllAnsweredFAQWithFAQCategories Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}


### PR DESCRIPTION
## Summary
- replace `http.Error` with `handlers.RenderErrorPage` throughout FAQ handlers to provide consistent error pages

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method CoreData.CurrentProfileUserID already declared)*
- `golangci-lint run` *(fails: typecheck errors, e.g., data.AllRoles undefined)*
- `go test ./...` *(fails: multiple packages build failed)*

------
https://chatgpt.com/codex/tasks/task_e_68909549b798832f8376ddb1fa89ad28