### PR TITLE
feat(admin): improve user writings page and route

### DIFF
--- a/core/templates/site/admin/userWritingsPage.gohtml
+++ b/core/templates/site/admin/userWritingsPage.gohtml
@@ -1,13 +1,15 @@
 {{ template "head" $ }}
 <h2>Writings by {{ .User.Username.String }}</h2>
 <table border="1">
-    <tr><th>ID</th><th>Date</th><th>Comments</th><th>Link</th></tr>
+    <tr><th>ID</th><th>Title</th><th>Category</th><th>Date</th><th>Comments</th><th>Actions</th></tr>
     {{- range .Writings }}
     <tr>
-        <td>{{ .Idwriting }}</td>
-        <td>{{ .Published }}</td>
+        <td><a href="/admin/writings/article/{{ .Idwriting }}">{{ .Idwriting }}</a></td>
+        <td>{{ .Title.String }}</td>
+        <td><a href="/admin/writings/category/{{ .WritingCategoryID }}">{{ .WritingCategoryID }}</a></td>
+        <td>{{ if .Published.Valid }}{{ .Published.Time }}{{ end }}</td>
         <td>{{ .Comments }}</td>
-        <td><a href="/writings/article/{{ .Idwriting }}">View</a></td>
+        <td><a href="/writings/article/{{ .Idwriting }}">View</a> | <a href="/writings/article/{{ .Idwriting }}/edit">Edit</a></td>
     </tr>
     {{- end }}
 </table>

--- a/handlers/admin/adminUserProfilePage_test.go
+++ b/handlers/admin/adminUserProfilePage_test.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -30,9 +29,6 @@ func TestAdminUserProfilePage_UserFound(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).
 		AddRow(userID, "u@example.com", "u", nil)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	for i := 0; i < 6; i++ {
-		mock.ExpectQuery("SELECT").WillReturnError(sql.ErrNoRows)
-	}
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/admin/user/%d", userID), nil)
 	req = mux.SetURLVars(req, map[string]string{"user": strconv.Itoa(userID)})

--- a/handlers/admin/adminUserWritingsPage_test.go
+++ b/handlers/admin/adminUserWritingsPage_test.go
@@ -1,0 +1,63 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestAdminUserWritingsPage(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	queries := db.New(sqlDB)
+
+	userRows := sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).
+		AddRow(1, "u@test", "user", nil)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
+		WithArgs(int32(1)).
+		WillReturnRows(userRows)
+
+	writingRows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "username", "comments"}).
+		AddRow(1, 1, 0, 0, 2, "Title", time.Now(), "", "", false, nil, nil, "user", 0)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,\n    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments\nFROM writing w\nLEFT JOIN users u ON w.users_idusers = u.idusers\nWHERE w.users_idusers = ?\nORDER BY w.published DESC")).
+		WithArgs(int32(1)).
+		WillReturnRows(writingRows)
+
+	req := httptest.NewRequest("GET", "/admin/user/1/writings", nil)
+	ctx := req.Context()
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd.SetCurrentProfileUserID(1)
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	adminUserWritingsPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `<a href="/admin/writings/article/1">1</a>`) {
+		t.Fatalf("missing admin link: %s", body)
+	}
+	if !strings.Contains(body, "Title") {
+		t.Fatalf("missing title: %s", body)
+	}
+}

--- a/handlers/writings/routes_admin.go
+++ b/handlers/writings/routes_admin.go
@@ -14,6 +14,7 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	war.HandleFunc("/users/roles", handlers.TaskHandler(userDisallowTask)).Methods("POST").MatcherFunc(userDisallowTask.Matcher())
 	war.HandleFunc("/categories", AdminCategoriesPage).Methods("GET")
 	war.HandleFunc("/category/{category}", AdminCategoryPage).Methods("GET")
+	war.HandleFunc("/article/{writing}", ArticlePage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 	war.HandleFunc("/categories", handlers.TaskHandler(writingCategoryChangeTask)).Methods("POST").MatcherFunc(writingCategoryChangeTask.Matcher())
 	war.HandleFunc("/categories", handlers.TaskHandler(writingCategoryCreateTask)).Methods("POST").MatcherFunc(writingCategoryCreateTask.Matcher())
 	war.HandleFunc("/category/{category}/permissions", AdminCategoryGrantsPage).Methods("GET")


### PR DESCRIPTION
## Summary
- add admin route to view individual writings
- show writing details with admin links on user writings page
- add tests for user writing page and update profile test

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893231f6d3c832fb98f9106b7fcd0e3