### PR TITLE
Clarify reply message for restricted threads

### DIFF
--- a/core/templates/site/showLinkComments.gohtml
+++ b/core/templates/site/showLinkComments.gohtml
@@ -28,7 +28,11 @@
                 <input type="submit" name="task" value="Reply">
             </form>
         {{ else }}
-            Please sign-in (or sign-up) to write a reply.<br>
+            {{ with cd.CurrentUserLoaded }}
+                You do not have permission to write a reply.<br>
+            {{ else }}
+                Please sign-in (or sign-up) to write a reply.<br>
+            {{ end }}
         {{ end }}
 
     {{ else }}

--- a/core/templates/site/writings/articlePage.gohtml
+++ b/core/templates/site/writings/articlePage.gohtml
@@ -23,7 +23,11 @@
                 <input type="submit" name="task" value="Reply">
             </form>
         {{ else }}
-            Please sign-in (or sign-up) to write a reply.<br>
+            {{ with cd.CurrentUserLoaded }}
+                You do not have permission to write a reply.<br>
+            {{ else }}
+                Please sign-in (or sign-up) to write a reply.<br>
+            {{ end }}
         {{ end }}
     {{ else }}
         Article doesn't exist.<br>


### PR DESCRIPTION
## Summary
- Show a permission-related message instead of sign-in prompt when logged-in users cannot reply

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894288ad204832f97ca6794714f5587