### PR TITLE
Use RenderErrorPage in admin handlers

### DIFF
--- a/handlers/admin/add_announcement_task.go
+++ b/handlers/admin/add_announcement_task.go
@@ -27,7 +27,7 @@ func (AddAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if cd == nil || !cd.HasRole("administrator") {
 		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		})
 	}
 	queries := cd.Queries()

--- a/handlers/admin/add_ip_ban_task.go
+++ b/handlers/admin/add_ip_ban_task.go
@@ -27,7 +27,7 @@ var _ notif.AdminEmailTemplateProvider = (*AddIPBanTask)(nil)
 func (AddIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if cd == nil || !cd.HasRole("administrator") {
-		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { http.Error(w, "Forbidden", http.StatusForbidden) })
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden")) })
 	}
 	queries := cd.Queries()
 

--- a/handlers/admin/adminAnnouncementsPage.go
+++ b/handlers/admin/adminAnnouncementsPage.go
@@ -3,9 +3,11 @@ package admin
 import (
 	"database/sql"
 	"errors"
-	"github.com/arran4/goa4web/core/consts"
+	"fmt"
 	"log"
 	"net/http"
+
+	"github.com/arran4/goa4web/core/consts"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
@@ -25,7 +27,7 @@ func AdminAnnouncementsPage(w http.ResponseWriter, r *http.Request) {
 	rows, err := queries.AdminListAnnouncementsWithNews(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list announcements: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data.Announcements = rows

--- a/handlers/admin/adminAuditLogPage.go
+++ b/handlers/admin/adminAuditLogPage.go
@@ -2,12 +2,14 @@ package admin
 
 import (
 	"database/sql"
-	"github.com/arran4/goa4web/core/consts"
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/arran4/goa4web/core/consts"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
@@ -61,7 +63,7 @@ func AdminAuditLogPage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		log.Printf("list audit logs: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 

--- a/handlers/admin/adminCommentsPage.go
+++ b/handlers/admin/adminCommentsPage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
@@ -19,7 +20,7 @@ func AdminCommentsPage(w http.ResponseWriter, r *http.Request) {
 		Offset: 0,
 	})
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data := struct {

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -1,12 +1,14 @@
 package admin
 
 import (
-	"github.com/arran4/goa4web/core/consts"
+	"fmt"
 	"log"
 	"net/http"
 	"net/mail"
 	"strconv"
 	"strings"
+
+	"github.com/arran4/goa4web/core/consts"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
@@ -37,7 +39,7 @@ func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		log.Printf("list pending emails: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	ids := make([]int32, 0, len(rows))

--- a/handlers/admin/adminExternalLinksPage.go
+++ b/handlers/admin/adminExternalLinksPage.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -24,7 +25,7 @@ func AdminExternalLinksPage(w http.ResponseWriter, r *http.Request) {
 	rows, err := queries.AdminListExternalLinks(r.Context(), db.AdminListExternalLinksParams{Limit: 200, Offset: 0})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list external links: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data := Data{CoreData: cd, Links: rows}

--- a/handlers/admin/adminFailedEmailsPage.go
+++ b/handlers/admin/adminFailedEmailsPage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"net/mail"
@@ -48,7 +49,7 @@ func AdminFailedEmailsPage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		log.Printf("list failed emails: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 

--- a/handlers/admin/adminHandler.go
+++ b/handlers/admin/adminHandler.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	_ "embed"
+	"fmt"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
@@ -35,7 +36,7 @@ func AdminPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	stats, err := queries.AdminGetDashboardStats(r.Context())
 	if err != nil {
-		http.Error(w, "database not available", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("database not available"))
 		return
 	}
 	data.Stats.Users = stats.Users

--- a/handlers/admin/adminIPBanPage.go
+++ b/handlers/admin/adminIPBanPage.go
@@ -3,9 +3,11 @@ package admin
 import (
 	"database/sql"
 	"errors"
-	"github.com/arran4/goa4web/core/consts"
+	"fmt"
 	"log"
 	"net/http"
+
+	"github.com/arran4/goa4web/core/consts"
 
 	"github.com/arran4/goa4web/core/common"
 
@@ -25,7 +27,7 @@ func AdminIPBanPage(w http.ResponseWriter, r *http.Request) {
 	rows, err := queries.ListBannedIps(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list banned ips: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data.Bans = rows

--- a/handlers/admin/adminNotificationsPage.go
+++ b/handlers/admin/adminNotificationsPage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
@@ -34,7 +35,7 @@ func AdminNotificationsPage(w http.ResponseWriter, r *http.Request) {
 	items, err := queries.AdminListRecentNotifications(r.Context(), 50)
 	if err != nil {
 		log.Printf("recent notifications: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	ids := make([]int32, 0, len(items))

--- a/handlers/admin/adminPageSizePage.go
+++ b/handlers/admin/adminPageSizePage.go
@@ -1,9 +1,11 @@
 package admin
 
 import (
-	"github.com/arran4/goa4web/core/consts"
+	"fmt"
 	"net/http"
 	"strconv"
+
+	"github.com/arran4/goa4web/core/consts"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
@@ -19,7 +21,7 @@ func AdminPageSizePage(w http.ResponseWriter, r *http.Request) {
 	cd.PageTitle = "Page Size"
 	if r.Method == http.MethodPost {
 		if err := r.ParseForm(); err != nil {
-			http.Error(w, "Bad Request", http.StatusBadRequest)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Bad Request"))
 			return
 		}
 		min, _ := strconv.Atoi(r.PostFormValue("min"))

--- a/handlers/admin/adminReloadConfigPage.go
+++ b/handlers/admin/adminReloadConfigPage.go
@@ -2,10 +2,12 @@ package admin
 
 import (
 	"errors"
-	"github.com/arran4/goa4web/core/consts"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/arran4/goa4web/core/consts"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
@@ -19,7 +21,7 @@ func (h *Handlers) AdminReloadConfigPage(w http.ResponseWriter, r *http.Request)
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Reload Config"
 	if cd == nil || !cd.HasRole("administrator") {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		return
 	}
 

--- a/handlers/admin/adminRequestQueuePage.go
+++ b/handlers/admin/adminRequestQueuePage.go
@@ -26,7 +26,7 @@ func adminRequestPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	id := cd.CurrentRequestID()
 	if id == 0 {
-		http.Error(w, "not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("not found"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Request %d", id)
@@ -66,12 +66,12 @@ func handleRequestAction(w http.ResponseWriter, r *http.Request, status string) 
 	comment := r.PostFormValue("comment")
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if cd == nil || !cd.HasRole("administrator") {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		return
 	}
 	req := cd.CurrentRequest()
 	if req == nil {
-		http.Error(w, "not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("not found"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Request %d", req.ID)

--- a/handlers/admin/adminRoleEditPage.go
+++ b/handlers/admin/adminRoleEditPage.go
@@ -15,7 +15,7 @@ func adminRoleEditFormPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	role, err := cd.SelectedRole()
 	if err != nil || role == nil {
-		http.Error(w, "role not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("role not found"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Edit Role %s", role.Name)
@@ -23,7 +23,7 @@ func adminRoleEditFormPage(w http.ResponseWriter, r *http.Request) {
 	id := cd.SelectedRoleID()
 	groups, err := buildGrantGroups(r.Context(), cd, id)
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 
@@ -41,7 +41,7 @@ func adminRoleEditSavePage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	id := cd.SelectedRoleID()
 	if err := r.ParseForm(); err != nil {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Bad Request"))
 		return
 	}
 	name := r.PostFormValue("name")

--- a/handlers/admin/adminRolePage.go
+++ b/handlers/admin/adminRolePage.go
@@ -19,7 +19,7 @@ func adminRolePage(w http.ResponseWriter, r *http.Request) {
 
 	role, err := cd.SelectedRole()
 	if err != nil || role == nil {
-		http.Error(w, "role not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("role not found"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Role %s", role.Name)
@@ -27,13 +27,13 @@ func adminRolePage(w http.ResponseWriter, r *http.Request) {
 	id := cd.SelectedRoleID()
 	users, err := queries.AdminListUsersByRoleID(r.Context(), id)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 
 	groups, err := buildGrantGroups(r.Context(), cd, id)
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 

--- a/handlers/admin/adminRolesPage.go
+++ b/handlers/admin/adminRolesPage.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -23,7 +24,7 @@ func AdminRolesPage(w http.ResponseWriter, r *http.Request) {
 	roles, err := cd.AllRoles()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("list roles: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data := Data{CoreData: cd, Roles: roles}

--- a/handlers/admin/adminSentEmailsPage.go
+++ b/handlers/admin/adminSentEmailsPage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"net/mail"
@@ -48,7 +49,7 @@ func AdminSentEmailsPage(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		log.Printf("list sent emails: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 

--- a/handlers/admin/adminUserBlogsPage.go
+++ b/handlers/admin/adminUserBlogsPage.go
@@ -15,18 +15,18 @@ func adminUserBlogsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	uid := cd.CurrentProfileUserID()
 	if uid == 0 {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	user := cd.CurrentProfileUser()
 	if user == nil {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	queries := cd.Queries()
 	rows, err := queries.AdminGetAllBlogEntriesByUser(r.Context(), uid)
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Blogs by %s", user.Username.String)

--- a/handlers/admin/adminUserCommentsPage.go
+++ b/handlers/admin/adminUserCommentsPage.go
@@ -15,18 +15,18 @@ func adminUserCommentsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	uid := cd.CurrentProfileUserID()
 	if uid == 0 {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	user := cd.CurrentProfileUser()
 	if user == nil {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	queries := cd.Queries()
 	rows, err := queries.AdminGetAllCommentsByUser(r.Context(), uid)
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Comments by %s", user.Username.String)

--- a/handlers/admin/adminUserForumPage.go
+++ b/handlers/admin/adminUserForumPage.go
@@ -15,18 +15,18 @@ func adminUserForumPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	uid := cd.CurrentProfileUserID()
 	if uid == 0 {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	user := cd.CurrentProfileUser()
 	if user == nil {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	queries := cd.Queries()
 	rows, err := queries.AdminGetThreadsStartedByUserWithTopic(r.Context(), uid)
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Forum threads by %s", user.Username.String)

--- a/handlers/admin/adminUserImagebbsPage.go
+++ b/handlers/admin/adminUserImagebbsPage.go
@@ -15,12 +15,12 @@ func adminUserImagebbsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	uid := cd.CurrentProfileUserID()
 	if uid == 0 {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	user := cd.CurrentProfileUser()
 	if user == nil {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	queries := cd.Queries()
@@ -30,7 +30,7 @@ func adminUserImagebbsPage(w http.ResponseWriter, r *http.Request) {
 		Offset:       0,
 	})
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Images by %s", user.Username.String)

--- a/handlers/admin/adminUserLinkerPage.go
+++ b/handlers/admin/adminUserLinkerPage.go
@@ -15,12 +15,12 @@ func adminUserLinkerPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	uid := cd.CurrentProfileUserID()
 	if uid == 0 {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	user := cd.CurrentProfileUser()
 	if user == nil {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	queries := cd.Queries()
@@ -30,7 +30,7 @@ func adminUserLinkerPage(w http.ResponseWriter, r *http.Request) {
 		Offset:       0,
 	})
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Links by %s", user.Username.String)

--- a/handlers/admin/adminUserListPage.go
+++ b/handlers/admin/adminUserListPage.go
@@ -1,8 +1,10 @@
 package admin
 
 import (
-	"github.com/arran4/goa4web/core/consts"
+	"fmt"
 	"net/http"
+
+	"github.com/arran4/goa4web/core/consts"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
@@ -15,7 +17,7 @@ func adminUserListPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	users, err := queries.AdminListAllUsers(r.Context())
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	data := struct {

--- a/handlers/admin/adminUserProfilePage.go
+++ b/handlers/admin/adminUserProfilePage.go
@@ -15,7 +15,7 @@ func adminUserProfilePage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	user := cd.CurrentProfileUser()
 	if user == nil {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("User %s", user.Username.String)

--- a/handlers/admin/adminUserSubscriptionsPage.go
+++ b/handlers/admin/adminUserSubscriptionsPage.go
@@ -15,18 +15,18 @@ func adminUserSubscriptionsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	uid := cd.CurrentProfileUserID()
 	if uid == 0 {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	user := cd.CurrentProfileUser()
 	if user == nil {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	queries := cd.Queries()
 	rows, err := queries.ListSubscriptionsByUser(r.Context(), uid)
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Subscriptions of %s", user.Username.String)

--- a/handlers/admin/adminUserWritingsPage.go
+++ b/handlers/admin/adminUserWritingsPage.go
@@ -15,18 +15,18 @@ func adminUserWritingsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	uid := cd.CurrentProfileUserID()
 	if uid == 0 {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	user := cd.CurrentProfileUser()
 	if user == nil {
-		http.Error(w, "user not found", http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("user not found"))
 		return
 	}
 	queries := cd.Queries()
 	rows, err := queries.AdminGetAllWritingsByAuthor(r.Context(), uid)
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Writings by %s", user.Username.String)

--- a/handlers/admin/api.go
+++ b/handlers/admin/api.go
@@ -2,11 +2,13 @@ package admin
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/adminapi"
 )
 
@@ -15,18 +17,18 @@ func (h *Handlers) AdminAPIServerShutdown(w http.ResponseWriter, r *http.Request
 	const prefix = "Goa4web "
 	auth := r.Header.Get("Authorization")
 	if !strings.HasPrefix(auth, prefix) {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Unauthorized"))
 		return
 	}
 	parts := strings.SplitN(strings.TrimPrefix(auth, prefix), ":", 2)
 	if len(parts) != 2 {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Unauthorized"))
 		return
 	}
 	ts, sig := parts[0], parts[1]
 	signer := adminapi.NewSigner(AdminAPISecret)
 	if !signer.Verify(r.Method, r.URL.Path, ts, sig) {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Unauthorized"))
 		return
 	}
 

--- a/handlers/admin/delete_announcement_task.go
+++ b/handlers/admin/delete_announcement_task.go
@@ -26,7 +26,7 @@ var _ notif.AdminEmailTemplateProvider = (*DeleteAnnouncementTask)(nil)
 func (DeleteAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if cd == nil || !cd.HasRole("administrator") {
-		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { http.Error(w, "Forbidden", http.StatusForbidden) })
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden")) })
 	}
 	queries := cd.Queries()
 	if err := r.ParseForm(); err != nil {

--- a/handlers/admin/delete_ip_ban_task.go
+++ b/handlers/admin/delete_ip_ban_task.go
@@ -24,7 +24,7 @@ var _ notif.AdminEmailTemplateProvider = (*DeleteIPBanTask)(nil)
 func (DeleteIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if cd == nil || !cd.HasRole("administrator") {
-		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { http.Error(w, "Forbidden", http.StatusForbidden) })
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden")) })
 	}
 	queries := cd.Queries()
 	if err := r.ParseForm(); err != nil {

--- a/handlers/admin/external_links_tasks.go
+++ b/handlers/admin/external_links_tasks.go
@@ -24,7 +24,7 @@ var _ tasks.AuditableTask = (*RefreshExternalLinkTask)(nil)
 func (RefreshExternalLinkTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if cd == nil || !cd.HasRole("administrator") {
-		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { http.Error(w, "Forbidden", http.StatusForbidden) })
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden")) })
 	}
 	if err := r.ParseForm(); err != nil {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
@@ -64,7 +64,7 @@ var _ tasks.AuditableTask = (*DeleteExternalLinkTask)(nil)
 func (DeleteExternalLinkTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if cd == nil || !cd.HasRole("administrator") {
-		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { http.Error(w, "Forbidden", http.StatusForbidden) })
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden")) })
 	}
 	if err := r.ParseForm(); err != nil {
 		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/admin/server_shutdown_task.go
+++ b/handlers/admin/server_shutdown_task.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -45,7 +46,7 @@ func (t *ServerShutdownTask) Action(w http.ResponseWriter, r *http.Request) any 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if cd == nil || !cd.HasRole("administrator") {
 		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		})
 	}
 	data := struct {


### PR DESCRIPTION
## Summary
- replace direct `http.Error` responses with `handlers.RenderErrorPage` across admin handlers for consistent templated errors
- keep role and authorization checks before rendering to protect privileged actions

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method CoreData.CurrentProfileUserID already declared at core/common/coredata.go:795:21)*
- `golangci-lint run` *(fails: typecheck errors such as data.AllRoles undefined and duplicate CoreData method)*
- `go test ./...` *(fails: multiple packages build failed due to duplicate CoreData method and other typecheck issues)*

------
https://chatgpt.com/codex/tasks/task_e_6890956180b0832fb3d985a122d06e85