### PR TITLE
Use error page for task handler errors

### DIFF
--- a/handlers/taskhandler.go
+++ b/handlers/taskhandler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"fmt"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/tasks"
@@ -55,10 +56,10 @@ func TaskHandler(t tasks.Task) func(http.ResponseWriter, *http.Request) {
 				return
 			}
 			log.Printf("task action: %v", result)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			RenderErrorPage(w, r, result)
 			return
 		default:
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			RenderErrorPage(w, r, fmt.Errorf(http.StatusText(http.StatusInternalServerError)))
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Use RenderErrorPage for unexpected TaskHandler errors instead of raw http.Error
- Still log task errors and preserve user-facing error messaging

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method CoreData.CurrentProfileUserID already declared)*
- `golangci-lint run` *(fails: typecheck errors such as method CoreData.CurrentProfileUserID already declared)*
- `go test ./...` *(fails: method CoreData.CurrentProfileUserID already declared, build failures across packages)*

------
https://chatgpt.com/codex/tasks/task_e_68909567f264832f9e26d41a96dd1fff