### PR TITLE
Avoid passing CoreData into templates

### DIFF
--- a/core/templates/site/admin/requestPage.gohtml
+++ b/core/templates/site/admin/requestPage.gohtml
@@ -1,12 +1,12 @@
 {{ template "head" $ }}
-{{ $req := .CurrentRequest }}
-{{ $user := .CurrentRequestUser }}
+{{ $req := cd.CurrentRequest }}
+{{ $user := cd.CurrentRequestUser }}
 <h2>Request {{ $req.ID }} for user <a href="/admin/user/{{ $user.Idusers }}">{{ $user.Username.String }}</a></h2>
 <p>Field: {{ $req.ChangeTable }}.{{ $req.ChangeField }} row {{ $req.ChangeRowID }}</p>
 <p>Value: {{ $req.ChangeValue.String }}</p>
 <p>Contact: {{ $req.ContactOptions.String }}</p>
 <p>Status: {{ $req.Status }}</p>
-{{ $comments := .CurrentRequestComments }}
+{{ $comments := cd.CurrentRequestComments }}
 {{ if $comments }}
 <h3>Comments</h3>
 <table border="1">

--- a/core/templates/site/admin/userProfile.gohtml
+++ b/core/templates/site/admin/userProfile.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-{{ $user := .CurrentProfileUser }}
+{{ $user := cd.CurrentProfileUser }}
 {{ if $user }}
 <h2>User {{ $user.Username.String }} (ID {{ $user.Idusers }})</h2>
 <p>
@@ -7,13 +7,13 @@
     <a href="/admin/user/{{ $user.Idusers }}/permissions">Permissions</a>
     {{- if $user.PublicProfileEnabledAt.Valid }} |
     <a href="/user/profile/{{ $user.Username.String }}">Public Profile</a>{{- end }}
-    {{ $stats := .CurrentProfileStats }}
+    {{ $stats := cd.CurrentProfileStats }}
     {{- if and $stats (gt $stats.Blogs 0) }} |
     <a href="/blogs/blogger/{{ $user.Username.String }}">Blogs</a>{{- end }}
     {{- if and $stats (gt $stats.Writings 0) }} |
     <a href="/writings/writer/{{ $user.Username.String }}">Writings</a>{{- end }}
 </p>
-{{ $emails := .CurrentProfileEmails }}
+{{ $emails := cd.CurrentProfileEmails }}
 {{ if $emails }}
 <table border="1">
 <tr><th>Email</th><th>Verified</th><th>Priority</th></tr>
@@ -24,7 +24,7 @@
 {{ else }}
 <p>No emails.</p>
 {{ end }}
-{{ $roles := .CurrentProfileRoles }}
+{{ $roles := cd.CurrentProfileRoles }}
 {{ if $roles }}
 <h3>Groups</h3>
 <ul>
@@ -44,12 +44,12 @@
     <li>Images: {{ $stats.Images }}</li>
     <li>Links: {{ $stats.Links }}</li>
     <li>Writings: {{ $stats.Writings }}</li>
-    <li>Bookmark entries: {{ .CurrentProfileBookmarkSize }}</li>
+    <li>Bookmark entries: {{ cd.CurrentProfileBookmarkSize }}</li>
 </ul>
 {{ else }}
 <p>No stats.</p>
 {{ end }}
-{{ $grants := .CurrentProfileGrants }}
+{{ $grants := cd.CurrentProfileGrants }}
 {{ if $grants }}
 <h3>Direct Grants</h3>
 <table border="1">
@@ -72,7 +72,7 @@
     <textarea name="comment" rows="3" cols="40"></textarea>
     <input type="submit" name="task" value="Add Comment">
 </form>
-{{ $comments := .CurrentProfileComments }}
+{{ $comments := cd.CurrentProfileComments }}
 {{ if $comments }}
 <table border="1">
     <tr><th>Date</th><th>Comment</th></tr>

