### PR TITLE
Fix private forum creation permissions and add logging

### DIFF
--- a/handlers/forum/permissions.go
+++ b/handlers/forum/permissions.go
@@ -3,6 +3,7 @@ package forum
 import (
 	"context"
 	"database/sql"
+	"log"
 
 	"github.com/arran4/goa4web/internal/db"
 )
@@ -21,8 +22,10 @@ func UserCanCreateThread(ctx context.Context, q db.Querier, topicID, uid int32) 
 		return true, nil
 	}
 	if err == sql.ErrNoRows {
+		log.Printf("UserCanCreateThread deny: uid=%d topic=%d", uid, topicID)
 		return false, nil
 	}
+	log.Printf("UserCanCreateThread error: uid=%d topic=%d err=%v", uid, topicID, err)
 	return false, err
 }
 
@@ -40,7 +43,9 @@ func UserCanCreateTopic(ctx context.Context, q db.Querier, categoryID, uid int32
 		return true, nil
 	}
 	if err == sql.ErrNoRows {
+		log.Printf("UserCanCreateTopic deny: uid=%d category=%d", uid, categoryID)
 		return false, nil
 	}
+	log.Printf("UserCanCreateTopic error: uid=%d category=%d err=%v", uid, categoryID, err)
 	return false, err
 }

--- a/handlers/privateforum/topic_create_task.go
+++ b/handlers/privateforum/topic_create_task.go
@@ -3,13 +3,13 @@ package privateforum
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/handlers/forum"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/arran4/goa4web/workers/postcountworker"
@@ -55,11 +55,8 @@ func (PrivateTopicCreateTask) Action(w http.ResponseWriter, r *http.Request) any
 	if creator != 0 && !seen {
 		uids = append(uids, creator)
 	}
-	allowed, err := forum.UserCanCreateTopic(r.Context(), queries, common.PrivateForumCategoryID, creator)
-	if err != nil {
-		return fmt.Errorf("UserCanCreateTopic fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-	}
-	if !allowed {
+	if !cd.HasGrant("privateforum", "topic", "post", 0) {
+		log.Printf("private topic create denied: user=%d", creator)
 		err := handlers.ErrForbidden
 		return fmt.Errorf("UserCanCreateTopic deny %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/privateforum/topic_create_task_test.go
+++ b/handlers/privateforum/topic_create_task_test.go
@@ -25,7 +25,7 @@ func TestPrivateTopicCreateTask_GrantsBeforeComment(t *testing.T) {
 	q := db.New(conn)
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
-		WithArgs(int64(1), "forum", "category", "post", int64(0), int64(1)).
+		WithArgs(int64(1), "privateforum", "topic", "post", nil, int64(1)).
 		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 	mock.ExpectExec("INSERT INTO forumtopic").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE forumtopic SET handler").WillReturnResult(sqlmock.NewResult(0, 1))

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -90,7 +90,7 @@ func TestPageTemplatesRender(t *testing.T) {
 			*common.CoreData
 			Stats struct{ Words, Comments, News, Blogs, Linker, Writing, Writings, Images int64 }
 		}{&common.CoreData{}, struct{ Words, Comments, News, Blogs, Linker, Writing, Writings, Images int64 }{}}},
-		{"blogsAdminPage", struct{ }{}},
+		{"blogsAdminPage", struct{ Rows any }{nil}},
 		{"adminPage", struct {
 			*common.CoreData
 			AdminSections []common.AdminSection


### PR DESCRIPTION
## Summary
- use private forum grant check for creating topics
- log permission denials and errors in forum permission helpers
- adjust tests for private forum and blogs admin template rendering

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68944f6ae5bc832f9badd13d0ca8c625