### PR TITLE
Link comment timestamps to anchors

### DIFF
--- a/core/templates/comment_test.go
+++ b/core/templates/comment_test.go
@@ -1,0 +1,46 @@
+package templates
+
+import (
+	"bytes"
+	"database/sql"
+	"html/template"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arran4/goa4web/internal/db"
+)
+
+type fakeCD struct{}
+
+func (*fakeCD) CommentEditing(*db.GetCommentsByThreadIdForUserRow) bool       { return false }
+func (*fakeCD) SelectedThreadCanReply() bool                                  { return false }
+func (*fakeCD) CanEditComment(*db.GetCommentsByThreadIdForUserRow) bool       { return false }
+func (*fakeCD) CommentEditURL(*db.GetCommentsByThreadIdForUserRow) string     { return "" }
+func (*fakeCD) CommentEditSaveURL(*db.GetCommentsByThreadIdForUserRow) string { return "" }
+func (*fakeCD) CommentAdminURL(*db.GetCommentsByThreadIdForUserRow) string    { return "" }
+
+func TestCommentTimestampSelfLink(t *testing.T) {
+	funcMap := template.FuncMap{
+		"cd":          func() *fakeCD { return &fakeCD{} },
+		"localTime":   func(t time.Time) time.Time { return t },
+		"a4code2html": func(s string) template.HTML { return template.HTML(s) },
+		"csrfField":   func() template.HTML { return "" },
+	}
+	tmpl := template.Must(template.New("root").Funcs(funcMap).ParseFiles("site/comment.gohtml", "site/languageCombobox.gohtml"))
+	var buf bytes.Buffer
+	cmt := &db.GetCommentsByThreadIdForUserRow{
+		Idcomments:     1,
+		Written:        sql.NullTime{Time: time.Unix(0, 0), Valid: true},
+		Text:           sql.NullString{String: "hi", Valid: true},
+		Posterusername: sql.NullString{String: "alice", Valid: true},
+		IsOwner:        true,
+	}
+	if err := tmpl.ExecuteTemplate(&buf, "comment", cmt); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "id=\"comment-1\" href=\"#comment-1\"") {
+		t.Fatalf("missing comment self-link: %s", out)
+	}
+}

--- a/core/templates/site/comment.gohtml
+++ b/core/templates/site/comment.gohtml
@@ -2,7 +2,7 @@
     {{ $cmt := . }}
     <table width="100%">
         <tr bgcolor="lightgrey">
-            <th>{{ localTime $cmt.Written.Time }}</th>
+            <th><a id="comment-{{ $cmt.Idcomments }}" href="#comment-{{ $cmt.Idcomments }}">{{ localTime $cmt.Written.Time }}</a></th>
         </tr>
         <tr>
             <td>


### PR DESCRIPTION
## Summary
- Link forum comment timestamps to `#comment-<id>` anchors for easy sharing
- Cover comment template with a test ensuring self-link

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68957077ce10832f99284f07927ef5cc