### PR TITLE
Add CoreData password reset helper

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -3,7 +3,9 @@ package common
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -74,6 +76,9 @@ type NavigationProvider interface {
 }
 
 // No package-level pagination constants as runtime config provides these values.
+
+// ErrPasswordResetRecentlyRequested indicates a password reset was requested too recently.
+var ErrPasswordResetRecentlyRequested = errors.New("reset recently requested")
 
 type CoreData struct {
 	a4codeMapper func(tag, val string) string
@@ -1893,6 +1898,38 @@ func (cd *CoreData) CreateWritingCommentForCommenter(commenterID, threadID, arti
 
 func (cd *CoreData) CreateLinkerCommentForCommenter(commenterID, threadID, linkID, languageID int32, text string) (int64, error) {
 	return cd.CreateCommentInSectionForCommenter("linker", "link", linkID, threadID, commenterID, languageID, text)
+}
+
+// CreatePasswordReset creates a new password reset entry for the given email and returns the verification code.
+func (cd *CoreData) CreatePasswordReset(email, hash, alg string) (string, error) {
+	if cd.queries == nil {
+		return "", nil
+	}
+	row, err := cd.queries.SystemGetUserByEmail(cd.ctx, email)
+	if err != nil {
+		return "", fmt.Errorf("user by email %w", err)
+	}
+	if reset, err := cd.queries.GetPasswordResetByUser(cd.ctx, db.GetPasswordResetByUserParams{
+		UserID:    row.Idusers,
+		CreatedAt: time.Now().Add(-time.Duration(cd.Config.PasswordResetExpiryHours) * time.Hour),
+	}); err == nil {
+		if time.Since(reset.CreatedAt) < 24*time.Hour {
+			return "", ErrPasswordResetRecentlyRequested
+		}
+		_ = cd.queries.SystemDeletePasswordReset(cd.ctx, reset.ID)
+	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		log.Printf("get reset: %v", err)
+		return "", fmt.Errorf("get reset %w", err)
+	}
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("rand %w", err)
+	}
+	code := hex.EncodeToString(buf[:])
+	if err := cd.queries.CreatePasswordResetForUser(cd.ctx, db.CreatePasswordResetForUserParams{UserID: row.Idusers, Passwd: hash, PasswdAlgorithm: alg, VerificationCode: code}); err != nil {
+		return "", fmt.Errorf("create reset %w", err)
+	}
+	return code, nil
 }
 
 // CanEditComment reports whether the current user may edit the supplied

--- a/handlers/auth/forgotPassword_event_test.go
+++ b/handlers/auth/forgotPassword_event_test.go
@@ -28,6 +28,7 @@ func TestForgotPasswordEventData(t *testing.T) {
 	q := db.New(conn)
 	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
+	mock.ExpectQuery("SystemGetUserByEmail").WithArgs("a@test.com").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test.com", "u"))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, passwd")).WithArgs(int32(1), sqlmock.AnyArg()).WillReturnError(sql.ErrNoRows)
 	mock.ExpectExec("INSERT INTO pending_passwords").WillReturnResult(sqlmock.NewResult(1, 1))
 

--- a/handlers/auth/forgotPassword_limit_test.go
+++ b/handlers/auth/forgotPassword_limit_test.go
@@ -28,6 +28,7 @@ func TestForgotPasswordRateLimit(t *testing.T) {
 
 	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
+	mock.ExpectQuery("SystemGetUserByEmail").WithArgs("a@test.com").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test.com", "u"))
 	resetRows := sqlmock.NewRows([]string{"id", "user_id", "passwd", "passwd_algorithm", "verification_code", "created_at", "verified_at"}).
 		AddRow(1, 1, "hash", "alg", "code", time.Now(), nil)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, passwd")).WithArgs(int32(1), sqlmock.AnyArg()).WillReturnRows(resetRows)
@@ -60,6 +61,7 @@ func TestForgotPasswordReplaceOld(t *testing.T) {
 
 	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "a@test.com", "u", nil))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
+	mock.ExpectQuery("SystemGetUserByEmail").WithArgs("a@test.com").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test.com", "u"))
 	oldRows := sqlmock.NewRows([]string{"id", "user_id", "passwd", "passwd_algorithm", "verification_code", "created_at", "verified_at"}).
 		AddRow(1, 1, "hash", "alg", "code", time.Now().Add(-25*time.Hour), nil)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, passwd")).WithArgs(int32(1), sqlmock.AnyArg()).WillReturnRows(oldRows)


### PR DESCRIPTION
## Summary
- add CoreData.CreatePasswordReset and associated error
- refactor forgot-password task to use CoreData helper
- update tests for new helper

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689535680a7c832f993d5dabc88b2bce