### PR TITLE
Generalize comment creation and reply checks

### DIFF
--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -180,14 +180,7 @@ func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	endUrl := fmt.Sprintf("/blogs/blog/%d/comments", bid)
 
-	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
-		LanguageID:         int32(languageId),
-		CommenterID:        uid,
-		ForumthreadID:      pthid,
-		Text:               sql.NullString{String: text, Valid: true},
-		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
-		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
-	})
+	cid, err := cd.CreateBlogCommentForCommenter(uid, pthid, int32(bid), int32(languageId), text)
 	if err != nil {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -109,7 +109,8 @@ func (CreateThreadTask) Page(w http.ResponseWriter, r *http.Request) {
 }
 
 func (CreateThreadTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
 	vars := mux.Vars(r)
 	topicId, err := strconv.Atoi(vars["topic"])
 	if err != nil {
@@ -162,14 +163,7 @@ func (CreateThreadTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d", topicId, threadId)
 
-	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
-		LanguageID:         int32(languageId),
-		CommenterID:        uid,
-		ForumthreadID:      int32(threadId),
-		Text:               sql.NullString{String: text, Valid: true},
-		GrantForumthreadID: sql.NullInt32{Int32: int32(threadId), Valid: true},
-		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
-	})
+	cid, err := cd.CreateForumCommentForCommenter(uid, int32(threadId), int32(topicId), int32(languageId), text)
 	if err != nil {
 		log.Printf("Error: makeThread: %s", err)
 		return fmt.Errorf("create comment %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/forum/forumThreadPage_quote_test.go
+++ b/handlers/forum/forumThreadPage_quote_test.go
@@ -49,9 +49,9 @@ func TestThreadPageQuotePrefillsReply(t *testing.T) {
 			"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "deleted_at", "last_index", "username", "is_owner",
 		}).AddRow(int32(2), int32(1), int32(1), int32(1), sql.NullTime{}, sql.NullString{String: "hi", Valid: true}, sql.NullTime{}, sql.NullTime{}, sql.NullString{String: "alice", Valid: true}, false))
 
-	mock.ExpectQuery(".*").
-		WithArgs(int32(1), "forum", sql.NullString{String: "topic", Valid: true}, "reply", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).
-		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery("SELECT category_path").
+		WithArgs(int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "title"}))
 
 	store := sessions.NewCookieStore([]byte("test"))
 	core.Store = store
@@ -69,7 +69,7 @@ func TestThreadPageQuotePrefillsReply(t *testing.T) {
 
 	q := db.New(dbconn)
 	cfg := config.NewRuntimeConfig()
-	cd := common.NewCoreData(req.Context(), q, cfg, common.WithSession(sess), common.WithUserRoles([]string{"user"}))
+	cd := common.NewCoreData(req.Context(), q, cfg, common.WithSession(sess), common.WithUserRoles([]string{"administrator"}))
 	cd.SetCurrentSection("forum")
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -266,14 +266,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	endUrl := fmt.Sprintf("/imagebbss/imagebbs/%d/comments", bid)
 
-	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
-		LanguageID:         int32(languageId),
-		CommenterID:        uid,
-		ForumthreadID:      pthid,
-		Text:               sql.NullString{String: text, Valid: true},
-		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
-		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
-	})
+	cid, err := cd.CreateImageBBSCommentForCommenter(uid, pthid, int32(bid), int32(languageId), text)
 	if err != nil {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -282,14 +282,7 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	endUrl := fmt.Sprintf("/linker/comments/%d", linkId)
 
-	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
-		LanguageID:         int32(languageId),
-		CommenterID:        uid,
-		ForumthreadID:      pthid,
-		Text:               sql.NullString{String: text, Valid: true},
-		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
-		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
-	})
+	cid, err := cd.CreateLinkerCommentForCommenter(uid, pthid, int32(linkId), int32(languageId), text)
 	if err != nil {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -164,14 +164,7 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 
 	endUrl := fmt.Sprintf("/linker/show/%d", linkId)
 
-	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
-		LanguageID:         int32(languageId),
-		CommenterID:        uid,
-		ForumthreadID:      pthid,
-		Text:               sql.NullString{String: text, Valid: true},
-		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
-		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
-	})
+	cid, err := cd.CreateLinkerCommentForCommenter(uid, pthid, int32(linkId), int32(languageId), text)
 	if err != nil {
 		log.Printf("Error: createComment: %s", err)
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -186,14 +186,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		evt.Data["Username"] = user.Username.String
 	}
 
-	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
-		LanguageID:         int32(languageId),
-		CommenterID:        uid,
-		ForumthreadID:      pthid,
-		Text:               sql.NullString{String: text, Valid: true},
-		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
-		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
-	})
+	cid, err := cd.CreateNewsCommentForCommenter(uid, pthid, int32(pid), int32(languageId), text)
 	if err != nil {
 		log.Printf("Error: createComment: %s", err)
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/news/newsReplyTask_event_test.go
+++ b/handlers/news/newsReplyTask_event_test.go
@@ -52,7 +52,7 @@ func TestNewsReplyTaskEventData(t *testing.T) {
 			AddRow(uid, nil, "alice", nil))
 
 	mock.ExpectExec("INSERT INTO comments").
-		WithArgs(int32(1), uid, pthid, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), uid).
+		WithArgs(int32(1), uid, pthid, sqlmock.AnyArg(), "news", sqlmock.AnyArg(), int32(pid), sqlmock.AnyArg(), uid).
 		WillReturnResult(sqlmock.NewResult(5, 1))
 
 	store := sessions.NewCookieStore([]byte("test"))

