### PR TITLE
feat: migrate private discussions

### DIFF
--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -20,6 +20,7 @@ import (
 	imagehandlers "github.com/arran4/goa4web/handlers/images"
 	linkerhandlers "github.com/arran4/goa4web/handlers/linker"
 	newshandlers "github.com/arran4/goa4web/handlers/news"
+	privateforumhandlers "github.com/arran4/goa4web/handlers/privateforum"
 	searchhandlers "github.com/arran4/goa4web/handlers/search"
 	userhandlers "github.com/arran4/goa4web/handlers/user"
 	writinghandlers "github.com/arran4/goa4web/handlers/writings"
@@ -53,6 +54,7 @@ func registerTasks(reg *tasks.Registry, ah *adminhandlers.Handlers) {
 	register("bookmarks", bookmarkhandlers.RegisterTasks())
 	register("faq", faqhandlers.RegisterTasks())
 	register("forum", forumhandlers.RegisterTasks())
+	register("privateforum", privateforumhandlers.RegisterTasks())
 	register("images", imagehandlers.RegisterTasks())
 	register("imagebbs", imagebbshandlers.RegisterTasks())
 	register("linker", linkerhandlers.RegisterTasks())

--- a/cmd/goa4web/modules.go
+++ b/cmd/goa4web/modules.go
@@ -13,6 +13,7 @@ import (
 	"github.com/arran4/goa4web/handlers/languages"
 	"github.com/arran4/goa4web/handlers/linker"
 	"github.com/arran4/goa4web/handlers/news"
+	"github.com/arran4/goa4web/handlers/privateforum"
 	"github.com/arran4/goa4web/handlers/search"
 	"github.com/arran4/goa4web/handlers/user"
 	"github.com/arran4/goa4web/handlers/writings"
@@ -34,6 +35,7 @@ func registerModules(reg *router.Registry, ah *admin.Handlers) {
 	languages.Register(reg)
 	linker.Register(reg)
 	news.Register(reg)
+	privateforum.Register(reg)
 	search.Register(reg)
 	images.Register(reg)
 	externallink.Register(reg)

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -182,6 +182,7 @@ type CoreData struct {
 	perms                    lazy.Value[[]*db.GetPermissionsByUserIDRow]
 	pref                     lazy.Value[*db.Preference]
 	preferredLanguageID      lazy.Value[int32]
+	privateForumTopics       lazy.Value[[]*PrivateTopic]
 	publicWritings           map[string]*lazy.Value[[]*db.ListPublicWritingsInCategoryForListerRow]
 	roleRows                 map[int32]*lazy.Value[*db.Role]
 	selectedThreadCanReply   lazy.Value[bool]
@@ -2422,22 +2423,22 @@ func assignIDFromString(m map[string]*int32, k, v string) {
 // parameters and finally form values.
 func (cd *CoreData) LoadSelectionsFromRequest(r *http.Request) {
 	mapping := map[string]*int32{
-		"boardno":  &cd.currentBoardID,
-		"board":    &cd.currentBoardID,
-		"thread":   &cd.currentThreadID,
-		"replyTo":  &cd.currentThreadID,
-		"topic":    &cd.currentTopicID,
-		"category": &cd.currentCategoryID,
+		"boardno":     &cd.currentBoardID,
+		"board":       &cd.currentBoardID,
+		"thread":      &cd.currentThreadID,
+		"replyTo":     &cd.currentThreadID,
+		"topic":       &cd.currentTopicID,
+		"category":    &cd.currentCategoryID,
 		"comment":     &cd.currentCommentID,
 		"editComment": &cd.currentCommentID,
-		"news":     &cd.currentNewsPostID,
-		"post":     &cd.currentImagePostID,
-		"writing":  &cd.currentWritingID,
-		"blog":     &cd.currentBlogID,
+		"news":        &cd.currentNewsPostID,
+		"post":        &cd.currentImagePostID,
+		"writing":     &cd.currentWritingID,
+		"blog":        &cd.currentBlogID,
 		"link":        &cd.currentLinkID,
-		"request":  &cd.currentRequestID,
-		"role":     &cd.currentRoleID,
-		"user":     &cd.currentProfileUserID,
+		"request":     &cd.currentRequestID,
+		"role":        &cd.currentRoleID,
+		"user":        &cd.currentProfileUserID,
 	}
 	for k, v := range mux.Vars(r) {
 		assignIDFromString(mapping, k, v)

--- a/core/common/privateforum.go
+++ b/core/common/privateforum.go
@@ -1,0 +1,61 @@
+package common
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/arran4/goa4web/internal/db"
+)
+
+const (
+	// PrivateForumCategoryID identifies the hidden category for private topics.
+	PrivateForumCategoryID int32 = 0
+)
+
+// PrivateTopic represents a private conversation with a computed title.
+type PrivateTopic struct {
+	*db.Forumtopic
+	DisplayTitle string
+}
+
+// PrivateForumTopics returns private forum topics visible to the current user.
+func (cd *CoreData) PrivateForumTopics() ([]*PrivateTopic, error) {
+	if cd == nil || cd.queries == nil {
+		return nil, nil
+	}
+	if !cd.HasGrant("privateforum", "topic", "see", 0) {
+		return nil, nil
+	}
+	return cd.privateForumTopics.Load(func() ([]*PrivateTopic, error) {
+		tops, err := cd.queries.ListPrivateTopicsByUserID(cd.ctx, sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0})
+		if err != nil {
+			return nil, err
+		}
+		var pts []*PrivateTopic
+		for _, t := range tops {
+			parts, _ := cd.queries.ListPrivateTopicParticipantsByTopicIDForUser(cd.ctx, db.ListPrivateTopicParticipantsByTopicIDForUserParams{
+				TopicID:  sql.NullInt32{Int32: t.Idforumtopic, Valid: true},
+				ViewerID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+			})
+			var names []string
+			for _, p := range parts {
+				if p.Idusers != cd.UserID {
+					names = append(names, p.Username.String)
+				}
+			}
+			title := strings.Join(names, ", ")
+			if len(names) > 1 && t.Title.Valid && t.Title.String != "" {
+				title = fmt.Sprintf("%s (%s)", title, t.Title.String)
+			}
+			pts = append(pts, &PrivateTopic{Forumtopic: t, DisplayTitle: title})
+		}
+		return pts, nil
+	})
+}
+
+// PrivateTopics returns private forum topics or nil on error.
+func (cd *CoreData) PrivateTopics() []*PrivateTopic {
+	pts, _ := cd.PrivateForumTopics()
+	return pts
+}

--- a/core/templates/assets/private_forum.js
+++ b/core/templates/assets/private_forum.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const input = document.getElementById('participant-input');
+    const addBtn = document.getElementById('add-participant');
+    const list = document.getElementById('participants');
+    const field = document.getElementById('participants-field');
+
+    function updateField() {
+        const names = Array.from(list.querySelectorAll('li')).map(li => li.textContent);
+        field.value = names.join(',');
+    }
+
+    addBtn?.addEventListener('click', (e) => {
+        e.preventDefault();
+        const name = input.value.trim();
+        if (!name) return;
+        const li = document.createElement('li');
+        li.textContent = name;
+        li.addEventListener('click', () => {
+            list.removeChild(li);
+            updateField();
+        });
+        list.appendChild(li);
+        input.value = '';
+        updateField();
+    });
+});

--- a/core/templates/embedded.go
+++ b/core/templates/embedded.go
@@ -30,6 +30,8 @@ var (
 	notificationsJSData []byte
 	//go:embed "assets/role_grants_editor.js"
 	roleGrantsEditorJSData []byte
+	//go:embed "assets/private_forum.js"
+	privateForumJSData []byte
 )
 
 func init() {
@@ -89,3 +91,6 @@ func GetNotificationsJSData() []byte { return notificationsJSData }
 // GetRoleGrantsEditorJSData returns the JavaScript powering the
 // role grants drag-and-drop editor.
 func GetRoleGrantsEditorJSData() []byte { return roleGrantsEditorJSData }
+
+// GetPrivateForumJSData returns the JavaScript for private forum pages.
+func GetPrivateForumJSData() []byte { return privateForumJSData }

--- a/core/templates/live.go
+++ b/core/templates/live.go
@@ -71,3 +71,12 @@ func GetRoleGrantsEditorJSData() []byte {
 	}
 	return b
 }
+
+// GetPrivateForumJSData returns the JavaScript for private forum pages.
+func GetPrivateForumJSData() []byte {
+	b, err := os.ReadFile("core/templates/assets/private_forum.js")
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/core/templates/site/privateForumPage.gohtml
+++ b/core/templates/site/privateForumPage.gohtml
@@ -1,0 +1,23 @@
+{{ define "privateForumPage" }}
+    {{ template "head" $ }}
+    <h1>Private Topics</h1>
+    <ul>
+    {{ range cd.PrivateTopics }}
+        <li>{{ .DisplayTitle }}</li>
+    {{ else }}
+        <li>No private topics</li>
+    {{ end }}
+    </ul>
+    <h2>Start conversation</h2>
+    <form id="private-form" method="POST">
+        <input type="hidden" name="task" value="{{ .CreateTask }}">
+        <input type="text" id="participant-input" placeholder="username">
+        <button type="button" id="add-participant">Add</button>
+        <ul id="participants"></ul>
+        <input type="hidden" name="participants" id="participants-field">
+        <textarea name="body" id="message-field" placeholder="Message"></textarea>
+        <button type="submit">Create</button>
+    </form>
+    <script src="/private/private_forum.js"></script>
+    {{ template "tail" $ }}
+{{ end }}

--- a/handlers/admin/role_grants.go
+++ b/handlers/admin/role_grants.go
@@ -45,6 +45,7 @@ var GrantActionMap = map[string]GrantDefinition{
 	"faq|question":        {Actions: []string{"see", "view", "post", "edit"}},
 	"faq|question/answer": {Actions: []string{"see"}},
 	"search|":             {Actions: []string{"search"}},
+	"privateforum|topic":  {Actions: []string{"see", "view", "reply", "post", "edit", "create"}, RequireItemID: true},
 }
 
 // GrantAction represents a single grant action and whether it's unsupported.

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 54
+	ExpectedSchemaVersion = 55
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/handlers/forum/adminForumHandler.go
+++ b/handlers/forum/adminForumHandler.go
@@ -63,7 +63,7 @@ func AdminForumPage(w http.ResponseWriter, r *http.Request) {
 	uid, _ := session.Values["UID"].(int32)
 
 	queries := cd.Queries()
-	rows, err := queries.GetAllForumTopicsForUser(r.Context(), db.GetAllForumTopicsForUserParams{
+	rows, err := queries.GetForumTopicsForUser(r.Context(), db.GetForumTopicsForUserParams{
 		ViewerID:      uid,
 		ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})

--- a/handlers/forum/forumAdminCategoryPage_test.go
+++ b/handlers/forum/forumAdminCategoryPage_test.go
@@ -44,9 +44,9 @@ func TestAdminCategoryPageLinks(t *testing.T) {
 	mock.ExpectQuery("SELECT idforumcategory, forumcategory_idforumcategory, language_idlanguage, title, description FROM forumcategory").
 		WillReturnRows(catRows)
 
-	topicsRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition"}).
-		AddRow(1, 0, 1, 0, "t", "d", 0, 0, time.Now())
-	mock.ExpectQuery("SELECT idforumtopic, lastposter, forumcategory_idforumcategory, language_idlanguage, title, description, threads, comments, lastaddition FROM forumtopic").
+	topicsRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler"}).
+		AddRow(1, 0, 1, 0, "t", "d", 0, 0, time.Now(), "")
+	mock.ExpectQuery("SELECT idforumtopic, lastposter, forumcategory_idforumcategory, language_idlanguage, title, description, threads, comments, lastaddition, handler FROM forumtopic").
 		WillReturnRows(topicsRows)
 
 	req, rr := setupRequest(t, queries, "/admin/forum/category/1", map[string]string{"category": "1"})

--- a/handlers/forum/forumAdminTopicPage_test.go
+++ b/handlers/forum/forumAdminTopicPage_test.go
@@ -26,8 +26,8 @@ func TestAdminTopicPage(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	topicID := 4
-	rows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition"}).
-		AddRow(topicID, 0, 1, 0, "t", "d", 2, 3, time.Now())
+	rows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler"}).
+		AddRow(topicID, 0, 1, 0, "t", "d", 2, 3, time.Now(), "")
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 
 	cd := common.NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
@@ -53,8 +53,8 @@ func TestAdminTopicEditFormPage(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	topicID := 4
-	topicRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition"}).
-		AddRow(topicID, 0, 1, 0, "t", "d", 2, 3, time.Now())
+	topicRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler"}).
+		AddRow(topicID, 0, 1, 0, "t", "d", 2, 3, time.Now(), "")
 	mock.ExpectQuery("SELECT").WillReturnRows(topicRows)
 
 	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}).

--- a/handlers/forum/forumAdminTopicsPage_test.go
+++ b/handlers/forum/forumAdminTopicsPage_test.go
@@ -26,8 +26,8 @@ func TestAdminTopicsPage(t *testing.T) {
 	countRows := sqlmock.NewRows([]string{"count"}).AddRow(1)
 	mock.ExpectQuery(`SELECT COUNT\(`).WillReturnRows(countRows)
 
-	rows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition"}).
-		AddRow(1, 0, 0, 0, "t", "d", 0, 0, time.Now())
+	rows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler"}).
+		AddRow(1, 0, 0, 0, "t", "d", 0, 0, time.Now(), "")
 	mock.ExpectQuery("SELECT t.idforumtopic").WillReturnRows(rows)
 
 	cd := common.NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -61,7 +61,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 	var topicRows []*ForumtopicPlus
 	if categoryId == 0 {
-		rows, err := queries.GetAllForumTopicsForUser(r.Context(), db.GetAllForumTopicsForUserParams{
+		rows, err := queries.GetForumTopicsForUser(r.Context(), db.GetForumTopicsForUserParams{
 			ViewerID:      uid,
 			ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 		})

--- a/handlers/forum/matchers_test.go
+++ b/handlers/forum/matchers_test.go
@@ -32,8 +32,8 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 	mock.ExpectQuery("SELECT t.idforumtopic").
 		WithArgs(int32(0), int32(1), int32(0), int32(0), sql.NullInt32{Int32: 0, Valid: false}).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "LastPosterUsername",
-		}).AddRow(1, 0, 0, 0, sql.NullString{}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullTime{}, sql.NullString{}))
+			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername",
+		}).AddRow(1, 0, 0, 0, sql.NullString{}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullTime{}, "", sql.NullString{}))
 
 		// handler will trigger another load
 	mock.ExpectQuery("SELECT th.idforumthread").
@@ -90,8 +90,8 @@ func TestRequireThreadAndTopicFalse(t *testing.T) {
 	mock.ExpectQuery("SELECT t.idforumtopic").
 		WithArgs(int32(0), int32(3), int32(0), int32(0), sql.NullInt32{Int32: 0, Valid: false}).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "LastPosterUsername",
-		}).AddRow(3, 0, 0, 0, sql.NullString{}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullTime{}, sql.NullString{}))
+			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername",
+		}).AddRow(3, 0, 0, 0, sql.NullString{}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullTime{}, "", sql.NullString{}))
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})

