### PR TITLE
Remove blog index from forum thread pages

### DIFF
--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -12,7 +12,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/handlers/blogs"
 	"github.com/arran4/goa4web/internal/db"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/workers/postcountworker"
@@ -102,8 +101,6 @@ func (CreateThreadTask) Page(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data.Languages = languageRows
-
-	blogs.CustomBlogIndex(cd, r)
 
 	handlers.TemplateHandler(w, r, "threadNewPage.gohtml", data)
 }

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -10,7 +10,6 @@ import (
 	"github.com/arran4/goa4web/a4code"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/handlers/blogs"
 	"github.com/arran4/goa4web/internal/db"
 
 	"github.com/arran4/goa4web/core"
@@ -124,8 +123,6 @@ func ThreadPage(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-
-	blogs.CustomBlogIndex(cd, r)
 
 	handlers.TemplateHandler(w, r, "threadPage.gohtml", data)
 }


### PR DESCRIPTION
## Summary
- ensure forum thread views don't reuse blog-specific index items

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestAdminCategoryPageLinks, TestAdminTopicPage, TestAdminTopicEditFormPage)*

------
https://chatgpt.com/codex/tasks/task_e_6895f3676214832fb1fe3c56430174aa