### PR TITLE
Group admin grant actions into pills

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -216,6 +216,10 @@ div.title {
         background: #ffcdd2;
 }
 
+.pill.inactive {
+        background: #ffcdd2;
+}
+
 .pill.unsupported {
         background: #d1c4e9;
 }

--- a/core/templates/site/admin/grantsPage.gohtml
+++ b/core/templates/site/admin/grantsPage.gohtml
@@ -1,18 +1,15 @@
 {{ template "head" $ }}
 <p><a href="/admin/grant/add">Add grant</a></p>
 <table border="1">
-    <tr><th>ID</th><th>User</th><th>Role</th><th>Section</th><th>Item</th><th>Item ID</th><th>Action</th><th>Active</th><th>Edit</th></tr>
+    <tr><th>User</th><th>Role</th><th>Section</th><th>Item</th><th>Item ID</th><th>Actions</th></tr>
     {{- range .Grants }}
     <tr>
-        <td><a href="/admin/grant/{{ .Grant.ID }}">{{ .Grant.ID }}</a></td>
-<td>{{ if .Grant.UserID.Valid }}<a href="/admin/user/{{ .Grant.UserID.Int32 }}">{{ .UserName }} ({{ .Grant.UserID.Int32 }})</a>{{ else if not .Grant.RoleID.Valid }}<a href="/admin/grants/anyone">{{ .UserName }}</a>{{ end }}</td>
-        <td>{{ if .Grant.RoleID.Valid }}<a href="/admin/role/{{ .Grant.RoleID.Int32 }}">{{ .RoleName }} ({{ .Grant.RoleID.Int32 }})</a>{{ end }}</td>
+        <td>{{ if .Grant.UserID.Valid }}<a href="/admin/user/{{ .Grant.UserID.Int32 }}">{{ .UserName }} ({{ .Grant.UserID.Int32 }})</a>{{ else if not .Grant.RoleID.Valid }}<a href="/admin/grants/anyone">{{ .UserName }}</a>{{ end }}</td>
+        <td>{{ if .Grant.RoleID.Valid }}<a href="/admin/role/{{ .Grant.RoleID.Int32 }}">{{ .RoleName }} ({{ .Grant.RoleID.Int32}})</a>{{ end }}</td>
         <td>{{ .Grant.Section }}</td>
         <td>{{ if .ItemLink }}<a href="{{ .ItemLink }}">{{ .Grant.Item.String }}</a>{{ else }}{{ .Grant.Item.String }}{{ end }}</td>
         <td>{{ if .Grant.ItemID.Valid }}{{ if .ItemLink }}<a href="{{ .ItemLink }}">{{ .Grant.ItemID.Int32 }}</a>{{ else }}{{ .Grant.ItemID.Int32 }}{{ end }}{{ end }}</td>
-        <td>{{ .Grant.Action }}</td>
-        <td>{{ if .Grant.Active }}yes{{ else }}no{{ end }}</td>
-        <td><a href="/admin/grant/{{ .Grant.ID }}">Edit</a></td>
+        <td>{{- range .Actions }}<a href="/admin/grant/{{ .ID }}" class="pill{{ if not .Active }} inactive{{ end }}">{{ .Name }}</a>{{ end }}</td>
     </tr>
     {{- end }}
 </table>

--- a/handlers/admin/adminGrantsPage_test.go
+++ b/handlers/admin/adminGrantsPage_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 )
 
