### PR TITLE
feat: add private forum topic table

### DIFF
--- a/core/common/privateforum.go
+++ b/core/common/privateforum.go
@@ -15,7 +15,7 @@ const (
 
 // PrivateTopic represents a private conversation with a computed title.
 type PrivateTopic struct {
-	*db.Forumtopic
+	*db.ListPrivateTopicsByUserIDRow
 	DisplayTitle string
 }
 
@@ -48,7 +48,7 @@ func (cd *CoreData) PrivateForumTopics() ([]*PrivateTopic, error) {
 			if len(names) > 1 && t.Title.Valid && t.Title.String != "" {
 				title = fmt.Sprintf("%s (%s)", title, t.Title.String)
 			}
-			pts = append(pts, &PrivateTopic{Forumtopic: t, DisplayTitle: title})
+			pts = append(pts, &PrivateTopic{ListPrivateTopicsByUserIDRow: t, DisplayTitle: title})
 		}
 		return pts, nil
 	})

--- a/core/templates/site/forum/categories.gohtml
+++ b/core/templates/site/forum/categories.gohtml
@@ -25,7 +25,7 @@
             <tr>
                 <td>
                     {{ template "getAllForumCategories" (call $.CopyDataToSubCategories .) }}
-                    {{ template "tableTopics" (call $.CopyDataToSubCategories .) }}
+                    {{ template "tableTopics" (dict "Topics" .Topics) }}
                     {{ if $.Admin }}
                         <a href="/admin/forum/categories/create?category={{ .Idforumcategory }}">Create Category</a><br>
                         {{ if ne .Idforumcategory 0 }}

--- a/core/templates/site/privateForumPage.gohtml
+++ b/core/templates/site/privateForumPage.gohtml
@@ -1,13 +1,7 @@
 {{ define "privateForumPage" }}
     {{ template "head" $ }}
     <h1>Private Topics</h1>
-    <ul>
-    {{ range cd.PrivateTopics }}
-        <li>{{ .DisplayTitle }}</li>
-    {{ else }}
-        <li>No private topics</li>
-    {{ end }}
-    </ul>
+    {{ template "tableTopics" (dict "Topics" cd.PrivateTopics) }}
     <h2>Start conversation</h2>
     <form id="private-form" method="POST">
         <input type="hidden" name="task" value="{{ .CreateTask }}">

--- a/core/templates/site/tableTopics.gohtml
+++ b/core/templates/site/tableTopics.gohtml
@@ -6,25 +6,20 @@
             <th>Threads
             <th>Replies
         </tr>
-        {{ range .Category.Topics }}
+        {{ range .Topics }}
         <tr>
             <td>
-                {{ if and $.Admin .Edit }}
-                    <form method="post">
-        {{ csrfField }}
-                        <input name="name" value="{{ .Title.String }}"><br>
-                        <textarea name="desc" cols="30" rows="3">{{ .Description.String }}</textarea><br>
-                        <input type="hidden" name="task" value="Forum topic change">
-                    </form>
-                {{ else }}
-                    <a href="/forum/topic/{{ .Idforumtopic }}">{{ .Title.String | a4code2html }}</a><br>
-                    <i>{{ .Description.String | a4code2html }}</i>
-                {{ end }}
+                {{ $title := .Title.String }}
+                {{ if .DisplayTitle }}{{ $title = .DisplayTitle }}{{ end }}
+                <a href="/forum/topic/{{ .Idforumtopic }}">{{ $title | a4code2html }}</a>{{ if cd.CanEditAny }} [<a href="/admin/forum/topics/topic/{{ .Idforumtopic }}/edit">ADMIN</a>]{{ end }}<br>
+                {{ with .Description.String }}<i>{{ . | a4code2html }}</i>{{ end }}
             </td>
             <td align="center">{{ .Lastaddition.Time }}<br>{{ .Lastposterusername.String }}</td>
             <td align="center">{{ .Threads.Int32 }}</td>
             <td align="center">{{ .Comments.Int32 }}</td>
         </tr>
+        {{ else }}
+        <tr><td colspan="4">No topics</td></tr>
         {{ end }}
     </table>
 {{ end }}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -366,7 +366,7 @@ type Querier interface {
 	ListLinkerCategoryPath(ctx context.Context, categoryID int32) ([]*ListLinkerCategoryPathRow, error)
 	ListNotificationsForLister(ctx context.Context, arg ListNotificationsForListerParams) ([]*Notification, error)
 	ListPrivateTopicParticipantsByTopicIDForUser(ctx context.Context, arg ListPrivateTopicParticipantsByTopicIDForUserParams) ([]*ListPrivateTopicParticipantsByTopicIDForUserRow, error)
-	ListPrivateTopicsByUserID(ctx context.Context, userID sql.NullInt32) ([]*Forumtopic, error)
+	ListPrivateTopicsByUserID(ctx context.Context, userID sql.NullInt32) ([]*ListPrivateTopicsByUserIDRow, error)
 	ListPublicWritingsByUserForLister(ctx context.Context, arg ListPublicWritingsByUserForListerParams) ([]*ListPublicWritingsByUserForListerRow, error)
 	ListPublicWritingsInCategoryForLister(ctx context.Context, arg ListPublicWritingsInCategoryForListerParams) ([]*ListPublicWritingsInCategoryForListerRow, error)
 	ListSiteNewsSearchFirstForLister(ctx context.Context, arg ListSiteNewsSearchFirstForListerParams) ([]int32, error)

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -261,8 +261,19 @@ WHERE th.forumtopic_idforumtopic=sqlc.arg(topic_id)
 ORDER BY th.lastaddition DESC;
 
 -- name: ListPrivateTopicsByUserID :many
-SELECT DISTINCT t.*
+SELECT t.idforumtopic,
+       t.lastposter,
+       t.forumcategory_idforumcategory,
+       t.language_idlanguage,
+       t.title,
+       t.description,
+       t.threads,
+       t.comments,
+       t.lastaddition,
+       t.handler,
+       lu.username AS LastPosterUsername
 FROM forumtopic t
+LEFT JOIN users lu ON lu.idusers = t.lastposter
 JOIN grants g ON g.item_id = t.idforumtopic
 WHERE t.handler = 'private'
   AND g.section = 'forum'


### PR DESCRIPTION
## Summary
- refactor topic table into reusable partial for private threads
- show private forum topics in same table layout as public forums
- include last poster username when loading private topics

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689427aadb28832f994e90bcd430305c