### PR TITLE
Allow global grants in blog, forum, and thread queries

### DIFF
--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -49,9 +49,9 @@ WITH RECURSIVE role_ids(id) AS (
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = sqlc.arg(lister_id) AS is_owner
 FROM blogs b
-JOIN grants g ON g.item_id = b.idblogs
+JOIN grants g ON (g.item_id = b.idblogs OR g.item_id IS NULL)
     AND g.section = 'blogs'
-    AND g.item = 'entry'
+    AND (g.item = 'entry' OR g.item IS NULL)
     AND g.action = 'see'
     AND g.active = 1
     AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
@@ -98,10 +98,10 @@ AND (
 AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'
-      AND g.item = 'entry'
+      AND (g.item = 'entry' OR g.item IS NULL)
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -130,10 +130,10 @@ WHERE b.idblogs IN (sqlc.slice(blogIds))
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -165,10 +165,10 @@ WHERE b.idblogs = sqlc.arg(id)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -198,10 +198,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -231,10 +231,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -263,10 +263,10 @@ WHERE (
 AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'
-      AND g.item = 'entry'
+      AND (g.item = 'entry' OR g.item IS NULL)
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -297,10 +297,10 @@ WHERE (LOWER(u.username) LIKE LOWER(sqlc.arg(query)) OR LOWER((SELECT email FROM
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'
-      AND g.item = 'entry'
+      AND (g.item = 'entry' OR g.item IS NULL)
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -128,10 +128,10 @@ WHERE b.idblogs = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -205,10 +205,10 @@ AND (
 AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'
-      AND g.item = 'entry'
+      AND (g.item = 'entry' OR g.item IS NULL)
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -301,10 +301,10 @@ WHERE b.idblogs IN (/*SLICE:blogids*/?)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -382,9 +382,9 @@ WITH RECURSIVE role_ids(id) AS (
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = ? AS is_owner
 FROM blogs b
-JOIN grants g ON g.item_id = b.idblogs
+JOIN grants g ON (g.item_id = b.idblogs OR g.item_id IS NULL)
     AND g.section = 'blogs'
-    AND g.item = 'entry'
+    AND (g.item = 'entry' OR g.item IS NULL)
     AND g.action = 'see'
     AND g.active = 1
     AND (g.user_id = ? OR g.user_id IS NULL)
@@ -491,10 +491,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -560,10 +560,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -636,10 +636,10 @@ WHERE (
 AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'
-      AND g.item = 'entry'
+      AND (g.item = 'entry' OR g.item IS NULL)
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -713,10 +713,10 @@ WHERE (LOWER(u.username) LIKE LOWER(?) OR LOWER((SELECT email FROM user_emails u
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'
-      AND g.item = 'entry'
+      AND (g.item = 'entry' OR g.item IS NULL)
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -79,10 +79,10 @@ WHERE t.idforumtopic = sqlc.arg(idforumtopic)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum'
-      AND g.item='topic'
+      AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -127,10 +127,10 @@ WHERE th.forumtopic_idforumtopic=sqlc.arg(topic_id)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum'
-      AND g.item='topic'
+      AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-forum.sql.go
+++ b/internal/db/queries-forum.sql.go
@@ -469,10 +469,10 @@ WHERE th.forumtopic_idforumtopic=?
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum'
-      AND g.item='topic'
+      AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -573,10 +573,10 @@ WHERE t.idforumtopic = ?
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum'
-      AND g.item='topic'
+      AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-threads.sql
+++ b/internal/db/queries-threads.sql
@@ -78,10 +78,10 @@ WHERE th.idforumthread=sqlc.arg(thread_id)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum'
-      AND g.item='topic'
+      AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-threads.sql.go
+++ b/internal/db/queries-threads.sql.go
@@ -218,10 +218,10 @@ WHERE th.idforumthread=?
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum'
-      AND g.item='topic'
+      AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries_blog_test.go
+++ b/internal/db/queries_blog_test.go
@@ -1,0 +1,34 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBlogQueriesAllowGlobalGrants(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"listBlogEntriesForLister", listBlogEntriesForLister},
+		{"listBlogEntriesByAuthorForLister", listBlogEntriesByAuthorForLister},
+		{"listBlogEntriesByIDsForLister", listBlogEntriesByIDsForLister},
+		{"getBlogEntryForListerByID", getBlogEntryForListerByID},
+		{"listBlogIDsBySearchWordFirstForLister", listBlogIDsBySearchWordFirstForLister},
+		{"listBlogIDsBySearchWordNextForLister", listBlogIDsBySearchWordNextForLister},
+		{"listBloggersForLister", listBloggersForLister},
+		{"listBloggersSearchForLister", listBloggersSearchForLister},
+	}
+
+	itemSub := "(g.item = 'entry' OR g.item IS NULL)"
+	idSub := "(g.item_id = b.idblogs OR g.item_id IS NULL)"
+
+	for _, c := range cases {
+		if !strings.Contains(c.query, itemSub) {
+			t.Errorf("%s missing global item check", c.name)
+		}
+		if !strings.Contains(c.query, idSub) {
+			t.Errorf("%s missing global item_id check", c.name)
+		}
+	}
+}

--- a/internal/db/queries_forum_test.go
+++ b/internal/db/queries_forum_test.go
@@ -1,0 +1,25 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestForumQueriesAllowGlobalGrants(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"getForumTopicByIdForUser", getForumTopicByIdForUser},
+		{"getForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostText", getForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostText},
+	}
+
+	for _, c := range cases {
+		if !strings.Contains(c.query, "g.item='topic' OR g.item IS NULL") {
+			t.Errorf("%s missing global item check", c.name)
+		}
+		if !strings.Contains(c.query, "g.item_id = t.idforumtopic OR g.item_id IS NULL") {
+			t.Errorf("%s missing global item_id check", c.name)
+		}
+	}
+}

--- a/internal/db/queries_threads_test.go
+++ b/internal/db/queries_threads_test.go
@@ -1,0 +1,15 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetThreadLastPosterAndPerms_AllowsGlobalGrants(t *testing.T) {
+	if !strings.Contains(getThreadLastPosterAndPerms, "g.item='topic' OR g.item IS NULL") {
+		t.Errorf("missing global item check")
+	}
+	if !strings.Contains(getThreadLastPosterAndPerms, "g.item_id = t.idforumtopic OR g.item_id IS NULL") {
+		t.Errorf("missing global item_id check")
+	}
+}


### PR DESCRIPTION
## Summary
- allow global grants in forum thread lookup query
- allow global grants in forum topic queries
- allow global grants in blog listing and lookup queries
- add regression tests ensuring global grants are supported

## Testing
- `sqlc generate`
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: panic in handlers/images TestImageRouteInvalidID)*

------
https://chatgpt.com/codex/tasks/task_e_6891e18c953c832f9bbcb1ee2e2f5644