### PR TITLE
Fix private topic creation test to mock permission check

### DIFF
--- a/handlers/privateforum/topic_create_task_test.go
+++ b/handlers/privateforum/topic_create_task_test.go
@@ -24,6 +24,9 @@ func TestPrivateTopicCreateTask_GrantsBeforeComment(t *testing.T) {
 
 	q := db.New(conn)
 
+	mock.ExpectQuery("SELECT 1 FROM grants").
+		WithArgs(int64(1), "forum", "category", "post", int64(0), int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 	mock.ExpectExec("INSERT INTO forumtopic").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE forumtopic SET handler").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO forumthread").WillReturnResult(sqlmock.NewResult(2, 1))


### PR DESCRIPTION
## Summary
- ensure TestPrivateTopicCreateTask_GrantsBeforeComment expects the SystemCheckGrant query before creating the topic

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689447036d30832fa05d87d6ebd85b35