### PR TITLE
Ensure forms include task input

### DIFF
--- a/core/templates/site/admin/auditLogPage.gohtml
+++ b/core/templates/site/admin/auditLogPage.gohtml
@@ -3,7 +3,7 @@
 <form method="get">
     User: <input name="user" value="{{$.User}}">
     Action: <input name="action" value="{{$.Action}}">
-    <input type="submit" value="Filter">
+    <input type="submit" name="task" value="Filter">
 </form>
 <table border="1">
     <tr><th>ID</th><th>User</th><th>Action</th><th>Time</th></tr>

--- a/core/templates/site/admin/pageSizePage.gohtml
+++ b/core/templates/site/admin/pageSizePage.gohtml
@@ -4,6 +4,6 @@
     Min page size: <input type="number" name="min" value="{{.Min}}"><br>
     Max page size: <input type="number" name="max" value="{{.Max}}"><br>
     Default page size: <input type="number" name="default" value="{{.Default}}"><br>
-    <input type="submit" value="Save">
+    <input type="submit" name="task" value="Save">
 </form>
 {{ template "tail" $ }}

--- a/core/templates/site/admin/pendingUsersPage.gohtml
+++ b/core/templates/site/admin/pendingUsersPage.gohtml
@@ -8,12 +8,12 @@
             <td>
                 <form style="display:inline" method="post" action="/admin/users/pending/approve">
                     {{ csrfField }}<input type="hidden" name="uid" value="{{.Idusers}}">
-                    <input type="submit" value="Approve">
+                    <input type="submit" name="task" value="Approve">
                 </form>
                 <form style="display:inline" method="post" action="/admin/users/pending/reject">
                     {{ csrfField }}<input type="hidden" name="uid" value="{{.Idusers}}">
                     Reason:<input name="reason">
-                    <input type="submit" value="Reject">
+                    <input type="submit" name="task" value="Reject">
                 </form>
             </td>
         </tr>

--- a/core/templates/site/admin/requestPage.gohtml
+++ b/core/templates/site/admin/requestPage.gohtml
@@ -22,7 +22,7 @@
 <form method="post" action="/admin/request/{{ $req.ID }}/comment">
     {{ csrfField }}
     <textarea name="comment" rows="3" cols="40"></textarea>
-    <input type="submit" value="Add Comment">
+    <input type="submit" name="task" value="Add Comment">
 </form>
 <a href="/admin/requests">Back</a>
 {{ template "tail" $ }}

--- a/core/templates/site/admin/roleEditPage.gohtml
+++ b/core/templates/site/admin/roleEditPage.gohtml
@@ -6,7 +6,7 @@
     Name: <input name="name" value="{{.Role.Name}}"><br>
     Can Login: <input type="checkbox" name="can_login" {{if .Role.CanLogin}}checked{{end}}><br>
     Is Admin: <input type="checkbox" name="is_admin" {{if .Role.IsAdmin}}checked{{end}}><br>
-    <input type="submit" value="Save">
+    <input type="submit" name="task" value="Save">
 </form>
 {{ template "roleGrantsEditor.gohtml" . }}
 {{ template "tail" $ }}

--- a/core/templates/site/admin/sessionsPage.gohtml
+++ b/core/templates/site/admin/sessionsPage.gohtml
@@ -9,7 +9,7 @@
         <td>
             <form method="POST" action="/admin/sessions/delete">
                 <input type="hidden" name="sid" value="{{ .SessionID }}">
-                <button type="submit">Delete</button>
+                <button type="submit" name="task" value="Delete">Delete</button>
             </form>
         </td>
     </tr>

--- a/core/templates/site/admin/userEditPage.gohtml
+++ b/core/templates/site/admin/userEditPage.gohtml
@@ -5,6 +5,6 @@
         <input type="hidden" name="uid" value="{{.User.Idusers}}">
         Username: <input name="username" value="{{.User.Username.String}}"><br>
         Email: <input name="email" value="{{.User.Email.String}}"><br>
-        <input type="submit" value="Save">
+        <input type="submit" name="task" value="Save">
     </form>
 {{ template "tail" $ }}

--- a/core/templates/site/admin/userPermissionsPage.gohtml
+++ b/core/templates/site/admin/userPermissionsPage.gohtml
@@ -27,7 +27,7 @@
     <select name="role">
         {{- range $.Roles }}<option value="{{.Name}}">{{.Name}}</option>{{- end }}
     </select>
