### PR TITLE
Link grant related items

### DIFF
--- a/core/templates/grant_links_test.go
+++ b/core/templates/grant_links_test.go
@@ -1,0 +1,100 @@
+package templates_test
+
+import (
+	"bytes"
+	"database/sql"
+	"embed"
+	"html/template"
+	"strings"
+	"testing"
+
+	"github.com/arran4/goa4web/internal/db"
+)
+
+//go:embed site/admin/grantPage.gohtml site/admin/grantsPage.gohtml
+var grantTemplates embed.FS
+
+type grantWithNames struct {
+	*db.Grant
+	UserName string
+	RoleName string
+	ItemLink string
+}
+
+func TestGrantPageLinks(t *testing.T) {
+	tmpl := template.Must(template.New("").Funcs(template.FuncMap{
+		"csrfField": func() template.HTML { return "" },
+	}).ParseFS(grantTemplates, "site/admin/grantPage.gohtml"))
+	template.Must(tmpl.New("head").Parse(""))
+	template.Must(tmpl.New("tail").Parse(""))
+
+	g := &db.Grant{
+		ID:      1,
+		UserID:  sql.NullInt32{Int32: 5, Valid: true},
+		RoleID:  sql.NullInt32{Int32: 7, Valid: true},
+		Section: "forum",
+		Item:    sql.NullString{String: "topic", Valid: true},
+		ItemID:  sql.NullInt32{Int32: 42, Valid: true},
+	}
+	data := struct{ Grant grantWithNames }{
+		Grant: grantWithNames{
+			Grant:    g,
+			UserName: "bob",
+			RoleName: "admin",
+			ItemLink: "/admin/forum/topics/topic/42",
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "grantPage.gohtml", data); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, `<a href="/admin/user/5">bob (5)</a>`) {
+		t.Fatalf("expected user link, got %s", html)
+	}
+	if !strings.Contains(html, `<a href="/admin/role/7">admin (7)</a>`) {
+		t.Fatalf("expected role link, got %s", html)
+	}
+	if !strings.Contains(html, `<a href="/admin/forum/topics/topic/42">topic</a>`) {
+		t.Fatalf("expected item link, got %s", html)
+	}
+}
+
+func TestGrantsPageLinks(t *testing.T) {
+	tmpl := template.Must(template.New("").Funcs(template.FuncMap{
+		"csrfField": func() template.HTML { return "" },
+	}).ParseFS(grantTemplates, "site/admin/grantsPage.gohtml"))
+	template.Must(tmpl.New("head").Parse(""))
+	template.Must(tmpl.New("tail").Parse(""))
+
+	g := &db.Grant{
+		ID:      1,
+		UserID:  sql.NullInt32{Int32: 5, Valid: true},
+		RoleID:  sql.NullInt32{Int32: 7, Valid: true},
+		Section: "forum",
+		Item:    sql.NullString{String: "topic", Valid: true},
+		ItemID:  sql.NullInt32{Int32: 42, Valid: true},
+		Active:  true,
+	}
+	data := struct{ Grants []grantWithNames }{
+		Grants: []grantWithNames{
+			{Grant: g, UserName: "bob", RoleName: "admin", ItemLink: "/admin/forum/topics/topic/42"},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "grantsPage.gohtml", data); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, `<a href="/admin/user/5">bob (5)</a>`) {
+		t.Fatalf("expected user link, got %s", html)
+	}
+	if !strings.Contains(html, `<a href="/admin/role/7">admin (7)</a>`) {
+		t.Fatalf("expected role link, got %s", html)
+	}
+	if !strings.Contains(html, `<a href="/admin/forum/topics/topic/42">topic</a>`) {
+		t.Fatalf("expected item link, got %s", html)
+	}
+}

--- a/core/templates/site/admin/grantPage.gohtml
+++ b/core/templates/site/admin/grantPage.gohtml
@@ -2,11 +2,11 @@
 <p><a href="/admin/grants">Back to grants</a></p>
 <table border="1">
     <tr><th>Field</th><th>Value</th></tr>
