### PR TITLE
Add admin topic dashboard and fix template calls

### DIFF
--- a/core/templates/site/forum/adminThreadsPage.gohtml
+++ b/core/templates/site/forum/adminThreadsPage.gohtml
@@ -1,17 +1,20 @@
 {{ template "head" $ }}
-{{ range $topic := call cd.AdminForumTopics }}
+{{ range $topic := cd.AdminForumTopics }}
     <h2>{{ $topic.Title.String }}</h2>
     <table border="1">
-        <tr><th>ID<th>Posts<th>Last Addition<th>View public</tr>
-        {{ range call cd.ForumThreads $topic.Idforumtopic }}
+        <tr><th>ID<th>First Post<th>Last Poster<th>Posts<th>Last Addition<th>Locked<th>View public</tr>
+        {{ range cd.ForumThreads $topic.Idforumtopic }}
             <tr>
                 <td><a href="/admin/forum/thread/{{ .Idforumthread }}">{{ .Idforumthread }}</a></td>
+                <td>{{ .Firstpost }}</td>
+                <td>{{ .Lastposter }}</td>
                 <td>{{ .Comments.Int32 }}</td>
                 <td>{{ .Lastaddition.Time }}</td>
+                <td>{{ .Locked.Bool }}</td>
                 <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic }}/thread/{{ .Idforumthread }}">View</a></td>
             </tr>
         {{ else }}
-            <tr><td colspan="4">No threads</td></tr>
+            <tr><td colspan="7">No threads</td></tr>
         {{ end }}
     </table>
 {{ else }}

--- a/core/templates/site/forum/adminTopicPage.gohtml
+++ b/core/templates/site/forum/adminTopicPage.gohtml
@@ -1,0 +1,43 @@
+{{ template "head" $ }}
+<h2>Forum Topic {{ .Topic.Idforumtopic }}</h2>
+<table border="1">
+    <tr><th>ID</th><td>{{ .Topic.Idforumtopic }}</td></tr>
+    <tr><th>Category</th><td>{{ .Topic.ForumcategoryIdforumcategory }}</td></tr>
+    <tr><th>Title</th><td>{{ .Topic.Title.String }}</td></tr>
+    <tr><th>Description</th><td>{{ .Topic.Description.String }}</td></tr>
+    <tr><th>Threads</th><td>{{ .Topic.Threads.Int32 }}</td></tr>
+    <tr><th>Comments</th><td>{{ .Topic.Comments.Int32 }}</td></tr>
+    <tr><th>Last Poster</th><td>{{ .Topic.Lastposter }}</td></tr>
+    <tr><th>Last Addition</th><td>{{ .Topic.Lastaddition.Time }}</td></tr>
+</table>
+<ul>
+    <li><a href="/forum/topic/{{ .Topic.Idforumtopic }}">Public Topic Page</a></li>
+    <li>
+        <a href="/admin/forum/topic/{{ .Topic.Idforumtopic }}/edit">Edit</a>
+        <form method="post" action="/admin/forum/topic/{{ .Topic.Idforumtopic }}/delete" style="display:inline">
+            {{ csrfField }}
+            <input type="submit" value="Delete">
+        </form>
+    </li>
+    <li><a href="/admin/forum/topic/{{ .Topic.Idforumtopic }}/grants">Permissions</a></li>
+    <li><a href="/admin/forum/topic/{{ .Topic.Idforumtopic }}/threads">Contents</a></li>
+</ul>
+<h3>Recent Threads</h3>
+<table border="1">
+    <tr><th>ID<th>First Post<th>Last Poster<th>Posts<th>Last Addition<th>Locked<th>View public</tr>
+    {{ range cd.ForumThreads .Topic.Idforumtopic }}
+        <tr>
+            <td><a href="/admin/forum/thread/{{ .Idforumthread }}">{{ .Idforumthread }}</a></td>
+            <td>{{ .Firstpost }}</td>
+            <td>{{ .Lastposter }}</td>
+            <td>{{ .Comments.Int32 }}</td>
+            <td>{{ .Lastaddition.Time }}</td>
+            <td>{{ .Locked.Bool }}</td>
+            <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic }}/thread/{{ .Idforumthread }}">View</a></td>
+        </tr>
+    {{ else }}
+        <tr><td colspan="7">No threads</td></tr>
+    {{ end }}
+</table>
+<p><a href="/admin/forum/topics">Back to topics</a></p>
+{{ template "tail" $ }}

