### PR TITLE
fix(admin): add task parameter to role grant update

### DIFF
--- a/core/templates/site/admin/roleGrantsEditor.gohtml
+++ b/core/templates/site/admin/roleGrantsEditor.gohtml
@@ -27,6 +27,7 @@
             <td>
                 <form method="post" action="/admin/role/{{ $.Role.ID }}/grant/update" class="commit-form">
                     {{ csrfField }}
+                    <input type="hidden" name="task" value="Update grants">
                     <input type="hidden" name="section" value="{{ .Section }}">
                     <input type="hidden" name="item" value="{{ .Item }}">
                     <input type="hidden" name="item_id" value="{{ if .ItemID.Valid }}{{ .ItemID.Int32 }}{{ end }}">


### PR DESCRIPTION
## Summary
- fix role grant editor form missing task value
- remove inadequate template test

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(hung, aborted)*
- `go vet ./core/templates`
- `golangci-lint run` *(hung, aborted)*
- `golangci-lint run ./core/...`
- `go test ./...` *(fails: TestAdminEmailTemplateTestAction_NoProvider, TestAdminAPIServerShutdown_Unauthorized, TestAdminReloadConfigPage_Unauthorized, TestServerShutdownTask_Unauthorized, TestBlogsBlogAddPage_Unauthorized, TestBlogsBlogEditPage_Unauthorized, TestGetPermissionsByUserIdAndSectionBlogsPage_Unauthorized, TestArticleReplyActionPage_UsesWritingParam, TestHandleDie)*

------
https://chatgpt.com/codex/tasks/task_e_689160849098832fbe5b931c5db8ed9f