### PR TITLE
Fix admin comment page template path

### DIFF
--- a/handlers/admin/adminCommentPage.go
+++ b/handlers/admin/adminCommentPage.go
@@ -55,5 +55,5 @@ func adminCommentPage(w http.ResponseWriter, r *http.Request) {
 		Comment *db.GetCommentsByIdsForUserWithThreadInfoRow
 		Context []*db.GetCommentsByThreadIdForUserRow
 	}{comment, contextRows}
-	handlers.TemplateHandler(w, r, "adminCommentPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "admin/commentPage.gohtml", data)
 }


### PR DESCRIPTION
## Summary
- fix admin comment page to reference correct template

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./handlers/admin/...` *(terminates: ^C)*
- `golangci-lint run` *(terminates: ^C)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689437d92850832f8414e8c3abf6d8dd