--- a/handlers/admin/adminCommentPage.go
+++ b/handlers/admin/adminCommentPage.go
@@ -52,9 +52,8 @@ func adminCommentPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	data := struct {
-		*common.CoreData
 		Comment *db.GetCommentsByIdsForUserWithThreadInfoRow
 		Context []*db.GetCommentsByThreadIdForUserRow
-	}{cd, comment, contextRows}
-	handlers.TemplateHandler(w, r, "commentPage.gohtml", data)
+	}{comment, contextRows}
+	handlers.TemplateHandler(w, r, "admin/commentPage.gohtml", data)
 }

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -88,5 +88,5 @@ func AdminEmailTemplatePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cd.SetCurrentTemplate(name, r.URL.Query().Get("error"))
-	handlers.TemplateHandler(w, r, "emailTemplateEditPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "emailTemplateEditPage.gohtml", struct{}{})
 }

--- a/handlers/admin/adminRequestQueuePage.go
+++ b/handlers/admin/adminRequestQueuePage.go
@@ -13,13 +13,13 @@ import (
 func AdminRequestQueuePage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Admin Requests"
-	handlers.TemplateHandler(w, r, "requestQueuePage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "requestQueuePage.gohtml", struct{}{})
 }
 
 func AdminRequestArchivePage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Request Archive"
-	handlers.TemplateHandler(w, r, "requestArchivePage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "requestArchivePage.gohtml", struct{}{})
 }
 
 func adminRequestPage(w http.ResponseWriter, r *http.Request) {
@@ -31,7 +31,7 @@ func adminRequestPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Request %d", id)
-	handlers.TemplateHandler(w, r, "requestPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "requestPage.gohtml", struct{}{})
 }
 
 func adminRequestAddCommentPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/admin/adminUserProfilePage.go
+++ b/handlers/admin/adminUserProfilePage.go
@@ -19,7 +19,7 @@ func adminUserProfilePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("User %s", user.Username.String)
-	handlers.TemplateHandler(w, r, "userProfile.gohtml", cd)
+	handlers.TemplateHandler(w, r, "userProfile.gohtml", struct{}{})
 }
 
 func adminUserAddCommentPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/auth/email_association_request_task.go
+++ b/handlers/auth/email_association_request_task.go
@@ -68,7 +68,7 @@ func (EmailAssociationRequestTask) Action(w http.ResponseWriter, r *http.Request
 		}
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handlers.TemplateHandler(w, r, "forgotPasswordRequestSentPage.gohtml", r.Context().Value(consts.KeyCoreData))
+		handlers.TemplateHandler(w, r, "forgotPasswordRequestSentPage.gohtml", struct{}{})
 	})
 }
 

