### PR TITLE
Add grants admin dashboard

### DIFF
--- a/core/templates/site/admin/grantAddPage.gohtml
+++ b/core/templates/site/admin/grantAddPage.gohtml
@@ -1,0 +1,89 @@
+{{ template "head" $ }}
+<h2>Add Grant</h2>
+{{ if or (eq .Subject "") (eq .ID 0) }}
+<form method="get">
+    <label>Subject:
+        <select name="subject">
+            <option value="user"{{ if or (eq .Subject "user") (eq .Subject "") }} selected{{ end }}>User</option>
+            <option value="role"{{ if eq .Subject "role" }} selected{{ end }}>Role</option>
+        </select>
+    </label>
+    {{ if or (eq .Subject "user") (eq .Subject "") }}
+    <label>User:
+        <input list="userOptions" name="id">
+        <datalist id="userOptions">
+            {{ range .Users }}
+            {{ if .Username.Valid }}<option value="{{ .Idusers }}">{{ .Username.String }}</option>{{ end }}
+            {{ end }}
+        </datalist>
+    </label>
+    {{ else }}
+    <label>Role:
+        <input list="roleOptions" name="id">
+        <datalist id="roleOptions">
+            {{ range .Roles }}
+            <option value="{{ .ID }}">{{ .Name }}</option>
+            {{ end }}
+        </datalist>
+    </label>
+    {{ end }}
+    <input type="submit" value="Next">
+</form>
+{{ else if eq .Section "" }}
+<form method="get">
+    <input type="hidden" name="subject" value="{{ .Subject }}">
+    <input type="hidden" name="id" value="{{ .ID }}">
+    <label>Section:
+        <select name="section">
+            {{ range .Sections }}
+            <option value="{{ . }}">{{ . }}</option>
+            {{ end }}
+        </select>
+    </label>
+    <input type="submit" value="Next">
+</form>
+{{ else if eq .Item "" }}
+<form method="get">
+    <input type="hidden" name="subject" value="{{ .Subject }}">
+    <input type="hidden" name="id" value="{{ .ID }}">
+    <input type="hidden" name="section" value="{{ .Section }}">
+    <label>Item:
+        <select name="item">
+            {{ range .Items }}
+            <option value="{{ . }}">{{ . }}</option>
+            {{ end }}
+        </select>
+    </label>
+    <input type="submit" value="Next">
+</form>
+{{ else }}
+<form method="post" action="/admin/{{ .Subject }}/{{ .ID }}/grant">
+    {{ csrfField }}
+    <input type="hidden" name="task" value="Create grant">
+    <input type="hidden" name="section" value="{{ .Section }}">
+    <input type="hidden" name="item" value="{{ .Item }}">
+    <label>Action:
+        <select name="action">
+            {{ range .Actions }}
+            <option value="{{ . }}">{{ . }}</option>
+            {{ end }}
+        </select>
+    </label>
+    {{ if .ItemOptions }}
+    <label>Item:
+        <input list="itemOptions" name="item_id"{{ if .RequireItemID }} required{{ end }}>
+        <datalist id="itemOptions">
+            {{ if not .RequireItemID }}<option value="">All</option>{{ end }}
+            {{ range .ItemOptions }}
+            <option value="{{ .ID }}">{{ .Label }}</option>
+            {{ end }}
+        </datalist>
+    </label>
+    {{ else }}
+    <label>Item ID:<input type="text" name="item_id"{{ if .RequireItemID }} required{{ end }}></label>
+    {{ end }}
+    <input type="submit" value="Add">
+</form>
+{{ end }}
+<p><a href="/admin/grants">Back to grants</a></p>
+{{ template "tail" $ }}

--- a/core/templates/site/admin/grantPage.gohtml
+++ b/core/templates/site/admin/grantPage.gohtml
@@ -1,0 +1,27 @@
+{{ template "head" $ }}
+<p><a href="/admin/grants">Back to grants</a></p>
+<table border="1">
+    <tr><th>Field</th><th>Value</th></tr>
+    <tr><td>User</td><td>{{ if .Grant.UserID.Valid }}{{ .Grant.UserName }} ({{ .Grant.UserID.Int32 }}){{ else }}-{{ end }}</td></tr>
+    <tr><td>Role</td><td>{{ if .Grant.RoleID.Valid }}{{ .Grant.RoleName }} ({{ .Grant.RoleID.Int32 }}){{ else }}-{{ end }}</td></tr>
+    <tr><td>Section</td><td>{{ .Grant.Section }}</td></tr>
+    <tr><td>Item</td><td>{{ .Grant.Item.String }}</td></tr>
+    <tr><td>Item ID</td><td>{{ if .Grant.ItemID.Valid }}{{ .Grant.ItemID.Int32 }}{{ else }}-{{ end }}</td></tr>
+    <tr><td>Action</td><td>{{ .Grant.Action }}</td></tr>
+    <tr><td>Active</td><td>{{ if .Grant.Active }}yes{{ else }}no{{ end }}</td></tr>
+</table>
+<h3>Edit</h3>
+<form method="post" action="/admin/grant/update">
+    {{ csrfField }}
+    <input type="hidden" name="task" value="Update grant">
+    <input type="hidden" name="grantid" value="{{ .Grant.ID }}">
+    <label>Active: <input type="checkbox" name="active" value="1" {{ if .Grant.Active }}checked{{ end }}></label>
+    <input type="submit" value="Save">
+</form>
+<form method="post" action="/admin/grant/delete" onsubmit="return confirm('Delete grant?');">
+    {{ csrfField }}
+    <input type="hidden" name="task" value="Delete grant">
+    <input type="hidden" name="grantid" value="{{ .Grant.ID }}">
+    <input type="submit" value="Delete">
+</form>
+{{ template "tail" $ }}

