### PR TITLE
Add admin link details page

### DIFF
--- a/core/templates/site/linker/adminLinkViewPage.gohtml
+++ b/core/templates/site/linker/adminLinkViewPage.gohtml
@@ -1,0 +1,9 @@
+{{ template "head" $ }}
+    <p><strong>Title:</strong> {{ .Link.Title.String }}</p>
+    <p><strong>URL:</strong> <a href="{{ .Link.Url.String }}">{{ .Link.Url.String }}</a></p>
+    <p><strong>Description:</strong> {{ .Link.Description.String }}</p>
+    <p><strong>Category:</strong> {{ .Link.Title_2.String }}</p>
+    <p><strong>Poster:</strong> {{ .Link.Username.String }}</p>
+    <p><strong>Listed:</strong> {{ if .Link.Listed.Valid }}{{ .Link.Listed.Time }}{{ end }}</p>
+    <p><a href="/admin/linker/link/{{ .Link.Idlinker }}/edit">Edit</a></p>
+{{ template "tail" $ }}

--- a/handlers/linker/linkerAdminLinkViewPage.go
+++ b/handlers/linker/linkerAdminLinkViewPage.go
@@ -1,0 +1,42 @@
+package linker
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// adminLinkViewPage displays information about a linker item.
+func adminLinkViewPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	link, id, err := cd.SelectedAdminLinkerItem(r)
+	if err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			http.NotFound(w, r)
+		default:
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
+		}
+		return
+	}
+
+	if link.Title.Valid {
+		cd.PageTitle = fmt.Sprintf("Link: %s", link.Title.String)
+	} else {
+		cd.PageTitle = fmt.Sprintf("Link %d", id)
+	}
+
+	data := struct {
+		Link *db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow
+	}{
+		Link: link,
+	}
+
+	handlers.TemplateHandler(w, r, "adminLinkViewPage.gohtml", data)
+}

--- a/handlers/linker/linkerAdminLinkViewPage_test.go
+++ b/handlers/linker/linkerAdminLinkViewPage_test.go
@@ -1,0 +1,46 @@
+package linker
+
+import (
+	"context"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestAdminLinkViewPage(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	queries := db.New(conn)
+	req := httptest.NewRequest("GET", "/admin/linker/link/1", nil)
+	req = mux.SetURLVars(req, map[string]string{"link": "1"})
+	w := httptest.NewRecorder()
+
+	ctx := req.Context()
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT l.idlinker")).
+		WithArgs(int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"idlinker", "language_idlanguage", "users_idusers", "linker_category_id", "forumthread_id", "title", "url", "description", "listed", "username", "title_2"}).
+			AddRow(1, 1, 2, 1, 0, "t", "http://u", "d", time.Unix(0, 0), "bob", "cat"))
+
+	adminLinkViewPage(w, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/handlers/linker/routes_admin.go
+++ b/handlers/linker/routes_admin.go
@@ -28,8 +28,9 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	lar.HandleFunc("/users/roles", handlers.TaskHandler(UserAllowTask)).Methods("POST").MatcherFunc(UserAllowTask.Matcher())
 	lar.HandleFunc("/users/roles", handlers.TaskHandler(UserDisallowTask)).Methods("POST").MatcherFunc(UserDisallowTask.Matcher())
 
-	lar.HandleFunc("/link/{link}", adminLinkPage).Methods("GET")
-	lar.HandleFunc("/link/{link}", handlers.TaskHandler(AdminEditLinkTask)).Methods("POST").MatcherFunc(AdminEditLinkTask.Matcher())
+	lar.HandleFunc("/link/{link}", adminLinkViewPage).Methods("GET")
+	lar.HandleFunc("/link/{link}/edit", adminLinkPage).Methods("GET")
+	lar.HandleFunc("/link/{link}/edit", handlers.TaskHandler(AdminEditLinkTask)).Methods("POST").MatcherFunc(AdminEditLinkTask.Matcher())
 
 	lar.HandleFunc("/category/{category}/grants", AdminCategoryGrantsPage).Methods("GET")
 	lar.HandleFunc("/category/{category}/grant", handlers.TaskHandler(categoryGrantCreateTask)).Methods("POST").MatcherFunc(categoryGrantCreateTask.Matcher())


### PR DESCRIPTION
## Summary
- Add view-only admin link page
- Wire up separate edit route for admin link
- Cover link view page with test

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: Template Error: html/template: "admin/commentPage.gohtml" is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68932362805c832f9a814bc434195d80