### PR TITLE
Fix FAQ admin question table category rendering

### DIFF
--- a/core/templates/site/faq/adminQuestionPage.gohtml
+++ b/core/templates/site/faq/adminQuestionPage.gohtml
@@ -1,35 +1,13 @@
 {{ template "head" $ }}
 <h4>Unanswered Questions</h4>
-{{ template "adminQuestionTable" .UnansweredRows }}
+{{ template "adminQuestionTable" (dict "Rows" .UnansweredRows "Categories" .Categories) }}
 
 <h4>FAQ Questions</h4>
-
-{{ template "adminQuestionTable" .AnsweredRows }}
+{{ template "adminQuestionTable" (dict "Rows" .AnsweredRows "Categories" .Categories) }}
 
 <h4>Dismissed Questions</h4>
-{{ template "adminQuestionTable" .DismissedRows }}
+{{ template "adminQuestionTable" (dict "Rows" .DismissedRows "Categories" .Categories) }}
 
 <p><a href="/admin/faq/question/0/edit">Create New Question</a></p>
-
-<table>
-<tr><th>Question</th><th>Category</th><th>Actions</th></tr>
-{{- range .Rows }}
-<tr>
-    <td>{{ .Question.String }}</td>
-    <td>{{ $cat := .FaqcategoriesIdfaqcategories }}{{ range $.Categories }}{{ if eq $cat .Idfaqcategories }}{{ .Name.String }}{{ end }}{{ end }}</td>
-    <td>
-        <a href="/admin/faq/question/{{ .Idfaq }}/edit">Edit</a> |
-        <a href="/admin/faq/revisions/{{ .Idfaq }}">History</a>
-        <form method="post" action="" style="display:inline;">
-            {{ csrfField }}
-            <input type="hidden" name="faq" value="{{ .Idfaq }}">
-            <input type="submit" name="task" value="Remove">
-        </form>
-    </td>
-</tr>
-{{- end }}
-</table>
-
-<p><a href="/admin/faq/question/create">Create New Question</a></p>
 
 {{ template "tail" $ }}

--- a/core/templates/site/faq/adminQuestionTable.gohtml
+++ b/core/templates/site/faq/adminQuestionTable.gohtml
@@ -1,7 +1,7 @@
 {{ define "adminQuestionTable" }}
 <table>
 <tr><th>Question</th><th>Category</th><th>Actions</th></tr>
-{{- range . }}
+{{- range .Rows }}
 <tr>
     <td>{{ .Question.String }}</td>
     <td>{{ $cat := .FaqcategoriesIdfaqcategories }}{{ range $.Categories }}{{ if eq $cat .Idfaqcategories }}{{ .Name.String }}{{ end }}{{ end }}</td>


### PR DESCRIPTION
## Summary
- pass categories to admin question table template
- simplify admin question page to use shared table with category support

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: html/template: "admin/commentPage.gohtml" is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68932ad4c458832fb314e69f2cbd012f