### PR TITLE
Remove redundant reply anchor from news posts

### DIFF
--- a/core/templates/site/news/post.gohtml
+++ b/core/templates/site/news/post.gohtml
@@ -7,9 +7,6 @@
             <td>{{ .News.String | a4code2html }}<br>-<br>{{ .Writername.String }}
             -
             [<a href="/news/news/{{ .Idsitenews }}">{{ .Comments.Int32 }} COMMENTS</a>]
-            {{ if cd.ShowReplyNews .Idsitenews }}
-                [<a href="/news/news/{{ .Idsitenews }}#reply">REPLY</a>]
-            {{ end }}
 
             {{ if cd.ShowEditNews .Idsitenews .UsersIdusers }}
                 [<a href="/news/news/{{ .Idsitenews }}/edit">EDIT</a>]


### PR DESCRIPTION
## Summary
- remove [REPLY] anchor link from news posts so users scroll to reply

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: template_render_test.go:113: render blogsAdminPage: template: adminPage.gohtml:21:17: executing "blogsAdminPage" at <.Rows>: can't evaluate field Rows in type struct {} )*

------
https://chatgpt.com/codex/tasks/task_e_68944d632f4c832f9618a172ae916aed