-    <button type="submit">Add</button>
+    <button type="submit" name="task" value="User Allow">Add</button>
 </form>
 <template id="roleOptions">
     {{- range $.Roles }}<option value="{{.Name}}">{{.Name}}</option>{{- end }}

--- a/core/templates/site/admin/userProfile.gohtml
+++ b/core/templates/site/admin/userProfile.gohtml
@@ -70,7 +70,7 @@
 <form method="post" action="/admin/user/{{ $user.Idusers }}/comment">
     {{ csrfField }}
     <textarea name="comment" rows="3" cols="40"></textarea>
-    <input type="submit" value="Add Comment">
+    <input type="submit" name="task" value="Add Comment">
 </form>
 {{ $comments := .CurrentProfileComments }}
 {{ if $comments }}

--- a/core/templates/site/admin/userResetPasswordConfirmPage.gohtml
+++ b/core/templates/site/admin/userResetPasswordConfirmPage.gohtml
@@ -2,7 +2,7 @@
 <p>Are you sure you want to reset the password for user {{ .User.Username.String }}?</p>
 <form method="post">
     {{ csrfField }}
-    <input type="submit" value="Reset password">
+    <input type="submit" name="task" value="Reset password">
 </form>
 <p><a href="{{ .Back }}">Cancel</a></p>
 {{ template "tail" $ }}

--- a/core/templates/site/admin/usersPage.gohtml
+++ b/core/templates/site/admin/usersPage.gohtml
@@ -13,7 +13,7 @@
             <option value="active" {{if eq $.Status "active"}}selected{{end}}>active</option>
             <option value="disabled" {{if eq $.Status "disabled"}}selected{{end}}>disabled</option>
         </select>
-        <input type="submit" value="Search">
+        <input type="submit" name="task" value="Search">
     </form>
     <table border="1">
         <tr>

--- a/core/templates/site/blogs/bloggerListPage.gohtml
+++ b/core/templates/site/blogs/bloggerListPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
     <form method="get">
         <input name="search" value="{{$.Search}}">
-        <input type="submit" value="Search">
+        <input type="submit" name="task" value="Search">
     </form>
     {{if .Search}}
         {{if .Rows}}

--- a/core/templates/site/confirmPage.gohtml
+++ b/core/templates/site/confirmPage.gohtml
@@ -2,7 +2,7 @@
 <p>{{ .Message }}</p>
 <form method="post">
     {{ csrfField }}
-    <input type="submit" value="{{ .ConfirmLabel }}">
+    <input type="submit" name="task" value="{{ .ConfirmLabel }}">
 </form>
 <a href="{{ .Back }}">Cancel</a>
 {{ template "tail" $ }}

--- a/core/templates/site/redirectBackPage.gohtml
+++ b/core/templates/site/redirectBackPage.gohtml
@@ -5,7 +5,7 @@
             <input type="hidden" name="{{$key}}" value="{{.}}">
         {{ end }}
     {{ end }}
-    <input type="submit" value="Go Back">
+    <input type="submit" name="task" value="Go Back">
 </form>
 {{ template "tail" $ }}
 

--- a/core/templates/site/tableTopics.gohtml
+++ b/core/templates/site/tableTopics.gohtml
@@ -14,6 +14,8 @@
         {{ csrfField }}
                         <input name="name" value="{{ .Title.String }}"><br>
                         <textarea name="desc" cols="30" rows="3">{{ .Description.String }}</textarea><br>
+                        <input type="hidden" name="task" value="Forum topic change">
+                    </form>
                 {{ else }}
                     <a href="/forum/topic/{{ .Idforumtopic }}">{{ .Title.String | a4code2html }}</a><br>
                     <i>{{ .Description.String | a4code2html }}</i>

--- a/core/templates/site/writings/writerListPage.gohtml
+++ b/core/templates/site/writings/writerListPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
     <form method="get">
         <input name="search" value="{{$.Search}}">
-        <input type="submit" value="Search">
+        <input type="submit" name="task" value="Search">
     </form>
     {{if .Rows}}
         <font size="5">All writers.</font><br>


### PR DESCRIPTION
## Summary
- add task inputs to forms missing a task name

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestAdminEmailTemplateTestAction_NoProvider, TestAdminAPIServerShutdown_Unauthorized, TestBlogsBlogAddPage_Unauthorized, TestBlogsBlogEditPage_Unauthorized, TestGetPermissionsByUserIdAndSectionBlogsPage_Unauthorized, TestArticleReplyActionPage_UsesWritingParam, TestHandleDie, TestServerShutdownTask_Unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_6891673e5ee8832f98fd579e48a9bbaa