### PR TITLE
Fix hr tag handling in a4code2html

### DIFF
--- a/a4code/a4code2html/a4code2html.go
+++ b/a4code/a4code2html/a4code2html.go
@@ -383,10 +383,10 @@ func (a *A4code2html) acommReader(r *bufio.Reader, w io.Writer) error {
 		switch a.CodeType {
 		case CTTableOfContents, CTTagStrip, CTWordsOnly:
 		default:
-			if _, err := io.WriteString(w, "<hr>"); err != nil {
+			if _, err := io.WriteString(w, "<hr />"); err != nil {
 				return err
 			}
-			a.stack = append(a.stack, "/>")
+			a.stack = append(a.stack, "")
 		}
 	default:
 		a.stack = append(a.stack, "")


### PR DESCRIPTION
## Summary
- render `[hr]` with a proper `<hr />` self-closing tag
- add table-driven test covering `[hr]` across CodeType modes
- align existing a4code2html tests with trimmed whitespace behavior

## Testing
- `go mod tidy`
- `go fmt a4code/a4code2html/a4code2html_test.go a4code/a4code2html/a4code2html.go`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68948d208d5c832f80d54d7dc0081f37