### PR TITLE
fix: prevent breadcrumb overlap

### DIFF
--- a/core/common/breadcrumb.go
+++ b/core/common/breadcrumb.go
@@ -37,6 +37,9 @@ func (cd *CoreData) Breadcrumbs() []Breadcrumb {
 	if err != nil {
 		log.Printf("breadcrumbs: %v", err)
 	}
+	if cd.PageTitle != "" && len(crumbs) > 0 {
+		crumbs = crumbs[:len(crumbs)-1]
+	}
 	return crumbs
 }
 

--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -23,6 +23,11 @@ body {
         flex: 1;
 }
 
+.navbar-left {
+        display: flex;
+        align-items: center;
+}
+
 .navbar-right {
         text-align: right;
 }
@@ -246,10 +251,9 @@ tr.unsupported td {
         white-space: nowrap;
         text-overflow: ellipsis;
         direction: rtl;
-        position: absolute;
-        left: 0;
-        top: 50%;
-        transform: translateY(-50%);
+        text-align: right;
+        flex: 1;
+        margin-left: 0.5em;
 }
 
 .breadcrumbs ol {

--- a/core/templates/site/header.gohtml
+++ b/core/templates/site/header.gohtml
@@ -8,8 +8,6 @@
                 <a href="?mode=admin">Enable admin mode</a>
             {{ end }}
         {{ end }}
-    </div>
-    <div class="navbar-center">
         {{- $crumbs := cd.Breadcrumbs }}
         {{- if $crumbs }}
             <nav class="breadcrumbs" aria-label="Breadcrumb">
@@ -24,6 +22,8 @@
                 </ol>
             </nav>
         {{- end }}
+    </div>
+    <div class="navbar-center">
         <strong>
            {{- if cd.PageTitle }}<a class="page-title-link" href=".">{{ cd.PageTitle }}</a> - {{ end -}}{{ cd.SiteTitle }}
         </strong>


### PR DESCRIPTION
## Summary
- ensure breadcrumb nav sits left of site title without overlap
- keep breadcrumb text with left-side ellipsis when constrained
- hide the current page breadcrumb when a page title is present

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894384209cc832fa95d7e213b299ec7