### PR TITLE
Use CoreData for thread comments template

### DIFF
--- a/core/templates/site/blogs/blogPage.gohtml
+++ b/core/templates/site/blogs/blogPage.gohtml
@@ -11,6 +11,6 @@
                     </td>
                 </tr>
         </table><br>
-        {{ template "threadComments" $ }}
+        {{ template "threadComments" }}
         {{ template "blogReply" $ }}
 {{ template "tail" $ }}

--- a/core/templates/site/blogs/commentPage.gohtml
+++ b/core/templates/site/blogs/commentPage.gohtml
@@ -11,6 +11,6 @@
                     </td>
                 </tr>
         </table><br>
-        {{ template "threadComments" $ }}
+        {{ template "threadComments" }}
         {{ template "blogReply" $ }}
 {{ template "tail" $ }}

--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
     {{ template "threadBreadcrumbs" $ }}
-    {{ template "threadComments" $ }}
+    {{ template "threadComments" }}
     {{ template "forumReply" $ }}
 
     <a href="/forum/topic/{{.Topic.Idforumtopic}}">Back</a>

--- a/core/templates/site/imagebbs/boardThreadPage.gohtml
+++ b/core/templates/site/imagebbs/boardThreadPage.gohtml
@@ -8,7 +8,7 @@
         </table><br>
     {{ end }}
     {{ if .Comments }}
-        {{ template "threadComments" $ }}
+        {{ template "threadComments" }}
     {{ end }}
     {{ if .Replyable }}
         <font size="4">Reply:</font><br>

--- a/core/templates/site/news/adminNewsPostPage.gohtml
+++ b/core/templates/site/news/adminNewsPostPage.gohtml
@@ -10,6 +10,6 @@
 <p><a href="/admin/news/{{ .Post.Idsitenews }}/delete">Delete</a></p>
 <a id="comments"></a>
 {{ if .Comments }}<hr><font size=4>Comments:</font>{{ end }}
-{{ template "threadComments" $ }}
+{{ template "threadComments" }}
 <p><a href="/admin/news">Back</a></p>
 {{ template "tail" $ }}

--- a/core/templates/site/news/postPage.gohtml
+++ b/core/templates/site/news/postPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
     {{ template "newsPost" $.Post }}
     <hr><font size=4>Replies:</font>
-    {{ template "threadComments" $ }}
+    {{ template "threadComments" }}
     <a id="reply"></a>
     {{ if or .IsReplyable }}
         <font size=4>Reply:</font>

--- a/core/templates/site/showLinkComments.gohtml
+++ b/core/templates/site/showLinkComments.gohtml
@@ -14,7 +14,7 @@
         </table><br>
 
         {{ with .ForumthreadID }}
-            {{ template "threadComments" $ }}
+            {{ template "threadComments" }}
         {{ end }}
 
         {{ if $.CanReply }}

--- a/core/templates/site/threadComments.gohtml
+++ b/core/templates/site/threadComments.gohtml
@@ -1,8 +1,8 @@
 {{ define "threadComments" }}
-    {{ if gt $.Offset 0 }}
-        <br>Skipping {{ $.Offset }} comments.<br><br><br>
+    {{ if gt (cd.Offset) 0 }}
+        <br>Skipping {{ cd.Offset }} comments.<br><br><br>
     {{ end }}
-    {{ range $.Comments }}
+    {{ range cd.SelectedThreadComments }}
         {{ template "comment" . }}
     {{ else }}
         No comments.

--- a/core/templates/site/writings/articlePage.gohtml
+++ b/core/templates/site/writings/articlePage.gohtml
@@ -12,7 +12,7 @@
         <hr>
         {{ .Writing.Writing.String | a4code2html }}
         <hr>Comments:<br>
-        {{ template "threadComments" $ }}
+        {{ template "threadComments" }}
         {{ if .CanReply }}
             <hr><font size="4">Reply:</font><br>
             <form method="post">


### PR DESCRIPTION
## Summary
- use CoreData accessors in threadComments template
- update thread comments inclusion across templates

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cd.SetBlogListParams undefined)*
- `golangci-lint run` *(fails: cd.SetBlogListParams undefined)*
- `go test ./...` *(fails: cd.SetBlogListParams undefined, blogsPage template can't evaluate BlogListUID, TestImageRouteInvalidID/TestCacheRouteInvalidID want 403 got 404)*

------
https://chatgpt.com/codex/tasks/task_e_6891ee51dd84832f8a35d127b6ad0e58