### PR TITLE
Stop passing CoreData to templates

### DIFF
--- a/core/templates/site/admin/requestPage.gohtml
+++ b/core/templates/site/admin/requestPage.gohtml
@@ -1,12 +1,12 @@
 {{ template "head" $ }}
-{{ $req := .CurrentRequest }}
-{{ $user := .CurrentRequestUser }}
+{{ $req := cd.CurrentRequest }}
+{{ $user := cd.CurrentRequestUser }}
 <h2>Request {{ $req.ID }} for user <a href="/admin/user/{{ $user.Idusers }}">{{ $user.Username.String }}</a></h2>
 <p>Field: {{ $req.ChangeTable }}.{{ $req.ChangeField }} row {{ $req.ChangeRowID }}</p>
 <p>Value: {{ $req.ChangeValue.String }}</p>
 <p>Contact: {{ $req.ContactOptions.String }}</p>
 <p>Status: {{ $req.Status }}</p>
-{{ $comments := .CurrentRequestComments }}
+{{ $comments := cd.CurrentRequestComments }}
 {{ if $comments }}
 <h3>Comments</h3>
 <table border="1">

--- a/core/templates/site/admin/userProfile.gohtml
+++ b/core/templates/site/admin/userProfile.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-{{ $user := .CurrentProfileUser }}
+{{ $user := cd.CurrentProfileUser }}
 {{ if $user }}
 <h2>User {{ $user.Username.String }} (ID {{ $user.Idusers }})</h2>
 <p>
@@ -7,13 +7,13 @@
     <a href="/admin/user/{{ $user.Idusers }}/permissions">Permissions</a>
     {{- if $user.PublicProfileEnabledAt.Valid }} |
     <a href="/user/profile/{{ $user.Username.String }}">Public Profile</a>{{- end }}
-    {{ $stats := .CurrentProfileStats }}
+    {{ $stats := cd.CurrentProfileStats }}
     {{- if and $stats (gt $stats.Blogs 0) }} |
     <a href="/blogs/blogger/{{ $user.Username.String }}">Blogs</a>{{- end }}
     {{- if and $stats (gt $stats.Writings 0) }} |
     <a href="/writings/writer/{{ $user.Username.String }}">Writings</a>{{- end }}
 </p>
-{{ $emails := .CurrentProfileEmails }}
+{{ $emails := cd.CurrentProfileEmails }}
 {{ if $emails }}
 <table border="1">
 <tr><th>Email</th><th>Verified</th><th>Priority</th></tr>
@@ -24,7 +24,7 @@
 {{ else }}
 <p>No emails.</p>
 {{ end }}
-{{ $roles := .CurrentProfileRoles }}
+{{ $roles := cd.CurrentProfileRoles }}
 {{ if $roles }}
 <h3>Groups</h3>
 <ul>
@@ -44,12 +44,12 @@
     <li>Images: {{ $stats.Images }}</li>
     <li>Links: {{ $stats.Links }}</li>
     <li>Writings: {{ $stats.Writings }}</li>
-    <li>Bookmark entries: {{ .CurrentProfileBookmarkSize }}</li>
+    <li>Bookmark entries: {{ cd.CurrentProfileBookmarkSize }}</li>
 </ul>
 {{ else }}
 <p>No stats.</p>
 {{ end }}
-{{ $grants := .CurrentProfileGrants }}
+{{ $grants := cd.CurrentProfileGrants }}
 {{ if $grants }}
 <h3>Direct Grants</h3>
 <table border="1">
@@ -72,7 +72,7 @@
     <textarea name="comment" rows="3" cols="40"></textarea>
     <input type="submit" name="task" value="Add Comment">
 </form>
-{{ $comments := .CurrentProfileComments }}
+{{ $comments := cd.CurrentProfileComments }}
 {{ if $comments }}
 <table border="1">
     <tr><th>Date</th><th>Comment</th></tr>

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -88,5 +88,5 @@ func AdminEmailTemplatePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cd.SetCurrentTemplate(name, r.URL.Query().Get("error"))
-	handlers.TemplateHandler(w, r, "emailTemplateEditPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "emailTemplateEditPage.gohtml", struct{}{})
 }

--- a/handlers/admin/adminRequestQueuePage.go
+++ b/handlers/admin/adminRequestQueuePage.go
@@ -13,13 +13,13 @@ import (
 func AdminRequestQueuePage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Admin Requests"
-	handlers.TemplateHandler(w, r, "requestQueuePage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "requestQueuePage.gohtml", struct{}{})
 }
 
 func AdminRequestArchivePage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Request Archive"
-	handlers.TemplateHandler(w, r, "requestArchivePage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "requestArchivePage.gohtml", struct{}{})
 }
 
 func adminRequestPage(w http.ResponseWriter, r *http.Request) {
@@ -31,7 +31,7 @@ func adminRequestPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Request %d", id)
-	handlers.TemplateHandler(w, r, "requestPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "requestPage.gohtml", struct{}{})
 }
 
 func adminRequestAddCommentPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/admin/adminUserProfilePage.go
+++ b/handlers/admin/adminUserProfilePage.go
@@ -19,7 +19,7 @@ func adminUserProfilePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("User %s", user.Username.String)
-	handlers.TemplateHandler(w, r, "userProfile.gohtml", cd)
+	handlers.TemplateHandler(w, r, "userProfile.gohtml", struct{}{})
 }
 
 func adminUserAddCommentPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/auth/email_association_request_task.go
+++ b/handlers/auth/email_association_request_task.go
@@ -68,7 +68,7 @@ func (EmailAssociationRequestTask) Action(w http.ResponseWriter, r *http.Request
 		}
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handlers.TemplateHandler(w, r, "forgotPasswordRequestSentPage.gohtml", r.Context().Value(consts.KeyCoreData))
+		handlers.TemplateHandler(w, r, "forgotPasswordRequestSentPage.gohtml", struct{}{})
 	})
 }
 

