### PR TITLE
Allow global grants in permission queries

### DIFF
--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -39,11 +39,11 @@ WHERE a.active = 1
   )
   AND EXISTS (
       SELECT 1 FROM grants g
-      WHERE g.section='news'
-        AND g.item='post'
-        AND g.action='view'
-        AND g.active=1
-        AND g.item_id = n.idsiteNews
+        WHERE g.section='news'
+          AND (g.item='post' OR g.item IS NULL)
+          AND g.action='view'
+          AND g.active=1
+          AND (g.item_id = n.idsiteNews OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-announcements.sql.go
+++ b/internal/db/queries-announcements.sql.go
@@ -113,11 +113,11 @@ WHERE a.active = 1
   )
   AND EXISTS (
       SELECT 1 FROM grants g
-      WHERE g.section='news'
-        AND g.item='post'
-        AND g.action='view'
-        AND g.active=1
-        AND g.item_id = n.idsiteNews
+        WHERE g.section='news'
+          AND (g.item='post' OR g.item IS NULL)
+          AND g.action='view'
+          AND g.active=1
+          AND (g.item_id = n.idsiteNews OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -49,9 +49,9 @@ WITH RECURSIVE role_ids(id) AS (
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = sqlc.arg(lister_id) AS is_owner
 FROM blogs b
-JOIN grants g ON g.item_id = b.idblogs
+JOIN grants g ON (g.item_id = b.idblogs OR g.item_id IS NULL)
     AND g.section = 'blogs'
-    AND g.item = 'entry'
+    AND (g.item = 'entry' OR g.item IS NULL)
     AND g.action = 'see'
     AND g.active = 1
     AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
@@ -98,10 +98,10 @@ AND (
 AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'
-      AND g.item = 'entry'
+      AND (g.item = 'entry' OR g.item IS NULL)
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -130,10 +130,10 @@ WHERE b.idblogs IN (sqlc.slice(blogIds))
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -165,10 +165,10 @@ WHERE b.idblogs = sqlc.arg(id)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -198,10 +198,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -231,10 +231,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -263,10 +263,10 @@ WHERE (
 AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'
-      AND g.item = 'entry'
+      AND (g.item = 'entry' OR g.item IS NULL)
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -297,10 +297,10 @@ WHERE (LOWER(u.username) LIKE LOWER(sqlc.arg(query)) OR LOWER((SELECT email FROM
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'
-      AND g.item = 'entry'
+      AND (g.item = 'entry' OR g.item IS NULL)
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -128,10 +128,10 @@ WHERE b.idblogs = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -205,10 +205,10 @@ AND (
 AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'
-      AND g.item = 'entry'
+      AND (g.item = 'entry' OR g.item IS NULL)
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -301,10 +301,10 @@ WHERE b.idblogs IN (/*SLICE:blogids*/?)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -382,9 +382,9 @@ WITH RECURSIVE role_ids(id) AS (
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = ? AS is_owner
 FROM blogs b
-JOIN grants g ON g.item_id = b.idblogs
+JOIN grants g ON (g.item_id = b.idblogs OR g.item_id IS NULL)
     AND g.section = 'blogs'
-    AND g.item = 'entry'
+    AND (g.item = 'entry' OR g.item IS NULL)
     AND g.action = 'see'
     AND g.active = 1
     AND (g.user_id = ? OR g.user_id IS NULL)
@@ -491,10 +491,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -560,10 +560,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section = 'blogs'
-        AND g.item = 'entry'
+        AND (g.item = 'entry' OR g.item IS NULL)
         AND g.action = 'see'
         AND g.active = 1
-        AND g.item_id = b.idblogs
+        AND (g.item_id = b.idblogs OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -636,10 +636,10 @@ WHERE (
 AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'
-      AND g.item = 'entry'
+      AND (g.item = 'entry' OR g.item IS NULL)
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -713,10 +713,10 @@ WHERE (LOWER(u.username) LIKE LOWER(?) OR LOWER((SELECT email FROM user_emails u
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'
-      AND g.item = 'entry'
+      AND (g.item = 'entry' OR g.item IS NULL)
       AND g.action = 'see'
       AND g.active = 1
-      AND g.item_id = b.idblogs
+      AND (g.item_id = b.idblogs OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-faq.sql
+++ b/internal/db/queries-faq.sql
@@ -60,10 +60,10 @@ INSERT INTO faq (question, users_idusers, language_idlanguage)
 SELECT sqlc.arg(question), sqlc.arg(writer_id), sqlc.arg(language_id)
 WHERE EXISTS (
     SELECT 1 FROM grants g
-    WHERE g.section = 'faq'
-      AND g.item = 'question'
-      AND g.action = 'post'
-      AND g.active = 1
+        WHERE g.section = 'faq'
+        AND (g.item = 'question' OR g.item IS NULL)
+        AND g.action = 'post'
+        AND g.active = 1
       AND (g.user_id = sqlc.arg(grantee_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (
           SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(writer_id)
@@ -75,10 +75,10 @@ INSERT INTO faq (question, answer, faqCategories_idfaqCategories, users_idusers,
 SELECT sqlc.arg(question), sqlc.arg(answer), sqlc.arg(category_id), sqlc.arg(writer_id), sqlc.arg(language_id)
 WHERE EXISTS (
     SELECT 1 FROM grants g
-    WHERE g.section = 'faq'
-      AND g.item = 'question'
-      AND g.action = 'post'
-      AND g.active = 1
+      WHERE g.section = 'faq'
+        AND (g.item = 'question' OR g.item IS NULL)
+        AND g.action = 'post'
+        AND g.active = 1
       AND (g.user_id = sqlc.arg(grantee_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (
           SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(writer_id)
@@ -146,10 +146,10 @@ INSERT INTO faq_revisions (faq_id, users_idusers, question, answer)
 SELECT sqlc.arg(faq_id), sqlc.arg(users_idusers), sqlc.arg(question), sqlc.arg(answer)
 WHERE EXISTS (
     SELECT 1 FROM grants g
-    WHERE g.section = 'faq'
-      AND g.item = 'question'
-      AND g.action = 'post'
-      AND g.active = 1
+      WHERE g.section = 'faq'
+        AND (g.item = 'question' OR g.item IS NULL)
+        AND g.action = 'post'
+        AND g.active = 1
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (
           SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)

--- a/internal/db/queries-faq.sql.go
+++ b/internal/db/queries-faq.sql.go
@@ -83,10 +83,10 @@ INSERT INTO faq (question, users_idusers, language_idlanguage)
 SELECT ?, ?, ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
-    WHERE g.section = 'faq'
-      AND g.item = 'question'
-      AND g.action = 'post'
-      AND g.active = 1
+        WHERE g.section = 'faq'
+        AND (g.item = 'question' OR g.item IS NULL)
+        AND g.action = 'post'
+        AND g.active = 1
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (
           SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
@@ -499,10 +499,10 @@ INSERT INTO faq (question, answer, faqCategories_idfaqCategories, users_idusers,
 SELECT ?, ?, ?, ?, ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
-    WHERE g.section = 'faq'
-      AND g.item = 'question'
-      AND g.action = 'post'
-      AND g.active = 1
+      WHERE g.section = 'faq'
+        AND (g.item = 'question' OR g.item IS NULL)
+        AND g.action = 'post'
+        AND g.active = 1
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (
           SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
@@ -536,10 +536,10 @@ INSERT INTO faq_revisions (faq_id, users_idusers, question, answer)
 SELECT ?, ?, ?, ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
-    WHERE g.section = 'faq'
-      AND g.item = 'question'
-      AND g.action = 'post'
-      AND g.active = 1
+      WHERE g.section = 'faq'
+        AND (g.item = 'question' OR g.item IS NULL)
+        AND g.action = 'post'
+        AND g.active = 1
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (
           SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -79,10 +79,10 @@ WHERE t.idforumtopic = sqlc.arg(idforumtopic)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum'
-      AND g.item='topic'
+      AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -127,10 +127,10 @@ WHERE th.forumtopic_idforumtopic=sqlc.arg(topic_id)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum'
-      AND g.item='topic'
+      AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-forum.sql.go
+++ b/internal/db/queries-forum.sql.go
@@ -469,10 +469,10 @@ WHERE th.forumtopic_idforumtopic=?
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum'
-      AND g.item='topic'
+      AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -573,10 +573,10 @@ WHERE t.idforumtopic = ?
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum'
-      AND g.item='topic'
+      AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-imagebbs.sql
+++ b/internal/db/queries-imagebbs.sql
@@ -148,10 +148,10 @@ WHERE i.imageboard_idimageboard = sqlc.arg(board_id)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='imagebbs'
-      AND g.item='board'
+      AND (g.item='board' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = i.imageboard_idimageboard
+      AND (g.item_id = i.imageboard_idimageboard OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(lister_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -171,10 +171,10 @@ WHERE i.idimagepost = sqlc.arg(id)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='imagebbs'
-      AND g.item='board'
+      AND (g.item='board' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = i.imageboard_idimageboard
+      AND (g.item_id = i.imageboard_idimageboard OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(lister_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-imagebbs.sql.go
+++ b/internal/db/queries-imagebbs.sql.go
@@ -232,10 +232,10 @@ WHERE i.idimagepost = ?
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='imagebbs'
-      AND g.item='board'
+      AND (g.item='board' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = i.imageboard_idimageboard
+      AND (g.item_id = i.imageboard_idimageboard OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -604,10 +604,10 @@ WHERE i.imageboard_idimageboard = ?
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='imagebbs'
-      AND g.item='board'
+      AND (g.item='board' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = i.imageboard_idimageboard
+      AND (g.item_id = i.imageboard_idimageboard OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-linker.sql
+++ b/internal/db/queries-linker.sql
@@ -221,7 +221,7 @@ WHERE l.idlinker = sqlc.arg(idlinker)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='linker'
-      AND g.item='link'
+      AND (g.item='link' OR g.item IS NULL)
       AND g.action IN ('view','comment','reply')
       AND g.active=1
       AND (g.item_id = l.idlinker OR g.item_id IS NULL)
@@ -251,10 +251,10 @@ WHERE l.idlinker IN (sqlc.slice(linkerIds))
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='linker'
-      AND g.item='link'
+      AND (g.item='link' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = l.idlinker
+      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );

--- a/internal/db/queries-linker.sql.go
+++ b/internal/db/queries-linker.sql.go
@@ -971,7 +971,7 @@ WHERE l.idlinker = ?
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='linker'
-      AND g.item='link'
+      AND (g.item='link' OR g.item IS NULL)
       AND g.action IN ('view','comment','reply')
       AND g.active=1
       AND (g.item_id = l.idlinker OR g.item_id IS NULL)
@@ -1101,10 +1101,10 @@ WHERE l.idlinker IN (/*SLICE:linkerids*/?)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='linker'
-      AND g.item='link'
+      AND (g.item='link' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = l.idlinker
+      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -3,8 +3,8 @@ INSERT INTO site_news (news, users_idusers, occurred, language_idlanguage)
 SELECT sqlc.arg(news), sqlc.arg(writer_id), NOW(), sqlc.arg(language_id)
 WHERE EXISTS (
     SELECT 1 FROM grants g
-    WHERE g.section='news'
-      AND g.item='post'
+      WHERE g.section='news'
+        AND (g.item='post' OR g.item IS NULL)
       AND g.action='post'
       AND g.active=1
       AND (g.item_id = 0 OR g.item_id IS NULL)
@@ -21,8 +21,8 @@ WHERE s.idsiteNews = sqlc.arg(post_id)
   AND s.users_idusers = sqlc.arg(writer_id)
   AND EXISTS (
     SELECT 1 FROM grants g
-    WHERE g.section='news'
-      AND g.item='post'
+      WHERE g.section='news'
+        AND (g.item='post' OR g.item IS NULL)
       AND g.action='post'
       AND g.active=1
       AND (g.item_id = sqlc.arg(grant_post_id) OR g.item_id IS NULL)
@@ -60,10 +60,10 @@ LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
 WHERE s.idsiteNews = sqlc.arg(id) AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='news'
-      AND g.item='post'
+      AND (g.item='post' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = s.idsiteNews
+      AND (g.item_id = s.idsiteNews OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -94,10 +94,10 @@ WHERE s.Idsitenews IN (sqlc.slice(newsIds))
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='news'
-      AND g.item='post'
+      AND (g.item='post' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = s.idsiteNews
+      AND (g.item_id = s.idsiteNews OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -76,8 +76,8 @@ INSERT INTO site_news (news, users_idusers, occurred, language_idlanguage)
 SELECT ?, ?, NOW(), ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
-    WHERE g.section='news'
-      AND g.item='post'
+      WHERE g.section='news'
+        AND (g.item='post' OR g.item IS NULL)
       AND g.action='post'
       AND g.active=1
       AND (g.item_id = 0 OR g.item_id IS NULL)
@@ -180,10 +180,10 @@ LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
 WHERE s.idsiteNews = ? AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='news'
-      AND g.item='post'
+      AND (g.item='post' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = s.idsiteNews
+      AND (g.item_id = s.idsiteNews OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -249,10 +249,10 @@ WHERE s.Idsitenews IN (/*SLICE:newsids*/?)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='news'
-      AND g.item='post'
+      AND (g.item='post' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = s.idsiteNews
+      AND (g.item_id = s.idsiteNews OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -458,8 +458,8 @@ WHERE s.idsiteNews = ?
   AND s.users_idusers = ?
   AND EXISTS (
     SELECT 1 FROM grants g
-    WHERE g.section='news'
-      AND g.item='post'
+      WHERE g.section='news'
+        AND (g.item='post' OR g.item IS NULL)
       AND g.action='post'
       AND g.active=1
       AND (g.item_id = ? OR g.item_id IS NULL)

--- a/internal/db/queries-search.sql
+++ b/internal/db/queries-search.sql
@@ -112,7 +112,7 @@ WHERE swl.word=sqlc.arg(word)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='forum'
-        AND g.item='topic'
+        AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
         AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
@@ -148,7 +148,7 @@ WHERE swl.word=sqlc.arg(word)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='forum'
-        AND g.item='topic'
+        AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
         AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
@@ -183,7 +183,7 @@ WHERE swl.word=sqlc.arg(word)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='forum'
-        AND g.item='topic'
+        AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
         AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
@@ -219,7 +219,7 @@ WHERE swl.word=sqlc.arg(word)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='forum'
-        AND g.item='topic'
+        AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
         AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
@@ -278,10 +278,10 @@ WHERE swl.word = sqlc.arg(word)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='writing'
-        AND g.item='article'
+        AND (g.item='article' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = w.idwriting
+        AND (g.item_id = w.idwriting OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -311,10 +311,10 @@ WHERE swl.word = sqlc.arg(word)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='writing'
-        AND g.item='article'
+        AND (g.item='article' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = w.idwriting
+        AND (g.item_id = w.idwriting OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -343,10 +343,10 @@ WHERE swl.word = sqlc.arg(word)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='news'
-        AND g.item='post'
+        AND (g.item='post' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = sn.idsiteNews
+        AND (g.item_id = sn.idsiteNews OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -376,10 +376,10 @@ WHERE swl.word = sqlc.arg(word)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='news'
-        AND g.item='post'
+        AND (g.item='post' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = sn.idsiteNews
+        AND (g.item_id = sn.idsiteNews OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -410,10 +410,10 @@ WHERE swl.word = sqlc.arg(word)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='linker'
-        AND g.item='link'
+        AND (g.item='link' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = l.idlinker
+        AND (g.item_id = l.idlinker OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -443,10 +443,10 @@ WHERE swl.word = sqlc.arg(word)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='linker'
-        AND g.item='link'
+        AND (g.item='link' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = l.idlinker
+        AND (g.item_id = l.idlinker OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );

--- a/internal/db/queries-search.sql.go
+++ b/internal/db/queries-search.sql.go
@@ -184,10 +184,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='linker'
-        AND g.item='link'
+        AND (g.item='link' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = l.idlinker
+        AND (g.item_id = l.idlinker OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -253,10 +253,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='linker'
-        AND g.item='link'
+        AND (g.item='link' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = l.idlinker
+        AND (g.item_id = l.idlinker OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -334,7 +334,7 @@ WHERE swl.word=?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='forum'
-        AND g.item='topic'
+        AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
         AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
@@ -415,7 +415,7 @@ WHERE swl.word=?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='forum'
-        AND g.item='topic'
+        AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
         AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
@@ -487,7 +487,7 @@ WHERE swl.word=?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='forum'
-        AND g.item='topic'
+        AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
         AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
@@ -578,7 +578,7 @@ WHERE swl.word=?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='forum'
-        AND g.item='topic'
+        AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
         AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
@@ -656,10 +656,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='news'
-        AND g.item='post'
+        AND (g.item='post' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = sn.idsiteNews
+        AND (g.item_id = sn.idsiteNews OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -725,10 +725,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='news'
-        AND g.item='post'
+        AND (g.item='post' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = sn.idsiteNews
+        AND (g.item_id = sn.idsiteNews OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -803,10 +803,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='writing'
-        AND g.item='article'
+        AND (g.item='article' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = w.idwriting
+        AND (g.item_id = w.idwriting OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -872,10 +872,10 @@ WHERE swl.word = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='writing'
-        AND g.item='article'
+        AND (g.item='article' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND g.item_id = w.idwriting
+        AND (g.item_id = w.idwriting OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-threads.sql
+++ b/internal/db/queries-threads.sql
@@ -78,10 +78,10 @@ WHERE th.idforumthread=sqlc.arg(thread_id)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum'
-      AND g.item='topic'
+      AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-threads.sql.go
+++ b/internal/db/queries-threads.sql.go
@@ -218,10 +218,10 @@ WHERE th.idforumthread=?
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum'
-      AND g.item='topic'
+      AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-users.sql
+++ b/internal/db/queries-users.sql
@@ -104,7 +104,7 @@ WHERE u.idusers = sqlc.arg(user_id)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='users'
-        AND g.item='public_profile'
+        AND (g.item='public_profile' OR g.item IS NULL)
         AND g.action='post'
         AND g.active=1
         AND (g.item_id = u.idusers OR g.item_id IS NULL)

--- a/internal/db/queries-users.sql.go
+++ b/internal/db/queries-users.sql.go
@@ -445,7 +445,7 @@ WHERE u.idusers = ?
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='users'
-        AND g.item='public_profile'
+        AND (g.item='public_profile' OR g.item IS NULL)
         AND g.action='post'
         AND g.active=1
         AND (g.item_id = u.idusers OR g.item_id IS NULL)

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -135,10 +135,10 @@ WHERE w.idwriting = sqlc.arg(idwriting)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='writing'
-      AND g.item='article'
+      AND (g.item='article' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = w.idwriting
+      AND (g.item_id = w.idwriting OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(lister_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -168,10 +168,10 @@ WHERE w.idwriting IN (sqlc.slice(writing_ids))
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='writing'
-      AND g.item='article'
+      AND (g.item='article' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = w.idwriting
+      AND (g.item_id = w.idwriting OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(lister_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -227,10 +227,10 @@ WHERE w.users_idusers = sqlc.arg(author_id)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='writing'
-      AND g.item='article'
+      AND (g.item='article' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = w.idwriting
+      AND (g.item_id = w.idwriting OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(lister_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -187,10 +187,10 @@ WHERE w.users_idusers = ?
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='writing'
-      AND g.item='article'
+      AND (g.item='article' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = w.idwriting
+      AND (g.item_id = w.idwriting OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -373,10 +373,10 @@ WHERE w.idwriting = ?
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='writing'
-      AND g.item='article'
+      AND (g.item='article' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = w.idwriting
+      AND (g.item_id = w.idwriting OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -901,10 +901,10 @@ WHERE w.idwriting IN (/*SLICE:writing_ids*/?)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='writing'
-      AND g.item='article'
+      AND (g.item='article' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND g.item_id = w.idwriting
+      AND (g.item_id = w.idwriting OR g.item_id IS NULL)
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )


### PR DESCRIPTION
## Summary
- allow global grants by permitting NULL `g.item` and `g.item_id` in permission checks
- regenerate SQL code via sqlc

## Testing
- `sqlc generate`
- `go mod tidy`
- `go fmt ./...`
- `go vet -v ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestImageRouteInvalidID, TestCommentsPageAllowsGlobalViewGrant)*

------
https://chatgpt.com/codex/tasks/task_e_6891e197b284832f86a9517c563c90a6