### PR TITLE
Show forum categories on admin user blogs page

### DIFF
--- a/core/templates/site/admin/userBlogsPage.gohtml
+++ b/core/templates/site/admin/userBlogsPage.gohtml
@@ -1,13 +1,14 @@
 {{ template "head" $ }}
 <h2>Blogs by <a href="/admin/user/{{ .User.Idusers }}">{{ .User.Username.String }}</a></h2>
 <table border="1">
-    <tr><th>ID</th><th>Date</th><th>Comments</th><th>Language</th><th>Snippet</th><th>Link</th></tr>
+    <tr><th>ID</th><th>Date</th><th>Comments</th><th>Language</th><th>Category</th><th>Snippet</th><th>Link</th></tr>
     {{- range .Blogs }}
     <tr>
         <td><a href="/admin/blogs/blog/{{ .Idblogs }}">{{ .Idblogs }}</a></td>
         <td>{{ .Written }}</td>
         <td>{{ .Comments }}</td>
         <td>{{ .LanguageIdlanguage }}</td>
+        <td>{{if .Idforumcategory.Valid}}<a href="/forum/category/{{ .Idforumcategory.Int32 }}">{{ .ForumcategoryTitle.String }}</a>{{end}}</td>
         <td>{{ left 40 (firstline (a4code2string .Blog.String)) }}</td>
         <td><a href="/blogs/blog/{{ .Idblogs }}">View</a></td>
     </tr>

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -308,10 +308,21 @@ GROUP BY u.idusers
 ORDER BY u.username
 LIMIT ? OFFSET ?;
 -- name: AdminGetAllBlogEntriesByUser :many
-SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0)
+SELECT b.idblogs,
+       b.forumthread_id,
+       b.users_idusers,
+       b.language_idlanguage,
+       b.blog,
+       b.written,
+       u.username,
+       coalesce(th.comments, 0),
+       fc.idforumcategory,
+       fc.title AS forumcategory_title
 FROM blogs b
 LEFT JOIN users u ON b.users_idusers = u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
+LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic = t.idforumtopic
+LEFT JOIN forumcategory fc ON t.forumcategory_idforumcategory = fc.idforumcategory
 WHERE b.users_idusers = sqlc.arg(author_id)
 ORDER BY b.written DESC;
 

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -13,10 +13,21 @@ import (
 )
 
 const adminGetAllBlogEntriesByUser = `-- name: AdminGetAllBlogEntriesByUser :many
-SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, u.username, coalesce(th.comments, 0)
+SELECT b.idblogs,
+       b.forumthread_id,
+       b.users_idusers,
+       b.language_idlanguage,
+       b.blog,
+       b.written,
+       u.username,
+       coalesce(th.comments, 0),
+       fc.idforumcategory,
+       fc.title AS forumcategory_title
 FROM blogs b
 LEFT JOIN users u ON b.users_idusers = u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
+LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic = t.idforumtopic
+LEFT JOIN forumcategory fc ON t.forumcategory_idforumcategory = fc.idforumcategory
 WHERE b.users_idusers = ?
 ORDER BY b.written DESC
 `
@@ -30,6 +41,8 @@ type AdminGetAllBlogEntriesByUserRow struct {
 	Written            time.Time
 	Username           sql.NullString
 	Comments           int32
+	Idforumcategory    sql.NullInt32
+	ForumcategoryTitle sql.NullString
 }
 
 func (q *Queries) AdminGetAllBlogEntriesByUser(ctx context.Context, authorID int32) ([]*AdminGetAllBlogEntriesByUserRow, error) {
@@ -50,6 +63,8 @@ func (q *Queries) AdminGetAllBlogEntriesByUser(ctx context.Context, authorID int
 			&i.Written,
 			&i.Username,
 			&i.Comments,
+			&i.Idforumcategory,
+			&i.ForumcategoryTitle,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- Join blog entries with forum categories and expose category details
- Display category links on the admin user blogs page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(hangs; aborted)*
- `golangci-lint run` *(hangs; aborted)*
- `go test ./...` *(fails: admin handler missing template)*

------
https://chatgpt.com/codex/tasks/task_e_6893257ded70832f8bbfc8d0b3115f1f