### PR TITLE
feat: add news coredata helpers and handler refactor

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -213,8 +213,6 @@ type CoreData struct {
 	writerWritings                   map[int32]*lazy.Value[[]*db.ListPublicWritingsByUserForListerRow]
 	writingCategories                lazy.Value[[]*db.WritingCategory]
 	writingRows                      map[int32]*lazy.Value[*db.GetWritingForListerByIDRow]
-	absoluteURLBase                  lazy.Value[string]
-	dbRegistry                       *dbdrivers.Registry
 
 	// marks records which template sections have been rendered to avoid
 	// duplicate output when re-rendering after an error.

--- a/core/common/coredata_news.go
+++ b/core/common/coredata_news.go
@@ -1,0 +1,281 @@
+package common
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+
+	searchutil "github.com/arran4/goa4web/workers/searchworker"
+
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// newsTopicName is the default name for the hidden news forum.
+const newsTopicName = "A NEWS TOPIC"
+
+// newsTopicDescription describes the hidden news forum.
+const newsTopicDescription = "THIS IS A HIDDEN FORUM FOR A NEWS TOPIC"
+
+// ThreadInfo summarises forum thread and topic identifiers.
+type ThreadInfo struct {
+	ThreadID int32
+	TopicID  int32
+}
+
+// ThreadInfo ensures a news post has a backing forum thread and topic.
+func (cd *CoreData) ThreadInfo(post *db.GetNewsPostByIdWithWriterIdAndThreadCommentCountRow) (ThreadInfo, error) {
+	ti := ThreadInfo{}
+	if cd.queries == nil || post == nil {
+		return ti, nil
+	}
+	pt, err := cd.queries.SystemGetForumTopicByTitle(cd.ctx, sql.NullString{String: newsTopicName, Valid: true})
+	if errors.Is(err, sql.ErrNoRows) {
+		id, err := cd.queries.SystemCreateForumTopic(cd.ctx, db.SystemCreateForumTopicParams{
+			ForumcategoryIdforumcategory: 0,
+			LanguageIdlanguage:           post.LanguageIdlanguage,
+			Title:                        sql.NullString{String: newsTopicName, Valid: true},
+			Description:                  sql.NullString{String: newsTopicDescription, Valid: true},
+			Handler:                      "news",
+		})
+		if err != nil {
+			return ti, fmt.Errorf("create forum topic: %w", err)
+		}
+		ti.TopicID = int32(id)
+	} else if err != nil {
+		return ti, fmt.Errorf("find forum topic: %w", err)
+	} else {
+		ti.TopicID = pt.Idforumtopic
+	}
+	threadID := post.ForumthreadID
+	if threadID == 0 {
+		id, err := cd.queries.SystemCreateThread(cd.ctx, ti.TopicID)
+		if err != nil {
+			return ti, fmt.Errorf("create thread: %w", err)
+		}
+		threadID = int32(id)
+		if err := cd.queries.SystemAssignNewsThreadID(cd.ctx, db.SystemAssignNewsThreadIDParams{ForumthreadID: threadID, Idsitenews: post.Idsitenews}); err != nil {
+			return ti, fmt.Errorf("assign news thread: %w", err)
+		}
+	}
+	ti.ThreadID = threadID
+	return ti, nil
+}
+
+// CreateNewsReply creates a comment for a news post ensuring the thread exists.
+func (cd *CoreData) CreateNewsReply(commenterID, postID, languageID int32, text string) (int64, ThreadInfo, error) {
+	if cd.queries == nil {
+		return 0, ThreadInfo{}, nil
+	}
+	post, err := cd.queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(cd.ctx, db.GetNewsPostByIdWithWriterIdAndThreadCommentCountParams{
+		ViewerID: commenterID,
+		ID:       postID,
+		UserID:   sql.NullInt32{Int32: commenterID, Valid: commenterID != 0},
+	})
+	if err != nil {
+		return 0, ThreadInfo{}, fmt.Errorf("get post: %w", err)
+	}
+	ti, err := cd.ThreadInfo(post)
+	if err != nil {
+		return 0, ThreadInfo{}, err
+	}
+	cid, err := cd.CreateNewsCommentForCommenter(commenterID, ti.ThreadID, postID, languageID, text)
+	if err != nil {
+		return 0, ThreadInfo{}, err
+	}
+	return cid, ti, nil
+}
+
+// UpdateNewsReply updates an existing comment and returns thread information.
+func (cd *CoreData) UpdateNewsReply(commentID, editorID, languageID int32, text string) (ThreadInfo, error) {
+	if cd.queries == nil {
+		return ThreadInfo{}, nil
+	}
+	comment, err := cd.CommentByID(commentID)
+	if err != nil {
+		return ThreadInfo{}, fmt.Errorf("load comment: %w", err)
+	}
+	thread, err := cd.queries.GetThreadLastPosterAndPerms(cd.ctx, db.GetThreadLastPosterAndPermsParams{
+		ViewerID:      editorID,
+		ThreadID:      comment.ForumthreadID,
+		ViewerMatchID: sql.NullInt32{Int32: editorID, Valid: editorID != 0},
+	})
+	if err != nil {
+		return ThreadInfo{}, fmt.Errorf("thread fetch: %w", err)
+	}
+	if err := cd.queries.UpdateCommentForEditor(cd.ctx, db.UpdateCommentForEditorParams{
+		LanguageID:  languageID,
+		Text:        sql.NullString{String: text, Valid: true},
+		CommentID:   commentID,
+		CommenterID: editorID,
+		EditorID:    sql.NullInt32{Int32: editorID, Valid: editorID != 0},
+	}); err != nil {
+		return ThreadInfo{}, fmt.Errorf("update comment: %w", err)
+	}
+	return ThreadInfo{ThreadID: thread.Idforumthread, TopicID: thread.ForumtopicIdforumtopic}, nil
+}
+
+// UpdateNewsPost modifies an existing news post.
+func (cd *CoreData) UpdateNewsPost(postID, languageID, userID int32, text string) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.UpdateNewsPostForWriter(cd.ctx, db.UpdateNewsPostForWriterParams{
+		PostID:      postID,
+		GrantPostID: sql.NullInt32{Int32: postID, Valid: true},
+		LanguageID:  languageID,
+		News:        sql.NullString{String: text, Valid: true},
+		GranteeID:   sql.NullInt32{Int32: userID, Valid: userID != 0},
+		WriterID:    userID,
+	})
+}
+
+// DeleteNewsPost deactivates a news post.
+func (cd *CoreData) DeleteNewsPost(postID int32) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.DeactivateNewsPost(cd.ctx, postID)
+}
+
+// CreateNewsPost inserts a new news post and grants edit rights to the author.
+func (cd *CoreData) CreateNewsPost(languageID, userID int32, text string) (int64, error) {
+	if cd.queries == nil {
+		return 0, nil
+	}
+	id, err := cd.queries.CreateNewsPostForWriter(cd.ctx, db.CreateNewsPostForWriterParams{
+		LanguageID: languageID,
+		News:       sql.NullString{String: text, Valid: true},
+		WriterID:   userID,
+		GranteeID:  sql.NullInt32{Int32: userID, Valid: true},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("create post: %w", err)
+	}
+	if _, err := cd.queries.AdminCreateGrant(cd.ctx, db.AdminCreateGrantParams{
+		UserID:   sql.NullInt32{Int32: userID, Valid: true},
+		RoleID:   sql.NullInt32{},
+		Section:  "news",
+		Item:     sql.NullString{String: "post", Valid: true},
+		RuleType: "allow",
+		ItemID:   sql.NullInt32{Int32: int32(id), Valid: true},
+		Action:   "edit",
+	}); err != nil {
+		log.Printf("create grant: %v", err)
+	}
+	return id, nil
+}
+
+// SearchNews finds news posts matching searchwords. Returns flags indicating empty or no results.
+func (cd *CoreData) SearchNews(r *http.Request, uid int32) ([]*db.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow, bool, bool, error) {
+	if cd.queries == nil {
+		return nil, false, false, nil
+	}
+	searchWords := searchutil.BreakupTextToWords(r.PostFormValue("searchwords"))
+	if len(searchWords) == 0 {
+		return nil, true, false, nil
+	}
+	var newsIDs []int32
+	for i, word := range searchWords {
+		if i == 0 {
+			ids, err := cd.queries.ListSiteNewsSearchFirstForLister(cd.ctx, db.ListSiteNewsSearchFirstForListerParams{
+				ListerID: uid,
+				Word:     sql.NullString{String: word, Valid: true},
+				UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
+			})
+			if err != nil {
+				if !errors.Is(err, sql.ErrNoRows) {
+					return nil, false, false, fmt.Errorf("news search first: %w", err)
+				}
+			}
+			newsIDs = ids
+		} else {
+			ids, err := cd.queries.ListSiteNewsSearchNextForLister(cd.ctx, db.ListSiteNewsSearchNextForListerParams{
+				ListerID: uid,
+				Word:     sql.NullString{String: word, Valid: true},
+				Ids:      newsIDs,
+				UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
+			})
+			if err != nil {
+				if !errors.Is(err, sql.ErrNoRows) {
+					return nil, false, false, fmt.Errorf("news search next: %w", err)
+				}
+			}
+			newsIDs = ids
+		}
+		if len(newsIDs) == 0 {
+			return nil, false, true, nil
+		}
+	}
+	news, err := cd.queries.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount(cd.ctx, db.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountParams{
+		ViewerID: uid,
+		Newsids:  newsIDs,
+		UserID:   sql.NullInt32{Int32: uid, Valid: uid != 0},
+	})
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, false, false, fmt.Errorf("get news: %w", err)
+		}
+	}
+	return news, false, false, nil
+}
+
+// AllowNewsUser grants a role to username.
+func (cd *CoreData) AllowNewsUser(username, role string) error {
+	if cd.queries == nil {
+		return nil
+	}
+	u, err := cd.queries.SystemGetUserByUsername(cd.ctx, sql.NullString{String: username, Valid: true})
+	if err != nil {
+		return fmt.Errorf("get user: %w", err)
+	}
+	return cd.queries.SystemCreateUserRole(cd.ctx, db.SystemCreateUserRoleParams{
+		UsersIdusers: u.Idusers,
+		Name:         role,
+	})
+}
+
+// DisallowNewsUser removes a role assignment.
+func (cd *CoreData) DisallowNewsUser(permissionID int32) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.AdminDeleteUserRole(cd.ctx, permissionID)
+}
+
+// AddAnnouncement enables or activates an announcement for a news post.
+func (cd *CoreData) AddAnnouncement(postID int32) error {
+	if cd.queries == nil {
+		return nil
+	}
+	ann, err := cd.NewsAnnouncementWithErr(postID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("get announcement: %w", err)
+	}
+	if ann == nil {
+		return cd.queries.AdminPromoteAnnouncement(cd.ctx, postID)
+	}
+	if !ann.Active {
+		return cd.queries.AdminSetAnnouncementActive(cd.ctx, db.AdminSetAnnouncementActiveParams{Active: true, ID: ann.ID})
+	}
+	return nil
+}
+
+// DeleteAnnouncement deactivates an announcement for a news post.
+func (cd *CoreData) DeleteAnnouncement(postID int32) error {
+	if cd.queries == nil {
+		return nil
+	}
+	ann, err := cd.NewsAnnouncementWithErr(postID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("announcement for news: %w", err)
+	}
+	if ann != nil && ann.Active {
+		return cd.queries.AdminSetAnnouncementActive(cd.ctx, db.AdminSetAnnouncementActiveParams{Active: false, ID: ann.ID})
+	}
+	return nil
+}

