### PR TITLE
Use RenderErrorPage for access checks

### DIFF
--- a/handlers/access.go
+++ b/handlers/access.go
@@ -1,17 +1,23 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
 )
 
 // VerifyAccess wraps h and denies the request if the caller lacks any of
-// the provided roles.
-func VerifyAccess(h http.HandlerFunc, roles ...string) http.HandlerFunc {
+// the provided roles. err is shown on the rendered error page; if err is nil
+// a generic "Forbidden" message is displayed.
+func VerifyAccess(h http.HandlerFunc, err error, roles ...string) http.HandlerFunc {
+	if err == nil {
+		err = fmt.Errorf("Forbidden")
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !common.Allowed(r, roles...) {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+			w.WriteHeader(http.StatusForbidden)
+			RenderErrorPage(w, r, err)
 			return
 		}
 		h(w, r)

--- a/handlers/access_test.go
+++ b/handlers/access_test.go
@@ -2,8 +2,10 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/arran4/goa4web/config"
@@ -14,7 +16,7 @@ import (
 func TestVerifyAccess(t *testing.T) {
 	h := VerifyAccess(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	}, "administrator")
+	}, fmt.Errorf("administrator role required"), "administrator")
 
 	req := httptest.NewRequest("GET", "/", nil)
 	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
@@ -24,6 +26,9 @@ func TestVerifyAccess(t *testing.T) {
 	h(rr, req)
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("expected %d got %d", http.StatusForbidden, rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "administrator role required") {
+		t.Fatalf("expected body to contain error message, got %q", rr.Body.String())
 	}
 
 	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -1,6 +1,8 @@
 package admin
 
 import (
+	"fmt"
+
 	"github.com/arran4/goa4web/handlers"
 	"github.com/gorilla/mux"
 
@@ -135,12 +137,12 @@ func (h *Handlers) RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navRe
 	// Verify administrator access within the handlers so direct CLI calls
 	// cannot bypass the permission checks.
 	ar.HandleFunc("/reload",
-		handlers.VerifyAccess(h.AdminReloadConfigPage, "administrator")).
+		handlers.VerifyAccess(h.AdminReloadConfigPage, fmt.Errorf("administrator role required"), "administrator")).
 		Methods("POST").
 		MatcherFunc(handlers.RequiredAccess("administrator"))
 	sst := h.NewServerShutdownTask()
 	ar.HandleFunc("/shutdown",
-		handlers.VerifyAccess(handlers.TaskHandler(sst), "administrator")).
+		handlers.VerifyAccess(handlers.TaskHandler(sst), fmt.Errorf("administrator role required"), "administrator")).
 		Methods("POST").
 		MatcherFunc(handlers.RequiredAccess("administrator")).
 		MatcherFunc(sst.Matcher())

--- a/handlers/news/routes_admin.go
+++ b/handlers/news/routes_admin.go
@@ -1,6 +1,8 @@
 package news
 
 import (
+	"fmt"
+
 	"github.com/arran4/goa4web/handlers"
 	"github.com/gorilla/mux"
 )
@@ -8,10 +10,11 @@ import (
 // RegisterAdminRoutes attaches news admin endpoints to ar.
 func RegisterAdminRoutes(ar *mux.Router) {
 	nr := ar.PathPrefix("/news").Subrouter()
-	nr.HandleFunc("", handlers.VerifyAccess(AdminNewsPage, "administrator")).Methods("GET")
-	nr.HandleFunc("/{news}", handlers.VerifyAccess(AdminNewsPostPage, "administrator")).Methods("GET")
-	nr.HandleFunc("/{news}/edit", handlers.VerifyAccess(adminNewsEditFormPage, "administrator")).Methods("GET")
-	nr.HandleFunc("/{news}/edit", handlers.VerifyAccess(handlers.TaskHandler(editTask), "administrator")).Methods("POST").MatcherFunc(editTask.Matcher())
-	nr.HandleFunc("/{news}/delete", handlers.VerifyAccess(AdminNewsDeleteConfirmPage, "administrator")).Methods("GET")
-	nr.HandleFunc("/{news}/delete", handlers.VerifyAccess(handlers.TaskHandler(deleteNewsPostTask), "administrator")).Methods("POST").MatcherFunc(deleteNewsPostTask.Matcher())
+	msg := fmt.Errorf("administrator role required")
+	nr.HandleFunc("", handlers.VerifyAccess(AdminNewsPage, msg, "administrator")).Methods("GET")
+	nr.HandleFunc("/{news}", handlers.VerifyAccess(AdminNewsPostPage, msg, "administrator")).Methods("GET")
+	nr.HandleFunc("/{news}/edit", handlers.VerifyAccess(adminNewsEditFormPage, msg, "administrator")).Methods("GET")
+	nr.HandleFunc("/{news}/edit", handlers.VerifyAccess(handlers.TaskHandler(editTask), msg, "administrator")).Methods("POST").MatcherFunc(editTask.Matcher())
+	nr.HandleFunc("/{news}/delete", handlers.VerifyAccess(AdminNewsDeleteConfirmPage, msg, "administrator")).Methods("GET")
+	nr.HandleFunc("/{news}/delete", handlers.VerifyAccess(handlers.TaskHandler(deleteNewsPostTask), msg, "administrator")).Methods("POST").MatcherFunc(deleteNewsPostTask.Matcher())
 }


### PR DESCRIPTION
## Summary
- use `handlers.RenderErrorPage` when access checks fail and allow caller-supplied errors
- provide administrator role context on admin and news routes
- test that access failures render the custom error message

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: method `CurrentProfileUserID` already declared)*
- `golangci-lint run ./...` *(fails: multiple typecheck errors)*
- `go test ./...` *(fails: method `CurrentProfileUserID` already declared)*

------
https://chatgpt.com/codex/tasks/task_e_6890956aa3b8832fb723f5ae497b30f0