### PR TITLE
Support custom handlers and grant sections for forum topic creation

### DIFF
--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -150,6 +150,7 @@ func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 				String: BloggerTopicDescription,
 				Valid:  true,
 			},
+			Handler: "blogs",
 		})
 		if err != nil {
 			return fmt.Errorf("createForumTopic fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/forum/forumAdminTopicsPage.go
+++ b/handlers/forum/forumAdminTopicsPage.go
@@ -117,6 +117,8 @@ func AdminTopicCreatePage(w http.ResponseWriter, r *http.Request) {
 		LanguageID:      int32(languageID),
 		Title:           sql.NullString{String: name, Valid: true},
 		Description:     sql.NullString{String: desc, Valid: true},
+		Handler:         "",
+		Section:         "forum",
 		GrantCategoryID: sql.NullInt32{Int32: int32(pcid), Valid: true},
 		GranteeID:       sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -235,6 +235,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 				String: ImageBBSTopicDescription,
 				Valid:  true,
 			},
+			Handler: "imagebbs",
 		})
 		if err != nil {
 			return fmt.Errorf("create forum topic fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -248,6 +248,7 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 				String: LinkerTopicDescription,
 				Valid:  true,
 			},
+			Handler: "linker",
 		})
 		if err != nil {
 			return fmt.Errorf("create forum topic fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -125,6 +125,7 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 				String: LinkerTopicName,
 				Valid:  true,
 			},
+			Handler: "linker",
 		})
 		if err != nil {
 			log.Printf("Error: createForumTopic: %s", err)

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -142,6 +142,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 				String: NewsTopicDescription,
 				Valid:  true,
 			},
+			Handler: "news",
 		})
 		if err != nil {
 			log.Printf("Error: createForumTopic: %s", err)

--- a/handlers/news/newsReplyTask_event_test.go
+++ b/handlers/news/newsReplyTask_event_test.go
@@ -44,7 +44,7 @@ func TestNewsReplyTaskEventData(t *testing.T) {
 	mock.ExpectQuery("SELECT idforumtopic").
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler"}).
-			AddRow(4, int32(0), 0, 0, NewsTopicName, "", 0, 0, sql.NullTime{}, ""))
+			AddRow(4, int32(0), 0, 0, NewsTopicName, "", 0, 0, sql.NullTime{}, "news"))
 
 	mock.ExpectQuery("SELECT u.idusers").
 		WithArgs(uid).

--- a/handlers/privateforum/topic_create_task.go
+++ b/handlers/privateforum/topic_create_task.go
@@ -66,6 +66,8 @@ func (PrivateTopicCreateTask) Action(w http.ResponseWriter, r *http.Request) any
 		LanguageID:      0,
 		Title:           sql.NullString{},
 		Description:     sql.NullString{},
+		Handler:         "private",
+		Section:         "privateforum",
 		GrantCategoryID: sql.NullInt32{Int32: common.PrivateForumCategoryID, Valid: true},
 		GranteeID:       sql.NullInt32{Int32: creator, Valid: creator != 0},
 	})
