### PR TITLE
Load selections from request in admin role handlers

### DIFF
--- a/handlers/admin/adminRoleEditPage.go
+++ b/handlers/admin/adminRoleEditPage.go
@@ -13,6 +13,7 @@ import (
 // adminRoleEditFormPage shows a form to update a role.
 func adminRoleEditFormPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	role, err := cd.SelectedRole()
 	if err != nil || role == nil {
 		http.Error(w, "role not found", http.StatusNotFound)
@@ -38,6 +39,7 @@ func adminRoleEditFormPage(w http.ResponseWriter, r *http.Request) {
 // adminRoleEditSavePage persists role updates.
 func adminRoleEditSavePage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	queries := cd.Queries()
 	id := cd.SelectedRoleID()
 	if err := r.ParseForm(); err != nil {

--- a/handlers/admin/adminRolePage.go
+++ b/handlers/admin/adminRolePage.go
@@ -15,6 +15,7 @@ import (
 // adminRolePage shows details for a role including grants and users.
 func adminRolePage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	queries := cd.Queries()
 
 	role, err := cd.SelectedRole()

--- a/handlers/admin/role_grant_create_task.go
+++ b/handlers/admin/role_grant_create_task.go
@@ -23,6 +23,7 @@ var _ tasks.Task = (*RoleGrantCreateTask)(nil)
 
 func (RoleGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	queries := cd.Queries()
 	roleID := cd.SelectedRoleID()
 	if roleID == 0 {

--- a/handlers/admin/role_grant_update_task.go
+++ b/handlers/admin/role_grant_update_task.go
@@ -23,6 +23,7 @@ var _ tasks.Task = (*RoleGrantUpdateTask)(nil)
 
 func (RoleGrantUpdateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 	queries := cd.Queries()
 	roleID := cd.SelectedRoleID()
 	if roleID == 0 {


### PR DESCRIPTION
## Summary
- call `cd.LoadSelectionsFromRequest` in admin role pages and grant tasks before accessing selected role data

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890acf332d4832fb574f3d367800050