### PR TITLE
Fix forum reply quoting

### DIFF
--- a/core/templates/site/comment.gohtml
+++ b/core/templates/site/comment.gohtml
@@ -18,8 +18,8 @@
                 {{ else }}
                     {{ $cmt.Text.String | a4code2html}}<br>-<br>{{ $cmt.Posterusername.String }}.
                     {{ if cd.SelectedThreadCanReply }}
-                        [<a href="?comment={{ $cmt.Idcomments }}&type=full#reply">FULL REPLY</a>]
-                        [<a href="?comment={{ $cmt.Idcomments }}#reply">PARAGRAPH REPLY</a>]
+                        [<a href="?quote={{ $cmt.Idcomments }}&type=full#reply">FULL REPLY</a>]
+                        [<a href="?quote={{ $cmt.Idcomments }}#reply">PARAGRAPH REPLY</a>]
                     {{ end }}
                     {{ if cd.CanEditComment $cmt }}[<a href="{{ cd.CommentEditURL $cmt }}">EDIT</a>]{{ end }}
                     {{ $admin := cd.CommentAdminURL $cmt }}{{ if $admin }}[<a href="{{ $admin }}">ADMIN</a>]{{ end }}

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -18,7 +18,7 @@ import (
 
 func ThreadPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		Category            *ForumcategoryPlus
+		Category       *ForumcategoryPlus
 		Topic          *ForumtopicPlus
 		Thread         *db.GetThreadLastPosterAndPermsRow
 		Comments       []*db.GetCommentsByThreadIdForUserRow
@@ -68,6 +68,7 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 	// middleware.
 
 	commentId, _ := strconv.Atoi(r.URL.Query().Get("comment"))
+	quoteId, _ := strconv.Atoi(r.URL.Query().Get("quote"))
 	data.Comments = commentRows
 
 	data.CanEditComment = func(cmt *db.GetCommentsByThreadIdForUserRow) bool {
@@ -113,13 +114,14 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	replyType := r.URL.Query().Get("type")
-	if c, err := cd.CurrentComment(r); err == nil && c != nil {
-		data.IsReplyable = false
-		switch replyType {
-		case "full":
-			data.Text = a4code.FullQuoteOf(c.Username.String, c.Text.String)
-		default:
-			data.Text = a4code.QuoteOfText(c.Username.String, c.Text.String)
+	if quoteId != 0 {
+		if c, err := cd.CommentByID(int32(quoteId)); err == nil && c != nil {
+			switch replyType {
+			case "full":
+				data.Text = a4code.FullQuoteOf(c.Username.String, c.Text.String)
+			default:
+				data.Text = a4code.QuoteOfText(c.Username.String, c.Text.String)
+			}
 		}
 	}
 

--- a/handlers/forum/forumThreadPage_quote_test.go
+++ b/handlers/forum/forumThreadPage_quote_test.go
@@ -1,0 +1,87 @@
+package forum
+
+import (
+	"context"
+	"database/sql"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestThreadPageQuotePrefillsReply(t *testing.T) {
+	dbconn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer dbconn.Close()
+
+	mock.ExpectQuery(".*").
+		WithArgs(int32(1), int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername",
+		}).AddRow(int32(1), int32(1), int32(1), int32(1), sql.NullInt32{}, sql.NullTime{}, sql.NullBool{}, sql.NullString{}))
+
+	mock.ExpectQuery(".*").
+		WithArgs(int32(1), int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername",
+		}).AddRow(int32(1), int32(1), int32(1), int32(1), sql.NullString{String: "topic", Valid: true}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullTime{}, "normal", sql.NullString{}))
+
+	mock.ExpectQuery(".*").
+		WithArgs(int32(1), int32(1), int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "deleted_at", "last_index", "posterusername", "is_owner",
+		}))
+
+	mock.ExpectQuery(".*").
+		WithArgs(int32(1), int32(1), int32(2), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "deleted_at", "last_index", "username", "is_owner",
+		}).AddRow(int32(2), int32(1), int32(1), int32(1), sql.NullTime{}, sql.NullString{String: "hi", Valid: true}, sql.NullTime{}, sql.NullTime{}, sql.NullString{String: "alice", Valid: true}, false))
+
+	mock.ExpectQuery(".*").
+		WithArgs(int32(1), "forum", sql.NullString{String: "topic", Valid: true}, "reply", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test-session"
+
+	req := httptest.NewRequest("GET", "/forum/topic/1/thread/1?quote=2", nil)
+	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "1"})
+	w := httptest.NewRecorder()
+	sess, _ := store.Get(req, core.SessionName)
+	sess.Values["UID"] = int32(1)
+	sess.Save(req, w)
+	for _, c := range w.Result().Cookies() {
+		req.AddCookie(c)
+	}
+
+	q := db.New(dbconn)
+	cfg := config.NewRuntimeConfig()
+	cd := common.NewCoreData(req.Context(), q, cfg, common.WithSession(sess), common.WithUserRoles([]string{"user"}))
+	cd.SetCurrentSection("forum")
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	ThreadPage(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+
+	if !strings.Contains(rr.Body.String(), "[quoteof") {
+		t.Fatalf("reply not quoted: %s", rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- avoid triggering edit mode when quoting a comment
- add a regression test for quoting

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689437bedd20832fb04a704abc5a7d3d