### PR TITLE
Fix vet and tests after merge

### DIFF
--- a/handlers/admin/adminUserGrantAddPage.go
+++ b/handlers/admin/adminUserGrantAddPage.go
@@ -64,7 +64,7 @@ func adminUserGrantAddPage(w http.ResponseWriter, r *http.Request) {
 		data.RequireItemID = def.RequireItemID
 		if section == "forum" && item == "category" {
 			queries := cd.Queries()
-			cats, _ := queries.GetAllForumCategories(r.Context())
+			cats, _ := queries.GetAllForumCategories(r.Context(), db.GetAllForumCategoriesParams{ViewerID: 0})
 			catMap := map[int32]*db.Forumcategory{}
 			for _, c := range cats {
 				catMap[c.Idforumcategory] = c

--- a/handlers/admin/user_grants_build_test.go
+++ b/handlers/admin/user_grants_build_test.go
@@ -24,8 +24,9 @@ func TestBuildUserGrantGroupsIncludesAvailableActionsWithoutGrants(t *testing.T)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants WHERE user_id = ? ORDER BY id\n")).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.title, f.description\nFROM forumcategory f\n")).
-		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "title", "description"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_idlanguage, f.title, f.description\nFROM forumcategory f\nWHERE (\nf.language_idlanguage = 0\nOR f.language_idlanguage IS NULL\nOR EXISTS (\nSELECT 1 FROM user_language ul\nWHERE ul.users_idusers = ?\nAND ul.language_idlanguage = f.language_idlanguage\n)\nOR NOT EXISTS (\nSELECT 1 FROM user_language ul WHERE ul.users_idusers = ?\n)\n)\n")).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language\n")).
 		WillReturnRows(sqlmock.NewRows([]string{"idlanguage", "nameof"}))
 

--- a/handlers/forum/forumAdminCategoryEditPage.go
+++ b/handlers/forum/forumAdminCategoryEditPage.go
@@ -22,13 +22,16 @@ func AdminCategoryEditPage(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderErrorPage(w, r, handlers.ErrBadRequest)
 		return
 	}
-	cat, err := queries.GetForumCategoryById(r.Context(), int32(cid))
+	cat, err := queries.GetForumCategoryById(r.Context(), db.GetForumCategoryByIdParams{
+		Idforumcategory: int32(cid),
+		ViewerID:        cd.UserID,
+	})
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Category not found"))
 		return
 	}
-	cats, err := queries.GetAllForumCategories(r.Context())
+	cats, err := queries.GetAllForumCategories(r.Context(), db.GetAllForumCategoriesParams{ViewerID: cd.UserID})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))

--- a/handlers/forum/forumAdminCategoryPage_test.go
+++ b/handlers/forum/forumAdminCategoryPage_test.go
@@ -38,13 +38,15 @@ func TestAdminCategoryPageLinks(t *testing.T) {
 	queries := db.New(sqlDB)
 	mock.MatchExpectationsInOrder(false)
 
-	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "title", "description"}).
-		AddRow(1, 0, "cat", "desc")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idforumcategory, forumcategory_idforumcategory, title, description FROM forumcategory WHERE idforumcategory = ?")).
+	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}).
+		AddRow(1, 0, 0, "cat", "desc")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idforumcategory, forumcategory_idforumcategory, language_idlanguage, title, description FROM forumcategory WHERE idforumcategory = ?")+`.*`).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(catRows)
 
-	topicsRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "title", "description", "threads", "comments", "lastaddition"})
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idforumtopic, lastposter, forumcategory_idforumcategory, title, description, threads, comments, lastaddition FROM forumtopic WHERE forumcategory_idforumcategory = ? ORDER BY lastaddition DESC")).
+	topicsRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition"})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idforumtopic, lastposter, forumcategory_idforumcategory, language_idlanguage, title, description, threads, comments, lastaddition FROM forumtopic WHERE forumcategory_idforumcategory = ?")+`.*`).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(topicsRows)
 
 	req, rr := setupRequest(t, queries, "/admin/forum/category/1", map[string]string{"category": "1"})
@@ -76,14 +78,16 @@ func TestAdminCategoryEditPage(t *testing.T) {
 	queries := db.New(sqlDB)
 	mock.MatchExpectationsInOrder(false)
 
-	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "title", "description"}).
-		AddRow(1, 0, "cat", "desc")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idforumcategory, forumcategory_idforumcategory, title, description FROM forumcategory WHERE idforumcategory = ?")).
+	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}).
+		AddRow(1, 0, 0, "cat", "desc")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idforumcategory, forumcategory_idforumcategory, language_idlanguage, title, description FROM forumcategory WHERE idforumcategory = ?")+`.*`).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(catRows)
 
-	allRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "title", "description"}).
-		AddRow(1, 0, "cat", "desc")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.title, f.description\nFROM forumcategory f")).
+	allRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}).
+		AddRow(1, 0, 0, "cat", "desc")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_idlanguage, f.title, f.description\nFROM forumcategory f\nWHERE (")+`.*`).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(allRows)
 
 	req, rr := setupRequest(t, queries, "/admin/forum/category/1/edit", map[string]string{"category": "1"})

--- a/handlers/forum/forumAdminTopicPage_test.go
+++ b/handlers/forum/forumAdminTopicPage_test.go
@@ -26,8 +26,8 @@ func TestAdminTopicPage(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	topicID := 4
-	rows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "title", "description", "threads", "comments", "lastaddition"}).
-		AddRow(topicID, 0, 1, "t", "d", 2, 3, time.Now())
+	rows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition"}).
+		AddRow(topicID, 0, 1, 0, "t", "d", 2, 3, time.Now())
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 
 	cd := common.NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
@@ -53,12 +53,12 @@ func TestAdminTopicEditFormPage(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	topicID := 4
-	topicRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "title", "description", "threads", "comments", "lastaddition"}).
-		AddRow(topicID, 0, 1, "t", "d", 2, 3, time.Now())
+	topicRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition"}).
+		AddRow(topicID, 0, 1, 0, "t", "d", 2, 3, time.Now())
 	mock.ExpectQuery("SELECT").WillReturnRows(topicRows)
 
-	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "title", "description"}).
-		AddRow(1, 0, "cat", "desc")
+	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}).
+		AddRow(1, 0, 0, "cat", "desc")
 	mock.ExpectQuery("SELECT").WillReturnRows(catRows)
 
 	roleRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).

--- a/handlers/imagebbs/routes_admin.go
+++ b/handlers/imagebbs/routes_admin.go
@@ -22,7 +22,6 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	bb.HandleFunc("/images", AdminBoardListPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 	bb.HandleFunc("/delete", handlers.TaskHandler(deleteBoardTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(deleteBoardTask.Matcher())
 	iar.HandleFunc("/approve/{post}", handlers.TaskHandler(approvePostTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(approvePostTask.Matcher())
-	iar.HandleFunc("/files", AdminFilesPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))
 
 	uar := ar.PathPrefix("/user/{user}/imagebbs").Subrouter()
 	uar.HandleFunc("/post/{post}", AdminPostDashboardPage).Methods("GET").MatcherFunc(handlers.RequiredAccess("administrator"))


### PR DESCRIPTION
## Summary
- update admin grant pages and forum handlers for new SQL query parameters
- align tests with language-aware forum queries
- drop unused image board files route to break import cycle

## Testing
- `go vet ./...`
- `go test ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_689344346d0c832f8dd8dc454b23a528