### PR TITLE
Check private forum grant before creating topic

### DIFF
--- a/handlers/privateforum/topic_create_task.go
+++ b/handlers/privateforum/topic_create_task.go
@@ -9,7 +9,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/handlers/forum"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/arran4/goa4web/workers/postcountworker"
@@ -55,13 +54,9 @@ func (PrivateTopicCreateTask) Action(w http.ResponseWriter, r *http.Request) any
 	if creator != 0 && !seen {
 		uids = append(uids, creator)
 	}
-	allowed, err := forum.UserCanCreateTopic(r.Context(), queries, common.PrivateForumCategoryID, creator)
-	if err != nil {
-		return fmt.Errorf("UserCanCreateTopic fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-	}
-	if !allowed {
+	if !cd.HasGrant("privateforum", "topic", "create", 0) {
 		err := handlers.ErrForbidden
-		return fmt.Errorf("UserCanCreateTopic deny %w", handlers.ErrRedirectOnSamePageHandler(err))
+		return fmt.Errorf("create private topic deny %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	tid, err := queries.CreateForumTopicForPoster(r.Context(), db.CreateForumTopicForPosterParams{
 		PosterID:        creator,

--- a/handlers/privateforum/topic_create_task_test.go
+++ b/handlers/privateforum/topic_create_task_test.go
@@ -25,7 +25,7 @@ func TestPrivateTopicCreateTask_GrantsBeforeComment(t *testing.T) {
 	q := db.New(conn)
 
 	mock.ExpectQuery("SELECT 1 FROM grants").
-		WithArgs(int64(1), "forum", "category", "post", int64(0), int64(1)).
+		WithArgs(int64(1), "privateforum", "topic", "create", nil, int64(1)).
 		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 	mock.ExpectExec("INSERT INTO forumtopic").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE forumtopic SET handler").WillReturnResult(sqlmock.NewResult(0, 1))


### PR DESCRIPTION
## Summary
- use private forum `create` grant instead of forum category check when creating private topics
- update private forum creation test to expect the grant lookup

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: template_render_test.go:113: render blogsAdminPage: can't evaluate field Rows in type struct {})*


------
https://chatgpt.com/codex/tasks/task_e_68944fe34e94832f9af76e361b6b42e8