--- a/handlers/news/admin_pages.go
+++ b/handlers/news/admin_pages.go
@@ -1,7 +1,6 @@
 package news
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -67,7 +66,9 @@ func AdminNewsPage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	handlers.TemplateHandler(w, r, "adminNewsListPage.gohtml", data)
+	if err := cd.ExecuteSiteTemplate(w, r, "adminNewsListPage.gohtml", data); err != nil {
+		handlers.RenderErrorPage(w, r, err)
+	}
 }
 
 func AdminNewsPostPage(w http.ResponseWriter, r *http.Request) {
@@ -141,7 +142,9 @@ func AdminNewsPostPage(w http.ResponseWriter, r *http.Request) {
 		return ""
 	}
 
-	handlers.TemplateHandler(w, r, "adminNewsPostPage.gohtml", data)
+	if err := cd.ExecuteSiteTemplate(w, r, "adminNewsPostPage.gohtml", data); err != nil {
+		handlers.RenderErrorPage(w, r, err)
+	}
 }
 
 func adminNewsEditFormPage(w http.ResponseWriter, r *http.Request) {
@@ -176,7 +179,9 @@ func adminNewsEditFormPage(w http.ResponseWriter, r *http.Request) {
 		Post:               post,
 		SelectedLanguageId: int(post.LanguageIdlanguage),
 	}
-	handlers.TemplateHandler(w, r, "adminNewsEditPage.gohtml", data)
+	if err := cd.ExecuteSiteTemplate(w, r, "adminNewsEditPage.gohtml", data); err != nil {
+		handlers.RenderErrorPage(w, r, err)
+	}
 }
 
 func AdminNewsDeleteConfirmPage(w http.ResponseWriter, r *http.Request) {
@@ -196,10 +201,7 @@ func AdminNewsDeleteConfirmPage(w http.ResponseWriter, r *http.Request) {
 		ConfirmLabel: "Confirm delete",
 		Back:         fmt.Sprintf("/admin/news/article/%d", pid),
 	}
-	handlers.TemplateHandler(w, r, "adminNewsDeleteConfirmPage.gohtml", data)
-}
-
-// NewsDelete deactivates a news post.
-func NewsDelete(ctx context.Context, q db.Querier, postID int32) error {
-	return q.DeactivateNewsPost(ctx, postID)
+	if err := cd.ExecuteSiteTemplate(w, r, "adminNewsDeleteConfirmPage.gohtml", data); err != nil {
+		handlers.RenderErrorPage(w, r, err)
+	}
 }

