### PR TITLE
Allow selecting multiple grant actions in grant wizards

### DIFF
--- a/core/templates/site/admin/adminRoleGrantAddPage.gohtml
+++ b/core/templates/site/admin/adminRoleGrantAddPage.gohtml
@@ -11,33 +11,25 @@
     </label>
     <input type="submit" value="Next">
 </form>
-{{ else if eq .Item "" }}
+{{ else }}
 <form method="get">
     <input type="hidden" name="section" value="{{ .Section }}">
     <label>Item:
         <select name="item">
             {{ range .Items }}
-            <option value="{{ . }}">{{ . }}</option>
+            <option value="{{ . }}"{{ if eq $.Item . }} selected{{ end }}>{{ . }}</option>
             {{ end }}
         </select>
     </label>
-    <input type="submit" value="Next">
+    <input type="submit" value="Change">
 </form>
-{{ else }}
 <form method="post" action="/admin/role/{{ .Role.ID }}/grant">
     {{ csrfField }}
     <input type="hidden" name="task" value="Create grant">
     <input type="hidden" name="section" value="{{ .Section }}">
     <input type="hidden" name="item" value="{{ .Item }}">
-    <label>Action:
-        <select name="action">
-            {{ range .Actions }}
-            <option value="{{ . }}">{{ . }}</option>
-            {{ end }}
-        </select>
-    </label>
-    {{ if .ItemOptions }}
-    <label>Item:
+    <label>Item ({{ .Item }}):
+        {{ if .ItemOptions }}
         <input list="itemOptions" name="item_id"{{ if .RequireItemID }} required{{ end }}>
         <datalist id="itemOptions">
             {{ if not .RequireItemID }}<option value="">All</option>{{ end }}
@@ -45,10 +37,16 @@
             <option value="{{ .ID }}">{{ .Label }}</option>
             {{ end }}
         </datalist>
+        {{ else }}
+        <input type="text" name="item_id"{{ if .RequireItemID }} required{{ end }}>
+        {{ end }}
     </label>
-    {{ else }}
-    <label>Item ID:<input type="text" name="item_id"{{ if .RequireItemID }} required{{ end }}></label>
-    {{ end }}
+    <fieldset>
+        <legend>Actions</legend>
+        {{ range .Actions }}
+        <label><input type="checkbox" name="action" value="{{ . }}"> {{ . }}</label><br>
+        {{ end }}
+    </fieldset>
     <input type="submit" value="Add">
 </form>
 {{ end }}

--- a/core/templates/site/admin/adminUserGrantAddPage.gohtml
+++ b/core/templates/site/admin/adminUserGrantAddPage.gohtml
@@ -11,33 +11,25 @@
     </label>
     <input type="submit" value="Next">
 </form>
-{{ else if eq .Item "" }}
+{{ else }}
 <form method="get">
     <input type="hidden" name="section" value="{{ .Section }}">
     <label>Item:
         <select name="item">
             {{ range .Items }}
-            <option value="{{ . }}">{{ . }}</option>
+            <option value="{{ . }}"{{ if eq $.Item . }} selected{{ end }}>{{ . }}</option>
             {{ end }}
         </select>
     </label>
-    <input type="submit" value="Next">
+    <input type="submit" value="Change">
 </form>
-{{ else }}
 <form method="post" action="/admin/user/{{ .User.Idusers }}/grant">
     {{ csrfField }}
     <input type="hidden" name="task" value="Create grant">
     <input type="hidden" name="section" value="{{ .Section }}">
     <input type="hidden" name="item" value="{{ .Item }}">
-    <label>Action:
-        <select name="action">
-            {{ range .Actions }}
-            <option value="{{ . }}">{{ . }}</option>
-            {{ end }}
-        </select>
-    </label>
-    {{ if .ItemOptions }}
-    <label>Item:
+    <label>Item ({{ .Item }}):
+        {{ if .ItemOptions }}
         <input list="itemOptions" name="item_id"{{ if .RequireItemID }} required{{ end }}>
         <datalist id="itemOptions">
             {{ if not .RequireItemID }}<option value="">All</option>{{ end }}
@@ -45,10 +37,16 @@
             <option value="{{ .ID }}">{{ .Label }}</option>
             {{ end }}
         </datalist>
