### PR TITLE
Fix reply permission for comments

### DIFF
--- a/handlers/admin/role_grants.go
+++ b/handlers/admin/role_grants.go
@@ -25,7 +25,7 @@ type GrantDefinition struct {
 var GrantActionMap = map[string]GrantDefinition{
 	"forum|":              {Actions: []string{"search"}},
 	"forum|topic":         {Actions: []string{"see", "view", "reply", "post", "edit"}, RequireItemID: true},
-	"forum|thread":        {Actions: []string{"see", "view", "reply", "post", "edit"}, RequireItemID: true},
+	"forum|thread":        {Actions: []string{"see", "view", "reply", "edit"}, RequireItemID: true},
 	"forum|category":      {Actions: []string{"see", "view"}, RequireItemID: true},
 	"linker|":             {Actions: []string{"search"}},
 	"linker|category":     {Actions: []string{"see", "view"}},

--- a/handlers/blogs/blogsCommentEditReplyTask.go
+++ b/handlers/blogs/blogsCommentEditReplyTask.go
@@ -76,16 +76,15 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 
-	if err = queries.UpdateCommentForCommenter(r.Context(), db.UpdateCommentForCommenterParams{
-		CommentID:      int32(commentId),
-		GrantCommentID: sql.NullInt32{Int32: int32(commentId), Valid: true},
-		LanguageID:     int32(languageId),
+	if err = queries.UpdateCommentForEditor(r.Context(), db.UpdateCommentForEditorParams{
+		LanguageID: int32(languageId),
 		Text: sql.NullString{
 			String: text,
 			Valid:  true,
 		},
-		GranteeID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
+		CommentID:   int32(commentId),
 		CommenterID: uid,
+		EditorID:    sql.NullInt32{Int32: uid, Valid: uid != 0},
 	}); err != nil {
 		return fmt.Errorf("update comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/forum/comment_edit_action_task.go
+++ b/handlers/forum/comment_edit_action_task.go
@@ -42,13 +42,12 @@ func (topicThreadCommentEditActionTask) Action(w http.ResponseWriter, r *http.Re
 	}
 	commentID, _ := strconv.Atoi(mux.Vars(r)["comment"])
 
-	if err = queries.UpdateCommentForCommenter(r.Context(), db.UpdateCommentForCommenterParams{
-		CommentID:      int32(commentID),
-		GrantCommentID: sql.NullInt32{Int32: int32(commentID), Valid: true},
-		LanguageID:     int32(languageID),
-		Text:           sql.NullString{String: text, Valid: true},
-		GranteeID:      sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-		CommenterID:    cd.UserID,
+	if err = queries.UpdateCommentForEditor(r.Context(), db.UpdateCommentForEditorParams{
+		LanguageID:  int32(languageID),
+		Text:        sql.NullString{String: text, Valid: true},
+		CommentID:   int32(commentID),
+		CommenterID: cd.UserID,
+		EditorID:    sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	}); err != nil {
 		return fmt.Errorf("update comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/forum/forumTopicThreadCommentEditPage.go
+++ b/handlers/forum/forumTopicThreadCommentEditPage.go
@@ -37,16 +37,15 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	commentId, _ := strconv.Atoi(mux.Vars(r)["comment"])
 
-	err = queries.UpdateCommentForCommenter(r.Context(), db.UpdateCommentForCommenterParams{
-		CommentID:      int32(commentId),
-		GrantCommentID: sql.NullInt32{Int32: int32(commentId), Valid: true},
-		LanguageID:     int32(languageId),
+	err = queries.UpdateCommentForEditor(r.Context(), db.UpdateCommentForEditorParams{
+		LanguageID: int32(languageId),
 		Text: sql.NullString{
 			String: text,
 			Valid:  true,
 		},
-		GranteeID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		CommentID:   int32(commentId),
 		CommenterID: cd.UserID,
+		EditorID:    sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	})
 	if err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/handlers/linker/edit_reply_task.go
+++ b/handlers/linker/edit_reply_task.go
@@ -64,16 +64,15 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 
-	if err = queries.UpdateCommentForCommenter(r.Context(), db.UpdateCommentForCommenterParams{
-		CommentID:      int32(commentId),
-		GrantCommentID: sql.NullInt32{Int32: int32(commentId), Valid: true},
-		LanguageID:     int32(languageId),
+	if err = queries.UpdateCommentForEditor(r.Context(), db.UpdateCommentForEditorParams{
+		LanguageID: int32(languageId),
 		Text: sql.NullString{
 			String: text,
 			Valid:  true,
 		},
-		GranteeID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		CommentID:   int32(commentId),
 		CommenterID: cd.UserID,
+		EditorID:    sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	}); err != nil {
 		return fmt.Errorf("update comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/news/edit_reply_task.go
+++ b/handlers/news/edit_reply_task.go
@@ -72,13 +72,12 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("thread fetch fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if err = queries.UpdateCommentForCommenter(r.Context(), db.UpdateCommentForCommenterParams{
-		CommentID:      int32(commentId),
-		GrantCommentID: sql.NullInt32{Int32: int32(commentId), Valid: true},
-		LanguageID:     int32(languageId),
-		Text:           sql.NullString{String: text, Valid: true},
-		GranteeID:      sql.NullInt32{Int32: uid, Valid: uid != 0},
-		CommenterID:    uid,
+	if err = queries.UpdateCommentForEditor(r.Context(), db.UpdateCommentForEditorParams{
+		LanguageID:  int32(languageId),
+		Text:        sql.NullString{String: text, Valid: true},
+		CommentID:   int32(commentId),
+		CommenterID: uid,
+		EditorID:    sql.NullInt32{Int32: uid, Valid: uid != 0},
 	}); err != nil {
 		return fmt.Errorf("update comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/writings/edit_reply_task.go
+++ b/handlers/writings/edit_reply_task.go
@@ -61,13 +61,12 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("get thread fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if err = queries.UpdateCommentForCommenter(r.Context(), db.UpdateCommentForCommenterParams{
-		CommentID:      comment.Idcomments,
-		GrantCommentID: sql.NullInt32{Int32: comment.Idcomments, Valid: true},
-		LanguageID:     int32(languageID),
-		Text:           sql.NullString{String: text, Valid: true},
-		GranteeID:      sql.NullInt32{Int32: uid, Valid: uid != 0},
-		CommenterID:    uid,
+	if err = queries.UpdateCommentForEditor(r.Context(), db.UpdateCommentForEditorParams{
+		LanguageID:  int32(languageID),
+		Text:        sql.NullString{String: text, Valid: true},
+		CommentID:   comment.Idcomments,
+		CommenterID: uid,
+		EditorID:    sql.NullInt32{Int32: uid, Valid: uid != 0},
 	}); err != nil {
 		return fmt.Errorf("update comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/writings/writingsArticleCommentEditPage.go
+++ b/handlers/writings/writingsArticleCommentEditPage.go
@@ -55,13 +55,12 @@ func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	uid = cd.UserID
-	if err = queries.UpdateCommentForCommenter(r.Context(), db.UpdateCommentForCommenterParams{
-		CommentID:      comment.Idcomments,
-		GrantCommentID: sql.NullInt32{Int32: comment.Idcomments, Valid: true},
-		LanguageID:     int32(languageId),
-		Text:           sql.NullString{String: text, Valid: true},
-		GranteeID:      sql.NullInt32{Int32: uid, Valid: uid != 0},
-		CommenterID:    uid,
+	if err = queries.UpdateCommentForEditor(r.Context(), db.UpdateCommentForEditorParams{
+		LanguageID:  int32(languageId),
+		Text:        sql.NullString{String: text, Valid: true},
+		CommentID:   comment.Idcomments,
+		CommenterID: uid,
+		EditorID:    sql.NullInt32{Int32: uid, Valid: uid != 0},
 	}); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -467,7 +467,7 @@ type Querier interface {
 	UpdateBlogEntryForWriter(ctx context.Context, arg UpdateBlogEntryForWriterParams) error
 	// This query updates the "list" column in the "bookmarks" table for a specific lister.
 	UpdateBookmarksForLister(ctx context.Context, arg UpdateBookmarksForListerParams) error
-	UpdateCommentForCommenter(ctx context.Context, arg UpdateCommentForCommenterParams) error
+	UpdateCommentForEditor(ctx context.Context, arg UpdateCommentForEditorParams) error
 	UpdateEmailForumUpdatesForLister(ctx context.Context, arg UpdateEmailForumUpdatesForListerParams) error
 	UpdateNewsPostForWriter(ctx context.Context, arg UpdateNewsPostForWriterParams) error
 	UpdatePreferenceForLister(ctx context.Context, arg UpdatePreferenceForListerParams) error

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -33,7 +33,7 @@ WHERE c.idcomments = sqlc.arg(id)
 )
 LIMIT 1;
 
--- name: UpdateCommentForCommenter :exec
+-- name: UpdateCommentForEditor :exec
 UPDATE comments c
 SET language_idlanguage = sqlc.arg(language_id), text = sqlc.arg(text)
 WHERE c.idcomments = sqlc.arg(comment_id)
@@ -41,11 +41,11 @@ WHERE c.idcomments = sqlc.arg(comment_id)
   AND EXISTS (
       SELECT 1 FROM grants g
       WHERE g.section='forum'
-        AND (g.item='comment' OR g.item IS NULL)
-        AND g.action='post'
+        AND (g.item='thread' OR g.item IS NULL)
+        AND g.action='edit'
         AND g.active=1
-        AND (g.item_id = sqlc.arg(grant_comment_id) OR g.item_id IS NULL)
-        AND (g.user_id = sqlc.arg(grantee_id) OR g.user_id IS NULL)
+        AND (g.item_id = c.forumthread_id OR g.item_id IS NULL)
+        AND (g.user_id = sqlc.arg(editor_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (
             SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(commenter_id)
         ))
@@ -101,15 +101,15 @@ SELECT sqlc.arg(language_id), sqlc.arg(commenter_id), sqlc.arg(forumthread_id), 
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'forum'
-      AND (g.item = 'comment' OR g.item IS NULL)
-      AND g.action = 'post'
+      AND (g.item = 'thread' OR g.item IS NULL)
+      AND g.action = 'reply'
       AND g.active = 1
       AND (g.item_id = sqlc.arg(grant_forumthread_id) OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(grantee_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (
           SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(commenter_id)
       ))
-);
+  );
 
 -- name: GetCommentsByThreadIdForUser :many
 WITH role_ids AS (

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -169,7 +169,6 @@ Many queries now filter results directly in SQL using `lister_id` together with 
 | `forum`    | `thread`   | `see`           | Show a thread in listings |
 | `forum`    | `thread`   | `view`          | View posts within a thread |
 | `forum`    | `thread`   | `reply`         | Reply within the thread |
-| `forum`    | `thread`   | `post`          | Add a new post in the thread |
 | `forum`    | `thread`   | `edit`          | Edit posts in the thread |
 | `forum`    | `topic`    | `see`           | Show a topic in listings |
 | `forum`    | `topic`    | `view`          | View the topic details |


### PR DESCRIPTION
## Summary
- check reply on threads when creating comments
- require edit on threads to update comments

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6892def58d28832f91bb13404ea0286c