### PR TITLE
Fix duplicate fields in CoreData struct

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -213,8 +213,6 @@ type CoreData struct {
 	writerWritings                   map[int32]*lazy.Value[[]*db.ListPublicWritingsByUserForListerRow]
 	writingCategories                lazy.Value[[]*db.WritingCategory]
 	writingRows                      map[int32]*lazy.Value[*db.GetWritingForListerByIDRow]
-	absoluteURLBase                  lazy.Value[string]
-	dbRegistry                       *dbdrivers.Registry
 
 	// marks records which template sections have been rendered to avoid
 	// duplicate output when re-rendering after an error.


### PR DESCRIPTION
## Summary
- remove duplicate `absoluteURLBase` and `dbRegistry` fields from `CoreData`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `golangci-lint run` *(fails: command hung, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6895b4df9ac0832fb0f95f0f8f787f4c