### PR TITLE
Fix writing title separator formatting

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -59,6 +59,7 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 			}
 			return string(out)
 		},
+		"trim": strings.TrimSpace,
 		"firstline": func(s string) string {
 			return strings.Split(s, "\n")[0]
 		},

--- a/core/templates/site/writings/articlePage.gohtml
+++ b/core/templates/site/writings/articlePage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
     {{ $writing := cd.CurrentWritingLoaded }}
     {{ if $writing }}
-        <font size="4">At {{ $writing.Published.Time }}, By {{ $writing.Writerusername.String }}; {{ $writing.Title.String | a4code2html }}</font>:
+        <font size="4">At {{ $writing.Published.Time }}, By {{ $writing.Writerusername.String }}; {{ $writing.Title.String | trim | a4code2html }}:</font>
         {{ if $writing.Private.Bool }} (Restricted access) {{ end }}
         {{ if or .CanEdit .IsAuthor }}
             [<a href="/writings/article/{{ $writing.Idwriting }}/edit">EDIT</a>]


### PR DESCRIPTION
## Summary
- add trim helper to strip trailing whitespace in templates
- use trim when rendering writing titles so the colon stays on the same line

## Testing
- `go fmt ./...`
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68942949b114832f954445fd70fc2027