### PR TITLE
Interlink image post admin pages

### DIFF
--- a/core/templates/site/admin/userImagebbsPage.gohtml
+++ b/core/templates/site/admin/userImagebbsPage.gohtml
@@ -9,6 +9,9 @@
         <td>{{ .ImageboardIdimageboard }}</td>
         <td>{{ if .Approved }}Yes{{ else }}No{{ end }}</td>
         <td>
+            <a href="/admin/user/{{ $.User.Idusers }}/imagebbs/post/{{ .Idimagepost }}">Dashboard</a> |
+            <a href="/admin/user/{{ $.User.Idusers }}/imagebbs/post/{{ .Idimagepost }}/edit">Edit</a> |
+            <a href="/admin/user/{{ $.User.Idusers }}/imagebbs/post/{{ .Idimagepost }}/comments">Comments</a> |
             <a href="/imagebbs/post/{{ .Idimagepost }}">View</a>
             {{- if not .Approved }}
             <form style="display:inline" method="post" action="/admin/imagebbs/approve/{{ .Idimagepost }}">

--- a/core/templates/site/imagebbs/adminPostDashboardPage.gohtml
+++ b/core/templates/site/imagebbs/adminPostDashboardPage.gohtml
@@ -2,7 +2,8 @@
 <h2>Image Post {{ .Post.Idimagepost }}</h2>
 <p><img src="{{ .Post.Fullimage }}" alt="post image"></p>
 <p>Description: {{ if .Post.Description.Valid }}{{ .Post.Description.String }}{{ end }}</p>
-<p>Board: {{ .Post.ImageboardIdimageboard }}</p>
+<p>User: <a href="/admin/user/{{ .Post.UsersIdusers }}">{{ if .Post.Username.Valid }}{{ .Post.Username.String }}{{ else }}{{ .Post.UsersIdusers }}{{ end }}</a></p>
+<p>Board: <a href="/admin/imagebbs/boards/board/{{ .Post.ImageboardIdimageboard }}">{{ .Post.ImageboardIdimageboard }}</a> | <a href="/imagebbs/board/{{ .Post.ImageboardIdimageboard }}">Public View</a></p>
 <p>Approved: {{ if .Post.Approved }}Yes{{ else }}No{{ end }}</p>
 <p>
     <a href="/admin/user/{{ .Post.UsersIdusers }}/imagebbs/post/{{ .Post.Idimagepost }}/edit">Edit</a> |


### PR DESCRIPTION
## Summary
- Link every user image post to a dedicated dashboard, edit, and comments view.
- Expand image post dashboard to reference the owning user and board with public view links.

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` (fails: undefined AdminFilesPage, invalid forum category calls)
- `golangci-lint run` (fails: undefined AdminFilesPage and forum category build errors)
- `go test ./...` (fails: undefined AdminFilesPage, forum category build errors)


------
https://chatgpt.com/codex/tasks/task_e_6893432958a0832fa734477806878b8d