### PR TITLE
Fix comment template access

### DIFF
--- a/core/templates/site/comment.gohtml
+++ b/core/templates/site/comment.gohtml
@@ -1,30 +1,32 @@
 {{ define "comment" }}
+    {{ $cmt := .Comment }}
+    {{ $data := .Data }}
     <table width="100%">
         <tr bgcolor="lightgrey">
-            <th>{{.Written.Time}}</th>
+            <th>{{ $cmt.Written.Time }}</th>
         </tr>
         <tr>
             <td>
-                {{ $canEdit := $.CanEditComment . }}
-                {{ $editing := $.Editing . }}
+                {{ $canEdit := $data.CanEditComment $cmt }}
+                {{ $editing := $data.Editing $cmt }}
                 {{ if and $canEdit $editing }}
                     <font size="4">Edit:</font><br>
-                    <form method="post" action="{{$.EditSaveURL .}}">
+                    <form method="post" action="{{ $data.EditSaveURL $cmt }}">
                         {{ csrfField }}
-                        <textarea id="reply" name="replytext" cols="40" rows="20">{{.Text.String}}</textarea><br>
+                        <textarea id="reply" name="replytext" cols="40" rows="20">{{ $cmt.Text.String }}</textarea><br>
                         {{ template "languageCombobox" }}
                         <input type="submit" name="task" value="Edit Reply">
                         <input type="submit" name="task" value="Cancel">
                     </form>
                 {{ else }}
-                    {{.Text.String | a4code2html}}<br>-<br>{{.Posterusername.String}}.
-                    {{if and $.CanReply $.IsReplyable}}
-                        [<a href="?comment={{.Idcomments}}&type=full#reply">FULL REPLY</a>]
-                        [<a href="?comment={{.Idcomments}}#reply">PARAGRAPH REPLY</a>]
-                    {{end}}
-                    {{if and $canEdit (not $editing)}}[<a href="{{$.EditURL .}}">EDIT</a>]{{end}}
-                    {{ $admin := $.AdminURL . }}{{if $admin}}[<a href="{{$admin}}">ADMIN</a>]{{end}}
-                {{end}}
+                    {{ $cmt.Text.String | a4code2html}}<br>-<br>{{ $cmt.Posterusername.String }}.
+                    {{ if and $data.CanReply $data.IsReplyable }}
+                        [<a href="?comment={{ $cmt.Idcomments }}&type=full#reply">FULL REPLY</a>]
+                        [<a href="?comment={{ $cmt.Idcomments }}#reply">PARAGRAPH REPLY</a>]
+                    {{ end }}
+                    {{ if and $canEdit (not $editing) }}[<a href="{{ $data.EditURL $cmt }}">EDIT</a>]{{ end }}
+                    {{ $admin := $data.AdminURL $cmt }}{{ if $admin }}[<a href="{{ $admin }}">ADMIN</a>]{{ end }}
+                {{ end }}
             </td>
         </tr>
     </table><br>

--- a/core/templates/site/threadComments.gohtml
+++ b/core/templates/site/threadComments.gohtml
@@ -3,7 +3,7 @@
         <br>Skipping {{ cd.Offset }} comments.<br><br><br>
     {{ end }}
     {{ range cd.SelectedThreadComments }}
-        {{ template "comment" . }}
+        {{ template "comment" (dict "Data" $ "Comment" .) }}
     {{ else }}
         No comments.
     {{ end }}


### PR DESCRIPTION
## Summary
- fix comment template to use explicit data struct when rendering
- pass view data alongside comment rows in thread comment template

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestValidID in handlers/images)*

------
https://chatgpt.com/codex/tasks/task_e_6892c1831ad4832f96f73134d3e0e3fa