### PR TITLE
Add CoreData helper for deleting FAQ questions

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1646,6 +1646,14 @@ func (cd *CoreData) PublicWritings(categoryID int32, r *http.Request) ([]*db.Lis
 // Queries returns the db.Queries instance associated with this CoreData.
 func (cd *CoreData) Queries() db.Querier { return cd.queries }
 
+// DeleteFAQQuestion removes a FAQ entry by ID.
+func (cd *CoreData) DeleteFAQQuestion(id int32) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.AdminDeleteFAQ(cd.ctx, id)
+}
+
 // RegisterExternalLinkClick records click statistics for url.
 func (cd *CoreData) RegisterExternalLinkClick(url string) {
 	if cd.queries == nil {

--- a/handlers/faq/delete_question_task.go
+++ b/handlers/faq/delete_question_task.go
@@ -28,9 +28,8 @@ func (DeleteQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("faq id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
 
-	if err := queries.AdminDeleteFAQ(r.Context(), int32(faq)); err != nil {
+	if err := cd.DeleteFAQQuestion(int32(faq)); err != nil {
 		return fmt.Errorf("delete faq fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 


### PR DESCRIPTION
## Summary
- add DeleteFAQQuestion method to CoreData
- use new DeleteFAQQuestion helper in DeleteQuestionTask

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689535584e80832fa8f3005147c434ef