### PR TITLE
Fix topic page category display and layout

### DIFF
--- a/core/templates/site/forum/topicsPage.gohtml
+++ b/core/templates/site/forum/topicsPage.gohtml
@@ -1,10 +1,10 @@
 {{ template "head" $ }}
 
-    {{ template "getAllForumCategories" $ }}
+    {{ if .Categories }}
+        {{ template "getAllForumCategories" $ }}
+    {{ end }}
 
-    <a href="/forum/topic/{{.Topic.Idforumtopic}}/thread">New Thread</a>
-    {{- if cd.CanEditAny }} | <a href="/admin/forum/topics/topic/{{.Topic.Idforumtopic}}/edit">Edit Topic</a>{{ end }}
-    {{- if .Subscribed }} | <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/unsubscribe" style="display:inline"><input type="hidden" name="task" value="Unsubscribe From Topic"/><input type="submit" value="Unsubscribe"/></form>{{ else }} | <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/subscribe" style="display:inline"><input type="hidden" name="task" value="Subscribe To Topic"/><input type="submit" value="Subscribe"/></form>{{ end }}<br />
+    <a href="/forum/topic/{{.Topic.Idforumtopic}}/thread">New Thread</a>{{- if cd.CanEditAny }} | <a href="/admin/forum/topics/topic/{{.Topic.Idforumtopic}}/edit">Edit Topic</a>{{ end }}{{- if .Subscribed }} | <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/unsubscribe" style="display:inline"><input type="hidden" name="task" value="Unsubscribe From Topic"/><input type="submit" value="Unsubscribe"/></form>{{ else }} | <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/subscribe" style="display:inline"><input type="hidden" name="task" value="Subscribe To Topic"/><input type="submit" value="Subscribe"/></form>{{ end }}<br />
 
     {{ template "topicThreads" $ }}
 {{ template "tail" $ }}

--- a/core/templates/site/topicThreads.gohtml
+++ b/core/templates/site/topicThreads.gohtml
@@ -1,5 +1,5 @@
 {{ define "topicThreads" }}
-    <font size="4">Threads:</font><br>
+    <h2>Threads</h2>
     {{- range .Threads }}
         <table width="100%" border=1>
             <tr>


### PR DESCRIPTION
## Summary
- Hide the "No categories to show" message on topic pages without a parent category
- Keep thread actions on a single line
- Promote the threads section heading for better visibility

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689436007b0c832f8ccbe20e706b1562