### PR TITLE
Use RenderErrorPage for search handlers

### DIFF
--- a/handlers/errorpage.go
+++ b/handlers/errorpage.go
@@ -23,7 +23,11 @@ func RenderErrorPage(w http.ResponseWriter, r *http.Request, err error) {
 		Error:    err.Error(),
 		BackURL:  r.Referer(),
 	}
+	contentType := w.Header().Get("Content-Type")
 	if err := cd.ExecuteSiteTemplate(w, r, "taskErrorAcknowledgementPage.gohtml", data); err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
+	if contentType != "" {
+		w.Header().Set("Content-Type", contentType)
 	}
 }

--- a/handlers/search/admin.go
+++ b/handlers/search/admin.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
@@ -34,7 +35,7 @@ func adminSearchPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	stats, err := queries.AdminGetSearchStats(r.Context())
 	if err != nil {
-		http.Error(w, "database not available", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("database not available"))
 		return
 	}
 	data.Stats.Words = stats.Words

--- a/handlers/search/admin_wordlist.go
+++ b/handlers/search/admin_wordlist.go
@@ -3,6 +3,7 @@ package search
 import (
 	"database/sql"
 	_ "embed"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -58,7 +59,7 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Query().Get("download") != "" {
 		rows, err := queries.AdminCompleteWordList(r.Context())
 		if err != nil {
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -81,7 +82,7 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 	if letter != "" {
 		totalCount, err = queries.AdminCountWordListByPrefix(r.Context(), letter)
 		if err != nil {
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 		prefRows, err2 := queries.AdminWordListWithCountsByPrefix(r.Context(), db.AdminWordListWithCountsByPrefixParams{
@@ -90,7 +91,7 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 			Offset: int32(offset),
 		})
 		if err2 != nil {
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 		for _, r := range prefRows {
@@ -99,7 +100,7 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 	} else {
 		totalCount, err = queries.AdminCountWordList(r.Context())
 		if err != nil {
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 		allRows, err2 := queries.AdminWordListWithCounts(r.Context(), db.AdminWordListWithCountsParams{
@@ -107,7 +108,7 @@ func adminSearchWordListPage(w http.ResponseWriter, r *http.Request) {
 			Offset: int32(offset),
 		})
 		if err2 != nil {
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 		for _, r := range allRows {
@@ -146,7 +147,7 @@ func adminSearchWordListDownloadPage(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := queries.AdminCompleteWordList(r.Context())
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 

--- a/handlers/search/searchResultBlogsActionPage.go
+++ b/handlers/search/searchResultBlogsActionPage.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"database/sql"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -36,7 +37,7 @@ func (SearchBlogsTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if !common.CanSearch(cd, "blogs") {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		return nil
 	}
 	data := Data{
@@ -52,7 +53,7 @@ func (SearchBlogsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	ftbn, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: hblogs.BloggerTopicName})
 	if err != nil {
 		log.Printf("findForumTopicByTitle Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return nil
 	}
 
@@ -97,7 +98,7 @@ func BlogSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, cd *
 			})
 			if err != nil {
 				log.Printf("ListBlogIDsBySearchWordFirstForLister Error: %s", err)
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 				return nil, false, false, err
 			}
 			blogIds = ids
@@ -113,7 +114,7 @@ func BlogSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, cd *
 			})
 			if err != nil {
 				log.Printf("ListBlogIDsBySearchWordNextForLister Error: %s", err)
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 				return nil, false, false, err
 			}
 			blogIds = ids
@@ -135,7 +136,7 @@ func BlogSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, cd *
 	})
 	if err != nil {
 		log.Printf("getBlogEntriesByIdsDescending Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return nil, false, false, err
 	}
 	blogs := make([]*db.Blog, 0, len(rows))

--- a/handlers/search/searchResultForumActionPage.go
+++ b/handlers/search/searchResultForumActionPage.go
@@ -3,6 +3,7 @@ package search
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -32,7 +33,7 @@ func (SearchForumTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if !common.CanSearch(cd, "forum") {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		return nil
 	}
 	data := Data{
@@ -79,7 +80,7 @@ func ForumCommentSearchNotInRestrictedTopic(w http.ResponseWriter, r *http.Reque
 				case errors.Is(err, sql.ErrNoRows):
 				default:
 					log.Printf("ListCommentIDsBySearchWordFirstForListerNotInRestrictedTopic Error: %s", err)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 					return nil, false, false, err
 				}
 			}
@@ -99,7 +100,7 @@ func ForumCommentSearchNotInRestrictedTopic(w http.ResponseWriter, r *http.Reque
 				case errors.Is(err, sql.ErrNoRows):
 				default:
 					log.Printf("ListCommentIDsBySearchWordNextForListerNotInRestrictedTopic Error: %s", err)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 					return nil, false, false, err
 				}
 			}
@@ -120,7 +121,7 @@ func ForumCommentSearchNotInRestrictedTopic(w http.ResponseWriter, r *http.Reque
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getCommentsByIds Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return nil, false, false, err
 		}
 	}
@@ -152,7 +153,7 @@ func ForumCommentSearchInRestrictedTopic(w http.ResponseWriter, r *http.Request,
 				case errors.Is(err, sql.ErrNoRows):
 				default:
 					log.Printf("ListCommentIDsBySearchWordFirstForListerInRestrictedTopic Error: %s", err)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 					return nil, false, false, err
 				}
 			}
@@ -174,7 +175,7 @@ func ForumCommentSearchInRestrictedTopic(w http.ResponseWriter, r *http.Request,
 				default:
 
 					log.Printf("ListCommentIDsBySearchWordNextForListerInRestrictedTopic Error: %s", err)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 					return nil, false, false, err
 				}
 			}
@@ -195,7 +196,7 @@ func ForumCommentSearchInRestrictedTopic(w http.ResponseWriter, r *http.Request,
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getCommentsByIds Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return nil, false, false, err
 		}
 	}

--- a/handlers/search/searchResultLinkerActionPage.go
+++ b/handlers/search/searchResultLinkerActionPage.go
@@ -3,6 +3,7 @@ package search
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -37,7 +38,7 @@ func (SearchLinkerTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if !common.CanSearch(cd, "linker") {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		return nil
 	}
 	data := Data{
@@ -53,7 +54,7 @@ func (SearchLinkerTask) Action(w http.ResponseWriter, r *http.Request) any {
 	ftbn, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: hlinker.LinkerTopicName})
 	if err != nil {
 		log.Printf("findForumTopicByTitle Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return nil
 	}
 
@@ -99,7 +100,7 @@ func LinkerSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, ui
 				case errors.Is(err, sql.ErrNoRows):
 				default:
 					log.Printf("LinkersSearchFirst Error: %s", err)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 					return nil, false, false, err
 				}
 			}
@@ -119,7 +120,7 @@ func LinkerSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, ui
 				case errors.Is(err, sql.ErrNoRows):
 				default:
 					log.Printf("LinkersSearchNext Error: %s", err)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 					return nil, false, false, err
 				}
 			}
@@ -136,7 +137,7 @@ func LinkerSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, ui
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getLinkers Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return nil, false, false, err
 		}
 	}

--- a/handlers/search/searchResultWritingsActionPage.go
+++ b/handlers/search/searchResultWritingsActionPage.go
@@ -3,6 +3,7 @@ package search
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -37,7 +38,7 @@ func (SearchWritingsTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if !common.CanSearch(cd, "writing") {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		return nil
 	}
 	data := Data{
@@ -53,7 +54,7 @@ func (SearchWritingsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	ftbn, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: hwritings.WritingTopicName})
 	if err != nil {
 		log.Printf("findForumTopicByTitle Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return nil
 	}
 
@@ -99,7 +100,7 @@ func WritingSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, c
 				case errors.Is(err, sql.ErrNoRows):
 				default:
 					log.Printf("writingSearchFirst Error: %s", err)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 					return nil, false, false, err
 				}
 			}
@@ -119,7 +120,7 @@ func WritingSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, c
 				case errors.Is(err, sql.ErrNoRows):
 				default:
 					log.Printf("writingSearchNext Error: %s", err)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 					return nil, false, false, err
 				}
 			}
@@ -145,7 +146,7 @@ func WritingSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, c
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getWritings Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return nil, false, false, err
 		}
 	}


### PR DESCRIPTION
## Summary
- replace http.Error calls in search handlers with handlers.RenderErrorPage
- keep existing Content-Type headers when rendering error pages

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method CoreData.CurrentProfileUserID already declared)*
- `golangci-lint run` *(fails: multiple typecheck errors)*
- `go test ./...` *(fails: build failures due to duplicate method declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6890955d5d8c832f82c3a135181016c1