### PR TITLE
Use RenderErrorPage in language tasks

### DIFF
--- a/handlers/languages/create_language_task.go
+++ b/handlers/languages/create_language_task.go
@@ -23,8 +23,9 @@ var _ notif.AdminEmailTemplateProvider = (*CreateLanguageTask)(nil)
 func (CreateLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if cd == nil || !cd.HasRole("administrator") {
-		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		})
 	}
 	queries := cd.Queries()

--- a/handlers/languages/delete_language_task.go
+++ b/handlers/languages/delete_language_task.go
@@ -23,8 +23,9 @@ var _ notif.AdminEmailTemplateProvider = (*DeleteLanguageTask)(nil)
 func (DeleteLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if cd == nil || !cd.HasRole("administrator") {
-		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		})
 	}
 	queries := cd.Queries()

--- a/handlers/languages/rename_language_task.go
+++ b/handlers/languages/rename_language_task.go
@@ -25,8 +25,9 @@ var _ notif.AdminEmailTemplateProvider = (*RenameLanguageTask)(nil)
 func (RenameLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if cd == nil || !cd.HasRole("administrator") {
-		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Forbidden"))
 		})
 	}
 	queries := cd.Queries()


### PR DESCRIPTION
## Summary
- refactor language admin task handlers to render error pages instead of raw HTTP errors

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method `CoreData.CurrentProfileUserID` already declared)*
- `golangci-lint run` *(fails: typecheck errors in several packages)*
- `go test ./...` *(fails: build errors in multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_6890956200b4832f9c269ce81871e053