### PR TITLE
Add CoreData helper for FAQ question creation

### DIFF
--- a/core/common/faq.go
+++ b/core/common/faq.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"database/sql"
+
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// CreateFAQQuestionParams groups input for CreateFAQQuestion.
+type CreateFAQQuestionParams struct {
+	Question   string
+	Answer     string
+	CategoryID int32
+	WriterID   int32
+	LanguageID int32
+}
+
+// CreateFAQQuestion creates a FAQ question and its initial revision.
+func (cd *CoreData) CreateFAQQuestion(p CreateFAQQuestionParams) (int64, error) {
+	if cd.queries == nil {
+		return 0, nil
+	}
+	res, err := cd.queries.InsertFAQQuestionForWriter(cd.ctx, db.InsertFAQQuestionForWriterParams{
+		Question:   sql.NullString{String: p.Question, Valid: p.Question != ""},
+		Answer:     sql.NullString{String: p.Answer, Valid: p.Answer != ""},
+		CategoryID: p.CategoryID,
+		WriterID:   p.WriterID,
+		LanguageID: p.LanguageID,
+		GranteeID:  sql.NullInt32{Int32: p.WriterID, Valid: p.WriterID != 0},
+	})
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	if err := cd.queries.InsertFAQRevisionForUser(cd.ctx, db.InsertFAQRevisionForUserParams{
+		FaqID:        int32(id),
+		UsersIdusers: p.WriterID,
+		Question:     sql.NullString{String: p.Question, Valid: p.Question != ""},
+		Answer:       sql.NullString{String: p.Answer, Valid: p.Answer != ""},
+		UserID:       sql.NullInt32{Int32: p.WriterID, Valid: p.WriterID != 0},
+		ViewerID:     p.WriterID,
+	}); err != nil {
+		return 0, err
+	}
+	return id, nil
+}


### PR DESCRIPTION
## Summary
- add `CreateFAQQuestion` on `CoreData` to insert a question and its first revision
- use `cd.CreateFAQQuestion` in FAQ create question task instead of raw SQL queries

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68953553ee60832f83a4cd829f106f23