### PR TITLE
Use RenderErrorPage in imagebbs handlers and access middleware

### DIFF
--- a/handlers/access.go
+++ b/handlers/access.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
@@ -11,7 +12,7 @@ import (
 func VerifyAccess(h http.HandlerFunc, roles ...string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !common.Allowed(r, roles...) {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+			RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 			return
 		}
 		h(w, r)

--- a/handlers/imagebbs/imagebbsAdminApprove.go
+++ b/handlers/imagebbs/imagebbsAdminApprove.go
@@ -29,8 +29,8 @@ func (ApprovePostTask) Action(w http.ResponseWriter, r *http.Request) any {
 	vars := mux.Vars(r)
 	pid, _ := strconv.Atoi(vars["post"])
 	if cd == nil || !cd.HasRole("administrator") {
-		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		})
 	}
 	queries := cd.Queries()

--- a/handlers/imagebbs/imagebbsAdminBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardPage.go
@@ -93,14 +93,14 @@ func AdminBoardPage(w http.ResponseWriter, r *http.Request) {
 	}
 	bid, _ := strconv.Atoi(bidStr)
 	if bid == 0 {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Bad Request"))
 		return
 	}
 
 	boards, err := cd.ImageBoards()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("imageBoards error: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 

--- a/handlers/imagebbs/imagebbsAdminBoardsPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardsPage.go
@@ -3,6 +3,7 @@ package imagebbs
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"html/template"
 	"log"
@@ -40,7 +41,7 @@ func AdminBoardsPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getAllImageBoards Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}

--- a/handlers/imagebbs/imagebbsAdminFilesPage.go
+++ b/handlers/imagebbs/imagebbsAdminFilesPage.go
@@ -2,6 +2,7 @@ package imagebbs
 
 import (
 	"database/sql"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -43,20 +44,20 @@ func AdminFilesPage(w http.ResponseWriter, r *http.Request) {
 	cleaned := filepath.Clean("/" + reqPath)
 	abs := filepath.Join(base, cleaned)
 	if rel, err := filepath.Rel(base, abs); err != nil || rel == ".." || strings.HasPrefix(rel, "..") {
-		http.Error(w, "invalid path", http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("invalid path"))
 		return
 	}
 
 	info, err := os.Stat(abs)
 	if err != nil || !info.IsDir() {
-		http.Error(w, "not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("not found"))
 		return
 	}
 
 	f, err := os.ReadDir(abs)
 	if err != nil {
 		log.Printf("readdir: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -102,8 +102,8 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("get image board fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if !cd.HasGrant("imagebbs", "board", "post", int32(bid)) {
-		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		})
 	}
 

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -112,7 +112,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getBlogEntryForListerByID_comments Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}
@@ -132,7 +132,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 
 	languageRows, err := data.CoreData.Languages()
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 
@@ -177,7 +177,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 			return
 		default:
 			log.Printf("getAllBoardsByParentBoardId Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}

--- a/handlers/imagebbs/imagebbsFeed.go
+++ b/handlers/imagebbs/imagebbsFeed.go
@@ -17,6 +17,7 @@ import (
 	"github.com/arran4/goa4web/a4code/a4code2html"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 )
 
@@ -77,7 +78,7 @@ func RssPage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query boards error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	var posts []*db.ListImagePostsByBoardForListerRow
@@ -91,7 +92,7 @@ func RssPage(w http.ResponseWriter, r *http.Request) {
 		})
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("feed query error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 		posts = append(posts, rows...)
@@ -99,7 +100,7 @@ func RssPage(w http.ResponseWriter, r *http.Request) {
 	feed := imagebbsFeed(r, "ImageBBS", 0, posts)
 	if err := feed.WriteRss(w); err != nil {
 		log.Printf("feed write error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 }
@@ -115,7 +116,7 @@ func AtomPage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query boards error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	var posts []*db.ListImagePostsByBoardForListerRow
@@ -129,7 +130,7 @@ func AtomPage(w http.ResponseWriter, r *http.Request) {
 		})
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("feed query error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 		posts = append(posts, rows...)
@@ -137,7 +138,7 @@ func AtomPage(w http.ResponseWriter, r *http.Request) {
 	feed := imagebbsFeed(r, "ImageBBS", 0, posts)
 	if err := feed.WriteAtom(w); err != nil {
 		log.Printf("feed write error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 }
@@ -164,7 +165,7 @@ func BoardRssPage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	title := fmt.Sprintf("Board %d", bid)
@@ -187,7 +188,7 @@ func BoardRssPage(w http.ResponseWriter, r *http.Request) {
 	feed := imagebbsFeed(r, title, bid, rows)
 	if err := feed.WriteRss(w); err != nil {
 		log.Printf("feed write error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 }
@@ -214,7 +215,7 @@ func BoardAtomPage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("feed query error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	title := fmt.Sprintf("Board %d", bid)
@@ -237,7 +238,7 @@ func BoardAtomPage(w http.ResponseWriter, r *http.Request) {
 	feed := imagebbsFeed(r, title, bid, rows)
 	if err := feed.WriteAtom(w); err != nil {
 		log.Printf("feed write error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 }

--- a/handlers/imagebbs/imagebbsPage.go
+++ b/handlers/imagebbs/imagebbsPage.go
@@ -1,6 +1,7 @@
 package imagebbs
 
 import (
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -29,7 +30,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	boards, err := data.CoreData.SubImageBoards(0)
 	if err != nil {
 		log.Printf("imageboards: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 

--- a/handlers/imagebbs/imagebbsPosterPage.go
+++ b/handlers/imagebbs/imagebbsPosterPage.go
@@ -38,7 +38,7 @@ func PosterPage(w http.ResponseWriter, r *http.Request) {
 			http.NotFound(w, r)
 		default:
 			log.Printf("SystemGetUserByUsername Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		}
 		return
 	}
@@ -52,7 +52,7 @@ func PosterPage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("ListImagePostsByPosterForLister Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 


### PR DESCRIPTION
## Summary
- replace `http.Error` with `handlers.RenderErrorPage` in ImageBBS handlers
- use the error page in `VerifyAccess` middleware

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: method CoreData.CurrentProfileUserID already declared)*
- `golangci-lint run` *(fails: typecheck errors in existing code)*
- `go test ./...` *(fails: build errors starting with duplicate CoreData.CurrentProfileUserID)*

------
https://chatgpt.com/codex/tasks/task_e_689095501c7c832f8ae52d8724a60ade