### PR TITLE
Auto-resize textareas to full width

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -6,6 +6,12 @@ body {
         flex-direction: column;
 }
 
+textarea {
+        width: 100%;
+        box-sizing: border-box;
+        overflow-y: hidden;
+}
+
 #bottom {
         flex: none;
 }

--- a/core/templates/assets/pasteimg.js
+++ b/core/templates/assets/pasteimg.js
@@ -12,6 +12,10 @@
         el.setRangeText(text, start, end, 'end');
         return start;
     }
+    function autoSize(el){
+        el.style.height = 'auto';
+        el.style.height = el.scrollHeight + 'px';
+    }
     function handlePaste(e){
         const items = e.clipboardData && e.clipboardData.items;
         if(!items) return;
@@ -23,6 +27,7 @@
                 const id = uuidv4();
                 const placeholder = '[img uploading:'+id+']';
                 const pos = insertAtCaret(e.target, placeholder);
+                autoSize(e.target);
                 const fd = new FormData();
                 fd.append('image', file);
                 fd.append('id', id);
@@ -45,12 +50,15 @@
                         const v = e.target.value;
                         e.target.value = v.substring(0,pos) + v.substring(pos).replace(placeholder, finalText);
                         e.target.setSelectionRange(pos+finalText.length, pos+finalText.length);
+                        autoSize(e.target);
                     } else {
                         e.target.value = e.target.value.replace(placeholder, '');
+                        autoSize(e.target);
                     }
                 };
                 xhr.onerror = function(){
                     e.target.value = e.target.value.replace(placeholder, '');
+                    autoSize(e.target);
                 };
                 xhr.send(fd);
             }
@@ -59,6 +67,10 @@
     window.addEventListener('load', function(){
         document.querySelectorAll('textarea').forEach(function(t){
             t.addEventListener('paste', handlePaste);
+            autoSize(t);
+            t.addEventListener('input', function(){
+                autoSize(this);
+            });
         });
     });
 })();


### PR DESCRIPTION
## Summary
- ensure textareas fill available width
- auto-expand textarea height on input and paste

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689573d1fb60832f86a7cd981ce23ba4