### PR TITLE
Allow global grants and seed public content

### DIFF
--- a/core/templates/site/admin/grantAddPage.gohtml
+++ b/core/templates/site/admin/grantAddPage.gohtml
@@ -1,11 +1,12 @@
 {{ template "head" $ }}
 <h2>Add Grant</h2>
-{{ if or (eq .Subject "") (eq .ID 0) }}
+{{ if or (eq .Subject "") (and (ne .Subject "everyone") (eq .ID 0)) }}
 <form method="get">
     <label>Subject:
         <select name="subject">
             <option value="user"{{ if or (eq .Subject "user") (eq .Subject "") }} selected{{ end }}>User</option>
             <option value="role"{{ if eq .Subject "role" }} selected{{ end }}>Role</option>
+            <option value="everyone"{{ if eq .Subject "everyone" }} selected{{ end }}>Everyone</option>
         </select>
     </label>
     {{ if or (eq .Subject "user") (eq .Subject "") }}
@@ -17,7 +18,7 @@
             {{ end }}
         </datalist>
     </label>
-    {{ else }}
+    {{ else if eq .Subject "role" }}
     <label>Role:
         <input list="roleOptions" name="id">
         <datalist id="roleOptions">
@@ -57,7 +58,7 @@
     <input type="submit" value="Next">
 </form>
 {{ else }}
-<form method="post" action="/admin/{{ .Subject }}/{{ .ID }}/grant">
+<form method="post" action="/admin/{{ if eq .Subject "everyone" }}grant{{ else }}{{ .Subject }}/{{ .ID }}/grant{{ end }}">
     {{ csrfField }}
     <input type="hidden" name="task" value="Create grant">
     <input type="hidden" name="section" value="{{ .Section }}">

--- a/core/templates/site/admin/grantPage.gohtml
+++ b/core/templates/site/admin/grantPage.gohtml
@@ -2,7 +2,7 @@
 <p><a href="/admin/grants">Back to grants</a></p>
 <table border="1">
     <tr><th>Field</th><th>Value</th></tr>
-    <tr><td>User</td><td>{{ if .Grant.UserID.Valid }}<a href="/admin/user/{{ .Grant.UserID.Int32 }}">{{ .Grant.UserName }} ({{ .Grant.UserID.Int32 }})</a>{{ else }}-{{ end }}</td></tr>
+    <tr><td>User</td><td>{{ if .Grant.UserID.Valid }}<a href="/admin/user/{{ .Grant.UserID.Int32 }}">{{ .Grant.UserName }} ({{ .Grant.UserID.Int32 }})</a>{{ else if not .Grant.RoleID.Valid }}{{ .Grant.UserName }}{{ else }}-{{ end }}</td></tr>
     <tr><td>Role</td><td>{{ if .Grant.RoleID.Valid }}<a href="/admin/role/{{ .Grant.RoleID.Int32 }}">{{ .Grant.RoleName }} ({{ .Grant.RoleID.Int32 }})</a>{{ else }}-{{ end }}</td></tr>
     <tr><td>Section</td><td>{{ .Grant.Section }}</td></tr>
     <tr><td>Item</td><td>{{ if .Grant.ItemLink }}<a href="{{ .Grant.ItemLink }}">{{ .Grant.Item.String }}</a>{{ else }}{{ .Grant.Item.String }}{{ end }}</td></tr>

--- a/core/templates/site/admin/grantsPage.gohtml
+++ b/core/templates/site/admin/grantsPage.gohtml
@@ -5,7 +5,7 @@
     {{- range .Grants }}
     <tr>
         <td><a href="/admin/grant/{{ .Grant.ID }}">{{ .Grant.ID }}</a></td>
-        <td>{{ if .Grant.UserID.Valid }}<a href="/admin/user/{{ .Grant.UserID.Int32 }}">{{ .UserName }} ({{ .Grant.UserID.Int32 }})</a>{{ end }}</td>
+        <td>{{ if .Grant.UserID.Valid }}<a href="/admin/user/{{ .Grant.UserID.Int32 }}">{{ .UserName }} ({{ .Grant.UserID.Int32 }})</a>{{ else if not .Grant.RoleID.Valid }}{{ .UserName }}{{ end }}</td>
         <td>{{ if .Grant.RoleID.Valid }}<a href="/admin/role/{{ .Grant.RoleID.Int32 }}">{{ .RoleName }} ({{ .Grant.RoleID.Int32 }})</a>{{ end }}</td>
         <td>{{ .Grant.Section }}</td>
         <td>{{ if .ItemLink }}<a href="{{ .ItemLink }}">{{ .Grant.Item.String }}</a>{{ else }}{{ .Grant.Item.String }}{{ end }}</td>

