### PR TITLE
Use RenderErrorPage in middleware

### DIFF
--- a/internal/middleware/core_utils_test.go
+++ b/internal/middleware/core_utils_test.go
@@ -58,14 +58,15 @@ func X2c(what string) byte {
 
 func TestHandleDie(t *testing.T) {
 	rr := httptest.NewRecorder()
-	handleDie(rr, "oops")
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handleDie(rr, req, "oops")
 	if rr.Code != http.StatusInternalServerError {
 		t.Errorf("expected status 500, got %d", rr.Code)
 	}
 	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
 		t.Errorf("expected Content-Type text/plain; charset=utf-8, got %q", ct)
 	}
-	if body := rr.Body.String(); body != "oops\n" {
+	if body := rr.Body.String(); body != "Internal Server Error\n" {
 		t.Errorf("unexpected body: %q", body)
 	}
 }

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -25,9 +25,9 @@ import (
 	"github.com/gorilla/sessions"
 )
 
-// handleDie responds with an internal server error.
-func handleDie(w http.ResponseWriter, message string) {
-	http.Error(w, message, http.StatusInternalServerError)
+// handleDie responds with an internal server error using RenderErrorPage.
+func handleDie(w http.ResponseWriter, r *http.Request, message string) {
+	handlers.RenderErrorPage(w, r, fmt.Errorf(message))
 }
 
 // TODO this should be a reciever on server to reduce the amount of data passed in and constructed inside it
@@ -69,7 +69,7 @@ func CoreAdderMiddlewareWithDB(sdb *sql.DB, cfg *config.RuntimeConfig, verbosity
 			if sdb == nil {
 				ue := common.UserError{Err: fmt.Errorf("db not initialized"), ErrorMessage: "database unavailable"}
 				log.Printf("%s: %v", ue.ErrorMessage, ue.Err)
-				http.Error(w, ue.ErrorMessage, http.StatusInternalServerError)
+				handlers.RenderErrorPage(w, r, fmt.Errorf("%s: %w", ue.ErrorMessage, ue.Err))
 				return
 			}
 
@@ -111,7 +111,7 @@ func CoreAdderMiddlewareWithDB(sdb *sql.DB, cfg *config.RuntimeConfig, verbosity
 				common.WithSelectionsFromRequest(r),
 				common.WithOffset(offset),
 				common.WithSiteTitle("Arran's Site"),
-      )
+			)
 			cd.UserID = uid
 
 			if navReg != nil {


### PR DESCRIPTION
## Summary
- use `handlers.RenderErrorPage` for middleware errors
- add request argument to `handleDie`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method CoreData.CurrentProfileUserID already declared at core/common/coredata.go:795:21)*
- `golangci-lint run ./...` *(fails: typecheck errors including method CoreData.CurrentProfileUserID already declared)*
- `go test ./...` *(fails: build failures, e.g., method CoreData.CurrentProfileUserID already declared)*

------
https://chatgpt.com/codex/tasks/task_e_68909546f1d0832fb010f7beedecbb1d