### PR TITLE
Use configured PageSize in CoreData pagination functions

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -456,7 +456,7 @@ func (cd *CoreData) BlogList() ([]*db.ListBlogEntriesByAuthorForListerRow, error
 			AuthorID: cd.blogListUID,
 			ListerID: cd.UserID,
 			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-			Limit:    15,
+			Limit:    int32(cd.PageSize()),
 			Offset:   int32(cd.blogListOffset),
 		})
 		if err != nil {
@@ -1269,7 +1269,7 @@ func (cd *CoreData) LatestNews(r *http.Request) ([]*NewsPost, error) {
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	replyID, _ := strconv.Atoi(r.URL.Query().Get("reply"))
 	return cd.latestNews.Load(func() ([]*NewsPost, error) {
-		return cd.fetchLatestNews(int32(offset), 15, replyID)
+		return cd.fetchLatestNews(int32(offset), int32(cd.PageSize()), replyID)
 	})
 }
 
@@ -1283,7 +1283,7 @@ func (cd *CoreData) LatestWritings(opts ...LatestWritingsOption) ([]*db.Writing,
 		if cd.queries == nil {
 			return nil, nil
 		}
-		params := db.GetPublicWritingsParams{Limit: 15}
+		params := db.GetPublicWritingsParams{Limit: int32(cd.PageSize())}
 		for _, o := range opts {
 			o(&params)
 		}
@@ -1371,7 +1371,7 @@ func (cd *CoreData) LinkerItemsForUser(catID, offset int32) ([]*db.GetAllLinkerI
 		ViewerID:         cd.UserID,
 		Idlinkercategory: catID,
 		ViewerUserID:     sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-		Limit:            15,
+		Limit:            int32(cd.PageSize()),
 		Offset:           offset,
 	})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -1470,7 +1470,7 @@ func (cd *CoreData) Notifications(r *http.Request) ([]*db.Notification, error) {
 		if cd.queries == nil || cd.UserID == 0 {
 			return nil, nil
 		}
-		limit := int32(cd.Config.PageSizeDefault)
+		limit := int32(cd.PageSize())
 		if showAll {
 			return cd.queries.ListNotificationsForLister(cd.ctx, db.ListNotificationsForListerParams{
 				ListerID: cd.UserID,
@@ -1575,7 +1575,7 @@ func (cd *CoreData) PublicWritings(categoryID int32, r *http.Request) ([]*db.Lis
 			ListerID:          cd.UserID,
 			WritingCategoryID: categoryID,
 			UserID:            sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-			Limit:             15,
+			Limit:             int32(cd.PageSize()),
 			Offset:            int32(offset),
 		})
 		if err != nil {
@@ -2057,7 +2057,7 @@ func (cd *CoreData) WriterWritings(userID int32, r *http.Request) ([]*db.ListPub
 			ListerID: cd.UserID,
 			AuthorID: userID,
 			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-			Limit:    15,
+			Limit:    int32(cd.PageSize()),
 			Offset:   int32(offset),
 		})
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
## Summary
- Use `PageSize()` for `BlogList` query limit
- Respect `PageSize()` across news, writings, linker, notifications, and writing list methods

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(hangs, aborted)*
- `golangci-lint run` *(hangs, aborted)*
- `go test ./...` *(fails: TestImageRouteInvalidID)*

------
https://chatgpt.com/codex/tasks/task_e_6891de613f74832f8066125655e82e1a