### PR TITLE
Fix news reply link

### DIFF
--- a/core/templates/site/news/post.gohtml
+++ b/core/templates/site/news/post.gohtml
@@ -8,7 +8,7 @@
             -
             [<a href="/news/news/{{ .Idsitenews }}">{{ .Comments.Int32 }} COMMENTS</a>]
             {{ if .ShowReply }}
-                [<a href="?reply={{ .Idsitenews }}#reply">REPLY</a>]
+                [<a href="/news/news/{{ .Idsitenews }}#reply">REPLY</a>]
             {{ end }}
 
             {{ if .ShowEdit }}


### PR DESCRIPTION
## Summary
- fix news reply links so they navigate to the post instead of the site root

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: handlers/images/routes_test.go:7:2: "strconv" imported and not used)*
- `golangci-lint run` *(fails: handlers/images/routes_test.go:7:2: "strconv" imported and not used)*
- `go test ./handlers/blogs` *(fails: TestCommentPageLockedThreadDisablesReply)*
- `go test ./handlers/images` *(fails: build failed: unused imports)*
- `go test ./handlers/linker` *(fails: TestCommentsPageAllowsGlobalViewGrant)*

------
https://chatgpt.com/codex/tasks/task_e_689204658d48832fb54f3eeb2aa2776a