### PR TITLE
Add grant detection rules page

### DIFF
--- a/core/templates/site/admin/grantRulesPage.gohtml
+++ b/core/templates/site/admin/grantRulesPage.gohtml
@@ -1,0 +1,22 @@
+{{ template "head" $ }}
+<h1>Grant Config Detection Rules</h1>
+<form method="get" action="/admin/grants/rules">
+  <label><input type="checkbox" name="include_admin" value="1" {{ if .IncludeAdmin }}checked{{ end }}>Include administrator as a user</label>
+  <input type="submit" value="Refresh">
+</form>
+{{ if .Topics }}
+<ul>
+  {{ range .Topics }}
+  <li>{{ .Title }} (ID {{ .ID }})
+    <form method="post" action="/admin/grants/rules" style="display:inline">
+      <input type="hidden" name="task" value="{{ $.TaskName }}">
+      <input type="hidden" name="topic_id" value="{{ .ID }}">
+      <input type="submit" value="Convert to private">
+    </form>
+  </li>
+  {{ end }}
+</ul>
+{{ else }}
+<p>No topics found.</p>
+{{ end }}
+{{ template "tail" $ }}

--- a/handlers/admin/forum_topic_private_task.go
+++ b/handlers/admin/forum_topic_private_task.go
@@ -1,0 +1,39 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// ConvertTopicToPrivateTask switches a forum topic to the private handler.
+type ConvertTopicToPrivateTask struct{ tasks.TaskString }
+
+var convertTopicToPrivateTask = &ConvertTopicToPrivateTask{TaskString: TaskForumTopicConvertPrivate}
+
+var _ tasks.Task = (*ConvertTopicToPrivateTask)(nil)
+
+func (ConvertTopicToPrivateTask) Action(w http.ResponseWriter, r *http.Request) any {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	tidStr := r.PostFormValue("topic_id")
+	tid, err := strconv.Atoi(tidStr)
+	if err != nil {
+		return fmt.Errorf("topic id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	if err := cd.Queries().SystemSetForumTopicHandlerByID(r.Context(), db.SystemSetForumTopicHandlerByIDParams{
+		Handler: "private",
+		ID:      int32(tid),
+	}); err != nil {
+		return fmt.Errorf("update topic handler %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	return handlers.RefreshDirectHandler{TargetURL: "/admin/grants/rules"}
+}

--- a/handlers/admin/grantRulesPage.go
+++ b/handlers/admin/grantRulesPage.go
@@ -1,0 +1,44 @@
+package admin
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+)
+
+type grantRuleTopic struct {
+	ID    int32
+	Title string
+}
+
+// AdminGrantRulesPage lists forum topics that only have user grants.
+func AdminGrantRulesPage(w http.ResponseWriter, r *http.Request) {
+	type Data struct {
+		IncludeAdmin bool
+		Topics       []*grantRuleTopic
+		TaskName     string
+	}
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.PageTitle = "Grant Config Rules"
+	includeAdmin := r.URL.Query().Get("include_admin") == "1"
+	rows, err := cd.Queries().AdminListTopicsWithUserGrantsNoRoles(r.Context(), includeAdmin)
+	if err != nil {
+		log.Printf("list topics with user grants: %v", err)
+		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
+		return
+	}
+	topics := make([]*grantRuleTopic, 0, len(rows))
+	for _, row := range rows {
+		title := ""
+		if row.Title.Valid {
+			title = row.Title.String
+		}
+		topics = append(topics, &grantRuleTopic{ID: row.Idforumtopic, Title: title})
+	}
+	data := Data{IncludeAdmin: includeAdmin, Topics: topics, TaskName: string(TaskForumTopicConvertPrivate)}
+	handlers.TemplateHandler(w, r, "grantRulesPage.gohtml", data)
+}

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -28,6 +28,7 @@ import (
 func (h *Handlers) RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
 	navReg.RegisterAdminControlCenter("Core", "Roles", "/admin/roles", 25)
 	navReg.RegisterAdminControlCenter("Core", "Grants", "/admin/grants", 27)
+	navReg.RegisterAdminControlCenter("Core", "Grant Rules", "/admin/grants/rules", 28)
 	navReg.RegisterAdminControlCenter("Core", "External Links", "/admin/external-links", 30)
 	navReg.RegisterAdminControlCenter("Core", "Notifications", "/admin/notifications", 90)
 	navReg.RegisterAdminControlCenter("Core", "Queued Emails", "/admin/email/queue", 110)
@@ -101,6 +102,8 @@ func (h *Handlers) RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navRe
 	ar.HandleFunc("/role/{role}/grant", handlers.TaskHandler(roleGrantCreateTask)).Methods("POST").MatcherFunc(roleGrantCreateTask.Matcher())
 	ar.HandleFunc("/role/{role}/grant/update", handlers.TaskHandler(roleGrantUpdateTask)).Methods("POST").MatcherFunc(roleGrantUpdateTask.Matcher())
 	ar.HandleFunc("/grant/delete", handlers.TaskHandler(roleGrantDeleteTask)).Methods("POST").MatcherFunc(roleGrantDeleteTask.Matcher())
+	ar.HandleFunc("/grants/rules", AdminGrantRulesPage).Methods("GET")
+	ar.HandleFunc("/grants/rules", handlers.TaskHandler(convertTopicToPrivateTask)).Methods("POST").MatcherFunc(convertTopicToPrivateTask.Matcher())
 	ar.HandleFunc("/grants/anyone", AdminAnyoneGrantsPage).Methods("GET")
 	ar.HandleFunc("/grants", AdminGrantsPage).Methods("GET")
 	ar.HandleFunc("/grant/add", adminGrantAddPage).Methods("GET")

--- a/handlers/admin/tasks.go
+++ b/handlers/admin/tasks.go
@@ -90,6 +90,9 @@ const (
 	// TaskForumTopicDelete removes a forum topic.
 	TaskForumTopicDelete tasks.TaskString = "Forum topic delete"
 
+	// TaskForumTopicConvertPrivate converts a forum topic to a private forum.
+	TaskForumTopicConvertPrivate tasks.TaskString = "Forum topic convert private"
+
 	// TaskForumThreadDelete removes a forum thread.
 	TaskForumThreadDelete tasks.TaskString = "Forum thread delete"
 

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -143,6 +143,7 @@ type Querier interface {
 	// admin task
 	AdminListSentEmails(ctx context.Context, arg AdminListSentEmailsParams) ([]*AdminListSentEmailsRow, error)
 	AdminListSessions(ctx context.Context) ([]*AdminListSessionsRow, error)
+	AdminListTopicsWithUserGrantsNoRoles(ctx context.Context, includeAdmin interface{}) ([]*AdminListTopicsWithUserGrantsNoRolesRow, error)
 	// admin task
 	AdminListUnsentPendingEmails(ctx context.Context, arg AdminListUnsentPendingEmailsParams) ([]*AdminListUnsentPendingEmailsRow, error)
 	// Admin


### PR DESCRIPTION
## Summary
- add admin page to list forum topics with only user grants
- allow converting these topics to private forums through a task
- register navigation and routes for grant rule management

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895376acf28832fa57e49e5cdd32471