### PR TITLE
Restrict private forum page access

### DIFF
--- a/core/templates/site/privateForumPage.gohtml
+++ b/core/templates/site/privateForumPage.gohtml
@@ -2,16 +2,18 @@
     {{ template "head" $ }}
     <h1>Private Topics</h1>
     {{ template "tableTopics" (dict "Topics" cd.PrivateTopics) }}
-    <h2>Start conversation</h2>
-    <form id="private-form" method="POST">
-        <input type="hidden" name="task" value="{{ .CreateTask }}">
-        <input type="text" id="participant-input" placeholder="username">
-        <button type="button" id="add-participant">Add</button>
-        <ul id="participants"></ul>
-        <input type="hidden" name="participants" id="participants-field">
-        <textarea name="body" id="message-field" placeholder="Message"></textarea>
-        <button type="submit">Create</button>
-    </form>
-    <script src="/private/private_forum.js"></script>
+    {{ if cd.HasGrant "privateforum" "topic" "create" 0 }}
+        <h2>Start conversation</h2>
+        <form id="private-form" method="POST">
+            <input type="hidden" name="task" value="{{ .CreateTask }}">
+            <input type="text" id="participant-input" placeholder="username">
+            <button type="button" id="add-participant">Add</button>
+            <ul id="participants"></ul>
+            <input type="hidden" name="participants" id="participants-field">
+            <textarea name="body" id="message-field" placeholder="Message"></textarea>
+            <button type="submit">Create</button>
+        </form>
+        <script src="/private/private_forum.js"></script>
+    {{ end }}
     {{ template "tail" $ }}
 {{ end }}

--- a/handlers/privateforum/page.go
+++ b/handlers/privateforum/page.go
@@ -1,6 +1,7 @@
 package privateforum
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
@@ -14,6 +15,12 @@ func Page(w http.ResponseWriter, r *http.Request) {
 		CreateTask tasks.TaskString
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if !cd.HasGrant("privateforum", "topic", "see", 0) {
+		if err := cd.ExecuteSiteTemplate(w, r, "noAccessPage.gohtml", struct{}{}); err != nil {
+			log.Printf("render no access page: %v", err)
+		}
+		return
+	}
 	cd.PageTitle = "Private Forum"
 	data := Data{CreateTask: TaskPrivateTopicCreate}
 	handlers.TemplateHandler(w, r, "privateForumPage", data)

--- a/handlers/privateforum/page_test.go
+++ b/handlers/privateforum/page_test.go
@@ -1,0 +1,75 @@
+package privateforum
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestPage_NoAccess(t *testing.T) {
+	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
+	req := httptest.NewRequest(http.MethodGet, "/private", nil)
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+
+	w := httptest.NewRecorder()
+	Page(w, req)
+
+	if body := w.Body.String(); !strings.Contains(body, "may not have permission") {
+		t.Fatalf("expected no access message, got %q", body)
+	}
+}
+
+func TestPage_Access(t *testing.T) {
+	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
+	req := httptest.NewRequest(http.MethodGet, "/private", nil)
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+
+	w := httptest.NewRecorder()
+	Page(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "Private Topics") {
+		t.Fatalf("expected private topics page, got %q", body)
+	}
+	if !strings.Contains(body, "<form id=\"private-form\"") {
+		t.Fatalf("expected create form, got %q", body)
+	}
+}
+
+func TestPage_SeeNoCreate(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	queries := db.New(conn)
+	cd := common.NewCoreData(context.Background(), queries, config.NewRuntimeConfig())
+	cd.UserID = 1
+
+	req := httptest.NewRequest(http.MethodGet, "/private", nil)
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+
+	mock.ExpectQuery("SELECT 1 FROM grants").WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery("SELECT 1 FROM grants").WillReturnError(sql.ErrNoRows)
+
+	w := httptest.NewRecorder()
+	Page(w, req)
+
+	body := w.Body.String()
+	if strings.Contains(body, "Start conversation") {
+		t.Fatalf("unexpected create form, got %q", body)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce `privateforum` `topic` `see` permission on `/private`
- hide private topic creation form without `privateforum` `topic` `create` grant
- add tests for authorized, unauthorized, and see-only private forum access

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68956fa45248832f9d1ba610ef8d85ff