### PR TITLE
Use link for comment edit cancellation

### DIFF
--- a/core/templates/site/comment.gohtml
+++ b/core/templates/site/comment.gohtml
@@ -13,7 +13,7 @@
                         <textarea id="reply" name="replytext" cols="40" rows="20">{{ $cmt.Text.String }}</textarea><br>
                         {{ template "languageCombobox" }}
                         <input type="submit" name="task" value="Edit Reply">
-                        <input type="submit" name="task" value="Cancel">
+                        <a href="?#comment-{{ $cmt.Idcomments }}">Cancel</a>
                     </form>
                 {{ else }}
                     {{ $cmt.Text.String | a4code2html}}<br>-<br>{{ $cmt.Posterusername.String }}.


### PR DESCRIPTION
## Summary
- stop posting to cancel comment editing and just link back to the thread

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(failed: command hung, terminated)*
- `golangci-lint run` *(failed: command hung, terminated)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894447bb55c832fa3a39b72f3528f48