### PR TITLE
Clarify reply permission message for signed-in users

### DIFF
--- a/core/templates/site/showLinkComments.gohtml
+++ b/core/templates/site/showLinkComments.gohtml
@@ -28,7 +28,7 @@
                 <input type="submit" name="task" value="Reply">
             </form>
         {{ else }}
-            {{ with cd.CurrentUserLoaded }}
+            {{ if cd.UserID }}
                 You do not have permission to write a reply.<br>
             {{ else }}
                 Please sign-in (or sign-up) to write a reply.<br>

--- a/core/templates/site/writings/articlePage.gohtml
+++ b/core/templates/site/writings/articlePage.gohtml
@@ -21,7 +21,7 @@
                 <input type="submit" name="task" value="Reply">
             </form>
         {{ else }}
-            {{ with cd.CurrentUserLoaded }}
+            {{ if cd.UserID }}
                 You do not have permission to write a reply.<br>
             {{ else }}
                 Please sign-in (or sign-up) to write a reply.<br>

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -90,7 +90,10 @@ func TestPageTemplatesRender(t *testing.T) {
 			*common.CoreData
 			Stats struct{ Words, Comments, News, Blogs, Linker, Writing, Writings, Images int64 }
 		}{&common.CoreData{}, struct{ Words, Comments, News, Blogs, Linker, Writing, Writings, Images int64 }{}}},
-		{"blogsAdminPage", struct{ }{}},
+		{"blogsAdminPage", struct {
+			*common.CoreData
+			Rows any
+		}{&common.CoreData{}, nil}},
 		{"adminPage", struct {
 			*common.CoreData
 			AdminSections []common.AdminSection


### PR DESCRIPTION
## Summary
- ensure reply forms only ask for sign-in when no user is logged in
- fix template rendering test data for admin blogs page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68944ea4aa28832f9d734ef0754329b0