### PR TITLE
Allow nullable language references

### DIFF
--- a/cmd/goa4web/blog_create.go
+++ b/cmd/goa4web/blog_create.go
@@ -43,7 +43,7 @@ func (c *blogCreateCmd) Run() error {
 	queries := db.New(conn)
 	_, err = queries.CreateBlogEntryForWriter(ctx, db.CreateBlogEntryForWriterParams{
 		UsersIdusers:       int32(c.UserID),
-		LanguageIdlanguage: int32(c.LangID),
+		LanguageIdlanguage: sql.NullInt32{Int32: int32(c.LangID), Valid: true},
 		Blog:               sql.NullString{String: c.Text, Valid: true},
 		UserID:             sql.NullInt32{Int32: int32(c.UserID), Valid: true},
 		ListerID:           int32(c.UserID),

--- a/cmd/goa4web/blog_update.go
+++ b/cmd/goa4web/blog_update.go
@@ -42,7 +42,7 @@ func (c *blogUpdateCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(conn)
 	err = queries.UpdateBlogEntryForWriter(ctx, db.UpdateBlogEntryForWriterParams{
-		LanguageID:   int32(c.LangID),
+		LanguageID:   sql.NullInt32{Int32: int32(c.LangID), Valid: true},
 		Blog:         sql.NullString{String: c.Text, Valid: c.Text != ""},
 		EntryID:      int32(c.ID),
 		WriterID:     0,

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -210,7 +210,7 @@ type CoreData struct {
 	writerWritings                   map[int32]*lazy.Value[[]*db.ListPublicWritingsByUserForListerRow]
 	writingCategories                lazy.Value[[]*db.WritingCategory]
 	writingRows                      map[int32]*lazy.Value[*db.GetWritingForListerByIDRow]
-  // marks records which template sections have been rendered to avoid
+	// marks records which template sections have been rendered to avoid
 	// duplicate output when re-rendering after an error.
 	marks map[string]struct{}
 }
@@ -1287,7 +1287,7 @@ func (cd *CoreData) DeleteLanguage(code string) (int32, string, error) {
 			}
 		}
 	}
-	counts, err := cd.queries.AdminLanguageUsageCounts(cd.ctx, db.AdminLanguageUsageCountsParams{ID: int32(id)})
+	counts, err := cd.queries.AdminLanguageUsageCounts(cd.ctx, db.AdminLanguageUsageCountsParams{ID: sql.NullInt32{Int32: int32(id), Valid: true}})
 	if err != nil {
 		return int32(id), name, err
 	}
@@ -1613,8 +1613,8 @@ func (cd *CoreData) Preference() (*db.Preference, error) {
 func (cd *CoreData) PreferredLanguageID(siteDefault string) int32 {
 	id, err := cd.preferredLanguageID.Load(func() (int32, error) {
 		if pref, err := cd.Preference(); err == nil && pref != nil {
-			if pref.LanguageIdlanguage != 0 {
-				return pref.LanguageIdlanguage, nil
+			if pref.LanguageIdlanguage.Valid {
+				return pref.LanguageIdlanguage.Int32, nil
 			}
 		}
 		if cd.queries == nil || siteDefault == "" {
@@ -1967,7 +1967,7 @@ func (cd *CoreData) CreateCommentInSectionForCommenter(section, itemType string,
 		return 0, nil
 	}
 	return cd.queries.CreateCommentInSectionForCommenter(cd.ctx, db.CreateCommentInSectionForCommenterParams{
-		LanguageID:    languageID,
+		LanguageID:    sql.NullInt32{Int32: languageID, Valid: true},
 		CommenterID:   sql.NullInt32{Int32: commenterID, Valid: commenterID != 0},
 		ForumthreadID: threadID,
 		Text:          sql.NullString{String: text, Valid: text != ""},

--- a/core/common/coredata_blogs.go
+++ b/core/common/coredata_blogs.go
@@ -65,7 +65,7 @@ func (cd *CoreData) UpdateBlogReply(commentID, commenterID, languageID int32, te
 		return nil
 	}
 	return cd.queries.UpdateCommentForEditor(cd.ctx, db.UpdateCommentForEditorParams{
-		LanguageID:  languageID,
+		LanguageID:  sql.NullInt32{Int32: languageID, Valid: true},
 		Text:        sql.NullString{String: text, Valid: true},
 		CommentID:   commentID,
 		CommenterID: commenterID,

--- a/core/common/coredata_forum.go
+++ b/core/common/coredata_forum.go
@@ -152,7 +152,7 @@ func (cd *CoreData) UpdateForumComment(commentID, languageID int32, text string)
 		return nil
 	}
 	return cd.queries.UpdateCommentForEditor(cd.ctx, db.UpdateCommentForEditorParams{
-		LanguageID:  languageID,
+		LanguageID:  sql.NullInt32{Int32: languageID, Valid: true},
 		Text:        sql.NullString{String: text, Valid: true},
 		CommentID:   commentID,
 		CommenterID: cd.UserID,
@@ -166,7 +166,7 @@ func (cd *CoreData) EditForumComment(commentID, commenterID, languageID int32, t
 		return nil
 	}
 	return cd.queries.UpdateCommentForEditor(cd.ctx, db.UpdateCommentForEditorParams{
-		LanguageID:  languageID,
+		LanguageID:  sql.NullInt32{Int32: languageID, Valid: true},
 		Text:        sql.NullString{String: text, Valid: true},
 		CommentID:   commentID,
 		CommenterID: commenterID,

--- a/core/common/coredata_misc.go
+++ b/core/common/coredata_misc.go
@@ -35,7 +35,7 @@ func (cd *CoreData) CreatePrivateTopic(p CreatePrivateTopicParams) (topicID, thr
 	tid, err := cd.queries.CreateForumTopicForPoster(cd.ctx, db.CreateForumTopicForPosterParams{
 		PosterID:        p.CreatorID,
 		ForumcategoryID: PrivateForumCategoryID,
-		LanguageID:      0,
+		LanguageID:      sql.NullInt32{},
 		Title:           sql.NullString{},
 		Description:     sql.NullString{},
 		Handler:         "private",

--- a/core/common/coredata_news.go
+++ b/core/common/coredata_news.go
@@ -105,7 +105,7 @@ func (cd *CoreData) UpdateNewsReply(commentID, editorID, languageID int32, text 
 		return ThreadInfo{}, fmt.Errorf("thread fetch: %w", err)
 	}
 	if err := cd.queries.UpdateCommentForEditor(cd.ctx, db.UpdateCommentForEditorParams{
-		LanguageID:  languageID,
+		LanguageID:  sql.NullInt32{Int32: languageID, Valid: true},
 		Text:        sql.NullString{String: text, Valid: true},
 		CommentID:   commentID,
 		CommenterID: editorID,
@@ -124,7 +124,7 @@ func (cd *CoreData) UpdateNewsPost(postID, languageID, userID int32, text string
 	return cd.queries.UpdateNewsPostForWriter(cd.ctx, db.UpdateNewsPostForWriterParams{
 		PostID:      postID,
 		GrantPostID: sql.NullInt32{Int32: postID, Valid: true},
-		LanguageID:  languageID,
+		LanguageID:  sql.NullInt32{Int32: languageID, Valid: true},
 		News:        sql.NullString{String: text, Valid: true},
 		GranteeID:   sql.NullInt32{Int32: userID, Valid: userID != 0},
 		WriterID:    userID,
@@ -145,7 +145,7 @@ func (cd *CoreData) CreateNewsPost(languageID, userID int32, text string) (int64
 		return 0, nil
 	}
 	id, err := cd.queries.CreateNewsPostForWriter(cd.ctx, db.CreateNewsPostForWriterParams{
-		LanguageID: languageID,
+		LanguageID: sql.NullInt32{Int32: languageID, Valid: true},
 		News:       sql.NullString{String: text, Valid: true},
 		WriterID:   userID,
 		GranteeID:  sql.NullInt32{Int32: userID, Valid: true},

--- a/core/common/coredata_user.go
+++ b/core/common/coredata_user.go
@@ -174,7 +174,7 @@ func (cd *CoreData) SetUserLanguage(userID, languageID int32) error {
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return cd.queries.InsertPreferenceForLister(cd.ctx, db.InsertPreferenceForListerParams{
-				LanguageID: languageID,
+				LanguageID: sql.NullInt32{Int32: languageID, Valid: true},
 				ListerID:   userID,
 				PageSize:   int32(cd.Config.PageSizeDefault),
 				Timezone:   sql.NullString{},
@@ -183,7 +183,7 @@ func (cd *CoreData) SetUserLanguage(userID, languageID int32) error {
 		return err
 	}
 	return cd.queries.UpdatePreferenceForLister(cd.ctx, db.UpdatePreferenceForListerParams{
-		LanguageID: languageID,
+		LanguageID: sql.NullInt32{Int32: languageID, Valid: true},
 		ListerID:   userID,
 		PageSize:   pref.PageSize,
 		Timezone:   pref.Timezone,
@@ -199,7 +199,7 @@ func (cd *CoreData) SetUserLanguages(userID int32, langs []int32) error {
 		return err
 	}
 	for _, l := range langs {
-		if err := cd.queries.InsertUserLang(cd.ctx, db.InsertUserLangParams{UsersIdusers: userID, LanguageIdlanguage: l}); err != nil {
+		if err := cd.queries.InsertUserLang(cd.ctx, db.InsertUserLangParams{UsersIdusers: userID, LanguageIdlanguage: sql.NullInt32{Int32: l, Valid: true}}); err != nil {
 			return err
 		}
 	}
@@ -215,7 +215,7 @@ func (cd *CoreData) SetTimezone(userID int32, tz string) error {
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return cd.queries.InsertPreferenceForLister(cd.ctx, db.InsertPreferenceForListerParams{
-				LanguageID: 0,
+				LanguageID: sql.NullInt32{},
 				ListerID:   userID,
 				PageSize:   int32(cd.Config.PageSizeDefault),
 				Timezone:   sql.NullString{String: tz, Valid: tz != ""},

--- a/core/common/faq.go
+++ b/core/common/faq.go
@@ -74,7 +74,6 @@ func (cd *CoreData) RenameFAQCategory(id int32, name string) error {
 	})
 }
 
-
 // CreateFAQQuestionParams groups input for CreateFAQQuestion.
 type CreateFAQQuestionParams struct {
 	Question   string
@@ -94,7 +93,7 @@ func (cd *CoreData) CreateFAQQuestion(p CreateFAQQuestionParams) (int64, error) 
 		Answer:     sql.NullString{String: p.Answer, Valid: p.Answer != ""},
 		CategoryID: p.CategoryID,
 		WriterID:   p.WriterID,
-		LanguageID: p.LanguageID,
+		LanguageID: sql.NullInt32{Int32: p.LanguageID, Valid: p.LanguageID != 0},
 		GranteeID:  sql.NullInt32{Int32: p.WriterID, Valid: p.WriterID != 0},
 	})
 	if err != nil {
@@ -116,4 +115,3 @@ func (cd *CoreData) CreateFAQQuestion(p CreateFAQQuestionParams) (int64, error) 
 	}
 	return id, nil
 }
-

--- a/core/templates/site/admin/userBlogsPage.gohtml
+++ b/core/templates/site/admin/userBlogsPage.gohtml
@@ -7,7 +7,7 @@
         <td><a href="/admin/blogs/blog/{{ .Idblogs }}">{{ .Idblogs }}</a></td>
         <td>{{ .Written }}</td>
         <td>{{ .Comments }}</td>
-        <td>{{ .LanguageIdlanguage }}</td>
+        <td>{{ if .LanguageIdlanguage.Valid }}{{ .LanguageIdlanguage.Int32 }}{{ end }}</td>
         <td>{{if .Idforumcategory.Valid}}<a href="/forum/category/{{ .Idforumcategory.Int32 }}">{{ .ForumcategoryTitle.String }}</a>{{end}}</td>
         <td>{{ left 40 (firstline (a4code2string .Blog.String)) }}</td>
         <td><a href="/blogs/blog/{{ .Idblogs }}">View</a></td>

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"net/http"
@@ -31,7 +32,7 @@ func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 	langID, _ := strconv.Atoi(r.URL.Query().Get("lang"))
 	role := r.URL.Query().Get("role")
 	rows, err := queries.AdminListUnsentPendingEmails(r.Context(), db.AdminListUnsentPendingEmailsParams{
-		LanguageID: int32(langID),
+		LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
 		RoleName:   role,
 	})
 	if err != nil {

--- a/handlers/admin/adminFailedEmailsPage.go
+++ b/handlers/admin/adminFailedEmailsPage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"net/http"
@@ -40,7 +41,7 @@ func AdminFailedEmailsPage(w http.ResponseWriter, r *http.Request) {
 	langID, _ := strconv.Atoi(r.URL.Query().Get("lang"))
 	role := r.URL.Query().Get("role")
 	rows, err := queries.AdminListFailedEmails(r.Context(), db.AdminListFailedEmailsParams{
-		LanguageID: int32(langID),
+		LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
 		RoleName:   role,
 		Limit:      int32(pageSize + 1),
 		Offset:     int32(offset),

--- a/handlers/admin/adminSentEmailsPage.go
+++ b/handlers/admin/adminSentEmailsPage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"net/http"
@@ -40,7 +41,7 @@ func AdminSentEmailsPage(w http.ResponseWriter, r *http.Request) {
 	langID, _ := strconv.Atoi(r.URL.Query().Get("lang"))
 	role := r.URL.Query().Get("role")
 	rows, err := queries.AdminListSentEmails(r.Context(), db.AdminListSentEmailsParams{
-		LanguageID: int32(langID),
+		LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
 		RoleName:   role,
 		Limit:      int32(pageSize + 1),
 		Offset:     int32(offset),

--- a/handlers/admin/role_grants.go
+++ b/handlers/admin/role_grants.go
@@ -194,8 +194,10 @@ func buildGrantGroupsFromGrants(ctx context.Context, cd *common.CoreData, grants
 					if w, err := queries.GetWritingForListerByID(ctx, db.GetWritingForListerByIDParams{ListerID: cd.UserID, Idwriting: g.ItemID.Int32, ListerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0}}); err == nil {
 						if w.Title.Valid {
 							info := w.Title.String
-							if name, ok := langMap[w.LanguageIdlanguage]; ok && name != "" {
-								info = fmt.Sprintf("[%s] %s", name, info)
+							if w.LanguageIdlanguage.Valid {
+								if name, ok := langMap[w.LanguageIdlanguage.Int32]; ok && name != "" {
+									info = fmt.Sprintf("[%s] %s", name, info)
+								}
 							}
 							gi.Info = info
 						}
@@ -220,8 +222,10 @@ func buildGrantGroupsFromGrants(ctx context.Context, cd *common.CoreData, grants
 						if len(text) > 40 {
 							text = text[:40] + "..."
 						}
-						if name, ok := langMap[qrow.LanguageIdlanguage]; ok && name != "" {
-							text = fmt.Sprintf("[%s] %s", name, text)
+						if qrow.LanguageIdlanguage.Valid {
+							if name, ok := langMap[qrow.LanguageIdlanguage.Int32]; ok && name != "" {
+								text = fmt.Sprintf("[%s] %s", name, text)
+							}
 						}
 						gi.Info = text
 					}

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -75,7 +75,7 @@ func (AddBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	id, err := queries.CreateBlogEntryForWriter(r.Context(), db.CreateBlogEntryForWriterParams{
 		UsersIdusers:       uid,
-		LanguageIdlanguage: int32(languageId),
+		LanguageIdlanguage: sql.NullInt32{Int32: int32(languageId), Valid: true},
 		Blog: sql.NullString{
 			String: text,
 			Valid:  true,

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -50,7 +50,7 @@ func (EditBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err = queries.UpdateBlogEntryForWriter(r.Context(), db.UpdateBlogEntryForWriterParams{
 		EntryID:      row.Idblogs,
 		GrantEntryID: sql.NullInt32{Int32: row.Idblogs, Valid: true},
-		LanguageID:   int32(languageId),
+		LanguageID:   sql.NullInt32{Int32: int32(languageId), Valid: true},
 		Blog: sql.NullString{
 			String: text,
 			Valid:  true,

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 57
+	ExpectedSchemaVersion = 58
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -93,7 +93,7 @@ func (AskTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err := queries.CreateFAQQuestionForWriter(r.Context(), db.CreateFAQQuestionForWriterParams{
 		Question:   sql.NullString{String: text, Valid: true},
 		WriterID:   uid,
-		LanguageID: int32(languageId),
+		LanguageID: sql.NullInt32{Int32: int32(languageId), Valid: true},
 		GranteeID:  sql.NullInt32{Int32: uid, Valid: true},
 	}); err != nil {
 		return fmt.Errorf("faq fetch fail: %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/forum/forumAdminCategoryCreatePage.go
+++ b/handlers/forum/forumAdminCategoryCreatePage.go
@@ -59,7 +59,7 @@ func AdminCategoryCreateSubmit(w http.ResponseWriter, r *http.Request) {
 	languageID, _ := strconv.Atoi(r.PostFormValue("language"))
 	if err := queries.AdminCreateForumCategory(r.Context(), db.AdminCreateForumCategoryParams{
 		ForumcategoryIdforumcategory: int32(pcid),
-		LanguageIdlanguage:           int32(languageID),
+		LanguageIdlanguage:           sql.NullInt32{Int32: int32(languageID), Valid: true},
 		Title:                        sql.NullString{Valid: true, String: name},
 		Description:                  sql.NullString{Valid: true, String: desc},
 	}); err != nil {

--- a/handlers/forum/forumAdminCategoryEditPage.go
+++ b/handlers/forum/forumAdminCategoryEditPage.go
@@ -82,7 +82,7 @@ func AdminCategoryEditSubmit(w http.ResponseWriter, r *http.Request) {
 		Description:                  sql.NullString{Valid: true, String: desc},
 		Idforumcategory:              int32(categoryId),
 		ForumcategoryIdforumcategory: int32(pcid),
-		LanguageIdlanguage:           int32(languageID),
+		LanguageIdlanguage:           sql.NullInt32{Int32: int32(languageID), Valid: true},
 	}); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return

--- a/handlers/forum/forumAdminTopicsPage.go
+++ b/handlers/forum/forumAdminTopicsPage.go
@@ -75,7 +75,7 @@ func AdminTopicEditPage(w http.ResponseWriter, r *http.Request) {
 		Title:                        sql.NullString{String: name, Valid: true},
 		Description:                  sql.NullString{String: desc, Valid: true},
 		ForumcategoryIdforumcategory: int32(cid),
-		LanguageIdlanguage:           int32(languageID),
+		LanguageIdlanguage:           sql.NullInt32{Int32: int32(languageID), Valid: true},
 		Idforumtopic:                 int32(tid),
 	}); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
@@ -114,7 +114,7 @@ func AdminTopicCreatePage(w http.ResponseWriter, r *http.Request) {
 	topicID, err := cd.Queries().CreateForumTopicForPoster(r.Context(), db.CreateForumTopicForPosterParams{
 		PosterID:        uid,
 		ForumcategoryID: int32(pcid),
-		LanguageID:      int32(languageID),
+		LanguageID:      sql.NullInt32{Int32: int32(languageID), Valid: true},
 		Title:           sql.NullString{String: name, Valid: true},
 		Description:     sql.NullString{String: desc, Valid: true},
 		Handler:         "",

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -153,7 +153,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if errors.Is(err, sql.ErrNoRows) {
 		ptidi, err := queries.SystemCreateForumTopic(r.Context(), db.SystemCreateForumTopicParams{
 			ForumcategoryIdforumcategory: 0,
-			LanguageIdlanguage:           0,
+			LanguageIdlanguage:           sql.NullInt32{},
 			Title: sql.NullString{
 				String: ImageBBSTopicName,
 				Valid:  true,

--- a/handlers/languages/admin.go
+++ b/handlers/languages/admin.go
@@ -1,6 +1,7 @@
 package languages
 
 import (
+	"database/sql"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -46,7 +47,7 @@ func adminLanguagePage(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Not Found"))
 		return
 	}
-	counts, err := cd.Queries().AdminLanguageUsageCounts(r.Context(), db.AdminLanguageUsageCountsParams{ID: int32(id)})
+	counts, err := cd.Queries().AdminLanguageUsageCounts(r.Context(), db.AdminLanguageUsageCountsParams{ID: sql.NullInt32{Int32: int32(id), Valid: true}})
 	if err != nil {
 		handlers.RenderErrorPage(w, r, err)
 		return

--- a/handlers/linker/edit_reply_task.go
+++ b/handlers/linker/edit_reply_task.go
@@ -65,7 +65,7 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if err = queries.UpdateCommentForEditor(r.Context(), db.UpdateCommentForEditorParams{
-		LanguageID: int32(languageId),
+		LanguageID: sql.NullInt32{Int32: int32(languageId), Valid: true},
 		Text: sql.NullString{
 			String: text,
 			Valid:  true,

--- a/handlers/linker/linkerAdminLinkPage.go
+++ b/handlers/linker/linkerAdminLinkPage.go
@@ -34,9 +34,14 @@ func adminLinkPage(w http.ResponseWriter, r *http.Request) {
 		Selected           int
 		SelectedLanguageId int
 	}{
-		Link:               link,
-		Selected:           int(link.LinkerCategoryID),
-		SelectedLanguageId: int(link.LanguageIdlanguage),
+		Link:     link,
+		Selected: int(link.LinkerCategoryID),
+		SelectedLanguageId: func() int {
+			if link.LanguageIdlanguage.Valid {
+				return int(link.LanguageIdlanguage.Int32)
+			}
+			return 0
+		}(),
 	}
 
 	handlers.TemplateHandler(w, r, "adminLinkPage.gohtml", data)
@@ -69,7 +74,7 @@ func (editLinkTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Url:                sql.NullString{Valid: true, String: URL},
 		Description:        sql.NullString{Valid: true, String: desc},
 		LinkerCategoryID:   int32(cat),
-		LanguageIdlanguage: int32(lang),
+		LanguageIdlanguage: sql.NullInt32{Int32: int32(lang), Valid: true},
 		Idlinker:           id,
 	}); err != nil {
 		return fmt.Errorf("update linker item fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/news/admin_pages.go
+++ b/handlers/news/admin_pages.go
@@ -175,9 +175,14 @@ func adminNewsEditFormPage(w http.ResponseWriter, r *http.Request) {
 		Post               *db.GetNewsPostByIdWithWriterIdAndThreadCommentCountRow
 		SelectedLanguageId int
 	}{
-		Languages:          langs,
-		Post:               post,
-		SelectedLanguageId: int(post.LanguageIdlanguage),
+		Languages: langs,
+		Post:      post,
+		SelectedLanguageId: func() int {
+			if post.LanguageIdlanguage.Valid {
+				return int(post.LanguageIdlanguage.Int32)
+			}
+			return 0
+		}(),
 	}
 	if err := cd.ExecuteSiteTemplate(w, r, "adminNewsEditPage.gohtml", data); err != nil {
 		handlers.RenderErrorPage(w, r, err)

--- a/handlers/user/userPagingPage.go
+++ b/handlers/user/userPagingPage.go
@@ -57,7 +57,7 @@ func (PagingSaveTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	if errors.Is(err, sql.ErrNoRows) {
 		err = queries.InsertPreferenceForLister(r.Context(), db.InsertPreferenceForListerParams{
-			LanguageID: 0,
+			LanguageID: sql.NullInt32{},
 			ListerID:   uid,
 			PageSize:   int32(size),
 			Timezone:   sql.NullString{},

--- a/handlers/writings/edit_reply_task.go
+++ b/handlers/writings/edit_reply_task.go
@@ -64,7 +64,7 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if err = queries.UpdateCommentForEditor(r.Context(), db.UpdateCommentForEditorParams{
-		LanguageID:  int32(languageID),
+		LanguageID:  sql.NullInt32{Int32: int32(languageID), Valid: true},
 		Text:        sql.NullString{String: text, Valid: true},
 		CommentID:   comment.Idcomments,
 		CommenterID: uid,

--- a/handlers/writings/submit_writing_task.go
+++ b/handlers/writings/submit_writing_task.go
@@ -72,7 +72,7 @@ func (SubmitWritingTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Abstract:          sql.NullString{Valid: true, String: abstract},
 		Writing:           sql.NullString{Valid: true, String: body},
 		Private:           sql.NullBool{Valid: true, Bool: private},
-		LanguageID:        int32(languageID),
+		LanguageID:        sql.NullInt32{Int32: int32(languageID), Valid: true},
 		GrantCategoryID:   sql.NullInt32{Int32: int32(categoryID), Valid: true},
 		GranteeID:         sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})

--- a/handlers/writings/update_writing_task.go
+++ b/handlers/writings/update_writing_task.go
@@ -54,7 +54,7 @@ func (UpdateWritingTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Abstract:   sql.NullString{Valid: true, String: abstract},
 		Content:    sql.NullString{Valid: true, String: body},
 		Private:    sql.NullBool{Valid: true, Bool: private},
-		LanguageID: int32(languageID),
+		LanguageID: sql.NullInt32{Int32: int32(languageID), Valid: true},
 		WritingID:  writing.Idwriting,
 		WriterID:   cd.UserID,
 		GranteeID:  sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},

--- a/handlers/writings/writingsArticleAddPage.go
+++ b/handlers/writings/writingsArticleAddPage.go
@@ -69,7 +69,7 @@ func ArticleAddActionPage(w http.ResponseWriter, r *http.Request) {
 		Abstract:          sql.NullString{Valid: true, String: abstract},
 		Writing:           sql.NullString{Valid: true, String: body},
 		Private:           sql.NullBool{Valid: true, Bool: private},
-		LanguageID:        int32(languageId),
+		LanguageID:        sql.NullInt32{Int32: int32(languageId), Valid: true},
 		GrantCategoryID:   sql.NullInt32{Int32: int32(categoryId), Valid: true},
 		GranteeID:         sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})

--- a/handlers/writings/writingsArticleCommentEditPage.go
+++ b/handlers/writings/writingsArticleCommentEditPage.go
@@ -56,7 +56,7 @@ func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 
 	uid = cd.UserID
 	if err = queries.UpdateCommentForEditor(r.Context(), db.UpdateCommentForEditorParams{
-		LanguageID:  int32(languageId),
+		LanguageID:  sql.NullInt32{Int32: int32(languageId), Valid: true},
 		Text:        sql.NullString{String: text, Valid: true},
 		CommentID:   comment.Idcomments,
 		CommenterID: uid,

--- a/handlers/writings/writingsArticleEditPage.go
+++ b/handlers/writings/writingsArticleEditPage.go
@@ -82,7 +82,7 @@ func ArticleEditActionPage(w http.ResponseWriter, r *http.Request) {
 		Abstract:   sql.NullString{Valid: true, String: abstract},
 		Content:    sql.NullString{Valid: true, String: body},
 		Private:    sql.NullBool{Valid: true, Bool: private},
-		LanguageID: int32(languageId),
+		LanguageID: sql.NullInt32{Int32: int32(languageId), Valid: true},
 		WritingID:  writing.Idwriting,
 		WriterID:   cd.UserID,
 		GranteeID:  sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},

--- a/internal/app/dbstart/testdata/original.mysql.sql
+++ b/internal/app/dbstart/testdata/original.mysql.sql
@@ -18,7 +18,7 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT NOW(),
   PRIMARY KEY (`idblogs`),
@@ -47,7 +47,7 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   PRIMARY KEY (`idcomments`),
@@ -67,7 +67,7 @@ CREATE TABLE `commentsSearch` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
@@ -163,7 +163,7 @@ CREATE TABLE `language` (
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
@@ -188,7 +188,7 @@ CREATE TABLE `linkerCategory` (
 
 CREATE TABLE `linkerQueue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -219,7 +219,7 @@ CREATE TABLE `permissions` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -245,7 +245,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `siteNews` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occured` datetime DEFAULT NULL,
@@ -279,7 +279,7 @@ CREATE TABLE `topicrestrictions` (
 CREATE TABLE `userlang` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   PRIMARY KEY (`iduserlang`),
   KEY `userpref_FKIndex1` (`language_idlanguage`),
   KEY `userpref_FKIndex2` (`users_idusers`)
@@ -309,7 +309,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `writingCategory_idwritingCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,

--- a/internal/app/dbstart/testdata/original.postgres.sql
+++ b/internal/app/dbstart/testdata/original.postgres.sql
@@ -18,7 +18,7 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT NOW(),
   PRIMARY KEY (`idblogs`),
@@ -47,7 +47,7 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   PRIMARY KEY (`idcomments`),
@@ -67,7 +67,7 @@ CREATE TABLE `commentsSearch` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
@@ -163,7 +163,7 @@ CREATE TABLE `language` (
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
@@ -188,7 +188,7 @@ CREATE TABLE `linkerCategory` (
 
 CREATE TABLE `linkerQueue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -219,7 +219,7 @@ CREATE TABLE `permissions` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -245,7 +245,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `siteNews` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occured` datetime DEFAULT NULL,
@@ -279,7 +279,7 @@ CREATE TABLE `topicrestrictions` (
 CREATE TABLE `userlang` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   PRIMARY KEY (`iduserlang`),
   KEY `userpref_FKIndex1` (`language_idlanguage`),
   KEY `userpref_FKIndex2` (`users_idusers`)
@@ -309,7 +309,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `writingCategory_idwritingCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,

--- a/internal/app/dbstart/testdata/original.sqlite.sql
+++ b/internal/app/dbstart/testdata/original.sqlite.sql
@@ -18,7 +18,7 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT NOW(),
   PRIMARY KEY (`idblogs`),
@@ -47,7 +47,7 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   PRIMARY KEY (`idcomments`),
@@ -67,7 +67,7 @@ CREATE TABLE `commentsSearch` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
@@ -163,7 +163,7 @@ CREATE TABLE `language` (
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
@@ -188,7 +188,7 @@ CREATE TABLE `linkerCategory` (
 
 CREATE TABLE `linkerQueue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -219,7 +219,7 @@ CREATE TABLE `permissions` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -245,7 +245,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `siteNews` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occured` datetime DEFAULT NULL,
@@ -279,7 +279,7 @@ CREATE TABLE `topicrestrictions` (
 CREATE TABLE `userlang` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   PRIMARY KEY (`iduserlang`),
   KEY `userpref_FKIndex1` (`language_idlanguage`),
   KEY `userpref_FKIndex2` (`users_idusers`)
@@ -309,7 +309,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `writingCategory_idwritingCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -59,7 +59,7 @@ type Blog struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            time.Time
 	DeletedAt          sql.NullTime
@@ -82,7 +82,7 @@ type Comment struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 	DeletedAt          sql.NullTime
@@ -99,7 +99,7 @@ type DeactivatedBlog struct {
 	Idblogs            int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            sql.NullTime
 	DeletedAt          sql.NullTime
@@ -110,7 +110,7 @@ type DeactivatedComment struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 	DeletedAt          sql.NullTime
@@ -134,7 +134,7 @@ type DeactivatedImagepost struct {
 
 type DeactivatedLinker struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -160,7 +160,7 @@ type DeactivatedWriting struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -194,7 +194,7 @@ type ExternalLink struct {
 type Faq struct {
 	Idfaq                        int32
 	FaqcategoriesIdfaqcategories int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	UsersIdusers                 int32
 	Answer                       sql.NullString
 	Question                     sql.NullString
@@ -217,7 +217,7 @@ type FaqRevision struct {
 type Forumcategory struct {
 	Idforumcategory              int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 }
@@ -236,7 +236,7 @@ type Forumtopic struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -297,7 +297,7 @@ type Language struct {
 
 type Linker struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -318,7 +318,7 @@ type LinkerCategory struct {
 
 type LinkerQueue struct {
 	Idlinkerqueue      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	Title              sql.NullString
@@ -378,7 +378,7 @@ type PendingPassword struct {
 
 type Preference struct {
 	Idpreferences        int32
-	LanguageIdlanguage   int32
+	LanguageIdlanguage   sql.NullInt32
 	UsersIdusers         int32
 	Emailforumupdates    sql.NullBool
 	PageSize             int32
@@ -424,7 +424,7 @@ type SiteAnnouncement struct {
 type SiteNews struct {
 	Idsitenews         int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
@@ -481,7 +481,7 @@ type UserEmail struct {
 type UserLanguage struct {
 	Iduserlang         int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 }
 
 type UserRole struct {
@@ -494,7 +494,7 @@ type Writing struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -1,6 +1,6 @@
 -- name: UpdateBlogEntryForWriter :exec
 UPDATE blogs b
-SET language_idlanguage = sqlc.arg(language_id), blog = sqlc.arg(blog)
+SET language_idlanguage = sqlc.narg(language_id), blog = sqlc.arg(blog)
 WHERE b.idblogs = sqlc.arg(entry_id)
   AND b.users_idusers = sqlc.arg(writer_id)
   AND EXISTS (
@@ -18,7 +18,7 @@ WHERE b.idblogs = sqlc.arg(entry_id)
 
 -- name: CreateBlogEntryForWriter :execlastid
 INSERT INTO blogs (users_idusers, language_idlanguage, blog, written)
-SELECT sqlc.arg(users_idusers), sqlc.arg(language_idlanguage), sqlc.arg(blog), CURRENT_TIMESTAMP
+SELECT sqlc.arg(users_idusers), sqlc.narg(language_idlanguage), sqlc.arg(blog), CURRENT_TIMESTAMP
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -36,7 +36,7 @@ type AdminGetAllBlogEntriesByUserRow struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            time.Time
 	Username           sql.NullString
@@ -98,7 +98,7 @@ WHERE EXISTS (
 
 type CreateBlogEntryForWriterParams struct {
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	UserID             sql.NullInt32
 	ListerID           int32
@@ -163,7 +163,7 @@ type GetBlogEntryForListerByIDRow struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            time.Time
 	Username           sql.NullString
@@ -243,7 +243,7 @@ type ListBlogEntriesByAuthorForListerRow struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            time.Time
 	Username           sql.NullString
@@ -339,7 +339,7 @@ type ListBlogEntriesByIDsForListerRow struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            time.Time
 }
@@ -433,7 +433,7 @@ type ListBlogEntriesForListerRow struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            time.Time
 	Username           sql.NullString
@@ -880,7 +880,7 @@ WHERE b.idblogs = ?
 `
 
 type UpdateBlogEntryForWriterParams struct {
-	LanguageID   int32
+	LanguageID   sql.NullInt32
 	Blog         sql.NullString
 	EntryID      int32
 	WriterID     int32

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -35,7 +35,7 @@ LIMIT 1;
 
 -- name: UpdateCommentForEditor :exec
 UPDATE comments c
-SET language_idlanguage = sqlc.arg(language_id), text = sqlc.arg(text)
+SET language_idlanguage = sqlc.narg(language_id), text = sqlc.arg(text)
 WHERE c.idcomments = sqlc.arg(comment_id)
   AND c.users_idusers = sqlc.arg(commenter_id)
   AND EXISTS (
@@ -99,7 +99,7 @@ ORDER BY c.written DESC
 
 -- name: CreateCommentInSectionForCommenter :execlastid
 INSERT INTO comments (language_idlanguage, users_idusers, forumthread_id, text, written)
-SELECT sqlc.arg(language_id), sqlc.narg(commenter_id), sqlc.arg(forumthread_id), sqlc.arg(text), NOW()
+SELECT sqlc.narg(language_id), sqlc.narg(commenter_id), sqlc.arg(forumthread_id), sqlc.arg(text), NOW()
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = sqlc.arg(section)

--- a/internal/db/queries-comments.sql.go
+++ b/internal/db/queries-comments.sql.go
@@ -28,7 +28,7 @@ type AdminGetAllCommentsByUserRow struct {
 	Idcomments             int32
 	ForumthreadID          int32
 	UsersIdusers           int32
-	LanguageIdlanguage     int32
+	LanguageIdlanguage     sql.NullInt32
 	Written                sql.NullTime
 	Text                   sql.NullString
 	DeletedAt              sql.NullTime
@@ -153,7 +153,7 @@ WHERE EXISTS (
 `
 
 type CreateCommentInSectionForCommenterParams struct {
-	LanguageID    int32
+	LanguageID    sql.NullInt32
 	CommenterID   sql.NullInt32
 	ForumthreadID int32
 	Text          sql.NullString
@@ -280,7 +280,7 @@ type GetCommentByIdForUserRow struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 	DeletedAt          sql.NullTime
@@ -364,7 +364,7 @@ type GetCommentsByIdsForUserWithThreadInfoRow struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 	DeletedAt          sql.NullTime
@@ -483,7 +483,7 @@ type GetCommentsBySectionThreadIdForUserRow struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 	DeletedAt          sql.NullTime
@@ -584,7 +584,7 @@ type GetCommentsByThreadIdForUserRow struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 	DeletedAt          sql.NullTime
@@ -698,7 +698,7 @@ WHERE c.idcomments = ?
 `
 
 type UpdateCommentForEditorParams struct {
-	LanguageID  int32
+	LanguageID  sql.NullInt32
 	Text        sql.NullString
 	CommentID   int32
 	CommenterID int32

--- a/internal/db/queries-deactivation.sql.go
+++ b/internal/db/queries-deactivation.sql.go
@@ -19,7 +19,7 @@ type AdminArchiveBlogParams struct {
 	Idblogs            int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            sql.NullTime
 }
@@ -45,7 +45,7 @@ type AdminArchiveCommentParams struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 }
@@ -103,7 +103,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 
 type AdminArchiveLinkParams struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -150,7 +150,7 @@ type AdminArchiveWritingParams struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime

--- a/internal/db/queries-faq.sql
+++ b/internal/db/queries-faq.sql
@@ -57,7 +57,7 @@ INSERT INTO faq_categories (name) VALUES (sqlc.arg(name));
 
 -- name: CreateFAQQuestionForWriter :exec
 INSERT INTO faq (question, users_idusers, language_idlanguage)
-SELECT sqlc.arg(question), sqlc.arg(writer_id), sqlc.arg(language_id)
+SELECT sqlc.arg(question), sqlc.arg(writer_id), sqlc.narg(language_id)
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'faq'
@@ -72,7 +72,7 @@ WHERE EXISTS (
 
 -- name: InsertFAQQuestionForWriter :execresult
 INSERT INTO faq (question, answer, faqCategories_idfaqCategories, users_idusers, language_idlanguage)
-SELECT sqlc.arg(question), sqlc.arg(answer), sqlc.arg(category_id), sqlc.arg(writer_id), sqlc.arg(language_id)
+SELECT sqlc.arg(question), sqlc.arg(answer), sqlc.arg(category_id), sqlc.arg(writer_id), sqlc.narg(language_id)
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'faq'

--- a/internal/db/queries-faq.sql.go
+++ b/internal/db/queries-faq.sql.go
@@ -306,7 +306,7 @@ WHERE EXISTS (
 type CreateFAQQuestionForWriterParams struct {
 	Question   sql.NullString
 	WriterID   int32
-	LanguageID int32
+	LanguageID sql.NullInt32
 	GranteeID  sql.NullInt32
 }
 
@@ -365,7 +365,7 @@ type GetAllAnsweredFAQWithFAQCategoriesForUserRow struct {
 	Name                         sql.NullString
 	Idfaq                        int32
 	FaqcategoriesIdfaqcategories int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	UsersIdusers                 int32
 	Answer                       sql.NullString
 	Question                     sql.NullString
@@ -667,7 +667,7 @@ type InsertFAQQuestionForWriterParams struct {
 	Answer     sql.NullString
 	CategoryID int32
 	WriterID   int32
-	LanguageID int32
+	LanguageID sql.NullInt32
 	GranteeID  sql.NullInt32
 }
 

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -248,7 +248,7 @@ INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, titl
 
 -- name: CreateForumTopicForPoster :execlastid
 INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description, handler)
-SELECT sqlc.arg(forumcategory_id), sqlc.arg(language_id), sqlc.arg(title), sqlc.arg(description), sqlc.arg(handler)
+SELECT sqlc.arg(forumcategory_id), sqlc.narg(language_id), sqlc.arg(title), sqlc.arg(description), sqlc.arg(handler)
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section=sqlc.arg(section)

--- a/internal/db/queries-forum.sql.go
+++ b/internal/db/queries-forum.sql.go
@@ -44,7 +44,7 @@ INSERT INTO forumcategory (forumcategory_idforumcategory, language_idlanguage, t
 
 type AdminCreateForumCategoryParams struct {
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 }
@@ -110,7 +110,7 @@ type AdminListForumCategoriesWithCountsParams struct {
 type AdminListForumCategoriesWithCountsRow struct {
 	Idforumcategory              int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Subcategorycount             int64
@@ -285,7 +285,7 @@ type AdminUpdateForumCategoryParams struct {
 	Title                        sql.NullString
 	Description                  sql.NullString
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Idforumcategory              int32
 }
 
@@ -308,7 +308,7 @@ type AdminUpdateForumTopicParams struct {
 	Title                        sql.NullString
 	Description                  sql.NullString
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Idforumtopic                 int32
 }
 
@@ -342,7 +342,7 @@ WHERE EXISTS (
 
 type CreateForumTopicForPosterParams struct {
 	ForumcategoryID int32
-	LanguageID      int32
+	LanguageID      sql.NullInt32
 	Title           sql.NullString
 	Description     sql.NullString
 	Handler         string
@@ -448,7 +448,7 @@ type GetAllForumCategoriesWithSubcategoryCountParams struct {
 type GetAllForumCategoriesWithSubcategoryCountRow struct {
 	Idforumcategory              int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Subcategorycount             int64
@@ -635,7 +635,7 @@ type GetAllForumTopicsByCategoryIdForUserWithLastPosterNameRow struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -869,7 +869,7 @@ type GetForumTopicByIdForUserRow struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -1003,7 +1003,7 @@ type GetForumTopicsForUserRow struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -1178,7 +1178,7 @@ type ListPrivateTopicsByUserIDRow struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -1229,7 +1229,7 @@ INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, titl
 
 type SystemCreateForumTopicParams struct {
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Handler                      string

--- a/internal/db/queries-languages.sql.go
+++ b/internal/db/queries-languages.sql.go
@@ -58,7 +58,7 @@ SELECT
 `
 
 type AdminLanguageUsageCountsParams struct {
-	ID int32
+	ID sql.NullInt32
 }
 
 type AdminLanguageUsageCountsRow struct {

--- a/internal/db/queries-linker.sql.go
+++ b/internal/db/queries-linker.sql.go
@@ -137,7 +137,7 @@ type AdminUpdateLinkerItemParams struct {
 	Url                sql.NullString
 	Description        sql.NullString
 	LinkerCategoryID   int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Idlinker           int32
 }
 
@@ -342,7 +342,7 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -430,7 +430,7 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -524,7 +524,7 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -622,7 +622,7 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRowRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -697,7 +697,7 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -760,7 +760,7 @@ JOIN linker_category c ON l.linker_category_id = c.idlinkerCategory
 
 type GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetailsRow struct {
 	Idlinkerqueue      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	Title              sql.NullString
@@ -950,7 +950,7 @@ WHERE l.idlinker = ?
 
 type GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -1019,7 +1019,7 @@ type GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams 
 
 type GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -1060,7 +1060,7 @@ WHERE l.idlinker IN (/*SLICE:linkerids*/?)
 
 type GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -1154,7 +1154,7 @@ type GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserParam
 
 type GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -1232,7 +1232,7 @@ type GetLinkerItemsByUserDescendingParams struct {
 
 type GetLinkerItemsByUserDescendingRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -1323,7 +1323,7 @@ type GetLinkerItemsByUserDescendingForUserParams struct {
 
 type GetLinkerItemsByUserDescendingForUserRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -1,6 +1,6 @@
 -- name: CreateNewsPostForWriter :execlastid
 INSERT INTO site_news (news, users_idusers, occurred, language_idlanguage)
-SELECT sqlc.arg(news), sqlc.arg(writer_id), NOW(), sqlc.arg(language_id)
+SELECT sqlc.arg(news), sqlc.arg(writer_id), NOW(), sqlc.narg(language_id)
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='news'
@@ -16,7 +16,7 @@ WHERE EXISTS (
 
 -- name: UpdateNewsPostForWriter :exec
 UPDATE site_news s
-SET news = sqlc.arg(news), language_idlanguage = sqlc.arg(language_id)
+SET news = sqlc.arg(news), language_idlanguage = sqlc.narg(language_id)
 WHERE s.idsiteNews = sqlc.arg(post_id)
   AND s.users_idusers = sqlc.arg(writer_id)
   AND EXISTS (

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -31,7 +31,7 @@ type AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow stru
 	Writerid           sql.NullInt32
 	Idsitenews         int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
@@ -106,7 +106,7 @@ WHERE EXISTS (
 type CreateNewsPostForWriterParams struct {
 	News       sql.NullString
 	WriterID   int32
-	LanguageID int32
+	LanguageID sql.NullInt32
 	GranteeID  sql.NullInt32
 }
 
@@ -216,7 +216,7 @@ type GetNewsPostByIdWithWriterIdAndThreadCommentCountRow struct {
 	Writerid           sql.NullInt32
 	Idsitenews         int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
@@ -285,7 +285,7 @@ type GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow struct {
 	Writerid           sql.NullInt32
 	Idsitenews         int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
@@ -383,7 +383,7 @@ type GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow struct {
 	Writerid           sql.NullInt32
 	Idsitenews         int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
@@ -487,7 +487,7 @@ WHERE s.idsiteNews = ?
 
 type UpdateNewsPostForWriterParams struct {
 	News        sql.NullString
-	LanguageID  int32
+	LanguageID  sql.NullInt32
 	PostID      int32
 	WriterID    int32
 	GrantPostID sql.NullInt32

--- a/internal/db/queries-pending_emails.sql
+++ b/internal/db/queries-pending_emails.sql
@@ -20,7 +20,7 @@ LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers
 LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers
 LEFT JOIN roles r ON ur.role_id = r.id
 WHERE pe.sent_at IS NULL
-  AND (sqlc.arg(language_id) IS NULL OR p.language_idlanguage = sqlc.arg(language_id))
+  AND (sqlc.narg(language_id) IS NULL OR p.language_idlanguage = sqlc.narg(language_id))
   AND (sqlc.arg(role_name) IS NULL OR r.name = sqlc.arg(role_name))
 ORDER BY pe.id;
 
@@ -48,7 +48,7 @@ LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers
 LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers
 LEFT JOIN roles r ON ur.role_id = r.id
 WHERE pe.sent_at IS NOT NULL
-  AND (sqlc.arg(language_id) IS NULL OR p.language_idlanguage = sqlc.arg(language_id))
+  AND (sqlc.narg(language_id) IS NULL OR p.language_idlanguage = sqlc.narg(language_id))
   AND (sqlc.arg(role_name) IS NULL OR r.name = sqlc.arg(role_name))
 ORDER BY pe.sent_at DESC
 LIMIT ? OFFSET ?;
@@ -61,7 +61,7 @@ LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers
 LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers
 LEFT JOIN roles r ON ur.role_id = r.id
 WHERE pe.sent_at IS NULL AND pe.error_count > 0
-  AND (sqlc.arg(language_id) IS NULL OR p.language_idlanguage = sqlc.arg(language_id))
+  AND (sqlc.narg(language_id) IS NULL OR p.language_idlanguage = sqlc.narg(language_id))
   AND (sqlc.arg(role_name) IS NULL OR r.name = sqlc.arg(role_name))
 ORDER BY pe.id
 LIMIT ? OFFSET ?;

--- a/internal/db/queries-pending_emails.sql.go
+++ b/internal/db/queries-pending_emails.sql.go
@@ -63,7 +63,7 @@ LIMIT ? OFFSET ?
 `
 
 type AdminListFailedEmailsParams struct {
-	LanguageID int32
+	LanguageID sql.NullInt32
 	RoleName   string
 	Limit      int32
 	Offset     int32
@@ -130,7 +130,7 @@ LIMIT ? OFFSET ?
 `
 
 type AdminListSentEmailsParams struct {
-	LanguageID int32
+	LanguageID sql.NullInt32
 	RoleName   string
 	Limit      int32
 	Offset     int32
@@ -198,7 +198,7 @@ ORDER BY pe.id
 `
 
 type AdminListUnsentPendingEmailsParams struct {
-	LanguageID int32
+	LanguageID sql.NullInt32
 	RoleName   string
 }
 

--- a/internal/db/queries-preferences.sql
+++ b/internal/db/queries-preferences.sql
@@ -19,10 +19,10 @@ WHERE users_idusers = sqlc.arg(lister_id);
 
 -- name: InsertPreferenceForLister :exec
 INSERT INTO preferences (language_idlanguage, users_idusers, page_size, timezone)
-VALUES (sqlc.arg(language_id), sqlc.arg(lister_id), sqlc.arg(page_size), sqlc.arg(timezone));
+VALUES (sqlc.narg(language_id), sqlc.arg(lister_id), sqlc.arg(page_size), sqlc.arg(timezone));
 
 -- name: UpdatePreferenceForLister :exec
-UPDATE preferences SET language_idlanguage = sqlc.arg(language_id), page_size = sqlc.arg(page_size), timezone = sqlc.arg(timezone) WHERE users_idusers = sqlc.arg(lister_id);
+UPDATE preferences SET language_idlanguage = sqlc.narg(language_id), page_size = sqlc.arg(page_size), timezone = sqlc.arg(timezone) WHERE users_idusers = sqlc.arg(lister_id);
 
 -- name: UpdateTimezoneForLister :exec
 UPDATE preferences

--- a/internal/db/queries-preferences.sql.go
+++ b/internal/db/queries-preferences.sql.go
@@ -53,7 +53,7 @@ VALUES (?, ?, ?, ?)
 `
 
 type InsertPreferenceForListerParams struct {
-	LanguageID int32
+	LanguageID sql.NullInt32
 	ListerID   int32
 	PageSize   int32
 	Timezone   sql.NullString
@@ -106,7 +106,7 @@ UPDATE preferences SET language_idlanguage = ?, page_size = ?, timezone = ? WHER
 `
 
 type UpdatePreferenceForListerParams struct {
-	LanguageID int32
+	LanguageID sql.NullInt32
 	PageSize   int32
 	Timezone   sql.NullString
 	ListerID   int32

--- a/internal/db/queries-user_languages.sql.go
+++ b/internal/db/queries-user_languages.sql.go
@@ -7,6 +7,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 )
 
 const deleteUserLanguagesForUser = `-- name: DeleteUserLanguagesForUser :exec
@@ -54,7 +55,7 @@ VALUES (?, ?)
 
 type InsertUserLangParams struct {
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 }
 
 func (q *Queries) InsertUserLang(ctx context.Context, arg InsertUserLangParams) error {

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -104,7 +104,7 @@ SET title = sqlc.arg(title),
     abstract = sqlc.arg(abstract),
     writing = sqlc.arg(content),
     private = sqlc.arg(private),
-    language_idlanguage = sqlc.arg(language_id)
+    language_idlanguage = sqlc.narg(language_id)
 WHERE w.idwriting = sqlc.arg(writing_id)
   AND w.users_idusers = sqlc.arg(writer_id)
   AND EXISTS (
@@ -126,7 +126,7 @@ VALUES (?, ?, ?, ?, ?, ?, NOW(), ?);
 
 -- name: CreateWritingForWriter :execlastid
 INSERT INTO writing (writing_category_id, title, abstract, writing, private, language_idlanguage, published, users_idusers)
-SELECT sqlc.arg(writing_category_id), sqlc.arg(title), sqlc.arg(abstract), sqlc.arg(writing), sqlc.arg(private), sqlc.arg(language_id), NOW(), sqlc.arg(writer_id)
+SELECT sqlc.arg(writing_category_id), sqlc.arg(title), sqlc.arg(abstract), sqlc.arg(writing), sqlc.arg(private), sqlc.narg(language_id), NOW(), sqlc.arg(writer_id)
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='writing'

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -24,7 +24,7 @@ type AdminGetAllWritingsByAuthorRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -87,7 +87,7 @@ type AdminGetWritingsByCategoryIdRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -198,7 +198,7 @@ type CreateWritingForWriterParams struct {
 	Abstract          sql.NullString
 	Writing           sql.NullString
 	Private           sql.NullBool
-	LanguageID        int32
+	LanguageID        sql.NullInt32
 	WriterID          int32
 	GrantCategoryID   sql.NullInt32
 	GranteeID         sql.NullInt32
@@ -255,7 +255,7 @@ type GetAllWritingsByAuthorForListerRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -441,7 +441,7 @@ type GetWritingForListerByIDRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -487,7 +487,7 @@ type InsertWritingParams struct {
 	Abstract           sql.NullString
 	Writing            sql.NullString
 	Private            sql.NullBool
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 }
 
@@ -554,7 +554,7 @@ type ListPublicWritingsByUserForListerRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -660,7 +660,7 @@ type ListPublicWritingsInCategoryForListerRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -1015,7 +1015,7 @@ type ListWritingsByIDsForListerRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -1129,7 +1129,7 @@ type SystemListPublicWritingsByAuthorRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -1200,7 +1200,7 @@ type SystemListPublicWritingsInCategoryRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -1328,7 +1328,7 @@ type UpdateWritingForWriterParams struct {
 	Abstract   sql.NullString
 	Content    sql.NullString
 	Private    sql.NullBool
-	LanguageID int32
+	LanguageID sql.NullInt32
 	WritingID  int32
 	WriterID   int32
 	GranteeID  sql.NullInt32

--- a/internal/db/queries_faq_test.go
+++ b/internal/db/queries_faq_test.go
@@ -27,7 +27,7 @@ func TestQueries_InsertFAQQuestionForWriter(t *testing.T) {
 		Answer:     sql.NullString{String: "a", Valid: true},
 		CategoryID: 1,
 		WriterID:   2,
-		LanguageID: 1,
+		LanguageID: sql.NullInt32{Int32: 1, Valid: true},
 		GranteeID:  sql.NullInt32{Int32: 2, Valid: true},
 	}); err != nil {
 		t.Fatalf("InsertFAQQuestionForWriter: %v", err)

--- a/migrations/0058.mysql.sql
+++ b/migrations/0058.mysql.sql
@@ -1,0 +1,47 @@
+-- Allow NULL language references
+ALTER TABLE blogs MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE blogs SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE comments MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE comments SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE faq MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE faq SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE forumcategory MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE forumcategory SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE forumtopic MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE forumtopic SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE linker MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE linker SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE linker_queue MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE linker_queue SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE preferences MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE preferences SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE site_news MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE site_news SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE user_language MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE user_language SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE writing MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE writing SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE deactivated_comments MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE deactivated_comments SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE deactivated_writings MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE deactivated_writings SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE deactivated_blogs MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE deactivated_blogs SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE deactivated_linker MODIFY language_idlanguage INT NULL DEFAULT NULL;
+UPDATE deactivated_linker SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+UPDATE schema_version SET version = 58 WHERE version = 57;

--- a/migrations/0058.postgres.sql
+++ b/migrations/0058.postgres.sql
@@ -1,0 +1,62 @@
+-- Allow NULL language references
+ALTER TABLE blogs ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE blogs ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE blogs SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE comments ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE comments ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE comments SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE faq ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE faq ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE faq SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE forumcategory ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE forumcategory ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE forumcategory SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE forumtopic ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE forumtopic ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE forumtopic SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE linker ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE linker ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE linker SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE linker_queue ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE linker_queue ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE linker_queue SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE preferences ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE preferences ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE preferences SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE site_news ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE site_news ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE site_news SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE user_language ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE user_language ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE user_language SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE writing ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE writing ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE writing SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE deactivated_comments ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE deactivated_comments ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE deactivated_comments SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE deactivated_writings ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE deactivated_writings ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE deactivated_writings SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE deactivated_blogs ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE deactivated_blogs ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE deactivated_blogs SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE deactivated_linker ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE deactivated_linker ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE deactivated_linker SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+UPDATE schema_version SET version = 58 WHERE version = 57;

--- a/migrations/0058.sqlite.sql
+++ b/migrations/0058.sqlite.sql
@@ -1,0 +1,62 @@
+-- Allow NULL language references
+ALTER TABLE blogs ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE blogs ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE blogs SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE comments ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE comments ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE comments SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE faq ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE faq ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE faq SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE forumcategory ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE forumcategory ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE forumcategory SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE forumtopic ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE forumtopic ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE forumtopic SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE linker ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE linker ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE linker SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE linker_queue ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE linker_queue ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE linker_queue SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE preferences ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE preferences ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE preferences SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE site_news ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE site_news ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE site_news SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE user_language ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE user_language ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE user_language SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE writing ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE writing ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE writing SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE deactivated_comments ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE deactivated_comments ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE deactivated_comments SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE deactivated_writings ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE deactivated_writings ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE deactivated_writings SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE deactivated_blogs ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE deactivated_blogs ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE deactivated_blogs SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+ALTER TABLE deactivated_linker ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE deactivated_linker ALTER COLUMN language_idlanguage DROP NOT NULL;
+UPDATE deactivated_linker SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+UPDATE schema_version SET version = 58 WHERE version = 57;

--- a/schema/schema.mysql.sql
+++ b/schema/schema.mysql.sql
@@ -2,7 +2,7 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `deleted_at` datetime DEFAULT NULL,
@@ -34,7 +34,7 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
@@ -57,7 +57,7 @@ CREATE TABLE `comments_search` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
@@ -87,7 +87,7 @@ CREATE TABLE IF NOT EXISTS `faq_revisions` (
 CREATE TABLE `forumcategory` (
   `idforumcategory` int(10) NOT NULL AUTO_INCREMENT,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   PRIMARY KEY (`idforumcategory`),
@@ -113,7 +113,7 @@ CREATE TABLE `forumtopic` (
   `idforumtopic` int(10) NOT NULL AUTO_INCREMENT,
   `lastposter` int(10) NOT NULL DEFAULT 0,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `threads` int(10) DEFAULT NULL,
@@ -172,7 +172,7 @@ CREATE TABLE `language` (
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
@@ -199,7 +199,7 @@ CREATE TABLE `linker_category` (
 
 CREATE TABLE `linker_queue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -258,7 +258,7 @@ CREATE TABLE `grants` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -287,7 +287,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `site_news` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occurred` datetime DEFAULT NULL,
@@ -311,7 +311,7 @@ CREATE TABLE `site_news_search` (
 CREATE TABLE `user_language` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   PRIMARY KEY (`iduserlang`),
   KEY `userpref_FKIndex1` (`language_idlanguage`),
   KEY `userpref_FKIndex2` (`users_idusers`)
@@ -354,7 +354,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `writing_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,
@@ -524,7 +524,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_comments` (
   `idcomments` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `written` datetime,
   `text` longtext,
   `deleted_at` datetime DEFAULT NULL,
@@ -536,7 +536,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_writings` (
   `idwriting` int NOT NULL,
   `users_idusers` int NOT NULL,
   `forumthread_id` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `writing_category_id` int NOT NULL,
   `title` tinytext,
   `published` datetime,
@@ -552,7 +552,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_blogs` (
   `idblogs` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `blog` longtext,
   `written` datetime,
   `deleted_at` datetime DEFAULT NULL,
@@ -578,7 +578,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_imageposts` (
 
 CREATE TABLE IF NOT EXISTS `deactivated_linker` (
   `idlinker` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `users_idusers` int NOT NULL,
   `linker_category_id` int NOT NULL,
   `forumthread_id` int NOT NULL,

--- a/schema/schema.postgres.sql
+++ b/schema/schema.postgres.sql
@@ -2,7 +2,7 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `deleted_at` datetime DEFAULT NULL,
@@ -34,7 +34,7 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
@@ -57,7 +57,7 @@ CREATE TABLE `comments_search` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
@@ -87,7 +87,7 @@ CREATE TABLE IF NOT EXISTS `faq_revisions` (
 CREATE TABLE `forumcategory` (
   `idforumcategory` int(10) NOT NULL AUTO_INCREMENT,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   PRIMARY KEY (`idforumcategory`),
@@ -113,7 +113,7 @@ CREATE TABLE `forumtopic` (
   `idforumtopic` int(10) NOT NULL AUTO_INCREMENT,
   `lastposter` int(10) NOT NULL DEFAULT 0,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `threads` int(10) DEFAULT NULL,
@@ -172,7 +172,7 @@ CREATE TABLE `language` (
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
@@ -199,7 +199,7 @@ CREATE TABLE `linker_category` (
 
 CREATE TABLE `linker_queue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -258,7 +258,7 @@ CREATE TABLE `grants` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -287,7 +287,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `site_news` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occurred` datetime DEFAULT NULL,
@@ -311,7 +311,7 @@ CREATE TABLE `site_news_search` (
 CREATE TABLE `user_language` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   PRIMARY KEY (`iduserlang`),
   KEY `userpref_FKIndex1` (`language_idlanguage`),
   KEY `userpref_FKIndex2` (`users_idusers`)
@@ -354,7 +354,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `writing_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,
@@ -524,7 +524,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_comments` (
   `idcomments` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `written` datetime,
   `text` longtext,
   `deleted_at` datetime DEFAULT NULL,
@@ -536,7 +536,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_writings` (
   `idwriting` int NOT NULL,
   `users_idusers` int NOT NULL,
   `forumthread_id` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `writing_category_id` int NOT NULL,
   `title` tinytext,
   `published` datetime,
@@ -552,7 +552,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_blogs` (
   `idblogs` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `blog` longtext,
   `written` datetime,
   `deleted_at` datetime DEFAULT NULL,
@@ -578,7 +578,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_imageposts` (
 
 CREATE TABLE IF NOT EXISTS `deactivated_linker` (
   `idlinker` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `users_idusers` int NOT NULL,
   `linker_category_id` int NOT NULL,
   `forumthread_id` int NOT NULL,

--- a/schema/schema.sqlite.sql
+++ b/schema/schema.sqlite.sql
@@ -2,7 +2,7 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `deleted_at` datetime DEFAULT NULL,
@@ -34,7 +34,7 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
@@ -57,7 +57,7 @@ CREATE TABLE `comments_search` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
@@ -87,7 +87,7 @@ CREATE TABLE IF NOT EXISTS `faq_revisions` (
 CREATE TABLE `forumcategory` (
   `idforumcategory` int(10) NOT NULL AUTO_INCREMENT,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   PRIMARY KEY (`idforumcategory`),
@@ -113,7 +113,7 @@ CREATE TABLE `forumtopic` (
   `idforumtopic` int(10) NOT NULL AUTO_INCREMENT,
   `lastposter` int(10) NOT NULL DEFAULT 0,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `threads` int(10) DEFAULT NULL,
@@ -172,7 +172,7 @@ CREATE TABLE `language` (
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
@@ -199,7 +199,7 @@ CREATE TABLE `linker_category` (
 
 CREATE TABLE `linker_queue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -258,7 +258,7 @@ CREATE TABLE `grants` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -287,7 +287,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `site_news` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occurred` datetime DEFAULT NULL,
@@ -311,7 +311,7 @@ CREATE TABLE `site_news_search` (
 CREATE TABLE `user_language` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   PRIMARY KEY (`iduserlang`),
   KEY `userpref_FKIndex1` (`language_idlanguage`),
   KEY `userpref_FKIndex2` (`users_idusers`)
@@ -354,7 +354,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `writing_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,
@@ -524,7 +524,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_comments` (
   `idcomments` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `written` datetime,
   `text` longtext,
   `deleted_at` datetime DEFAULT NULL,
@@ -536,7 +536,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_writings` (
   `idwriting` int NOT NULL,
   `users_idusers` int NOT NULL,
   `forumthread_id` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `writing_category_id` int NOT NULL,
   `title` tinytext,
   `published` datetime,
@@ -552,7 +552,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_blogs` (
   `idblogs` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `blog` longtext,
   `written` datetime,
   `deleted_at` datetime DEFAULT NULL,
@@ -578,7 +578,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_imageposts` (
 
 CREATE TABLE IF NOT EXISTS `deactivated_linker` (
   `idlinker` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `users_idusers` int NOT NULL,
   `linker_category_id` int NOT NULL,
   `forumthread_id` int NOT NULL,

--- a/testdata/schema/original.mysql.sql
+++ b/testdata/schema/original.mysql.sql
@@ -18,7 +18,7 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT NOW(),
   PRIMARY KEY (`idblogs`),
@@ -47,7 +47,7 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   PRIMARY KEY (`idcomments`),
@@ -67,7 +67,7 @@ CREATE TABLE `commentsSearch` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
@@ -163,7 +163,7 @@ CREATE TABLE `language` (
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
@@ -188,7 +188,7 @@ CREATE TABLE `linkerCategory` (
 
 CREATE TABLE `linkerQueue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -219,7 +219,7 @@ CREATE TABLE `permissions` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -245,7 +245,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `siteNews` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occured` datetime DEFAULT NULL,
@@ -279,7 +279,7 @@ CREATE TABLE `topicrestrictions` (
 CREATE TABLE `userlang` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   PRIMARY KEY (`iduserlang`),
   KEY `userpref_FKIndex1` (`language_idlanguage`),
   KEY `userpref_FKIndex2` (`users_idusers`)
@@ -309,7 +309,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `writingCategory_idwritingCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,

--- a/testdata/schema/original.postgres.sql
+++ b/testdata/schema/original.postgres.sql
@@ -18,7 +18,7 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT NOW(),
   PRIMARY KEY (`idblogs`),
@@ -47,7 +47,7 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   PRIMARY KEY (`idcomments`),
@@ -67,7 +67,7 @@ CREATE TABLE `commentsSearch` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
@@ -163,7 +163,7 @@ CREATE TABLE `language` (
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
@@ -188,7 +188,7 @@ CREATE TABLE `linkerCategory` (
 
 CREATE TABLE `linkerQueue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -219,7 +219,7 @@ CREATE TABLE `permissions` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -245,7 +245,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `siteNews` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occured` datetime DEFAULT NULL,
@@ -279,7 +279,7 @@ CREATE TABLE `topicrestrictions` (
 CREATE TABLE `userlang` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   PRIMARY KEY (`iduserlang`),
   KEY `userpref_FKIndex1` (`language_idlanguage`),
   KEY `userpref_FKIndex2` (`users_idusers`)
@@ -309,7 +309,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `writingCategory_idwritingCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,

--- a/testdata/schema/original.sqlite.sql
+++ b/testdata/schema/original.sqlite.sql
@@ -18,7 +18,7 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT NOW(),
   PRIMARY KEY (`idblogs`),
@@ -47,7 +47,7 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   PRIMARY KEY (`idcomments`),
@@ -67,7 +67,7 @@ CREATE TABLE `commentsSearch` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
@@ -163,7 +163,7 @@ CREATE TABLE `language` (
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
@@ -188,7 +188,7 @@ CREATE TABLE `linkerCategory` (
 
 CREATE TABLE `linkerQueue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -219,7 +219,7 @@ CREATE TABLE `permissions` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -245,7 +245,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `siteNews` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occured` datetime DEFAULT NULL,
@@ -279,7 +279,7 @@ CREATE TABLE `topicrestrictions` (
 CREATE TABLE `userlang` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   PRIMARY KEY (`iduserlang`),
   KEY `userpref_FKIndex1` (`language_idlanguage`),
   KEY `userpref_FKIndex2` (`users_idusers`)
@@ -309,7 +309,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `writingCategory_idwritingCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,


### PR DESCRIPTION
## Summary
- allow `language_idlanguage` to be NULL across all tables and convert existing zero values
- update queries and handlers to use `sql.NullInt32` for optional language IDs
- bump expected schema version and add migration 0058

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestAdminCategoryPageLinks, TestAdminTopicPage, TestAdminTopicEditFormPage)*

------
https://chatgpt.com/codex/tasks/task_e_6895f21606dc832faf0b3b01f6c03077