--- a/handlers/news/announcement_delete_task.go
+++ b/handlers/news/announcement_delete_task.go
@@ -1,18 +1,15 @@
 package news
 
 import (
-	"database/sql"
-	"errors"
 	"fmt"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"strconv"
 
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -24,22 +21,10 @@ var announcementDeleteTask = &AnnouncementDeleteTask{TaskString: TaskDelete}
 var _ tasks.Task = (*AnnouncementDeleteTask)(nil)
 
 func (AnnouncementDeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
-	vars := mux.Vars(r)
-	pid, _ := strconv.Atoi(vars["news"])
-
-	ann, err := cd.NewsAnnouncementWithErr(int32(pid))
-	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("announcement for news fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-		}
-		return nil
-	}
-	if ann != nil && ann.Active {
-		if err := queries.AdminSetAnnouncementActive(r.Context(), db.AdminSetAnnouncementActiveParams{Active: false, ID: ann.ID}); err != nil {
-			return fmt.Errorf("deactivate announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
-		}
+	pid, _ := strconv.Atoi(mux.Vars(r)["news"])
+	if err := cd.DeleteAnnouncement(int32(pid)); err != nil {
+		return fmt.Errorf("delete announcement fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	return nil
 }

--- a/handlers/news/newsDeleteTask.go
+++ b/handlers/news/newsDeleteTask.go
@@ -21,15 +21,15 @@ var deleteNewsPostTask = &DeleteNewsPostTask{TaskString: TaskDelete}
 var _ tasks.Task = (*DeleteNewsPostTask)(nil)
 
 func (DeleteNewsPostTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	pid, err := strconv.Atoi(mux.Vars(r)["news"])
 	if err != nil {
 		return fmt.Errorf("post id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := NewsDelete(r.Context(), queries, int32(pid)); err != nil {
+	if err := cd.DeleteNewsPost(int32(pid)); err != nil {
 		return fmt.Errorf("delete news post fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+	if cd != nil {
 		if evt := cd.Event(); evt != nil {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}

--- a/handlers/news/newsNewPostTask.go
+++ b/handlers/news/newsNewPostTask.go
@@ -1,9 +1,7 @@
 package news
 
 import (
-	"database/sql"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -12,7 +10,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
@@ -69,52 +66,30 @@ func (NewPostTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("languageId parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	text := r.PostFormValue("text")
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	session, ok := core.GetSessionOrFail(w, r)
 	if !ok {
 		return handlers.SessionFetchFail{}
 	}
 	uid, _ := session.Values["UID"].(int32)
 
-	if cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData); !cd.HasGrant("news", "post", "post", 0) {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if !cd.HasGrant("news", "post", "post", 0) {
 		r.URL.RawQuery = "error=" + url.QueryEscape("Forbidden")
 		handlers.TaskErrorAcknowledgementPage(w, r)
 		return nil
 	}
-	id, err := queries.CreateNewsPostForWriter(r.Context(), db.CreateNewsPostForWriterParams{
-		LanguageID: int32(languageId),
-		News:       sql.NullString{String: text, Valid: true},
-		WriterID:   uid,
-		GranteeID:  sql.NullInt32{Int32: uid, Valid: true},
-	})
+	id, err := cd.CreateNewsPost(int32(languageId), uid, text)
 	if err != nil {
 		return fmt.Errorf("create news post fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	// give the author edit rights on the new post
-	if _, err := queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
-		UserID:   sql.NullInt32{Int32: uid, Valid: true},
-		RoleID:   sql.NullInt32{},
-		Section:  "news",
-		Item:     sql.NullString{String: "post", Valid: true},
-		RuleType: "allow",
-		ItemID:   sql.NullInt32{Int32: int32(id), Valid: true},
-		ItemRule: sql.NullString{},
-		Action:   "edit",
-		Extra:    sql.NullString{},
-	}); err != nil {
-		log.Printf("create grant: %v", err)
-	}
-
-	if u, err := queries.SystemGetUserByID(r.Context(), uid); err == nil {
-		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-			if evt := cd.Event(); evt != nil {
-				if evt.Data == nil {
-					evt.Data = map[string]any{}
-				}
-				evt.Data["Author"] = u.Username.String
-				evt.Data["PostURL"] = cd.AbsoluteURL(fmt.Sprintf("/news/news/%d", id))
+	if u, err := cd.CurrentUser(); err == nil && u != nil {
+		if evt := cd.Event(); evt != nil {
+			if evt.Data == nil {
+				evt.Data = map[string]any{}
 			}
+			evt.Data["Author"] = u.Username.String
+			evt.Data["PostURL"] = cd.AbsoluteURL(fmt.Sprintf("/news/news/%d", id))
 		}
 	}
 

--- a/handlers/news/newsPage.go
+++ b/handlers/news/newsPage.go
@@ -21,7 +21,9 @@ func NewsPage(w http.ResponseWriter, r *http.Request) {
 		cd.PrevLink = fmt.Sprintf("?offset=%d", offset-ps)
 		cd.StartLink = "?offset=0"
 	}
-	handlers.TemplateHandler(w, r, "newsPage", struct{}{})
+	if err := cd.ExecuteSiteTemplate(w, r, "newsPage", struct{}{}); err != nil {
+		handlers.RenderErrorPage(w, r, err)
+	}
 }
 
 func CustomNewsIndex(data *common.CoreData, r *http.Request) {

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -144,5 +144,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	handlers.TemplateHandler(w, r, "postPage.gohtml", data)
+	if err := cd.ExecuteSiteTemplate(w, r, "postPage.gohtml", data); err != nil {
+		handlers.RenderErrorPage(w, r, err)
+	}
 }

--- a/handlers/news/newsReplyTask_event_test.go
+++ b/handlers/news/newsReplyTask_event_test.go
@@ -46,14 +46,14 @@ func TestNewsReplyTaskEventData(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler"}).
 			AddRow(4, int32(0), 0, 0, NewsTopicName, "", 0, 0, sql.NullTime{}, "news"))
 
+	mock.ExpectExec("INSERT INTO comments").
+		WithArgs(int32(1), uid, pthid, sqlmock.AnyArg(), "news", sqlmock.AnyArg(), int32(pid), sqlmock.AnyArg(), uid).
+		WillReturnResult(sqlmock.NewResult(5, 1))
+
 	mock.ExpectQuery("SELECT u.idusers").
 		WithArgs(uid).
 		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).
 			AddRow(uid, nil, "alice", nil))
-
-	mock.ExpectExec("INSERT INTO comments").
-		WithArgs(int32(1), uid, pthid, sqlmock.AnyArg(), "news", sqlmock.AnyArg(), int32(pid), sqlmock.AnyArg(), uid).
-		WillReturnResult(sqlmock.NewResult(5, 1))
 
 	store := sessions.NewCookieStore([]byte("test"))
 	core.Store = store

--- a/handlers/news/search_test.go
+++ b/handlers/news/search_test.go
@@ -1,6 +1,7 @@
 package news
 
 import (
+	"context"
 	"database/sql"
 	"net/http/httptest"
 	"net/url"
@@ -10,6 +11,8 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 )
 
@@ -41,9 +44,8 @@ func TestNewsSearchFiltersUnauthorized(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	ctx := req.Context()
 	req = req.WithContext(ctx)
-	rr := httptest.NewRecorder()
-
-	news, emptyWords, noResults, err := NewsSearch(rr, req, queries, 1)
+	cd := common.NewCoreData(context.Background(), queries, config.NewRuntimeConfig())
+	news, emptyWords, noResults, err := cd.SearchNews(req, 1)
 	if err != nil {
 		t.Fatalf("NewsSearch: %v", err)
 	}

--- a/handlers/news/user_allow_task.go
+++ b/handlers/news/user_allow_task.go
@@ -1,7 +1,6 @@
 package news
 
 import (
-	"database/sql"
 	"fmt"
 	"net/http"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -33,7 +31,6 @@ func (UserAllowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *
 }
 
 func (UserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	username := r.PostFormValue("username")
 	role := r.PostFormValue("role")
 	data := struct {
@@ -43,12 +40,8 @@ func (UserAllowTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}{
 		Back: "/news",
 	}
-	if u, err := queries.SystemGetUserByUsername(r.Context(), sql.NullString{Valid: true, String: username}); err != nil {
-		data.Errors = append(data.Errors, fmt.Errorf("SystemGetUserByUsername: %w", err).Error())
-	} else if err := queries.SystemCreateUserRole(r.Context(), db.SystemCreateUserRoleParams{
-		UsersIdusers: u.Idusers,
-		Name:         role,
-	}); err != nil {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	if err := cd.AllowNewsUser(username, role); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("permissionUserAllow: %w", err).Error())
 	}
 

--- a/handlers/news/user_disallow_task.go
+++ b/handlers/news/user_disallow_task.go
@@ -32,7 +32,6 @@ func (UserDisallowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent
 }
 
 func (UserDisallowTask) Action(w http.ResponseWriter, r *http.Request) any {
-	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	permid := r.PostFormValue("permid")
 	data := struct {
 		Errors   []string
@@ -43,7 +42,7 @@ func (UserDisallowTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	if permidi, err := strconv.Atoi(permid); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("strconv.Atoi: %w", err).Error())
-	} else if err := queries.AdminDeleteUserRole(r.Context(), int32(permidi)); err != nil {
+	} else if err := r.Context().Value(consts.KeyCoreData).(*common.CoreData).DisallowNewsUser(int32(permidi)); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("CreateLanguage: %w", err).Error())
 	}
 	return handlers.TemplateWithDataHandler("runTaskPage.gohtml", data)


### PR DESCRIPTION
## Summary
- centralize news operations in new `coredata_news` helpers
- refactor news handlers to use CoreData and render templates via CoreData

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68959776e154832f8088516cdb787a1c