### PR TITLE
Add CoreData user helpers and refactor registration

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1646,6 +1646,49 @@ func (cd *CoreData) PublicWritings(categoryID int32, r *http.Request) ([]*db.Lis
 // Queries returns the db.Queries instance associated with this CoreData.
 func (cd *CoreData) Queries() db.Querier { return cd.queries }
 
+// UserExists reports whether a user already exists with the supplied username
+// or email address.
+func (cd *CoreData) UserExists(username, email string) (bool, error) {
+	if cd.queries == nil {
+		return false, nil
+	}
+	if username != "" {
+		if _, err := cd.queries.SystemGetUserByUsername(cd.ctx, sql.NullString{String: username, Valid: true}); err == nil {
+			return true, nil
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return false, fmt.Errorf("user by username: %w", err)
+		}
+	}
+	if email != "" {
+		if _, err := cd.queries.SystemGetUserByEmail(cd.ctx, email); err == nil {
+			return true, nil
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return false, fmt.Errorf("user by email: %w", err)
+		}
+	}
+	return false, nil
+}
+
+// CreateUserWithEmail inserts a user with the supplied username, email and
+// password hash/algorithm, returning the new user ID.
+func (cd *CoreData) CreateUserWithEmail(u, e, hash, alg string) (int32, error) {
+	if cd.queries == nil {
+		return 0, errors.New("no queries")
+	}
+	id, err := cd.queries.SystemInsertUser(cd.ctx, sql.NullString{String: u, Valid: u != ""})
+	if err != nil {
+		return 0, err
+	}
+	uid := int32(id)
+	if err := cd.queries.InsertUserEmail(cd.ctx, db.InsertUserEmailParams{UserID: uid, Email: e, VerifiedAt: sql.NullTime{}, LastVerificationCode: sql.NullString{}}); err != nil {
+		return 0, err
+	}
+	if err := cd.queries.InsertPassword(cd.ctx, db.InsertPasswordParams{UsersIdusers: uid, Passwd: hash, PasswdAlgorithm: sql.NullString{String: alg, Valid: alg != ""}}); err != nil {
+		return 0, err
+	}
+	return uid, nil
+}
+
 // RegisterExternalLinkClick records click statistics for url.
 func (cd *CoreData) RegisterExternalLinkClick(url string) {
 	if cd.queries == nil {


### PR DESCRIPTION
## Summary
- add UserExists and CreateUserWithEmail helpers to CoreData
- use new CoreData helpers in registration flow

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68953564b020832fa47924978fd6648e