### PR TITLE
Reorder topic and category headings on topic page

### DIFF
--- a/core/templates/site/forum/topicsPage.gohtml
+++ b/core/templates/site/forum/topicsPage.gohtml
@@ -1,9 +1,9 @@
 {{ template "head" $ }}
 
-    <h1>Topic: {{ .Topic.Title.String }}</h1>
     {{ if .Category }}
-        <h2>Category: {{ .Category.Title.String }}</h2>
+        <h1>Category: {{ .Category.Title.String }}</h1>
     {{ end }}
+    <h2>Topic: {{ .Topic.Title.String }}</h2>
 
     <div class="topic-actions">
         <a href="/forum/topic/{{.Topic.Idforumtopic}}/thread">New Thread</a>


### PR DESCRIPTION
## Summary
- Show category heading above topic heading on topic page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestAdminCategoryPageLinks, TestAdminTopicPage, TestAdminTopicEditFormPage)*

------
https://chatgpt.com/codex/tasks/task_e_6895f4f9b830832f9fdaa3177438eb26