--- a/handlers/news/newsReplyTask_event_test.go
+++ b/handlers/news/newsReplyTask_event_test.go
@@ -43,8 +43,8 @@ func TestNewsReplyTaskEventData(t *testing.T) {
 
 	mock.ExpectQuery("SELECT idforumtopic").
 		WithArgs(sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition"}).
-			AddRow(4, int32(0), 0, 0, NewsTopicName, "", 0, 0, sql.NullTime{}))
+		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler"}).
+			AddRow(4, int32(0), 0, 0, NewsTopicName, "", 0, 0, sql.NullTime{}, ""))
 
 	mock.ExpectQuery("SELECT u.idusers").
 		WithArgs(uid).

--- a/handlers/privateforum/consts.go
+++ b/handlers/privateforum/consts.go
@@ -1,0 +1,8 @@
+package privateforum
+
+import "github.com/arran4/goa4web/internal/tasks"
+
+const (
+	// TaskPrivateTopicCreate creates a new private conversation topic.
+	TaskPrivateTopicCreate tasks.TaskString = "Private topic create"
+)

--- a/handlers/privateforum/customindex.go
+++ b/handlers/privateforum/customindex.go
@@ -1,0 +1,12 @@
+package privateforum
+
+import (
+	"net/http"
+
+	"github.com/arran4/goa4web/core/common"
+)
+
+// CustomIndex injects private forum specific index items. None are added yet.
+var CustomIndex = func(cd *common.CoreData, r *http.Request) {
+	cd.CustomIndexItems = []common.IndexItem{}
+}

