### PR TITLE
Show topic and category heading on forum topic page

### DIFF
--- a/core/templates/site/forum/topicsPage.gohtml
+++ b/core/templates/site/forum/topicsPage.gohtml
@@ -1,7 +1,8 @@
 {{ template "head" $ }}
 
-    {{ if .Categories }}
-        {{ template "getAllForumCategories" $ }}
+    <h1>Topic: {{ .Topic.Title.String }}</h1>
+    {{ if .Category }}
+        <h2>Category: {{ .Category.Title.String }}</h2>
     {{ end }}
 
     <div>

--- a/handlers/forum/forumTopicPage.go
+++ b/handlers/forum/forumTopicPage.go
@@ -90,6 +90,7 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 		data.Categories = []*ForumcategoryPlus{
 			category,
 		}
+		data.Category = category
 	}
 
 	threadRows, err := cd.ForumThreads(int32(topicId))


### PR DESCRIPTION
## Summary
- Drop category summary table on forum topic page and add heading indicating current topic and category
- Populate topic page template data with the category for heading display

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68957399d28c832f8ef875963666d5e8