### PR TITLE
Use template-based error handling in linker handlers

### DIFF
--- a/handlers/linker/delete_category_task.go
+++ b/handlers/linker/delete_category_task.go
@@ -23,7 +23,7 @@ func (deleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	rows, _ := cd.LinkerCategoryCounts()
 	for _, c := range rows {
 		if int(c.Idlinkercategory) == cid && c.Linkcount > 0 {
-			http.Error(w, "Category in use", http.StatusBadRequest)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Category in use"))
 			return nil
 		}
 	}
@@ -32,7 +32,7 @@ func (deleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("count links fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if count > 0 {
-		http.Error(w, "Category in use", http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Category in use"))
 		return nil
 	}
 	if err := queries.AdminDeleteLinkerCategory(r.Context(), int32(cid)); err != nil {

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -50,7 +50,7 @@ func AdminAddPage(w http.ResponseWriter, r *http.Request) {
 
 	languageRows, err := data.CoreData.Languages()
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data.Languages = languageRows

--- a/handlers/linker/linkerAdminCategoriesPage.go
+++ b/handlers/linker/linkerAdminCategoriesPage.go
@@ -3,6 +3,7 @@ package linker
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -29,7 +30,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("adminCategories Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}

--- a/handlers/linker/linkerAdminCategoryGrantsPage.go
+++ b/handlers/linker/linkerAdminCategoryGrantsPage.go
@@ -31,7 +31,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	cid, err := strconv.Atoi(mux.Vars(r)["category"])
 	if err != nil {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Bad Request"))
 		return
 	}
 	data := Data{CoreData: cd, CategoryID: int32(cid), Actions: []string{"see", "view"}}
@@ -42,7 +42,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 	grants, err := queries.ListGrants(r.Context())
 	if err != nil {
 		log.Printf("ListGrants: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	for _, g := range grants {

--- a/handlers/linker/linkerAdminCategoryPage.go
+++ b/handlers/linker/linkerAdminCategoryPage.go
@@ -16,7 +16,7 @@ func AdminCategoryPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cid, err := strconv.Atoi(mux.Vars(r)["category"])
 	if err != nil {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Bad Request"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Linker Category %d", cid)

--- a/handlers/linker/linkerAdminLinkPage.go
+++ b/handlers/linker/linkerAdminLinkPage.go
@@ -23,7 +23,7 @@ func adminLinkPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 			http.NotFound(w, r)
 		default:
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		}
 		return
 	}

--- a/handlers/linker/linkerAdminQueuePage.go
+++ b/handlers/linker/linkerAdminQueuePage.go
@@ -3,6 +3,7 @@ package linker
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -48,7 +49,7 @@ func AdminQueuePage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}
@@ -121,7 +122,7 @@ func AdminQueueUpdateActionPage(w http.ResponseWriter, r *http.Request) {
 		Idlinkerqueue:    int32(qid),
 	}); err != nil {
 		log.Printf("updateLinkerQueuedItem Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	handlers.TaskDoneAutoRefreshPage(w, r)

--- a/handlers/linker/linkerAdminUserLevelsPage.go
+++ b/handlers/linker/linkerAdminUserLevelsPage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"sort"
@@ -47,7 +48,7 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 	users, err := queries.AdminListAllUsers(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("AdminListAllUsers Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	userMap := make(map[int32]*UserInfo)
@@ -58,7 +59,7 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 	rows, err := queries.GetUserRoles(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("getUsersPermissions Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	for _, row := range rows {

--- a/handlers/linker/linkerCategoriesPage.go
+++ b/handlers/linker/linkerCategoriesPage.go
@@ -3,6 +3,7 @@ package linker
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -35,7 +36,7 @@ func CategoriesPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getAllLinkerCategories Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -76,7 +76,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 
 	languageRows, err := cd.Languages()
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data.Languages = languageRows
@@ -95,7 +95,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 			return
 		default:
 			log.Printf("getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}
@@ -103,7 +103,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 	if !(cd.HasGrant("linker", "link", "view", link.Idlinker) ||
 		cd.HasGrant("linker", "link", "comment", link.Idlinker) ||
 		cd.HasGrant("linker", "link", "reply", link.Idlinker)) {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		return
 	}
 
@@ -121,7 +121,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getBlogEntryForListerByID_comments Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}
@@ -234,7 +234,7 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			return nil
 		default:
 			log.Printf("getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return nil
 		}
 	}
@@ -242,7 +242,7 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if !(cd.HasGrant("linker", "link", "view", link.Idlinker) ||
 		cd.HasGrant("linker", "link", "comment", link.Idlinker) ||
 		cd.HasGrant("linker", "link", "reply", link.Idlinker)) {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		return nil
 	}
 

--- a/handlers/linker/linkerFeed.go
+++ b/handlers/linker/linkerFeed.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/arran4/goa4web/a4code/a4code2html"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/gorilla/feeds"
 )
@@ -64,12 +65,12 @@ func RssPage(w http.ResponseWriter, r *http.Request) {
 	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
 	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(catID)})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	feed := linkerFeed(r, rows)
 	if err := feed.WriteRss(w); err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 }
@@ -79,12 +80,12 @@ func AtomPage(w http.ResponseWriter, r *http.Request) {
 	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
 	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(catID)})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	feed := linkerFeed(r, rows)
 	if err := feed.WriteAtom(w); err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 }

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -40,7 +40,7 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 
 	languageRows, err := cd.Languages()
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data.Languages = languageRows
@@ -52,12 +52,12 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		log.Printf("getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 
 	if !cd.HasGrant("linker", "link", "view", link.Idlinker) {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		return
 	}
 
@@ -100,12 +100,12 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		log.Printf("getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 
 	if !cd.HasGrant("linker", "link", "view", link.Idlinker) {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		return
 	}
 

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -53,7 +53,7 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 
 	languageRows, err := data.CoreData.Languages()
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data.Languages = languageRows

--- a/handlers/linker/linkerUserPage.go
+++ b/handlers/linker/linkerUserPage.go
@@ -36,7 +36,7 @@ func UserPage(w http.ResponseWriter, r *http.Request) {
 			http.NotFound(w, r)
 		default:
 			log.Printf("SystemGetUserByUsername Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		}
 		return
 	}
@@ -51,7 +51,7 @@ func UserPage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("GetLinkerItemsByUserDescending Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 


### PR DESCRIPTION
## Summary
- replace `http.Error` calls in linker handlers with `handlers.RenderErrorPage`
- ensure forbidden access displays a templated message

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method CoreData.CurrentProfileUserID already declared)*
- `golangci-lint run ./...` *(fails: typecheck errors)*
- `go test ./...` *(fails: build errors in multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_68909559bbec832fb64e62dbfa54906b