### PR TITLE
refactor: replace http.Error with error page

### DIFF
--- a/handlers/errorpage.go
+++ b/handlers/errorpage.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
@@ -25,7 +26,8 @@ func RenderErrorPage(w http.ResponseWriter, r *http.Request, err error) {
 	}
 	contentType := w.Header().Get("Content-Type")
 	if err := cd.ExecuteSiteTemplate(w, r, "taskErrorAcknowledgementPage.gohtml", data); err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "Internal Server Error")
 	}
 	if contentType != "" {
 		w.Header().Set("Content-Type", contentType)

--- a/handlers/externallink/redirect.go
+++ b/handlers/externallink/redirect.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 )
 
 // RedirectHandler shows a confirmation page before leaving the site or
@@ -19,7 +20,8 @@ func RedirectHandler(w http.ResponseWriter, r *http.Request) {
 	ts := r.URL.Query().Get("ts")
 	sig := r.URL.Query().Get("sig")
 	if signer == nil || raw == "" || !signer.Verify(raw, ts, sig) {
-		http.Error(w, "invalid link", http.StatusBadRequest)
+		w.WriteHeader(http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("invalid link"))
 		return
 	}
 	if r.URL.Query().Get("go") != "" {
@@ -44,6 +46,7 @@ func RedirectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := cd.ExecuteSiteTemplate(w, r, "externalLinkPage.gohtml", data); err != nil {
 		log.Printf("Template Error: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 	}
 }

--- a/handlers/template.go
+++ b/handlers/template.go
@@ -1,11 +1,12 @@
 package handlers
 
 import (
-	"github.com/arran4/goa4web/core/consts"
+	"fmt"
 	"log"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 )
 
 // TemplateHandler renders the template and handles any template error.
@@ -28,7 +29,8 @@ func TemplateHandler(w http.ResponseWriter, r *http.Request, tmpl string, data a
 			BackURL: r.Referer(),
 		}
 		if err2 := cd.ExecuteSiteTemplate(w, r, "taskErrorAcknowledgementPage.gohtml", errData); err2 != nil {
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			w.WriteHeader(http.StatusInternalServerError)
+			RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		}
 	}
 }

--- a/internal/middleware/csrf/csrf_test.go
+++ b/internal/middleware/csrf/csrf_test.go
@@ -2,6 +2,7 @@ package csrf
 
 import (
 	"crypto/sha256"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,6 +16,7 @@ import (
 	"github.com/arran4/goa4web/config"
 
 	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/handlers"
 )
 
 var (
@@ -38,7 +40,8 @@ func TestCSRFLoginFlow(t *testing.T) {
 
 	handler := csrf.Protect(key[:], csrf.Secure(false), csrf.ErrorHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Logf("failure: %v", csrf.FailureReason(r))
-		http.Error(w, "fail", http.StatusForbidden)
+		w.WriteHeader(http.StatusForbidden)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("fail"))
 	})))(r)
 
 	req := csrf.PlaintextHTTPRequest(httptest.NewRequest("GET", "/login", nil))

--- a/internal/middleware/taskbus_test.go
+++ b/internal/middleware/taskbus_test.go
@@ -2,13 +2,15 @@ package middleware
 
 import (
 	"context"
-	"github.com/arran4/goa4web/core/consts"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -60,7 +62,8 @@ func TestTaskEventMiddleware(t *testing.T) {
 	}
 
 	failureHandler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "fail", http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("fail"))
 	}))
 	req = httptest.NewRequest("POST", "/p", strings.NewReader("task=Add"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")


### PR DESCRIPTION
## Summary
- centralize HTTP error handling through handlers.RenderErrorPage
- clean up fallback error page template rendering

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestAdminEmailTemplateTestAction_NoProvider, TestAdminAPIServerShutdown_Unauthorized, TestAdminReloadConfigPage_Unauthorized, TestServerShutdownTask_Unauthorized, TestBlogsBlogAddPage_Unauthorized, TestBlogsBlogEditPage_Unauthorized, TestGetPermissionsByUserIdAndSectionBlogsPage_Unauthorized, TestArticleReplyActionPage_UsesWritingParam, TestHandleDie, and others)*

------
https://chatgpt.com/codex/tasks/task_e_6890b561a2a0832f8232bfc137b666fb