+        {{ else }}
+        <input type="text" name="item_id"{{ if .RequireItemID }} required{{ end }}>
+        {{ end }}
     </label>
-    {{ else }}
-    <label>Item ID:<input type="text" name="item_id"{{ if .RequireItemID }} required{{ end }}></label>
-    {{ end }}
+    <fieldset>
+        <legend>Actions</legend>
+        {{ range .Actions }}
+        <label><input type="checkbox" name="action" value="{{ . }}"> {{ . }}</label><br>
+        {{ end }}
+    </fieldset>
     <input type="submit" value="Add">
 </form>
 {{ end }}

--- a/core/templates/site/admin/grantAddPage.gohtml
+++ b/core/templates/site/admin/grantAddPage.gohtml
@@ -43,7 +43,7 @@
     </label>
     <input type="submit" value="Next">
 </form>
-{{ else if eq .Item "" }}
+{{ else }}
 <form method="get">
     <input type="hidden" name="subject" value="{{ .Subject }}">
     <input type="hidden" name="id" value="{{ .ID }}">
@@ -51,27 +51,19 @@
     <label>Item:
         <select name="item">
             {{ range .Items }}
-            <option value="{{ . }}">{{ . }}</option>
+            <option value="{{ . }}"{{ if eq $.Item . }} selected{{ end }}>{{ . }}</option>
             {{ end }}
         </select>
     </label>
-    <input type="submit" value="Next">
+    <input type="submit" value="Change">
 </form>
-{{ else }}
 <form method="post" action="/admin/{{ if eq .Subject "anyone" }}grant{{ else }}{{ .Subject }}/{{ .ID }}/grant{{ end }}">
     {{ csrfField }}
     <input type="hidden" name="task" value="Create grant">
     <input type="hidden" name="section" value="{{ .Section }}">
     <input type="hidden" name="item" value="{{ .Item }}">
-    <label>Action:
-        <select name="action">
-            {{ range .Actions }}
-            <option value="{{ . }}">{{ . }}</option>
-            {{ end }}
-        </select>
-    </label>
-    {{ if .ItemOptions }}
-    <label>Item:
+    <label>Item ({{ .Item }}):
+        {{ if .ItemOptions }}
         <input list="itemOptions" name="item_id"{{ if .RequireItemID }} required{{ end }}>
         <datalist id="itemOptions">
             {{ if not .RequireItemID }}<option value="">All</option>{{ end }}
@@ -79,10 +71,16 @@
             <option value="{{ .ID }}">{{ .Label }}</option>
             {{ end }}
         </datalist>
+        {{ else }}
+        <input type="text" name="item_id"{{ if .RequireItemID }} required{{ end }}>
+        {{ end }}
     </label>
-    {{ else }}
-    <label>Item ID:<input type="text" name="item_id"{{ if .RequireItemID }} required{{ end }}></label>
-    {{ end }}
+    <fieldset>
+        <legend>Actions</legend>
+        {{ range .Actions }}
+        <label><input type="checkbox" name="action" value="{{ . }}"> {{ . }}</label><br>
+        {{ end }}
+    </fieldset>
     <input type="submit" value="Add">
 </form>
 {{ end }}

