### PR TITLE
Delay message entry until participants added for private forums

### DIFF
--- a/core/templates/assets/private_forum.js
+++ b/core/templates/assets/private_forum.js
@@ -3,10 +3,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const addBtn = document.getElementById('add-participant');
     const list = document.getElementById('participants');
     const field = document.getElementById('participants-field');
+    const message = document.getElementById('message-field');
+    const createBtn = document.getElementById('create-button');
 
-    function updateField() {
+    function updateParticipants() {
         const names = Array.from(list.querySelectorAll('li')).map(li => li.textContent);
         field.value = names.join(',');
+        const show = names.length > 0;
+        if (message) message.style.display = show ? '' : 'none';
+        if (createBtn) createBtn.style.display = show ? '' : 'none';
     }
 
     addBtn?.addEventListener('click', (e) => {
@@ -17,10 +22,12 @@ document.addEventListener('DOMContentLoaded', () => {
         li.textContent = name;
         li.addEventListener('click', () => {
             list.removeChild(li);
-            updateField();
+            updateParticipants();
         });
         list.appendChild(li);
         input.value = '';
-        updateField();
+        updateParticipants();
     });
+
+    updateParticipants();
 });

--- a/core/templates/site/privateForumPage.gohtml
+++ b/core/templates/site/privateForumPage.gohtml
@@ -3,15 +3,16 @@
     <h1>Private Topics</h1>
     {{ template "tableTopics" (dict "Topics" cd.PrivateTopics) }}
     {{ if cd.HasGrant "privateforum" "topic" "create" 0 }}
-        <h2>Start conversation</h2>
+        <h2>Start group discussion</h2>
+        <p>Add people to start a shared conversation.</p>
         <form id="private-form" method="POST">
             <input type="hidden" name="task" value="{{ .CreateTask }}">
             <input type="text" id="participant-input" placeholder="username">
             <button type="button" id="add-participant">Add</button>
             <ul id="participants"></ul>
             <input type="hidden" name="participants" id="participants-field">
-            <textarea name="body" id="message-field" placeholder="Message"></textarea>
-            <button type="submit">Create</button>
+            <textarea name="body" id="message-field" placeholder="Message" style="display:none"></textarea>
+            <button type="submit" id="create-button" style="display:none">Create</button>
         </form>
         <script src="/private/private_forum.js"></script>
     {{ end }}


### PR DESCRIPTION
## Summary
- Clarify that private discussions are group chats and require participants
- Hide message field and submit button until at least one person is added

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestAdminCategoryPageLinks, TestAdminTopicPage, TestAdminTopicEditFormPage)*
- `go test ./handlers/privateforum`


------
https://chatgpt.com/codex/tasks/task_e_6895f5dd5a7c832fa17693fc1582f543