--- a/core/templates/site/forum/adminTopicThreadsPage.gohtml
+++ b/core/templates/site/forum/adminTopicThreadsPage.gohtml
@@ -1,0 +1,20 @@
+{{ template "head" $ }}
+<h2>Forum Topic {{ .Topic.Idforumtopic }} Threads</h2>
+<table border="1">
+    <tr><th>ID<th>First Post<th>Last Poster<th>Posts<th>Last Addition<th>Locked<th>View public</tr>
+    {{ range cd.ForumThreads .Topic.Idforumtopic }}
+        <tr>
+            <td><a href="/admin/forum/thread/{{ .Idforumthread }}">{{ .Idforumthread }}</a></td>
+            <td>{{ .Firstpost }}</td>
+            <td>{{ .Lastposter }}</td>
+            <td>{{ .Comments.Int32 }}</td>
+            <td>{{ .Lastaddition.Time }}</td>
+            <td>{{ .Locked.Bool }}</td>
+            <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic }}/thread/{{ .Idforumthread }}">View</a></td>
+        </tr>
+    {{ else }}
+        <tr><td colspan="7">No threads</td></tr>
+    {{ end }}
+</table>
+<p><a href="/admin/forum/topic/{{ .Topic.Idforumtopic }}">Back to topic</a></p>
+{{ template "tail" $ }}

--- a/core/templates/site/forum/adminTopicsPage.gohtml
+++ b/core/templates/site/forum/adminTopicsPage.gohtml
@@ -8,10 +8,11 @@
             <th>Threads
             <th>Posts
             <th>View
+            <th>Admin
             <th>Restrictions
             <th>Options?
         </tr>
-        {{ range call cd.AdminForumTopics }}
+        {{ range cd.AdminForumTopics }}
             <tr>
                 <td>{{ .Idforumtopic }}</td>
                 <td>
@@ -20,10 +21,11 @@
                         <input name="name" value="{{ .Title.String }}">
                 </td>
                 <td><textarea name="desc">{{ .Description.String }}</textarea></td>
-                <td>{{ $fcid := .ForumcategoryIdforumcategory }} <select name="cid" value="{{ .ForumcategoryIdforumcategory }}"><option value="0">None</option>{{ range call cd.ForumCategories }}<option value="{{.Idforumcategory}}" {{if eq $fcid .Idforumcategory}}selected{{end}}>{{.Title.String}}</option>  {{ end }}</select></td>
+                <td>{{ $fcid := .ForumcategoryIdforumcategory }} <select name="cid" value="{{ .ForumcategoryIdforumcategory }}"><option value="0">None</option>{{ range cd.ForumCategories }}<option value="{{.Idforumcategory}}" {{if eq $fcid .Idforumcategory}}selected{{end}}>{{.Title.String}}</option>  {{ end }}</select></td>
                 <td align="center">{{ .Threads.Int32 }}</td>
                 <td align="center">{{ .Comments.Int32 }}</td>
                 <td><a href="/forum/topic/{{ .Idforumtopic }}">View</a></td>
+                <td><a href="/admin/forum/topic/{{ .Idforumtopic }}">Dashboard</a></td>
                 <td><a href="/admin/forum/topic/{{ .Idforumtopic }}/grants">Grants</a></td>
                 <td>
                         <input type="hidden" name="tid" value="{{ .Idforumtopic }}">
@@ -36,7 +38,7 @@
                 </td>
             </tr>
         {{ else }}
