### PR TITLE
Add breadcrumbs to admin routes

### DIFF
--- a/core/common/breadcrumb.go
+++ b/core/common/breadcrumb.go
@@ -31,6 +31,8 @@ func (cd *CoreData) Breadcrumbs() []Breadcrumb {
 		crumbs, err = cd.linkerBreadcrumbs()
 	case "imagebbs":
 		crumbs, err = cd.imageboardBreadcrumbs()
+	case "admin":
+		crumbs, err = cd.adminBreadcrumbs()
 	default:
 		return nil
 	}
@@ -182,6 +184,44 @@ func (cd *CoreData) imageboardBreadcrumbs() ([]Breadcrumb, error) {
 	}
 	if threadID != 0 {
 		crumbs = append(crumbs, Breadcrumb{Title: fmt.Sprintf("Thread %d", threadID)})
+	}
+	return crumbs, nil
+}
+
+func (cd *CoreData) adminBreadcrumbs() ([]Breadcrumb, error) {
+	crumbs := []Breadcrumb{{Title: "Admin", Link: "/admin"}}
+	switch {
+	case cd.currentProfileUserID != 0:
+		crumbs = append(crumbs, Breadcrumb{Title: "Users", Link: "/admin/user"})
+		if u := cd.CurrentProfileUser(); u != nil {
+			title := fmt.Sprintf("User %d", u.Idusers)
+			if u.Username.Valid {
+				title = fmt.Sprintf("User %s", u.Username.String)
+			}
+			crumbs = append(crumbs, Breadcrumb{Title: title})
+		} else {
+			crumbs = append(crumbs, Breadcrumb{Title: fmt.Sprintf("User %d", cd.currentProfileUserID)})
+		}
+	case cd.currentRoleID != 0:
+		crumbs = append(crumbs, Breadcrumb{Title: "Roles", Link: "/admin/roles"})
+		if r, err := cd.RoleByID(cd.currentRoleID); err == nil && r != nil {
+			title := fmt.Sprintf("Role %d", cd.currentRoleID)
+			if r.Name != "" {
+				title = fmt.Sprintf("Role %s", r.Name)
+			}
+			crumbs = append(crumbs, Breadcrumb{Title: title})
+		} else {
+			crumbs = append(crumbs, Breadcrumb{Title: fmt.Sprintf("Role %d", cd.currentRoleID)})
+		}
+	case cd.currentRequestID != 0:
+		crumbs = append(crumbs, Breadcrumb{Title: "Requests", Link: "/admin/requests"})
+		crumbs = append(crumbs, Breadcrumb{Title: fmt.Sprintf("Request %d", cd.currentRequestID)})
+	default:
+		if cd.PageTitle != "" {
+			crumbs = append(crumbs, Breadcrumb{Title: cd.PageTitle})
+		} else {
+			crumbs = append(crumbs, Breadcrumb{Title: "Admin"})
+		}
 	}
 	return crumbs, nil
 }

--- a/handlers/admin/routes.go
+++ b/handlers/admin/routes.go
@@ -26,6 +26,7 @@ import (
 // RegisterRoutes attaches the admin endpoints to ar. The router is expected to
 // already have any required authentication middleware applied.
 func (h *Handlers) RegisterRoutes(ar *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
+	ar.Use(handlers.SectionMiddleware("admin"))
 	navReg.RegisterAdminControlCenter("Core", "Roles", "/admin/roles", 25)
 	navReg.RegisterAdminControlCenter("Core", "Grants", "/admin/grants", 27)
 	navReg.RegisterAdminControlCenter("Core", "Grant Rules", "/admin/grants/rules", 28)


### PR DESCRIPTION
## Summary
- include admin routes in breadcrumb system
- display admin navigation crumbs for users, roles, and requests

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689573555e2c832f9ad357a1048e276f