### PR TITLE
Refactor FAQ retrieval into CoreData AllAnsweredFAQ

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -120,6 +120,7 @@ type CoreData struct {
 	adminUserGrants          map[int32]*lazy.Value[[]*db.Grant]
 	adminUserRoles           map[int32]*lazy.Value[[]*db.GetPermissionsByUserIDRow]
 	adminUserStats           map[int32]*lazy.Value[*db.AdminUserPostCountsByIDRow]
+	allAnsweredFAQ           lazy.Value[[]*CategoryFAQs]
 	allRoles                 lazy.Value[[]*db.Role]
 	annMu                    sync.Mutex
 	announcement             lazy.Value[*db.GetActiveAnnouncementWithNewsForListerRow]

--- a/core/common/faq.go
+++ b/core/common/faq.go
@@ -1,0 +1,64 @@
+package common
+
+import (
+	"database/sql"
+	"errors"
+	"log"
+
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// FAQ represents a single FAQ entry grouped by category.
+type FAQ struct {
+	CategoryID int
+	Question   string
+	Answer     string
+}
+
+// CategoryFAQs groups FAQ entries under a single category.
+type CategoryFAQs struct {
+	Category *db.GetAllAnsweredFAQWithFAQCategoriesForUserRow
+	FAQs     []*FAQ
+}
+
+// AllAnsweredFAQ returns answered FAQ entries grouped by category for the
+// current user. Results are cached for the lifetime of the CoreData instance.
+func (cd *CoreData) AllAnsweredFAQ() ([]*CategoryFAQs, error) {
+	return cd.allAnsweredFAQ.Load(func() ([]*CategoryFAQs, error) {
+		if cd.queries == nil {
+			return nil, nil
+		}
+		faqRows, err := cd.queries.GetAllAnsweredFAQWithFAQCategoriesForUser(cd.ctx, db.GetAllAnsweredFAQWithFAQCategoriesForUserParams{
+			ViewerID: cd.UserID,
+			UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, nil
+			}
+			log.Printf("getAllAnsweredFAQWithFAQCategories Error: %s", err)
+			return nil, err
+		}
+		var (
+			result  []*CategoryFAQs
+			current CategoryFAQs
+		)
+		for _, row := range faqRows {
+			if current.Category == nil || current.Category.Idfaqcategories.Int32 != row.Idfaqcategories.Int32 {
+				if current.Category != nil && current.Category.Idfaqcategories.Int32 != 0 {
+					result = append(result, &current)
+				}
+				current = CategoryFAQs{Category: row}
+			}
+			current.FAQs = append(current.FAQs, &FAQ{
+				CategoryID: int(row.Idfaqcategories.Int32),
+				Question:   row.Question.String,
+				Answer:     row.Answer.String,
+			})
+		}
+		if current.Category != nil && current.Category.Idfaqcategories.Int32 != 0 {
+			result = append(result, &current)
+		}
+		return result, nil
+	})
+}

--- a/core/templates/site/faq/page.gohtml
+++ b/core/templates/site/faq/page.gohtml
@@ -1,6 +1,6 @@
 {{ define "faqPage" }}
     {{ template "head" $ }}
-    {{ range $index, $categoryFAQs := .FAQ }}
+    {{ range $index, $categoryFAQs := (cd).AllAnsweredFAQ }}
         <font size="5">Section: {{ $categoryFAQs.Category.Name.String }}</font><br>
         <table width="100%">
         {{ range $index, $faq := $categoryFAQs.FAQs }}

--- a/handlers/faq/page.go
+++ b/handlers/faq/page.go
@@ -1,73 +1,24 @@
 package faq
 
 import (
-	"database/sql"
-	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/core/consts"
-	"log"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 )
 
 func Page(w http.ResponseWriter, r *http.Request) {
-	type FAQ struct {
-		CategoryID int
-		Question   string
-		Answer     string
-	}
-
-	type CategoryFAQs struct {
-		Category *db.GetAllAnsweredFAQWithFAQCategoriesForUserRow
-		FAQs     []*FAQ
-	}
-
-	type Data struct {
-		FAQ []*CategoryFAQs
-	}
-
-	data := Data{}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "FAQ"
 
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-
-	var currentCategoryFAQs CategoryFAQs
-
-	faqRows, err := queries.GetAllAnsweredFAQWithFAQCategoriesForUser(r.Context(), db.GetAllAnsweredFAQWithFAQCategoriesForUserParams{
-		ViewerID: cd.UserID,
-		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-	})
-	if err != nil {
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-		default:
-			log.Printf("getAllAnsweredFAQWithFAQCategories Error: %s", err)
-			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
-			return
-		}
+	if _, err := cd.AllAnsweredFAQ(); err != nil {
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
+		return
 	}
 
-	for _, row := range faqRows {
-		if currentCategoryFAQs.Category == nil || currentCategoryFAQs.Category.Idfaqcategories.Int32 != row.Idfaqcategories.Int32 {
-			if currentCategoryFAQs.Category != nil && currentCategoryFAQs.Category.Idfaqcategories.Int32 != 0 {
-				data.FAQ = append(data.FAQ, &currentCategoryFAQs)
-			}
-			currentCategoryFAQs = CategoryFAQs{Category: row}
-		}
-		currentCategoryFAQs.FAQs = append(currentCategoryFAQs.FAQs, &FAQ{CategoryID: int(row.Idfaqcategories.Int32), Question: row.Question.String, Answer: row.Answer.String})
-	}
-
-	if currentCategoryFAQs.Category != nil && currentCategoryFAQs.Category.Idfaqcategories.Int32 != 0 {
-		data.FAQ = append(data.FAQ, &currentCategoryFAQs)
-	}
-
-	// index links provided via middleware
-
-	handlers.TemplateHandler(w, r, "faqPage", data)
+	handlers.TemplateHandler(w, r, "faqPage", cd)
 }
 
 func CustomFAQIndex(data *common.CoreData, r *http.Request) {

--- a/handlers/template_render_test.go
+++ b/handlers/template_render_test.go
@@ -42,10 +42,7 @@ func TestPageTemplatesRender(t *testing.T) {
 		data any
 	}{
 		{"newsPage", struct{}{}},
-		{"faqPage", struct {
-			*common.CoreData
-			FAQ any
-		}{&common.CoreData{}, nil}},
+		{"faqPage", struct{ *common.CoreData }{&common.CoreData{}}},
 		{"userPage", struct{ *common.CoreData }{&common.CoreData{}}},
 		{"linkerPage", struct {
 			*common.CoreData


### PR DESCRIPTION
## Summary
- add CoreData.AllAnsweredFAQ for grouped FAQ retrieval
- simplify FAQ handler to rely on CoreData method
- update FAQ template and tests to use cd.AllAnsweredFAQ

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./... && echo VETDONE`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68953536c3f4832f94f1ee9ce5aed95e