### PR TITLE
Add anyone grants page and link

### DIFF
--- a/core/templates/grant_links_test.go
+++ b/core/templates/grant_links_test.go
@@ -98,3 +98,49 @@ func TestGrantsPageLinks(t *testing.T) {
 		t.Fatalf("expected item link, got %s", html)
 	}
 }
+
+func TestGrantPageLinksAnyone(t *testing.T) {
+	tmpl := template.Must(template.New("").Funcs(template.FuncMap{
+		"csrfField": func() template.HTML { return "" },
+	}).ParseFS(grantTemplates, "site/admin/grantPage.gohtml"))
+	template.Must(tmpl.New("head").Parse(""))
+	template.Must(tmpl.New("tail").Parse(""))
+
+	g := &db.Grant{ID: 1}
+	data := struct{ Grant grantWithNames }{
+		Grant: grantWithNames{Grant: g, UserName: "Anyone"},
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "grantPage.gohtml", data); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, `<a href="/admin/grants/anyone">Anyone</a>`) {
+		t.Fatalf("expected anyone link, got %s", html)
+	}
+}
+
+func TestGrantsPageLinksAnyone(t *testing.T) {
+	tmpl := template.Must(template.New("").Funcs(template.FuncMap{
+		"csrfField": func() template.HTML { return "" },
+	}).ParseFS(grantTemplates, "site/admin/grantsPage.gohtml"))
+	template.Must(tmpl.New("head").Parse(""))
+	template.Must(tmpl.New("tail").Parse(""))
+
+	g := &db.Grant{ID: 1, Active: true}
+	data := struct{ Grants []grantWithNames }{
+		Grants: []grantWithNames{
+			{Grant: g, UserName: "Anyone"},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "grantsPage.gohtml", data); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, `<a href="/admin/grants/anyone">Anyone</a>`) {
+		t.Fatalf("expected anyone link, got %s", html)
+	}
+}

--- a/core/templates/site/admin/grantAddPage.gohtml
+++ b/core/templates/site/admin/grantAddPage.gohtml
@@ -1,12 +1,12 @@
 {{ template "head" $ }}
 <h2>Add Grant</h2>
-{{ if or (eq .Subject "") (and (ne .Subject "everyone") (eq .ID 0)) }}
+{{ if or (eq .Subject "") (and (ne .Subject "anyone") (eq .ID 0)) }}
 <form method="get">
     <label>Subject:
         <select name="subject">
             <option value="user"{{ if or (eq .Subject "user") (eq .Subject "") }} selected{{ end }}>User</option>
             <option value="role"{{ if eq .Subject "role" }} selected{{ end }}>Role</option>
-            <option value="everyone"{{ if eq .Subject "everyone" }} selected{{ end }}>Everyone</option>
+            <option value="anyone"{{ if eq .Subject "anyone" }} selected{{ end }}>Anyone</option>
         </select>
     </label>
     {{ if or (eq .Subject "user") (eq .Subject "") }}
@@ -58,7 +58,7 @@
     <input type="submit" value="Next">
 </form>
 {{ else }}
-<form method="post" action="/admin/{{ if eq .Subject "everyone" }}grant{{ else }}{{ .Subject }}/{{ .ID }}/grant{{ end }}">
+<form method="post" action="/admin/{{ if eq .Subject "anyone" }}grant{{ else }}{{ .Subject }}/{{ .ID }}/grant{{ end }}">
     {{ csrfField }}
     <input type="hidden" name="task" value="Create grant">
     <input type="hidden" name="section" value="{{ .Section }}">

--- a/core/templates/site/admin/grantPage.gohtml
+++ b/core/templates/site/admin/grantPage.gohtml
@@ -2,7 +2,7 @@
 <p><a href="/admin/grants">Back to grants</a></p>
 <table border="1">
     <tr><th>Field</th><th>Value</th></tr>
-    <tr><td>User</td><td>{{ if .Grant.UserID.Valid }}<a href="/admin/user/{{ .Grant.UserID.Int32 }}">{{ .Grant.UserName }} ({{ .Grant.UserID.Int32 }})</a>{{ else if not .Grant.RoleID.Valid }}{{ .Grant.UserName }}{{ else }}-{{ end }}</td></tr>
+<tr><td>User</td><td>{{ if .Grant.UserID.Valid }}<a href="/admin/user/{{ .Grant.UserID.Int32 }}">{{ .Grant.UserName }} ({{ .Grant.UserID.Int32 }})</a>{{ else if not .Grant.RoleID.Valid }}<a href="/admin/grants/anyone">{{ .Grant.UserName }}</a>{{ else }}-{{ end }}</td></tr>
     <tr><td>Role</td><td>{{ if .Grant.RoleID.Valid }}<a href="/admin/role/{{ .Grant.RoleID.Int32 }}">{{ .Grant.RoleName }} ({{ .Grant.RoleID.Int32 }})</a>{{ else }}-{{ end }}</td></tr>
     <tr><td>Section</td><td>{{ .Grant.Section }}</td></tr>
     <tr><td>Item</td><td>{{ if .Grant.ItemLink }}<a href="{{ .Grant.ItemLink }}">{{ .Grant.Item.String }}</a>{{ else }}{{ .Grant.Item.String }}{{ end }}</td></tr>