--- a/core/templates/site/admin/grantsPage.gohtml
+++ b/core/templates/site/admin/grantsPage.gohtml
@@ -1,0 +1,19 @@
+{{ template "head" $ }}
+<p><a href="/admin/grant/add">Add grant</a></p>
+<table border="1">
+    <tr><th>ID</th><th>User</th><th>Role</th><th>Section</th><th>Item</th><th>Item ID</th><th>Action</th><th>Active</th><th>Edit</th></tr>
+    {{- range .Grants }}
+    <tr>
+        <td><a href="/admin/grant/{{ .Grant.ID }}">{{ .Grant.ID }}</a></td>
+        <td>{{ if .Grant.UserID.Valid }}{{ .UserName }} ({{ .Grant.UserID.Int32 }}){{ end }}</td>
+        <td>{{ if .Grant.RoleID.Valid }}{{ .RoleName }} ({{ .Grant.RoleID.Int32 }}){{ end }}</td>
+        <td>{{ .Grant.Section }}</td>
+        <td>{{ .Grant.Item.String }}</td>
+        <td>{{ if .Grant.ItemID.Valid }}{{ .Grant.ItemID.Int32 }}{{ end }}</td>
+        <td>{{ .Grant.Action }}</td>
+        <td>{{ if .Grant.Active }}yes{{ else }}no{{ end }}</td>
+        <td><a href="/admin/grant/{{ .Grant.ID }}">Edit</a></td>
+    </tr>
+    {{- end }}
+</table>
+{{ template "tail" $ }}

--- a/handlers/admin/adminGrantAddPage.go
+++ b/handlers/admin/adminGrantAddPage.go
@@ -1,0 +1,101 @@
+package admin
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// adminGrantAddPage displays a multi-step form for creating a new grant.
+func adminGrantAddPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Add Grant"
+	queries := cd.Queries()
+
+	subject := r.URL.Query().Get("subject")
+	idStr := r.URL.Query().Get("id")
+	section := r.URL.Query().Get("section")
+	item := r.URL.Query().Get("item")
+
+	id, _ := strconv.Atoi(idStr)
+
+	data := struct {
+		Subject       string
+		ID            int
+		Section       string
+		Item          string
+		Users         []*db.ListUsersWithRolesRow
+		Roles         []*db.Role
+		Sections      []string
+		Items         []string
+		Actions       []string
+		ItemOptions   []ItemOption
+		RequireItemID bool
+	}{Subject: subject, ID: id, Section: section, Item: item}
+
+	if subject == "" || id == 0 {
+		users, _ := queries.ListUsersWithRoles(r.Context())
+		roles, _ := queries.AdminListRoles(r.Context())
+		data.Users = users
+		data.Roles = roles
+	} else if section == "" {
+		sectSet := map[string]struct{}{}
+		for k := range GrantActionMap {
+			parts := strings.Split(k, "|")
+			if len(parts) > 0 {
+				sectSet[parts[0]] = struct{}{}
+			}
+		}
+		for s := range sectSet {
+			data.Sections = append(data.Sections, s)
+		}
+	} else if item == "" {
+		itemSet := map[string]struct{}{}
+		for k := range GrantActionMap {
+			parts := strings.Split(k, "|")
+			if len(parts) == 2 && parts[0] == section {
+				itemSet[parts[1]] = struct{}{}
+			}
+		}
+		for it := range itemSet {
+			data.Items = append(data.Items, it)
+		}
+	} else {
+		def := GrantActionMap[section+"|"+item]
+		data.Actions = def.Actions
+		data.RequireItemID = def.RequireItemID
+		if section == "forum" && item == "category" {
+			cats, _ := queries.GetAllForumCategories(r.Context(), db.GetAllForumCategoriesParams{ViewerID: 0})
+			catMap := map[int32]*db.Forumcategory{}
+			for _, c := range cats {
+				catMap[c.Idforumcategory] = c
+			}
+			var buildPath func(int32) string
+			buildPath = func(id int32) string {
+				if id == 0 {
+					return ""
+				}
+				c, ok := catMap[id]
+				if !ok || !c.Title.Valid {
+					return ""
+				}
+				parent := buildPath(c.ForumcategoryIdforumcategory)
+				if parent != "" {
+					return parent + "/" + c.Title.String
+				}
+				return c.Title.String
+			}
+			for _, c := range cats {
+				label := buildPath(c.Idforumcategory)
+				data.ItemOptions = append(data.ItemOptions, ItemOption{ID: c.Idforumcategory, Label: label})
+			}
+		}
+	}
+
+	handlers.TemplateHandler(w, r, "grantAddPage.gohtml", data)
+}

