### PR TITLE
Use CoreData for login credentials and errors

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -2007,6 +2007,10 @@ func (cd *CoreData) SetCurrentTemplate(name, errMsg string) {
 	cd.currentTemplateError = errMsg
 }
 
+// SetTemplateError stores an error message for template rendering without changing
+// the current template name.
+func (cd *CoreData) SetTemplateError(errMsg string) { cd.currentTemplateError = errMsg }
+
 // SetCurrentThreadAndTopic stores the requested thread and topic IDs.
 func (cd *CoreData) SetCurrentThreadAndTopic(threadID, topicID int32) {
 	cd.currentThreadID = threadID
@@ -2202,6 +2206,14 @@ func (cd *CoreData) UnreadNotificationCount() int64 {
 		log.Printf("load unread notification count: %v", err)
 	}
 	return count
+}
+
+// UserCredentials fetches the stored password hash and algorithm for username.
+func (cd *CoreData) UserCredentials(username string) (*db.SystemGetLoginRow, error) {
+	if cd.queries == nil {
+		return nil, fmt.Errorf("no queries available")
+	}
+	return cd.queries.SystemGetLogin(cd.ctx, sql.NullString{String: username, Valid: true})
 }
 
 // UserByID loads a user record by ID once and caches it.

--- a/core/templates/site/loginPage.gohtml
+++ b/core/templates/site/loginPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
-    {{- if $.Error }}
-    <p style="color:red">{{ $.Error }}</p>
+    {{- if cd.TemplateError }}
+    <p style="color:red">{{ cd.TemplateError }}</p>
     {{- end }}
     Login:<br>
     <form method="post">

--- a/handlers/auth/loginPage.go
+++ b/handlers/auth/loginPage.go
@@ -52,8 +52,9 @@ func (h redirectBackPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 var _ http.Handler = (*redirectBackPageHandler)(nil)
 
 func renderLoginForm(w http.ResponseWriter, r *http.Request, errMsg string) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.SetTemplateError(errMsg)
 	type Data struct {
-		Error   string
 		Code    string
 		Back    string
 		BackSig string
@@ -63,9 +64,8 @@ func renderLoginForm(w http.ResponseWriter, r *http.Request, errMsg string) {
 	}
 	handlers.SetPageTitle(r, "Login")
 	data := Data{
-		Error:   errMsg,
 		Code:    r.FormValue("code"),
-		Back:    r.Context().Value(consts.KeyCoreData).(*common.CoreData).SanitizeBackURL(r, r.FormValue("back")),
+		Back:    cd.SanitizeBackURL(r, r.FormValue("back")),
 		BackSig: r.FormValue("back_sig"),
 		BackTS:  r.FormValue("back_ts"),
 		Method:  r.FormValue("method"),

--- a/handlers/auth/login_task.go
+++ b/handlers/auth/login_task.go
@@ -61,7 +61,7 @@ func (LoginTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 
-	row, err := queries.SystemGetLogin(r.Context(), sql.NullString{String: username, Valid: true})
+	row, err := cd.UserCredentials(username)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			if err := queries.SystemInsertLoginAttempt(r.Context(), db.SystemInsertLoginAttemptParams{Username: username, IpAddress: strings.Split(r.RemoteAddr, ":")[0]}); err != nil {


### PR DESCRIPTION
## Summary
- add CoreData.UserCredentials to look up a user's stored password hash and algorithm
- leverage cd.UserCredentials in login_task for authentication
- surface login errors via CoreData and update login template to read cd.TemplateError
- add CoreData.SetTemplateError and use it in the login form

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895355fc27c832f99fdf99824362281