### PR TITLE
Rework imageboard admin navigation

### DIFF
--- a/core/templates/site/admin/usageStatsPage.gohtml
+++ b/core/templates/site/admin/usageStatsPage.gohtml
@@ -62,7 +62,7 @@
     <tr><th>ID</th><th>Board</th><th>Posts</th></tr>
     {{- range .Imageboards }}
     <tr>
-        <td><a href="/admin/imagebbs/boards/board/{{ .Idimageboard }}">{{ .Idimageboard }}</a></td>
+        <td><a href="/admin/imagebbs/board/{{ .Idimageboard }}">{{ .Idimageboard }}</a></td>
         <td><a href="/imagebbs/board/{{ .Idimageboard }}">{{ .Title.String }}</a></td>
         <td>{{ .Count }}</td>
     </tr>

--- a/core/templates/site/imagebbs/adminBoardListPage.gohtml
+++ b/core/templates/site/imagebbs/adminBoardListPage.gohtml
@@ -1,5 +1,10 @@
 {{ template "head" $ }}
-<h2>Posts for Board {{ .Board.Idimageboard }}</h2>
+<ul>
+    <li><a href="/admin/imagebbs/board/{{ .Board.Idimageboard }}">Dashboard</a></li>
+    <li><a href="/admin/imagebbs/board/{{ .Board.Idimageboard }}/edit">Edit</a></li>
+    <li><a href="/imagebbs/board/{{ .Board.Idimageboard }}">Public View</a></li>
+</ul>
+<h2>Images for Board {{ .Board.Idimageboard }}</h2>
 <table border="1">
 <tr><th>ID<th>User<th>Description<th>Posted<th>Comments<th>Approved</tr>
 {{ range .Posts }}

--- a/core/templates/site/imagebbs/adminBoardPage.gohtml
+++ b/core/templates/site/imagebbs/adminBoardPage.gohtml
@@ -1,9 +1,19 @@
 {{ template "head" $ }}
-<form method="post" action="/admin/imagebbs/boards/board/{{ .Board.Idimageboard }}/edit">
+<ul>
+    <li><a href="/admin/imagebbs/board/{{ .Board.Idimageboard }}">Dashboard</a></li>
+    <li><a href="/admin/imagebbs/board/{{ .Board.Idimageboard }}/images">Images</a></li>
+    <li><a href="/imagebbs/board/{{ .Board.Idimageboard }}">Public View</a></li>
+</ul>
+<form method="post" action="/admin/imagebbs/board/{{ .Board.Idimageboard }}/edit">
     {{ csrfField }}
     Name: <input name="name" value="{{ .Board.Title.String }}"><br>
     Description: <textarea name="desc" cols="40" rows="5">{{ .Board.Description.String }}</textarea><br>
     Parent Board: <select name="pbid" value="{{ .Board.ImageboardIdimageboard }}"><option value="0">None</option>{{ if .Boards }}{{ range .Boards }}<option value="{{ .Idimageboard }}" {{ if eq $.Board.ImageboardIdimageboard .Idimageboard }}selected{{ end }}>{{ .Title.String }}</option>{{ end }}{{ end }}</select><br>
     <input type="submit" name="task" value="Modify board">
+</form>
+
+<form method="post" action="/admin/imagebbs/board/{{ .Board.Idimageboard }}/delete" onsubmit="return confirm('Delete board?');">
+    {{ csrfField }}
+    <input type="submit" name="task" value="Delete board">
 </form>
 {{ template "tail" $ }}

--- a/core/templates/site/imagebbs/adminBoardViewPage.gohtml
+++ b/core/templates/site/imagebbs/adminBoardViewPage.gohtml
@@ -3,8 +3,24 @@
 <p>Title: {{ .Board.Title.String }}</p>
 <p>Description: {{ .Board.Description.String }}</p>
 <ul>
-    <li><a href="/admin/imagebbs/boards/board/{{ .Board.Idimageboard }}/edit">Edit</a></li>
-    <li><a href="/admin/imagebbs/boards/board/{{ .Board.Idimageboard }}/list">List Content</a></li>
+    <li><a href="/admin/imagebbs/board/{{ .Board.Idimageboard }}/edit">Edit</a></li>
+    <li><a href="/admin/imagebbs/board/{{ .Board.Idimageboard }}/images">List Content</a></li>
     <li><a href="/imagebbs/board/{{ .Board.Idimageboard }}">Public View</a></li>
+    <li><form style="display:inline" method="post" action="/admin/imagebbs/board/{{ .Board.Idimageboard }}/delete" onsubmit="return confirm('Delete board?');">{{ csrfField }}<input type="submit" name="task" value="Delete board"></form></li>
+    <li><a href="/admin/imagebbs/boards">Back to Boards</a></li>
 </ul>
