### PR TITLE
Fix anchor for edited forum comments

### DIFF
--- a/core/templates/site/comment.gohtml
+++ b/core/templates/site/comment.gohtml
@@ -7,6 +7,7 @@
         <tr>
             <td>
                 {{ if cd.CommentEditing $cmt }}
+                    <a id="edit"></a>
                     <font size="4">Edit:</font><br>
                     <form method="post" action="{{ cd.CommentEditSaveURL $cmt }}">
                         {{ csrfField }}


### PR DESCRIPTION
## Summary
- ensure `#edit` anchor scrolls to the in-place comment editor by adding an `id="edit"` marker

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894443836cc832f9184ac1e75288764