### PR TITLE
Allow global grants for FAQ question queries

### DIFF
--- a/internal/db/queries-faq.sql
+++ b/internal/db/queries-faq.sql
@@ -61,7 +61,7 @@ SELECT sqlc.arg(question), sqlc.arg(writer_id), sqlc.arg(language_id)
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'faq'
-      AND g.item = 'question'
+      AND (g.item = 'question' OR g.item IS NULL)
       AND g.action = 'post'
       AND g.active = 1
       AND (g.user_id = sqlc.arg(grantee_id) OR g.user_id IS NULL)
@@ -76,7 +76,7 @@ SELECT sqlc.arg(question), sqlc.arg(answer), sqlc.arg(category_id), sqlc.arg(wri
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'faq'
-      AND g.item = 'question'
+      AND (g.item = 'question' OR g.item IS NULL)
       AND g.action = 'post'
       AND g.active = 1
       AND (g.user_id = sqlc.arg(grantee_id) OR g.user_id IS NULL)
@@ -147,7 +147,7 @@ SELECT sqlc.arg(faq_id), sqlc.arg(users_idusers), sqlc.arg(question), sqlc.arg(a
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'faq'
-      AND g.item = 'question'
+      AND (g.item = 'question' OR g.item IS NULL)
       AND g.action = 'post'
       AND g.active = 1
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)

--- a/internal/db/queries-faq.sql.go
+++ b/internal/db/queries-faq.sql.go
@@ -84,7 +84,7 @@ SELECT ?, ?, ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'faq'
-      AND g.item = 'question'
+      AND (g.item = 'question' OR g.item IS NULL)
       AND g.action = 'post'
       AND g.active = 1
       AND (g.user_id = ? OR g.user_id IS NULL)
@@ -500,7 +500,7 @@ SELECT ?, ?, ?, ?, ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'faq'
-      AND g.item = 'question'
+      AND (g.item = 'question' OR g.item IS NULL)
       AND g.action = 'post'
       AND g.active = 1
       AND (g.user_id = ? OR g.user_id IS NULL)
@@ -537,7 +537,7 @@ SELECT ?, ?, ?, ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'faq'
-      AND g.item = 'question'
+      AND (g.item = 'question' OR g.item IS NULL)
       AND g.action = 'post'
       AND g.active = 1
       AND (g.user_id = ? OR g.user_id IS NULL)

--- a/internal/db/queries_faq_test.go
+++ b/internal/db/queries_faq_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -34,5 +35,24 @@ func TestQueries_InsertFAQQuestionForWriter(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestFAQQueriesAllowGlobalGrants(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"createFAQQuestionForWriter", createFAQQuestionForWriter},
+		{"insertFAQQuestionForWriter", insertFAQQuestionForWriter},
+		{"insertFAQRevisionForUser", insertFAQRevisionForUser},
+	}
+
+	itemSub := "(g.item = 'question' OR g.item IS NULL)"
+
+	for _, c := range cases {
+		if !strings.Contains(c.query, itemSub) {
+			t.Errorf("%s missing global item check", c.name)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- allow FAQ question creation and revision queries to use global grants
- verify FAQ queries permit global item grants
- regenerate sqlc code

## Testing
- `sqlc generate`
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cd.SetBlogListParams undefined in core/common/coredata_test.go)*
- `golangci-lint run` *(fails: cd.SetBlogListParams undefined in core/common/coredata_test.go)*
- `go test ./...` *(fails: cd.SetBlogListParams undefined in core/common/coredata_test.go)*

------
https://chatgpt.com/codex/tasks/task_e_6891f0b93950832f965d612e10f2c29a