### PR TITLE
avoid admin mode query for admin links

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -89,6 +90,11 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 			cd, _ := r.Context().Value(consts.KeyCoreData).(*CoreData)
 			if cd == nil || !cd.AdminMode {
 				return u
+			}
+			if parsed, err := url.Parse(u); err == nil {
+				if parsed.Path == "/admin" || strings.HasPrefix(parsed.Path, "/admin/") {
+					return u
+				}
 			}
 			if strings.Contains(u, "?") {
 				return u + "&mode=admin"

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -96,3 +96,32 @@ func TestLatestNewsRespectsPermissions(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestAddmodeSkipsAdminLinks(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	cd := &common.CoreData{AdminMode: true}
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	funcs := cd.Funcs(req)
+	addmode := funcs["addmode"].(func(string) string)
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"/admin", "/admin"},
+		{"/admin/tools", "/admin/tools"},
+		{"/admin/tools?flag=1", "/admin/tools?flag=1"},
+		{"http://example.com/admin", "http://example.com/admin"},
+		{"/administrator", "/administrator?mode=admin"},
+		{"/user", "/user?mode=admin"},
+		{"/user?id=1", "/user?id=1&mode=admin"},
+	}
+
+	for _, tt := range tests {
+		if got := addmode(tt.in); got != tt.want {
+			t.Errorf("addmode(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- stop appending `mode=admin` to URLs already under `/admin`
- test that admin links omit the `mode=admin` query
- ensure only `/admin` and its subpaths bypass the query parameter

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet -v ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689439a715a8832f8ca1bd5a78b3077d