### PR TITLE
Improve forum category admin management

### DIFF
--- a/core/templates/site/forum/forumAdminCategoryEditPage.gohtml
+++ b/core/templates/site/forum/forumAdminCategoryEditPage.gohtml
@@ -7,4 +7,9 @@
     <p>Description <textarea name="desc">{{ .Category.Description.String }}</textarea></p>
     <input type="submit" name="task" value="Forum category change">
 </form>
+<form method="post" action="/admin/forum/category/delete" style="margin-top:1em">
+    {{ csrfField }}
+    <input type="hidden" name="cid" value="{{ .Category.Idforumcategory }}">
+    <input type="submit" name="task" value="Delete Category">
+</form>
 {{ template "tail" $ }}

--- a/core/templates/site/forum/forumAdminCategoryPage.gohtml
+++ b/core/templates/site/forum/forumAdminCategoryPage.gohtml
@@ -6,6 +6,7 @@
 </p>
 <p>{{ .Category.Description.String }}</p>
 <h3 id="topics">Topics</h3>
+<p><a href="/admin/forum/topics">Create Topic</a></p>
 <table border="1">
     <tr>
         <th>ID</th>
@@ -17,12 +18,19 @@
     </tr>
     {{ range .Topics }}
     <tr>
-        <td>{{ .Idforumtopic }}</td>
+        <td><a href="/admin/forum/topic/{{ .Idforumtopic }}">{{ .Idforumtopic }}</a></td>
         <td>{{ .Title.String }}</td>
         <td>{{ .Description.String }}</td>
         <td>{{ .Threads.Int32 }}</td>
         <td>{{ .Comments.Int32 }}</td>
-        <td><a href="/admin/forum/topic/{{ .Idforumtopic }}/edit">Manage</a></td>
+        <td>
+            <a href="/admin/forum/topic/{{ .Idforumtopic }}/edit">Edit</a> |
+            <a href="/admin/forum/topic/{{ .Idforumtopic }}/grants">Grants</a>
+            <form method="post" action="/admin/forum/topic/{{ .Idforumtopic }}/delete" style="display:inline">
+                {{ csrfField }}
+                <input type="submit" name="task" value="Forum topic delete">
+            </form>
+        </td>
     </tr>
     {{ end }}
 </table>


### PR DESCRIPTION
## Summary
- Link topic IDs in category admin page to their admin view
- Provide quick access to edit, grant, and delete actions for category topics
- Allow deleting a forum category from its edit page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: handlers/imagebbs/routes_admin.go:23:27: undefined: AdminFilesPage)*
- `golangci-lint run` *(fails: could not import github.com/arran4/goa4web/handlers/forum)*
- `go test ./...` *(fails: handlers/forum/forumAdminCategoryEditPage.go:25:56: cannot use int32(cid) as db.GetForumCategoryByIdParams value)*

------
https://chatgpt.com/codex/tasks/task_e_68934311cb28832f96cb7cdc33fb8fb5