### PR TITLE
Remove recursive role grant union

### DIFF
--- a/handlers/images/routes_test.go
+++ b/handlers/images/routes_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -12,9 +11,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
-	imagesign "github.com/arran4/goa4web/internal/images"
 	"github.com/arran4/goa4web/internal/navigation"
-	"github.com/arran4/goa4web/internal/sign"
 )
 
 func TestValidID(t *testing.T) {

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -18,8 +18,8 @@ LIMIT 1;
 UPDATE site_announcements SET active = ? WHERE id = ?;
 
 -- name: GetActiveAnnouncementWithNewsForLister :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT a.id, n.idsiteNews, n.news
 FROM site_announcements a

--- a/internal/db/queries-announcements.sql.go
+++ b/internal/db/queries-announcements.sql.go
@@ -92,8 +92,8 @@ func (q *Queries) AdminSetAnnouncementActive(ctx context.Context, arg AdminSetAn
 }
 
 const getActiveAnnouncementWithNewsForLister = `-- name: GetActiveAnnouncementWithNewsForLister :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT a.id, n.idsiteNews, n.news
 FROM site_announcements a

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -43,8 +43,8 @@ FROM blogs
 WHERE idblogs = ?;
 
 -- name: ListBlogEntriesForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = sqlc.arg(lister_id) AS is_owner
@@ -74,8 +74,8 @@ ORDER BY b.written DESC
 LIMIT ? OFFSET ?;
 
 -- name: ListBlogEntriesByAuthorForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = sqlc.arg(lister_id) AS is_owner
@@ -109,8 +109,8 @@ ORDER BY b.written DESC
 LIMIT ? OFFSET ?;
 
 -- name: ListBlogEntriesByIDsForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written
 FROM blogs b
@@ -141,8 +141,8 @@ ORDER BY b.written DESC
 LIMIT ? OFFSET ?;
 
 -- name: GetBlogEntryForListerByID :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = sqlc.arg(lister_id) AS is_owner
@@ -175,8 +175,8 @@ WHERE b.idblogs = sqlc.arg(id)
 LIMIT 1;
 
 -- name: ListBlogIDsBySearchWordFirstForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT DISTINCT cs.blog_id
 FROM blogs_search cs
@@ -207,8 +207,8 @@ WHERE swl.word = ?
   );
 
 -- name: ListBlogIDsBySearchWordNextForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT DISTINCT cs.blog_id
 FROM blogs_search cs
@@ -242,8 +242,8 @@ WHERE swl.word = ?
 
 
 -- name: ListBloggersForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT u.username, COUNT(b.idblogs) AS count
 FROM blogs b
@@ -275,8 +275,8 @@ ORDER BY u.username
 LIMIT ? OFFSET ?;
 
 -- name: ListBloggersSearchForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT u.username, COUNT(b.idblogs) AS count
 FROM blogs b

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -104,8 +104,8 @@ func (q *Queries) CreateBlogEntryForWriter(ctx context.Context, arg CreateBlogEn
 }
 
 const getBlogEntryForListerByID = `-- name: GetBlogEntryForListerByID :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = ? AS is_owner
@@ -181,8 +181,8 @@ func (q *Queries) GetBlogEntryForListerByID(ctx context.Context, arg GetBlogEntr
 }
 
 const listBlogEntriesByAuthorForLister = `-- name: ListBlogEntriesByAuthorForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = ? AS is_owner
@@ -280,8 +280,8 @@ func (q *Queries) ListBlogEntriesByAuthorForLister(ctx context.Context, arg List
 }
 
 const listBlogEntriesByIDsForLister = `-- name: ListBlogEntriesByIDsForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written
 FROM blogs b
@@ -376,8 +376,8 @@ func (q *Queries) ListBlogEntriesByIDsForLister(ctx context.Context, arg ListBlo
 }
 
 const listBlogEntriesForLister = `-- name: ListBlogEntriesForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0),
        b.users_idusers = ? AS is_owner
@@ -468,8 +468,8 @@ func (q *Queries) ListBlogEntriesForLister(ctx context.Context, arg ListBlogEntr
 }
 
 const listBlogIDsBySearchWordFirstForLister = `-- name: ListBlogIDsBySearchWordFirstForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT DISTINCT cs.blog_id
 FROM blogs_search cs
@@ -536,8 +536,8 @@ func (q *Queries) ListBlogIDsBySearchWordFirstForLister(ctx context.Context, arg
 }
 
 const listBlogIDsBySearchWordNextForLister = `-- name: ListBlogIDsBySearchWordNextForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT DISTINCT cs.blog_id
 FROM blogs_search cs
@@ -615,8 +615,8 @@ func (q *Queries) ListBlogIDsBySearchWordNextForLister(ctx context.Context, arg 
 }
 
 const listBloggersForLister = `-- name: ListBloggersForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT u.username, COUNT(b.idblogs) AS count
 FROM blogs b
@@ -691,8 +691,8 @@ func (q *Queries) ListBloggersForLister(ctx context.Context, arg ListBloggersFor
 }
 
 const listBloggersSearchForLister = `-- name: ListBloggersSearchForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT u.username, COUNT(b.idblogs) AS count
 FROM blogs b

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -1,6 +1,6 @@
 -- name: GetCommentByIdForUser :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT c.*, pu.Username,
        c.users_idusers = sqlc.arg(viewer_id) AS is_owner
@@ -58,8 +58,8 @@ WHERE c.Idcomments=?;
 
 
 -- name: GetCommentsByIdsForUserWithThreadInfo :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT c.*, pu.username AS posterusername,
        c.users_idusers = sqlc.arg(viewer_id) AS is_owner,
@@ -112,8 +112,8 @@ WHERE EXISTS (
 );
 
 -- name: GetCommentsByThreadIdForUser :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT c.*, pu.username AS posterusername,
        c.users_idusers = sqlc.arg(viewer_id) AS is_owner

--- a/internal/db/queries-comments.sql.go
+++ b/internal/db/queries-comments.sql.go
@@ -223,8 +223,8 @@ func (q *Queries) GetCommentById(ctx context.Context, idcomments int32) (*Commen
 }
 
 const getCommentByIdForUser = `-- name: GetCommentByIdForUser :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT c.idcomments, c.forumthread_id, c.users_idusers, c.language_idlanguage, c.written, c.text, c.deleted_at, c.last_index, pu.Username,
        c.users_idusers = ? AS is_owner
@@ -303,8 +303,8 @@ func (q *Queries) GetCommentByIdForUser(ctx context.Context, arg GetCommentByIdF
 }
 
 const getCommentsByIdsForUserWithThreadInfo = `-- name: GetCommentsByIdsForUserWithThreadInfo :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT c.idcomments, c.forumthread_id, c.users_idusers, c.language_idlanguage, c.written, c.text, c.deleted_at, c.last_index, pu.username AS posterusername,
        c.users_idusers = ? AS is_owner,
@@ -419,8 +419,8 @@ func (q *Queries) GetCommentsByIdsForUserWithThreadInfo(ctx context.Context, arg
 }
 
 const getCommentsByThreadIdForUser = `-- name: GetCommentsByThreadIdForUser :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT c.idcomments, c.forumthread_id, c.users_idusers, c.language_idlanguage, c.written, c.text, c.deleted_at, c.last_index, pu.username AS posterusername,
        c.users_idusers = ? AS is_owner

--- a/internal/db/queries-faq.sql
+++ b/internal/db/queries-faq.sql
@@ -4,8 +4,8 @@ FROM faq
 WHERE faqCategories_idfaqCategories = '0' OR answer IS NULL;
 
 -- name: GetFAQAnsweredQuestions :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT idfaq, faqCategories_idfaqCategories, language_idlanguage, users_idusers, answer, question
 FROM faq
@@ -99,8 +99,8 @@ SELECT *
 FROM faq_categories;
 
 -- name: GetAllAnsweredFAQWithFAQCategoriesForUser :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT c.idfaqCategories, c.name, f.idfaq, f.faqCategories_idfaqCategories, f.language_idlanguage, f.users_idusers, f.answer, f.question
 FROM faq f

--- a/internal/db/queries-faq.sql.go
+++ b/internal/db/queries-faq.sql.go
@@ -113,8 +113,8 @@ func (q *Queries) CreateFAQQuestionForWriter(ctx context.Context, arg CreateFAQQ
 }
 
 const getAllAnsweredFAQWithFAQCategoriesForUser = `-- name: GetAllAnsweredFAQWithFAQCategoriesForUser :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT c.idfaqCategories, c.name, f.idfaq, f.faqCategories_idfaqCategories, f.language_idlanguage, f.users_idusers, f.answer, f.question
 FROM faq f
@@ -263,8 +263,8 @@ func (q *Queries) GetAllFAQQuestions(ctx context.Context) ([]*Faq, error) {
 }
 
 const getFAQAnsweredQuestions = `-- name: GetFAQAnsweredQuestions :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT idfaq, faqCategories_idfaqCategories, language_idlanguage, users_idusers, answer, question
 FROM faq

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -18,12 +18,8 @@ GROUP BY t.idforumtopic;
 UPDATE forumtopic SET title = ?, description = ?, forumcategory_idforumcategory = ? WHERE idforumtopic = ?;
 
 -- name: GetAllForumTopicsByCategoryIdForUserWithLastPosterName :many
-WITH role_ids(id) AS (
-    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
-    UNION
-    SELECT r2.id FROM role_ids ri
-    JOIN grants g ON g.role_id = ri.id AND g.section='role' AND g.active = 1
-    JOIN roles r2 ON r2.name = g.action
+WITH role_ids AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT t.*, lu.username AS LastPosterUsername
 FROM forumtopic t
@@ -42,12 +38,8 @@ WHERE t.forumcategory_idforumcategory = sqlc.arg(category_id)
 ORDER BY t.lastaddition DESC;
 
 -- name: GetAllForumTopicsForUser :many
-WITH role_ids(id) AS (
-    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
-    UNION
-    SELECT r2.id FROM role_ids ri
-    JOIN grants g ON g.role_id = ri.id AND g.section='role' AND g.active = 1
-    JOIN roles r2 ON r2.name = g.action
+WITH role_ids AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT t.*, lu.username AS LastPosterUsername
 FROM forumtopic t
@@ -65,12 +57,8 @@ WHERE EXISTS (
 ORDER BY t.lastaddition DESC;
 
 -- name: GetForumTopicByIdForUser :one
-WITH role_ids(id) AS (
-    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
-    UNION
-    SELECT r2.id FROM role_ids ri
-    JOIN grants g ON g.role_id = ri.id AND g.section='role' AND g.active = 1
-    JOIN roles r2 ON r2.name = g.action
+WITH role_ids AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT t.*, lu.username AS LastPosterUsername
 FROM forumtopic t
@@ -110,12 +98,8 @@ FROM forumtopic
 WHERE idforumtopic = ?;
 
 -- name: GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostText :many
-WITH role_ids(id) AS (
-    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
-    UNION
-    SELECT r2.id FROM role_ids ri
-    JOIN grants g ON g.role_id = ri.id AND g.section='role' AND g.active = 1
-    JOIN roles r2 ON r2.name = g.action
+WITH role_ids AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT th.*, lu.username AS lastposterusername, lu.idusers AS lastposterid, fcu.username as firstpostusername, fc.written as firstpostwritten, fc.text as firstposttext
 FROM forumthread th

--- a/internal/db/queries-forum.sql.go
+++ b/internal/db/queries-forum.sql.go
@@ -286,12 +286,8 @@ func (q *Queries) GetAllForumTopics(ctx context.Context) ([]*Forumtopic, error) 
 }
 
 const getAllForumTopicsByCategoryIdForUserWithLastPosterName = `-- name: GetAllForumTopicsByCategoryIdForUserWithLastPosterName :many
-WITH role_ids(id) AS (
-    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
-    UNION
-    SELECT r2.id FROM role_ids ri
-    JOIN grants g ON g.role_id = ri.id AND g.section='role' AND g.active = 1
-    JOIN roles r2 ON r2.name = g.action
+WITH role_ids AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.title, t.description, t.threads, t.comments, t.lastaddition, lu.username AS LastPosterUsername
 FROM forumtopic t
@@ -362,12 +358,8 @@ func (q *Queries) GetAllForumTopicsByCategoryIdForUserWithLastPosterName(ctx con
 }
 
 const getAllForumTopicsForUser = `-- name: GetAllForumTopicsForUser :many
-WITH role_ids(id) AS (
-    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
-    UNION
-    SELECT r2.id FROM role_ids ri
-    JOIN grants g ON g.role_id = ri.id AND g.section='role' AND g.active = 1
-    JOIN roles r2 ON r2.name = g.action
+WITH role_ids AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.title, t.description, t.threads, t.comments, t.lastaddition, lu.username AS LastPosterUsername
 FROM forumtopic t
@@ -452,12 +444,8 @@ func (q *Queries) GetForumCategoryById(ctx context.Context, idforumcategory int3
 }
 
 const getForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostText = `-- name: GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostText :many
-WITH role_ids(id) AS (
-    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
-    UNION
-    SELECT r2.id FROM role_ids ri
-    JOIN grants g ON g.role_id = ri.id AND g.section='role' AND g.active = 1
-    JOIN roles r2 ON r2.name = g.action
+WITH role_ids AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT th.idforumthread, th.firstpost, th.lastposter, th.forumtopic_idforumtopic, th.comments, th.lastaddition, th.locked, lu.username AS lastposterusername, lu.idusers AS lastposterid, fcu.username as firstpostusername, fc.written as firstpostwritten, fc.text as firstposttext
 FROM forumthread th
@@ -559,12 +547,8 @@ func (q *Queries) GetForumTopicById(ctx context.Context, idforumtopic int32) (*F
 }
 
 const getForumTopicByIdForUser = `-- name: GetForumTopicByIdForUser :one
-WITH role_ids(id) AS (
-    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
-    UNION
-    SELECT r2.id FROM role_ids ri
-    JOIN grants g ON g.role_id = ri.id AND g.section='role' AND g.active = 1
-    JOIN roles r2 ON r2.name = g.action
+WITH role_ids AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.title, t.description, t.threads, t.comments, t.lastaddition, lu.username AS LastPosterUsername
 FROM forumtopic t

--- a/internal/db/queries-imagebbs.sql
+++ b/internal/db/queries-imagebbs.sql
@@ -73,8 +73,8 @@ UPDATE imagepost SET approved = 1 WHERE idimagepost = ?;
 
 
 -- name: ListBoardsByParentIDForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT b.*
 FROM imageboard b
@@ -93,8 +93,8 @@ WHERE b.imageboard_idimageboard = sqlc.arg(parent_id)
 LIMIT ? OFFSET ?;
 
 -- name: ListBoardsForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT b.*
 FROM imageboard b
@@ -111,8 +111,8 @@ WHERE b.deleted_at IS NULL AND EXISTS (
 LIMIT ? OFFSET ?;
 
 -- name: ListImagePostsByPosterForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT i.*, u.username, th.comments
 FROM imagepost i
@@ -135,8 +135,8 @@ ORDER BY i.posted DESC
 LIMIT ? OFFSET ?;
 
 -- name: ListImagePostsByBoardForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT i.*, u.username, th.comments
 FROM imagepost i
@@ -158,8 +158,8 @@ WHERE i.imageboard_idimageboard = sqlc.arg(board_id)
 LIMIT ? OFFSET ?;
 
 -- name: GetImagePostByIDForLister :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT i.*, u.username, th.comments
 FROM imagepost i

--- a/internal/db/queries-imagebbs.sql.go
+++ b/internal/db/queries-imagebbs.sql.go
@@ -219,8 +219,8 @@ func (q *Queries) GetImageBoardById(ctx context.Context, idimageboard int32) (*I
 }
 
 const getImagePostByIDForLister = `-- name: GetImagePostByIDForLister :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT i.idimagepost, i.forumthread_id, i.users_idusers, i.imageboard_idimageboard, i.posted, i.description, i.thumbnail, i.fullimage, i.file_size, i.approved, i.deleted_at, i.last_index, u.username, th.comments
 FROM imagepost i
@@ -467,8 +467,8 @@ func (q *Queries) GetImagePostsByUserDescendingAll(ctx context.Context, arg GetI
 }
 
 const listBoardsByParentIDForLister = `-- name: ListBoardsByParentIDForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT b.idimageboard, b.imageboard_idimageboard, b.title, b.description, b.approval_required
 FROM imageboard b
@@ -531,8 +531,8 @@ func (q *Queries) ListBoardsByParentIDForLister(ctx context.Context, arg ListBoa
 }
 
 const listBoardsForLister = `-- name: ListBoardsForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT b.idimageboard, b.imageboard_idimageboard, b.title, b.description, b.approval_required
 FROM imageboard b
@@ -591,8 +591,8 @@ func (q *Queries) ListBoardsForLister(ctx context.Context, arg ListBoardsForList
 }
 
 const listImagePostsByBoardForLister = `-- name: ListImagePostsByBoardForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT i.idimagepost, i.forumthread_id, i.users_idusers, i.imageboard_idimageboard, i.posted, i.description, i.thumbnail, i.fullimage, i.file_size, i.approved, i.deleted_at, i.last_index, u.username, th.comments
 FROM imagepost i
@@ -684,8 +684,8 @@ func (q *Queries) ListImagePostsByBoardForLister(ctx context.Context, arg ListIm
 }
 
 const listImagePostsByPosterForLister = `-- name: ListImagePostsByPosterForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT i.idimagepost, i.forumthread_id, i.users_idusers, i.imageboard_idimageboard, i.posted, i.description, i.thumbnail, i.fullimage, i.file_size, i.approved, i.deleted_at, i.last_index, u.username, th.comments
 FROM imagepost i

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -50,8 +50,8 @@ FROM site_news
 WHERE idsiteNews = ?;
 
 -- name: GetNewsPostByIdWithWriterIdAndThreadCommentCount :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
@@ -71,8 +71,8 @@ LIMIT 1;
 
 
 -- name: GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
@@ -104,8 +104,8 @@ WHERE s.Idsitenews IN (sqlc.slice(newsIds))
 ORDER BY s.occurred DESC;
 
 -- name: GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -170,8 +170,8 @@ func (q *Queries) GetForumThreadIdByNewsPostId(ctx context.Context, idsitenews i
 }
 
 const getNewsPostByIdWithWriterIdAndThreadCommentCount = `-- name: GetNewsPostByIdWithWriterIdAndThreadCommentCount :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
@@ -226,8 +226,8 @@ func (q *Queries) GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx context.C
 }
 
 const getNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount = `-- name: GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s
@@ -325,8 +325,8 @@ func (q *Queries) GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount(ctx 
 }
 
 const getNewsPostsWithWriterUsernameAndThreadCommentCountDescending = `-- name: GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, th.comments as Comments
 FROM site_news s

--- a/internal/db/queries-permissions.sql
+++ b/internal/db/queries-permissions.sql
@@ -63,8 +63,8 @@ FROM user_roles ur
 WHERE ur.users_idusers = ?;
 
 -- name: SystemCheckGrant :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT 1 FROM grants g
 WHERE g.section = sqlc.arg(section)

--- a/internal/db/queries-permissions.sql.go
+++ b/internal/db/queries-permissions.sql.go
@@ -475,8 +475,8 @@ func (q *Queries) ListUsersWithRoles(ctx context.Context) ([]*ListUsersWithRoles
 }
 
 const systemCheckGrant = `-- name: SystemCheckGrant :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT 1 FROM grants g
 WHERE g.section = ?

--- a/internal/db/queries-search.sql
+++ b/internal/db/queries-search.sql
@@ -86,8 +86,8 @@ ON DUPLICATE KEY UPDATE word_count=VALUES(word_count);
 
 
 -- name: ListCommentIDsBySearchWordFirstForListerNotInRestrictedTopic :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT DISTINCT cs.comment_id
 FROM comments_search cs
@@ -121,8 +121,8 @@ WHERE swl.word=sqlc.arg(word)
   );
 
 -- name: ListCommentIDsBySearchWordNextForListerNotInRestrictedTopic :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT DISTINCT cs.comment_id
 FROM comments_search cs
@@ -157,8 +157,8 @@ WHERE swl.word=sqlc.arg(word)
   );
 
 -- name: ListCommentIDsBySearchWordFirstForListerInRestrictedTopic :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT DISTINCT cs.comment_id
 FROM comments_search cs
@@ -192,8 +192,8 @@ WHERE swl.word=sqlc.arg(word)
   );
 
 -- name: ListCommentIDsBySearchWordNextForListerInRestrictedTopic :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT DISTINCT cs.comment_id
 FROM comments_search cs
@@ -255,8 +255,8 @@ ON DUPLICATE KEY UPDATE word_count=VALUES(word_count);
 DELETE FROM writing_search
 WHERE writing_id = sqlc.arg(writing_id);
 -- name: ListWritingSearchFirstForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT DISTINCT cs.writing_id
 FROM writing_search cs
@@ -287,8 +287,8 @@ WHERE swl.word = sqlc.arg(word)
   );
 
 -- name: ListWritingSearchNextForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT DISTINCT cs.writing_id
 FROM writing_search cs
@@ -320,8 +320,8 @@ WHERE swl.word = sqlc.arg(word)
   );
 
 -- name: ListSiteNewsSearchFirstForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT DISTINCT cs.site_news_id
 FROM site_news_search cs
@@ -352,8 +352,8 @@ WHERE swl.word = sqlc.arg(word)
   );
 
 -- name: ListSiteNewsSearchNextForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT DISTINCT cs.site_news_id
 FROM site_news_search cs
@@ -387,8 +387,8 @@ WHERE swl.word = sqlc.arg(word)
 
 
 -- name: LinkerSearchFirst :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT DISTINCT cs.linker_id
 FROM linker_search cs
@@ -419,8 +419,8 @@ WHERE swl.word = sqlc.arg(word)
   );
 
 -- name: LinkerSearchNext :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT DISTINCT cs.linker_id
 FROM linker_search cs

--- a/internal/db/queries-search.sql.go
+++ b/internal/db/queries-search.sql.go
@@ -161,8 +161,8 @@ func (q *Queries) AdminWordListWithCountsByPrefix(ctx context.Context, arg Admin
 }
 
 const linkerSearchFirst = `-- name: LinkerSearchFirst :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT DISTINCT cs.linker_id
 FROM linker_search cs
@@ -229,8 +229,8 @@ func (q *Queries) LinkerSearchFirst(ctx context.Context, arg LinkerSearchFirstPa
 }
 
 const linkerSearchNext = `-- name: LinkerSearchNext :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT DISTINCT cs.linker_id
 FROM linker_search cs
@@ -308,8 +308,8 @@ func (q *Queries) LinkerSearchNext(ctx context.Context, arg LinkerSearchNextPara
 }
 
 const listCommentIDsBySearchWordFirstForListerInRestrictedTopic = `-- name: ListCommentIDsBySearchWordFirstForListerInRestrictedTopic :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT DISTINCT cs.comment_id
 FROM comments_search cs
@@ -389,8 +389,8 @@ func (q *Queries) ListCommentIDsBySearchWordFirstForListerInRestrictedTopic(ctx 
 }
 
 const listCommentIDsBySearchWordFirstForListerNotInRestrictedTopic = `-- name: ListCommentIDsBySearchWordFirstForListerNotInRestrictedTopic :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT DISTINCT cs.comment_id
 FROM comments_search cs
@@ -460,8 +460,8 @@ func (q *Queries) ListCommentIDsBySearchWordFirstForListerNotInRestrictedTopic(c
 }
 
 const listCommentIDsBySearchWordNextForListerInRestrictedTopic = `-- name: ListCommentIDsBySearchWordNextForListerInRestrictedTopic :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT DISTINCT cs.comment_id
 FROM comments_search cs
@@ -551,8 +551,8 @@ func (q *Queries) ListCommentIDsBySearchWordNextForListerInRestrictedTopic(ctx c
 }
 
 const listCommentIDsBySearchWordNextForListerNotInRestrictedTopic = `-- name: ListCommentIDsBySearchWordNextForListerNotInRestrictedTopic :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT DISTINCT cs.comment_id
 FROM comments_search cs
@@ -633,8 +633,8 @@ func (q *Queries) ListCommentIDsBySearchWordNextForListerNotInRestrictedTopic(ct
 }
 
 const listSiteNewsSearchFirstForLister = `-- name: ListSiteNewsSearchFirstForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT DISTINCT cs.site_news_id
 FROM site_news_search cs
@@ -701,8 +701,8 @@ func (q *Queries) ListSiteNewsSearchFirstForLister(ctx context.Context, arg List
 }
 
 const listSiteNewsSearchNextForLister = `-- name: ListSiteNewsSearchNextForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT DISTINCT cs.site_news_id
 FROM site_news_search cs
@@ -780,8 +780,8 @@ func (q *Queries) ListSiteNewsSearchNextForLister(ctx context.Context, arg ListS
 }
 
 const listWritingSearchFirstForLister = `-- name: ListWritingSearchFirstForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT DISTINCT cs.writing_id
 FROM writing_search cs
@@ -848,8 +848,8 @@ func (q *Queries) ListWritingSearchFirstForLister(ctx context.Context, arg ListW
 }
 
 const listWritingSearchNextForLister = `-- name: ListWritingSearchNextForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT DISTINCT cs.writing_id
 FROM writing_search cs

--- a/internal/db/queries-threads.sql
+++ b/internal/db/queries-threads.sql
@@ -50,12 +50,8 @@ SET lastaddition = (
 WHERE idforumthread = ?;
 
 -- name: GetThreadLastPosterAndPerms :one
-WITH role_ids(id) AS (
-    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
-    UNION
-    SELECT r2.id FROM role_ids ri
-    JOIN grants g ON g.role_id = ri.id AND g.section='role' AND g.active = 1
-    JOIN roles r2 ON r2.name = g.action
+WITH role_ids AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
 SELECT th.*, lu.username AS LastPosterUsername
 FROM forumthread th

--- a/internal/db/queries-threads.sql.go
+++ b/internal/db/queries-threads.sql.go
@@ -190,12 +190,8 @@ func (q *Queries) GetForumTopicIdByThreadId(ctx context.Context, idforumthread i
 }
 
 const getThreadLastPosterAndPerms = `-- name: GetThreadLastPosterAndPerms :one
-WITH role_ids(id) AS (
-    SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
-    UNION
-    SELECT r2.id FROM role_ids ri
-    JOIN grants g ON g.role_id = ri.id AND g.section='role' AND g.active = 1
-    JOIN roles r2 ON r2.name = g.action
+WITH role_ids AS (
+    SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT th.idforumthread, th.firstpost, th.lastposter, th.forumtopic_idforumtopic, th.comments, th.lastaddition, th.locked, lu.username AS LastPosterUsername
 FROM forumthread th

--- a/internal/db/queries-uploadimages.sql
+++ b/internal/db/queries-uploadimages.sql
@@ -16,8 +16,8 @@ WHERE EXISTS (
 );
 
 -- name: ListUploadedImagesByUserForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT ui.iduploadedimage, ui.users_idusers, ui.path, ui.width, ui.height, ui.file_size, ui.uploaded
 FROM uploaded_images ui

--- a/internal/db/queries-uploadimages.sql.go
+++ b/internal/db/queries-uploadimages.sql.go
@@ -98,8 +98,8 @@ func (q *Queries) CreateUploadedImageForUploader(ctx context.Context, arg Create
 }
 
 const listUploadedImagesByUserForLister = `-- name: ListUploadedImagesByUserForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT ui.iduploadedimage, ui.users_idusers, ui.path, ui.width, ui.height, ui.file_size, ui.uploaded
 FROM uploaded_images ui

--- a/internal/db/queries-user_emails.sql
+++ b/internal/db/queries-user_emails.sql
@@ -3,8 +3,8 @@ INSERT INTO user_emails (user_id, email, verified_at, last_verification_code, ve
 VALUES (?, ?, ?, ?, ?, ?);
 
 -- name: ListUserEmailsForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT ue.id, ue.user_id, ue.email, ue.verified_at, ue.last_verification_code, ue.verification_expires_at, ue.notification_priority
 FROM user_emails ue

--- a/internal/db/queries-user_emails.sql.go
+++ b/internal/db/queries-user_emails.sql.go
@@ -186,8 +186,8 @@ func (q *Queries) InsertUserEmail(ctx context.Context, arg InsertUserEmailParams
 }
 
 const listUserEmailsForLister = `-- name: ListUserEmailsForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT ue.id, ue.user_id, ue.email, ue.verified_at, ue.last_verification_code, ue.verification_expires_at, ue.notification_priority
 FROM user_emails ue

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -21,8 +21,8 @@ FROM writing
 WHERE idwriting = ?;
 
 -- name: ListPublicWritingsByUserForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT w.*, u.username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
@@ -64,8 +64,8 @@ ORDER BY w.published DESC
 LIMIT ? OFFSET ?;
 
 -- name: ListPublicWritingsInCategoryForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT w.*, u.Username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) as Comments
@@ -125,8 +125,8 @@ INSERT INTO writing (writing_category_id, title, abstract, writing, private, lan
 VALUES (?, ?, ?, ?, ?, ?, NOW(), ?);
 
 -- name: GetWritingForListerByID :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT w.*, u.idusers AS WriterId, u.Username AS WriterUsername
 FROM writing w
@@ -146,8 +146,8 @@ ORDER BY w.published DESC
 ;
 
 -- name: ListWritingsByIDsForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT w.*, u.idusers AS WriterId, u.username AS WriterUsername
 FROM writing w
@@ -194,8 +194,8 @@ ORDER BY wc.idwritingcategory
 LIMIT ? OFFSET ?;
 
 -- name: ListWritingCategoriesForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT wc.*
 FROM writing_category wc
@@ -216,8 +216,8 @@ UPDATE writing SET forumthread_id = ? WHERE idwriting = ?;
 
 
 -- name: GetAllWritingsByAuthorForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT w.*, u.username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
@@ -244,8 +244,8 @@ LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.users_idusers = sqlc.arg(author_id)
 ORDER BY w.published DESC;
 -- name: ListWritersForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT u.username, COUNT(w.idwriting) AS count
 FROM writing w
@@ -277,8 +277,8 @@ ORDER BY u.username
 LIMIT ? OFFSET ?;
 
 -- name: ListWritersSearchForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT u.username, COUNT(w.idwriting) AS count
 FROM writing w

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -176,8 +176,8 @@ func (q *Queries) AdminUpdateWritingCategory(ctx context.Context, arg AdminUpdat
 }
 
 const getAllWritingsByAuthorForLister = `-- name: GetAllWritingsByAuthorForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
@@ -363,8 +363,8 @@ func (q *Queries) GetWritingCategoryById(ctx context.Context, idwritingcategory 
 }
 
 const getWritingForListerByID = `-- name: GetWritingForListerByID :one
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.idusers AS WriterId, u.Username AS WriterUsername
 FROM writing w
@@ -460,8 +460,8 @@ func (q *Queries) InsertWriting(ctx context.Context, arg InsertWritingParams) (i
 }
 
 const listPublicWritingsByUserForLister = `-- name: ListPublicWritingsByUserForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
@@ -566,8 +566,8 @@ func (q *Queries) ListPublicWritingsByUserForLister(ctx context.Context, arg Lis
 }
 
 const listPublicWritingsInCategoryForLister = `-- name: ListPublicWritingsInCategoryForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.Username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) as Comments
@@ -672,8 +672,8 @@ func (q *Queries) ListPublicWritingsInCategoryForLister(ctx context.Context, arg
 }
 
 const listWritersForLister = `-- name: ListWritersForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT u.username, COUNT(w.idwriting) AS count
 FROM writing w
@@ -748,8 +748,8 @@ func (q *Queries) ListWritersForLister(ctx context.Context, arg ListWritersForLi
 }
 
 const listWritersSearchForLister = `-- name: ListWritersSearchForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT u.username, COUNT(w.idwriting) AS count
 FROM writing w
@@ -828,8 +828,8 @@ func (q *Queries) ListWritersSearchForLister(ctx context.Context, arg ListWriter
 }
 
 const listWritingCategoriesForLister = `-- name: ListWritingCategoriesForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT wc.idwritingcategory, wc.writing_category_id, wc.title, wc.description
 FROM writing_category wc
@@ -879,8 +879,8 @@ func (q *Queries) ListWritingCategoriesForLister(ctx context.Context, arg ListWr
 }
 
 const listWritingsByIDsForLister = `-- name: ListWritingsByIDsForLister :many
-WITH role_ids(id) AS (
-    SELECT DISTINCT ur.role_id FROM user_roles ur WHERE ur.users_idusers = ?
+WITH role_ids AS (
+    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.idusers AS WriterId, u.username AS WriterUsername
 FROM writing w


### PR DESCRIPTION
## Summary
- simplify forum and thread queries by removing role grant recursion from `role_ids`
- regenerate sqlc outputs
- drop explicit column list from `role_ids` CTEs and alias `role_id` as `id`
- tidy unused imports in tests for clean vet output

## Testing
- `sqlc generate`
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestCommentPageLockedThreadDisablesReply, TestCommentPageUnlockedThreadShowsReply, TestValidID, TestCommentsPageAllowsGlobalViewGrant)*

------
https://chatgpt.com/codex/tasks/task_e_689207915dec832fafe4da077ef43748