### PR TITLE
Use generic offset for blog listings

### DIFF
--- a/core/templates/site/blogs/page.gohtml
+++ b/core/templates/site/blogs/page.gohtml
@@ -2,7 +2,7 @@
     {{ template "head" $ }}
     {{ $rows := cd.BlogList }}
     {{ if $rows }}
-        {{ if cd.BlogListUID }}
+        {{ if cd.CurrentProfileUserID }}
             <font size="5"><a href="/blogs/blogger/{{ (index $rows 0).Username.String }}">{{ (index $rows 0).Username.String }}</a>'s blogs.</font><br>
         {{ else }}
             <font size="5"><a href="/blogs/bloggers">All bloggers</a>' blogs.</font><br>
@@ -19,14 +19,14 @@
                 </td>
             </tr>
         {{ else }}
-            {{ if gt (cd.BlogListOffset) 0 }}
-                {{ if cd.BlogListUID }}
+            {{ if gt (cd.Offset) 0 }}
+                {{ if cd.CurrentProfileUserID }}
                     There are no more blogs under this user.<br>
                 {{ else }}
                     There are no more blogs.<br>
                 {{ end }}
             {{ else }}
-                {{ if cd.BlogListUID }}
+                {{ if cd.CurrentProfileUserID }}
                     Nothing under this blog.<br>
                 {{ else }}
                     There are no blogs here.<br>

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -23,14 +23,14 @@ import (
 )
 
 func Page(w http.ResponseWriter, r *http.Request) {
-	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	buid := r.URL.Query().Get("uid")
 	userID, _ := strconv.Atoi(buid)
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Blogs"
-	cd.SetBlogListParams(int32(userID), offset)
+	cd.SetCurrentProfileUserID(int32(userID))
 
+	offset := cd.Offset()
 	ps := cd.PageSize()
 	qv := r.URL.Query()
 	qv.Set("offset", strconv.Itoa(offset+ps))


### PR DESCRIPTION
## Summary
- remove SetBlogListParams and dedicated blog list fields from CoreData
- expose generic offset and profile user id accessors
- update blog handler and template to use generic offset

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891da668178832fb80ddf8f05225dcd