### PR TITLE
Add FAQ category support to ask page

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -149,6 +149,7 @@ type CoreData struct {
 	currentWritingID         int32
 	event                    *eventbus.TaskEvent
 	externalLinks            map[string]*lazy.Value[*db.ExternalLink]
+	faqCategories            lazy.Value[[]*db.FaqCategory]
 	forumCategories          lazy.Value[[]*db.Forumcategory]
 	forumComments            map[int32]*lazy.Value[*db.GetCommentByIdForUserRow]
 	forumThreadComments      map[int32]*lazy.Value[[]*db.GetCommentsByThreadIdForUserRow]
@@ -1075,6 +1076,16 @@ func (cd *CoreData) fetchLatestNews(offset, limit int32) ([]*db.GetNewsPostsWith
 		posts = append(posts, row)
 	}
 	return posts, nil
+}
+
+// FAQCategories returns FAQ categories loaded on demand.
+func (cd *CoreData) FAQCategories() ([]*db.FaqCategory, error) {
+	return cd.faqCategories.Load(func() ([]*db.FaqCategory, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		return cd.queries.AdminGetFAQCategories(cd.ctx)
+	})
 }
 
 // ForumCategories loads all forum categories once.

--- a/core/templates/site/faq/askPage.gohtml
+++ b/core/templates/site/faq/askPage.gohtml
@@ -3,6 +3,14 @@
         <form method="post" action="">
         {{ csrfField }}
             <textarea name="text" cols="60" rows="20"></textarea><br>
+            Please select a category:
+            <select name="category">
+                {{- range (cd).FAQCategories }}
+                    <option value="{{ .Idfaqcategories }}">{{ .Name.String }}</option>
+                {{- else }}
+                    <option disabled>No categories</option>
+                {{- end }}
+            </select><br>
             {{ template "languageCombobox" }}
             <input type="submit" name="task" value="Ask">
         </form>

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -59,6 +59,11 @@ func (AskTask) Page(w http.ResponseWriter, r *http.Request) {
 	}
 	data.Languages = languageRows
 
+	if _, err := cd.FAQCategories(); err != nil {
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
+		return
+	}
+
 	handlers.TemplateHandler(w, r, "askPage.gohtml", data)
 }
 


### PR DESCRIPTION
## Summary
- add lazy-loaded FAQCategories accessor to CoreData
- preload FAQ categories in ask task and show category dropdown

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(hangs: no output)*
- `golangci-lint run` *(hangs: no output)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895353abbf4832fa79cca13c690dc4c