### PR TITLE
Align subscribe link with New Thread on forum topics

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -291,3 +291,9 @@ tr.unsupported td {
         color: inherit;
 }
 
+/* Forum topic actions */
+.topic-actions form {
+        display: inline;
+        margin: 0;
+}
+

--- a/core/templates/site/forum/topicsPage.gohtml
+++ b/core/templates/site/forum/topicsPage.gohtml
@@ -4,14 +4,18 @@
         {{ template "getAllForumCategories" $ }}
     {{ end }}
 
-    <div>
+    <div class="topic-actions">
         <a href="/forum/topic/{{.Topic.Idforumtopic}}/thread">New Thread</a>
         {{- if and cd.IsAdmin cd.IsAdminMode }} | [<a href="/admin/forum/topics/topic/{{.Topic.Idforumtopic}}/edit">ADMIN</a>]{{ end }}
-        {{- if .Subscribed }} |
-            <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/unsubscribe" style="display:inline"><input type="hidden" name="task" value="Unsubscribe From Topic"/><input type="submit" value="Unsubscribe"/></form>
-        {{ else }} |
-            <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/subscribe" style="display:inline"><input type="hidden" name="task" value="Subscribe To Topic"/><input type="submit" value="Subscribe"/></form>
-        {{ end }}
+        {{- if .Subscribed }} | <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/unsubscribe">
+                <input type="hidden" name="task" value="Unsubscribe From Topic"/>
+                <input type="submit" value="Unsubscribe"/>
+            </form>
+        {{- else }} | <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/subscribe">
+                <input type="hidden" name="task" value="Subscribe To Topic"/>
+                <input type="submit" value="Subscribe"/>
+            </form>
+        {{- end }}
     </div>
 
     {{ template "topicThreads" $ }}


### PR DESCRIPTION
## Summary
- keep topic subscribe/unsubscribe links inline with "New Thread" and the separator bar via CSS

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689572ea6dc0832fb351448b08a4a4f4