+
+<h3>Recent Posts</h3>
+<table border="1">
+<tr><th>ID<th>User<th>Description<th>Posted</tr>
+{{ range .Posts }}
+<tr>
+<td>{{ .Idimagepost }}</td>
+<td>{{ .Username.String }}</td>
+<td>{{ .Description.String }}</td>
+<td>{{ if .Posted.Valid }}{{ .Posted.Time }}{{ end }}</td>
+</tr>
+{{ end }}
+</table>
+<p><a href="/admin/imagebbs/board/{{ .Board.Idimageboard }}/images">View all</a></p>
 {{ template "tail" $ }}

--- a/core/templates/site/imagebbs/adminBoardsPage.gohtml
+++ b/core/templates/site/imagebbs/adminBoardsPage.gohtml
@@ -1,44 +1,27 @@
 {{ template "head" $ }}
-<a href="/admin/imagebbs/boards/new">Create New Board</a><br>
-                <table border="1">
-                        <tr>
-                                <th>ID
-                                <th>Title
-                                <th>Description
-                                <th>Parent board
-                                <th>Threads
-                                <th>View
-                                <th>Visible
-                                <th>Options?
-                        {{ range .Boards }}
-                                <tr>
-                                        <form method="post" action="/admin/imagebbs/boards/board/{{.Idimageboard}}/edit">
-        {{ csrfField }}
-                                                <td><a href="/admin/imagebbs/boards/board/{{ .Idimageboard }}">{{ .Idimageboard }}</a>
-                                                <td><input name="name" value="{{ .Title.String }}">
-                                                <td><textarea name="desc">{{ .Description.String }}</textarea>
-                                                <td>{{ $pbid := .ImageboardIdimageboard }} {{ $pbid }} <select name="pbid" value="{{ .ImageboardIdimageboard }}"><option value="0">None</option>{{ range $.Boards }}<option value="{{.Idimageboard}}" {{if eq $pbid .Idimageboard}}selected{{end}}>{{.Title.String}}</option>{{ end }}</select>
-                                                <td>{{ .Threads }}
-                                                <td><a href="/imagebbs/board/{{ .Idimageboard }}">View</a>
-                                                <td>{{ if .Visible }}Yes{{ else }}No{{ end }}
-                                                <td>
-                                                        <input type="hidden" name="bid" value="{{ .Idimageboard }}">
-                                                        <input type="submit" name="task" value="Modify board">
-                                                </td>
-                                        </form>
-                                </tr>
-                        {{ end }}
-                </table>
-
-    <h2>New board:</h2>
-    <form method="post" action="/admin/imagebbs/boards/new">
-        {{ csrfField }}
-        Name: <input name="name" value=""><br>
-        Description: <textarea name="desc" cols="40" rows="5"></textarea><br>
-        Parent Board: <select name="pbid" value=""><option value="0">None</option>{{ range $.Boards }}<option value="{{.Idimageboard}}">{{.Title.String}}</option>{{ end }}</select>
-        <input type="submit" name="task" value="New board">
-    </form>
+<table border="1">
+    <tr><th>ID<th>Title<th>Threads<th>Dashboard<th>Edit</tr>
+    {{ range .Boards }}
+    <tr>
+        <td>{{ .Idimageboard }}</td>
+        <td>{{ .Title.String }}</td>
+        <td>{{ .Threads }}</td>
+        <td><a href="/admin/imagebbs/board/{{ .Idimageboard }}">View</a></td>
+        <td><a href="/admin/imagebbs/board/{{ .Idimageboard }}/edit">Edit</a></td>
+    </tr>
+    {{ end }}
+</table>
+<h2>New board:</h2>
+<form method="post" action="/admin/imagebbs/boards/new">
+    {{ csrfField }}
+    Name: <input name="name" value=""><br>
+    Description: <textarea name="desc" cols="40" rows="5"></textarea><br>
+    Parent Board: <select name="pbid"><option value="0">None</option>{{ range .AllBoards }}<option value="{{ .Idimageboard }}">{{ .Title.String }}</option>{{ end }}</select><br>
+    <input type="submit" name="task" value="New board">
+</form>
 <div>
-    {{ .Tree }}
+    {{ if .PrevPage }}<a href="?page={{ .PrevPage }}">Prev</a>{{ end }}
+    {{ if and .PrevPage .NextPage }} | {{ end }}
+    {{ if .NextPage }}<a href="?page={{ .NextPage }}">Next</a>{{ end }}
 </div>
 {{ template "tail" $ }}

