### PR TITLE
Fix tests and vet by updating blog template and image ID validation

### DIFF
--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -346,7 +346,7 @@ func TestBlogListForSelectedAuthorLazy(t *testing.T) {
 	ctx := context.Background()
 	cd := common.NewCoreData(ctx, queries, cfg, common.WithUserRoles([]string{"administrator"}))
 	cd.UserID = 1
-	cd.SetBlogListParams(1, 0)
+	cd.SetCurrentProfileUserID(1)
 
 	if _, err := cd.BlogListForSelectedAuthor(); err != nil {
 		t.Fatalf("BlogListForSelectedAuthor: %v", err)

--- a/core/templates/site/blogs/page.gohtml
+++ b/core/templates/site/blogs/page.gohtml
@@ -1,7 +1,7 @@
 {{ define "blogsPage" }}
     {{ template "head" $ }}
     {{ $rows := "" }}
-    {{ if cd.BlogListUID }}
+    {{ if cd.CurrentProfileUserID }}
         {{ $rows = cd.BlogListForSelectedAuthor }}
     {{ else }}
         {{ $rows = cd.BlogList }}

--- a/handlers/images/routes.go
+++ b/handlers/images/routes.go
@@ -37,6 +37,11 @@ func verifyMiddleware(prefix string) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			id := mux.Vars(r)["id"]
+			if !validID(id) {
+				w.WriteHeader(http.StatusForbidden)
+				handlers.RenderErrorPage(w, r, fmt.Errorf("invalid id"))
+				return
+			}
 			ts := r.URL.Query().Get("ts")
 			sig := r.URL.Query().Get("sig")
 			data := id


### PR DESCRIPTION
## Summary
- update blog tests to use SetCurrentProfileUserID
- switch blog template to CurrentProfileUserID check
- validate image IDs in middleware to return 403 on invalid ids

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891f575d518832f9eba5e199c3d4dba