### PR TITLE
Add admin review link to FAQ notification emails

### DIFF
--- a/core/templates/email/adminNotificationFaqAskEmail.gohtml
+++ b/core/templates/email/adminNotificationFaqAskEmail.gohtml
@@ -1,3 +1,4 @@
 <p>New FAQ question submitted.</p>
 <p>{{.Item.Question}}</p>
+<p><a href="{{.URL}}">Review it</a></p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/adminNotificationFaqAskEmail.gotxt
+++ b/core/templates/email/adminNotificationFaqAskEmail.gotxt
@@ -1,4 +1,5 @@
 New FAQ question submitted.
 
 {{.Item.Question}}
+Review it: {{.URL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/eventbus"
@@ -94,10 +95,17 @@ func (AskTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	evt := cd.Event()
-	evt.Path = "/admin/faq"
+	path := "/admin/faq/questions"
+	evt.Path = path
 	if evt.Data == nil {
 		evt.Data = map[string]any{}
 	}
+	cfg := cd.Config
+	page := "http://" + r.Host + path
+	if cfg.HTTPHostname != "" {
+		page = strings.TrimRight(cfg.HTTPHostname, "/") + path
+	}
+	evt.Data["URL"] = page
 	evt.Data["Question"] = text
 
 	// The BusWorker sends notifications based on event metadata.

--- a/handlers/faq/faqTemplates_test.go
+++ b/handlers/faq/faqTemplates_test.go
@@ -1,6 +1,7 @@
 package faq
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/arran4/goa4web/internal/eventbus"
@@ -38,4 +39,27 @@ func TestAskTaskTemplatesCompile(t *testing.T) {
 	var task AskTask
 	requireEmailTemplates(t, task.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	requireNotificationTemplate(t, task.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+}
+
+func TestAdminNotificationFaqAskEmailIncludesLink(t *testing.T) {
+	url := "http://example.com/admin/faq/questions"
+	data := notif.EmailData{URL: url, Item: map[string]any{"Question": "test?"}}
+	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
+	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
+
+	var sb strings.Builder
+	if err := textTmpls.ExecuteTemplate(&sb, "adminNotificationFaqAskEmail.gotxt", data); err != nil {
+		t.Fatalf("render text: %v", err)
+	}
+	if !strings.Contains(sb.String(), url) {
+		t.Errorf("text template missing url: %s", sb.String())
+	}
+
+	sb.Reset()
+	if err := htmlTmpls.ExecuteTemplate(&sb, "adminNotificationFaqAskEmail.gohtml", data); err != nil {
+		t.Fatalf("render html: %v", err)
+	}
+	if !strings.Contains(sb.String(), url) {
+		t.Errorf("html template missing url: %s", sb.String())
+	}
 }

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -90,7 +90,10 @@ func TestPageTemplatesRender(t *testing.T) {
 			*common.CoreData
 			Stats struct{ Words, Comments, News, Blogs, Linker, Writing, Writings, Images int64 }
 		}{&common.CoreData{}, struct{ Words, Comments, News, Blogs, Linker, Writing, Writings, Images int64 }{}}},
-		{"blogsAdminPage", struct{ }{}},
+		{"blogsAdminPage", struct {
+			*common.CoreData
+			Rows any
+		}{&common.CoreData{}, nil}},
 		{"adminPage", struct {
 			*common.CoreData
 			AdminSections []common.AdminSection


### PR DESCRIPTION
## Summary
- include admin FAQ questions page link in submitted question notifications
- update FAQ notification email templates to show review link
- test that admin notification email includes the review URL

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68944f3c8c28832f8191ccafcdee1579