### PR TITLE
Add admin coredata helpers and refactor admin pages

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -213,8 +213,6 @@ type CoreData struct {
 	writerWritings                   map[int32]*lazy.Value[[]*db.ListPublicWritingsByUserForListerRow]
 	writingCategories                lazy.Value[[]*db.WritingCategory]
 	writingRows                      map[int32]*lazy.Value[*db.GetWritingForListerByIDRow]
-	absoluteURLBase                  lazy.Value[string]
-	dbRegistry                       *dbdrivers.Registry
 
 	// marks records which template sections have been rendered to avoid
 	// duplicate output when re-rendering after an error.

--- a/core/common/coredata_admin.go
+++ b/core/common/coredata_admin.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"database/sql"
+	"errors"
+
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// AdminListUsers returns all users with admin roles.
+func (cd *CoreData) AdminListUsers() ([]*db.AdminListAllUsersRow, error) {
+	if cd.queries == nil {
+		return nil, nil
+	}
+	rows, err := cd.queries.AdminListAllUsers(cd.ctx)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// AdminDashboardStats returns aggregate site statistics for the admin dashboard.
+func (cd *CoreData) AdminDashboardStats() (*db.AdminGetDashboardStatsRow, error) {
+	if cd.queries == nil {
+		return nil, nil
+	}
+	stats, err := cd.queries.AdminGetDashboardStats(cd.ctx)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+	return stats, nil
+}
+
+// AdminCommentsByUser lists all comments authored by the specified user.
+func (cd *CoreData) AdminCommentsByUser(userID int32) ([]*db.AdminGetAllCommentsByUserRow, error) {
+	if cd.queries == nil {
+		return nil, nil
+	}
+	rows, err := cd.queries.AdminGetAllCommentsByUser(cd.ctx, userID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/core/templates/site/admin/page.gohtml
+++ b/core/templates/site/admin/page.gohtml
@@ -4,27 +4,32 @@
     <p><a href="/admin">Refresh</a></p>
 <p>Select an option:</p>
 <ul>
-    {{- range $s := .AdminSections }}
-    <li>{{ $s.Name }}
-        <ul>
-            {{- range $l := $s.Links }}
-            <li><a href="{{ $l.Link }}">{{ $l.Name }}</a></li>
-            {{- end }}
-        </ul>
-    </li>
+    {{- if cd.Nav }}
+        {{- range $s := cd.Nav.AdminSections }}
+        <li>{{ $s.Name }}
+            <ul>
+                {{- range $l := $s.Links }}
+                <li><a href="{{ $l.Link }}">{{ $l.Name }}</a></li>
+                {{- end }}
+            </ul>
+        </li>
+        {{- end }}
     {{- end }}
 </ul>
 
 <h3>Site statistics</h3>
+{{ $stats := cd.AdminDashboardStats }}
+{{ if $stats }}
 <table border="1">
     <tr><th>Item</th><th>Count</th></tr>
-    <tr><td>Users</td><td>{{ .Stats.Users }}</td></tr>
-    <tr><td>Languages</td><td>{{ .Stats.Languages }}</td></tr>
-    <tr><td>News Posts</td><td>{{ .Stats.News }}</td></tr>
-    <tr><td>Blogs</td><td>{{ .Stats.Blogs }}</td></tr>
-    <tr><td>Forum Topics</td><td>{{ .Stats.ForumTopics }}</td></tr>
-    <tr><td>Forum Threads</td><td>{{ .Stats.ForumThreads }}</td></tr>
-    <tr><td>Writings</td><td>{{ .Stats.Writings }}</td></tr>
+    <tr><td>Users</td><td>{{ $stats.Users }}</td></tr>
+    <tr><td>Languages</td><td>{{ $stats.Languages }}</td></tr>
+    <tr><td>News Posts</td><td>{{ $stats.News }}</td></tr>
+    <tr><td>Blogs</td><td>{{ $stats.Blogs }}</td></tr>
+    <tr><td>Forum Topics</td><td>{{ $stats.ForumTopics }}</td></tr>
+    <tr><td>Forum Threads</td><td>{{ $stats.ForumThreads }}</td></tr>
+    <tr><td>Writings</td><td>{{ $stats.Writings }}</td></tr>
 </table>
+{{ end }}
     {{ template "tail" $ }}
 {{ end }}

--- a/core/templates/site/admin/userCommentsPage.gohtml
+++ b/core/templates/site/admin/userCommentsPage.gohtml
@@ -1,8 +1,9 @@
 {{ template "head" $ }}
-<h2>Comments by {{ .User.Username.String }}</h2>
+{{ $u := cd.CurrentProfileUser }}
+<h2>Comments by {{ $u.Username.String }}</h2>
 <table border="1">
     <tr><th>ID</th><th>Date</th><th>Topic</th><th>Thread</th><th>Excerpt</th><th>Link</th></tr>
-    {{- range .Comments }}
+    {{- range cd.AdminCommentsByUser $u.Idusers }}
     <tr>
         <td><a href="/admin/comment/{{ .Idcomments }}">{{ .Idcomments }}</a></td>
         <td>{{ if .Written.Valid }}{{ localTime .Written.Time }}{{ end }}</td>

--- a/core/templates/site/admin/userList.gohtml
+++ b/core/templates/site/admin/userList.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <ul>
-{{ range .Users }}
+{{ range cd.AdminListUsers }}
     <li><a href="/admin/user/{{ .Idusers }}">{{ .Username.String }}</a></li>
 {{ end }}
 </ul>

--- a/handlers/admin/adminHandler.go
+++ b/handlers/admin/adminHandler.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	_ "embed"
 	"fmt"
 	"net/http"
 
@@ -11,39 +10,11 @@ import (
 )
 
 func AdminPage(w http.ResponseWriter, r *http.Request) {
-	type Stats struct {
-		Users        int64
-		Languages    int64
-		News         int64
-		Blogs        int64
-		ForumTopics  int64
-		ForumThreads int64
-		Writings     int64
-	}
-
-	type Data struct {
-		AdminSections []common.AdminSection
-		Stats         Stats
-	}
-
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Admin"
-	data := Data{
-		AdminSections: cd.Nav.AdminSections(),
-	}
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
-	stats, err := queries.AdminGetDashboardStats(r.Context())
-	if err != nil {
+	if _, err := cd.AdminDashboardStats(); err != nil {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("database not available"))
 		return
 	}
-	data.Stats.Users = stats.Users
-	data.Stats.Languages = stats.Languages
-	data.Stats.News = stats.News
-	data.Stats.Blogs = stats.Blogs
-	data.Stats.ForumTopics = stats.ForumTopics
-	data.Stats.ForumThreads = stats.ForumThreads
-	data.Stats.Writings = stats.Writings
-
-	handlers.TemplateHandler(w, r, "adminPage", data)
+	handlers.TemplateHandler(w, r, "adminPage", struct{}{})
 }

--- a/handlers/admin/adminUserListPage.go
+++ b/handlers/admin/adminUserListPage.go
@@ -8,22 +8,14 @@ import (
 
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 )
 
 func adminUserListPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.PageTitle = "Users"
-	queries := cd.Queries()
-	users, err := queries.AdminListAllUsers(r.Context())
-	if err != nil {
+	if _, err := cd.AdminListUsers(); err != nil {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
-	data := struct {
-		Users []*db.AdminListAllUsersRow
-	}{
-		Users: users,
-	}
-	handlers.TemplateHandler(w, r, "userList.gohtml", data)
+	handlers.TemplateHandler(w, r, "userList.gohtml", struct{}{})
 }


### PR DESCRIPTION
## Summary
- add coredata helpers for admin user list, dashboard stats, and user comments
- refactor admin handlers to use new coredata helpers
- move admin templates to fetch data directly from coredata
- remove duplicate fields from CoreData struct to fix build issues

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895977301f4832fb4281541499b90c6