--- a/handlers/admin/adminGrantAddPage.go
+++ b/handlers/admin/adminGrantAddPage.go
@@ -38,7 +38,7 @@ func adminGrantAddPage(w http.ResponseWriter, r *http.Request) {
 		RequireItemID bool
 	}{Subject: subject, ID: id, Section: section, Item: item}
 
-	if subject == "" || id == 0 {
+	if subject == "" || (id == 0 && subject != "everyone") {
 		users, _ := queries.ListUsersWithRoles(r.Context())
 		roles, _ := queries.AdminListRoles(r.Context())
 		data.Users = users

--- a/handlers/admin/global_grant_create_task.go
+++ b/handlers/admin/global_grant_create_task.go
@@ -1,0 +1,64 @@
+package admin
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// GlobalGrantCreateTask creates a new grant that applies to everyone.
+type GlobalGrantCreateTask struct{ tasks.TaskString }
+
+var globalGrantCreateTask = &GlobalGrantCreateTask{TaskString: TaskRoleGrantCreate}
+
+var _ tasks.Task = (*GlobalGrantCreateTask)(nil)
+
+func (GlobalGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) any {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
+	queries := cd.Queries()
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	section := r.PostFormValue("section")
+	item := r.PostFormValue("item")
+	action := r.PostFormValue("action")
+	itemIDStr := r.PostFormValue("item_id")
+	var itemID sql.NullInt32
+	if itemIDStr != "" {
+		id, err := strconv.Atoi(itemIDStr)
+		if err != nil {
+			return fmt.Errorf("item id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		itemID = sql.NullInt32{Int32: int32(id), Valid: true}
+	}
+	if section == "" || action == "" {
+		return fmt.Errorf("missing section or action %w", handlers.ErrRedirectOnSamePageHandler(fmt.Errorf("")))
+	}
+	if def, ok := GrantActionMap[section+"|"+item]; ok && def.RequireItemID && !itemID.Valid {
+		return fmt.Errorf("missing item id %w", handlers.ErrRedirectOnSamePageHandler(fmt.Errorf("")))
+	}
+	if _, err := queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
+		UserID:   sql.NullInt32{},
+		RoleID:   sql.NullInt32{},
+		Section:  section,
+		Item:     sql.NullString{String: item, Valid: item != ""},
+		RuleType: "allow",
+		ItemID:   itemID,
+		ItemRule: sql.NullString{},
+		Action:   action,
+		Extra:    sql.NullString{},
+	}); err != nil {
+		log.Printf("CreateGrant: %v", err)
+		return fmt.Errorf("create grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	return handlers.RefreshDirectHandler{TargetURL: "/admin/grants"}
+}

--- a/handlers/admin/global_grant_create_task_test.go
+++ b/handlers/admin/global_grant_create_task_test.go
@@ -1,0 +1,47 @@
+package admin
+
+import (
+	"context"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// TestGlobalGrantCreateTask_ItemIDRequired verifies missing item_id errors.
+func TestGlobalGrantCreateTask_ItemIDRequired(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	body := url.Values{
+		"section": {"forum"},
+		"item":    {"topic"},
+		"action":  {"see"},
+	}
+	req := httptest.NewRequest("POST", "/admin/grant", strings.NewReader(body.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	cd := common.NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	if res := globalGrantCreateTask.Action(rr, req); res == nil {
+		t.Fatalf("expected error, got nil")
+	} else if err, ok := res.(error); !ok || err == nil {
+		t.Fatalf("expected error, got %v", res)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/handlers/admin/grants.go
+++ b/handlers/admin/grants.go
@@ -43,6 +43,8 @@ func AdminGrantsPage(w http.ResponseWriter, r *http.Request) {
 				userNames[g.UserID.Int32] = u.Username.String
 				gw.UserName = u.Username.String
 			}
+		} else if !g.RoleID.Valid {
+			gw.UserName = "Everyone"
 		}
 		if g.RoleID.Valid {
 			if name, ok := roleNames[g.RoleID.Int32]; ok {
@@ -90,6 +92,8 @@ func adminGrantPage(w http.ResponseWriter, r *http.Request) {
 		if u, err := queries.SystemGetUserByID(r.Context(), g.UserID.Int32); err == nil && u.Username.Valid {
 			gw.UserName = u.Username.String
 		}
+	} else if !g.RoleID.Valid {
+		gw.UserName = "Everyone"
 	}
 	if g.RoleID.Valid {
 		if ro, err := queries.AdminGetRoleByID(r.Context(), g.RoleID.Int32); err == nil {

--- a/handlers/admin/grants_routes_test.go
+++ b/handlers/admin/grants_routes_test.go
@@ -53,3 +53,30 @@ func TestRegisterRoutesRegistersGrantAdd(t *testing.T) {
 		t.Fatalf("grant add route not registered")
 	}
 }
+
+func TestRegisterRoutesRegistersGrantCreate(t *testing.T) {
+	h := New()
+	r := mux.NewRouter()
+	ar := r.PathPrefix("/admin").Subrouter()
+	navReg := navpkg.NewRegistry()
+	h.RegisterRoutes(ar, &config.RuntimeConfig{}, navReg)
+	var found bool
+	r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		path, err := route.GetPathTemplate()
+		if err != nil {
+			return nil
+		}
+		if path == "/admin/grant" {
+			methods, _ := route.GetMethods()
+			for _, m := range methods {
+				if m == "POST" {
+					found = true
+				}
+			}
+		}
+		return nil
+	})
+	if !found {
+		t.Fatalf("grant create route not registered")
+	}
+}

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -103,6 +103,7 @@ func (h *Handlers) RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navRe
 	ar.HandleFunc("/grant/delete", handlers.TaskHandler(roleGrantDeleteTask)).Methods("POST").MatcherFunc(roleGrantDeleteTask.Matcher())
 	ar.HandleFunc("/grants", AdminGrantsPage).Methods("GET")
 	ar.HandleFunc("/grant/add", adminGrantAddPage).Methods("GET")
+	ar.HandleFunc("/grant", handlers.TaskHandler(globalGrantCreateTask)).Methods("POST").MatcherFunc(globalGrantCreateTask.Matcher())
 	ar.HandleFunc("/grant/{grant}", adminGrantPage).Methods("GET")
 	ar.HandleFunc("/grant/update", handlers.TaskHandler(grantUpdateTask)).Methods("POST").MatcherFunc(grantUpdateTask.Matcher())
 	ar.HandleFunc("/user/{user}/reset", adminUserResetPasswordConfirmPage).Methods("GET")

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 56
+	ExpectedSchemaVersion = 57
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/migrations/0057.mysql.sql
+++ b/migrations/0057.mysql.sql
@@ -1,0 +1,27 @@
+-- Grant public view access to blogs, writings and news
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'blogs', 'entry', 'allow', 'see', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'blogs', 'entry', 'allow', 'view', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'writing', 'category', 'allow', 'see', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'writing', 'category', 'allow', 'view', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'writing', 'article', 'allow', 'see', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'writing', 'article', 'allow', 'view', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'news', 'post', 'allow', 'see', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'news', 'post', 'allow', 'view', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+UPDATE schema_version SET version = 57 WHERE version = 56;

--- a/migrations/0057.postgres.sql
+++ b/migrations/0057.postgres.sql
@@ -1,0 +1,27 @@
+-- Grant public view access to blogs, writings and news
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'blogs', 'entry', 'allow', 'see', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'blogs', 'entry', 'allow', 'view', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'writing', 'category', 'allow', 'see', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'writing', 'category', 'allow', 'view', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'writing', 'article', 'allow', 'see', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'writing', 'article', 'allow', 'view', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'news', 'post', 'allow', 'see', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'news', 'post', 'allow', 'view', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+UPDATE schema_version SET version = 57 WHERE version = 56;

--- a/migrations/0057.sqlite.sql
+++ b/migrations/0057.sqlite.sql
@@ -1,0 +1,27 @@
+-- Grant public view access to blogs, writings and news
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'blogs', 'entry', 'allow', 'see', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'blogs', 'entry', 'allow', 'view', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'writing', 'category', 'allow', 'see', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'writing', 'category', 'allow', 'view', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'writing', 'article', 'allow', 'see', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'writing', 'article', 'allow', 'view', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'news', 'post', 'allow', 'see', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+INSERT INTO grants (created_at, user_id, role_id, section, item, rule_type, action, active)
+SELECT NOW(), NULL, NULL, 'news', 'post', 'allow', 'view', 1
+ON DUPLICATE KEY UPDATE action=VALUES(action);
+
+UPDATE schema_version SET version = 57 WHERE version = 56;


### PR DESCRIPTION
## Summary
- support creating grants that apply to everyone via the admin UI
- show global grants in lists and detail pages as "Everyone"
- seed blogs, writing categories/articles and news posts with public read access and bump schema version

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestProcessSpecialCommands, TestA4code2htmlComplex, TestA4code2htmlUnclosed, TestA4code2htmlBadURL, TestSpoiler, TestPageTemplatesRender)*

------
https://chatgpt.com/codex/tasks/task_e_68947f702458832fa32295b5024664f2