### PR TITLE
Use templated error page for writings

### DIFF
--- a/handlers/writings/matchers.go
+++ b/handlers/writings/matchers.go
@@ -31,7 +31,9 @@ func RequireWritingAuthor(next http.Handler) http.Handler {
 			return
 		}
 		if !cd.HasContentWriterRole() || writing.UsersIdusers != cd.UserID {
-			http.NotFound(w, r)
+			if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd); err != nil {
+				log.Printf("render no access page: %v", err)
+			}
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/handlers/writings/writingsAdminCategoryGrantsPage.go
+++ b/handlers/writings/writingsAdminCategoryGrantsPage.go
@@ -2,6 +2,7 @@ package writings
 
 import (
 	"database/sql"
+	"fmt"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -32,7 +33,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	cid, err := strconv.Atoi(mux.Vars(r)["category"])
 	if err != nil {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Bad Request"))
 		return
 	}
 
@@ -44,7 +45,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 	grants, err := queries.ListGrants(r.Context())
 	if err != nil {
 		log.Printf("ListGrants: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	for _, g := range grants {

--- a/handlers/writings/writingsAdminCategoryPage.go
+++ b/handlers/writings/writingsAdminCategoryPage.go
@@ -18,17 +18,17 @@ func AdminCategoryPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	cid, err := strconv.Atoi(mux.Vars(r)["category"])
 	if err != nil {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Bad Request"))
 		return
 	}
 	cat, err := queries.GetWritingCategoryById(r.Context(), int32(cid))
 	if err != nil {
-		http.Error(w, "Category not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Category not found"))
 		return
 	}
 	writings, err := queries.AdminGetWritingsByCategoryId(r.Context(), int32(cid))
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Writing Category %d", cid)

--- a/handlers/writings/writingsAdminUserLevelsPage.go
+++ b/handlers/writings/writingsAdminUserLevelsPage.go
@@ -3,6 +3,7 @@ package writings
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"sort"
@@ -43,7 +44,7 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 	users, err := queries.AdminListAllUsers(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("AdminListAllUsers Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	userMap := make(map[int32]*UserInfo)
@@ -54,7 +55,7 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 	rows, err := queries.GetUserRoles(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("getUsersPermissions Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	for _, row := range rows {

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -2,6 +2,7 @@ package writings
 
 import (
 	"database/sql"
+	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
@@ -30,7 +31,7 @@ func ArticleAddPage(w http.ResponseWriter, r *http.Request) {
 
 	languageRows, err := data.CoreData.Languages()
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data.Languages = languageRows
@@ -65,7 +66,7 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		log.Printf("insertWriting Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -46,14 +46,14 @@ func ArticleEditPage(w http.ResponseWriter, r *http.Request) {
 	writing, err := cd.CurrentWriting()
 	if err != nil || writing == nil {
 		log.Printf("current writing: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data.Writing = writing
 
 	languageRows, err := cd.Languages()
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data.Languages = languageRows
@@ -67,7 +67,7 @@ func ArticleEditActionPage(w http.ResponseWriter, r *http.Request) {
 	writing, err := cd.CurrentWriting()
 	if err != nil || writing == nil {
 		log.Printf("current writing: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 
@@ -90,7 +90,7 @@ func ArticleEditActionPage(w http.ResponseWriter, r *http.Request) {
 		GranteeID:  sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	}); err != nil {
 		log.Printf("updateWriting Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 
@@ -112,7 +112,7 @@ func ArticleEditActionPage(w http.ResponseWriter, r *http.Request) {
 
 	if err := queries.SystemDeleteWritingSearchByWritingID(r.Context(), writing.Idwriting); err != nil {
 		log.Printf("writingSearchDelete Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -41,7 +41,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 	writing, err := cd.CurrentWriting()
 	if err != nil {
 		log.Printf("get writing: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	if writing == nil || !cd.HasGrant("writing", "article", "view", writing.Idwriting) {
@@ -59,7 +59,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 	languages, err := cd.Languages()
 	if err != nil {
 		log.Printf("languages: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 
@@ -117,12 +117,12 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 			return
 		default:
 			log.Printf("get writing: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}
 	if writing == nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 

--- a/handlers/writings/writingsCategoryPage.go
+++ b/handlers/writings/writingsCategoryPage.go
@@ -33,7 +33,7 @@ func CategoryPage(w http.ResponseWriter, r *http.Request) {
 	cats, err := cd.CurrentUserVisibleWritingCategories()
 	if err != nil {
 		log.Printf("writingCategories: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Category %d", data.CategoryId)

--- a/handlers/writings/writingsFeed.go
+++ b/handlers/writings/writingsFeed.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/arran4/goa4web/a4code/a4code2html"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/gorilla/feeds"
 )
 
@@ -64,12 +65,12 @@ func RssPage(w http.ResponseWriter, r *http.Request) {
 	feed, err := feedGen(r, cd)
 	if err != nil {
 		log.Printf("FeedGen Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	if err := feed.WriteRss(w); err != nil {
 		log.Printf("Feed write Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 }
@@ -79,12 +80,12 @@ func AtomPage(w http.ResponseWriter, r *http.Request) {
 	feed, err := feedGen(r, cd)
 	if err != nil {
 		log.Printf("FeedGen Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	if err := feed.WriteAtom(w); err != nil {
 		log.Printf("Feed write Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 }

--- a/handlers/writings/writingsWriterListPage.go
+++ b/handlers/writings/writingsWriterListPage.go
@@ -41,7 +41,7 @@ func WriterListPage(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
 	}

--- a/handlers/writings/writingsWriterPage.go
+++ b/handlers/writings/writingsWriterPage.go
@@ -38,7 +38,7 @@ func WriterPage(w http.ResponseWriter, r *http.Request) {
 			http.NotFound(w, r)
 		default:
 			log.Printf("SystemGetUserByUsername Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		}
 		return
 	}
@@ -46,7 +46,7 @@ func WriterPage(w http.ResponseWriter, r *http.Request) {
 	rows, err := cd.WriterWritings(u.Idusers, r)
 	if err != nil {
 		log.Printf("WriterWritings: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 


### PR DESCRIPTION
## Summary
- render standardized error pages in writings handlers
- show friendly template when write permissions fail

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method CoreData.CurrentProfileUserID already declared)*
- `golangci-lint run` *(fails: typecheck errors)*
- `go test ./...` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68909554c06c832fba7ebaf99b935464