### PR TITLE
Use RenderErrorPage for template errors in RoleCheckerMiddleware

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -31,7 +31,7 @@ func RoleCheckerMiddleware(roles ...string) func(http.Handler) http.Handler {
 				err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd)
 				if err != nil {
 					log.Printf("Template Error: %s", err)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					handlers.RenderErrorPage(w, r, err)
 				}
 				return
 			}


### PR DESCRIPTION
## Summary
- replace `http.Error` fallback with `handlers.RenderErrorPage` in `RoleCheckerMiddleware`
- log template execution errors before rendering the error page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method CoreData.CurrentProfileUserID already declared)*
- `golangci-lint run` *(fails: multiple typecheck errors)*
- `go test ./...` *(fails: method CoreData.CurrentProfileUserID already declared)*

------
https://chatgpt.com/codex/tasks/task_e_689095784ffc832f92d2932d26b05338