### PR TITLE
Fix image board page data loading

### DIFF
--- a/core/templates/site/boardPosts.gohtml
+++ b/core/templates/site/boardPosts.gohtml
@@ -1,11 +1,13 @@
 {{ define "boardPosts" }}
-    {{- if .Posts }}
+    {{ $cd := cd }}
+    {{ $posts := $cd.SelectedBoardPosts }}
+    {{- if $posts }}
         <font size="4">Pictures:</font><br>
-        {{- range .Posts }}
+        {{- range $posts }}
             <table>
                 <tr>
                     <th><a href="{{ .Fullimage.String }}" target="_BLANK"><img src="{{ .Thumbnail.String }}"></a>
-                    <td>{{ .Description.String }}<hr>{{ .Username.String }} - Posted: {{ .Posted.Time }} - [<a href="/imagebbs/board/{{ $.BoardNumber }}/thread/{{ .ForumthreadID }}">{{ .Comments.Int32 }} COMMENTS</a>]
+                    <td>{{ .Description.String }}<hr>{{ .Username.String }} - Posted: {{ .Posted.Time }} - [<a href="/imagebbs/board/{{ $cd.SelectedBoardID }}/thread/{{ .ForumthreadID }}">{{ .Comments.Int32 }} COMMENTS</a>]
             </table><br>
         {{- end }}
     {{- else }}

--- a/core/templates/site/subBoards.gohtml
+++ b/core/templates/site/subBoards.gohtml
@@ -1,8 +1,10 @@
 {{ define "subBoards" }}
-    {{- if .Boards }}
-        <font size="4">{{ if .IsSubBoard }}Sub-{{ end }}Boards:</font><br>
+    {{ $cd := cd }}
+    {{ $boards := $cd.SelectedBoardSubBoards }}
+    {{- if $boards }}
+        <font size="4">{{ if gt ($cd.SelectedBoardID) 0 }}Sub-{{ end }}Boards:</font><br>
         <table>
-            {{- range .Boards }}
+            {{- range $boards }}
                 <tr>
                     <th><a href="/imagebbs/board/{{ .Idimageboard }}">{{ .Title.String }}</a>
                     <td>{{ .Description.String }}

--- a/handlers/blogs/blogsCommentPage_replyable_test.go
+++ b/handlers/blogs/blogsCommentPage_replyable_test.go
@@ -32,7 +32,7 @@ func setupCommentRequest(t *testing.T, queries db.Querier, store *sessions.Cooki
 		req.AddCookie(c)
 	}
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithSession(sess))
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithSession(sess), common.WithUserRoles([]string{"administrator"}))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	return req, sess

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -53,29 +53,18 @@ func (UploadImageTask) IndexData(data map[string]any) []searchworker.IndexEventD
 var _ searchworker.IndexedTask = UploadImageTask{}
 
 func BoardPage(w http.ResponseWriter, r *http.Request) {
-	type Data struct {
-		IsSubBoard  bool
-		BoardNumber int
-	}
-
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	vars := mux.Vars(r)
-	bidStr := vars["board"]
-	if bidStr == "" {
-		bidStr = vars["boardno"]
-	}
-	bid, _ := strconv.Atoi(bidStr)
+	cd.LoadSelectionsFromRequest(r)
+	bid := cd.SelectedBoardID()
 
-	data := Data{IsSubBoard: bid != 0, BoardNumber: bid}
-
-	if !cd.HasGrant("imagebbs", "board", "view", int32(bid)) {
+	if !cd.HasGrant("imagebbs", "board", "view", bid) {
 		_ = templates.GetCompiledSiteTemplates(cd.Funcs(r)).ExecuteTemplate(w, "noAccessPage.gohtml", struct{}{})
 		return
 	}
 
 	cd.PageTitle = fmt.Sprintf("Board %d", bid)
 
-	handlers.TemplateHandler(w, r, "boardPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "boardPage.gohtml", struct{}{})
 }
 
 func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/imagebbs/imagebbsBoardPage_test.go
+++ b/handlers/imagebbs/imagebbsBoardPage_test.go
@@ -1,0 +1,59 @@
+package imagebbs
+
+import (
+	"context"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestBoardPageRendersSubBoards(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	boardRows := sqlmock.NewRows([]string{"idimageboard", "imageboard_idimageboard", "title", "description", "approval_required"}).
+		AddRow(4, 3, "child", "sub", false)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idimageboard, b.imageboard_idimageboard, b.title")).
+		WithArgs(int32(0), int32(3), sqlmock.AnyArg(), int32(200), int32(0)).
+		WillReturnRows(boardRows)
+
+	postRows := sqlmock.NewRows([]string{"idimagepost", "forumthread_id", "users_idusers", "imageboard_idimageboard", "posted", "description", "thumbnail", "fullimage", "file_size", "approved", "deleted_at", "last_index", "username", "comments"}).
+		AddRow(1, 1, 1, 3, time.Unix(0, 0), "desc", "/t", "/f", 10, true, nil, nil, "alice", 0)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT i.idimagepost, i.forumthread_id, i.users_idusers")).
+		WithArgs(int32(0), int32(3), sqlmock.AnyArg(), int32(200), int32(0)).
+		WillReturnRows(postRows)
+
+	req := httptest.NewRequest("GET", "/imagebbs/board/3", nil)
+	req = mux.SetURLVars(req, map[string]string{"board": "3"})
+	q := db.New(conn)
+	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	BoardPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "Sub-Boards") {
+		t.Fatalf("expected sub boards in output: %s", body)
+	}
+	if !strings.Contains(body, "Pictures:") {
+		t.Fatalf("expected pictures in output: %s", body)
+	}
+}


### PR DESCRIPTION
## Summary
- load sub-board and post data in image board page handler
- add test ensuring board page renders sub-boards and images

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./handlers/imagebbs -run TestBoardPageRendersSubBoards -count=1`
- `go test ./handlers/blogs -run TestCommentPageLockedThreadDisablesReply -count=1`
- `go test ./handlers/blogs -run TestCommentPageUnlockedThreadShowsReply -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891fd783ecc832f9599a629dad77377