### PR TITLE
Add CoreData helper for removing FAQ questions

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1646,6 +1646,22 @@ func (cd *CoreData) PublicWritings(categoryID int32, r *http.Request) ([]*db.Lis
 // Queries returns the db.Queries instance associated with this CoreData.
 func (cd *CoreData) Queries() db.Querier { return cd.queries }
 
+// SelectedQuestionFromCategory deletes the specified FAQ question after
+// verifying it belongs to the provided category.
+func (cd *CoreData) SelectedQuestionFromCategory(questionID, categoryID int32) error {
+	if cd.queries == nil {
+		return fmt.Errorf("queries not available")
+	}
+	question, err := cd.queries.AdminGetFAQByID(cd.ctx, questionID)
+	if err != nil {
+		return err
+	}
+	if question.FaqcategoriesIdfaqcategories != categoryID {
+		return fmt.Errorf("question %d not in category %d", questionID, categoryID)
+	}
+	return cd.queries.AdminDeleteFAQ(cd.ctx, questionID)
+}
+
 // RegisterExternalLinkClick records click statistics for url.
 func (cd *CoreData) RegisterExternalLinkClick(url string) {
 	if cd.queries == nil {

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -357,3 +357,52 @@ func TestBlogListForSelectedAuthorLazy(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 }
+
+func TestSelectedQuestionFromCategory(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	queries := db.New(conn)
+	ctx := context.Background()
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+
+	row := sqlmock.NewRows([]string{"idfaq", "faqcategories_idfaqcategories", "language_idlanguage", "users_idusers", "answer", "question"}).
+		AddRow(1, 2, 0, 0, sql.NullString{}, sql.NullString{})
+	mock.ExpectQuery("SELECT idfaq, faqcategories_idfaqcategories").WithArgs(int32(1)).WillReturnRows(row)
+	mock.ExpectExec("UPDATE faq SET deleted_at").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := cd.SelectedQuestionFromCategory(1, 2); err != nil {
+		t.Fatalf("SelectedQuestionFromCategory: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSelectedQuestionFromCategoryWrongCategory(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	queries := db.New(conn)
+	ctx := context.Background()
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+
+	row := sqlmock.NewRows([]string{"idfaq", "faqcategories_idfaqcategories", "language_idlanguage", "users_idusers", "answer", "question"}).
+		AddRow(1, 3, 0, 0, sql.NullString{}, sql.NullString{})
+	mock.ExpectQuery("SELECT idfaq, faqcategories_idfaqcategories").WithArgs(int32(1)).WillReturnRows(row)
+
+	if err := cd.SelectedQuestionFromCategory(1, 2); err == nil {
+		t.Fatalf("expected error")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/handlers/faq/remove_question_task.go
+++ b/handlers/faq/remove_question_task.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// RemoveQuestionTask deletes a question from the FAQ list.
+// RemoveQuestionTask removes a question from a FAQ category.
 type RemoveQuestionTask struct{ tasks.TaskString }
 
 var removeQuestionTask = &RemoveQuestionTask{TaskString: TaskRemoveRemove}
@@ -24,14 +24,17 @@ func (RemoveQuestionTask) Match(req *http.Request, m *mux.RouteMatch) bool {
 }
 
 func (RemoveQuestionTask) Action(w http.ResponseWriter, r *http.Request) any {
-	faq, err := strconv.Atoi(r.PostFormValue("faq"))
+	questionID, err := strconv.Atoi(r.PostFormValue("faq"))
 	if err != nil {
 		return fmt.Errorf("faq id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
+	categoryID, err := strconv.Atoi(r.PostFormValue("cid"))
+	if err != nil {
+		return fmt.Errorf("cid parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	queries := cd.Queries()
 
-	if err := queries.AdminDeleteFAQ(r.Context(), int32(faq)); err != nil {
+	if err := cd.SelectedQuestionFromCategory(int32(questionID), int32(categoryID)); err != nil {
 		return fmt.Errorf("delete faq fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 


### PR DESCRIPTION
## Summary
- rename CoreData.RemoveQuestionFromCategory to SelectedQuestionFromCategory
- use renamed helper in RemoveQuestionTask and update variable names
- adjust unit tests accordingly

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895355aabec832fbeb3a42b699e95a3