### PR TITLE
Avoid missing DisplayTitle in forum topic template

### DIFF
--- a/handlers/forum/forum.go
+++ b/handlers/forum/forum.go
@@ -12,11 +12,13 @@ type ForumtopicPlus struct {
 	ForumcategoryIdforumcategory int32
 	Title                        sql.NullString
 	Description                  sql.NullString
-	Threads                      sql.NullInt32
-	Comments                     sql.NullInt32
-	Lastaddition                 sql.NullTime
-	Lastposterusername           sql.NullString
-	Edit                         bool
+	// DisplayTitle optionally overrides Title for display purposes.
+	DisplayTitle       string
+	Threads            sql.NullInt32
+	Comments           sql.NullInt32
+	Lastaddition       sql.NullTime
+	Lastposterusername sql.NullString
+	Edit               bool
 }
 
 type ForumcategoryPlus struct {


### PR DESCRIPTION
## Summary
- add optional `DisplayTitle` field to `ForumtopicPlus`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689440d249ec832fb06216a72bb5e64c