### PR TITLE
Add CreateFAQCategory to CoreData

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1377,6 +1377,14 @@ func (cd *CoreData) LinkerCategoryCounts() ([]*db.GetLinkerCategoryLinkCountsRow
 	})
 }
 
+// CreateFAQCategory adds a new FAQ category.
+func (cd *CoreData) CreateFAQCategory(name string) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.AdminCreateFAQCategory(cd.ctx, sql.NullString{String: name, Valid: name != ""})
+}
+
 // LinkerItemsForUser returns linker items for the given category and offset respecting viewer permissions.
 func (cd *CoreData) LinkerItemsForUser(catID, offset int32) ([]*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow, error) {
 	if cd.queries == nil {

--- a/handlers/faq/create_category_task.go
+++ b/handlers/faq/create_category_task.go
@@ -1,7 +1,6 @@
 package faq
 
 import (
-	"database/sql"
 	"fmt"
 	"net/http"
 
@@ -25,9 +24,8 @@ func (CreateCategoryTask) Match(r *http.Request, m *mux.RouteMatch) bool {
 func (CreateCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	text := r.PostFormValue("cname")
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
 
-	if err := queries.AdminCreateFAQCategory(r.Context(), sql.NullString{String: text, Valid: true}); err != nil {
+	if err := cd.CreateFAQCategory(text); err != nil {
 		return fmt.Errorf("create category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 


### PR DESCRIPTION
## Summary
- add CreateFAQCategory helper to CoreData
- use CoreData.CreateFAQCategory in FAQ category creation task

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895353c8928832f9b9bb81035a67234