### PR TITLE
feat: add blog admin index page

### DIFF
--- a/core/templates/site/blogs/adminPage.gohtml
+++ b/core/templates/site/blogs/adminPage.gohtml
@@ -1,0 +1,18 @@
+{{ define "blogsAdminPage" }}
+    {{ template "head" $ }}
+    <table border="1">
+        <tr><th>ID<th>Date<th>Writer<th>Comments<th>View</tr>
+        {{ range cd.BlogList }}
+            <tr>
+                <td><a href="/admin/blogs/blog/{{ .Idblogs }}">{{ .Idblogs }}</a></td>
+                <td><a href="/admin/blogs/blog/{{ .Idblogs }}">{{ .Written }}</a></td>
+                <td>{{ if .Username.Valid }}<a href="/admin/user/{{ .UsersIdusers }}">{{ .Username.String }}</a>{{ else }}{{ .UsersIdusers }}{{ end }}</td>
+                <td><a href="/admin/blogs/blog/{{ .Idblogs }}#comments">{{ .Comments }}</a></td>
+                <td><a href="/blogs/blog/{{ .Idblogs }}">Public</a></td>
+            </tr>
+        {{ else }}
+            <tr><td colspan="5">No blogs.</td></tr>
+        {{ end }}
+    </table>
+    {{ template "tail" $ }}
+{{ end }}

--- a/handlers/blogs/blogsAdminPage.go
+++ b/handlers/blogs/blogsAdminPage.go
@@ -1,0 +1,24 @@
+package blogs
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+)
+
+// AdminPage shows the blog administration index with a list of blogs.
+func AdminPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	offset := cd.Offset()
+	ps := cd.PageSize()
+	cd.NextLink = fmt.Sprintf("/admin/blogs?offset=%d", offset+ps)
+	if offset > 0 {
+		cd.PrevLink = fmt.Sprintf("/admin/blogs?offset=%d", offset-ps)
+		cd.StartLink = "/admin/blogs?offset=0"
+	}
+	cd.PageTitle = "Blog Admin"
+	handlers.TemplateHandler(w, r, "blogsAdminPage.gohtml", struct{}{})
+}

--- a/handlers/blogs/routes_admin.go
+++ b/handlers/blogs/routes_admin.go
@@ -8,8 +8,8 @@ import (
 // RegisterAdminRoutes attaches blog admin endpoints to ar.
 func RegisterAdminRoutes(ar *mux.Router) {
 	br := ar.PathPrefix("/blogs").Subrouter()
-	br.HandleFunc("", GetPermissionsByUserIdAndSectionBlogsPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
-	br.HandleFunc("/", GetPermissionsByUserIdAndSectionBlogsPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
+	br.HandleFunc("", AdminPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
+	br.HandleFunc("/", AdminPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 	br.HandleFunc("/users/roles", GetPermissionsByUserIdAndSectionBlogsPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 	br.HandleFunc("/users/roles", UsersPermissionsPermissionUserAllowPage).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(userAllowTask.Matcher())
 	br.HandleFunc("/users/roles", UsersPermissionsDisallowPage).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(userDisallowTask.Matcher())

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -91,6 +91,7 @@ func TestPageTemplatesRender(t *testing.T) {
 			*common.CoreData
 			Stats struct{ Words, Comments, News, Blogs, Linker, Writing, Writings, Images int64 }
 		}{&common.CoreData{}, struct{ Words, Comments, News, Blogs, Linker, Writing, Writings, Images int64 }{}}},
+		{"blogsAdminPage", struct{ *common.CoreData }{&common.CoreData{}}},
 		{"adminPage", struct {
 			*common.CoreData
 			AdminSections []common.AdminSection


### PR DESCRIPTION
## Summary
- add dedicated admin page for blog listings
- register blog admin root to new listing page
- cover new admin page in template render tests

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: html/template: "admin/commentPage.gohtml" is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6893261923d8832fb95cd463583b3e46