### PR TITLE
handlers: stop passing CoreData to TemplateHandler

### DIFF
--- a/handlers/bookmarks/page.go
+++ b/handlers/bookmarks/page.go
@@ -10,27 +10,21 @@ import (
 )
 
 func Page(w http.ResponseWriter, r *http.Request) {
-	type Data struct {
-		*common.CoreData
-	}
-
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	data := Data{
-		CoreData: r.Context().Value(consts.KeyCoreData).(*common.CoreData),
-	}
-	data.CoreData.PageTitle = "Bookmarks"
+	cd.PageTitle = "Bookmarks"
 
 	if uid == 0 {
-		handlers.TemplateHandler(w, r, "infoPage.gohtml", data)
+		handlers.TemplateHandler(w, r, "infoPage.gohtml", struct{}{})
 		return
 	}
 
-	handlers.TemplateHandler(w, r, "bookmarksPage", data)
+	handlers.TemplateHandler(w, r, "bookmarksPage", struct{}{})
 }
 
 func bookmarksCustomIndex(data *common.CoreData, r *http.Request) {

--- a/handlers/forum/adminForumFlaggedPostsPage.go
+++ b/handlers/forum/adminForumFlaggedPostsPage.go
@@ -10,11 +10,7 @@ import (
 
 // adminForumFlaggedPostsPage displays posts flagged for moderator review.
 func AdminForumFlaggedPostsPage(w http.ResponseWriter, r *http.Request) {
-	type Data struct {
-		*common.CoreData
-	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Forum - Flagged Posts"
-	data := Data{CoreData: cd}
-	handlers.TemplateHandler(w, r, "forumFlaggedPostsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "forumFlaggedPostsPage.gohtml", struct{}{})
 }

--- a/handlers/forum/adminForumModeratorLogsPage.go
+++ b/handlers/forum/adminForumModeratorLogsPage.go
@@ -10,11 +10,7 @@ import (
 
 // adminForumModeratorLogsPage displays recent moderator actions.
 func AdminForumModeratorLogsPage(w http.ResponseWriter, r *http.Request) {
-	type Data struct {
-		*common.CoreData
-	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Forum - Moderator Logs"
-	data := Data{CoreData: cd}
-	handlers.TemplateHandler(w, r, "forumModeratorLogsPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "forumModeratorLogsPage.gohtml", struct{}{})
 }


### PR DESCRIPTION
## Summary
- stop passing CoreData structs to TemplateHandler in bookmark and forum admin handlers

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891ea683a64832f9df10af5c3d26e48