### PR TITLE
Return ID from SystemInsertUser

### DIFF
--- a/cmd/goa4web/user_add.go
+++ b/cmd/goa4web/user_add.go
@@ -64,16 +64,12 @@ func createUser(root *rootCmd, username, email, password string, admin bool) err
 	if err != nil {
 		return fmt.Errorf("hash password: %w", err)
 	}
-	res, err := queries.SystemInsertUser(ctx, sql.NullString{String: username, Valid: true})
+	id, err := queries.SystemInsertUser(ctx, sql.NullString{String: username, Valid: true})
 	if err != nil {
 		if strings.Contains(err.Error(), "Duplicate entry") || strings.Contains(err.Error(), "UNIQUE constraint failed") {
 			return fmt.Errorf("user already exists")
 		}
 		return fmt.Errorf("insert user: %w", err)
-	}
-	id, err := res.LastInsertId()
-	if err != nil {
-		return fmt.Errorf("last insert id: %w", err)
 	}
 	if email != "" {
 		if err := queries.InsertUserEmail(ctx, db.InsertUserEmailParams{UserID: int32(id), Email: email, VerifiedAt: sql.NullTime{Time: time.Now(), Valid: true}, LastVerificationCode: sql.NullString{}, NotificationPriority: 100}); err != nil {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -432,7 +432,7 @@ type Querier interface {
 	SystemInsertDeadLetter(ctx context.Context, message string) error
 	SystemInsertLoginAttempt(ctx context.Context, arg SystemInsertLoginAttemptParams) error
 	SystemInsertSession(ctx context.Context, arg SystemInsertSessionParams) error
-	SystemInsertUser(ctx context.Context, username sql.NullString) (sql.Result, error)
+	SystemInsertUser(ctx context.Context, username sql.NullString) (int64, error)
 	SystemLatestDeadLetter(ctx context.Context) (interface{}, error)
 	SystemListAllUsers(ctx context.Context) ([]*SystemListAllUsersRow, error)
 	SystemListBoardsByParentID(ctx context.Context, arg SystemListBoardsByParentIDParams) ([]*Imageboard, error)

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -43,10 +43,9 @@ FROM users u JOIN user_emails ue ON ue.user_id = u.idusers
 WHERE ue.email = ?
 LIMIT 1;
 
--- name: SystemInsertUser :execresult
+-- name: SystemInsertUser :execlastid
 INSERT INTO users (username)
-VALUES (?)
-;
+VALUES (?);
 
 -- name: SystemListAllUsers :many
 SELECT u.idusers, u.username,

--- a/internal/db/queries-users.sql.go
+++ b/internal/db/queries-users.sql.go
@@ -375,13 +375,17 @@ func (q *Queries) SystemGetUserByUsername(ctx context.Context, username sql.Null
 	return &i, err
 }
 
-const systemInsertUser = `-- name: SystemInsertUser :execresult
+const systemInsertUser = `-- name: SystemInsertUser :execlastid
 INSERT INTO users (username)
 VALUES (?)
 `
 
-func (q *Queries) SystemInsertUser(ctx context.Context, username sql.NullString) (sql.Result, error) {
-	return q.db.ExecContext(ctx, systemInsertUser, username)
+func (q *Queries) SystemInsertUser(ctx context.Context, username sql.NullString) (int64, error) {
+	result, err := q.db.ExecContext(ctx, systemInsertUser, username)
+	if err != nil {
+		return 0, err
+	}
+	return result.LastInsertId()
 }
 
 const systemListAllUsers = `-- name: SystemListAllUsers :many


### PR DESCRIPTION
## Summary
- switch SystemInsertUser to `:execlastid` so new user ID is returned
- use returned ID in registration handler and `user_add` CLI

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891743b0d10832fb565277cb2142179