--- a/handlers/privateforum/topic_create_task.go
+++ b/handlers/privateforum/topic_create_task.go
@@ -114,14 +114,7 @@ func (PrivateTopicCreateTask) Action(w http.ResponseWriter, r *http.Request) any
 			return fmt.Errorf("create reply grant %w", handlers.ErrRedirectOnSamePageHandler(err))
 		}
 	}
-	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
-		LanguageID:         0,
-		CommenterID:        creator,
-		ForumthreadID:      threadID,
-		Text:               sql.NullString{String: body, Valid: body != ""},
-		GrantForumthreadID: sql.NullInt32{Int32: threadID, Valid: true},
-		GranteeID:          sql.NullInt32{Int32: creator, Valid: creator != 0},
-	})
+	cid, err := cd.CreateForumCommentForCommenter(creator, threadID, topicID, 0, body)
 	if err != nil {
 		return fmt.Errorf("create comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -144,14 +144,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("language parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
-		LanguageID:         int32(languageID),
-		CommenterID:        uid,
-		ForumthreadID:      pthid,
-		Text:               sql.NullString{String: text, Valid: true},
-		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
-		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
-	})
+	cid, err := cd.CreateWritingCommentForCommenter(uid, pthid, writing.Idwriting, int32(languageID), text)
 	if err != nil {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -212,14 +212,7 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	text := r.PostFormValue("replytext")
 	languageId, _ := strconv.Atoi(r.PostFormValue("language"))
 
-	cid, err := queries.CreateCommentForCommenter(r.Context(), db.CreateCommentForCommenterParams{
-		LanguageID:         int32(languageId),
-		CommenterID:        uid,
-		ForumthreadID:      pthid,
-		Text:               sql.NullString{String: text, Valid: true},
-		GrantForumthreadID: sql.NullInt32{Int32: pthid, Valid: true},
-		GranteeID:          sql.NullInt32{Int32: uid, Valid: true},
-	})
+	cid, err := cd.CreateWritingCommentForCommenter(uid, pthid, writing.Idwriting, int32(languageId), text)
 	if err != nil {
 		log.Printf("Error: createComment: %s", err)
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -214,7 +214,7 @@ type Querier interface {
 	CreateBlogEntryForWriter(ctx context.Context, arg CreateBlogEntryForWriterParams) (int64, error)
 	// This query adds a new entry to the "bookmarks" table for a lister.
 	CreateBookmarksForLister(ctx context.Context, arg CreateBookmarksForListerParams) error
-	CreateCommentForCommenter(ctx context.Context, arg CreateCommentForCommenterParams) (int64, error)
+	CreateCommentInSectionForCommenter(ctx context.Context, arg CreateCommentInSectionForCommenterParams) (int64, error)
 	CreateFAQQuestionForWriter(ctx context.Context, arg CreateFAQQuestionForWriterParams) error
 	CreateForumTopicForPoster(ctx context.Context, arg CreateForumTopicForPosterParams) (int64, error)
 	CreateImagePostForPoster(ctx context.Context, arg CreateImagePostForPosterParams) (int64, error)

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -97,19 +97,19 @@ WHERE c.Idcomments IN (sqlc.slice('ids'))
 ORDER BY c.written DESC
 ;
 
--- name: CreateCommentForCommenter :execlastid
+-- name: CreateCommentInSectionForCommenter :execlastid
 INSERT INTO comments (language_idlanguage, users_idusers, forumthread_id, text, written)
-SELECT sqlc.arg(language_id), sqlc.arg(commenter_id), sqlc.arg(forumthread_id), sqlc.arg(text), NOW()
+SELECT sqlc.arg(language_id), sqlc.narg(commenter_id), sqlc.arg(forumthread_id), sqlc.arg(text), NOW()
 WHERE EXISTS (
     SELECT 1 FROM grants g
-    WHERE g.section = 'forum'
-      AND (g.item = 'thread' OR g.item IS NULL)
+    WHERE g.section = sqlc.arg(section)
+      AND (g.item = sqlc.arg(item_type) OR g.item IS NULL)
       AND g.action = 'reply'
       AND g.active = 1
-      AND (g.item_id = sqlc.arg(grant_forumthread_id) OR g.item_id IS NULL)
-      AND (g.user_id = sqlc.arg(grantee_id) OR g.user_id IS NULL)
+      AND (g.item_id = sqlc.arg(item_id) OR g.item_id IS NULL)
+      AND (g.user_id = sqlc.narg(commenter_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (
-          SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(commenter_id)
+          SELECT ur.role_id FROM user_roles ur WHERE ur.users_idusers = sqlc.narg(commenter_id)
       ))
   );
 


### PR DESCRIPTION
## Summary
- make SelectedThreadCanReply section-aware with helpers for each content type
- add section-aware CreateCommentInSectionForCommenter and wrapper helpers
- adjust handlers and tests to use new commenter-based helpers

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./handlers/news -run TestNewsReplyTaskEventData -count=1`
- `go test ./handlers/forum -run TestThreadPageQuotePrefillsReply -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68949f1d7120832fa6d0c8ab1cccae7a