### PR TITLE
Show all grant options for roles without existing grants

### DIFF
--- a/handlers/admin/role_grants.go
+++ b/handlers/admin/role_grants.go
@@ -235,6 +235,18 @@ func buildGrantGroups(ctx context.Context, cd *common.CoreData, roleID int32) ([
 		}
 	}
 
+	// Ensure all section/item pairs appear even when the role has no grants.
+	for key := range GrantActionMap {
+		parts := strings.Split(key, "|")
+		if len(parts) != 2 {
+			continue
+		}
+		gkey := fmt.Sprintf("%s|%s|0", parts[0], parts[1])
+		if _, ok := groupMap[gkey]; !ok {
+			groupMap[gkey] = &GrantGroup{Section: parts[0], Item: parts[1], ItemID: sql.NullInt32{}}
+		}
+	}
+
 	groups := make([]GrantGroup, 0, len(groupMap))
 	for _, grp := range groupMap {
 		if acts, ok := GrantActionMap[grp.Section+"|"+grp.Item]; ok {

--- a/handlers/admin/role_grants_build_test.go
+++ b/handlers/admin/role_grants_build_test.go
@@ -1,0 +1,53 @@
+package admin
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// TestBuildGrantGroupsIncludesAvailableActionsWithoutGrants ensures that even when a role
+// has no grants, buildGrantGroups still returns groups for all supported section/item pairs.
+func TestBuildGrantGroupsIncludesAvailableActionsWithoutGrants(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+	q := db.New(conn)
+	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants WHERE role_id = ? ORDER BY id\n")).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.title, f.description\nFROM forumcategory f\n")).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "title", "description"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language\n")).
+		WillReturnRows(sqlmock.NewRows([]string{"idlanguage", "nameof"}))
+
+	groups, err := buildGrantGroups(context.Background(), cd, 1)
+	if err != nil {
+		t.Fatalf("buildGrantGroups: %v", err)
+	}
+	if len(groups) != len(GrantActionMap) {
+		t.Fatalf("expected %d groups, got %d", len(GrantActionMap), len(groups))
+	}
+	var found bool
+	for _, g := range groups {
+		if g.Section == "forum" && g.Item == "topic" && len(g.Available) == len(GrantActionMap["forum|topic"]) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("missing forum|topic group")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- always include grant rows for each section/item combo even when a role has no grants
- test that roles with no grants still show all possible grant actions

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68918de3e9ec832fbf3f76c11b3c222c