### PR TITLE
Wrap forum topic actions to display inline

### DIFF
--- a/core/templates/site/forum/topicsPage.gohtml
+++ b/core/templates/site/forum/topicsPage.gohtml
@@ -4,13 +4,15 @@
         {{ template "getAllForumCategories" $ }}
     {{ end }}
 
-    <a href="/forum/topic/{{.Topic.Idforumtopic}}/thread">New Thread</a>
-    {{- if and cd.IsAdmin cd.IsAdminMode }} | [<a href="/admin/forum/topics/topic/{{.Topic.Idforumtopic}}/edit">ADMIN</a>]{{ end }}
-    {{- if .Subscribed }} | 
-      <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/unsubscribe" style="display:inline"><input type="hidden" name="task" value="Unsubscribe From Topic"/><input type="submit" value="Unsubscribe"/></form>
-    {{ else }} | 
-      <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/subscribe" style="display:inline"><input type="hidden" name="task" value="Subscribe To Topic"/><input type="submit" value="Subscribe"/></form>
-    {{ end }}<br />
+    <div>
+        <a href="/forum/topic/{{.Topic.Idforumtopic}}/thread">New Thread</a>
+        {{- if and cd.IsAdmin cd.IsAdminMode }} | [<a href="/admin/forum/topics/topic/{{.Topic.Idforumtopic}}/edit">ADMIN</a>]{{ end }}
+        {{- if .Subscribed }} |
+            <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/unsubscribe" style="display:inline"><input type="hidden" name="task" value="Unsubscribe From Topic"/><input type="submit" value="Unsubscribe"/></form>
+        {{ else }} |
+            <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/subscribe" style="display:inline"><input type="hidden" name="task" value="Subscribe To Topic"/><input type="submit" value="Subscribe"/></form>
+        {{ end }}
+    </div>
 
     {{ template "topicThreads" $ }}
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- Keep "New Thread", admin link, and subscribe/unsubscribe forms on one line by wrapping them in a div

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68956fea13bc832f9ecae3780f92b5c5