### PR TITLE
Track successful task runs for notifications

### DIFF
--- a/cmd/goa4web/notifications_tasks_data.go
+++ b/cmd/goa4web/notifications_tasks_data.go
@@ -3,6 +3,7 @@ package main
 import (
 	"sort"
 
+	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -28,40 +29,41 @@ func taskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 	for _, e := range entries {
 		info := taskTemplateInfo{Section: e.Section, Task: e.Task.Name()}
 		t := e.Task
+		evt := eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}
 		if tp, ok := t.(notif.SelfNotificationTemplateProvider); ok {
-			if et := tp.SelfEmailTemplate(); et != nil {
+			if et := tp.SelfEmailTemplate(evt); et != nil {
 				info.SelfEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.SelfInternalNotificationTemplate(); nt != nil {
+			if nt := tp.SelfInternalNotificationTemplate(evt); nt != nil {
 				info.SelfInternal = *nt
 			}
 		}
 		if tp, ok := t.(notif.DirectEmailNotificationTemplateProvider); ok {
-			if et := tp.DirectEmailTemplate(); et != nil {
+			if et := tp.DirectEmailTemplate(evt); et != nil {
 				info.DirectEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 		}
 		if tp, ok := t.(notif.SubscribersNotificationTemplateProvider); ok {
-			if et := tp.SubscribedEmailTemplate(); et != nil {
+			if et := tp.SubscribedEmailTemplate(evt); et != nil {
 				info.SubEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.SubscribedInternalNotificationTemplate(); nt != nil {
+			if nt := tp.SubscribedInternalNotificationTemplate(evt); nt != nil {
 				info.SubInternal = *nt
 			}
 		}
 		if tp, ok := t.(notif.AdminEmailTemplateProvider); ok {
-			if et := tp.AdminEmailTemplate(); et != nil {
+			if et := tp.AdminEmailTemplate(evt); et != nil {
 				info.AdminEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.AdminInternalNotificationTemplate(); nt != nil {
+			if nt := tp.AdminInternalNotificationTemplate(evt); nt != nil {
 				info.AdminInternal = *nt
 			}
 		}
 		if tp, ok := t.(notif.TargetUsersNotificationProvider); ok {
-			if et := tp.TargetEmailTemplate(); et != nil {
+			if et := tp.TargetEmailTemplate(evt); et != nil {
 				info.TargetEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.TargetInternalNotificationTemplate(); nt != nil {
+			if nt := tp.TargetInternalNotificationTemplate(evt); nt != nil {
 				info.TargetInternal = *nt
 			}
 		}

--- a/handlers/admin/add_announcement_task.go
+++ b/handlers/admin/add_announcement_task.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -49,11 +51,11 @@ func (AddAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (AddAnnouncementTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (AddAnnouncementTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("announcementEmail")
 }
 
-func (AddAnnouncementTask) AdminInternalNotificationTemplate() *string {
+func (AddAnnouncementTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("announcement")
 	return &v
 }

--- a/handlers/admin/add_ip_ban_task.go
+++ b/handlers/admin/add_ip_ban_task.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -65,11 +67,11 @@ func (AddIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (AddIPBanTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (AddIPBanTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminAddIPBanEmail")
 }
 
-func (AddIPBanTask) AdminInternalNotificationTemplate() *string {
+func (AddIPBanTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminAddIPBanEmail")
 	return &v
 }

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -7,6 +7,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -31,40 +32,41 @@ func gatherTaskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 	for _, e := range entries {
 		info := taskTemplateInfo{Section: e.Section, Task: e.Task.Name()}
 		t := e.Task
+		evt := eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}
 		if tp, ok := t.(notif.SelfNotificationTemplateProvider); ok {
-			if et := tp.SelfEmailTemplate(); et != nil {
+			if et := tp.SelfEmailTemplate(evt); et != nil {
 				info.SelfEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.SelfInternalNotificationTemplate(); nt != nil {
+			if nt := tp.SelfInternalNotificationTemplate(evt); nt != nil {
 				info.SelfInternal = *nt
 			}
 		}
 		if tp, ok := t.(notif.DirectEmailNotificationTemplateProvider); ok {
-			if et := tp.DirectEmailTemplate(); et != nil {
+			if et := tp.DirectEmailTemplate(evt); et != nil {
 				info.DirectEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 		}
 		if tp, ok := t.(notif.SubscribersNotificationTemplateProvider); ok {
-			if et := tp.SubscribedEmailTemplate(); et != nil {
+			if et := tp.SubscribedEmailTemplate(evt); et != nil {
 				info.SubEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.SubscribedInternalNotificationTemplate(); nt != nil {
+			if nt := tp.SubscribedInternalNotificationTemplate(evt); nt != nil {
 				info.SubInternal = *nt
 			}
 		}
 		if tp, ok := t.(notif.AdminEmailTemplateProvider); ok {
-			if et := tp.AdminEmailTemplate(); et != nil {
+			if et := tp.AdminEmailTemplate(evt); et != nil {
 				info.AdminEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.AdminInternalNotificationTemplate(); nt != nil {
+			if nt := tp.AdminInternalNotificationTemplate(evt); nt != nil {
 				info.AdminInternal = *nt
 			}
 		}
 		if tp, ok := t.(notif.TargetUsersNotificationProvider); ok {
-			if et := tp.TargetEmailTemplate(); et != nil {
+			if et := tp.TargetEmailTemplate(evt); et != nil {
 				info.TargetEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.TargetInternalNotificationTemplate(); nt != nil {
+			if nt := tp.TargetInternalNotificationTemplate(evt); nt != nil {
 				info.TargetInternal = *nt
 			}
 		}

--- a/handlers/admin/adminIPBanTemplates_test.go
+++ b/handlers/admin/adminIPBanTemplates_test.go
@@ -3,6 +3,8 @@ package admin
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -28,6 +30,6 @@ func TestAdminIPBanTemplatesExist(t *testing.T) {
 		&DeleteIPBanTask{TaskString: TaskDelete},
 	}
 	for _, p := range admins {
-		checkIPBanEmailTemplates(t, p.AdminEmailTemplate())
+		checkIPBanEmailTemplates(t, p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/admin/adminUserPasswordReset.go
+++ b/handlers/admin/adminUserPasswordReset.go
@@ -83,11 +83,11 @@ func (UserPasswordResetTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, err
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (UserPasswordResetTask) TargetEmailTemplate() *notif.EmailTemplates {
+func (UserPasswordResetTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminPasswordResetEmail")
 }
 
-func (UserPasswordResetTask) TargetInternalNotificationTemplate() *string {
+func (UserPasswordResetTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("admin_password_reset")
 	return &v
 }

--- a/handlers/admin/announcementTemplates_test.go
+++ b/handlers/admin/announcementTemplates_test.go
@@ -3,6 +3,8 @@ package admin
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -38,7 +40,7 @@ func TestAnnouncementTemplatesExist(t *testing.T) {
 		deleteAnnouncementTask,
 	}
 	for _, p := range admins {
-		checkEmailTemplates(t, p.AdminEmailTemplate())
-		checkNotificationTemplate(t, p.AdminInternalNotificationTemplate())
+		checkEmailTemplates(t, p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		checkNotificationTemplate(t, p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/admin/delete_announcement_task.go
+++ b/handlers/admin/delete_announcement_task.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -49,11 +51,11 @@ func (DeleteAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any
 	return nil
 }
 
-func (DeleteAnnouncementTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (DeleteAnnouncementTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("announcementEmail")
 }
 
-func (DeleteAnnouncementTask) AdminInternalNotificationTemplate() *string {
+func (DeleteAnnouncementTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("announcement")
 	return &v
 }

--- a/handlers/admin/delete_ip_ban_task.go
+++ b/handlers/admin/delete_ip_ban_task.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -52,11 +54,11 @@ func (DeleteIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (DeleteIPBanTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (DeleteIPBanTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminRemoveIPBanEmail")
 }
 
-func (DeleteIPBanTask) AdminInternalNotificationTemplate() *string {
+func (DeleteIPBanTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminRemoveIPBanEmail")
 	return &v
 }

--- a/handlers/admin/news_user_tasks.go
+++ b/handlers/admin/news_user_tasks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/notifications"
@@ -22,20 +23,20 @@ func roleInfoByPermID(ctx context.Context, q db.Querier, id int32) (int32, strin
 	return 0, "", "", sql.ErrNoRows
 }
 
-func (NewsUserAllowTask) AdminEmailTemplate() *notifications.EmailTemplates {
+func (NewsUserAllowTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notifications.EmailTemplates {
 	return notifications.NewEmailTemplates("newsPermissionEmail")
 }
 
-func (NewsUserAllowTask) AdminInternalNotificationTemplate() *string {
+func (NewsUserAllowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notifications.NotificationTemplateFilenameGenerator("news_permission")
 	return &v
 }
 
-func (NewsUserRemoveTask) AdminEmailTemplate() *notifications.EmailTemplates {
+func (NewsUserRemoveTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notifications.EmailTemplates {
 	return notifications.NewEmailTemplates("newsPermissionEmail")
 }
 
-func (NewsUserRemoveTask) AdminInternalNotificationTemplate() *string {
+func (NewsUserRemoveTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notifications.NotificationTemplateFilenameGenerator("news_permission")
 	return &v
 }
@@ -50,11 +51,11 @@ func (NewsUserAllowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) 
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (NewsUserAllowTask) TargetEmailTemplate() *notifications.EmailTemplates {
+func (NewsUserAllowTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notifications.EmailTemplates {
 	return notifications.NewEmailTemplates("setUserRoleEmail")
 }
 
-func (NewsUserAllowTask) TargetInternalNotificationTemplate() *string {
+func (NewsUserAllowTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notifications.NotificationTemplateFilenameGenerator("set_user_role")
 	return &v
 }
@@ -69,11 +70,11 @@ func (NewsUserRemoveTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error)
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (NewsUserRemoveTask) TargetEmailTemplate() *notifications.EmailTemplates {
+func (NewsUserRemoveTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notifications.EmailTemplates {
 	return notifications.NewEmailTemplates("deleteUserRoleEmail")
 }
 
-func (NewsUserRemoveTask) TargetInternalNotificationTemplate() *string {
+func (NewsUserRemoveTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notifications.NotificationTemplateFilenameGenerator("delete_user_role")
 	return &v
 }

--- a/handlers/admin/news_user_tasks_templates_test.go
+++ b/handlers/admin/news_user_tasks_templates_test.go
@@ -3,6 +3,8 @@ package admin
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -38,7 +40,7 @@ func TestNewsUserTasksTemplates(t *testing.T) {
 		&NewsUserRemoveTask{TaskString: TaskNewsUserRemove},
 	}
 	for _, p := range admins {
-		requireEmailTemplates(t, p.AdminEmailTemplate())
-		requireNotificationTemplate(t, p.AdminInternalNotificationTemplate())
+		requireEmailTemplates(t, p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		requireNotificationTemplate(t, p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/admin/server_shutdown_task.go
+++ b/handlers/admin/server_shutdown_task.go
@@ -62,10 +62,11 @@ func (t *ServerShutdownTask) Action(w http.ResponseWriter, r *http.Request) any 
 	go func() {
 		if t.h != nil && t.h.Srv != nil && t.h.Srv.Bus != nil {
 			evt := eventbus.TaskEvent{
-				Path:   path,
-				Task:   TaskServerShutdown,
-				UserID: uid,
-				Time:   time.Now(),
+				Path:    path,
+				Task:    TaskServerShutdown,
+				UserID:  uid,
+				Time:    time.Now(),
+				Outcome: eventbus.TaskOutcomeSuccess,
 			}
 			if err := t.h.Srv.Bus.Publish(evt); err != nil {
 				log.Printf("publish shutdown event: %v", err)

--- a/handlers/auth/forgotPassword_test.go
+++ b/handlers/auth/forgotPassword_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -38,15 +40,15 @@ func TestForgotPasswordTemplatesExist(t *testing.T) {
 		emailAssociationRequestTask,
 	}
 	for _, p := range admins {
-		requireEmailTemplates(t, p.AdminEmailTemplate())
-		requireNotificationTemplate(t, p.AdminInternalNotificationTemplate())
+		requireEmailTemplates(t, p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		requireNotificationTemplate(t, p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 
 	selfProviders := []notif.SelfNotificationTemplateProvider{
 		forgotPasswordTask,
 	}
 	for _, p := range selfProviders {
-		requireEmailTemplates(t, p.SelfEmailTemplate())
-		requireNotificationTemplate(t, p.SelfInternalNotificationTemplate())
+		requireEmailTemplates(t, p.SelfEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		requireNotificationTemplate(t, p.SelfInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/auth/forgot_password_task.go
+++ b/handlers/auth/forgot_password_task.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -120,29 +122,29 @@ func (ForgotPasswordTask) AuditRecord(data map[string]any) string {
 	return "password reset requested"
 }
 
-func (EmailAssociationRequestTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (EmailAssociationRequestTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationEmailAssociationRequestEmail")
 }
 
-func (EmailAssociationRequestTask) AdminInternalNotificationTemplate() *string {
+func (EmailAssociationRequestTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationEmailAssociationRequestEmail")
 	return &v
 }
 
-func (f ForgotPasswordTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (f ForgotPasswordTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationUserRequestPasswordResetEmail")
 }
 
-func (f ForgotPasswordTask) AdminInternalNotificationTemplate() *string {
+func (f ForgotPasswordTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationUserRequestPasswordResetEmail")
 	return &v
 }
 
-func (f ForgotPasswordTask) SelfEmailTemplate() *notif.EmailTemplates {
+func (f ForgotPasswordTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("passwordResetEmail")
 }
 
-func (f ForgotPasswordTask) SelfInternalNotificationTemplate() *string {
+func (f ForgotPasswordTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("password_reset")
 	return &s
 }

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -3,6 +3,7 @@ package blogs
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/arran4/goa4web/core/consts"
 
 	"github.com/arran4/goa4web/internal/db"
@@ -29,20 +30,20 @@ var _ notif.SubscribersNotificationTemplateProvider = (*AddBlogTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*AddBlogTask)(nil)
 var _ notif.GrantsRequiredProvider = (*AddBlogTask)(nil)
 
-func (AddBlogTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (AddBlogTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationBlogAddEmail")
 }
 
-func (AddBlogTask) AdminInternalNotificationTemplate() *string {
+func (AddBlogTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationBlogAddEmail")
 	return &v
 }
 
-func (AddBlogTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (AddBlogTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("blogAddEmail")
 }
 
-func (AddBlogTask) SubscribedInternalNotificationTemplate() *string {
+func (AddBlogTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("blog_add")
 	return &s
 }

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -3,7 +3,9 @@ package blogs
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/eventbus"
 
 	"github.com/arran4/goa4web/internal/db"
 
@@ -25,11 +27,11 @@ var editBlogTask = &EditBlogTask{TaskString: TaskEdit}
 var _ tasks.Task = (*EditBlogTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*EditBlogTask)(nil)
 
-func (EditBlogTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (EditBlogTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationBlogEditEmail")
 }
 
-func (EditBlogTask) AdminInternalNotificationTemplate() *string {
+func (EditBlogTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationBlogEditEmail")
 	return &v
 }

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -4,9 +4,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"strconv"
+
+	"github.com/arran4/goa4web/core/consts"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
@@ -34,11 +35,17 @@ var (
 	_ notif.GrantsRequiredProvider                  = (*ReplyBlogTask)(nil)
 )
 
-func (ReplyBlogTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (ReplyBlogTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	return notif.NewEmailTemplates("replyEmail")
 }
 
-func (ReplyBlogTask) SubscribedInternalNotificationTemplate() *string {
+func (ReplyBlogTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	s := notif.NotificationTemplateFilenameGenerator("reply")
 	return &s
 }

--- a/handlers/blogs/blogsCommentEditCancelTask.go
+++ b/handlers/blogs/blogsCommentEditCancelTask.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/gorilla/mux"
@@ -22,11 +24,11 @@ var cancelTask = &CancelTask{TaskString: TaskCancel}
 var _ tasks.Task = (*CancelTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*CancelTask)(nil)
 
-func (CancelTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (CancelTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationBlogCommentCancelEmail")
 }
 
-func (CancelTask) AdminInternalNotificationTemplate() *string {
+func (CancelTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationBlogCommentCancelEmail")
 	return &v
 }

--- a/handlers/blogs/blogsCommentEditReplyTask.go
+++ b/handlers/blogs/blogsCommentEditReplyTask.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
@@ -26,11 +28,11 @@ var editReplyTask = &EditReplyTask{TaskString: TaskEditReply}
 var _ tasks.Task = (*EditReplyTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*EditReplyTask)(nil)
 
-func (EditReplyTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (EditReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationBlogCommentEditEmail")
 }
 
-func (EditReplyTask) AdminInternalNotificationTemplate() *string {
+func (EditReplyTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationBlogCommentEditEmail")
 	return &v
 }

--- a/handlers/blogs/user_allow_task.go
+++ b/handlers/blogs/user_allow_task.go
@@ -18,11 +18,11 @@ var _ tasks.Task = (*UserAllowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*UserAllowTask)(nil)
 var _ notif.TargetUsersNotificationProvider = (*UserAllowTask)(nil)
 
-func (UserAllowTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (UserAllowTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationBlogUserAllowEmail")
 }
 
-func (UserAllowTask) AdminInternalNotificationTemplate() *string {
+func (UserAllowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationBlogUserAllowEmail")
 	return &v
 }
@@ -42,11 +42,11 @@ func (UserAllowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (UserAllowTask) TargetEmailTemplate() *notif.EmailTemplates {
+func (UserAllowTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("setUserRoleEmail")
 }
 
-func (UserAllowTask) TargetInternalNotificationTemplate() *string {
+func (UserAllowTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("set_user_role")
 	return &v
 }

--- a/handlers/blogs/user_disallow_task.go
+++ b/handlers/blogs/user_disallow_task.go
@@ -18,11 +18,11 @@ var _ tasks.Task = (*UserDisallowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*UserDisallowTask)(nil)
 var _ notif.TargetUsersNotificationProvider = (*UserDisallowTask)(nil)
 
-func (UserDisallowTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (UserDisallowTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationBlogUserDisallowEmail")
 }
 
-func (UserDisallowTask) AdminInternalNotificationTemplate() *string {
+func (UserDisallowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationBlogUserDisallowEmail")
 	return &v
 }
@@ -42,11 +42,11 @@ func (UserDisallowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (UserDisallowTask) TargetEmailTemplate() *notif.EmailTemplates {
+func (UserDisallowTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("deleteUserRoleEmail")
 }
 
-func (UserDisallowTask) TargetInternalNotificationTemplate() *string {
+func (UserDisallowTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("delete_user_role")
 	return &v
 }

--- a/handlers/blogs/users_allow_task.go
+++ b/handlers/blogs/users_allow_task.go
@@ -3,6 +3,8 @@ package blogs
 import (
 	"net/http"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -15,11 +17,11 @@ var usersAllowTask = &UsersAllowTask{TaskString: TaskUsersAllow}
 var _ tasks.Task = (*UsersAllowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*UsersAllowTask)(nil)
 
-func (UsersAllowTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (UsersAllowTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationBlogUsersAllowEmail")
 }
 
-func (UsersAllowTask) AdminInternalNotificationTemplate() *string {
+func (UsersAllowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationBlogUsersAllowEmail")
 	return &v
 }

--- a/handlers/blogs/users_disallow_task.go
+++ b/handlers/blogs/users_disallow_task.go
@@ -3,6 +3,8 @@ package blogs
 import (
 	"net/http"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -15,11 +17,11 @@ var usersDisallowTask = &UsersDisallowTask{TaskString: TaskUsersDisallow}
 var _ tasks.Task = (*UsersDisallowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*UsersDisallowTask)(nil)
 
-func (UsersDisallowTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (UsersDisallowTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationBlogUsersDisallowEmail")
 }
 
-func (UsersDisallowTask) AdminInternalNotificationTemplate() *string {
+func (UsersDisallowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationBlogUsersDisallowEmail")
 	return &v
 }

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -3,10 +3,12 @@ package faq
 import (
 	"database/sql"
 	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/eventbus"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
@@ -24,11 +26,11 @@ var askTask = &AskTask{TaskString: TaskAsk}
 var _ tasks.Task = (*AskTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*AskTask)(nil)
 
-func (AskTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (AskTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationFaqAskEmail")
 }
 
-func (AskTask) AdminInternalNotificationTemplate() *string {
+func (AskTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationFaqAskEmail")
 	return &v
 }

--- a/handlers/faq/faqTemplates_test.go
+++ b/handlers/faq/faqTemplates_test.go
@@ -3,6 +3,8 @@ package faq
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -34,6 +36,6 @@ func requireNotificationTemplate(t *testing.T, name *string) {
 
 func TestAskTaskTemplatesCompile(t *testing.T) {
 	var task AskTask
-	requireEmailTemplates(t, task.AdminEmailTemplate())
-	requireNotificationTemplate(t, task.AdminInternalNotificationTemplate())
+	requireEmailTemplates(t, task.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+	requireNotificationTemplate(t, task.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 }

--- a/handlers/forum/category_change_task.go
+++ b/handlers/forum/category_change_task.go
@@ -1,6 +1,7 @@
 package forum
 
 import (
+	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -15,11 +16,11 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*CategoryChangeTask)(nil)
 )
 
-func (CategoryChangeTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (CategoryChangeTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationForumCategoryChangeEmail")
 }
 
-func (CategoryChangeTask) AdminInternalNotificationTemplate() *string {
+func (CategoryChangeTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationForumCategoryChangeEmail")
 	return &v
 }

--- a/handlers/forum/category_create_task.go
+++ b/handlers/forum/category_create_task.go
@@ -1,6 +1,7 @@
 package forum
 
 import (
+	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -15,11 +16,11 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*CategoryCreateTask)(nil)
 )
 
-func (CategoryCreateTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (CategoryCreateTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationForumCategoryCreateEmail")
 }
 
-func (CategoryCreateTask) AdminInternalNotificationTemplate() *string {
+func (CategoryCreateTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationForumCategoryCreateEmail")
 	return &v
 }

--- a/handlers/forum/delete_category_task.go
+++ b/handlers/forum/delete_category_task.go
@@ -1,6 +1,7 @@
 package forum
 
 import (
+	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -15,11 +16,11 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*DeleteCategoryTask)(nil)
 )
 
-func (DeleteCategoryTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (DeleteCategoryTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationForumDeleteCategoryEmail")
 }
 
-func (DeleteCategoryTask) AdminInternalNotificationTemplate() *string {
+func (DeleteCategoryTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationForumDeleteCategoryEmail")
 	return &v
 }

--- a/handlers/forum/forumAdminTemplates_test.go
+++ b/handlers/forum/forumAdminTemplates_test.go
@@ -3,6 +3,8 @@ package forum
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -32,6 +34,6 @@ func TestForumAdminTemplatesExist(t *testing.T) {
 		threadDeleteTask,
 	}
 	for _, p := range admins {
-		requireAdminEmailTemplates(t, p.AdminEmailTemplate())
+		requireAdminEmailTemplates(t, p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/forum/forumTemplates_test.go
+++ b/handlers/forum/forumTemplates_test.go
@@ -3,6 +3,8 @@ package forum
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -38,7 +40,7 @@ func TestForumTemplatesExist(t *testing.T) {
 		replyTask,
 	}
 	for _, p := range providers {
-		checkEmailTemplates(t, p.SubscribedEmailTemplate())
-		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate())
+		checkEmailTemplates(t, p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -3,10 +3,11 @@ package forum
 import (
 	"database/sql"
 	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/arran4/goa4web/core/consts"
 
 	"github.com/arran4/goa4web/core/common"
 
@@ -49,20 +50,20 @@ func (CreateThreadTask) IndexData(data map[string]any) []searchworker.IndexEvent
 	return nil
 }
 
-func (CreateThreadTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (CreateThreadTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("threadEmail")
 }
 
-func (CreateThreadTask) SubscribedInternalNotificationTemplate() *string {
+func (CreateThreadTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("thread")
 	return &s
 }
 
-func (CreateThreadTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (CreateThreadTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationForumThreadCreateEmail")
 }
 
-func (CreateThreadTask) AdminInternalNotificationTemplate() *string {
+func (CreateThreadTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationForumThreadCreateEmail")
 	return &v
 }

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -3,10 +3,11 @@ package forum
 import (
 	"database/sql"
 	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/arran4/goa4web/core/consts"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
@@ -46,20 +47,32 @@ func (ReplyTask) IndexData(data map[string]any) []searchworker.IndexEventData {
 
 var _ searchworker.IndexedTask = ReplyTask{}
 
-func (ReplyTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (ReplyTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	return notif.NewEmailTemplates("replyEmail")
 }
 
-func (ReplyTask) SubscribedInternalNotificationTemplate() *string {
+func (ReplyTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	s := notif.NotificationTemplateFilenameGenerator("reply")
 	return &s
 }
 
-func (ReplyTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (ReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	return notif.NewEmailTemplates("adminNotificationForumReplyEmail")
 }
 
-func (ReplyTask) AdminInternalNotificationTemplate() *string {
+func (ReplyTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationForumReplyEmail")
 	return &v
 }

--- a/handlers/forum/thread_delete_task.go
+++ b/handlers/forum/thread_delete_task.go
@@ -1,6 +1,7 @@
 package forum
 
 import (
+	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -15,11 +16,11 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*ThreadDeleteTask)(nil)
 )
 
-func (ThreadDeleteTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (ThreadDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationForumThreadDeleteEmail")
 }
 
-func (ThreadDeleteTask) AdminInternalNotificationTemplate() *string {
+func (ThreadDeleteTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationForumThreadDeleteEmail")
 	return &v
 }

--- a/handlers/forum/topic_change_task.go
+++ b/handlers/forum/topic_change_task.go
@@ -1,6 +1,7 @@
 package forum
 
 import (
+	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -15,11 +16,11 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*TopicChangeTask)(nil)
 )
 
-func (TopicChangeTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (TopicChangeTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationForumTopicChangeEmail")
 }
 
-func (TopicChangeTask) AdminInternalNotificationTemplate() *string {
+func (TopicChangeTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationForumTopicChangeEmail")
 	return &v
 }

--- a/handlers/forum/topic_create_task.go
+++ b/handlers/forum/topic_create_task.go
@@ -1,6 +1,7 @@
 package forum
 
 import (
+	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -15,11 +16,11 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*TopicCreateTask)(nil)
 )
 
-func (TopicCreateTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (TopicCreateTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationForumTopicCreateEmail")
 }
 
-func (TopicCreateTask) AdminInternalNotificationTemplate() *string {
+func (TopicCreateTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationForumTopicCreateEmail")
 	return &v
 }

--- a/handlers/forum/topic_delete_task.go
+++ b/handlers/forum/topic_delete_task.go
@@ -1,6 +1,7 @@
 package forum
 
 import (
+	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -15,11 +16,11 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*TopicDeleteTask)(nil)
 )
 
-func (TopicDeleteTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (TopicDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationForumTopicDeleteEmail")
 }
 
-func (TopicDeleteTask) AdminInternalNotificationTemplate() *string {
+func (TopicDeleteTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationForumTopicDeleteEmail")
 	return &v
 }

--- a/handlers/imagebbs/imagebbsAdminApprove.go
+++ b/handlers/imagebbs/imagebbsAdminApprove.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/core/common"
@@ -46,11 +48,11 @@ func (ApprovePostTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (ApprovePostTask) SelfEmailTemplate() *notif.EmailTemplates {
+func (ApprovePostTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("imagePostApprovedEmail")
 }
 
-func (ApprovePostTask) SelfInternalNotificationTemplate() *string {
+func (ApprovePostTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("image_post_approved")
 	return &s
 }

--- a/handlers/imagebbs/imagebbsAdminBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardPage.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/core/common"
@@ -28,11 +30,11 @@ var modifyBoardTask = &ModifyBoardTask{TaskString: TaskModifyBoard}
 var _ tasks.Task = (*ModifyBoardTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*ModifyBoardTask)(nil)
 
-func (ModifyBoardTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (ModifyBoardTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("imageBoardUpdateEmail")
 }
 
-func (ModifyBoardTask) AdminInternalNotificationTemplate() *string {
+func (ModifyBoardTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("imageBoardUpdateEmail")
 	return &v
 }

--- a/handlers/imagebbs/imagebbsAdminNewBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminNewBoardPage.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 
@@ -25,11 +27,11 @@ var newBoardTask = &NewBoardTask{TaskString: TaskNewBoard}
 var _ tasks.Task = (*NewBoardTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*NewBoardTask)(nil)
 
-func (NewBoardTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (NewBoardTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationImageBoardNewEmail")
 }
 
-func (NewBoardTask) AdminInternalNotificationTemplate() *string {
+func (NewBoardTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationImageBoardNewEmail")
 	return &v
 }

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -46,11 +46,17 @@ func (ReplyTask) IndexData(data map[string]any) []searchworker.IndexEventData {
 
 var _ searchworker.IndexedTask = ReplyTask{}
 
-func (ReplyTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (ReplyTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	return notif.NewEmailTemplates("replyEmail")
 }
 
-func (ReplyTask) SubscribedInternalNotificationTemplate() *string {
+func (ReplyTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	s := notif.NotificationTemplateFilenameGenerator("reply")
 	return &s
 }

--- a/handlers/imagebbs/imagebbsTemplates_test.go
+++ b/handlers/imagebbs/imagebbsTemplates_test.go
@@ -3,6 +3,8 @@ package imagebbs
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -38,9 +40,9 @@ func TestImageBbsTemplatesExist(t *testing.T) {
 		modifyBoardTask,
 	}
 	for _, p := range admins {
-		checkEmailTemplates(t, p.AdminEmailTemplate())
+		checkEmailTemplates(t, p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 		if p != newBoardTask {
-			checkNotificationTemplate(t, p.AdminInternalNotificationTemplate())
+			checkNotificationTemplate(t, p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 		}
 	}
 
@@ -48,15 +50,15 @@ func TestImageBbsTemplatesExist(t *testing.T) {
 		approvePostTask,
 	}
 	for _, p := range selfProviders {
-		checkEmailTemplates(t, p.SelfEmailTemplate())
-		checkNotificationTemplate(t, p.SelfInternalNotificationTemplate())
+		checkEmailTemplates(t, p.SelfEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		checkNotificationTemplate(t, p.SelfInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 
 	subs := []notif.SubscribersNotificationTemplateProvider{
 		replyTask,
 	}
 	for _, p := range subs {
-		checkEmailTemplates(t, p.SubscribedEmailTemplate())
-		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate())
+		checkEmailTemplates(t, p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/languages/create_language_task.go
+++ b/handlers/languages/create_language_task.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -48,11 +50,11 @@ func (CreateLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (CreateLanguageTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (CreateLanguageTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationLanguageCreateEmail")
 }
 
-func (CreateLanguageTask) AdminInternalNotificationTemplate() *string {
+func (CreateLanguageTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationLanguageCreateEmail")
 	return &v
 }

--- a/handlers/languages/delete_language_task.go
+++ b/handlers/languages/delete_language_task.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -57,11 +59,11 @@ func (DeleteLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (DeleteLanguageTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (DeleteLanguageTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationLanguageDeleteEmail")
 }
 
-func (DeleteLanguageTask) AdminInternalNotificationTemplate() *string {
+func (DeleteLanguageTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationLanguageDeleteEmail")
 	return &v
 }

--- a/handlers/languages/languagesTemplates_test.go
+++ b/handlers/languages/languagesTemplates_test.go
@@ -3,6 +3,8 @@ package languages
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -39,7 +41,7 @@ func TestLanguageTaskTemplates(t *testing.T) {
 		createLanguageTask,
 	}
 	for _, a := range admins {
-		requireEmailTemplates(t, a.AdminEmailTemplate())
-		requireNotificationTemplate(t, a.AdminInternalNotificationTemplate())
+		requireEmailTemplates(t, a.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		requireNotificationTemplate(t, a.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/languages/rename_language_task.go
+++ b/handlers/languages/rename_language_task.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -54,11 +56,11 @@ func (RenameLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (RenameLanguageTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (RenameLanguageTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationLanguageRenameEmail")
 }
 
-func (RenameLanguageTask) AdminInternalNotificationTemplate() *string {
+func (RenameLanguageTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationLanguageRenameEmail")
 	return &v
 }

--- a/handlers/linker/approve_task.go
+++ b/handlers/linker/approve_task.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -77,20 +79,20 @@ func (approveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (approveTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (approveTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("linkerApprovedEmail")
 }
 
-func (approveTask) SubscribedInternalNotificationTemplate() *string {
+func (approveTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("linker_approved")
 	return &s
 }
 
-func (approveTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (approveTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationLinkerApprovedEmail")
 }
 
-func (approveTask) AdminInternalNotificationTemplate() *string {
+func (approveTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationLinkerApprovedEmail")
 	return &v
 }

--- a/handlers/linker/bulk_approve_task.go
+++ b/handlers/linker/bulk_approve_task.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/db"
@@ -84,20 +86,20 @@ func (bulkApproveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (bulkApproveTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (bulkApproveTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("linkerApprovedEmail")
 }
 
-func (bulkApproveTask) SubscribedInternalNotificationTemplate() *string {
+func (bulkApproveTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("linker_approved")
 	return &s
 }
 
-func (bulkApproveTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (bulkApproveTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationLinkerApprovedEmail")
 }
 
-func (bulkApproveTask) AdminInternalNotificationTemplate() *string {
+func (bulkApproveTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationLinkerApprovedEmail")
 	return &v
 }

--- a/handlers/linker/bulk_delete_task.go
+++ b/handlers/linker/bulk_delete_task.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	notif "github.com/arran4/goa4web/internal/notifications"
@@ -73,20 +75,20 @@ func (bulkDeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (bulkDeleteTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (bulkDeleteTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("linkerRejectedEmail")
 }
 
-func (bulkDeleteTask) SubscribedInternalNotificationTemplate() *string {
+func (bulkDeleteTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("linker_rejected")
 	return &s
 }
 
-func (bulkDeleteTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (bulkDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationLinkerRejectedEmail")
 }
 
-func (bulkDeleteTask) AdminInternalNotificationTemplate() *string {
+func (bulkDeleteTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationLinkerRejectedEmail")
 	return &v
 }

--- a/handlers/linker/delete_task.go
+++ b/handlers/linker/delete_task.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -61,20 +63,20 @@ func (deleteTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (deleteTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (deleteTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("linkerRejectedEmail")
 }
 
-func (deleteTask) SubscribedInternalNotificationTemplate() *string {
+func (deleteTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("linker_rejected")
 	return &s
 }
 
-func (deleteTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (deleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationLinkerRejectedEmail")
 }
 
-func (deleteTask) AdminInternalNotificationTemplate() *string {
+func (deleteTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationLinkerRejectedEmail")
 	return &v
 }

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -4,10 +4,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/eventbus"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
@@ -98,20 +100,20 @@ func (addTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (addTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (addTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("linkerAddEmail")
 }
 
-func (addTask) SubscribedInternalNotificationTemplate() *string {
+func (addTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("linker_add")
 	return &s
 }
 
-func (addTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (addTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationLinkerAddEmail")
 }
 
-func (addTask) AdminInternalNotificationTemplate() *string {
+func (addTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationLinkerAddEmail")
 	return &v
 }

--- a/handlers/linker/linkerTemplates_test.go
+++ b/handlers/linker/linkerTemplates_test.go
@@ -3,6 +3,8 @@ package linker
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -34,7 +36,7 @@ func requireNotificationTemplate(t *testing.T, name *string) {
 
 func TestLinkerTemplatesExist(t *testing.T) {
 	requireEmailTemplates(t, "linkerAddEmail")
-	requireNotificationTemplate(t, AdminAddTask.SubscribedInternalNotificationTemplate())
+	requireNotificationTemplate(t, AdminAddTask.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	requireEmailTemplates(t, "adminNotificationLinkerAddEmail")
-	requireNotificationTemplate(t, AdminAddTask.AdminInternalNotificationTemplate())
+	requireNotificationTemplate(t, AdminAddTask.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 }

--- a/handlers/linker/user_allow_task.go
+++ b/handlers/linker/user_allow_task.go
@@ -69,11 +69,11 @@ func (userAllowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (userAllowTask) TargetEmailTemplate() *notif.EmailTemplates {
+func (userAllowTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("setUserRoleEmail")
 }
 
-func (userAllowTask) TargetInternalNotificationTemplate() *string {
+func (userAllowTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("set_user_role")
 	return &v
 }

--- a/handlers/linker/user_disallow_task.go
+++ b/handlers/linker/user_disallow_task.go
@@ -62,11 +62,11 @@ func (userDisallowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (userDisallowTask) TargetEmailTemplate() *notif.EmailTemplates {
+func (userDisallowTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("deleteUserRoleEmail")
 }
 
-func (userDisallowTask) TargetInternalNotificationTemplate() *string {
+func (userDisallowTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("delete_user_role")
 	return &v
 }

--- a/handlers/news/cancel_edit_task.go
+++ b/handlers/news/cancel_edit_task.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/handlers"
@@ -20,11 +22,11 @@ var cancelTask = &CancelTask{TaskString: TaskCancel}
 var _ tasks.Task = (*CancelTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*CancelTask)(nil)
 
-func (CancelTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (CancelTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationNewsCommentCancelEmail")
 }
 
-func (CancelTask) AdminInternalNotificationTemplate() *string {
+func (CancelTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsCommentCancelEmail")
 	return &v
 }

--- a/handlers/news/edit_reply_task.go
+++ b/handlers/news/edit_reply_task.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/core"
@@ -26,11 +28,11 @@ var editReplyTask = &EditReplyTask{TaskString: TaskEditReply}
 var _ tasks.Task = (*EditReplyTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*EditReplyTask)(nil)
 
-func (EditReplyTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (EditReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationNewsCommentEditEmail")
 }
 
-func (EditReplyTask) AdminInternalNotificationTemplate() *string {
+func (EditReplyTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsCommentEditEmail")
 	return &v
 }

--- a/handlers/news/newsAdminUserLevelsPage_test.go
+++ b/handlers/news/newsAdminUserLevelsPage_test.go
@@ -3,6 +3,8 @@ package news_test
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers/admin"
 	notif "github.com/arran4/goa4web/internal/notifications"
@@ -35,10 +37,10 @@ func checkNotificationTemplate(t *testing.T, name *string) {
 
 func TestNewsUserLevelTasksTemplates(t *testing.T) {
 	allow := admin.NewsUserAllowTask{TaskString: admin.TaskNewsUserAllow}
-	checkEmailTemplates(t, allow.AdminEmailTemplate())
-	checkNotificationTemplate(t, allow.AdminInternalNotificationTemplate())
+	checkEmailTemplates(t, allow.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+	checkNotificationTemplate(t, allow.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 
 	remove := admin.NewsUserRemoveTask{TaskString: admin.TaskNewsUserRemove}
-	checkEmailTemplates(t, remove.AdminEmailTemplate())
-	checkNotificationTemplate(t, remove.AdminInternalNotificationTemplate())
+	checkEmailTemplates(t, remove.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+	checkNotificationTemplate(t, remove.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 }

--- a/handlers/news/newsAnnouncementTasks.go
+++ b/handlers/news/newsAnnouncementTasks.go
@@ -1,6 +1,7 @@
 package news
 
 import (
+	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -8,11 +9,11 @@ import (
 var _ tasks.Task = (*AnnouncementAddTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*AnnouncementAddTask)(nil)
 
-func (AnnouncementAddTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (AnnouncementAddTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationNewsAddEmail")
 }
 
-func (AnnouncementAddTask) AdminInternalNotificationTemplate() *string {
+func (AnnouncementAddTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsAddEmail")
 	return &v
 }
@@ -20,11 +21,11 @@ func (AnnouncementAddTask) AdminInternalNotificationTemplate() *string {
 var _ tasks.Task = (*AnnouncementDeleteTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*AnnouncementDeleteTask)(nil)
 
-func (AnnouncementDeleteTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (AnnouncementDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationNewsDeleteEmail")
 }
 
-func (AnnouncementDeleteTask) AdminInternalNotificationTemplate() *string {
+func (AnnouncementDeleteTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsDeleteEmail")
 	return &v
 }

--- a/handlers/news/newsEditPostTask.go
+++ b/handlers/news/newsEditPostTask.go
@@ -3,10 +3,12 @@ package news
 import (
 	"database/sql"
 	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/eventbus"
 
 	"github.com/gorilla/mux"
 
@@ -24,11 +26,11 @@ var editTask = &EditTask{TaskString: TaskEdit}
 var _ tasks.Task = (*EditTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*EditTask)(nil)
 
-func (EditTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (EditTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationNewsEditEmail")
 }
 
-func (EditTask) AdminInternalNotificationTemplate() *string {
+func (EditTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsEditEmail")
 	return &v
 }

--- a/handlers/news/newsNewPostTask.go
+++ b/handlers/news/newsNewPostTask.go
@@ -31,20 +31,20 @@ var (
 	_ notif.AutoSubscribeProvider                   = (*NewPostTask)(nil)
 )
 
-func (NewPostTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (NewPostTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationNewsAddEmail")
 }
 
-func (NewPostTask) AdminInternalNotificationTemplate() *string {
+func (NewPostTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsAddEmail")
 	return &v
 }
 
-func (NewPostTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (NewPostTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("newsAddEmail")
 }
 
-func (NewPostTask) SubscribedInternalNotificationTemplate() *string {
+func (NewPostTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("news_add")
 	return &s
 }

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -4,10 +4,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/arran4/goa4web/core/consts"
 
 	"github.com/gorilla/mux"
 
@@ -45,20 +46,32 @@ func (ReplyTask) IndexData(data map[string]any) []searchworker.IndexEventData {
 
 var _ searchworker.IndexedTask = ReplyTask{}
 
-func (ReplyTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (ReplyTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	return notif.NewEmailTemplates("replyEmail")
 }
 
-func (ReplyTask) SubscribedInternalNotificationTemplate() *string {
+func (ReplyTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	s := notif.NotificationTemplateFilenameGenerator("reply")
 	return &s
 }
 
-func (ReplyTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (ReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	return notif.NewEmailTemplates("adminNotificationNewsReplyEmail")
 }
 
-func (ReplyTask) AdminInternalNotificationTemplate() *string {
+func (ReplyTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsReplyEmail")
 	return &v
 }

--- a/handlers/news/newsTemplates_test.go
+++ b/handlers/news/newsTemplates_test.go
@@ -3,6 +3,8 @@ package news
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -38,8 +40,8 @@ func TestNewsTemplatesExist(t *testing.T) {
 		replyTask,
 	}
 	for _, p := range subs {
-		checkEmailTemplates(t, p.SubscribedEmailTemplate())
-		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate())
+		checkEmailTemplates(t, p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 
 	admins := []notif.AdminEmailTemplateProvider{
@@ -54,7 +56,7 @@ func TestNewsTemplatesExist(t *testing.T) {
 		announcementDeleteTask,
 	}
 	for _, p := range admins {
-		checkEmailTemplates(t, p.AdminEmailTemplate())
-		checkNotificationTemplate(t, p.AdminInternalNotificationTemplate())
+		checkEmailTemplates(t, p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		checkNotificationTemplate(t, p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/news/user_allow_task.go
+++ b/handlers/news/user_allow_task.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -21,11 +23,11 @@ var userAllowTask = &UserAllowTask{TaskString: TaskUserAllow}
 var _ tasks.Task = (*UserAllowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*UserAllowTask)(nil)
 
-func (UserAllowTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (UserAllowTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationNewsUserAllowEmail")
 }
 
-func (UserAllowTask) AdminInternalNotificationTemplate() *string {
+func (UserAllowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsUserAllowEmail")
 	return &v
 }

--- a/handlers/news/user_disallow_task.go
+++ b/handlers/news/user_disallow_task.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -20,11 +22,11 @@ var userDisallowTask = &UserDisallowTask{TaskString: TaskUserDisallow}
 var _ tasks.Task = (*UserDisallowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*UserDisallowTask)(nil)
 
-func (UserDisallowTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (UserDisallowTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationNewsUserDisallowEmail")
 }
 
-func (UserDisallowTask) AdminInternalNotificationTemplate() *string {
+func (UserDisallowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsUserDisallowEmail")
 	return &v
 }

--- a/handlers/search/remakeBlogFinishedTask.go
+++ b/handlers/search/remakeBlogFinishedTask.go
@@ -3,6 +3,8 @@ package search
 import (
 	"net/http"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -18,20 +20,20 @@ var _ notif.SelfNotificationTemplateProvider = (*RemakeBlogFinishedTask)(nil)
 
 func (RemakeBlogFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
 
-func (RemakeBlogFinishedTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (RemakeBlogFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("searchRebuildBlogEmail")
 }
 
-func (RemakeBlogFinishedTask) AdminInternalNotificationTemplate() *string {
+func (RemakeBlogFinishedTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_blog")
 	return &s
 }
 
-func (RemakeBlogFinishedTask) SelfEmailTemplate() *notif.EmailTemplates {
+func (RemakeBlogFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("searchRebuildBlogEmail")
 }
 
-func (RemakeBlogFinishedTask) SelfInternalNotificationTemplate() *string {
+func (RemakeBlogFinishedTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_blog")
 	return &s
 }

--- a/handlers/search/remakeCommentsFinishedTask.go
+++ b/handlers/search/remakeCommentsFinishedTask.go
@@ -3,6 +3,8 @@ package search
 import (
 	"net/http"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -18,20 +20,20 @@ var _ notif.SelfNotificationTemplateProvider = (*RemakeCommentsFinishedTask)(nil
 
 func (RemakeCommentsFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
 
-func (RemakeCommentsFinishedTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (RemakeCommentsFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("searchRebuildCommentsEmail")
 }
 
-func (RemakeCommentsFinishedTask) AdminInternalNotificationTemplate() *string {
+func (RemakeCommentsFinishedTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_comments")
 	return &s
 }
 
-func (RemakeCommentsFinishedTask) SelfEmailTemplate() *notif.EmailTemplates {
+func (RemakeCommentsFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("searchRebuildCommentsEmail")
 }
 
-func (RemakeCommentsFinishedTask) SelfInternalNotificationTemplate() *string {
+func (RemakeCommentsFinishedTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_comments")
 	return &s
 }

--- a/handlers/search/remakeImageFinishedTask.go
+++ b/handlers/search/remakeImageFinishedTask.go
@@ -3,6 +3,8 @@ package search
 import (
 	"net/http"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -18,20 +20,20 @@ var _ notif.SelfNotificationTemplateProvider = (*RemakeImageFinishedTask)(nil)
 
 func (RemakeImageFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
 
-func (RemakeImageFinishedTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (RemakeImageFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("searchRebuildImageEmail")
 }
 
-func (RemakeImageFinishedTask) AdminInternalNotificationTemplate() *string {
+func (RemakeImageFinishedTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_image")
 	return &s
 }
 
-func (RemakeImageFinishedTask) SelfEmailTemplate() *notif.EmailTemplates {
+func (RemakeImageFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("searchRebuildImageEmail")
 }
 
-func (RemakeImageFinishedTask) SelfInternalNotificationTemplate() *string {
+func (RemakeImageFinishedTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_image")
 	return &s
 }

--- a/handlers/search/remakeLinkerFinishedTask.go
+++ b/handlers/search/remakeLinkerFinishedTask.go
@@ -3,6 +3,8 @@ package search
 import (
 	"net/http"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -18,20 +20,20 @@ var _ notif.SelfNotificationTemplateProvider = (*RemakeLinkerFinishedTask)(nil)
 
 func (RemakeLinkerFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
 
-func (RemakeLinkerFinishedTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (RemakeLinkerFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("searchRebuildLinkerEmail")
 }
 
-func (RemakeLinkerFinishedTask) AdminInternalNotificationTemplate() *string {
+func (RemakeLinkerFinishedTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_linker")
 	return &s
 }
 
-func (RemakeLinkerFinishedTask) SelfEmailTemplate() *notif.EmailTemplates {
+func (RemakeLinkerFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("searchRebuildLinkerEmail")
 }
 
-func (RemakeLinkerFinishedTask) SelfInternalNotificationTemplate() *string {
+func (RemakeLinkerFinishedTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_linker")
 	return &s
 }

--- a/handlers/search/remakeNewsFinishedTask.go
+++ b/handlers/search/remakeNewsFinishedTask.go
@@ -3,6 +3,8 @@ package search
 import (
 	"net/http"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -18,20 +20,20 @@ var _ notif.SelfNotificationTemplateProvider = (*RemakeNewsFinishedTask)(nil)
 
 func (RemakeNewsFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
 
-func (RemakeNewsFinishedTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (RemakeNewsFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("searchRebuildNewsEmail")
 }
 
-func (RemakeNewsFinishedTask) AdminInternalNotificationTemplate() *string {
+func (RemakeNewsFinishedTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_news")
 	return &s
 }
 
-func (RemakeNewsFinishedTask) SelfEmailTemplate() *notif.EmailTemplates {
+func (RemakeNewsFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("searchRebuildNewsEmail")
 }
 
-func (RemakeNewsFinishedTask) SelfInternalNotificationTemplate() *string {
+func (RemakeNewsFinishedTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_news")
 	return &s
 }

--- a/handlers/search/remakeWritingFinishedTask.go
+++ b/handlers/search/remakeWritingFinishedTask.go
@@ -3,6 +3,8 @@ package search
 import (
 	"net/http"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -18,20 +20,20 @@ var _ notif.SelfNotificationTemplateProvider = (*RemakeWritingFinishedTask)(nil)
 
 func (RemakeWritingFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
 
-func (RemakeWritingFinishedTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (RemakeWritingFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("searchRebuildWritingEmail")
 }
 
-func (RemakeWritingFinishedTask) AdminInternalNotificationTemplate() *string {
+func (RemakeWritingFinishedTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_writing")
 	return &s
 }
 
-func (RemakeWritingFinishedTask) SelfEmailTemplate() *notif.EmailTemplates {
+func (RemakeWritingFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("searchRebuildWritingEmail")
 }
 
-func (RemakeWritingFinishedTask) SelfInternalNotificationTemplate() *string {
+func (RemakeWritingFinishedTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("search_rebuild_writing")
 	return &s
 }

--- a/handlers/user/addEmailTask.go
+++ b/handlers/user/addEmailTask.go
@@ -145,7 +145,7 @@ func (AddEmailTask) Notify(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }
 
-func (AddEmailTask) DirectEmailTemplate() *notif.EmailTemplates {
+func (AddEmailTask) DirectEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("verifyEmail")
 }
 

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -27,11 +27,11 @@ func TestPermissionUserTasksTemplates(t *testing.T) {
 		&PermissionUserDisallowTask{TaskString: TaskUserDisallow},
 	}
 	for _, p := range admins {
-		et := p.AdminEmailTemplate()
+		et := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
 		if et == nil || et.Text == "" || et.HTML == "" || et.Subject == "" {
 			t.Errorf("incomplete templates for %T", p)
 		}
-		nt := p.AdminInternalNotificationTemplate()
+		nt := p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
 		if nt == nil || *nt == "" {
 			t.Errorf("missing internal template for %T", p)
 		}
@@ -69,7 +69,7 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{"user": "2"})
 	cd := common.NewCoreData(req.Context(), queries, config.NewRuntimeConfig())
 	cd.LoadSelectionsFromRequest(req)
-	evt := &eventbus.TaskEvent{}
+	evt := &eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}
 	cd.SetEvent(evt)
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/user/permissionUpdateTask.go
+++ b/handlers/user/permissionUpdateTask.go
@@ -93,11 +93,11 @@ func (PermissionUpdateTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, erro
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (PermissionUpdateTask) TargetEmailTemplate() *notif.EmailTemplates {
+func (PermissionUpdateTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("updateUserRoleEmail")
 }
 
-func (PermissionUpdateTask) TargetInternalNotificationTemplate() *string {
+func (PermissionUpdateTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("update_user_role")
 	return &v
 }

--- a/handlers/user/permissionUserAllowTask.go
+++ b/handlers/user/permissionUserAllowTask.go
@@ -23,11 +23,11 @@ var _ tasks.Task = (*PermissionUserAllowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*PermissionUserAllowTask)(nil)
 var _ notif.TargetUsersNotificationProvider = (*PermissionUserAllowTask)(nil)
 
-func (PermissionUserAllowTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (PermissionUserAllowTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminPermissionAllowEmail")
 }
 
-func (PermissionUserAllowTask) AdminInternalNotificationTemplate() *string {
+func (PermissionUserAllowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminPermissionAllowEmail")
 	return &v
 }
@@ -80,11 +80,11 @@ func (PermissionUserAllowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, e
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (PermissionUserAllowTask) TargetEmailTemplate() *notif.EmailTemplates {
+func (PermissionUserAllowTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("setUserRoleEmail")
 }
 
-func (PermissionUserAllowTask) TargetInternalNotificationTemplate() *string {
+func (PermissionUserAllowTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("set_user_role")
 	return &v
 }

--- a/handlers/user/permissionUserDisallowTask.go
+++ b/handlers/user/permissionUserDisallowTask.go
@@ -23,11 +23,11 @@ var _ tasks.Task = (*PermissionUserDisallowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*PermissionUserDisallowTask)(nil)
 var _ notif.TargetUsersNotificationProvider = (*PermissionUserDisallowTask)(nil)
 
-func (PermissionUserDisallowTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (PermissionUserDisallowTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminPermissionDisallowEmail")
 }
 
-func (PermissionUserDisallowTask) AdminInternalNotificationTemplate() *string {
+func (PermissionUserDisallowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminPermissionDisallowEmail")
 	return &v
 }
@@ -96,11 +96,11 @@ func (PermissionUserDisallowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (PermissionUserDisallowTask) TargetEmailTemplate() *notif.EmailTemplates {
+func (PermissionUserDisallowTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("deleteUserRoleEmail")
 }
 
-func (PermissionUserDisallowTask) TargetInternalNotificationTemplate() *string {
+func (PermissionUserDisallowTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("delete_user_role")
 	return &v
 }

--- a/handlers/user/resendVerificationEmailTask.go
+++ b/handlers/user/resendVerificationEmailTask.go
@@ -2,10 +2,11 @@ package user
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
-	"net/http"
 )
 
 // ResendVerificationEmailTask resends the verification link for an unverified user email address.
@@ -20,7 +21,7 @@ func (ResendVerificationEmailTask) Action(w http.ResponseWriter, r *http.Request
 	return addEmailTask.Resend(w, r)
 }
 
-func (ResendVerificationEmailTask) DirectEmailTemplate() *notif.EmailTemplates {
+func (ResendVerificationEmailTask) DirectEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("verifyEmail")
 }
 

--- a/handlers/user/testMailTask.go
+++ b/handlers/user/testMailTask.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
@@ -39,11 +41,11 @@ func (TestMailTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return handlers.RefreshDirectHandler{TargetURL: "/usr/email"}
 }
 
-func (TestMailTask) SelfEmailTemplate() *notif.EmailTemplates {
+func (TestMailTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("testEmail")
 }
 
-func (TestMailTask) SelfInternalNotificationTemplate() *string {
+func (TestMailTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("testEmail")
 	return &s
 }

--- a/handlers/writings/edit_reply_task.go
+++ b/handlers/writings/edit_reply_task.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
@@ -84,11 +86,11 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return handlers.RedirectHandler(fmt.Sprintf("/writings/article/%d", writing.Idwriting))
 }
 
-func (EditReplyTask) AdminEmailTemplate() *notif.EmailTemplates {
+func (EditReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("adminNotificationNewsCommentEditEmail")
 }
 
-func (EditReplyTask) AdminInternalNotificationTemplate() *string {
+func (EditReplyTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("adminNotificationNewsCommentEditEmail")
 	return &v
 }

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -40,11 +40,17 @@ func (ReplyTask) IndexData(data map[string]any) []searchworker.IndexEventData {
 	return nil
 }
 
-func (ReplyTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (ReplyTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	return notif.NewEmailTemplates("replyEmail")
 }
 
-func (ReplyTask) SubscribedInternalNotificationTemplate() *string {
+func (ReplyTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
+	if evt.Outcome != eventbus.TaskOutcomeSuccess {
+		return nil
+	}
 	s := notif.NotificationTemplateFilenameGenerator("reply")
 	return &s
 }

--- a/handlers/writings/submit_writing_task.go
+++ b/handlers/writings/submit_writing_task.go
@@ -100,11 +100,11 @@ func (SubmitWritingTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return handlers.RedirectHandler(fmt.Sprintf("/writings/article/%d", articleID))
 }
 
-func (SubmitWritingTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (SubmitWritingTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("writingEmail")
 }
 
-func (SubmitWritingTask) SubscribedInternalNotificationTemplate() *string {
+func (SubmitWritingTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("writing")
 	return &s
 }

--- a/handlers/writings/templates_test.go
+++ b/handlers/writings/templates_test.go
@@ -3,6 +3,8 @@ package writings
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -10,7 +12,7 @@ import (
 func TestReplyTemplatesCompile(t *testing.T) {
 	// Ensure the ReplyTask exposes templates that actually exist so users
 	// receive notification emails when someone responds.
-	et := replyTask.SubscribedEmailTemplate()
+	et := replyTask.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
 	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
 	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
 	if htmlTmpls.Lookup(et.HTML) == nil {
@@ -24,7 +26,7 @@ func TestReplyTemplatesCompile(t *testing.T) {
 	}
 
 	nt := templates.GetCompiledNotificationTemplates(map[string]any{})
-	it := replyTask.SubscribedInternalNotificationTemplate()
+	it := replyTask.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
 	if nt.Lookup(*it) == nil {
 		t.Fatalf("missing notification template %s", *it)
 	}

--- a/handlers/writings/update_writing_task.go
+++ b/handlers/writings/update_writing_task.go
@@ -95,11 +95,11 @@ func (UpdateWritingTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (UpdateWritingTask) SubscribedEmailTemplate() *notif.EmailTemplates {
+func (UpdateWritingTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("writingUpdateEmail")
 }
 
-func (UpdateWritingTask) SubscribedInternalNotificationTemplate() *string {
+func (UpdateWritingTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	s := notif.NotificationTemplateFilenameGenerator("writing_update")
 	return &s
 }

--- a/handlers/writings/user_allow_task.go
+++ b/handlers/writings/user_allow_task.go
@@ -60,11 +60,11 @@ func (UserAllowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (UserAllowTask) TargetEmailTemplate() *notif.EmailTemplates {
+func (UserAllowTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("setUserRoleEmail")
 }
 
-func (UserAllowTask) TargetInternalNotificationTemplate() *string {
+func (UserAllowTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("set_user_role")
 	return &v
 }

--- a/handlers/writings/user_disallow_task.go
+++ b/handlers/writings/user_disallow_task.go
@@ -59,11 +59,11 @@ func (UserDisallowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) {
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (UserDisallowTask) TargetEmailTemplate() *notif.EmailTemplates {
+func (UserDisallowTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
 	return notif.NewEmailTemplates("deleteUserRoleEmail")
 }
 
-func (UserDisallowTask) TargetInternalNotificationTemplate() *string {
+func (UserDisallowTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	v := notif.NotificationTemplateFilenameGenerator("delete_user_role")
 	return &v
 }

--- a/handlers/writings/writingsTemplates_test.go
+++ b/handlers/writings/writingsTemplates_test.go
@@ -3,6 +3,8 @@ package writings
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
@@ -39,7 +41,7 @@ func TestWritingsTemplatesExist(t *testing.T) {
 		replyTask,
 	}
 	for _, p := range providers {
-		checkEmailTemplates(t, p.SubscribedEmailTemplate())
-		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate())
+		checkEmailTemplates(t, p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/internal/eventbus/eventbus.go
+++ b/internal/eventbus/eventbus.go
@@ -28,12 +28,18 @@ type Message interface {
 
 // TaskEvent represents a task or notification that occurred in the application.
 type TaskEvent struct {
-	Path   string         // Path or URI describing the event source
-	Task   tasks.Task     // Name of the action/task performed
-	UserID int32          // ID of the user performing the action
-	Time   time.Time      // Time the event occurred
-	Data   map[string]any // Optional template data associated with the event
+	Path    string         // Path or URI describing the event source
+	Task    tasks.Task     // Name of the action/task performed
+	UserID  int32          // ID of the user performing the action
+	Time    time.Time      // Time the event occurred
+	Data    map[string]any // Optional template data associated with the event
+	Outcome string         // Outcome describes the result of the task run
 }
+
+const (
+	// TaskOutcomeSuccess indicates the task completed without error.
+	TaskOutcomeSuccess = "success"
+)
 
 // Type implements the Message interface.
 func (TaskEvent) Type() MessageType { return TaskMessageType }

--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -143,6 +143,9 @@ func (m *TaskEventMiddleware) Middleware(next http.Handler) http.Handler {
 		cd.SetEvent(evt)
 		sr := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(sr, r)
+		if sr.status < http.StatusBadRequest && evt.Outcome == "" {
+			evt.Outcome = eventbus.TaskOutcomeSuccess
+		}
 		if task != "" && sr.status < http.StatusBadRequest {
 			if err := m.bus.Publish(*evt); err != nil {
 				if err == eventbus.ErrBusClosed {

--- a/internal/notifications/permission_tasks_test.go
+++ b/internal/notifications/permission_tasks_test.go
@@ -19,17 +19,21 @@ import (
 
 type allowTaskNoEmail struct{ user.PermissionUserAllowTask }
 
-func (allowTaskNoEmail) TargetEmailTemplate() *notif.EmailTemplates { return nil }
+func (allowTaskNoEmail) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates { return nil }
 
 type disallowTaskNoEmail struct {
 	user.PermissionUserDisallowTask
 }
 
-func (disallowTaskNoEmail) TargetEmailTemplate() *notif.EmailTemplates { return nil }
+func (disallowTaskNoEmail) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
+	return nil
+}
 
 type updateTaskNoEmail struct{ user.PermissionUpdateTask }
 
-func (updateTaskNoEmail) TargetEmailTemplate() *notif.EmailTemplates { return nil }
+func (updateTaskNoEmail) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
+	return nil
+}
 
 func TestProcessEventPermissionTasks(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -76,7 +80,7 @@ func TestProcessEventPermissionTasks(t *testing.T) {
 			WithArgs(int32(2), sqlmock.AnyArg(), sqlmock.AnyArg()).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
-		bus.Publish(eventbus.TaskEvent{Path: "/admin", Task: c.task, UserID: 1, Data: map[string]any{"targetUserID": int32(2), "Username": "bob"}})
+		bus.Publish(eventbus.TaskEvent{Path: "/admin", Task: c.task, UserID: 1, Data: map[string]any{"targetUserID": int32(2), "Username": "bob"}, Outcome: eventbus.TaskOutcomeSuccess})
 		time.Sleep(10 * time.Millisecond)
 	}
 	time.Sleep(200 * time.Millisecond)

--- a/internal/notifications/reply_templates_test.go
+++ b/internal/notifications/reply_templates_test.go
@@ -3,6 +3,8 @@ package notifications_test
 import (
 	"testing"
 
+	"github.com/arran4/goa4web/internal/eventbus"
+
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers/writings"
 )
@@ -14,7 +16,7 @@ func TestReplyTemplatesExist(t *testing.T) {
 	html := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
 	text := templates.GetCompiledEmailTextTemplates(map[string]any{})
 	nt := templates.GetCompiledNotificationTemplates(map[string]any{})
-	et := task.SubscribedEmailTemplate()
+	et := task.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
 	if html.Lookup(et.HTML) == nil {
 		t.Errorf("missing html template %s", et.HTML)
 	}
@@ -24,7 +26,7 @@ func TestReplyTemplatesExist(t *testing.T) {
 	if text.Lookup(et.Subject) == nil {
 		t.Errorf("missing subject template %s", et.Subject)
 	}
-	ntName := task.SubscribedInternalNotificationTemplate()
+	ntName := task.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
 	if nt.Lookup(*ntName) == nil {
 		t.Errorf("missing notification template %s", *ntName)
 	}

--- a/internal/notifications/subscriptionsinterfaces.go
+++ b/internal/notifications/subscriptionsinterfaces.go
@@ -21,15 +21,15 @@ func NewEmailTemplates(prefix string) *EmailTemplates {
 // AdminEmailTemplateProvider indicates the notification should be sent via
 // email to administrators using the provided templates.
 type AdminEmailTemplateProvider interface {
-	AdminEmailTemplate() *EmailTemplates
-	AdminInternalNotificationTemplate() *string
+	AdminEmailTemplate(evt eventbus.TaskEvent) *EmailTemplates
+	AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string
 }
 
 // SelfNotificationTemplateProvider is used for mandatory self notifications such as password
 // resets or verifications.
 type SelfNotificationTemplateProvider interface {
-	SelfEmailTemplate() *EmailTemplates
-	SelfInternalNotificationTemplate() *string
+	SelfEmailTemplate(evt eventbus.TaskEvent) *EmailTemplates
+	SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string
 }
 
 // SelfEmailBroadcaster indicates the notification should be sent to all
@@ -44,14 +44,14 @@ type SelfEmailBroadcaster interface {
 // Internal notifications are not supported for this provider.
 type DirectEmailNotificationTemplateProvider interface {
 	DirectEmailAddress(evt eventbus.TaskEvent) (string, error)
-	DirectEmailTemplate() *EmailTemplates
+	DirectEmailTemplate(evt eventbus.TaskEvent) *EmailTemplates
 }
 
 // SubscribersNotificationTemplateProvider indicates the notification should be delivered to
 // subscribed users.
 type SubscribersNotificationTemplateProvider interface {
-	SubscribedEmailTemplate() *EmailTemplates
-	SubscribedInternalNotificationTemplate() *string
+	SubscribedEmailTemplate(evt eventbus.TaskEvent) *EmailTemplates
+	SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string
 }
 
 // AutoSubscribeProvider describes events that automatically create a
@@ -67,8 +67,8 @@ type AutoSubscribeProvider interface {
 // to the returned user IDs.
 type TargetUsersNotificationProvider interface {
 	TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error)
-	TargetEmailTemplate() *EmailTemplates
-	TargetInternalNotificationTemplate() *string
+	TargetEmailTemplate(evt eventbus.TaskEvent) *EmailTemplates
+	TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string
 }
 
 // GrantsRequiredProvider exposes the permission context for subscription

--- a/workers/backgroundtaskworker/worker.go
+++ b/workers/backgroundtaskworker/worker.go
@@ -34,11 +34,12 @@ func Worker(ctx context.Context, bus *eventbus.Bus, q db.Querier) {
 				}
 				if t != nil {
 					nEvt := eventbus.TaskEvent{
-						Path:   evt.Path,
-						Task:   t,
-						UserID: evt.UserID,
-						Time:   time.Now(),
-						Data:   evt.Data,
+						Path:    evt.Path,
+						Task:    t,
+						UserID:  evt.UserID,
+						Time:    time.Now(),
+						Data:    evt.Data,
+						Outcome: eventbus.TaskOutcomeSuccess,
 					}
 					if err := bus.Publish(nEvt); err != nil && err != eventbus.ErrBusClosed {
 						log.Printf("background publish: %v", err)


### PR DESCRIPTION
## Summary
- guard reply notification templates across news, forums, blogs, writings and imageboards so they only emit when `Outcome` is `success`
- update template listing utilities and tests to pass task events marked as successful

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6892cb1b88b0832f9ea20c8d5b5fc324