### PR TITLE
Use CSS classes for a4code block styling

### DIFF
--- a/a4code/a4code2html/a4code2html.go
+++ b/a4code/a4code2html/a4code2html.go
@@ -325,7 +325,7 @@ func (a *A4code2html) acommReader(r *bufio.Reader, w io.Writer) error {
 		switch a.CodeType {
 		case CTTableOfContents, CTTagStrip, CTWordsOnly:
 		default:
-			if _, err := io.WriteString(w, "<table width=90% align=center bgcolor=lightblue><tr><th>Code: <tr><td><pre>"); err != nil {
+			if _, err := io.WriteString(w, "<table class=\"a4code-block a4code-code\"><tr><th>Code: <tr><td><pre>"); err != nil {
 				return err
 			}
 			if err := a.directOutputReader(r, w, "[/code]", "code]"); err != nil {
@@ -343,7 +343,7 @@ func (a *A4code2html) acommReader(r *bufio.Reader, w io.Writer) error {
 			if err != nil && err != io.EOF {
 				return err
 			}
-			if _, err := io.WriteString(w, fmt.Sprintf("<table width=90%% align=center bgcolor=lightgreen><tr><th>Quote of %s: <tr><td>", name)); err != nil {
+			if _, err := io.WriteString(w, fmt.Sprintf("<table class=\"a4code-block a4code-quoteof\"><tr><th>Quote of %s: <tr><td>", name)); err != nil {
 				return err
 			}
 			a.stack = append(a.stack, "</table>")
@@ -352,7 +352,7 @@ func (a *A4code2html) acommReader(r *bufio.Reader, w io.Writer) error {
 		switch a.CodeType {
 		case CTTableOfContents, CTTagStrip, CTWordsOnly:
 		default:
-			if _, err := io.WriteString(w, "<table width=90% align=center bgcolor=lightgreen><tr><th>Quote: <tr><td>"); err != nil {
+			if _, err := io.WriteString(w, "<table class=\"a4code-block a4code-quote\"><tr><th>Quote: <tr><td>"); err != nil {
 				return err
 			}
 			a.stack = append(a.stack, "</table>")
@@ -370,7 +370,7 @@ func (a *A4code2html) acommReader(r *bufio.Reader, w io.Writer) error {
 		switch a.CodeType {
 		case CTTableOfContents, CTTagStrip, CTWordsOnly:
 		default:
-			if _, err := io.WriteString(w, "<table width=90% align=center><tr><td>"); err != nil {
+			if _, err := io.WriteString(w, "<table class=\"a4code-block a4code-indent\"><tr><td>"); err != nil {
 				return err
 			}
 			a.stack = append(a.stack, "</table>")

--- a/a4code/a4code2html/a4code2html_test.go
+++ b/a4code/a4code2html/a4code2html_test.go
@@ -128,7 +128,7 @@ func TestCodeSlashClose(t *testing.T) {
 	c := New()
 	c.SetInput("[code]foo[/code]")
 	got, _ := io.ReadAll(c.Process())
-	want := "<table width=90% align=center bgcolor=lightblue><tr><th>Code: <tr><td><pre>]foo</pre></table>"
+	want := "<table class=\"a4code-block a4code-code\"><tr><th>Code: <tr><td><pre>]foo</pre></table>"
 	if string(got) != want {
 		t.Errorf("got %q want %q", string(got), want)
 	}

--- a/a4code/ast.go
+++ b/a4code/ast.go
@@ -245,7 +245,7 @@ type Code struct{ Value string }
 func (*Code) isNode() {}
 
 func (c *Code) html(w io.Writer) {
-	io.WriteString(w, "<table width=90% align=center bgcolor=lightblue><tr><th>Code: <tr><td><pre>")
+	io.WriteString(w, "<table class=\"a4code-block a4code-code\"><tr><th>Code: <tr><td><pre>")
 	io.WriteString(w, htmlEscape(c.Value))
 	io.WriteString(w, "</pre></table>")
 }
@@ -263,7 +263,7 @@ func (*Quote) isNode()                {}
 func (q *Quote) childrenPtr() *[]Node { return &q.Children }
 
 func (q *Quote) html(w io.Writer) {
-	io.WriteString(w, "<table width=90% align=center bgcolor=lightgreen><tr><th>Quote: <tr><td>")
+	io.WriteString(w, "<table class=\"a4code-block a4code-quote\"><tr><th>Quote: <tr><td>")
 	for _, c := range q.Children {
 		c.html(w)
 	}
@@ -288,7 +288,7 @@ func (*QuoteOf) isNode()                {}
 func (q *QuoteOf) childrenPtr() *[]Node { return &q.Children }
 
 func (q *QuoteOf) html(w io.Writer) {
-	io.WriteString(w, "<table width=90% align=center bgcolor=lightgreen><tr><th>Quote of ")
+	io.WriteString(w, "<table class=\"a4code-block a4code-quoteof\"><tr><th>Quote of ")
 	io.WriteString(w, htmlEscape(q.Name))
 	io.WriteString(w, ": <tr><td>")
 	for _, c := range q.Children {
@@ -335,7 +335,7 @@ func (*Indent) isNode()                {}
 func (i *Indent) childrenPtr() *[]Node { return &i.Children }
 
 func (i *Indent) html(w io.Writer) {
-	io.WriteString(w, "<table width=90% align=center><tr><td>")
+	io.WriteString(w, "<table class=\"a4code-block a4code-indent\"><tr><td>")
 	for _, c := range i.Children {
 		c.html(w)
 	}

--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -221,3 +221,19 @@ tr.unsupported td {
 .hidden {
         display: none;
 }
+
+/* A4code block styling */
+.a4code-block {
+        width: 90%;
+        margin: 0.5em auto;
+}
+
+.a4code-code {
+        background-color: lightblue;
+}
+
+.a4code-quote,
+.a4code-quoteof {
+        background-color: lightgreen;
+}
+


### PR DESCRIPTION
## Summary
- Emit class-based table markup for `a4code` code, quote, quote-of and indent blocks
- Move width, alignment and color styling into `.a4code-*` CSS classes for consistent spacing

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestCommentPageLockedThreadDisablesReply, TestCommentPageUnlockedThreadShowsReply)*

------
https://chatgpt.com/codex/tasks/task_e_6891fce7374c832fa9cb0ca82f2c152f