### PR TITLE
Add virtual anyone role to role listings

### DIFF
--- a/core/common/coredata_allroles_test.go
+++ b/core/common/coredata_allroles_test.go
@@ -24,8 +24,15 @@ func TestAllRolesLazy(t *testing.T) {
 
 	cd := NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
 
-	if _, err := cd.AllRoles(); err != nil {
+	roles, err := cd.AllRoles()
+	if err != nil {
 		t.Fatalf("AllRoles: %v", err)
+	}
+	if len(roles) != 3 {
+		t.Fatalf("expected 3 roles, got %d", len(roles))
+	}
+	if roles[0].Name != "anyone" || roles[0].ID != 0 {
+		t.Fatalf("expected anyone role first, got %+v", roles[0])
 	}
 	if _, err := cd.AllRoles(); err != nil {
 		t.Fatalf("AllRoles second call: %v", err)

--- a/handlers/access_test.go
+++ b/handlers/access_test.go
@@ -19,7 +19,7 @@ func TestVerifyAccess(t *testing.T) {
 	}, fmt.Errorf("administrator role required"), "administrator")
 
 	req := httptest.NewRequest("GET", "/", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
 
 	rr := httptest.NewRecorder()

--- a/handlers/admin/reload_shutdown_test.go
+++ b/handlers/admin/reload_shutdown_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestAdminReloadConfigPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	h := New()
@@ -42,7 +42,7 @@ func TestAdminReloadRoute_Unauthorized(t *testing.T) {
 	h.RegisterRoutes(ar, cfg, navReg)
 
 	req := httptest.NewRequest("POST", "/admin/reload", nil)
-	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"anonymous"}))
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"anyone"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -84,7 +84,7 @@ func TestAdminShutdownRoute_Unauthorized(t *testing.T) {
 	h.RegisterRoutes(ar, cfg, navReg)
 
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
-	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"anonymous"}))
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"anyone"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -123,7 +123,7 @@ func TestAdminShutdownRoute_Authorized(t *testing.T) {
 func TestServerShutdownTask_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
 	cfg := config.NewRuntimeConfig()
-	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"anonymous"}))
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"anyone"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	h := New()
@@ -139,7 +139,7 @@ func TestServerShutdownTask_Unauthorized(t *testing.T) {
 func TestServerShutdownMatcher_Denied(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/shutdown", nil)
 	cfg := config.NewRuntimeConfig()
-	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"anonymous"}))
+	cd := common.NewCoreData(req.Context(), nil, cfg, common.WithUserRoles([]string{"anyone"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	h := New()

--- a/handlers/admin/send_notification_task.go
+++ b/handlers/admin/send_notification_task.go
@@ -42,7 +42,7 @@ func (SendNotificationTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 			ids = append(ids, u.Idusers)
 		}
-	} else if role != "" && role != "anonymous" {
+	} else if role != "" && role != "anyone" {
 		rows, err := queries.AdminListUserIDsByRole(r.Context(), role)
 		if err != nil {
 			return fmt.Errorf("list role fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/auth/loginPage_test.go
+++ b/handlers/auth/loginPage_test.go
@@ -108,7 +108,7 @@ func TestLoginAction_InvalidPassword(t *testing.T) {
 
 func TestLoginPageHiddenFields(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/login?code=abc&back=%2Ffoo&method=POST&data=x", nil)
-	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -401,7 +401,7 @@ func TestLoginAction_Throttle(t *testing.T) {
 func TestRedirectBackPageHandlerGET(t *testing.T) {
 	t.Skip("skip due to template environment")
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -420,7 +420,7 @@ func TestRedirectBackPageHandlerGET(t *testing.T) {
 func TestRedirectBackPageHandlerEmptyMethod(t *testing.T) {
 	t.Skip("skip due to template environment")
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -440,7 +440,7 @@ func TestRedirectBackPageHandler(t *testing.T) {
 	cases := map[string]string{"empty": "", "get": http.MethodGet}
 	for name, method := range cases {
 		t.Run(name, func(t *testing.T) {
-			cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+			cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 			req = req.WithContext(ctx)
@@ -462,7 +462,7 @@ func TestRedirectBackPageHandler(t *testing.T) {
 	}
 
 	t.Run("post", func(t *testing.T) {
-		cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+		cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 		req = req.WithContext(ctx)

--- a/handlers/blogs/blogsIndexPermissions_test.go
+++ b/handlers/blogs/blogsIndexPermissions_test.go
@@ -30,9 +30,9 @@ func TestCustomBlogIndexRoles(t *testing.T) {
 		t.Errorf("content writer should see write blog")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 	CustomBlogIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "Blogs Admin") || common.ContainsItem(cd.CustomIndexItems, "Write blog") {
-		t.Errorf("anonymous should not see writer/admin items")
+		t.Errorf("anyone should not see writer/admin items")
 	}
 }

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -127,7 +127,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 
 func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -139,7 +139,7 @@ func TestBlogsBlogAddPage_Unauthorized(t *testing.T) {
 
 func TestBlogsBlogEditPage_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/1/edit", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/handlers/faq/page_test.go
+++ b/handlers/faq/page_test.go
@@ -15,9 +15,9 @@ func TestCustomFAQIndexRoles(t *testing.T) {
 		t.Errorf("admin should not see question controls")
 	}
 
-	cd = common.NewCoreData(nil, nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+	cd = common.NewCoreData(nil, nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 	CustomFAQIndex(cd, nil)
 	if common.ContainsItem(cd.CustomIndexItems, "Question Qontrols") {
-		t.Errorf("anonymous should not see admin items")
+		t.Errorf("anyone should not see admin items")
 	}
 }

--- a/handlers/matchers_test.go
+++ b/handlers/matchers_test.go
@@ -26,7 +26,7 @@ func TestRequiredAccessAllowed(t *testing.T) {
 
 func TestRequiredAccessDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/news/newsIndexPermissions_test.go
+++ b/handlers/news/newsIndexPermissions_test.go
@@ -36,9 +36,9 @@ func TestCustomNewsIndexRoles(t *testing.T) {
 		t.Errorf("content writer should not see news admin link")
 	}
 
-	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 	CustomNewsIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "News Admin") {
-		t.Errorf("anonymous should not see admin items")
+		t.Errorf("anyone should not see admin items")
 	}
 }

--- a/internal/app/dbstart/testdata/seed.sql
+++ b/internal/app/dbstart/testdata/seed.sql
@@ -1,6 +1,6 @@
 -- Basic role definitions
 INSERT INTO roles (name, can_login, is_admin) VALUES
-  ('anonymous', 0, 0),
+  ('anyone', 0, 0),
   ('user', 1, 0),
   ('content writer', 1, 0),
   ('moderator', 1, 0),

--- a/internal/app/server/coredata_middleware_test.go
+++ b/internal/app/server/coredata_middleware_test.go
@@ -65,7 +65,7 @@ func TestCoreDataMiddlewareUserRoles(t *testing.T) {
 	)
 	srv.CoreDataMiddleware()(handler).ServeHTTP(httptest.NewRecorder(), req)
 
-	want := []string{"anonymous", "user", "moderator"}
+	want := []string{"anyone", "user", "moderator"}
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {
 		t.Fatalf("roles mismatch (-want +got):\n%s", diff)
 	}
@@ -115,7 +115,7 @@ func TestCoreDataMiddlewareAnonymous(t *testing.T) {
 	)
 	srv.CoreDataMiddleware()(handler).ServeHTTP(httptest.NewRecorder(), req)
 
-	want := []string{"anonymous"}
+	want := []string{"anyone"}
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {
 		t.Fatalf("roles mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/router/roles_test.go
+++ b/internal/router/roles_test.go
@@ -38,7 +38,7 @@ func TestRoleCheckerMiddlewareAllowed(t *testing.T) {
 
 func TestRoleCheckerMiddlewareDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin", nil)
-	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anonymous"}))
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 

--- a/seed.sql
+++ b/seed.sql
@@ -1,6 +1,6 @@
 -- Basic role definitions
 INSERT INTO roles (name, can_login, is_admin) VALUES
-  ('anonymous', 0, 0),
+  ('anyone', 0, 0),
   ('user', 1, 0),
   ('content writer', 1, 0),
   ('moderator', 1, 0),

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -6,7 +6,7 @@ This document describes how Goa4Web evaluates permissions using roles and grants
 
 Roles define high level capabilities that can be assigned to users. The standard roles are:
 
-- **anonymous** – guests who are not signed in
+- **anyone** – guests who are not signed in
 - **user** – regular authenticated user
 - **content writer** – may publish blogs and writing articles
 - **moderator** – moderation abilities
@@ -22,7 +22,7 @@ Users can hold multiple roles through the `user_roles` table. Roles are assigned
 explicitly without inheritance.
 
 The `user` role does not need to be explicitly assigned. Any authenticated
-account automatically gains the `user` role while the `anonymous` role applies
+account automatically gains the `user` role while the `anyone` role applies
 to every connection regardless of login state.
 
 ## Grants Table
@@ -128,7 +128,7 @@ The migrations seed baseline rules for the `news` section:
 
 | Role | Action | Item | Description |
 |------|-------|------|-------------|
-| `anonymous` | `see`, `view` | `post` | browse published news |
+| `anyone` | `see`, `view` | `post` | browse published news |
 | `user` | `reply` | `post` | participate in discussions |
 | `content writer`, `administrator` | `post` | `post` | create new entries |
 | `content writer` | `edit` | `post` | update own news post via item-specific grant |


### PR DESCRIPTION
## Summary
- prepend anyone role when listing roles so /admin/roles shows entry for all visitors
- rename anonymous role references to anyone across code, docs, seeds, and tests

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./core/common`
- `go test ./...` *(fails: TestProcessSpecialCommands, TestA4code2htmlComplex, TestA4code2htmlUnclosed, TestA4code2htmlBadURL, TestSpoiler in `a4code/a4code2html`)*

------
https://chatgpt.com/codex/tasks/task_e_68948d842840832fab212bddb17e7bc1