### PR TITLE
refactor: centralize permission constants

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -467,7 +467,7 @@ func (cd *CoreData) BlogList() ([]*db.ListBlogEntriesForListerRow, error) {
 		}
 		var list []*db.ListBlogEntriesForListerRow
 		for _, row := range rows {
-			if !cd.HasGrant("blogs", "entry", "see", row.Idblogs) {
+			if !cd.HasGrant(SectionBlogs, ItemEntry, ActionSee, row.Idblogs) {
 				continue
 			}
 			list = append(list, row)
@@ -497,7 +497,7 @@ func (cd *CoreData) BlogListForSelectedAuthor() ([]*db.ListBlogEntriesByAuthorFo
 		}
 		var list []*db.ListBlogEntriesByAuthorForListerRow
 		for _, row := range rows {
-			if !cd.HasGrant("blogs", "entry", "see", row.Idblogs) {
+			if !cd.HasGrant(SectionBlogs, ItemEntry, ActionSee, row.Idblogs) {
 				continue
 			}
 			list = append(list, row)
@@ -1067,20 +1067,20 @@ func (cd *CoreData) fetchLatestNews(offset, limit int32, replyID int) ([]*NewsPo
 	}
 	var posts []*NewsPost
 	for _, row := range rows {
-		if !cd.HasGrant("news", "post", "see", row.Idsitenews) {
+		if !cd.HasGrant(SectionNews, ItemPost, ActionSee, row.Idsitenews) {
 			continue
 		}
 		ann, err := cd.queries.GetLatestAnnouncementByNewsID(cd.ctx, row.Idsitenews)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return nil, err
 		}
-		if !cd.HasGrant("news", "post", "see", row.Idsitenews) {
+		if !cd.HasGrant(SectionNews, ItemPost, ActionSee, row.Idsitenews) {
 			continue
 		}
 		posts = append(posts, &NewsPost{
 			GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow: row,
 			ShowReply:    cd.UserID != 0,
-			ShowEdit:     cd.HasGrant("news", "post", "edit", row.Idsitenews) && (cd.AdminMode || cd.UserID != 0),
+			ShowEdit:     cd.HasGrant(SectionNews, ItemPost, ActionEdit, row.Idsitenews) && (cd.AdminMode || cd.UserID != 0),
 			Editing:      replyID == int(row.Idsitenews),
 			Announcement: ann,
 		})
@@ -1317,7 +1317,7 @@ func (cd *CoreData) LatestWritings(opts ...LatestWritingsOption) ([]*db.Writing,
 		}
 		var writings []*db.Writing
 		for _, row := range rows {
-			if !cd.HasGrant("writing", "article", "see", row.Idwriting) {
+			if !cd.HasGrant(SectionWriting, ItemArticle, ActionSee, row.Idwriting) {
 				continue
 			}
 			writings = append(writings, row)
@@ -1403,7 +1403,7 @@ func (cd *CoreData) LinkerItemsForUser(catID, offset int32) ([]*db.GetAllLinkerI
 	}
 	var out []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow
 	for _, row := range rows {
-		if cd.HasGrant("linker", "link", "see", row.Idlinker) {
+		if cd.HasGrant(SectionLinker, ItemLink, ActionSee, row.Idlinker) {
 			out = append(out, row)
 		}
 	}
@@ -1610,7 +1610,7 @@ func (cd *CoreData) PublicWritings(categoryID int32, r *http.Request) ([]*db.Lis
 		}
 		var res []*db.ListPublicWritingsInCategoryForListerRow
 		for _, row := range rows {
-			if cd.HasGrant("writing", "article", "see", row.Idwriting) {
+			if cd.HasGrant(SectionWriting, ItemArticle, ActionSee, row.Idwriting) {
 				res = append(res, row)
 			}
 		}
@@ -2018,7 +2018,7 @@ func (cd *CoreData) VisibleWritingCategories(userID int32) ([]*db.WritingCategor
 		}
 		var cats []*db.WritingCategory
 		for _, row := range rows {
-			if cd.HasGrant("writing", "category", "see", row.Idwritingcategory) {
+			if cd.HasGrant(SectionWriting, ItemCategory, ActionSee, row.Idwritingcategory) {
 				cats = append(cats, row)
 			}
 		}
@@ -2089,7 +2089,7 @@ func (cd *CoreData) WriterWritings(userID int32, r *http.Request) ([]*db.ListPub
 		}
 		var list []*db.ListPublicWritingsByUserForListerRow
 		for _, row := range rows {
-			if !cd.HasGrant("writing", "article", "see", row.Idwriting) {
+			if !cd.HasGrant(SectionWriting, ItemArticle, ActionSee, row.Idwriting) {
 				continue
 			}
 			list = append(list, row)

--- a/core/common/permissions.go
+++ b/core/common/permissions.go
@@ -2,11 +2,72 @@ package common
 
 import (
 	"database/sql"
+
 	"github.com/arran4/goa4web/internal/db"
 )
 
+// Section identifies a permission area such as forum or news.
+type Section string
+
+// Item describes a specific item type within a section.
+type Item string
+
+// Action represents an operation that can be performed on an item.
+type Action string
+
+// Typed section names used throughout the permission system.
+const (
+	SectionForum    Section = "forum"    // Forum section
+	SectionLinker   Section = "linker"   // Link directory section
+	SectionImageBBS Section = "imagebbs" // Image board section
+	SectionNews     Section = "news"     // News section
+	SectionBlogs    Section = "blogs"    // Blogs section
+	SectionWriting  Section = "writing"  // Writings section
+	SectionFAQ      Section = "faq"      // FAQ section
+	SectionSearch   Section = "search"   // Search section
+	SectionRole     Section = "role"     // Role management section
+)
+
+// Typed item names used within sections. Use ItemNone when no item applies.
+const (
+	ItemNone           Item = ""                // No specific item
+	ItemTopic          Item = "topic"           // Forum topic item
+	ItemThread         Item = "thread"          // Forum thread item
+	ItemCategory       Item = "category"        // Generic category item
+	ItemLink           Item = "link"            // Individual link item
+	ItemBoard          Item = "board"           // Image board item
+	ItemPost           Item = "post"            // News post item
+	ItemEntry          Item = "entry"           // Blog entry item
+	ItemArticle        Item = "article"         // Writing article item
+	ItemQuestion       Item = "question"        // FAQ question item
+	ItemQuestionAnswer Item = "question/answer" // FAQ question with answer item
+)
+
+// Typed action names representing common permission verbs.
+const (
+	ActionSee       Action = "see"        // Discover or list the item
+	ActionView      Action = "view"       // Display item details
+	ActionComment   Action = "comment"    // Add a comment
+	ActionReply     Action = "reply"      // Reply within an existing thread
+	ActionPost      Action = "post"       // Create new content
+	ActionEdit      Action = "edit"       // Modify existing content
+	ActionEditAny   Action = "edit-any"   // Modify content created by others
+	ActionDeleteOwn Action = "delete-own" // Remove own content
+	ActionDeleteAny Action = "delete-any" // Remove content created by others
+	ActionAdmin     Action = "admin"      // Perform administrative tasks
+	ActionLock      Action = "lock"       // Lock a thread or item
+	ActionPin       Action = "pin"        // Pin or sticky an item
+	ActionMove      Action = "move"       // Move an item elsewhere
+	ActionInvite    Action = "invite"     // Invite additional users
+	ActionApprove   Action = "approve"    // Approve submitted content
+	ActionModerate  Action = "moderate"   // Moderate problematic content
+	ActionSearch    Action = "search"     // Run a search query
+	ActionPromote   Action = "promote"    // Promote content
+	ActionDemote    Action = "demote"     // Demote content
+)
+
 // HasGrant reports whether the current user is allowed the given action.
-func (cd *CoreData) HasGrant(section, item, action string, itemID int32) bool {
+func (cd *CoreData) HasGrant(section Section, item Item, action Action, itemID int32) bool {
 	if cd.HasRole("administrator") {
 		return true
 	}
@@ -15,9 +76,9 @@ func (cd *CoreData) HasGrant(section, item, action string, itemID int32) bool {
 	}
 	_, err := cd.queries.SystemCheckGrant(cd.ctx, db.SystemCheckGrantParams{
 		ViewerID: cd.UserID,
-		Section:  section,
-		Item:     sql.NullString{String: item, Valid: item != ""},
-		Action:   action,
+		Section:  string(section),
+		Item:     sql.NullString{String: string(item), Valid: item != ItemNone},
+		Action:   string(action),
 		ItemID:   sql.NullInt32{Int32: itemID, Valid: itemID != 0},
 		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	})

--- a/core/common/search.go
+++ b/core/common/search.go
@@ -2,12 +2,12 @@ package common
 
 // CanSearch reports whether cd permits running a search in the given section.
 // It checks both a section specific grant and a global search grant.
-func CanSearch(cd *CoreData, section string) bool {
+func CanSearch(cd *CoreData, section Section) bool {
 	if cd == nil {
 		return false
 	}
-	if cd.HasGrant(section, "", "search", 0) {
+	if cd.HasGrant(section, ItemNone, ActionSearch, 0) {
 		return true
 	}
-	return cd.HasGrant("search", "", "search", 0)
+	return cd.HasGrant(SectionSearch, ItemNone, ActionSearch, 0)
 }

--- a/handlers/admin/role_grants_build_test.go
+++ b/handlers/admin/role_grants_build_test.go
@@ -34,12 +34,16 @@ func TestBuildGrantGroupsIncludesAvailableActionsWithoutGrants(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildGrantGroups: %v", err)
 	}
-	if len(groups) != len(GrantActionMap) {
-		t.Fatalf("expected %d groups, got %d", len(GrantActionMap), len(groups))
+	expected := 0
+	for _, items := range GrantActionMap {
+		expected += len(items)
+	}
+	if len(groups) != expected {
+		t.Fatalf("expected %d groups, got %d", expected, len(groups))
 	}
 	var found bool
 	for _, g := range groups {
-		if g.Section == "forum" && g.Item == "topic" && len(g.Available) == len(GrantActionMap["forum|topic"]) {
+		if g.Section == common.SectionForum && g.Item == common.ItemTopic && len(g.Available) == len(GrantActionMap[common.SectionForum][common.ItemTopic]) {
 			found = true
 			break
 		}

--- a/handlers/blogs/blogsBlogPage.go
+++ b/handlers/blogs/blogsBlogPage.go
@@ -98,7 +98,7 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if !data.CoreData.HasGrant("blogs", "entry", "view", blog.Idblogs) {
+	if !data.CoreData.HasGrant(common.SectionBlogs, common.ItemEntry, common.ActionView, blog.Idblogs) {
 		if err := templates.GetCompiledSiteTemplates(r.Context().Value(consts.KeyCoreData).(*common.CoreData).Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", struct{}{}); err != nil {
 			log.Printf("render no access page: %v", err)
 		}

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -78,7 +78,7 @@ func (AskTask) Action(w http.ResponseWriter, r *http.Request) any {
 	uid, _ := session.Values["UID"].(int32)
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	if !cd.HasGrant("faq", "question", "post", 0) {
+	if !cd.HasGrant(common.SectionFAQ, common.ItemQuestion, common.ActionPost, 0) {
 		r.URL.RawQuery = "error=" + url.QueryEscape("Forbidden")
 		handlers.TaskErrorAcknowledgementPage(w, r)
 		return nil

--- a/handlers/faq/create_question_task.go
+++ b/handlers/faq/create_question_task.go
@@ -35,7 +35,7 @@ func (CreateQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
-	if !cd.HasGrant("faq", "question", "post", 0) {
+	if !cd.HasGrant(common.SectionFAQ, common.ItemQuestion, common.ActionPost, 0) {
 		r.URL.RawQuery = "error=" + url.QueryEscape("Forbidden")
 		handlers.TaskErrorAcknowledgementPage(w, r)
 		return nil

--- a/handlers/faq/page.go
+++ b/handlers/faq/page.go
@@ -73,7 +73,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 func CustomFAQIndex(data *common.CoreData, r *http.Request) {
 	userHasAdmin := data.HasRole("administrator") && data.AdminMode
 	data.CustomIndexItems = []common.IndexItem{}
-	if data.HasGrant("faq", "question", "post", 0) {
+	if data.HasGrant(common.SectionFAQ, common.ItemQuestion, common.ActionPost, 0) {
 		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
 			Name: "Ask",
 			Link: "/faq/ask",

--- a/handlers/forum/forumAdminCategoryGrantsPage.go
+++ b/handlers/forum/forumAdminCategoryGrantsPage.go
@@ -25,7 +25,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 		CategoryID int32
 		Grants     []GrantInfo
 		Roles      []*db.Role
-		Actions    []string
+		Actions    []common.Action
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
@@ -36,7 +36,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Forum - Category %d Grants", cid)
-	data := Data{CoreData: cd, CategoryID: int32(cid), Actions: []string{"see", "view"}}
+	data := Data{CoreData: cd, CategoryID: int32(cid), Actions: []common.Action{common.ActionSee, common.ActionView}}
 	if roles, err := cd.AllRoles(); err == nil {
 		data.Roles = roles
 	}
@@ -48,7 +48,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, g := range grants {
-		if g.Section == "forum" && g.Item.Valid && g.Item.String == "category" && g.ItemID.Valid && g.ItemID.Int32 == int32(cid) {
+		if common.Section(g.Section) == common.SectionForum && g.Item.Valid && common.Item(g.Item.String) == common.ItemCategory && g.ItemID.Valid && g.ItemID.Int32 == int32(cid) {
 			gi := GrantInfo{Grant: g}
 			if g.UserID.Valid {
 				if u, err := queries.SystemGetUserByID(r.Context(), g.UserID.Int32); err == nil {

--- a/handlers/forum/forumAdminTopicGrantsPage.go
+++ b/handlers/forum/forumAdminTopicGrantsPage.go
@@ -24,7 +24,7 @@ func AdminTopicGrantsPage(w http.ResponseWriter, r *http.Request) {
 		TopicID int32
 		Grants  []GrantInfo
 		Roles   []*db.Role
-		Actions []string
+		Actions []common.Action
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
@@ -35,7 +35,7 @@ func AdminTopicGrantsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cd.PageTitle = fmt.Sprintf("Forum - Topic %d Grants", tid)
-	data := Data{CoreData: cd, TopicID: int32(tid), Actions: []string{"see", "view", "reply", "post", "edit"}}
+	data := Data{CoreData: cd, TopicID: int32(tid), Actions: []common.Action{common.ActionSee, common.ActionView, common.ActionReply, common.ActionPost, common.ActionEdit}}
 	if roles, err := cd.AllRoles(); err == nil {
 		data.Roles = roles
 	}
@@ -47,7 +47,7 @@ func AdminTopicGrantsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, g := range grants {
-		if g.Section == "forum" && g.Item.Valid && g.Item.String == "topic" && g.ItemID.Valid && g.ItemID.Int32 == int32(tid) {
+		if common.Section(g.Section) == common.SectionForum && g.Item.Valid && common.Item(g.Item.String) == common.ItemTopic && g.ItemID.Valid && g.ItemID.Int32 == int32(tid) {
 			gi := GrantInfo{Grant: g}
 			if g.UserID.Valid {
 				if u, err := queries.SystemGetUserByID(r.Context(), g.UserID.Int32); err == nil {

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -172,7 +172,7 @@ func CustomForumIndex(data *common.CoreData, r *http.Request) {
 		)
 	}
 	if threadId != "" && topicId != "" {
-		if tid, err := strconv.Atoi(topicId); err == nil && data.HasGrant("forum", "topic", "reply", int32(tid)) {
+		if tid, err := strconv.Atoi(topicId); err == nil && data.HasGrant(common.SectionForum, common.ItemTopic, common.ActionReply, int32(tid)) {
 			data.CustomIndexItems = append(data.CustomIndexItems,
 				common.IndexItem{
 					Name: "Write Reply",
@@ -182,7 +182,7 @@ func CustomForumIndex(data *common.CoreData, r *http.Request) {
 		}
 	}
 	if categoryId != "" && topicId != "" {
-		if tid, err := strconv.Atoi(topicId); err == nil && data.HasGrant("forum", "topic", "post", int32(tid)) {
+		if tid, err := strconv.Atoi(topicId); err == nil && data.HasGrant(common.SectionForum, common.ItemTopic, common.ActionPost, int32(tid)) {
 			data.CustomIndexItems = append(data.CustomIndexItems,
 				common.IndexItem{
 					Name: "Create Thread",

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -68,7 +68,7 @@ func BoardPage(w http.ResponseWriter, r *http.Request) {
 
 	data := Data{IsSubBoard: bid != 0, BoardNumber: bid}
 
-	if !cd.HasGrant("imagebbs", "board", "view", int32(bid)) {
+	if !cd.HasGrant(common.SectionImageBBS, common.ItemBoard, common.ActionView, int32(bid)) {
 		_ = templates.GetCompiledSiteTemplates(cd.Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", struct{}{})
 		return
 	}
@@ -101,7 +101,7 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("get image board fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if !cd.HasGrant("imagebbs", "board", "post", int32(bid)) {
+	if !cd.HasGrant(common.SectionImageBBS, common.ItemBoard, common.ActionPost, int32(bid)) {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		})

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -102,7 +102,7 @@ func BoardThreadPage(w http.ResponseWriter, r *http.Request) {
 
 	data := Data{CoreData: cd, Replyable: true, BoardId: bid, ForumThreadId: thid}
 
-	if !data.CoreData.HasGrant("imagebbs", "board", "view", int32(bid)) {
+	if !data.CoreData.HasGrant(common.SectionImageBBS, common.ItemBoard, common.ActionView, int32(bid)) {
 		_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{})
 		return
 	}

--- a/handlers/imagebbs/imagebbsFeed.go
+++ b/handlers/imagebbs/imagebbsFeed.go
@@ -152,7 +152,7 @@ func BoardRssPage(w http.ResponseWriter, r *http.Request) {
 	}
 	bid, _ := strconv.Atoi(bidStr)
 	queries := cd.Queries()
-	if !cd.HasGrant("imagebbs", "board", "see", int32(bid)) {
+	if !cd.HasGrant(common.SectionImageBBS, common.ItemBoard, common.ActionSee, int32(bid)) {
 		_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{})
 		return
 	}
@@ -202,7 +202,7 @@ func BoardAtomPage(w http.ResponseWriter, r *http.Request) {
 	}
 	bid, _ := strconv.Atoi(bidStr)
 	queries := cd.Queries()
-	if !cd.HasGrant("imagebbs", "board", "see", int32(bid)) {
+	if !cd.HasGrant(common.SectionImageBBS, common.ItemBoard, common.ActionSee, int32(bid)) {
 		_ = cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{})
 		return
 	}

--- a/handlers/linker/linkerAdminCategoryGrantsPage.go
+++ b/handlers/linker/linkerAdminCategoryGrantsPage.go
@@ -25,7 +25,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 		CategoryID int32
 		Grants     []GrantInfo
 		Roles      []*db.Role
-		Actions    []string
+		Actions    []common.Action
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
@@ -34,7 +34,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderErrorPage(w, r, handlers.ErrBadRequest)
 		return
 	}
-	data := Data{CoreData: cd, CategoryID: int32(cid), Actions: []string{"see", "view"}}
+	data := Data{CoreData: cd, CategoryID: int32(cid), Actions: []common.Action{common.ActionSee, common.ActionView}}
 	cd.PageTitle = fmt.Sprintf("Category %d Grants", cid)
 	if roles, err := cd.AllRoles(); err == nil {
 		data.Roles = roles
@@ -46,7 +46,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, g := range grants {
-		if g.Section == "linker" && g.Item.Valid && g.Item.String == "category" && g.ItemID.Valid && g.ItemID.Int32 == int32(cid) {
+		if common.Section(g.Section) == common.SectionLinker && g.Item.Valid && common.Item(g.Item.String) == common.ItemCategory && g.ItemID.Valid && g.ItemID.Int32 == int32(cid) {
 			gi := GrantInfo{Grant: g}
 			if g.UserID.Valid {
 				if u, err := queries.SystemGetUserByID(r.Context(), g.UserID.Int32); err == nil {

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -100,9 +100,9 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if !(cd.HasGrant("linker", "link", "view", link.Idlinker) ||
-		cd.HasGrant("linker", "link", "comment", link.Idlinker) ||
-		cd.HasGrant("linker", "link", "reply", link.Idlinker)) {
+	if !(cd.HasGrant(common.SectionLinker, common.ItemLink, common.ActionView, link.Idlinker) ||
+		cd.HasGrant(common.SectionLinker, common.ItemLink, common.ActionComment, link.Idlinker) ||
+		cd.HasGrant(common.SectionLinker, common.ItemLink, common.ActionReply, link.Idlinker)) {
 		handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		return
 	}
@@ -239,9 +239,9 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 
-	if !(cd.HasGrant("linker", "link", "view", link.Idlinker) ||
-		cd.HasGrant("linker", "link", "comment", link.Idlinker) ||
-		cd.HasGrant("linker", "link", "reply", link.Idlinker)) {
+	if !(cd.HasGrant(common.SectionLinker, common.ItemLink, common.ActionView, link.Idlinker) ||
+		cd.HasGrant(common.SectionLinker, common.ItemLink, common.ActionComment, link.Idlinker) ||
+		cd.HasGrant(common.SectionLinker, common.ItemLink, common.ActionReply, link.Idlinker)) {
 		handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		return nil
 	}

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -56,7 +56,7 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !cd.HasGrant("linker", "link", "view", link.Idlinker) {
+	if !cd.HasGrant(common.SectionLinker, common.ItemLink, common.ActionView, link.Idlinker) {
 		handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		return
 	}
@@ -104,7 +104,7 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !cd.HasGrant("linker", "link", "view", link.Idlinker) {
+	if !cd.HasGrant(common.SectionLinker, common.ItemLink, common.ActionView, link.Idlinker) {
 		handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		return
 	}

--- a/handlers/linker/linkerUserPage.go
+++ b/handlers/linker/linkerUserPage.go
@@ -59,7 +59,7 @@ func UserPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{CoreData: cd, Username: username, HasOffset: offset != 0}
 	cd.PageTitle = fmt.Sprintf("Links by %s", username)
 	for _, row := range rows {
-		if !cd.HasGrant("linker", "link", "see", row.Idlinker) {
+		if !cd.HasGrant(common.SectionLinker, common.ItemLink, common.ActionSee, row.Idlinker) {
 			continue
 		}
 		data.Links = append(data.Links, row)

--- a/handlers/news/helpers.go
+++ b/handlers/news/helpers.go
@@ -9,7 +9,7 @@ func canEditNewsPost(cd *common.CoreData, postID int32) bool {
 	if cd == nil {
 		return false
 	}
-	if cd.HasGrant("news", "post", "edit", postID) && (cd.AdminMode || cd.UserID != 0) {
+	if cd.HasGrant(common.SectionNews, common.ItemPost, common.ActionEdit, postID) && (cd.AdminMode || cd.UserID != 0) {
 		return true
 	}
 	return false

--- a/handlers/news/newsEditPostTask.go
+++ b/handlers/news/newsEditPostTask.go
@@ -47,7 +47,7 @@ func (EditTask) Action(w http.ResponseWriter, r *http.Request) any {
 	postId, _ := strconv.Atoi(vars["news"])
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	if !cd.HasGrant("news", "post", "edit", int32(postId)) {
+	if !cd.HasGrant(common.SectionNews, common.ItemPost, common.ActionEdit, int32(postId)) {
 		r.URL.RawQuery = "error=" + url.QueryEscape("Forbidden")
 		handlers.TaskErrorAcknowledgementPage(w, r)
 		return nil

--- a/handlers/news/newsNewPostTask.go
+++ b/handlers/news/newsNewPostTask.go
@@ -76,7 +76,7 @@ func (NewPostTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	if cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData); !cd.HasGrant("news", "post", "post", 0) {
+	if cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData); !cd.HasGrant(common.SectionNews, common.ItemPost, common.ActionPost, 0) {
 		r.URL.RawQuery = "error=" + url.QueryEscape("Forbidden")
 		handlers.TaskErrorAcknowledgementPage(w, r)
 		return nil

--- a/handlers/news/newsPage.go
+++ b/handlers/news/newsPage.go
@@ -30,14 +30,14 @@ func CustomNewsIndex(data *common.CoreData, r *http.Request) {
 		Name: "RSS Feed",
 		Link: "/news.rss",
 	})
-	userHasAdmin := data.HasGrant("news", "post", "edit", 0) && data.AdminMode
+	userHasAdmin := data.HasGrant(common.SectionNews, common.ItemPost, common.ActionEdit, 0) && data.AdminMode
 	if userHasAdmin {
 		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
 			Name: "User Roles",
 			Link: "/admin/news/users/roles",
 		})
 	}
-	userHasWriter := data.HasGrant("news", "post", "post", 0)
+	userHasWriter := data.HasGrant(common.SectionNews, common.ItemPost, common.ActionPost, 0)
 	if userHasWriter || userHasAdmin {
 		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
 			Name: "Add News",

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -78,7 +78,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	if !cd.HasGrant("news", "post", "view", post.Idsitenews) {
+	if !cd.HasGrant(common.SectionNews, common.ItemPost, common.ActionView, post.Idsitenews) {
 		if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{}); err != nil {
 			log.Printf("render no access page: %v", err)
 		}

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -95,7 +95,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	if !cd.HasGrant("news", "post", "reply", int32(pid)) {
+	if !cd.HasGrant(common.SectionNews, common.ItemPost, common.ActionReply, int32(pid)) {
 		handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		return nil
 	}

--- a/handlers/news/newsRssPage.go
+++ b/handlers/news/newsRssPage.go
@@ -33,7 +33,7 @@ func NewsRssPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, row := range posts {
-		if !cd.HasGrant("news", "post", "see", row.Idsitenews) {
+		if !cd.HasGrant(common.SectionNews, common.ItemPost, common.ActionSee, row.Idsitenews) {
 			continue
 		}
 		text := row.News.String

--- a/handlers/news/searchResultNewsActionPage.go
+++ b/handlers/news/searchResultNewsActionPage.go
@@ -27,7 +27,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	if !common.CanSearch(cd, "news") {
+	if !common.CanSearch(cd, common.SectionNews) {
 		handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		return
 	}

--- a/handlers/search/permissions_test.go
+++ b/handlers/search/permissions_test.go
@@ -24,20 +24,20 @@ func TestCanSearch(t *testing.T) {
 	// No grants
 	mock.ExpectQuery("SELECT 1 FROM grants").WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery("SELECT 1 FROM grants").WillReturnError(sql.ErrNoRows)
-	if common.CanSearch(cd, "news") {
+	if common.CanSearch(cd, common.SectionNews) {
 		t.Fatalf("expected false")
 	}
 
 	// Global grant only
 	mock.ExpectQuery("SELECT 1 FROM grants").WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery("SELECT 1 FROM grants").WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
-	if !common.CanSearch(cd, "news") {
+	if !common.CanSearch(cd, common.SectionNews) {
 		t.Fatalf("expected true with global grant")
 	}
 
 	// Grant present for section
 	mock.ExpectQuery("SELECT 1 FROM grants").WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
-	if !common.CanSearch(cd, "news") {
+	if !common.CanSearch(cd, common.SectionNews) {
 		t.Fatalf("expected true with section grant")
 	}
 

--- a/handlers/search/searchResultBlogsActionPage.go
+++ b/handlers/search/searchResultBlogsActionPage.go
@@ -36,7 +36,7 @@ func (SearchBlogsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	if !common.CanSearch(cd, "blogs") {
+	if !common.CanSearch(cd, common.SectionBlogs) {
 		handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		return nil
 	}

--- a/handlers/search/searchResultForumActionPage.go
+++ b/handlers/search/searchResultForumActionPage.go
@@ -32,7 +32,7 @@ func (SearchForumTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	if !common.CanSearch(cd, "forum") {
+	if !common.CanSearch(cd, common.SectionForum) {
 		handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		return nil
 	}

--- a/handlers/search/searchResultLinkerActionPage.go
+++ b/handlers/search/searchResultLinkerActionPage.go
@@ -37,7 +37,7 @@ func (SearchLinkerTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	if !common.CanSearch(cd, "linker") {
+	if !common.CanSearch(cd, common.SectionLinker) {
 		handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		return nil
 	}

--- a/handlers/search/searchResultWritingsActionPage.go
+++ b/handlers/search/searchResultWritingsActionPage.go
@@ -37,7 +37,7 @@ func (SearchWritingsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	if !common.CanSearch(cd, "writing") {
+	if !common.CanSearch(cd, common.SectionWriting) {
 		handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		return nil
 	}

--- a/handlers/writings/writingsAdminCategoryGrantsPage.go
+++ b/handlers/writings/writingsAdminCategoryGrantsPage.go
@@ -25,7 +25,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 		CategoryID int32
 		Grants     []GrantInfo
 		Roles      []*db.Role
-		Actions    []string
+		Actions    []common.Action
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
@@ -37,7 +37,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := Data{CoreData: cd, CategoryID: int32(cid), Actions: []string{"see", "view", "post", "edit"}}
+	data := Data{CoreData: cd, CategoryID: int32(cid), Actions: []common.Action{common.ActionSee, common.ActionView, common.ActionPost, common.ActionEdit}}
 	if roles, err := cd.AllRoles(); err == nil {
 		data.Roles = roles
 	}
@@ -49,7 +49,7 @@ func AdminCategoryGrantsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, g := range grants {
-		if g.Section == "writing" && g.Item.Valid && g.Item.String == "category" && g.ItemID.Valid && g.ItemID.Int32 == int32(cid) {
+		if common.Section(g.Section) == common.SectionWriting && g.Item.Valid && common.Item(g.Item.String) == common.ItemCategory && g.ItemID.Valid && g.ItemID.Int32 == int32(cid) {
 			gi := GrantInfo{Grant: g}
 			if g.UserID.Valid {
 				if u, err := queries.SystemGetUserByID(r.Context(), g.UserID.Int32); err == nil {

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -44,7 +44,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
-	if writing == nil || !cd.HasGrant("writing", "article", "view", writing.Idwriting) {
+	if writing == nil || !cd.HasGrant(common.SectionWriting, common.ItemArticle, common.ActionView, writing.Idwriting) {
 		if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{}); err != nil {
 			log.Printf("render no access page: %v", err)
 		}

--- a/handlers/writings/writingsWriterPage.go
+++ b/handlers/writings/writingsWriterPage.go
@@ -56,7 +56,7 @@ func WriterPage(w http.ResponseWriter, r *http.Request) {
 		IsOffset: offset != 0,
 	}
 	for _, row := range rows {
-		if !data.CoreData.HasGrant("writing", "article", "see", row.Idwriting) {
+		if !data.CoreData.HasGrant(common.SectionWriting, common.ItemArticle, common.ActionSee, row.Idwriting) {
 			continue
 		}
 		data.Abstracts = append(data.Abstracts, row)

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -74,6 +74,8 @@ Sections may introduce extra actions but these form the base vocabulary used by
 the templates and permission checks.
 The grant editor uses the mapping defined in `handlers/admin/role_grants.go`
 to list available actions for each section and item type.
+Section, item, and action identifiers are centralised as typed constants in
+`core/common/permissions.go` and should be referenced instead of raw strings.
 Announcements use these actions to control which news posts appear globally. Administrator pages call `AdminPromoteAnnouncement` and `AdminDemoteAnnouncement` while `GetActiveAnnouncementWithNewsForUser` retrieves the visible announcement.
 
 Each section may define additional actions, but these are the core verbs used by the system.


### PR DESCRIPTION
## Summary
- define typed Section, Item, and Action constants
- replace string literals in grant mapping and permission checks
- document centralized permission constants
- restructure GrantActionMap into a nested map keyed by section and item

## Testing
- `go vet ./...` *(fails: cd.SetBlogListParams undefined)*
- `golangci-lint run handlers/admin/... core/common/...` *(fails: cd.SetBlogListParams undefined)*
- `go test ./...` *(fails: cd.SetBlogListParams undefined; TestPageTemplatesRender/blogsPage; TestImageRouteInvalidID)*

------
https://chatgpt.com/codex/tasks/task_e_6891ef67be08832f9104c04fe1660635