### PR TITLE
Fix tableTopics template admin check

### DIFF
--- a/core/templates/site/tableTopics.gohtml
+++ b/core/templates/site/tableTopics.gohtml
@@ -11,7 +11,7 @@
             <td>
                 {{ $title := .Title.String }}
                 {{ if .DisplayTitle }}{{ $title = .DisplayTitle }}{{ end }}
-                <a href="/forum/topic/{{ .Idforumtopic }}">{{ $title | a4code2html }}</a>{{ if cd.CanEditAny }} [<a href="/admin/forum/topics/topic/{{ .Idforumtopic }}/edit">ADMIN</a>]{{ end }}<br>
+                <a href="/forum/topic/{{ .Idforumtopic }}">{{ $title | a4code2html }}</a>{{ if and cd.IsAdmin cd.IsAdminMode }} [<a href="/admin/forum/topics/topic/{{ .Idforumtopic }}/edit">ADMIN</a>]{{ end }}<br>
                 {{ with .Description.String }}<i>{{ . | a4code2html }}</i>{{ end }}
             </td>
             <td align="center">{{ localTime .Lastaddition.Time }}<br>{{ .Lastposterusername.String }}</td>


### PR DESCRIPTION
## Summary
- replace removed `CanEditAny` permission with `IsAdmin`/`IsAdminMode` check in `tableTopics` template

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: render blogsAdminPage: template: adminPage.gohtml:21:17: executing "blogsAdminPage" at <.Rows>: can't evaluate field Rows in type struct {})*

------
https://chatgpt.com/codex/tasks/task_e_68944d2713b8832f9aba82139b1bbc99