### PR TITLE
refactor: remove unused handleDie helper

### DIFF
--- a/internal/middleware/core_utils_test.go
+++ b/internal/middleware/core_utils_test.go
@@ -3,8 +3,6 @@ package middleware
 import (
 	"bufio"
 	"bytes"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -54,21 +52,6 @@ func X2c(what string) byte {
 	}
 
 	return digit(what[0])*16 + digit(what[1])
-}
-
-func TestHandleDie(t *testing.T) {
-	rr := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	handleDie(rr, req, "oops")
-	if rr.Code != http.StatusInternalServerError {
-		t.Errorf("expected status 500, got %d", rr.Code)
-	}
-	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
-		t.Errorf("expected Content-Type text/plain; charset=utf-8, got %q", ct)
-	}
-	if body := rr.Body.String(); body != "Internal Server Error\n" {
-		t.Errorf("unexpected body: %q", body)
-	}
 }
 
 func TestConfigurationSetGet(t *testing.T) {

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -13,15 +13,6 @@ import (
 	"github.com/gorilla/sessions"
 )
 
-// handleDie responds with a plain text internal server error.
-func handleDie(w http.ResponseWriter, r *http.Request, message string) {
-	// TODO: remove message parameter once callers are updated.
-	_ = message
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	w.WriteHeader(http.StatusInternalServerError)
-	fmt.Fprintln(w, http.StatusText(http.StatusInternalServerError))
-}
-
 // RequestLoggerMiddleware logs incoming requests along with the user and session IDs.
 func RequestLoggerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- remove unused handleDie helper from middleware
- drop handleDie test and associated imports

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./... && echo vet-ok`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68918e0c2ae0832f8ffc5fcfce01b8ec