--- a/handlers/admin/tasks.go
+++ b/handlers/admin/tasks.go
@@ -102,6 +102,9 @@ const (
 	// TaskModifyBoard modifies the settings of an image board.
 	TaskModifyBoard tasks.TaskString = "Modify board"
 
+	// TaskDeleteBoard deletes an existing image board.
+	TaskDeleteBoard tasks.TaskString = "Delete board"
+
 	// TaskNewCategory creates a new writing category.
 	TaskNewCategory tasks.TaskString = "New Category"
 

--- a/handlers/imagebbs/imagebbsAdminBoardDelete.go
+++ b/handlers/imagebbs/imagebbsAdminBoardDelete.go
@@ -1,0 +1,34 @@
+package imagebbs
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// DeleteBoardTask removes an image board.
+type DeleteBoardTask struct{ tasks.TaskString }
+
+var deleteBoardTask = &DeleteBoardTask{TaskString: TaskDeleteBoard}
+
+var _ tasks.Task = (*DeleteBoardTask)(nil)
+
+func (DeleteBoardTask) Action(w http.ResponseWriter, r *http.Request) any {
+	vars := mux.Vars(r)
+	bid, _ := strconv.Atoi(vars["board"])
+	if bid == 0 {
+		return handlers.ErrRedirectOnSamePageHandler(handlers.ErrBadRequest)
+	}
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if err := cd.Queries().AdminDeleteImageBoard(r.Context(), int32(bid)); err != nil {
+		return fmt.Errorf("delete image board %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	return handlers.RefreshDirectHandler{TargetURL: "/admin/imagebbs/boards"}
+}

--- a/handlers/imagebbs/imagebbsAdminBoardListPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardListPage.go
@@ -14,7 +14,7 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 )
 
-// AdminBoardListPage lists posts for a specific board.
+// AdminBoardListPage lists images for a specific board.
 func AdminBoardListPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		Board    *db.Imageboard
@@ -81,6 +81,6 @@ func AdminBoardListPage(w http.ResponseWriter, r *http.Request) {
 	if nextPage != 0 {
 		data.NextPage = nextPage
 	}
-	cd.PageTitle = "Board Posts"
+	cd.PageTitle = "Board Images"
 	handlers.TemplateHandler(w, r, "adminBoardListPage.gohtml", data)
 }

--- a/handlers/imagebbs/imagebbsAdminBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardPage.go
@@ -74,7 +74,7 @@ func (ModifyBoardTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("update image board fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	return handlers.RefreshDirectHandler{TargetURL: "/admin/imagebbs/boards"}
+	return handlers.RefreshDirectHandler{TargetURL: fmt.Sprintf("/admin/imagebbs/board/%d", bid)}
 }
 
 // AdminBoardPage shows a form to edit an existing board.

--- a/handlers/imagebbs/routes_admin.go
+++ b/handlers/imagebbs/routes_admin.go
@@ -14,10 +14,12 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	br.HandleFunc("", AdminBoardsPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 	br.HandleFunc("/new", AdminNewBoardPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 	br.HandleFunc("/new", handlers.TaskHandler(newBoardTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(newBoardTask.Matcher())
-	bb := br.PathPrefix("/board/{board}").Subrouter()
+
+	bb := iar.PathPrefix("/board/{board}").Subrouter()
 	bb.HandleFunc("", AdminBoardViewPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 	bb.HandleFunc("/edit", AdminBoardPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 	bb.HandleFunc("/edit", handlers.TaskHandler(modifyBoardTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(modifyBoardTask.Matcher())
-	bb.HandleFunc("/list", AdminBoardListPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
+	bb.HandleFunc("/images", AdminBoardListPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
+	bb.HandleFunc("/delete", handlers.TaskHandler(deleteBoardTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(deleteBoardTask.Matcher())
 	iar.HandleFunc("/approve/{post}", handlers.TaskHandler(approvePostTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(approvePostTask.Matcher())
 }

--- a/handlers/imagebbs/tasks.go
+++ b/handlers/imagebbs/tasks.go
@@ -21,6 +21,9 @@ const (
 	// TaskModifyBoard modifies the settings of an image board.
 	TaskModifyBoard tasks.TaskString = "Modify board"
 
+	// TaskDeleteBoard deletes an existing image board.
+	TaskDeleteBoard tasks.TaskString = "Delete board"
+
 	// TaskApprove approves an item in moderation queues.
 	TaskApprove tasks.TaskString = "Approve"
 )


### PR DESCRIPTION
## Summary
- add board-level admin routes and deletion
- paginate board list and link to dashboard
- show recent posts on board dashboard

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(hangs, aborted)*
- `golangci-lint run` *(hangs, aborted)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68933ea58158832f9dfa0865b66ab504