--- a/handlers/privateforum/page.go
+++ b/handlers/privateforum/page.go
@@ -1,0 +1,20 @@
+package privateforum
+
+import (
+	"net/http"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+func Page(w http.ResponseWriter, r *http.Request) {
+	type Data struct {
+		CreateTask tasks.TaskString
+	}
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Private Forum"
+	data := Data{CreateTask: TaskPrivateTopicCreate}
+	handlers.TemplateHandler(w, r, "privateForumPage", data)
+}

--- a/handlers/privateforum/routes.go
+++ b/handlers/privateforum/routes.go
@@ -1,0 +1,27 @@
+package privateforum
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/handlers"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
+	"github.com/arran4/goa4web/internal/router"
+)
+
+// RegisterRoutes attaches the private forum endpoints to r.
+func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
+	navReg.RegisterIndexLink("Private", "/private", SectionWeight)
+	pr := r.PathPrefix("/private").Subrouter()
+	pr.Use(handlers.IndexMiddleware(CustomIndex), handlers.SectionMiddleware("privateforum"))
+	pr.HandleFunc("", Page).Methods(http.MethodGet)
+	pr.HandleFunc("", handlers.TaskHandler(privateTopicCreateTask)).Methods(http.MethodPost).MatcherFunc(privateTopicCreateTask.Matcher())
+	pr.HandleFunc("/private_forum.js", handlers.PrivateForumJS).Methods(http.MethodGet)
+}
+
+// Register registers the private forum router module.
+func Register(reg *router.Registry) {
+	reg.RegisterModule("privateforum", []string{"private"}, RegisterRoutes)
+}

