### PR TITLE
Support global grants for item queries

### DIFF
--- a/handlers/images/routes_test.go
+++ b/handlers/images/routes_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -11,6 +12,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
+	imagesign "github.com/arran4/goa4web/internal/images"
 	"github.com/arran4/goa4web/internal/navigation"
 )
 
@@ -41,6 +43,11 @@ func TestImageRouteInvalidID(t *testing.T) {
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/images/image/abc!", nil)
 
+	signer := imagesign.NewSigner(cfg, "k")
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithImageSigner(signer))
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+	ref := signer.SignedRef("image:" + "abc!")
+	req.URL.RawQuery = strings.SplitN(ref, "?", 2)[1]
 	r.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusNotFound {
@@ -56,6 +63,11 @@ func TestCacheRouteInvalidID(t *testing.T) {
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/images/cache/abc!", nil)
 
+	signer := imagesign.NewSigner(cfg, "k")
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithImageSigner(signer))
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+	ref := signer.SignedRef("cache:" + "abc!")
+	req.URL.RawQuery = strings.SplitN(ref, "?", 2)[1]
 	r.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusNotFound {

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -43,7 +43,7 @@ WHERE a.active = 1
         AND g.item='post'
         AND g.action='view'
         AND g.active=1
-        AND g.item_id = n.idsiteNews
+        AND (g.item_id = n.idsiteNews OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-announcements.sql.go
+++ b/internal/db/queries-announcements.sql.go
@@ -117,7 +117,7 @@ WHERE a.active = 1
         AND g.item='post'
         AND g.action='view'
         AND g.active=1
-        AND g.item_id = n.idsiteNews
+        AND (g.item_id = n.idsiteNews OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -49,7 +49,7 @@ WITH RECURSIVE role_ids(id) AS (
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = sqlc.arg(lister_id) AS is_owner
 FROM blogs b
-JOIN grants g ON g.item_id = b.idblogs
+JOIN grants g ON (g.item_id = b.idblogs OR g.item_id IS NULL)
     AND g.section = 'blogs'
     AND g.item = 'entry'
     AND g.action = 'see'
@@ -101,7 +101,7 @@ AND EXISTS (
       AND g.item = 'entry'
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -133,7 +133,7 @@ WHERE b.idblogs IN (sqlc.slice(blogIds))
         AND g.item = 'entry'
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -168,7 +168,7 @@ WHERE b.idblogs = sqlc.arg(id)
         AND g.item = 'entry'
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -201,7 +201,7 @@ WHERE swl.word = ?
         AND g.item = 'entry'
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -234,7 +234,7 @@ WHERE swl.word = ?
         AND g.item = 'entry'
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -266,7 +266,7 @@ AND EXISTS (
       AND g.item = 'entry'
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -300,7 +300,7 @@ WHERE (LOWER(u.username) LIKE LOWER(sqlc.arg(query)) OR LOWER((SELECT email FROM
       AND g.item = 'entry'
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -131,7 +131,7 @@ WHERE b.idblogs = ?
         AND g.item = 'entry'
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -208,7 +208,7 @@ AND EXISTS (
       AND g.item = 'entry'
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -304,7 +304,7 @@ WHERE b.idblogs IN (/*SLICE:blogids*/?)
         AND g.item = 'entry'
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -382,7 +382,7 @@ WITH RECURSIVE role_ids(id) AS (
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = ? AS is_owner
 FROM blogs b
-JOIN grants g ON g.item_id = b.idblogs
+JOIN grants g ON (g.item_id = b.idblogs OR g.item_id IS NULL)
     AND g.section = 'blogs'
     AND g.item = 'entry'
     AND g.action = 'see'
@@ -494,7 +494,7 @@ WHERE swl.word = ?
         AND g.item = 'entry'
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -563,7 +563,7 @@ WHERE swl.word = ?
         AND g.item = 'entry'
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -639,7 +639,7 @@ AND EXISTS (
       AND g.item = 'entry'
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -716,7 +716,7 @@ WHERE (LOWER(u.username) LIKE LOWER(?) OR LOWER((SELECT email FROM user_emails u
       AND g.item = 'entry'
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -82,7 +82,7 @@ WHERE t.idforumtopic = sqlc.arg(idforumtopic)
       AND g.item='topic'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -130,7 +130,7 @@ WHERE th.forumtopic_idforumtopic=sqlc.arg(topic_id)
       AND g.item='topic'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-forum.sql.go
+++ b/internal/db/queries-forum.sql.go
@@ -472,7 +472,7 @@ WHERE th.forumtopic_idforumtopic=?
       AND g.item='topic'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -576,7 +576,7 @@ WHERE t.idforumtopic = ?
       AND g.item='topic'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-imagebbs.sql
+++ b/internal/db/queries-imagebbs.sql
@@ -151,7 +151,7 @@ WHERE i.imageboard_idimageboard = sqlc.arg(board_id)
       AND g.item='board'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = i.imageboard_idimageboard
+      AND (g.item_id = i.imageboard_idimageboard OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(lister_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -174,7 +174,7 @@ WHERE i.idimagepost = sqlc.arg(id)
       AND g.item='board'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = i.imageboard_idimageboard
+      AND (g.item_id = i.imageboard_idimageboard OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(lister_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-imagebbs.sql.go
+++ b/internal/db/queries-imagebbs.sql.go
@@ -235,7 +235,7 @@ WHERE i.idimagepost = ?
       AND g.item='board'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = i.imageboard_idimageboard
+      AND (g.item_id = i.imageboard_idimageboard OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -607,7 +607,7 @@ WHERE i.imageboard_idimageboard = ?
       AND g.item='board'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = i.imageboard_idimageboard
+      AND (g.item_id = i.imageboard_idimageboard OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-linker.sql
+++ b/internal/db/queries-linker.sql
@@ -254,7 +254,7 @@ WHERE l.idlinker IN (sqlc.slice(linkerIds))
       AND g.item='link'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = l.idlinker
+      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );

--- a/internal/db/queries-linker.sql.go
+++ b/internal/db/queries-linker.sql.go
@@ -1104,7 +1104,7 @@ WHERE l.idlinker IN (/*SLICE:linkerids*/?)
       AND g.item='link'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = l.idlinker
+      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -63,7 +63,7 @@ WHERE s.idsiteNews = sqlc.arg(id) AND EXISTS (
       AND g.item='post'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = s.idsiteNews
+      AND (g.item_id = s.idsiteNews OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -97,7 +97,7 @@ WHERE s.Idsitenews IN (sqlc.slice(newsIds))
       AND g.item='post'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = s.idsiteNews
+      AND (g.item_id = s.idsiteNews OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -183,7 +183,7 @@ WHERE s.idsiteNews = ? AND EXISTS (
       AND g.item='post'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = s.idsiteNews
+      AND (g.item_id = s.idsiteNews OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -252,7 +252,7 @@ WHERE s.Idsitenews IN (/*SLICE:newsids*/?)
       AND g.item='post'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = s.idsiteNews
+      AND (g.item_id = s.idsiteNews OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )

--- a/internal/db/queries-search.sql
+++ b/internal/db/queries-search.sql
@@ -281,7 +281,7 @@ WHERE swl.word = sqlc.arg(word)
         AND g.item='article'
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = w.idwriting
+        AND (g.item_id = w.idwriting OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -314,7 +314,7 @@ WHERE swl.word = sqlc.arg(word)
         AND g.item='article'
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = w.idwriting
+        AND (g.item_id = w.idwriting OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -346,7 +346,7 @@ WHERE swl.word = sqlc.arg(word)
         AND g.item='post'
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = sn.idsiteNews
+        AND (g.item_id = sn.idsiteNews OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -379,7 +379,7 @@ WHERE swl.word = sqlc.arg(word)
         AND g.item='post'
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = sn.idsiteNews
+        AND (g.item_id = sn.idsiteNews OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -413,7 +413,7 @@ WHERE swl.word = sqlc.arg(word)
         AND g.item='link'
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = l.idlinker
+        AND (g.item_id = l.idlinker OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -446,7 +446,7 @@ WHERE swl.word = sqlc.arg(word)
         AND g.item='link'
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = l.idlinker
+        AND (g.item_id = l.idlinker OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );

--- a/internal/db/queries-search.sql.go
+++ b/internal/db/queries-search.sql.go
@@ -187,7 +187,7 @@ WHERE swl.word = ?
         AND g.item='link'
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = l.idlinker
+        AND (g.item_id = l.idlinker OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -256,7 +256,7 @@ WHERE swl.word = ?
         AND g.item='link'
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = l.idlinker
+        AND (g.item_id = l.idlinker OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -659,7 +659,7 @@ WHERE swl.word = ?
         AND g.item='post'
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = sn.idsiteNews
+        AND (g.item_id = sn.idsiteNews OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -728,7 +728,7 @@ WHERE swl.word = ?
         AND g.item='post'
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = sn.idsiteNews
+        AND (g.item_id = sn.idsiteNews OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -806,7 +806,7 @@ WHERE swl.word = ?
         AND g.item='article'
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = w.idwriting
+        AND (g.item_id = w.idwriting OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -875,7 +875,7 @@ WHERE swl.word = ?
         AND g.item='article'
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = w.idwriting
+        AND (g.item_id = w.idwriting OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-threads.sql
+++ b/internal/db/queries-threads.sql
@@ -81,7 +81,7 @@ WHERE th.idforumthread=sqlc.arg(thread_id)
       AND g.item='topic'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-threads.sql.go
+++ b/internal/db/queries-threads.sql.go
@@ -221,7 +221,7 @@ WHERE th.idforumthread=?
       AND g.item='topic'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -138,7 +138,7 @@ WHERE w.idwriting = sqlc.arg(idwriting)
       AND g.item='article'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = w.idwriting
+      AND (g.item_id = w.idwriting OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(lister_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -171,7 +171,7 @@ WHERE w.idwriting IN (sqlc.slice(writing_ids))
       AND g.item='article'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = w.idwriting
+      AND (g.item_id = w.idwriting OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(lister_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -230,7 +230,7 @@ WHERE w.users_idusers = sqlc.arg(author_id)
       AND g.item='article'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = w.idwriting
+      AND (g.item_id = w.idwriting OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(lister_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -190,7 +190,7 @@ WHERE w.users_idusers = ?
       AND g.item='article'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = w.idwriting
+      AND (g.item_id = w.idwriting OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -376,7 +376,7 @@ WHERE w.idwriting = ?
       AND g.item='article'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = w.idwriting
+      AND (g.item_id = w.idwriting OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -904,7 +904,7 @@ WHERE w.idwriting IN (/*SLICE:writing_ids*/?)
       AND g.item='article'
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = w.idwriting
+      AND (g.item_id = w.idwriting OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries_imagebbs_test.go
+++ b/internal/db/queries_imagebbs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -30,6 +31,38 @@ func TestQueries_ListBoardsByParentIDForLister(t *testing.T) {
 	if len(res) != 1 {
 		t.Fatalf("unexpected result count %d", len(res))
 	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestQueries_ListImagePostsByBoardForLister_GlobalGrant(t *testing.T) {
+	if !strings.Contains(listImagePostsByBoardForLister, "g.item_id = i.imageboard_idimageboard OR g.item_id IS NULL") {
+		t.Fatalf("global grant clause missing")
+	}
+
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+	q := New(conn)
+
+	rows := sqlmock.NewRows([]string{"idimagepost", "forumthread_id", "users_idusers", "imageboard_idimageboard", "posted", "description", "thumbnail", "fullimage", "file_size", "approved", "deleted_at", "last_index", "username", "comments"}).
+		AddRow(1, 0, 1, 2, nil, nil, nil, nil, 0, true, nil, nil, "alice", 0)
+
+	mock.ExpectQuery(regexp.QuoteMeta(listImagePostsByBoardForLister)).
+		WithArgs(int32(1), int32(2), sql.NullInt32{Int32: 1, Valid: true}, int32(5), int32(0)).
+		WillReturnRows(rows)
+
+	res, err := q.ListImagePostsByBoardForLister(context.Background(), ListImagePostsByBoardForListerParams{ListerID: 1, BoardID: 2, ListerUserID: sql.NullInt32{Int32: 1, Valid: true}, Limit: 5, Offset: 0})
+	if err != nil {
+		t.Fatalf("ListImagePostsByBoardForLister: %v", err)
+	}
+	if len(res) != 1 || res[0].Idimagepost != 1 {
+		t.Fatalf("unexpected result %+v", res)
+	}
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}

--- a/internal/db/queries_writers_test.go
+++ b/internal/db/queries_writers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -53,6 +54,38 @@ func TestQueries_ListWritersSearchForLister(t *testing.T) {
 		t.Fatalf("ListWritersSearchForLister: %v", err)
 	}
 	if len(res) != 1 || res[0].Username.String != "bob" || res[0].Count != 2 {
+		t.Fatalf("unexpected result %+v", res)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestQueries_GetWritingForListerByID_GlobalGrant(t *testing.T) {
+	if !strings.Contains(getWritingForListerByID, "g.item_id = w.idwriting OR g.item_id IS NULL") {
+		t.Fatalf("global grant clause missing")
+	}
+
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+	q := New(conn)
+
+	rows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "WriterId", "WriterUsername"}).
+		AddRow(1, 1, 0, 0, 0, nil, nil, nil, nil, false, nil, nil, 1, "bob")
+
+	mock.ExpectQuery(regexp.QuoteMeta(getWritingForListerByID)).
+		WithArgs(int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
+		WillReturnRows(rows)
+
+	res, err := q.GetWritingForListerByID(context.Background(), GetWritingForListerByIDParams{ListerID: 1, Idwriting: 1, ListerMatchID: sql.NullInt32{Int32: 1, Valid: true}})
+	if err != nil {
+		t.Fatalf("GetWritingForListerByID: %v", err)
+	}
+	if res.Idwriting != 1 {
 		t.Fatalf("unexpected result %+v", res)
 	}
 


### PR DESCRIPTION
## Summary
- allow global grants by permitting `g.item_id` to be NULL across item filters
- regenerate sqlc code and expand tests for global grants
- fix image route tests to use signed requests

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891e1853174832f9c61c1dc9053df13