--- a/handlers/admin/grant_update_task.go
+++ b/handlers/admin/grant_update_task.go
@@ -1,0 +1,38 @@
+package admin
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// GrantUpdateTask updates the active flag on a grant.
+type GrantUpdateTask struct{ tasks.TaskString }
+
+var grantUpdateTask = &GrantUpdateTask{TaskString: TaskGrantUpdateActive}
+
+var _ tasks.Task = (*GrantUpdateTask)(nil)
+
+func (GrantUpdateTask) Action(w http.ResponseWriter, r *http.Request) any {
+	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	id, err := strconv.Atoi(r.PostFormValue("grantid"))
+	if err != nil {
+		return fmt.Errorf("grant id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	active := r.PostFormValue("active") == "1"
+	if err := queries.AdminUpdateGrantActive(r.Context(), db.AdminUpdateGrantActiveParams{Active: active, ID: int32(id)}); err != nil {
+		log.Printf("UpdateGrant: %v", err)
+		return fmt.Errorf("update grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	return handlers.RefreshDirectHandler{TargetURL: fmt.Sprintf("/admin/grant/%d", id)}
+}

--- a/handlers/admin/grants.go
+++ b/handlers/admin/grants.go
@@ -1,0 +1,100 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// grantWithNames augments a grant with user and role names.
+type grantWithNames struct {
+	*db.Grant
+	UserName string
+	RoleName string
+}
+
+// AdminGrantsPage lists all grants.
+func AdminGrantsPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Grants"
+	queries := cd.Queries()
+	grants, err := queries.ListGrants(r.Context())
+	if err != nil {
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
+		return
+	}
+	userNames := map[int32]string{}
+	roleNames := map[int32]string{}
+	var rows []grantWithNames
+	for _, g := range grants {
+		gw := grantWithNames{Grant: g}
+		if g.UserID.Valid {
+			if name, ok := userNames[g.UserID.Int32]; ok {
+				gw.UserName = name
+			} else if u, err := queries.SystemGetUserByID(r.Context(), g.UserID.Int32); err == nil && u.Username.Valid {
+				userNames[g.UserID.Int32] = u.Username.String
+				gw.UserName = u.Username.String
+			}
+		}
+		if g.RoleID.Valid {
+			if name, ok := roleNames[g.RoleID.Int32]; ok {
+				gw.RoleName = name
+			} else if ro, err := queries.AdminGetRoleByID(r.Context(), g.RoleID.Int32); err == nil {
+				roleNames[g.RoleID.Int32] = ro.Name
+				gw.RoleName = ro.Name
+			}
+		}
+		rows = append(rows, gw)
+	}
+	data := struct{ Grants []grantWithNames }{rows}
+	handlers.TemplateHandler(w, r, "grantsPage.gohtml", data)
+}
+
+// adminGrantPage shows a single grant for editing.
+func adminGrantPage(w http.ResponseWriter, r *http.Request) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	idStr := mux.Vars(r)["grant"]
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		handlers.RenderErrorPage(w, r, fmt.Errorf("grant not found"))
+		return
+	}
+	grants, err := queries.ListGrants(r.Context())
+	if err != nil {
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
+		return
+	}
+	var g *db.Grant
+	for _, gr := range grants {
+		if int(gr.ID) == id {
+			g = gr
+			break
+		}
+	}
+	if g == nil {
+		http.NotFound(w, r)
+		return
+	}
+	gw := grantWithNames{Grant: g}
+	if g.UserID.Valid {
+		if u, err := queries.SystemGetUserByID(r.Context(), g.UserID.Int32); err == nil && u.Username.Valid {
+			gw.UserName = u.Username.String
+		}
+	}
+	if g.RoleID.Valid {
+		if ro, err := queries.AdminGetRoleByID(r.Context(), g.RoleID.Int32); err == nil {
+			gw.RoleName = ro.Name
+		}
+	}
+	cd.PageTitle = fmt.Sprintf("Grant %d", g.ID)
+	data := struct{ Grant grantWithNames }{gw}
+	handlers.TemplateHandler(w, r, "grantPage.gohtml", data)
+}

--- a/handlers/admin/grants_routes_test.go
+++ b/handlers/admin/grants_routes_test.go
@@ -1,0 +1,55 @@
+package admin
+
+import (
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/config"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
+)
+
+func TestRegisterRoutesRegistersGrantsLink(t *testing.T) {
+	h := New()
+	r := mux.NewRouter()
+	ar := r.PathPrefix("/admin").Subrouter()
+	navReg := navpkg.NewRegistry()
+	h.RegisterRoutes(ar, &config.RuntimeConfig{}, navReg)
+	links := navReg.AdminLinks()
+	for _, l := range links {
+		if l.Name == "Grants" {
+			if l.Link != "/admin/grants" {
+				t.Fatalf("expected /admin/grants got %s", l.Link)
+			}
+			return
+		}
+	}
+	t.Fatalf("Grants link not registered")
+}
+
+func TestRegisterRoutesRegistersGrantAdd(t *testing.T) {
+	h := New()
+	r := mux.NewRouter()
+	ar := r.PathPrefix("/admin").Subrouter()
+	navReg := navpkg.NewRegistry()
+	h.RegisterRoutes(ar, &config.RuntimeConfig{}, navReg)
+	var found bool
+	r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		path, err := route.GetPathTemplate()
+		if err != nil {
+			return nil
+		}
+		if path == "/admin/grant/add" {
+			methods, _ := route.GetMethods()
+			for _, m := range methods {
+				if m == "GET" {
+					found = true
+				}
+			}
+		}
+		return nil
+	})
+	if !found {
+		t.Fatalf("grant add route not registered")
+	}
+}

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -27,6 +27,7 @@ import (
 // already have any required authentication middleware applied.
 func (h *Handlers) RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
 	navReg.RegisterAdminControlCenter("Core", "Roles", "/admin/roles", 25)
+	navReg.RegisterAdminControlCenter("Core", "Grants", "/admin/grants", 27)
 	navReg.RegisterAdminControlCenter("Core", "External Links", "/admin/external-links", 30)
 	navReg.RegisterAdminControlCenter("Core", "Notifications", "/admin/notifications", 90)
 	navReg.RegisterAdminControlCenter("Core", "Queued Emails", "/admin/email/queue", 110)
@@ -100,6 +101,10 @@ func (h *Handlers) RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navRe
 	ar.HandleFunc("/role/{role}/grant", handlers.TaskHandler(roleGrantCreateTask)).Methods("POST").MatcherFunc(roleGrantCreateTask.Matcher())
 	ar.HandleFunc("/role/{role}/grant/update", handlers.TaskHandler(roleGrantUpdateTask)).Methods("POST").MatcherFunc(roleGrantUpdateTask.Matcher())
 	ar.HandleFunc("/grant/delete", handlers.TaskHandler(roleGrantDeleteTask)).Methods("POST").MatcherFunc(roleGrantDeleteTask.Matcher())
+	ar.HandleFunc("/grants", AdminGrantsPage).Methods("GET")
+	ar.HandleFunc("/grant/add", adminGrantAddPage).Methods("GET")
+	ar.HandleFunc("/grant/{grant}", adminGrantPage).Methods("GET")
+	ar.HandleFunc("/grant/update", handlers.TaskHandler(grantUpdateTask)).Methods("POST").MatcherFunc(grantUpdateTask.Matcher())
 	ar.HandleFunc("/user/{user}/reset", adminUserResetPasswordConfirmPage).Methods("GET")
 	ar.HandleFunc("/user/{user}/reset", handlers.TaskHandler(userPasswordResetTask)).Methods("POST").MatcherFunc(userPasswordResetTask.Matcher())
 	ar.HandleFunc("/announcements", AdminAnnouncementsPage).Methods("GET")

--- a/handlers/admin/tasks.go
+++ b/handlers/admin/tasks.go
@@ -289,4 +289,7 @@ const (
 
 	// TaskRoleGrantUpdate updates grants for a role.
 	TaskRoleGrantUpdate tasks.TaskString = "Update grants"
+
+	// TaskGrantUpdateActive updates a grant's active state.
+	TaskGrantUpdateActive tasks.TaskString = "Update grant"
 )


### PR DESCRIPTION
## Summary
- add grants dashboard and edit page
- allow toggling grant active status
- link grants section in admin nav
- add multi-step wizard for creating grants

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689439ca85d8832fa122836131973c9c