--- a/handlers/privateforum/section.go
+++ b/handlers/privateforum/section.go
@@ -1,0 +1,6 @@
+package privateforum
+
+const (
+	// SectionWeight controls the order of the Private Forum section in navigation.
+	SectionWeight = 200
+)

--- a/handlers/privateforum/tasks.go
+++ b/handlers/privateforum/tasks.go
@@ -1,0 +1,3 @@
+package privateforum
+
+// Additional private forum tasks can be declared here.

--- a/handlers/privateforum/tasks_register.go
+++ b/handlers/privateforum/tasks_register.go
@@ -1,0 +1,10 @@
+package privateforum
+
+import "github.com/arran4/goa4web/internal/tasks"
+
+// RegisterTasks registers private forum related tasks with the global registry.
+func RegisterTasks() []tasks.NamedTask {
+	return []tasks.NamedTask{
+		privateTopicCreateTask,
+	}
+}

--- a/handlers/privateforum/topic_create_task.go
+++ b/handlers/privateforum/topic_create_task.go
@@ -1,0 +1,124 @@
+package privateforum
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/arran4/goa4web/workers/postcountworker"
+	"github.com/arran4/goa4web/workers/searchworker"
+)
+
+// PrivateTopicCreateTask creates a new private conversation and assigns grants.
+type PrivateTopicCreateTask struct{ tasks.TaskString }
+
+var privateTopicCreateTask = &PrivateTopicCreateTask{TaskString: TaskPrivateTopicCreate}
+
+var _ tasks.Task = (*PrivateTopicCreateTask)(nil)
+
+// Action creates a new private topic and assigns view permissions to participants.
+func (PrivateTopicCreateTask) Action(w http.ResponseWriter, r *http.Request) any {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	parts := strings.Split(r.PostFormValue("participants"), ",")
+	body := strings.TrimSpace(r.PostFormValue("body"))
+	var uids []int32
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{String: p, Valid: true})
+		if err != nil {
+			continue
+		}
+		uids = append(uids, u.Idusers)
+	}
+	creator := cd.UserID
+	seen := false
+	for _, id := range uids {
+		if id == creator {
+			seen = true
+			break
+		}
+	}
+	if creator != 0 && !seen {
+		uids = append(uids, creator)
+	}
+	tid, err := queries.SystemCreateForumTopic(r.Context(), db.SystemCreateForumTopicParams{
+		ForumcategoryIdforumcategory: common.PrivateForumCategoryID,
+		LanguageIdlanguage:           0,
+		Title:                        sql.NullString{},
+		Description:                  sql.NullString{},
+	})
+	if err != nil {
+		return fmt.Errorf("create topic %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	topicID := int32(tid)
+	if err := queries.SystemSetForumTopicHandlerByID(r.Context(), db.SystemSetForumTopicHandlerByIDParams{Handler: "private", ID: topicID}); err != nil {
+		return fmt.Errorf("set handler %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	thid, err := queries.SystemCreateThread(r.Context(), topicID)
+	if err != nil {
+		return fmt.Errorf("create thread %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	threadID := int32(thid)
+	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
+		LanguageID:         0,
+		CommenterID:        creator,
+		ForumthreadID:      threadID,
+		Text:               sql.NullString{String: body, Valid: body != ""},
+		GrantForumthreadID: sql.NullInt32{Int32: threadID, Valid: true},
+		GranteeID:          sql.NullInt32{Int32: creator, Valid: creator != 0},
+	})
+	if err != nil {
+		return fmt.Errorf("create comment %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	if cid == 0 {
+		err := handlers.ErrForbidden
+		return fmt.Errorf("create comment %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	if evt := cd.Event(); evt != nil {
+		if evt.Data == nil {
+			evt.Data = map[string]any{}
+		}
+		evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(cid), ThreadID: threadID, TopicID: topicID}
+		evt.Data[searchworker.EventKey] = searchworker.IndexEventData{Type: searchworker.TypeComment, ID: int32(cid), Text: body}
+	}
+	for _, uid := range uids {
+		for _, act := range []string{"see", "view"} {
+			_, _ = queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
+				UserID:   sql.NullInt32{Int32: uid, Valid: true},
+				RoleID:   sql.NullInt32{},
+				Section:  "forum",
+				Item:     sql.NullString{String: "topic", Valid: true},
+				RuleType: "allow",
+				ItemID:   sql.NullInt32{Int32: topicID, Valid: true},
+				ItemRule: sql.NullString{},
+				Action:   act,
+				Extra:    sql.NullString{},
+			})
+		}
+		_, _ = queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
+			UserID:   sql.NullInt32{Int32: uid, Valid: true},
+			RoleID:   sql.NullInt32{},
+			Section:  "forum",
+			Item:     sql.NullString{String: "thread", Valid: true},
+			RuleType: "allow",
+			ItemID:   sql.NullInt32{Int32: threadID, Valid: true},
+			ItemRule: sql.NullString{},
+			Action:   "reply",
+			Extra:    sql.NullString{},
+		})
+	}
+	return handlers.RefreshDirectHandler{TargetURL: fmt.Sprintf("/forum/topic/%d/thread/%d", topicID, threadID)}
+}