-    <tr><td>User</td><td>{{ if .Grant.UserID.Valid }}{{ .Grant.UserName }} ({{ .Grant.UserID.Int32 }}){{ else }}-{{ end }}</td></tr>
-    <tr><td>Role</td><td>{{ if .Grant.RoleID.Valid }}{{ .Grant.RoleName }} ({{ .Grant.RoleID.Int32 }}){{ else }}-{{ end }}</td></tr>
+    <tr><td>User</td><td>{{ if .Grant.UserID.Valid }}<a href="/admin/user/{{ .Grant.UserID.Int32 }}">{{ .Grant.UserName }} ({{ .Grant.UserID.Int32 }})</a>{{ else }}-{{ end }}</td></tr>
+    <tr><td>Role</td><td>{{ if .Grant.RoleID.Valid }}<a href="/admin/role/{{ .Grant.RoleID.Int32 }}">{{ .Grant.RoleName }} ({{ .Grant.RoleID.Int32 }})</a>{{ else }}-{{ end }}</td></tr>
     <tr><td>Section</td><td>{{ .Grant.Section }}</td></tr>
-    <tr><td>Item</td><td>{{ .Grant.Item.String }}</td></tr>
-    <tr><td>Item ID</td><td>{{ if .Grant.ItemID.Valid }}{{ .Grant.ItemID.Int32 }}{{ else }}-{{ end }}</td></tr>
+    <tr><td>Item</td><td>{{ if .Grant.ItemLink }}<a href="{{ .Grant.ItemLink }}">{{ .Grant.Item.String }}</a>{{ else }}{{ .Grant.Item.String }}{{ end }}</td></tr>
+    <tr><td>Item ID</td><td>{{ if .Grant.ItemID.Valid }}{{ if .Grant.ItemLink }}<a href="{{ .Grant.ItemLink }}">{{ .Grant.ItemID.Int32 }}</a>{{ else }}{{ .Grant.ItemID.Int32 }}{{ end }}{{ else }}-{{ end }}</td></tr>
     <tr><td>Action</td><td>{{ .Grant.Action }}</td></tr>
     <tr><td>Active</td><td>{{ if .Grant.Active }}yes{{ else }}no{{ end }}</td></tr>
 </table>

--- a/core/templates/site/admin/grantsPage.gohtml
+++ b/core/templates/site/admin/grantsPage.gohtml
@@ -5,11 +5,11 @@
     {{- range .Grants }}
     <tr>
         <td><a href="/admin/grant/{{ .Grant.ID }}">{{ .Grant.ID }}</a></td>
-        <td>{{ if .Grant.UserID.Valid }}{{ .UserName }} ({{ .Grant.UserID.Int32 }}){{ end }}</td>
-        <td>{{ if .Grant.RoleID.Valid }}{{ .RoleName }} ({{ .Grant.RoleID.Int32 }}){{ end }}</td>
+        <td>{{ if .Grant.UserID.Valid }}<a href="/admin/user/{{ .Grant.UserID.Int32 }}">{{ .UserName }} ({{ .Grant.UserID.Int32 }})</a>{{ end }}</td>
+        <td>{{ if .Grant.RoleID.Valid }}<a href="/admin/role/{{ .Grant.RoleID.Int32 }}">{{ .RoleName }} ({{ .Grant.RoleID.Int32 }})</a>{{ end }}</td>
         <td>{{ .Grant.Section }}</td>
-        <td>{{ .Grant.Item.String }}</td>
-        <td>{{ if .Grant.ItemID.Valid }}{{ .Grant.ItemID.Int32 }}{{ end }}</td>
+        <td>{{ if .ItemLink }}<a href="{{ .ItemLink }}">{{ .Grant.Item.String }}</a>{{ else }}{{ .Grant.Item.String }}{{ end }}</td>
+        <td>{{ if .Grant.ItemID.Valid }}{{ if .ItemLink }}<a href="{{ .ItemLink }}">{{ .Grant.ItemID.Int32 }}</a>{{ else }}{{ .Grant.ItemID.Int32 }}{{ end }}{{ end }}</td>
         <td>{{ .Grant.Action }}</td>
         <td>{{ if .Grant.Active }}yes{{ else }}no{{ end }}</td>
         <td><a href="/admin/grant/{{ .Grant.ID }}">Edit</a></td>

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -90,7 +90,7 @@ func TestPageTemplatesRender(t *testing.T) {
 			*common.CoreData
 			Stats struct{ Words, Comments, News, Blogs, Linker, Writing, Writings, Images int64 }
 		}{&common.CoreData{}, struct{ Words, Comments, News, Blogs, Linker, Writing, Writings, Images int64 }{}}},
-		{"blogsAdminPage", struct{ }{}},
+		{"blogsAdminPage", struct{ Rows any }{nil}},
 		{"adminPage", struct {
 			*common.CoreData
 			AdminSections []common.AdminSection


### PR DESCRIPTION
## Summary
- link admin grant listings to user, role and item admin pages
- test that grant pages render correct links
- provide rows field for blogs admin template test

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68944ef1b270832f80efc451ae538b25