### PR TITLE
Require item IDs for forum grants

### DIFF
--- a/core/templates/site/admin/adminRoleGrantAddPage.gohtml
+++ b/core/templates/site/admin/adminRoleGrantAddPage.gohtml
@@ -38,16 +38,16 @@
     </label>
     {{ if .ItemOptions }}
     <label>Item:
-        <input list="itemOptions" name="item_id">
+        <input list="itemOptions" name="item_id"{{ if .RequireItemID }} required{{ end }}>
         <datalist id="itemOptions">
-            <option value="">All</option>
+            {{ if not .RequireItemID }}<option value="">All</option>{{ end }}
             {{ range .ItemOptions }}
             <option value="{{ .ID }}">{{ .Label }}</option>
             {{ end }}
         </datalist>
     </label>
     {{ else }}
-    <label>Item ID:<input type="text" name="item_id"></label>
+    <label>Item ID:<input type="text" name="item_id"{{ if .RequireItemID }} required{{ end }}></label>
     {{ end }}
     <input type="submit" value="Add">
 </form>

--- a/handlers/admin/adminRoleGrantAddPage.go
+++ b/handlers/admin/adminRoleGrantAddPage.go
@@ -33,13 +33,14 @@ func adminRoleGrantAddPage(w http.ResponseWriter, r *http.Request) {
 
 	data := struct {
 		*common.CoreData
-		Role        *db.Role
-		Section     string
-		Item        string
-		Sections    []string
-		Items       []string
-		Actions     []string
-		ItemOptions []ItemOption
+		Role          *db.Role
+		Section       string
+		Item          string
+		Sections      []string
+		Items         []string
+		Actions       []string
+		ItemOptions   []ItemOption
+		RequireItemID bool
 	}{CoreData: cd, Role: role, Section: section, Item: item}
 
 	if section == "" {
@@ -65,7 +66,9 @@ func adminRoleGrantAddPage(w http.ResponseWriter, r *http.Request) {
 			data.Items = append(data.Items, it)
 		}
 	} else {
-		data.Actions = GrantActionMap[section+"|"+item]
+		def := GrantActionMap[section+"|"+item]
+		data.Actions = def.Actions
+		data.RequireItemID = def.RequireItemID
 		if section == "forum" && item == "category" {
 			queries := cd.Queries()
 			cats, _ := queries.GetAllForumCategories(r.Context())

--- a/handlers/admin/role_grant_create_task.go
+++ b/handlers/admin/role_grant_create_task.go
@@ -47,6 +47,9 @@ func (RoleGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if section == "" || action == "" {
 		return fmt.Errorf("missing section or action %w", handlers.ErrRedirectOnSamePageHandler(fmt.Errorf("")))
 	}
+	if def, ok := GrantActionMap[section+"|"+item]; ok && def.RequireItemID && !itemID.Valid {
+		return fmt.Errorf("missing item id %w", handlers.ErrRedirectOnSamePageHandler(fmt.Errorf("")))
+	}
 	if _, err := queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
 		UserID:   sql.NullInt32{},
 		RoleID:   sql.NullInt32{Int32: roleID, Valid: true},

--- a/handlers/admin/role_grant_create_task_test.go
+++ b/handlers/admin/role_grant_create_task_test.go
@@ -1,0 +1,51 @@
+package admin
+
+import (
+	"context"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// TestRoleGrantCreateTask_ItemIDRequired verifies that grants needing an item ID
+// fail when no item_id is supplied.
+func TestRoleGrantCreateTask_ItemIDRequired(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	body := url.Values{
+		"section": {"forum"},
+		"item":    {"topic"},
+		"action":  {"see"},
+	}
+	req := httptest.NewRequest("POST", "/admin/role/1/grant", strings.NewReader(body.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = mux.SetURLVars(req, map[string]string{"role": "1"})
+
+	cd := common.NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
+	cd.LoadSelectionsFromRequest(req)
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	if res := roleGrantCreateTask.Action(rr, req); res == nil {
+		t.Fatalf("expected error, got nil")
+	} else if err, ok := res.(error); !ok || err == nil {
+		t.Fatalf("expected error, got %v", res)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/handlers/admin/role_grant_update_task.go
+++ b/handlers/admin/role_grant_update_task.go
@@ -48,6 +48,9 @@ func (RoleGrantUpdateTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 		itemID = sql.NullInt32{Int32: int32(id), Valid: true}
 	}
+	if def, ok := GrantActionMap[section+"|"+item]; ok && def.RequireItemID && !itemID.Valid {
+		return fmt.Errorf("missing item id %w", handlers.ErrRedirectOnSamePageHandler(fmt.Errorf("")))
+	}
 	desiredActive := map[string]struct{}{}
 	for _, a := range strings.Split(actionsStr, ",") {
 		if a != "" {

--- a/handlers/admin/role_grants_build_test.go
+++ b/handlers/admin/role_grants_build_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
@@ -11,8 +12,9 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 )
 
-// TestBuildGrantGroupsIncludesAvailableActionsWithoutGrants ensures that even when a role
-// has no grants, buildGrantGroups still returns groups for all supported section/item pairs.
+// TestBuildGrantGroupsIncludesAvailableActionsWithoutGrants ensures that when a role has
+// no grants, buildGrantGroups still returns groups for section/item pairs that do not
+// require an item ID.
 func TestBuildGrantGroupsIncludesAvailableActionsWithoutGrants(t *testing.T) {
 	conn, mock, err := sqlmock.New()
 	if err != nil {
@@ -34,28 +36,74 @@ func TestBuildGrantGroupsIncludesAvailableActionsWithoutGrants(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildGrantGroups: %v", err)
 	}
-	if len(groups) != len(GrantActionMap) {
-		t.Fatalf("expected %d groups, got %d", len(GrantActionMap), len(groups))
+	expected := 0
+	for _, def := range GrantActionMap {
+		if !def.RequireItemID {
+			expected++
+		}
+	}
+	if len(groups) != expected {
+		t.Fatalf("expected %d groups, got %d", expected, len(groups))
 	}
 	var topicFound bool
-	for _, g := range groups {
-		if g.Section == "forum" && g.Item == "topic" && len(g.Available) == len(GrantActionMap["forum|topic"]) {
-			topicFound = true
-			break
-		}
-	}
-	if !topicFound {
-		t.Fatalf("missing forum|topic group")
-	}
 	var searchFound bool
 	for _, g := range groups {
-		if g.Section == "forum" && g.Item == "" && len(g.Available) == len(GrantActionMap["forum|"]) {
-			searchFound = true
-			break
+		if g.Section == "forum" && g.Item == "topic" {
+			topicFound = true
 		}
+		if g.Section == "forum" && g.Item == "" && len(g.Available) == len(GrantActionMap["forum|"].Actions) {
+			searchFound = true
+		}
+	}
+	if topicFound {
+		t.Fatalf("unexpected forum|topic group")
 	}
 	if !searchFound {
 		t.Fatalf("missing forum| search group")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+// TestBuildGrantGroupsSkipsInvalidItemIDGrants ensures that grants requiring an
+// item ID are ignored when the item ID is missing.
+func TestBuildGrantGroupsSkipsInvalidItemIDGrants(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+	q := db.New(conn)
+	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+
+	rows := sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}).
+		AddRow(1, time.Now(), time.Now(), 0, 1, "forum", "topic", "", nil, "", "view", "", true)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants WHERE role_id = ? ORDER BY id\n")).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.title, f.description\nFROM forumcategory f\n")).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "title", "description"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language\n")).
+		WillReturnRows(sqlmock.NewRows([]string{"idlanguage", "nameof"}))
+
+	groups, err := buildGrantGroups(context.Background(), cd, 1)
+	if err != nil {
+		t.Fatalf("buildGrantGroups: %v", err)
+	}
+	expected := 0
+	for _, def := range GrantActionMap {
+		if !def.RequireItemID {
+			expected++
+		}
+	}
+	if len(groups) != expected {
+		t.Fatalf("expected %d groups, got %d", expected, len(groups))
+	}
+	for _, g := range groups {
+		if g.Section == "forum" && g.Item == "topic" {
+			t.Fatalf("unexpected forum|topic group")
+		}
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)

--- a/handlers/images/routes.go
+++ b/handlers/images/routes.go
@@ -21,7 +21,7 @@ import (
 
 // validID reports whether s consists solely of alphanumeric characters.
 func validID(s string) bool {
-	if s == "" {
+	if s == "" || s == "." || s == ".." {
 		return false
 	}
 	for i := 0; i < len(s); i++ {

--- a/handlers/images/routes_test.go
+++ b/handlers/images/routes_test.go
@@ -22,7 +22,9 @@ func TestValidID(t *testing.T) {
 		{"abcd", true},
 		{"1234", true},
 		{"a1b2c3", true},
+		{"a.b", true},
 		{"abc!", false},
+		{".", false},
 		{"..", false},
 		{"a/bc", false},
 	}

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -74,9 +74,10 @@ Sections may introduce extra actions but these form the base vocabulary used by
 the templates and permission checks.
 Grants with an empty `item` provide section-wide search access. For instance,
 `forum|` paired with the `search` action allows a user to search all forum
-topics.
-The grant editor uses the mapping defined in `handlers/admin/role_grants.go`
-to list available actions for each section and item type.
+topics. The grant editor uses the mapping defined in `handlers/admin/role_grants.go`
+to list available actions for each section and item type. Some combinations
+require an `item_id`; for example, grants in the `forum` section targeting a
+`category`, `topic` or `thread` must specify the corresponding identifier.
 Announcements use these actions to control which news posts appear globally. Administrator pages call `AdminPromoteAnnouncement` and `AdminDemoteAnnouncement` while `GetActiveAnnouncementWithNewsForUser` retrieves the visible announcement.
 
 Each section may define additional actions, but these are the core verbs used by the system.


### PR DESCRIPTION
## Summary
- support per-section rules in `GrantActionMap`
- require `item_id` for forum `category`, `topic` and `thread` grants
- mark grant form item field as required when needed and document the rule
- skip grants missing required `item_id` in admin listing
- keep period support in image ID validation and extend tests

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6892c146f880832fb84089d5aad2efdd