--- a/handlers/static.go
+++ b/handlers/static.go
@@ -32,6 +32,12 @@ func RoleGrantsEditorJS(w http.ResponseWriter, r *http.Request) {
 	http.ServeContent(w, r, "role_grants_editor.js", time.Time{}, bytes.NewReader(templates.GetRoleGrantsEditorJSData()))
 }
 
+// PrivateForumJS serves the JavaScript for the private forum pages.
+func PrivateForumJS(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/javascript")
+	http.ServeContent(w, r, "private_forum.js", time.Time{}, bytes.NewReader(templates.GetPrivateForumJSData()))
+}
+
 // RedirectPermanent returns a handler that redirects to the provided path using StatusPermanentRedirect.
 func RedirectPermanent(to string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -242,6 +242,7 @@ type Forumtopic struct {
 	Threads                      sql.NullInt32
 	Comments                     sql.NullInt32
 	Lastaddition                 sql.NullTime
+	Handler                      string
 }
 
 type Grant struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -229,7 +229,6 @@ type Querier interface {
 	GetAllForumThreadsWithTopic(ctx context.Context) ([]*GetAllForumThreadsWithTopicRow, error)
 	GetAllForumTopics(ctx context.Context, arg GetAllForumTopicsParams) ([]*Forumtopic, error)
 	GetAllForumTopicsByCategoryIdForUserWithLastPosterName(ctx context.Context, arg GetAllForumTopicsByCategoryIdForUserWithLastPosterNameParams) ([]*GetAllForumTopicsByCategoryIdForUserWithLastPosterNameRow, error)
-	GetAllForumTopicsForUser(ctx context.Context, arg GetAllForumTopicsForUserParams) ([]*GetAllForumTopicsForUserRow, error)
 	GetAllImagePostsForIndex(ctx context.Context) ([]*GetAllImagePostsForIndexRow, error)
 	GetAllLinkerCategories(ctx context.Context) ([]*LinkerCategory, error)
 	GetAllLinkerCategoriesForUser(ctx context.Context, arg GetAllLinkerCategoriesForUserParams) ([]*LinkerCategory, error)
@@ -269,6 +268,7 @@ type Querier interface {
 	GetForumTopicByIdForUser(ctx context.Context, arg GetForumTopicByIdForUserParams) (*GetForumTopicByIdForUserRow, error)
 	GetForumTopicIdByThreadId(ctx context.Context, idforumthread int32) (int32, error)
 	GetForumTopicsByCategoryId(ctx context.Context, arg GetForumTopicsByCategoryIdParams) ([]*Forumtopic, error)
+	GetForumTopicsForUser(ctx context.Context, arg GetForumTopicsForUserParams) ([]*GetForumTopicsForUserRow, error)
 	GetImageBoardById(ctx context.Context, idimageboard int32) (*Imageboard, error)
 	GetImagePostByIDForLister(ctx context.Context, arg GetImagePostByIDForListerParams) (*GetImagePostByIDForListerRow, error)
 	GetImagePostInfoByPath(ctx context.Context, arg GetImagePostInfoByPathParams) (*GetImagePostInfoByPathRow, error)
@@ -362,6 +362,8 @@ type Querier interface {
 	ListImageboardPath(ctx context.Context, boardID int32) ([]*ListImageboardPathRow, error)
 	ListLinkerCategoryPath(ctx context.Context, categoryID int32) ([]*ListLinkerCategoryPathRow, error)
 	ListNotificationsForLister(ctx context.Context, arg ListNotificationsForListerParams) ([]*Notification, error)
+	ListPrivateTopicParticipantsByTopicIDForUser(ctx context.Context, arg ListPrivateTopicParticipantsByTopicIDForUserParams) ([]*ListPrivateTopicParticipantsByTopicIDForUserRow, error)
+	ListPrivateTopicsByUserID(ctx context.Context, userID sql.NullInt32) ([]*Forumtopic, error)
 	ListPublicWritingsByUserForLister(ctx context.Context, arg ListPublicWritingsByUserForListerParams) ([]*ListPublicWritingsByUserForListerRow, error)
 	ListPublicWritingsInCategoryForLister(ctx context.Context, arg ListPublicWritingsInCategoryForListerParams) ([]*ListPublicWritingsInCategoryForListerRow, error)
 	ListSiteNewsSearchFirstForLister(ctx context.Context, arg ListSiteNewsSearchFirstForListerParams) ([]int32, error)
@@ -471,6 +473,7 @@ type Querier interface {
 	SystemRegisterExternalLinkClick(ctx context.Context, url string) error
 	SystemSetBlogLastIndex(ctx context.Context, id int32) error
 	SystemSetCommentLastIndex(ctx context.Context, idcomments int32) error
+	SystemSetForumTopicHandlerByID(ctx context.Context, arg SystemSetForumTopicHandlerByIDParams) error
 	SystemSetImagePostLastIndex(ctx context.Context, idimagepost int32) error
 	SystemSetLinkerLastIndex(ctx context.Context, idlinker int32) error
 	SystemSetSiteNewsLastIndex(ctx context.Context, idsitenews int32) error

--- a/migrations/0055.postgres.sql
+++ b/migrations/0055.postgres.sql
@@ -1,0 +1,43 @@
+-- Migrate legacy 'Private discussion' category into private topics
+ALTER TABLE forumtopic ADD COLUMN handler varchar(32) NOT NULL DEFAULT '';
+
+UPDATE forumtopic
+SET handler='private', forumcategory_idforumcategory = 0
+WHERE forumcategory_idforumcategory IN (
+    SELECT idforumcategory FROM forumcategory WHERE title='Private discussion'
+);
+
+INSERT INTO grants (created_at, user_id, section, item, rule_type, item_id, action, active)
+SELECT now(), 1, 'forum', 'topic', 'allow', t.idforumtopic, 'see', 1
+FROM forumtopic t
+WHERE t.handler='private'
+  AND NOT EXISTS (
+      SELECT 1 FROM grants g WHERE g.user_id=1 AND g.section='forum' AND g.item='topic' AND g.action='see' AND g.item_id=t.idforumtopic
+  );
+
+INSERT INTO grants (created_at, user_id, section, item, rule_type, item_id, action, active)
+SELECT now(), 1, 'forum', 'topic', 'allow', t.idforumtopic, 'view', 1
+FROM forumtopic t
+WHERE t.handler='private'
+  AND NOT EXISTS (
+      SELECT 1 FROM grants g WHERE g.user_id=1 AND g.section='forum' AND g.item='topic' AND g.action='view' AND g.item_id=t.idforumtopic
+  );
+
+INSERT INTO grants (created_at, user_id, section, item, rule_type, action, active)
+SELECT now(), u.idusers, 'privateforum', 'topic', 'allow', 'see', 1
+FROM users u
+JOIN passwords p ON p.users_idusers = u.idusers
+WHERE u.deleted_at IS NULL
+GROUP BY u.idusers;
+
+INSERT INTO grants (created_at, user_id, section, item, rule_type, action, active)
+SELECT now(), u.idusers, 'privateforum', 'topic', 'allow', 'create', 1
+FROM users u
+JOIN passwords p ON p.users_idusers = u.idusers
+WHERE u.deleted_at IS NULL
+GROUP BY u.idusers;
+
+DELETE FROM forumcategory WHERE title='Private discussion';
+
+-- Update schema version
+UPDATE schema_version SET version = 55 WHERE version = 54;

--- a/migrations/0055.sqlite.sql
+++ b/migrations/0055.sqlite.sql
@@ -1,0 +1,43 @@
+-- Migrate legacy 'Private discussion' category into private topics
+ALTER TABLE forumtopic ADD COLUMN handler varchar(32) NOT NULL DEFAULT '';
+
+UPDATE forumtopic
+SET handler='private', forumcategory_idforumcategory = 0
+WHERE forumcategory_idforumcategory IN (
+    SELECT idforumcategory FROM forumcategory WHERE title='Private discussion'
+);
+
+INSERT INTO grants (created_at, user_id, section, item, rule_type, item_id, action, active)
+SELECT CURRENT_TIMESTAMP, 1, 'forum', 'topic', 'allow', t.idforumtopic, 'see', 1
+FROM forumtopic t
+WHERE t.handler='private'
+  AND NOT EXISTS (
+      SELECT 1 FROM grants g WHERE g.user_id=1 AND g.section='forum' AND g.item='topic' AND g.action='see' AND g.item_id=t.idforumtopic
+  );
+
+INSERT INTO grants (created_at, user_id, section, item, rule_type, item_id, action, active)
+SELECT CURRENT_TIMESTAMP, 1, 'forum', 'topic', 'allow', t.idforumtopic, 'view', 1
+FROM forumtopic t
+WHERE t.handler='private'
+  AND NOT EXISTS (
+      SELECT 1 FROM grants g WHERE g.user_id=1 AND g.section='forum' AND g.item='topic' AND g.action='view' AND g.item_id=t.idforumtopic
+  );
+
+INSERT INTO grants (created_at, user_id, section, item, rule_type, action, active)
+SELECT CURRENT_TIMESTAMP, u.idusers, 'privateforum', 'topic', 'allow', 'see', 1
+FROM users u
+JOIN passwords p ON p.users_idusers = u.idusers
+WHERE u.deleted_at IS NULL
+GROUP BY u.idusers;
+
+INSERT INTO grants (created_at, user_id, section, item, rule_type, action, active)
+SELECT CURRENT_TIMESTAMP, u.idusers, 'privateforum', 'topic', 'allow', 'create', 1
+FROM users u
+JOIN passwords p ON p.users_idusers = u.idusers
+WHERE u.deleted_at IS NULL
+GROUP BY u.idusers;
+
+DELETE FROM forumcategory WHERE title='Private discussion';
+
+-- Update schema version
+UPDATE schema_version SET version = 55 WHERE version = 54;

--- a/schema/schema.mysql.sql
+++ b/schema/schema.mysql.sql
@@ -119,6 +119,7 @@ CREATE TABLE `forumtopic` (
   `threads` int(10) DEFAULT NULL,
   `comments` int(10) DEFAULT NULL,
   `lastaddition` datetime DEFAULT NULL,
+  `handler` varchar(32) NOT NULL DEFAULT '',
   PRIMARY KEY (`idforumtopic`),
   KEY `forumtopic_FKIndex1` (`forumcategory_idforumcategory`),
   KEY `forumtopic_FKIndex2` (`lastposter`),

--- a/schema/schema.postgres.sql
+++ b/schema/schema.postgres.sql
@@ -119,6 +119,7 @@ CREATE TABLE `forumtopic` (
   `threads` int(10) DEFAULT NULL,
   `comments` int(10) DEFAULT NULL,
   `lastaddition` datetime DEFAULT NULL,
+  `handler` varchar(32) NOT NULL DEFAULT '',
   PRIMARY KEY (`idforumtopic`),
   KEY `forumtopic_FKIndex1` (`forumcategory_idforumcategory`),
   KEY `forumtopic_FKIndex2` (`lastposter`),

--- a/schema/schema.sqlite.sql
+++ b/schema/schema.sqlite.sql
@@ -119,6 +119,7 @@ CREATE TABLE `forumtopic` (
   `threads` int(10) DEFAULT NULL,
   `comments` int(10) DEFAULT NULL,
   `lastaddition` datetime DEFAULT NULL,
+  `handler` varchar(32) NOT NULL DEFAULT '',
   PRIMARY KEY (`idforumtopic`),
   KEY `forumtopic_FKIndex1` (`forumcategory_idforumcategory`),
   KEY `forumtopic_FKIndex2` (`lastposter`),

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -181,6 +181,12 @@ Many queries now filter results directly in SQL using `lister_id` together with 
 | `imagebbs` | `board`    | `post`          | Create a new post on the board |
 | `images`   | `upload`   | `see`           | List uploaded images |
 | `images`   | `upload`   | `post`          | Upload an image |
+| `privateforum` | `topic` | `see`           | Show a private topic in lists |
+| `privateforum` | `topic` | `view`          | View a private topic |
+| `privateforum` | `topic` | `reply`         | Reply within a private topic |
+| `privateforum` | `topic` | `post`          | Start a private conversation |
+| `privateforum` | `topic` | `edit`          | Edit posts in a private topic |
+| `privateforum` | `topic` | `create`        | Create a private topic |
 | `linker`   | —          | `search`        | Search links |
 | `linker`   | `category` | `see`           | Browse link categories |
 | `linker`   | `category` | `view`          | View links in a category |


### PR DESCRIPTION
## Summary
- add handler column and migration to convert legacy "Private discussion" topics
- enable participant-based private topic titles with creation task and UI
- document new `privateforum` grants and remove standalone search option

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893591315fc832fbb4cd97305e108e2