### PR TITLE
Preserve brackets when quoting markup

### DIFF
--- a/a4code/quote.go
+++ b/a4code/quote.go
@@ -15,8 +15,10 @@ func FullQuoteOf(username, text string) string {
 		switch text[it] {
 		case ']':
 			bc--
+			out.WriteByte(text[it])
 		case '[':
 			bc++
+			out.WriteByte(text[it])
 		case '\\':
 			if it+1 < len(text) {
 				if text[it+1] == '[' || text[it+1] == ']' {

--- a/a4code/quote_test.go
+++ b/a4code/quote_test.go
@@ -85,3 +85,29 @@ func TestFullQuoteOfEscaping(t *testing.T) {
 		t.Errorf("quote text = %q", tnode.Value)
 	}
 }
+
+func TestFullQuoteOfImage(t *testing.T) {
+	text := "[img http://example.com/foo.jpg]"
+	got := FullQuoteOf("bob", text)
+	want := "[quoteof \"bob\" [img http://example.com/foo.jpg]]\n"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+	ast, err := ParseString(got)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(ast.Children) < 1 {
+		t.Fatalf("no nodes parsed")
+	}
+	q, ok := ast.Children[0].(*QuoteOf)
+	if !ok {
+		t.Fatalf("expected QuoteOf, got %T", ast.Children[0])
+	}
+	if len(q.Children) < 2 {
+		t.Fatalf("unexpected children %v", q.Children)
+	}
+	if _, ok := q.Children[1].(*Image); !ok {
+		t.Fatalf("expected Image node, got %T", q.Children[1])
+	}
+}


### PR DESCRIPTION
## Summary
- keep bracket characters when building quoted text so nested markup like `[img]` remains intact
- add regression test for quoting an image tag

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689444b980fc832fa2f187b4677a5ab0