### PR TITLE
Fix initial private topic comment permissions

### DIFF
--- a/handlers/privateforum/topic_create_task_test.go
+++ b/handlers/privateforum/topic_create_task_test.go
@@ -1,0 +1,56 @@
+package privateforum
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestPrivateTopicCreateTask_GrantsBeforeComment(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	q := db.New(conn)
+
+	mock.ExpectExec("INSERT INTO forumtopic").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("UPDATE forumtopic SET handler").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO forumthread").WillReturnResult(sqlmock.NewResult(2, 1))
+	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO comments").WillReturnResult(sqlmock.NewResult(3, 1))
+
+	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd.UserID = 1
+
+	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("body=hello"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+
+	res := privateTopicCreateTask.Action(w, req)
+	if err, ok := res.(error); ok {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := res.(handlers.RefreshDirectHandler); !ok {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -407,6 +407,7 @@ type Querier interface {
 	SystemCountLanguages(ctx context.Context) (int64, error)
 	SystemCountRecentLoginAttempts(ctx context.Context, arg SystemCountRecentLoginAttemptsParams) (int64, error)
 	SystemCreateForumTopic(ctx context.Context, arg SystemCreateForumTopicParams) (int64, error)
+	SystemCreateGrant(ctx context.Context, arg SystemCreateGrantParams) (int64, error)
 	SystemCreateNotification(ctx context.Context, arg SystemCreateNotificationParams) error
 	SystemCreateSearchWord(ctx context.Context, word string) (int64, error)
 	SystemCreateThread(ctx context.Context, forumtopicIdforumtopic int32) (int64, error)

--- a/internal/db/queries-permissions.sql
+++ b/internal/db/queries-permissions.sql
@@ -76,6 +76,11 @@ WHERE g.section = sqlc.arg(section)
   AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 LIMIT 1;
 
+-- name: SystemCreateGrant :execlastid
+INSERT INTO grants (
+    created_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active
+) VALUES (NOW(), ?, ?, ?, ?, ?, ?, ?, ?, ?, 1);
+
 -- name: AdminCreateGrant :execlastid
 INSERT INTO grants (
     created_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active

--- a/internal/db/queries-permissions.sql.go
+++ b/internal/db/queries-permissions.sql.go
@@ -535,6 +535,42 @@ func (q *Queries) SystemCheckRoleGrant(ctx context.Context, arg SystemCheckRoleG
 	return column_1, err
 }
 
+const systemCreateGrant = `-- name: SystemCreateGrant :execlastid
+INSERT INTO grants (
+    created_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active
+) VALUES (NOW(), ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+`
+
+type SystemCreateGrantParams struct {
+	UserID   sql.NullInt32
+	RoleID   sql.NullInt32
+	Section  string
+	Item     sql.NullString
+	RuleType string
+	ItemID   sql.NullInt32
+	ItemRule sql.NullString
+	Action   string
+	Extra    sql.NullString
+}
+
+func (q *Queries) SystemCreateGrant(ctx context.Context, arg SystemCreateGrantParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, systemCreateGrant,
+		arg.UserID,
+		arg.RoleID,
+		arg.Section,
+		arg.Item,
+		arg.RuleType,
+		arg.ItemID,
+		arg.ItemRule,
+		arg.Action,
+		arg.Extra,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.LastInsertId()
+}
+
 const systemCreateUserRole = `-- name: SystemCreateUserRole :exec
 INSERT INTO user_roles (users_idusers, role_id)
 SELECT ?, r.id FROM roles r WHERE r.name = ?


### PR DESCRIPTION
## Summary
- ensure reply grants are added before creating the first comment in a private topic
- add regression test ensuring grants are issued prior to comment insert
- surface errors when creating grants for private topics
- use system-level grant creation for private topic permissions

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894370f46cc832f8f682843ce0957a1