-            <tr><td colspan="9">No topics</td></tr>
+            <tr><td colspan="10">No topics</td></tr>
         {{ end }}
         <tr>
             <td>New</td>
@@ -46,9 +48,10 @@
                     <input name="name" value="">
             </td>
             <td><textarea name="desc"></textarea></td>
-            <td><select name="pcid" value=""><option value="0">None</option>{{ range call cd.ForumCategories }}<option value="{{.Idforumcategory}}">{{.Title.String}}</option>{{ end }}</select></td>
+            <td><select name="pcid" value=""><option value="0">None</option>{{ range cd.ForumCategories }}<option value="{{.Idforumcategory}}">{{.Title.String}}</option>{{ end }}</select></td>
             <td>0</td>
             <td>0</td>
+            <td></td>
             <td></td>
             <td>TBA</td>
             <td>

--- a/handlers/forum/forumAdminTopicPage.go
+++ b/handlers/forum/forumAdminTopicPage.go
@@ -1,0 +1,61 @@
+package forum
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/gorilla/mux"
+)
+
+// AdminTopicPage shows a dashboard for a single forum topic.
+func AdminTopicPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	tid, err := strconv.Atoi(mux.Vars(r)["topic"])
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, handlers.ErrBadRequest)
+		return
+	}
+	topic, err := cd.Queries().GetForumTopicById(r.Context(), int32(tid))
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Topic not found"))
+		return
+	}
+	cd.PageTitle = fmt.Sprintf("Forum Topic %d", tid)
+	data := struct {
+		Topic *db.Forumtopic
+	}{
+		Topic: topic,
+	}
+	handlers.TemplateHandler(w, r, "adminTopicPage.gohtml", data)
+}
+
+// AdminTopicThreadsPage shows all threads for a single forum topic.
+func AdminTopicThreadsPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	tid, err := strconv.Atoi(mux.Vars(r)["topic"])
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		handlers.RenderErrorPage(w, r, handlers.ErrBadRequest)
+		return
+	}
+	topic, err := cd.Queries().GetForumTopicById(r.Context(), int32(tid))
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Topic not found"))
+		return
+	}
+	cd.PageTitle = fmt.Sprintf("Forum Topic %d Threads", tid)
+	data := struct {
+		Topic *db.Forumtopic
+	}{
+		Topic: topic,
+	}
+	handlers.TemplateHandler(w, r, "adminTopicThreadsPage.gohtml", data)
+}

--- a/handlers/forum/routes_admin.go
+++ b/handlers/forum/routes_admin.go
@@ -24,6 +24,8 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	far.HandleFunc("/topics", AdminTopicsPage).Methods("GET")
 	far.HandleFunc("/topics", handlers.TaskDoneAutoRefreshPage).Methods("POST")
 	far.HandleFunc("/topic", AdminTopicCreatePage).Methods("POST").MatcherFunc(topicCreateTask.Matcher())
+	far.HandleFunc("/topic/{topic}", AdminTopicPage).Methods("GET")
+	far.HandleFunc("/topic/{topic}/threads", AdminTopicThreadsPage).Methods("GET")
 	far.HandleFunc("/conversations", AdminThreadsPage).Methods("GET")
 	far.HandleFunc("/thread/{thread}", AdminThreadPage).Methods("GET")
 	far.HandleFunc("/thread/{thread}/delete", AdminThreadDeleteConfirmPage).Methods("GET")


### PR DESCRIPTION
## Summary
- fix admin topics and threads templates by removing erroneous `call` usage
- add admin topic dashboard handler and route
- provide basic topic dashboard template linking to view, edit, permissions and delete
- expand dashboard with topic details, admin thread list preview, and per-topic thread page
- add thread context columns for admin thread listings

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(hung, manually terminated)*
- `golangci-lint run` *(hung, manually terminated)*
- `go test ./...` *(fails: html/template: "admin/commentPage.gohtml" is undefined)*


------
https://chatgpt.com/codex/tasks/task_e_689328aa5150832f9bc1fdf879851317