### PR TITLE
Load sub boards from CoreData

### DIFF
--- a/core/templates/site/subBoards.gohtml
+++ b/core/templates/site/subBoards.gohtml
@@ -1,6 +1,6 @@
 {{ define "subBoards" }}
     {{ $cd := cd }}
-    {{ $boards := $cd.SelectedBoardSubBoards }}
+    {{ $boards := $cd.SubImageBoards $cd.SelectedBoardID }}
     {{- if $boards }}
         <font size="4">{{ if gt ($cd.SelectedBoardID) 0 }}Sub-{{ end }}Boards:</font><br>
         <table>

--- a/handlers/imagebbs/imagebbsPage.go
+++ b/handlers/imagebbs/imagebbsPage.go
@@ -1,42 +1,17 @@
 package imagebbs
 
 import (
-	"fmt"
-	"github.com/arran4/goa4web/core/consts"
-	"log"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 )
 
 func Page(w http.ResponseWriter, r *http.Request) {
-	type Data struct {
-		*common.CoreData
-		Boards      []*db.Imageboard
-		IsSubBoard  bool
-		BoardNumber int
-	}
-
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Image Board"
-	data := Data{
-		CoreData:    cd,
-		IsSubBoard:  false,
-		BoardNumber: 0,
-	}
-
-	boards, err := data.CoreData.SubImageBoards(0)
-	if err != nil {
-		log.Printf("imageboards: %v", err)
-		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
-		return
-	}
-
-	data.Boards = boards
-
-	handlers.TemplateHandler(w, r, "imagebbsPage", data)
+	handlers.TemplateHandler(w, r, "imagebbsPage", struct{}{})
 }
 
 func CustomImageBBSIndex(data *common.CoreData, r *http.Request) {

--- a/handlers/images/routes_test.go
+++ b/handlers/images/routes_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -12,9 +11,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
-	imagesign "github.com/arran4/goa4web/internal/images"
 	"github.com/arran4/goa4web/internal/navigation"
-	"github.com/arran4/goa4web/internal/sign"
 )
 
 func TestValidID(t *testing.T) {


### PR DESCRIPTION
## Summary
- Retrieve image board sublists directly from CoreData, avoiding missing field errors
- Simplify image board index handler to rely solely on CoreData
- Clean unused imports from image routes test to satisfy vet

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: handlers/blogs, handlers/images, handlers/linker)*

------
https://chatgpt.com/codex/tasks/task_e_689209ee3688832f9255a6b6433089e7