### PR TITLE
Remove Manage Users link from forum admin page

### DIFF
--- a/core/templates/site/forum/adminPage.gohtml
+++ b/core/templates/site/forum/adminPage.gohtml
@@ -5,7 +5,6 @@
     <li><a href="/admin/forum/categories">Manage Categories</a></li>
     <li><a href="/admin/forum/topics">Manage Topics</a></li>
     <li><a href="/admin/forum/conversations">Manage Conversations</a></li>
-    <li><a href="/admin/forum/users">Manage Users</a></li>
 </ul>
 
 <p>Forum statistics:</p>


### PR DESCRIPTION
## Summary
- remove obsolete Manage Users entry from forum admin dashboard

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: html/template: "admin/commentPage.gohtml" is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_689327de84f4832f8c3f24fb7b8fd615