### PR TITLE
Enhance admin user dashboard

### DIFF
--- a/core/templates/site/admin/adminUserPage.gohtml
+++ b/core/templates/site/admin/adminUserPage.gohtml
@@ -1,13 +1,53 @@
 {{ template "head" $ }}
-    {{- $u := cd.CurrentProfileUser }}
-    <h3>{{ $u.Username.String }} ({{ $u.Email.String }})</h3>
-    <a href="/admin/user/{{ cd.CurrentProfileUser.Idusers }}/blogs">Configure user's blogs</a>
-    <a href="/admin/user/{{ cd.CurrentProfileUser.Idusers }}/writings">Configure user's writings</a>
-    <a href="/admin/user/{{ cd.CurrentProfileUser.Idusers }}/linker">Configure user's linker</a>
-    <a href="/admin/user/{{ cd.CurrentProfileUser.Idusers }}/imagebbs">Configure user's imagebbs</a>
-    <a href="/admin/user/{{ cd.CurrentProfileUser.Idusers }}/forum">Configure user's forum</a>
-    <a href="/admin/user/{{ cd.CurrentProfileUser.Idusers }}/comments">Configure user's comments</a>
-    <a href="/admin/user/{{ cd.CurrentProfileUser.Idusers }}/subscriptions">Configure user's subscriptions</a>
-    <a href="/admin/user/{{ cd.CurrentProfileUser.Idusers }}/edit">Configure user's edit</a>
-    <a href="/admin/user/{{ cd.CurrentProfileUser.Idusers }}/grants">Configure user's grants</a>
+{{- $u := cd.CurrentProfileUser }}
+<h3>{{ $u.Username.String }} ({{ $u.Email.String }})</h3>
+
+<h4>Quick Links</h4>
+<ul>
+    <li><a href="/admin/user/{{ $u.Idusers }}/blogs">Blogs</a></li>
+    <li><a href="/admin/user/{{ $u.Idusers }}/writings">Writings</a></li>
+    <li><a href="/admin/user/{{ $u.Idusers }}/linker">Linker</a></li>
+    <li><a href="/admin/user/{{ $u.Idusers }}/imagebbs">Image BBS</a></li>
+    <li><a href="/admin/user/{{ $u.Idusers }}/forum">Forum</a></li>
+    <li><a href="/admin/user/{{ $u.Idusers }}/comments">Comments</a></li>
+    <li><a href="/admin/user/{{ $u.Idusers }}/subscriptions">Subscriptions</a></li>
+    <li><a href="/admin/user/{{ $u.Idusers }}/grants">Grants</a></li>
+    <li><a href="/admin/user/{{ $u.Idusers }}/permissions">Permissions</a></li>
+    <li><a href="/admin/user/{{ $u.Idusers }}/edit">Edit Profile</a></li>
+    <li><a href="/admin/user/{{ $u.Idusers }}/reset">Reset Password</a></li>
+    <li><a href="/admin/user/{{ $u.Idusers }}/disable">Disable Account</a></li>
+</ul>
+
+{{- $stats := cd.CurrentProfileStats }}
+{{- if $stats }}
+<h4>Posting Stats</h4>
+<ul>
+    <li>Blogs: {{ $stats.Blogs }}</li>
+    <li>News: {{ $stats.News }}</li>
+    <li>Comments: {{ $stats.Comments }}</li>
+    <li>Images: {{ $stats.Images }}</li>
+    <li>Links: {{ $stats.Links }}</li>
+    <li>Writings: {{ $stats.Writings }}</li>
+    <li>Bookmark entries: {{ cd.CurrentProfileBookmarkSize }}</li>
+</ul>
+{{- end }}
+
+<h4>Admin Notes</h4>
+<form method="post" action="/admin/user/{{ $u.Idusers }}/comment">
+    {{ csrfField }}
+    <textarea name="comment" rows="3" cols="40"></textarea>
+    <input type="submit" name="task" value="Add Comment">
+</form>
+{{- $comments := cd.CurrentProfileComments }}
+{{- if $comments }}
+<table>
+    <tr><th>Date</th><th>Comment</th></tr>
+    {{- range $comments }}
+    <tr><td>{{ .CreatedAt.Format "2006-01-02 15:04" }}</td><td>{{ .Comment }}</td></tr>
+    {{- end }}
+</table>
+{{- else }}
+<p>No comments.</p>
+{{- end }}
+
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- Expand admin user dashboard with quick links to management pages
- Show posting stats and bookmark counts for the selected user
- Provide admin notes section with comment form and existing notes

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: html/template: "admin/commentPage.gohtml" is undefined in TestAdminUserProfilePage_UserFound)*


------
https://chatgpt.com/codex/tasks/task_e_68932562980c832f8a12540669dce94f