### PR TITLE
Clarify role titles with colon

### DIFF
--- a/core/templates/site/admin/adminRolePage.gohtml
+++ b/core/templates/site/admin/adminRolePage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-<h2>Role {{ .Role.Name }} (ID {{ .Role.ID }})</h2>
+<h2>Role: {{ .Role.Name }} (ID {{ .Role.ID }})</h2>
 <p><a href="/admin/role/{{ .Role.ID }}/edit">Edit Role</a></p>
 <table border="1">
     <tr><th>Can Login</th><th>Is Admin</th><th>Public Profiles</th></tr>

--- a/handlers/admin/adminRoleEditPage.go
+++ b/handlers/admin/adminRoleEditPage.go
@@ -19,7 +19,7 @@ func adminRoleEditFormPage(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("role not found"))
 		return
 	}
-	cd.PageTitle = fmt.Sprintf("Edit Role %s", role.Name)
+	cd.PageTitle = fmt.Sprintf("Edit Role: %s", role.Name)
 
 	id := cd.SelectedRoleID()
 	groups, err := buildGrantGroups(r.Context(), cd, id)

--- a/handlers/admin/adminRolePage.go
+++ b/handlers/admin/adminRolePage.go
@@ -22,7 +22,7 @@ func adminRolePage(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("role not found"))
 		return
 	}
-	cd.PageTitle = fmt.Sprintf("Role %s", role.Name)
+	cd.PageTitle = fmt.Sprintf("Role: %s", role.Name)
 
 	id := cd.SelectedRoleID()
 	users, err := queries.AdminListUsersByRoleID(r.Context(), id)


### PR DESCRIPTION
## Summary
- clarify admin role page titles with colon to separate role names
- update admin role edit handler to use colon as well

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68918dfa0ed4832f910e265fdc593ac9