### PR TITLE
Add CoreData CreateLanguage helper

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1280,6 +1280,24 @@ func (cd *CoreData) Languages() ([]*db.Language, error) {
 	})
 }
 
+// CreateLanguage inserts a new language and returns its ID.
+//
+// Parameters:
+//
+//	code - Language code (currently unused).
+//	name - Display name of the language.
+func (cd *CoreData) CreateLanguage(code, name string) (int64, error) {
+	if cd.queries == nil {
+		return 0, nil
+	}
+	_ = code
+	res, err := cd.queries.AdminInsertLanguage(cd.ctx, sql.NullString{String: name, Valid: true})
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
 // LatestNews returns recent news posts with permission data.
 func (cd *CoreData) LatestNews(r *http.Request) ([]*db.GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow, error) {
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))

--- a/handlers/languages/create_language_task.go
+++ b/handlers/languages/create_language_task.go
@@ -1,7 +1,6 @@
 package languages
 
 import (
-	"database/sql"
 	"fmt"
 	"net/http"
 
@@ -30,22 +29,17 @@ func (CreateLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 			handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		})
 	}
-	queries := cd.Queries()
 	cname := r.PostFormValue("cname")
-	res, err := queries.AdminInsertLanguage(r.Context(), sql.NullString{String: cname, Valid: true})
+	id, err := cd.CreateLanguage("", cname)
 	if err != nil {
 		return fmt.Errorf("create language fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if id, err := res.LastInsertId(); err == nil {
-		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-			if evt := cd.Event(); evt != nil {
-				if evt.Data == nil {
-					evt.Data = map[string]any{}
-				}
-				evt.Data["LanguageID"] = id
-				evt.Data["LanguageName"] = cname
-			}
+	if evt := cd.Event(); evt != nil {
+		if evt.Data == nil {
+			evt.Data = map[string]any{}
 		}
+		evt.Data["LanguageID"] = id
+		evt.Data["LanguageName"] = cname
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- add CoreData.CreateLanguage to wrap language insert and return new ID
- use CoreData.CreateLanguage in admin language creation task instead of direct query

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895351f7a28832fa56e6e7f0e53e6bf