### PR TITLE
chore: normalize writing section name

### DIFF
--- a/cmd/goa4web/help.go
+++ b/cmd/goa4web/help.go
@@ -111,7 +111,7 @@ func (c *helpCmd) showHelp(args []string) error {
 			}
 		}
 		return nil
-	case "writing", "writings":
+	case "writing":
 		cmd, err := parseWritingCmd(c.rootCmd, append(args[1:], "-h"))
 		if err != nil && err != flag.ErrHelp {
 			return fmt.Errorf("writing: %w", err)

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -59,7 +59,7 @@ func registerTasks(reg *tasks.Registry, ah *adminhandlers.Handlers) {
 	register("news", newshandlers.RegisterTasks())
 	register("search", searchhandlers.RegisterTasks())
 	register("user", userhandlers.RegisterTasks())
-	register("writings", writinghandlers.RegisterTasks())
+	register("writing", writinghandlers.RegisterTasks())
 }
 
 func main() {
@@ -271,7 +271,7 @@ func (r *rootCmd) Run() error {
 			return fmt.Errorf("blog: %w", err)
 		}
 		return c.Run()
-	case "writing", "writings":
+	case "writing":
 		c, err := parseWritingCmd(r, args[1:])
 		if err != nil {
 			return fmt.Errorf("writing: %w", err)

--- a/cmd/goa4web/templates/root_usage.txt
+++ b/cmd/goa4web/templates/root_usage.txt
@@ -11,7 +11,7 @@ Commands:
   blog    manage blog entries
   news    manage news posts
   faq     manage frequently asked questions
-  writing manage writings
+  writing manage writing articles
   ipban   manage IP bans
   audit   show recent audit log entries
   db      manage database

--- a/cmd/goa4web/templates/writing_usage.txt
+++ b/cmd/goa4web/templates/writing_usage.txt
@@ -3,9 +3,9 @@ Usage:
 
 Commands:
   tree      show writing categories
-  list      list writings
-  read      read a writing
-  comments  manage comments for a writing
+  list      list writing articles
+  read      read a writing article
+  comments  manage comments for a writing article
 
 Examples:
   {{.Prog}} writing tree

--- a/handlers/admin/role_grants.go
+++ b/handlers/admin/role_grants.go
@@ -144,7 +144,7 @@ func buildGrantGroups(ctx context.Context, cd *common.CoreData, roleID int32) ([
 						gi.Info = l.Title.String
 					}
 				}
-			case "writings":
+			case "writing":
 				switch g.Item.String {
 				case "category":
 					gi.Link = fmt.Sprintf("/admin/writings/category/%d/permissions#g%d", g.ItemID.Int32, g.ID)

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 52
+	ExpectedSchemaVersion = 53
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/migrations/0053.mysql.sql
+++ b/migrations/0053.mysql.sql
@@ -1,0 +1,5 @@
+-- Normalize writing section name
+UPDATE grants SET section = 'writing' WHERE section = 'writings';
+
+-- Update schema version
+UPDATE schema_version SET version = 53 WHERE version = 52;

--- a/migrations/0053.postgres.sql
+++ b/migrations/0053.postgres.sql
@@ -1,0 +1,5 @@
+-- Normalize writing section name
+UPDATE grants SET section = 'writing' WHERE section = 'writings';
+
+-- Update schema version
+UPDATE schema_version SET version = 53 WHERE version = 52;

--- a/migrations/0053.sqlite.sql
+++ b/migrations/0053.sqlite.sql
@@ -1,0 +1,5 @@
+-- Normalize writing section name
+UPDATE grants SET section = 'writing' WHERE section = 'writings';
+
+-- Update schema version
+UPDATE schema_version SET version = 53 WHERE version = 52;

--- a/readme.md
+++ b/readme.md
@@ -330,7 +330,7 @@ The script adds tables for notifications and email queues, updates existing colu
 
 ### Permission section checker
 
-The `/admin/permissions/sections` page lists all distinct values found in the `permissions.section` column. It provides buttons to convert existing rows between `writing` and `writings`. These one-off tools help normalise data if older migrations used inconsistent names.
+The `/admin/permissions/sections` page lists all distinct values found in the `grants.section` column. It provides tools to convert any legacy `writings` entries to `writing` so older migrations remain consistent.
 
 The linked counts let you drill down to view all permissions for a section via `/admin/permissions/sections/view?section=<name>`.
 
@@ -411,7 +411,7 @@ used examples include:
 - `grant` – control the default permission grants applied to new users.
 - `board` – create and update image boards.
 - `blog` – inspect blog posts and their comments.
-- `writing` – access writings and comment threads.
+- `writing` – access writing articles and comment threads.
 - `news` – list news items and manage comments.
 - `faq` – administer frequently asked questions.
 - `ipban` – list or update IP bans.

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -8,7 +8,7 @@ Roles define high level capabilities that can be assigned to users. The standard
 
 - **anonymous** – guests who are not signed in
 - **user** – regular authenticated user
-- **content writer** – may publish blogs and writings
+- **content writer** – may publish blogs and writing articles
 - **moderator** – moderation abilities
 - **administrator** – full access
 
@@ -131,7 +131,7 @@ The migrations seed baseline rules for the `news` section:
 
 When a writer publishes a post they automatically receive an `edit` grant tied to that post, effectively granting them update rights for that item.
 
-Other content sections such as blogs and writings follow the same pattern: authors can post entries and receive item-scoped `edit` grants while administrators hold broader `edit` privileges.
+Other content sections such as blogs and writing follow the same pattern: authors can post entries and receive item-scoped `edit` grants while administrators hold broader `edit` privileges.
 FAQ and blog listings also honour lister language preferences and check grants in SQL. Queries such as `ListBlogEntriesForLister`, `ListBlogEntriesByAuthorForLister` and `GetFAQAnsweredQuestions` filter content based on `lister_id` and permitted languages.
 
 ### Announcements


### PR DESCRIPTION
## Summary
- standardize on `writing` section name in grants editor and CLI
- migrate existing `writings` grants to `writing`
- document the unified section name

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cd.SetBlogListParams undefined)*
- `golangci-lint run` *(fails: cd.SetBlogListParams undefined)*
- `go test ./...` *(fails: missing SetBlogListParams and template render/HTTP status mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6891efa90f2c832f912aef2fb954e0a7