-func TestAdminAnyoneGrantsPage(t *testing.T) {
+func TestAdminGrantsPageGroupsActions(t *testing.T) {
 	sqlDB, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
@@ -25,17 +25,24 @@ func TestAdminAnyoneGrantsPage(t *testing.T) {
 	queries := db.New(sqlDB)
 
 	grantsRows := sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}).
-		AddRow(1, nil, nil, nil, nil, "forum", "", "allow", nil, nil, "search", nil, true)
+		AddRow(1, nil, nil, 5, 7, "forum", "topic", "allow", 42, nil, "search", nil, true).
+		AddRow(2, nil, nil, 5, 7, "forum", "topic", "allow", 42, nil, "view", nil, true)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants ORDER BY id")).WillReturnRows(grantsRows)
 
-	req := httptest.NewRequest("GET", "/admin/grants/anyone", nil)
+	userRows := sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(5, nil, "bob", nil)
+	mock.ExpectQuery("SELECT u\\.idusers").WithArgs(5).WillReturnRows(userRows)
+
+	roleRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).AddRow(7, "admin", true, false, nil)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles WHERE id = ?")).WithArgs(7).WillReturnRows(roleRows)
+
+	req := httptest.NewRequest("GET", "/admin/grants", nil)
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()
-	AdminAnyoneGrantsPage(rr, req)
+	AdminGrantsPage(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d", rr.Code)
@@ -44,10 +51,13 @@ func TestAdminAnyoneGrantsPage(t *testing.T) {
 		t.Fatalf("expectations: %v", err)
 	}
 	body := rr.Body.String()
-	if !strings.Contains(body, `<a href="/admin/grants/anyone">Anyone</a>`) {
-		t.Fatalf("missing link: %s", body)
+	if strings.Count(body, `<a href="/admin/user/5">bob (5)</a>`) != 1 {
+		t.Fatalf("expected single user link: %s", body)
 	}
 	if !strings.Contains(body, `<a href="/admin/grant/1" class="pill">search</a>`) {
-		t.Fatalf("missing action pill: %s", body)
+		t.Fatalf("missing search action: %s", body)
+	}
+	if !strings.Contains(body, `<a href="/admin/grant/2" class="pill">view</a>`) {
+		t.Fatalf("missing view action: %s", body)
 	}
 }

--- a/handlers/admin/grants.go
+++ b/handlers/admin/grants.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -21,6 +22,20 @@ type grantWithNames struct {
 	ItemLink string
 }
 
+type grantAction struct {
+	ID     int32
+	Name   string
+	Active bool
+}
+
+type grantGroup struct {
+	*db.Grant
+	UserName string
+	RoleName string
+	ItemLink string
+	Actions  []grantAction
+}
+
 // AdminGrantsPage lists all grants.
 func AdminGrantsPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
@@ -31,33 +46,8 @@ func AdminGrantsPage(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
-	userNames := map[int32]string{}
-	roleNames := map[int32]string{}
-	var rows []grantWithNames
-	for _, g := range grants {
-		gw := grantWithNames{Grant: g}
-		if g.UserID.Valid {
-			if name, ok := userNames[g.UserID.Int32]; ok {
-				gw.UserName = name
-			} else if u, err := queries.SystemGetUserByID(r.Context(), g.UserID.Int32); err == nil && u.Username.Valid {
-				userNames[g.UserID.Int32] = u.Username.String
-				gw.UserName = u.Username.String
-			}
-		} else if !g.RoleID.Valid {
-			gw.UserName = "Anyone"
-		}
-		if g.RoleID.Valid {
-			if name, ok := roleNames[g.RoleID.Int32]; ok {
-				gw.RoleName = name
-			} else if ro, err := queries.AdminGetRoleByID(r.Context(), g.RoleID.Int32); err == nil {
-				roleNames[g.RoleID.Int32] = ro.Name
-				gw.RoleName = ro.Name
-			}
-		}
-		gw.ItemLink = grantItemLink(g)
-		rows = append(rows, gw)
-	}
-	data := struct{ Grants []grantWithNames }{rows}
+	rows := groupGrants(r.Context(), queries, grants)
+	data := struct{ Grants []grantGroup }{rows}
 	handlers.TemplateHandler(w, r, "grantsPage.gohtml", data)
 }
 
@@ -71,15 +61,15 @@ func AdminAnyoneGrantsPage(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
-	var rows []grantWithNames
+	var filtered []*db.Grant
 	for _, g := range grants {
 		if g.UserID.Valid || g.RoleID.Valid {
 			continue
 		}
-		gw := grantWithNames{Grant: g, UserName: "Anyone", ItemLink: grantItemLink(g)}
-		rows = append(rows, gw)
+		filtered = append(filtered, g)
 	}
-	data := struct{ Grants []grantWithNames }{rows}
+	rows := groupGrants(r.Context(), queries, filtered)
+	data := struct{ Grants []grantGroup }{rows}
 	handlers.TemplateHandler(w, r, "grantsPage.gohtml", data)
 }
 
@@ -154,4 +144,64 @@ func grantItemLink(g *db.Grant) string {
 		}
 	}
 	return ""
+}
+
+func groupGrants(ctx context.Context, queries db.Querier, grants []*db.Grant) []grantGroup {
+	userNames := map[int32]string{}
+	roleNames := map[int32]string{}
+	groups := []*grantGroup{}
+	groupMap := map[string]*grantGroup{}
+	for _, g := range grants {
+		key := groupKey(g)
+		grp, ok := groupMap[key]
+		if !ok {
+			grp = &grantGroup{Grant: g, ItemLink: grantItemLink(g)}
+			if g.UserID.Valid {
+				if name, ok := userNames[g.UserID.Int32]; ok {
+					grp.UserName = name
+				} else if u, err := queries.SystemGetUserByID(ctx, g.UserID.Int32); err == nil && u.Username.Valid {
+					userNames[g.UserID.Int32] = u.Username.String
+					grp.UserName = u.Username.String
+				}
+			} else if !g.RoleID.Valid {
+				grp.UserName = "Anyone"
+			}
+			if g.RoleID.Valid {
+				if name, ok := roleNames[g.RoleID.Int32]; ok {
+					grp.RoleName = name
+				} else if ro, err := queries.AdminGetRoleByID(ctx, g.RoleID.Int32); err == nil {
+					roleNames[g.RoleID.Int32] = ro.Name
+					grp.RoleName = ro.Name
+				}
+			}
+			groupMap[key] = grp
+			groups = append(groups, grp)
+		}
+		grp.Actions = append(grp.Actions, grantAction{ID: g.ID, Name: g.Action, Active: g.Active})
+	}
+	res := make([]grantGroup, len(groups))
+	for i, g := range groups {
+		res[i] = *g
+	}
+	return res
+}
+
+func groupKey(g *db.Grant) string {
+	user := ""
+	if g.UserID.Valid {
+		user = strconv.Itoa(int(g.UserID.Int32))
+	}
+	role := ""
+	if g.RoleID.Valid {
+		role = strconv.Itoa(int(g.RoleID.Int32))
+	}
+	item := ""
+	if g.Item.Valid {
+		item = g.Item.String
+	}
+	itemID := ""
+	if g.ItemID.Valid {
+		itemID = strconv.Itoa(int(g.ItemID.Int32))
+	}
+	return fmt.Sprintf("%s|%s|%s|%s|%s", user, role, g.Section, item, itemID)
 }


### PR DESCRIPTION
## Summary
- group grants by user/role/section/item and render actions as pill links
- style inactive grant pills
- test grouped display

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68953651c7dc832fa0a13a25ccb4ac9f