--- a/core/templates/site/admin/grantsPage.gohtml
+++ b/core/templates/site/admin/grantsPage.gohtml
@@ -5,7 +5,7 @@
     {{- range .Grants }}
     <tr>
         <td><a href="/admin/grant/{{ .Grant.ID }}">{{ .Grant.ID }}</a></td>
-        <td>{{ if .Grant.UserID.Valid }}<a href="/admin/user/{{ .Grant.UserID.Int32 }}">{{ .UserName }} ({{ .Grant.UserID.Int32 }})</a>{{ else if not .Grant.RoleID.Valid }}{{ .UserName }}{{ end }}</td>
+<td>{{ if .Grant.UserID.Valid }}<a href="/admin/user/{{ .Grant.UserID.Int32 }}">{{ .UserName }} ({{ .Grant.UserID.Int32 }})</a>{{ else if not .Grant.RoleID.Valid }}<a href="/admin/grants/anyone">{{ .UserName }}</a>{{ end }}</td>
         <td>{{ if .Grant.RoleID.Valid }}<a href="/admin/role/{{ .Grant.RoleID.Int32 }}">{{ .RoleName }} ({{ .Grant.RoleID.Int32 }})</a>{{ end }}</td>
         <td>{{ .Grant.Section }}</td>
         <td>{{ if .ItemLink }}<a href="{{ .ItemLink }}">{{ .Grant.Item.String }}</a>{{ else }}{{ .Grant.Item.String }}{{ end }}</td>

--- a/handlers/admin/adminAnyoneGrantsPage_test.go
+++ b/handlers/admin/adminAnyoneGrantsPage_test.go
@@ -1,0 +1,50 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestAdminAnyoneGrantsPage(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	queries := db.New(sqlDB)
+
+	grantsRows := sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}).
+		AddRow(1, nil, nil, nil, nil, "forum", "", "allow", nil, nil, "search", nil, true)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants ORDER BY id")).WillReturnRows(grantsRows)
+
+	req := httptest.NewRequest("GET", "/admin/grants/anyone", nil)
+	ctx := req.Context()
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	AdminAnyoneGrantsPage(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `<a href="/admin/grants/anyone">Anyone</a>`) {
+		t.Fatalf("missing link: %s", body)
+	}
+}

--- a/handlers/admin/adminGrantAddPage.go
+++ b/handlers/admin/adminGrantAddPage.go
@@ -38,7 +38,7 @@ func adminGrantAddPage(w http.ResponseWriter, r *http.Request) {
 		RequireItemID bool
 	}{Subject: subject, ID: id, Section: section, Item: item}
 
-	if subject == "" || (id == 0 && subject != "everyone") {
+	if subject == "" || (id == 0 && subject != "anyone") {
 		users, _ := queries.ListUsersWithRoles(r.Context())
 		roles, _ := queries.AdminListRoles(r.Context())
 		data.Users = users

--- a/handlers/admin/global_grant_create_task.go
+++ b/handlers/admin/global_grant_create_task.go
@@ -14,7 +14,7 @@ import (
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
-// GlobalGrantCreateTask creates a new grant that applies to everyone.
+// GlobalGrantCreateTask creates a new grant that applies to anyone.
 type GlobalGrantCreateTask struct{ tasks.TaskString }
 
 var globalGrantCreateTask = &GlobalGrantCreateTask{TaskString: TaskRoleGrantCreate}

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -101,6 +101,7 @@ func (h *Handlers) RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navRe
 	ar.HandleFunc("/role/{role}/grant", handlers.TaskHandler(roleGrantCreateTask)).Methods("POST").MatcherFunc(roleGrantCreateTask.Matcher())
 	ar.HandleFunc("/role/{role}/grant/update", handlers.TaskHandler(roleGrantUpdateTask)).Methods("POST").MatcherFunc(roleGrantUpdateTask.Matcher())
 	ar.HandleFunc("/grant/delete", handlers.TaskHandler(roleGrantDeleteTask)).Methods("POST").MatcherFunc(roleGrantDeleteTask.Matcher())
+	ar.HandleFunc("/grants/anyone", AdminAnyoneGrantsPage).Methods("GET")
 	ar.HandleFunc("/grants", AdminGrantsPage).Methods("GET")
 	ar.HandleFunc("/grant/add", adminGrantAddPage).Methods("GET")
 	ar.HandleFunc("/grant", handlers.TaskHandler(globalGrantCreateTask)).Methods("POST").MatcherFunc(globalGrantCreateTask.Matcher())


### PR DESCRIPTION
## Summary
- add admin page for grants that apply to anyone
- link "Anyone" entries to the new page
- update grant form and tests for the new naming

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestProcessSpecialCommands, TestA4code2htmlComplex, TestA4code2htmlUnclosed, TestA4code2htmlBadURL, TestSpoiler)*

------
https://chatgpt.com/codex/tasks/task_e_68948f1f86f4832f8c22864483792ae0