### PR TITLE
Fix writing search template for correct IDs

### DIFF
--- a/core/templates/site/search/resultWritingsActionPage.gohtml
+++ b/core/templates/site/search/resultWritingsActionPage.gohtml
@@ -7,7 +7,7 @@
     {{- else }}
         <ul>
         {{- range $i, $result := .Writings }}
-            <li>{{ $i }}: <a href="/writings/article/{{$result.Idwritings}}">{{ $result.Title.String }}</a></li>
+            <li>{{ $i }}: <a href="/writings/article/{{$result.Idwriting}}">{{ $result.Title.String }}</a></li>
         {{- end }}
         </ul>
     {{ end }}


### PR DESCRIPTION
## Summary
- fix search results template to use Idwriting field

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: handlers/images/routes_test.go:7:2: "strconv" imported and not used)*
- `golangci-lint run`
- `go test ./...` *(fails: TestCommentPageLockedThreadDisablesReply, TestCommentPageUnlockedThreadShowsReply, TestValidID, TestCommentsPageAllowsGlobalViewGrant)*

------
https://chatgpt.com/codex/tasks/task_e_689205253fc8832facee14b87829fc12