@@ -77,9 +79,6 @@ func (PrivateTopicCreateTask) Action(w http.ResponseWriter, r *http.Request) any
 		return fmt.Errorf("create topic %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	topicID := int32(tid)
-	if err := queries.SystemSetForumTopicHandlerByID(r.Context(), db.SystemSetForumTopicHandlerByIDParams{Handler: "private", ID: topicID}); err != nil {
-		return fmt.Errorf("set handler %w", handlers.ErrRedirectOnSamePageHandler(err))
-	}
 	thid, err := queries.SystemCreateThread(r.Context(), topicID)
 	if err != nil {
 		return fmt.Errorf("create thread %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/privateforum/topic_create_task_test.go
+++ b/handlers/privateforum/topic_create_task_test.go
@@ -28,7 +28,6 @@ func TestPrivateTopicCreateTask_GrantsBeforeComment(t *testing.T) {
 		WithArgs(int64(1), "privateforum", "topic", "create", nil, int64(1)).
 		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 	mock.ExpectExec("INSERT INTO forumtopic").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("UPDATE forumtopic SET handler").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO forumthread").WillReturnResult(sqlmock.NewResult(2, 1))
 	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"bytes"
+	"database/sql"
 	"github.com/arran4/goa4web/handlers/forum"
 	"net/http"
 	"net/http/httptest"
@@ -90,7 +91,15 @@ func TestPageTemplatesRender(t *testing.T) {
 			*common.CoreData
 			Stats struct{ Words, Comments, News, Blogs, Linker, Writing, Writings, Images int64 }
 		}{&common.CoreData{}, struct{ Words, Comments, News, Blogs, Linker, Writing, Writings, Images int64 }{}}},
-		{"blogsAdminPage", struct{  }{}},
+		{"blogsAdminPage", struct {
+			*common.CoreData
+			Rows []struct {
+				Username sql.NullString
+				Email    string
+				Roles    sql.NullString
+				Idusers  int32
+			}
+		}{&common.CoreData{}, nil}},
 		{"adminPage", struct {
 			*common.CoreData
 			AdminSections []common.AdminSection

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -106,6 +106,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			LanguageIdlanguage:           writing.LanguageIdlanguage,
 			Title:                        sql.NullString{String: WritingTopicName, Valid: true},
 			Description:                  sql.NullString{String: WritingTopicDescription, Valid: true},
+			Handler:                      "writing",
 		})
 		if err != nil {
 			return fmt.Errorf("create forum topic fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -169,6 +169,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 				String: WritingTopicDescription,
 				Valid:  true,
 			},
+			Handler: "writing",
 		})
 		if err != nil {
 			log.Printf("Error: createForumTopic: %s", err)

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -225,14 +225,14 @@ WHERE (
 INSERT INTO forumcategory (forumcategory_idforumcategory, language_idlanguage, title, description) VALUES (?, ?, ?, ?);
 
 -- name: SystemCreateForumTopic :execlastid
-INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description) VALUES (?, ?, ?, ?);
+INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description, handler) VALUES (?, ?, ?, ?, ?);
 
 -- name: CreateForumTopicForPoster :execlastid
-INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description)
-SELECT sqlc.arg(forumcategory_id), sqlc.arg(language_id), sqlc.arg(title), sqlc.arg(description)
+INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description, handler)
+SELECT sqlc.arg(forumcategory_id), sqlc.arg(language_id), sqlc.arg(title), sqlc.arg(description), sqlc.arg(handler)
 WHERE EXISTS (
     SELECT 1 FROM grants g
-    WHERE g.section='forum'
+    WHERE g.section=sqlc.arg(section)
       AND (g.item='category' OR g.item IS NULL)
       AND g.action='post'
       AND g.active=1

--- a/internal/db/queries-forum.sql.go
+++ b/internal/db/queries-forum.sql.go
@@ -276,11 +276,11 @@ func (q *Queries) AdminUpdateForumTopic(ctx context.Context, arg AdminUpdateForu
 }
 
 const createForumTopicForPoster = `-- name: CreateForumTopicForPoster :execlastid
-INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description)
-SELECT ?, ?, ?, ?
+INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description, handler)
+SELECT ?, ?, ?, ?, ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
-    WHERE g.section='forum'
+    WHERE g.section=?
       AND (g.item='category' OR g.item IS NULL)
       AND g.action='post'
       AND g.active=1
@@ -297,6 +297,8 @@ type CreateForumTopicForPosterParams struct {
 	LanguageID      int32
 	Title           sql.NullString
 	Description     sql.NullString
+	Handler         string
+	Section         string
 	GrantCategoryID sql.NullInt32
 	GranteeID       sql.NullInt32
 	PosterID        int32
@@ -308,6 +310,8 @@ func (q *Queries) CreateForumTopicForPoster(ctx context.Context, arg CreateForum
 		arg.LanguageID,
 		arg.Title,
 		arg.Description,
+		arg.Handler,
+		arg.Section,
 		arg.GrantCategoryID,
 		arg.GranteeID,
 		arg.PosterID,
@@ -1172,7 +1176,7 @@ func (q *Queries) ListPrivateTopicsByUserID(ctx context.Context, userID sql.Null
 }
 
 const systemCreateForumTopic = `-- name: SystemCreateForumTopic :execlastid
-INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description) VALUES (?, ?, ?, ?)
+INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description, handler) VALUES (?, ?, ?, ?, ?)
 `
 
 type SystemCreateForumTopicParams struct {
@@ -1180,6 +1184,7 @@ type SystemCreateForumTopicParams struct {
 	LanguageIdlanguage           int32
 	Title                        sql.NullString
 	Description                  sql.NullString
+	Handler                      string
 }
 
 func (q *Queries) SystemCreateForumTopic(ctx context.Context, arg SystemCreateForumTopicParams) (int64, error) {
@@ -1188,6 +1193,7 @@ func (q *Queries) SystemCreateForumTopic(ctx context.Context, arg SystemCreateFo
 		arg.LanguageIdlanguage,
 		arg.Title,
 		arg.Description,
+		arg.Handler,
 	)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Summary
- allow specifying handler and permission section when inserting forum topics
- create private topics with handler and section set during insert
- adjust tests and template render data for new behavior
- include handler when system modules create topics (imagebbs, news, blogs, writings, linker)

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68945b8b9fc8832f82f14757433ef756