--- a/handlers/auth/forgot_password_task.go
+++ b/handlers/auth/forgot_password_task.go
@@ -110,7 +110,7 @@ func (ForgotPasswordTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 	cd.PageTitle = "Password Reset"
-	return handlers.TemplateWithDataHandler("forgotPasswordEmailSentPage.gohtml", cd)
+	return handlers.TemplateWithDataHandler("forgotPasswordEmailSentPage.gohtml", struct{}{})
 }
 
 func (ForgotPasswordTask) AuditRecord(data map[string]any) string {
@@ -152,5 +152,5 @@ func (ForgotPasswordTask) SelfEmailBroadcast() bool { return true }
 func (ForgotPasswordTask) Page(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Password Reset"
-	handlers.TemplateHandler(w, r, "forgotPasswordPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "forgotPasswordPage.gohtml", struct{}{})
 }

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -33,7 +33,7 @@ var _ tasks.Task = (*RegisterTask)(nil)
 func (RegisterTask) Page(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Register"
-	handlers.TemplateHandler(w, r, "registerPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "registerPage.gohtml", struct{}{})
 }
 
 // RegisterActionPage handles user creation from the registration form.

--- a/handlers/blogs/blogsBlogPage.go
+++ b/handlers/blogs/blogsBlogPage.go
@@ -88,7 +88,7 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			if err := templates.GetCompiledSiteTemplates(r.Context().Value(consts.KeyCoreData).(*common.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData); err != nil {
+			if err := templates.GetCompiledSiteTemplates(r.Context().Value(consts.KeyCoreData).(*common.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", struct{}{}); err != nil {
 				log.Printf("render no access page: %v", err)
 			}
 			return
@@ -99,7 +99,7 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if !data.CoreData.HasGrant("blogs", "entry", "view", blog.Idblogs) {
-		if err := templates.GetCompiledSiteTemplates(r.Context().Value(consts.KeyCoreData).(*common.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData); err != nil {
+		if err := templates.GetCompiledSiteTemplates(r.Context().Value(consts.KeyCoreData).(*common.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", struct{}{}); err != nil {
 			log.Printf("render no access page: %v", err)
 		}
 		return

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -109,7 +109,7 @@ func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 			cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-			_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd)
+			_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{})
 			return nil
 		default:
 			return fmt.Errorf("getBlogEntryForListerByID fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -87,7 +87,7 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			if err := templates.GetCompiledSiteTemplates(r.Context().Value(consts.KeyCoreData).(*common.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", data.CoreData); err != nil {
+			if err := templates.GetCompiledSiteTemplates(r.Context().Value(consts.KeyCoreData).(*common.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", struct{}{}); err != nil {
 				log.Printf("render no access page: %v", err)
 			}
 			return

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -40,7 +40,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		cd.PrevLink = "/blogs?" + qv.Encode()
 	}
 
-	handlers.TemplateHandler(w, r, "blogsPage", cd)
+	handlers.TemplateHandler(w, r, "blogsPage", struct{}{})
 }
 
 func CustomBlogIndex(data *common.CoreData, r *http.Request) {

--- a/handlers/forum/forumAdminThreadsPage.go
+++ b/handlers/forum/forumAdminThreadsPage.go
@@ -18,7 +18,7 @@ func AdminThreadsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Forum Admin Threads"
 
-	handlers.TemplateHandler(w, r, "adminThreadsPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "adminThreadsPage.gohtml", struct{}{})
 }
 
 func AdminThreadDeletePage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/forum/forumAdminTopicsPage.go
+++ b/handlers/forum/forumAdminTopicsPage.go
@@ -17,7 +17,7 @@ func AdminTopicsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Forum Admin Topics"
 
-	handlers.TemplateHandler(w, r, "adminTopicsPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "adminTopicsPage.gohtml", struct{}{})
 }
 
 func AdminTopicEditPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -103,7 +103,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{CoreData: cd, Replyable: true, BoardId: bid, ForumThreadId: thid}
 
 	if !data.CoreData.HasGrant("imagebbs", "board", "view", int32(bid)) {
-		_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd)
+		_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{})
 		return
 	}
 
@@ -174,7 +174,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd)
+			_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{})
 			return
 		default:
 			log.Printf("getAllBoardsByParentBoardId Error: %s", err)
@@ -222,7 +222,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd)
+			_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{})
 			return nil
 		default:
 			return fmt.Errorf("get image post fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/imagebbs/imagebbsFeed.go
+++ b/handlers/imagebbs/imagebbsFeed.go
@@ -153,7 +153,7 @@ func BoardRssPage(w http.ResponseWriter, r *http.Request) {
 	bid, _ := strconv.Atoi(bidStr)
 	queries := cd.Queries()
 	if !cd.HasGrant("imagebbs", "board", "see", int32(bid)) {
-		_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd)
+		_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{})
 		return
 	}
 	rows, err := queries.ListImagePostsByBoardForLister(r.Context(), db.ListImagePostsByBoardForListerParams{
@@ -203,7 +203,7 @@ func BoardAtomPage(w http.ResponseWriter, r *http.Request) {
 	bid, _ := strconv.Atoi(bidStr)
 	queries := cd.Queries()
 	if !cd.HasGrant("imagebbs", "board", "see", int32(bid)) {
-		_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd)
+		_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{})
 		return
 	}
 	rows, err := queries.ListImagePostsByBoardForLister(r.Context(), db.ListImagePostsByBoardForListerParams{

--- a/handlers/languages/admin.go
+++ b/handlers/languages/admin.go
@@ -20,7 +20,7 @@ func adminLanguageRedirect(w http.ResponseWriter, r *http.Request) {
 func adminLanguagesPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Languages"
-	handlers.TemplateHandler(w, r, "languagesPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "languagesPage.gohtml", struct{}{})
 }
 
 func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -89,7 +89,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd); err != nil {
+			if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{}); err != nil {
 				log.Printf("render no access page: %v", err)
 			}
 			return
@@ -228,7 +228,7 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd); err != nil {
+			if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{}); err != nil {
 				log.Printf("render no access page: %v", err)
 			}
 			return nil

--- a/handlers/news/admin_pages.go
+++ b/handlers/news/admin_pages.go
@@ -27,7 +27,7 @@ func AdminNewsPage(w http.ResponseWriter, r *http.Request) {
 		cd.StartLink = "/admin/news?offset=0"
 	}
 	cd.PageTitle = "News Admin"
-	handlers.TemplateHandler(w, r, "adminNewsListPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "adminNewsListPage.gohtml", struct{}{})
 }
 
 type CommentPlus struct {

--- a/handlers/news/newsPage.go
+++ b/handlers/news/newsPage.go
@@ -21,7 +21,7 @@ func NewsPage(w http.ResponseWriter, r *http.Request) {
 		cd.PrevLink = fmt.Sprintf("?offset=%d", offset-ps)
 		cd.StartLink = "?offset=0"
 	}
-	handlers.TemplateHandler(w, r, "newsPage", cd)
+	handlers.TemplateHandler(w, r, "newsPage", struct{}{})
 }
 
 func CustomNewsIndex(data *common.CoreData, r *http.Request) {

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -73,13 +73,13 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if post == nil {
-		if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd); err != nil {
+		if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{}); err != nil {
 			log.Printf("render no access page: %v", err)
 		}
 		return
 	}
 	if !cd.HasGrant("news", "post", "view", post.Idsitenews) {
-		if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd); err != nil {
+		if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{}); err != nil {
 			log.Printf("render no access page: %v", err)
 		}
 		return

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -40,7 +40,7 @@ func TestPageTemplatesRender(t *testing.T) {
 		name string
 		data any
 	}{
-		{"newsPage", struct{ *common.CoreData }{&common.CoreData{}}},
+		{"newsPage", struct{}{}},
 		{"faqPage", struct {
 			*common.CoreData
 			FAQ any
@@ -65,7 +65,7 @@ func TestPageTemplatesRender(t *testing.T) {
 			*common.CoreData
 			Boards any
 		}{&common.CoreData{}, nil}},
-		{"blogsPage", &common.CoreData{}},
+		{"blogsPage", struct{}{}},
 		{"writingsPage", struct {
 			WritingCategoryID int32
 		}{0}},

--- a/handlers/writings/matchers.go
+++ b/handlers/writings/matchers.go
@@ -31,7 +31,7 @@ func RequireWritingAuthor(next http.Handler) http.Handler {
 			return
 		}
 		if !cd.HasContentWriterRole() || writing.UsersIdusers != cd.UserID {
-			if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd); err != nil {
+			if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{}); err != nil {
 				log.Printf("render no access page: %v", err)
 			}
 			return

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -76,7 +76,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	writing, err := cd.CurrentWriting()
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd); err != nil {
+			if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{}); err != nil {
 				log.Printf("render no access page: %v", err)
 			}
 			return nil

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -45,7 +45,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if writing == nil || !cd.HasGrant("writing", "article", "view", writing.Idwriting) {
-		if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd); err != nil {
+		if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{}); err != nil {
 			log.Printf("render no access page: %v", err)
 		}
 		return
@@ -111,7 +111,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd); err != nil {
+			if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{}); err != nil {
 				log.Printf("render no access page: %v", err)
 			}
 			return

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -28,7 +28,7 @@ func RoleCheckerMiddleware(roles ...string) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !common.Allowed(r, roles...) {
 				cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-				err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", cd)
+				err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{})
 				if err != nil {
 					log.Printf("Template Error: %s", err)
 					handlers.RenderErrorPage(w, r, err)


### PR DESCRIPTION
## Summary
- stop sending CoreData directly to templates and use empty structs instead
- have admin templates pull context from the `cd` helper rather than relying on passed CoreData
- point the admin comment page at its own template and provide only the necessary fields

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891d231d764832fb7f174e5271079e4