### PR TITLE
Clarify role grant page labeling

### DIFF
--- a/core/templates/site/admin/adminRoleGrantAddPage.gohtml
+++ b/core/templates/site/admin/adminRoleGrantAddPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-<h2>Add Grant to {{ .Role.Name }}</h2>
+<h2>Add Grant to Role {{ .Role.Name }}</h2>
 {{ if eq .Section "" }}
 <form method="get">
     <label>Section:
@@ -26,7 +26,7 @@
 {{ else }}
 <form method="post" action="/admin/role/{{ .Role.ID }}/grant">
     {{ csrfField }}
-    <input type="hidden" name="task" value="Add grant">
+    <input type="hidden" name="task" value="Create grant">
     <input type="hidden" name="section" value="{{ .Section }}">
     <input type="hidden" name="item" value="{{ .Item }}">
     <label>Action:

--- a/handlers/admin/adminRoleGrantAddPage.go
+++ b/handlers/admin/adminRoleGrantAddPage.go
@@ -26,19 +26,19 @@ func adminRoleGrantAddPage(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("role not found"))
 		return
 	}
-	cd.PageTitle = fmt.Sprintf("Add Grant: %s", role.Name)
+	cd.PageTitle = fmt.Sprintf("Add Grant to Role: %s", role.Name)
 
 	section := r.URL.Query().Get("section")
 	item := r.URL.Query().Get("item")
 
 	data := struct {
-		Role        *db.Role
-		Section     string
-		Item        string
-		Sections    []string
-		Items       []string
-		Actions     []string
-		ItemOptions []ItemOption
+		Role          *db.Role
+		Section       string
+		Item          string
+		Sections      []string
+		Items         []string
+		Actions       []string
+		ItemOptions   []ItemOption
 		RequireItemID bool
 	}{Role: role, Section: section, Item: item}
 


### PR DESCRIPTION
## Summary
- Clarify role grant add page with explicit role label
- Match task name to expected `Create grant` constant

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: process hung)*
- `golangci-lint run` *(fails: process hung)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689308cdeb8c832f9e4cd69efc93ba51