### PR TITLE
Add forum topic grant handling

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -209,7 +209,7 @@ type CoreData struct {
 	writerWritings                   map[int32]*lazy.Value[[]*db.ListPublicWritingsByUserForListerRow]
 	writingCategories                lazy.Value[[]*db.WritingCategory]
 	writingRows                      map[int32]*lazy.Value[*db.GetWritingForListerByIDRow]
-  // marks records which template sections have been rendered to avoid
+	// marks records which template sections have been rendered to avoid
 	// duplicate output when re-rendering after an error.
 	marks map[string]struct{}
 }
@@ -1860,6 +1860,10 @@ func sectionItemType(section string) string {
 		return "entry"
 	case "news":
 		return "post"
+	case "forum":
+		return "topic"
+	case "privateforum":
+		return "topic"
 	case "imagebbs":
 		return "board"
 	case "linker":

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/lazy"
 )
 
 func TestCoreDataLatestNewsLazy(t *testing.T) {
@@ -425,6 +426,44 @@ func TestSelectedQuestionFromCategoryWrongCategory(t *testing.T) {
 
 	if err := cd.SelectedQuestionFromCategory(1, 2); err == nil {
 		t.Fatalf("expected error")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSelectedThreadCanReply(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	queries := db.New(conn)
+	ctx := context.Background()
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{"user"}))
+	cd.UserID = 1
+	cd.SetCurrentSection("forum")
+	threadID, topicID := int32(3), int32(2)
+	cd.SetCurrentThreadAndTopic(threadID, topicID)
+
+	if _, err := cd.ForumThreadByID(threadID, lazy.Set(&db.GetThreadLastPosterAndPermsRow{})); err != nil {
+		t.Fatalf("ForumThreadByID preload: %v", err)
+	}
+
+	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(
+		int32(1),
+		"forum",
+		sql.NullString{String: "topic", Valid: true},
+		"reply",
+		sql.NullInt32{Int32: topicID, Valid: true},
+		sql.NullInt32{Int32: 1, Valid: true},
+	).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	if !cd.SelectedThreadCanReply() {
+		t.Fatalf("SelectedThreadCanReply() = false; want true")
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/core/common/sectionitemtype_test.go
+++ b/core/common/sectionitemtype_test.go
@@ -1,0 +1,18 @@
+package common
+
+import "testing"
+
+func TestSectionItemType(t *testing.T) {
+	tests := []struct {
+		section string
+		want    string
+	}{
+		{"forum", "topic"},
+		{"privateforum", "topic"},
+	}
+	for _, tt := range tests {
+		if got := sectionItemType(tt.section); got != tt.want {
+			t.Errorf("sectionItemType(%q) = %q; want %q", tt.section, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- map `forum` and `privateforum` sections to the `topic` grant item
- allow replying to forum threads when granted
- cover section item type and reply permission in tests

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./core/common -run TestSelectedThreadCanReply -v`
- `go test ./core/common -run TestSectionItemType -v`
- `go test ./...` *(fails: ExpectedQuery … SELECT idforumtopic …)*

------
https://chatgpt.com/codex/tasks/task_e_6895f37d1f9c832f98267dcc6c1bc8c3