### PR TITLE
Remove link from admin news list date

### DIFF
--- a/core/templates/site/news/adminNewsListPage.gohtml
+++ b/core/templates/site/news/adminNewsListPage.gohtml
@@ -4,7 +4,7 @@
     {{ range cd.AdminLatestNews }}
         <tr>
             <td><a href="/admin/news/{{ .Idsitenews }}">{{ .Idsitenews }}</a></td>
-            <td><a href="/admin/news/{{ .Idsitenews }}">{{ .Occurred.Time }}</a></td>
+            <td>{{ .Occurred.Time }}</td>
             <td>{{ if .Writerid.Valid }}<a href="/admin/user/{{ .Writerid.Int32 }}">{{ .Writername.String }}</a>{{ else }}{{ .Writername.String }}{{ end }}</td>
             <td><a href="/admin/news/{{ .Idsitenews }}#comments">{{ .Comments.Int32 }}</a></td>
             <td><a href="/news/news/{{ .Idsitenews }}">Public</a></td>


### PR DESCRIPTION
## Summary
- remove link from date column on admin news page to avoid non-functional navigation

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689326940a9c832fb4f75c40e0896e3a