### PR TITLE
Replace http.Error with RenderErrorPage in forum handlers

### DIFF
--- a/handlers/forum/adminForumHandler.go
+++ b/handlers/forum/adminForumHandler.go
@@ -93,7 +93,8 @@ func AdminForumPage(w http.ResponseWriter, r *http.Request) {
 
 	stats, err := queries.AdminGetForumStats(r.Context())
 	if err != nil {
-		http.Error(w, "database not available", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("database not available"))
 		return
 	}
 	data.Stats.Categories = stats.Categories

--- a/handlers/forum/adminForumWordListHandler.go
+++ b/handlers/forum/adminForumWordListHandler.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	_ "embed"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 
@@ -30,7 +31,8 @@ func AdminForumWordListPage(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			w.WriteHeader(http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}

--- a/handlers/forum/forumAdminCategoryGrantsPage.go
+++ b/handlers/forum/forumAdminCategoryGrantsPage.go
@@ -31,7 +31,8 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	cid, err := strconv.Atoi(mux.Vars(r)["category"])
 	if err != nil {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		w.WriteHeader(http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Bad Request"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Forum - Category %d Grants", cid)
@@ -42,7 +43,8 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 	grants, err := queries.ListGrants(r.Context())
 	if err != nil {
 		log.Printf("ListGrants: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	for _, g := range grants {

--- a/handlers/forum/forumAdminCategoryPage.go
+++ b/handlers/forum/forumAdminCategoryPage.go
@@ -18,17 +18,20 @@ func AdminCategoryPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	cid, err := strconv.Atoi(mux.Vars(r)["category"])
 	if err != nil {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		w.WriteHeader(http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Bad Request"))
 		return
 	}
 	cat, err := queries.GetForumCategoryById(r.Context(), int32(cid))
 	if err != nil {
-		http.Error(w, "Category not found", http.StatusNotFound)
+		w.WriteHeader(http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Category not found"))
 		return
 	}
 	topics, err := queries.GetForumTopicsByCategoryId(r.Context(), int32(cid))
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Forum Category %d", cid)

--- a/handlers/forum/forumAdminTopicGrantsPage.go
+++ b/handlers/forum/forumAdminTopicGrantsPage.go
@@ -30,7 +30,8 @@ func AdminTopicGrantsPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	tid, err := strconv.Atoi(mux.Vars(r)["topic"])
 	if err != nil {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		w.WriteHeader(http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Bad Request"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Forum - Topic %d Grants", tid)
@@ -41,7 +42,8 @@ func AdminTopicGrantsPage(w http.ResponseWriter, r *http.Request) {
 	grants, err := queries.ListGrants(r.Context())
 	if err != nil {
 		log.Printf("ListGrants: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	for _, g := range grants {

--- a/handlers/forum/forumFeed.go
+++ b/handlers/forum/forumFeed.go
@@ -14,6 +14,7 @@ import (
 	"github.com/arran4/goa4web/a4code/a4code2html"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/feeds"
 	"github.com/gorilla/mux"
@@ -71,21 +72,24 @@ func TopicRssPage(w http.ResponseWriter, r *http.Request) {
 		if !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("GetForumTopicByIdForUser error: %s", err)
 		}
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Forum - %s Feed", topic.Title.String)
 	rows, err := cd.ForumThreads(int32(topicID))
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 
 	feed := TopicFeed(r, topic.Title.String, topicID, rows)
 	if err := feed.WriteRss(w); err != nil {
 		log.Printf("feed write error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 }
@@ -103,7 +107,8 @@ func TopicAtomPage(w http.ResponseWriter, r *http.Request) {
 		if !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("GetForumTopicByIdForUser error: %s", err)
 		}
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 
@@ -111,14 +116,16 @@ func TopicAtomPage(w http.ResponseWriter, r *http.Request) {
 	rows, err := cd.ForumThreads(int32(topicID))
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 
 	feed := TopicFeed(r, topic.Title.String, topicID, rows)
 	if err := feed.WriteAtom(w); err != nil {
 		log.Printf("feed write error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 }

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -98,7 +98,8 @@ func (CreateThreadTask) Page(w http.ResponseWriter, r *http.Request) {
 
 	languageRows, err := cd.Languages()
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data.Languages = languageRows
@@ -124,11 +125,13 @@ func (CreateThreadTask) Action(w http.ResponseWriter, r *http.Request) any {
 	allowed, err := UserCanCreateThread(r.Context(), queries, int32(topicId), uid)
 	if err != nil {
 		log.Printf("UserCanCreateThread error: %v", err)
-		http.Error(w, "forbidden", http.StatusForbidden)
+		w.WriteHeader(http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("forbidden"))
 		return nil
 	}
 	if !allowed {
-		http.Error(w, "forbidden", http.StatusForbidden)
+		w.WriteHeader(http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("forbidden"))
 		return nil
 	}
 

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -57,20 +57,23 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 
 	languageRows, err := cd.Languages()
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data.Languages = languageRows
 	threadRow, err := cd.SelectedThread()
 	if err != nil || threadRow == nil {
 		log.Printf("current thread: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	topicRow, err := cd.CurrentTopic()
 	if err != nil || topicRow == nil {
 		log.Printf("current topic: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Forum - %s", topicRow.Title.String)
@@ -91,7 +94,8 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getBlogEntryForListerByID_comments Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			w.WriteHeader(http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}
@@ -177,7 +181,8 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 		})
 		if err != nil {
 			log.Printf("getCommentByIdForUser Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			w.WriteHeader(http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 		switch replyType {

--- a/handlers/forum/forumTopicPage.go
+++ b/handlers/forum/forumTopicPage.go
@@ -55,7 +55,8 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 	categoryRows, err := data.CoreData.ForumCategories()
 	if err != nil {
 		log.Printf("getAllForumCategories Error: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	topicRow, err := data.CoreData.ForumTopicByID(int32(topicId))
@@ -64,7 +65,8 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 			http.NotFound(w, r)
 		} else {
 			log.Printf("showTableTopics Error: %v", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			w.WriteHeader(http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		}
 		return
 	}


### PR DESCRIPTION
## Summary
- use `handlers.RenderErrorPage` across forum handlers instead of `http.Error`
- keep HTTP status codes by writing headers before rendering error pages

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` (fails: method CoreData.CurrentProfileUserID already declared)
- `golangci-lint run ./...` (fails: typecheck errors)
- `go test ./...` (fails: method CoreData.CurrentProfileUserID already declared)


------
https://chatgpt.com/codex/tasks/task_e_689095567f60832f92020f74d20fce8c