--- a/handlers/auth/forgot_password_task.go
+++ b/handlers/auth/forgot_password_task.go
@@ -152,5 +152,5 @@ func (ForgotPasswordTask) SelfEmailBroadcast() bool { return true }
 func (ForgotPasswordTask) Page(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Password Reset"
-	handlers.TemplateHandler(w, r, "forgotPasswordPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "forgotPasswordPage.gohtml", struct{}{})
 }

--- a/handlers/auth/registerPage.go
+++ b/handlers/auth/registerPage.go
@@ -33,7 +33,7 @@ var _ tasks.Task = (*RegisterTask)(nil)
 func (RegisterTask) Page(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Register"
-	handlers.TemplateHandler(w, r, "registerPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "registerPage.gohtml", struct{}{})
 }
 
 // RegisterActionPage handles user creation from the registration form.

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -40,7 +40,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		cd.PrevLink = "/blogs?" + qv.Encode()
 	}
 
-	handlers.TemplateHandler(w, r, "blogsPage", cd)
+	handlers.TemplateHandler(w, r, "blogsPage", struct{}{})
 }
 
 func CustomBlogIndex(data *common.CoreData, r *http.Request) {

--- a/handlers/forum/forumAdminThreadsPage.go
+++ b/handlers/forum/forumAdminThreadsPage.go
@@ -18,7 +18,7 @@ func AdminThreadsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Forum Admin Threads"
 
-	handlers.TemplateHandler(w, r, "adminThreadsPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "adminThreadsPage.gohtml", struct{}{})
 }
 
 func AdminThreadDeletePage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/forum/forumAdminTopicsPage.go
+++ b/handlers/forum/forumAdminTopicsPage.go
@@ -17,7 +17,7 @@ func AdminTopicsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Forum Admin Topics"
 
-	handlers.TemplateHandler(w, r, "adminTopicsPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "adminTopicsPage.gohtml", struct{}{})
 }
 
 func AdminTopicEditPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/languages/admin.go
+++ b/handlers/languages/admin.go
@@ -20,7 +20,7 @@ func adminLanguageRedirect(w http.ResponseWriter, r *http.Request) {
 func adminLanguagesPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Languages"
-	handlers.TemplateHandler(w, r, "languagesPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "languagesPage.gohtml", struct{}{})
 }
 
 func adminLanguagesRenamePage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/news/admin_pages.go
+++ b/handlers/news/admin_pages.go
@@ -27,7 +27,7 @@ func AdminNewsPage(w http.ResponseWriter, r *http.Request) {
 		cd.StartLink = "/admin/news?offset=0"
 	}
 	cd.PageTitle = "News Admin"
-	handlers.TemplateHandler(w, r, "adminNewsListPage.gohtml", cd)
+	handlers.TemplateHandler(w, r, "adminNewsListPage.gohtml", struct{}{})
 }
 
 type CommentPlus struct {

--- a/handlers/news/newsPage.go
+++ b/handlers/news/newsPage.go
@@ -21,7 +21,7 @@ func NewsPage(w http.ResponseWriter, r *http.Request) {
 		cd.PrevLink = fmt.Sprintf("?offset=%d", offset-ps)
 		cd.StartLink = "?offset=0"
 	}
-	handlers.TemplateHandler(w, r, "newsPage", cd)
+	handlers.TemplateHandler(w, r, "newsPage", struct{}{})
 }
 
 func CustomNewsIndex(data *common.CoreData, r *http.Request) {

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -40,7 +40,7 @@ func TestPageTemplatesRender(t *testing.T) {
 		name string
 		data any
 	}{
-		{"newsPage", struct{ *common.CoreData }{&common.CoreData{}}},
+		{"newsPage", struct{}{}},
 		{"faqPage", struct {
 			*common.CoreData
 			FAQ any
@@ -65,7 +65,7 @@ func TestPageTemplatesRender(t *testing.T) {
 			*common.CoreData
 			Boards any
 		}{&common.CoreData{}, nil}},
-		{"blogsPage", &common.CoreData{}},
+		{"blogsPage", struct{}{}},
 		{"writingsPage", struct {
 			WritingCategoryID int32
 		}{0}},


### PR DESCRIPTION
## Summary
- avoid sending CoreData directly to templates in news, auth, admin, forum, and languages handlers
- teach admin request and user profile templates to pull data from the `cd` helper instead of `.Current*` fields
- update template rendering test for the news page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891d231d764832fb7f174e5271079e4