### PR TITLE
Grant login roles access to private forum

### DIFF
--- a/migrations/0055.mysql.sql
+++ b/migrations/0055.mysql.sql
@@ -36,6 +36,43 @@ JOIN passwords p ON p.users_idusers = u.idusers
 WHERE u.deleted_at IS NULL
 GROUP BY u.idusers;
 
+-- Grant login roles full access to the private forum
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'privateforum', 'topic', 'allow', 'see', 1
+FROM roles r
+WHERE r.can_login = 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'privateforum', 'topic', 'allow', 'view', 1
+FROM roles r
+WHERE r.can_login = 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'privateforum', 'topic', 'allow', 'reply', 1
+FROM roles r
+WHERE r.can_login = 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'privateforum', 'topic', 'allow', 'post', 1
+FROM roles r
+WHERE r.can_login = 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'privateforum', 'topic', 'allow', 'edit', 1
+FROM roles r
+WHERE r.can_login = 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT NOW(), r.id, 'privateforum', 'topic', 'allow', 'create', 1
+FROM roles r
+WHERE r.can_login = 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
 DELETE FROM forumcategory WHERE title='Private discussion';
 
 -- Update schema version

--- a/migrations/0055.postgres.sql
+++ b/migrations/0055.postgres.sql
@@ -37,6 +37,43 @@ JOIN passwords p ON p.users_idusers = u.idusers
 WHERE u.deleted_at IS NULL
 GROUP BY u.idusers;
 
+-- Grant login roles full access to the private forum
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT now(), r.id, 'privateforum', 'topic', 'allow', 'see', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT now(), r.id, 'privateforum', 'topic', 'allow', 'view', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT now(), r.id, 'privateforum', 'topic', 'allow', 'reply', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT now(), r.id, 'privateforum', 'topic', 'allow', 'post', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT now(), r.id, 'privateforum', 'topic', 'allow', 'edit', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT now(), r.id, 'privateforum', 'topic', 'allow', 'create', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
 DELETE FROM forumcategory WHERE title='Private discussion';
 
 -- Update schema version

--- a/migrations/0055.sqlite.sql
+++ b/migrations/0055.sqlite.sql
@@ -37,6 +37,43 @@ JOIN passwords p ON p.users_idusers = u.idusers
 WHERE u.deleted_at IS NULL
 GROUP BY u.idusers;
 
+-- Grant login roles full access to the private forum
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT CURRENT_TIMESTAMP, r.id, 'privateforum', 'topic', 'allow', 'see', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT CURRENT_TIMESTAMP, r.id, 'privateforum', 'topic', 'allow', 'view', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT CURRENT_TIMESTAMP, r.id, 'privateforum', 'topic', 'allow', 'reply', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT CURRENT_TIMESTAMP, r.id, 'privateforum', 'topic', 'allow', 'post', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT CURRENT_TIMESTAMP, r.id, 'privateforum', 'topic', 'allow', 'edit', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
+INSERT INTO grants (created_at, role_id, section, item, rule_type, action, active)
+SELECT CURRENT_TIMESTAMP, r.id, 'privateforum', 'topic', 'allow', 'create', 1
+FROM roles r
+WHERE r.can_login = 1
+ON CONFLICT DO NOTHING;
+
 DELETE FROM forumcategory WHERE title='Private discussion';
 
 -- Update schema version

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -113,7 +113,9 @@ fields.
 ## Seeding
 
 The `seed.sql` file provides initial roles and establishes the role hierarchy.
-It also grants the `user` role to existing accounts lacking a role.
+It also grants the `user` role to existing accounts lacking a role. Migration
+55 ensures all roles with `can_login` receive user-level access to the private
+forum (`see`, `view`, `reply`, `post`, `edit`, `create`).
 
 ## CLI Tools
 


### PR DESCRIPTION
## Summary
- grant all login-capable roles full private forum access in migration 55
- document default private forum grants for login roles

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(hangs; aborted)*
- `golangci-lint run` *(hangs; aborted)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689426b82c84832fad2255014683804e