--- a/handlers/admin/adminGrantAddPage.go
+++ b/handlers/admin/adminGrantAddPage.go
@@ -54,7 +54,7 @@ func adminGrantAddPage(w http.ResponseWriter, r *http.Request) {
 		for s := range sectSet {
 			data.Sections = append(data.Sections, s)
 		}
-	} else if item == "" {
+	} else {
 		itemSet := map[string]struct{}{}
 		for k := range GrantActionMap {
 			parts := strings.Split(k, "|")
@@ -65,7 +65,10 @@ func adminGrantAddPage(w http.ResponseWriter, r *http.Request) {
 		for it := range itemSet {
 			data.Items = append(data.Items, it)
 		}
-	} else {
+		if item == "" && len(data.Items) > 0 {
+			item = data.Items[0]
+			data.Item = item
+		}
 		def := GrantActionMap[section+"|"+item]
 		data.Actions = def.Actions
 		data.RequireItemID = def.RequireItemID

--- a/handlers/admin/adminRoleGrantAddPage.go
+++ b/handlers/admin/adminRoleGrantAddPage.go
@@ -53,7 +53,7 @@ func adminRoleGrantAddPage(w http.ResponseWriter, r *http.Request) {
 		for s := range sectSet {
 			data.Sections = append(data.Sections, s)
 		}
-	} else if item == "" {
+	} else {
 		itemSet := map[string]struct{}{}
 		for k := range GrantActionMap {
 			parts := strings.Split(k, "|")
@@ -64,7 +64,10 @@ func adminRoleGrantAddPage(w http.ResponseWriter, r *http.Request) {
 		for it := range itemSet {
 			data.Items = append(data.Items, it)
 		}
-	} else {
+		if item == "" && len(data.Items) > 0 {
+			item = data.Items[0]
+			data.Item = item
+		}
 		def := GrantActionMap[section+"|"+item]
 		data.Actions = def.Actions
 		data.RequireItemID = def.RequireItemID

--- a/handlers/admin/adminUserGrantAddPage.go
+++ b/handlers/admin/adminUserGrantAddPage.go
@@ -47,7 +47,7 @@ func adminUserGrantAddPage(w http.ResponseWriter, r *http.Request) {
 		for s := range sectSet {
 			data.Sections = append(data.Sections, s)
 		}
-	} else if item == "" {
+	} else {
 		itemSet := map[string]struct{}{}
 		for k := range GrantActionMap {
 			parts := strings.Split(k, "|")
@@ -58,7 +58,10 @@ func adminUserGrantAddPage(w http.ResponseWriter, r *http.Request) {
 		for it := range itemSet {
 			data.Items = append(data.Items, it)
 		}
-	} else {
+		if item == "" && len(data.Items) > 0 {
+			item = data.Items[0]
+			data.Item = item
+		}
 		def := GrantActionMap[section+"|"+item]
 		data.Actions = def.Actions
 		data.RequireItemID = def.RequireItemID

--- a/handlers/admin/global_grant_create_task.go
+++ b/handlers/admin/global_grant_create_task.go
@@ -30,7 +30,7 @@ func (GlobalGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) any 
 	}
 	section := r.PostFormValue("section")
 	item := r.PostFormValue("item")
-	action := r.PostFormValue("action")
+	actions := r.PostForm["action"]
 	itemIDStr := r.PostFormValue("item_id")
 	var itemID sql.NullInt32
 	if itemIDStr != "" {
@@ -40,25 +40,27 @@ func (GlobalGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) any 
 		}
 		itemID = sql.NullInt32{Int32: int32(id), Valid: true}
 	}
-	if section == "" || action == "" {
+	if section == "" || len(actions) == 0 {
 		return fmt.Errorf("missing section or action %w", handlers.ErrRedirectOnSamePageHandler(fmt.Errorf("")))
 	}
 	if def, ok := GrantActionMap[section+"|"+item]; ok && def.RequireItemID && !itemID.Valid {
 		return fmt.Errorf("missing item id %w", handlers.ErrRedirectOnSamePageHandler(fmt.Errorf("")))
 	}
-	if _, err := queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
-		UserID:   sql.NullInt32{},
-		RoleID:   sql.NullInt32{},
-		Section:  section,
-		Item:     sql.NullString{String: item, Valid: item != ""},
-		RuleType: "allow",
-		ItemID:   itemID,
-		ItemRule: sql.NullString{},
-		Action:   action,
-		Extra:    sql.NullString{},
-	}); err != nil {
-		log.Printf("CreateGrant: %v", err)
-		return fmt.Errorf("create grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+	for _, action := range actions {
+		if _, err := queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
+			UserID:   sql.NullInt32{},
+			RoleID:   sql.NullInt32{},
+			Section:  section,
+			Item:     sql.NullString{String: item, Valid: item != ""},
+			RuleType: "allow",
+			ItemID:   itemID,
+			ItemRule: sql.NullString{},
+			Action:   action,
+			Extra:    sql.NullString{},
+		}); err != nil {
+			log.Printf("CreateGrant: %v", err)
+			return fmt.Errorf("create grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
 	}
 	return handlers.RefreshDirectHandler{TargetURL: "/admin/grants"}
 }

--- a/handlers/admin/role_grant_create_task.go
+++ b/handlers/admin/role_grant_create_task.go
@@ -34,7 +34,7 @@ func (RoleGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	section := r.PostFormValue("section")
 	item := r.PostFormValue("item")
-	action := r.PostFormValue("action")
+	actions := r.PostForm["action"]
 	itemIDStr := r.PostFormValue("item_id")
 	var itemID sql.NullInt32
 	if itemIDStr != "" {
@@ -44,25 +44,27 @@ func (RoleGrantCreateTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 		itemID = sql.NullInt32{Int32: int32(id), Valid: true}
 	}
-	if section == "" || action == "" {
+	if section == "" || len(actions) == 0 {
 		return fmt.Errorf("missing section or action %w", handlers.ErrRedirectOnSamePageHandler(fmt.Errorf("")))
 	}
 	if def, ok := GrantActionMap[section+"|"+item]; ok && def.RequireItemID && !itemID.Valid {
 		return fmt.Errorf("missing item id %w", handlers.ErrRedirectOnSamePageHandler(fmt.Errorf("")))
 	}
-	if _, err := queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
-		UserID:   sql.NullInt32{},
-		RoleID:   sql.NullInt32{Int32: roleID, Valid: true},
-		Section:  section,
-		Item:     sql.NullString{String: item, Valid: item != ""},
-		RuleType: "allow",
-		ItemID:   itemID,
-		ItemRule: sql.NullString{},
-		Action:   action,
-		Extra:    sql.NullString{},
-	}); err != nil {
-		log.Printf("CreateGrant: %v", err)
-		return fmt.Errorf("create grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+	for _, action := range actions {
+		if _, err := queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
+			UserID:   sql.NullInt32{},
+			RoleID:   sql.NullInt32{Int32: roleID, Valid: true},
+			Section:  section,
+			Item:     sql.NullString{String: item, Valid: item != ""},
+			RuleType: "allow",
+			ItemID:   itemID,
+			ItemRule: sql.NullString{},
+			Action:   action,
+			Extra:    sql.NullString{},
+		}); err != nil {
+			log.Printf("CreateGrant: %v", err)
+			return fmt.Errorf("create grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
 	}
 	return handlers.RefreshDirectHandler{TargetURL: fmt.Sprintf("/admin/role/%d", roleID)}
 }

--- a/handlers/admin/role_grant_create_task_test.go
+++ b/handlers/admin/role_grant_create_task_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 )
 
@@ -44,6 +46,45 @@ func TestRoleGrantCreateTask_ItemIDRequired(t *testing.T) {
 		t.Fatalf("expected error, got nil")
 	} else if err, ok := res.(error); !ok || err == nil {
 		t.Fatalf("expected error, got %v", res)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+// TestRoleGrantCreateTask_MultipleActions verifies multiple action selections create
+// a grant for each action.
+func TestRoleGrantCreateTask_MultipleActions(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	body := url.Values{
+		"section": {"forum"},
+		"item":    {"topic"},
+		"item_id": {"1"},
+		"action":  {"see", "view"},
+	}
+	req := httptest.NewRequest("POST", "/admin/role/1/grant", strings.NewReader(body.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = mux.SetURLVars(req, map[string]string{"role": "1"})
+
+	insert := regexp.QuoteMeta("INSERT INTO grants (")
+	mock.ExpectExec(insert).WithArgs(nil, int64(1), "forum", "topic", "allow", int64(1), nil, "see", nil).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(nil, int64(1), "forum", "topic", "allow", int64(1), nil, "view", nil).WillReturnResult(sqlmock.NewResult(2, 1))
+
+	cd := common.NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
+	cd.LoadSelectionsFromRequest(req)
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	if res := roleGrantCreateTask.Action(rr, req); res == nil {
+		t.Fatalf("expected response, got nil")
+	} else if _, ok := res.(handlers.RefreshDirectHandler); !ok {
+		t.Fatalf("expected RefreshDirectHandler, got %T", res)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)


### PR DESCRIPTION
## Summary
- Reorder item field before action selection and allow selecting multiple actions across grant wizards
- Update grant creation handlers to loop over selected actions
- Add test verifying multiple actions create individual grants
- Display selected item name alongside item ID input
- Configure item type and item ID together on the same page of grant wizards

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895360c55ac832fb773ddc79e66fed6