### PR TITLE
Add configurable database timezone

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -5,6 +5,8 @@ const (
 	EnvDBConn = "DB_CONN"
 	// EnvDBDriver selects the database driver.
 	EnvDBDriver = "DB_DRIVER"
+	// EnvDBTimezone sets the database timezone.
+	EnvDBTimezone = "DB_TIMEZONE"
 
 	// EnvEmailProvider selects the mail sending backend.
 	EnvEmailProvider = "EMAIL_PROVIDER"

--- a/config/options_runtime.go
+++ b/config/options_runtime.go
@@ -35,6 +35,7 @@ type BoolOption struct {
 var StringOptions = []StringOption{
 	{"db-conn", EnvDBConn, "database connection string", "", nil, "db_conn.txt", func(c *RuntimeConfig) *string { return &c.DBConn }},
 	{"db-driver", EnvDBDriver, "database driver", "mysql", nil, "db_driver.txt", func(c *RuntimeConfig) *string { return &c.DBDriver }},
+	{"db-timezone", EnvDBTimezone, "database timezone", "Australia/Melbourne", nil, "", func(c *RuntimeConfig) *string { return &c.DBTimezone }},
 	{"listen", EnvListen, "server listen address", ":8080", nil, "", func(c *RuntimeConfig) *string { return &c.HTTPListen }},
 	{"hostname", EnvHostname, "server base URL", "", nil, "", func(c *RuntimeConfig) *string { return &c.HTTPHostname }},
 	{"hsts-header", EnvHSTSHeader, "Strict-Transport-Security header value", "max-age=63072000; includeSubDomains", nil, "", func(c *RuntimeConfig) *string { return &c.HSTSHeaderValue }},

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -14,6 +14,7 @@ const DefaultPageSize = 15
 type RuntimeConfig struct {
 	DBConn            string
 	DBDriver          string
+	DBTimezone        string
 	DBLogVerbosity    int
 	EmailLogVerbosity int
 	LogFlags          int
@@ -310,6 +311,9 @@ func normalizeRuntimeConfig(cfg *RuntimeConfig) {
 	}
 	if cfg.StatsStartYear == 0 {
 		cfg.StatsStartYear = 2005
+	}
+	if cfg.DBTimezone == "" {
+		cfg.DBTimezone = "Australia/Melbourne"
 	}
 	if cfg.Timezone == "" {
 		cfg.Timezone = "Australia/Melbourne"

--- a/config/runtime_config_db_test.go
+++ b/config/runtime_config_db_test.go
@@ -42,3 +42,35 @@ func TestLoadDBConfigFromFileValues(t *testing.T) {
 		t.Fatalf("want fileval got %q", cfg.DBConn)
 	}
 }
+
+func TestDBTimezonePrecedence(t *testing.T) {
+	env := map[string]string{
+		config.EnvDBTimezone: "env",
+	}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("db-timezone", "cli", "")
+	vals := map[string]string{
+		config.EnvDBTimezone: "file",
+	}
+	_ = fs.Parse([]string{"--db-timezone=cli"})
+	cfg := config.NewRuntimeConfig(
+		config.WithFlagSet(fs),
+		config.WithFileValues(vals),
+		config.WithGetenv(func(k string) string { return env[k] }),
+	)
+	if cfg.DBTimezone != "cli" {
+		t.Fatalf("merged %#v", cfg)
+	}
+}
+
+func TestDefaultDBTimezone(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg := config.NewRuntimeConfig(
+		config.WithFlagSet(fs),
+		config.WithFileValues(map[string]string{}),
+		config.WithGetenv(func(string) string { return "" }),
+	)
+	if cfg.DBTimezone != "Australia/Melbourne" {
+		t.Fatalf("want Australia/Melbourne got %q", cfg.DBTimezone)
+	}
+}

--- a/examples/config.env
+++ b/examples/config.env
@@ -20,6 +20,8 @@ DB_CONN=
 DB_DRIVER=mysql
 # database logging verbosity (default: 0)
 DB_LOG_VERBOSITY=0
+# database timezone (default: Australia/Melbourne)
+DB_TIMEZONE=Australia/Melbourne
 # default language name (default: )
 DEFAULT_LANGUAGE=
 # dead letter queue file path (default: )

--- a/examples/config.json
+++ b/examples/config.json
@@ -10,6 +10,7 @@
   "DB_CONN": "",
   "DB_DRIVER": "mysql",
   "DB_LOG_VERBOSITY": "0",
+  "DB_TIMEZONE": "Australia/Melbourne",
   "DEFAULT_LANGUAGE": "",
   "DLQ_FILE": "",
   "DLQ_PROVIDER": "",

--- a/internal/app/dbstart/dbstart.go
+++ b/internal/app/dbstart/dbstart.go
@@ -15,6 +15,7 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/dbdrivers"
+	dbmysql "github.com/arran4/goa4web/internal/dbdrivers/mysql"
 )
 
 // parseS3Dir validates S3 paths in the form s3://bucket/prefix. The bucket
@@ -41,6 +42,9 @@ func InitDB(cfg *config.RuntimeConfig, reg *dbdrivers.Registry) (*sql.DB, *commo
 	conn := cfg.DBConn
 	if conn == "" {
 		return nil, &common.UserError{Err: fmt.Errorf("connection string required"), ErrorMessage: "missing connection"}
+	}
+	if cfg.DBDriver == "mysql" {
+		dbmysql.SetTimezone(cfg.DBTimezone)
 	}
 	c, err := reg.Connector(cfg.DBDriver, conn)
 	if err != nil {

--- a/internal/dbdrivers/mysql/driver.go
+++ b/internal/dbdrivers/mysql/driver.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/arran4/goa4web/internal/dbdrivers"
 	sqlmysql "github.com/go-sql-driver/mysql"
@@ -13,6 +14,15 @@ import (
 
 // Driver implements the dbdrivers.DBDriver interface for MySQL.
 type Driver struct{}
+
+var dbTimezone = "Australia/Melbourne"
+
+// SetTimezone sets the timezone used when connecting to the database.
+func SetTimezone(tz string) {
+	if tz != "" {
+		dbTimezone = tz
+	}
+}
 
 // Name returns the driver name.
 func (Driver) Name() string { return "mysql" }
@@ -30,6 +40,13 @@ func (Driver) OpenConnector(dsn string) (driver.Connector, error) {
 	cfg, err := sqlmysql.ParseDSN(dsn)
 	if err != nil {
 		return nil, err
+	}
+	if cfg.Loc == nil {
+		loc, err := time.LoadLocation(dbTimezone)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Loc = loc
 	}
 	return sqlmysql.NewConnector(cfg)
 }


### PR DESCRIPTION
## Summary
- add DB_TIMEZONE config option with default Australia/Melbourne
- configure MySQL connector to apply configured timezone
- document new option in example configs

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: core/common/coredata.go: absoluteURLBase redeclared)*
- `golangci-lint run ./...` *(fails: core/common/coredata.go: absoluteURLBase redeclared, handlers/user/admin_users.go: "context" imported and not used)*
- `go test ./...` *(fails: core/common/coredata.go: absoluteURLBase redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_689595d506e0832fbedfe87c59e8374e