### PR TITLE
Add CoreData FAQ category deletion helper

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1646,6 +1646,14 @@ func (cd *CoreData) PublicWritings(categoryID int32, r *http.Request) ([]*db.Lis
 // Queries returns the db.Queries instance associated with this CoreData.
 func (cd *CoreData) Queries() db.Querier { return cd.queries }
 
+// DeleteFAQCategory removes a FAQ category.
+func (cd *CoreData) DeleteFAQCategory(id int32) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.AdminDeleteFAQCategory(cd.ctx, id)
+}
+
 // RegisterExternalLinkClick records click statistics for url.
 func (cd *CoreData) RegisterExternalLinkClick(url string) {
 	if cd.queries == nil {

--- a/handlers/faq/delete_category_task.go
+++ b/handlers/faq/delete_category_task.go
@@ -28,9 +28,8 @@ func (DeleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("cid parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
 
-	if err := queries.AdminDeleteFAQCategory(r.Context(), int32(cid)); err != nil {
+	if err := cd.DeleteFAQCategory(int32(cid)); err != nil {
 		return fmt.Errorf("delete category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 


### PR DESCRIPTION
## Summary
- add `DeleteFAQCategory` helper to CoreData
- use CoreData helper in FAQ delete category task

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68953542f31c832fa6bb34f3fc9f2070