### PR TITLE
Fix missing details in forum thread creation emails

### DIFF
--- a/core/templates/email/adminNotificationForumThreadCreateEmail.gotxt
+++ b/core/templates/email/adminNotificationForumThreadCreateEmail.gotxt
@@ -1,5 +1,4 @@
 User {{.Item.Username}} created a new forum thread.
 
-View thread:
-{{.Item.ThreadURL}}
+View thread: {{.Item.ThreadURL}}
 Manage notifications: {{.UnsubscribeUrl}}

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -155,6 +155,7 @@ func (CreateThreadTask) Action(w http.ResponseWriter, r *http.Request) any {
 			}
 			evt.Data["TopicTitle"] = topicTitle
 			evt.Data["Author"] = author
+			evt.Data["Username"] = author
 		}
 	}
 
@@ -179,8 +180,10 @@ func (CreateThreadTask) Action(w http.ResponseWriter, r *http.Request) any {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
+			fullURL := cd.AbsoluteURL(endUrl)
 			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(cid), ThreadID: int32(threadId), TopicID: int32(topicId)}
-			evt.Data["PostURL"] = cd.AbsoluteURL(endUrl)
+			evt.Data["PostURL"] = fullURL
+			evt.Data["ThreadURL"] = fullURL
 		}
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {


### PR DESCRIPTION
## Summary
- include author and thread URL in forum thread creation notifications
- inline thread link in admin notification email template

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895783a677c832f9cfe65a692315e82