### PR TITLE
refactor: use RenderErrorPage in news handlers

### DIFF
--- a/handlers/news/admin_pages.go
+++ b/handlers/news/admin_pages.go
@@ -127,7 +127,7 @@ func adminNewsEditFormPage(w http.ResponseWriter, r *http.Request) {
 	}
 	langs, err := cd.Languages()
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, err)
 		return
 	}
 	cd.PageTitle = "Edit News"

--- a/handlers/news/newsAdminUserLevelsPage.go
+++ b/handlers/news/newsAdminUserLevelsPage.go
@@ -43,7 +43,7 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 	users, err := queries.AdminListAllUsers(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("AdminListAllUsers Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, err)
 		return
 	}
 	userMap := make(map[int32]*UserInfo)
@@ -54,7 +54,7 @@ func AdminUserRolesPage(w http.ResponseWriter, r *http.Request) {
 	rows, err := queries.GetUserRoles(r.Context())
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("getUsersPermissions Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, err)
 		return
 	}
 	for _, row := range rows {

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -62,7 +62,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 	posts, err := cd.LatestNewsList(0, 50)
 	if err != nil {
 		log.Printf("LatestNewsList: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, err)
 		return
 	}
 	var post *common.NewsPost
@@ -98,7 +98,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getBlogEntryForUserById_comments Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, err)
 			return
 		}
 	}
@@ -121,7 +121,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 	cd = r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	languageRows, err := cd.Languages()
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, err)
 		return
 	}
 	data.Languages = languageRows

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -96,7 +96,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if !cd.HasGrant("news", "post", "reply", int32(pid)) {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		return nil
 	}
 
@@ -107,7 +107,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	})
 	if err != nil {
 		log.Printf("GetNewsPostByIdWithWriterIdAndThreadCommentCountForUser Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, err)
 		return nil
 	}
 

--- a/handlers/news/newsRssPage.go
+++ b/handlers/news/newsRssPage.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gorilla/feeds"
 
 	"github.com/arran4/goa4web/a4code/a4code2html"
+	"github.com/arran4/goa4web/handlers"
 )
 
 func NewsRssPage(w http.ResponseWriter, r *http.Request) {
@@ -20,7 +21,7 @@ func NewsRssPage(w http.ResponseWriter, r *http.Request) {
 	posts, err := cd.LatestNews(r)
 	if err != nil {
 		log.Printf("latestNews: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, err)
 		return
 	}
 
@@ -59,7 +60,7 @@ func NewsRssPage(w http.ResponseWriter, r *http.Request) {
 
 	if err := feed.WriteRss(w); err != nil {
 		log.Printf("Feed write Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, err)
 		return
 	}
 }

--- a/handlers/news/searchResultNewsActionPage.go
+++ b/handlers/news/searchResultNewsActionPage.go
@@ -28,7 +28,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if !common.CanSearch(cd, "news") {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, errors.New("Forbidden"))
 		return
 	}
 	data := Data{
@@ -45,7 +45,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 	ftbn, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{Valid: true, String: NewsTopicName})
 	if err != nil {
 		log.Printf("findForumTopicByTitle Error: %s", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, err)
 		return
 	}
 
@@ -91,7 +91,7 @@ func NewsSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, uid 
 				case errors.Is(err, sql.ErrNoRows):
 				default:
 					log.Printf("newsSearchFirst Error: %s", err)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					handlers.RenderErrorPage(w, r, err)
 					return nil, false, false, err
 				}
 			}
@@ -111,7 +111,7 @@ func NewsSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, uid 
 				case errors.Is(err, sql.ErrNoRows):
 				default:
 					log.Printf("newsSearchNext Error: %s", err)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					handlers.RenderErrorPage(w, r, err)
 					return nil, false, false, err
 				}
 			}
@@ -132,7 +132,7 @@ func NewsSearch(w http.ResponseWriter, r *http.Request, queries db.Querier, uid 
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getNews Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, err)
 			return nil, false, false, err
 		}
 	}
@@ -164,7 +164,7 @@ func forumCommentSearchInRestrictedTopic(w http.ResponseWriter, r *http.Request,
 				case errors.Is(err, sql.ErrNoRows):
 				default:
 					log.Printf("ListCommentIDsBySearchWordFirstForListerInRestrictedTopic Error: %s", err)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					handlers.RenderErrorPage(w, r, err)
 					return nil, false, false, err
 				}
 			}
@@ -185,7 +185,7 @@ func forumCommentSearchInRestrictedTopic(w http.ResponseWriter, r *http.Request,
 				case errors.Is(err, sql.ErrNoRows):
 				default:
 					log.Printf("ListCommentIDsBySearchWordNextForListerInRestrictedTopic Error: %s", err)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					handlers.RenderErrorPage(w, r, err)
 					return nil, false, false, err
 				}
 			}
@@ -206,7 +206,7 @@ func forumCommentSearchInRestrictedTopic(w http.ResponseWriter, r *http.Request,
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getCommentsByIds Error: %s", err)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			handlers.RenderErrorPage(w, r, err)
 			return nil, false, false, err
 		}
 	}


### PR DESCRIPTION
## Summary
- replace direct http.Error calls with handlers.RenderErrorPage across news handlers for consistent error pages

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: method CoreData.CurrentProfileUserID already declared)*

------
https://chatgpt.com/codex/tasks/task_e_6890954ccce4832f80111d6f3b3e9acd