### PR TITLE
core: add AssociateEmail helper for email requests

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -73,6 +73,16 @@ type NavigationProvider interface {
 	AdminSections() []AdminSection
 }
 
+// ErrEmailAlreadyAssociated is returned when a user already has an email set.
+var ErrEmailAlreadyAssociated = errors.New("email already associated")
+
+// AssociateEmailParams carries the data required to request an email association.
+type AssociateEmailParams struct {
+	Username string
+	Email    string
+	Reason   string
+}
+
 // No package-level pagination constants as runtime config provides these values.
 
 type CoreData struct {
@@ -1645,6 +1655,33 @@ func (cd *CoreData) PublicWritings(categoryID int32, r *http.Request) ([]*db.Lis
 
 // Queries returns the db.Queries instance associated with this CoreData.
 func (cd *CoreData) Queries() db.Querier { return cd.queries }
+
+// AssociateEmail creates an email association request for a user.
+func (cd *CoreData) AssociateEmail(p AssociateEmailParams) (*db.SystemGetUserByUsernameRow, int64, error) {
+	row, err := cd.queries.SystemGetUserByUsername(cd.ctx, sql.NullString{String: p.Username, Valid: true})
+	if err != nil {
+		return nil, 0, fmt.Errorf("user not found %w", err)
+	}
+	if row.Email != "" {
+		return nil, 0, ErrEmailAlreadyAssociated
+	}
+	res, err := cd.queries.AdminInsertRequestQueue(cd.ctx, db.AdminInsertRequestQueueParams{
+		UsersIdusers:   row.Idusers,
+		ChangeTable:    "user_emails",
+		ChangeField:    "email",
+		ChangeRowID:    row.Idusers,
+		ChangeValue:    sql.NullString{String: p.Email, Valid: true},
+		ContactOptions: sql.NullString{String: p.Email, Valid: true},
+	})
+	if err != nil {
+		log.Printf("insert admin request: %v", err)
+		return nil, 0, fmt.Errorf("insert admin request %w", err)
+	}
+	id, _ := res.LastInsertId()
+	_ = cd.queries.AdminInsertRequestComment(cd.ctx, db.AdminInsertRequestCommentParams{RequestID: int32(id), Comment: p.Reason})
+	_ = cd.queries.InsertAdminUserComment(cd.ctx, db.InsertAdminUserCommentParams{UsersIdusers: row.Idusers, Comment: "email association requested"})
+	return row, id, nil
+}
 
 // RegisterExternalLinkClick records click statistics for url.
 func (cd *CoreData) RegisterExternalLinkClick(url string) {


### PR DESCRIPTION
## Summary
- add `AssociateEmail` on `CoreData` for user email association requests
- use new helper in email association request task

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68953561ee34832f8d4665ef7939d55f