### PR TITLE
feat: add bookmark saving to coredata

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -502,6 +502,19 @@ func (cd *CoreData) Bookmarks() (*db.GetBookmarksForUserRow, error) {
 	})
 }
 
+// SaveBookmark persists the user's bookmark list and updates the cache.
+func (cd *CoreData) SaveBookmark(p db.UpdateBookmarksForListerParams) error {
+	if cd.queries == nil {
+		return nil
+	}
+	if err := cd.queries.UpdateBookmarksForLister(cd.ctx, p); err != nil {
+		return err
+	}
+	cd.bookmarks = lazy.Value[*db.GetBookmarksForUserRow]{}
+	cd.bookmarks.Set(&db.GetBookmarksForUserRow{List: p.List})
+	return nil
+}
+
 // IsAdmin reports whether the current user has the administrator role.
 func (cd *CoreData) IsAdmin() bool {
 	return cd.HasRole("administrator")

--- a/handlers/bookmarks/saveTask.go
+++ b/handlers/bookmarks/saveTask.go
@@ -34,14 +34,14 @@ func EditPage(w http.ResponseWriter, r *http.Request) {
 
 func (SaveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	if err := queries.UpdateBookmarksForLister(r.Context(), db.UpdateBookmarksForListerParams{
+	if err := cd.SaveBookmark(db.UpdateBookmarksForListerParams{
 		List: sql.NullString{
 			String: text,
 			Valid:  true,


### PR DESCRIPTION
## Summary
- add SaveBookmark to CoreData with lazy caching
- use CoreData.SaveBookmark in bookmarks SaveTask

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./core/... ./handlers/bookmarks/...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895351ba828832f85c2f0e51b96345f