### PR TITLE
Link item IDs on role grant page

### DIFF
--- a/core/templates/role_grants_editor_link_test.go
+++ b/core/templates/role_grants_editor_link_test.go
@@ -1,0 +1,46 @@
+package templates_test
+
+import (
+	"bytes"
+	"database/sql"
+	"embed"
+	"html/template"
+	"strings"
+	"testing"
+
+	admin "github.com/arran4/goa4web/handlers/admin"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+//go:embed site/admin/roleGrantsEditor.gohtml
+var roleGrantsEditorTemplate embed.FS
+
+func TestRoleGrantsEditor_ItemIDLink(t *testing.T) {
+	tmpl := template.Must(template.New("").Funcs(template.FuncMap{
+		"csrfField": func() template.HTML { return "" },
+	}).ParseFS(roleGrantsEditorTemplate, "site/admin/roleGrantsEditor.gohtml"))
+
+	data := struct {
+		Role        *db.Role
+		GrantGroups []admin.GrantGroup
+	}{
+		Role: &db.Role{ID: 1, Name: "test"},
+		GrantGroups: []admin.GrantGroup{
+			{
+				Section: "forum",
+				Item:    "topic",
+				ItemID:  sql.NullInt32{Int32: 42, Valid: true},
+				Link:    "/admin/forum/topic/42",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "roleGrantsEditor.gohtml", data); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, `<a href="/admin/forum/topic/42">42</a>`) {
+		t.Fatalf("expected link in output, got %s", html)
+	}
+}

--- a/core/templates/site/admin/roleGrantsEditor.gohtml
+++ b/core/templates/site/admin/roleGrantsEditor.gohtml
@@ -6,7 +6,7 @@
         <tr data-section="{{ .Section }}" data-item="{{ .Item }}" data-itemid="{{ if .ItemID.Valid }}{{ .ItemID.Int32 }}{{ end }}"{{ if .Unsupported }} class="unsupported"{{ end }}>
             <td>{{ .Section }}</td>
             <td>{{ .Item }}</td>
-            <td>{{ if .ItemID.Valid }}{{ .ItemID.Int32 }}{{ end }}</td>
+            <td>{{ if .ItemID.Valid }}{{ if .Link }}<a href="{{ .Link }}">{{ .ItemID.Int32 }}</a>{{ else }}{{ .ItemID.Int32 }}{{ end }}{{ end }}</td>
             <td>{{ .Info }}</td>
             <td class="have">
                 {{- range .Have }}


### PR DESCRIPTION
## Summary
- link Item ID to its target in role grants editor
- add test covering Item ID link rendering

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893084b9aac832f8cf0d1fe3a69646c