### PR TITLE
Allow null imageboard references

### DIFF
--- a/cmd/goa4web/board_create.go
+++ b/cmd/goa4web/board_create.go
@@ -39,7 +39,7 @@ func (c *boardCreateCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(conn)
 	err = queries.AdminCreateImageBoard(ctx, db.AdminCreateImageBoardParams{
-		ImageboardIdimageboard: int32(c.Parent),
+		ImageboardIdimageboard: sql.NullInt32{Int32: int32(c.Parent), Valid: c.Parent != 0},
 		Title:                  sql.NullString{String: c.Name, Valid: c.Name != ""},
 		Description:            sql.NullString{String: c.Description, Valid: c.Description != ""},
 		ApprovalRequired:       false,

--- a/cmd/goa4web/board_update.go
+++ b/cmd/goa4web/board_update.go
@@ -49,7 +49,7 @@ func (c *boardUpdateCmd) Run() error {
 	err = queries.AdminUpdateImageBoard(ctx, db.AdminUpdateImageBoardParams{
 		Title:                  sql.NullString{String: c.Name, Valid: c.Name != ""},
 		Description:            sql.NullString{String: c.Description, Valid: c.Description != ""},
-		ImageboardIdimageboard: int32(c.Parent),
+		ImageboardIdimageboard: sql.NullInt32{Int32: int32(c.Parent), Valid: c.Parent != 0},
 		ApprovalRequired:       c.ApprovalNeeded,
 		Idimageboard:           int32(c.ID),
 	})

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -210,7 +210,7 @@ type CoreData struct {
 	writerWritings                   map[int32]*lazy.Value[[]*db.ListPublicWritingsByUserForListerRow]
 	writingCategories                lazy.Value[[]*db.WritingCategory]
 	writingRows                      map[int32]*lazy.Value[*db.GetWritingForListerByIDRow]
-  // marks records which template sections have been rendered to avoid
+	// marks records which template sections have been rendered to avoid
 	// duplicate output when re-rendering after an error.
 	marks map[string]struct{}
 }
@@ -1196,7 +1196,7 @@ func (cd *CoreData) ImageBoardPosts(boardID int32) ([]*db.ListImagePostsByBoardF
 	return lv.Load(func() ([]*db.ListImagePostsByBoardForListerRow, error) {
 		return cd.queries.ListImagePostsByBoardForLister(cd.ctx, db.ListImagePostsByBoardForListerParams{
 			ListerID:     cd.UserID,
-			BoardID:      boardID,
+			BoardID:      sql.NullInt32{Int32: boardID, Valid: true},
 			ListerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 			Limit:        200,
 			Offset:       0,
@@ -2177,7 +2177,7 @@ func (cd *CoreData) SubImageBoards(parentID int32) ([]*db.Imageboard, error) {
 	return lv.Load(func() ([]*db.Imageboard, error) {
 		return cd.queries.ListBoardsByParentIDForLister(cd.ctx, db.ListBoardsByParentIDForListerParams{
 			ListerID:     cd.UserID,
-			ParentID:     parentID,
+			ParentID:     sql.NullInt32{Int32: parentID, Valid: parentID != 0},
 			ListerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 			Limit:        200,
 			Offset:       0,

--- a/core/templates/site/admin/userImagebbsPage.gohtml
+++ b/core/templates/site/admin/userImagebbsPage.gohtml
@@ -6,7 +6,7 @@
     <tr>
         <td><a href="/admin/user/{{ $.User.Idusers }}/imagebbs/post/{{ .Idimagepost }}">{{ .Idimagepost }}</a></td>
         <td>{{ .Posted }}</td>
-        <td>{{ .ImageboardIdimageboard }}</td>
+        <td>{{ .ImageboardIdimageboard.Int32 }}</td>
         <td>{{ if .Approved }}Yes{{ else }}No{{ end }}</td>
         <td>
             <a href="/admin/user/{{ $.User.Idusers }}/imagebbs/post/{{ .Idimagepost }}">Dashboard</a> |

--- a/core/templates/site/imagebbs/adminBoardPage.gohtml
+++ b/core/templates/site/imagebbs/adminBoardPage.gohtml
@@ -8,7 +8,7 @@
     {{ csrfField }}
     Name: <input name="name" value="{{ .Board.Title.String }}"><br>
     Description: <textarea name="desc" cols="40" rows="5">{{ .Board.Description.String }}</textarea><br>
-    Parent Board: <select name="pbid" value="{{ .Board.ImageboardIdimageboard }}"><option value="0">None</option>{{ if .Boards }}{{ range .Boards }}<option value="{{ .Idimageboard }}" {{ if eq $.Board.ImageboardIdimageboard .Idimageboard }}selected{{ end }}>{{ .Title.String }}</option>{{ end }}{{ end }}</select><br>
+    Parent Board: <select name="pbid" value="{{ .Board.ImageboardIdimageboard.Int32 }}"><option value="0">None</option>{{ if .Boards }}{{ range .Boards }}<option value="{{ .Idimageboard }}" {{ if eq $.Board.ImageboardIdimageboard.Int32 .Idimageboard }}selected{{ end }}>{{ .Title.String }}</option>{{ end }}{{ end }}</select><br>
     <input type="submit" name="task" value="Modify board">
 </form>
 

--- a/core/templates/site/imagebbs/adminPostDashboardPage.gohtml
+++ b/core/templates/site/imagebbs/adminPostDashboardPage.gohtml
@@ -3,7 +3,7 @@
 <p><img src="{{ .Post.Fullimage }}" alt="post image"></p>
 <p>Description: {{ if .Post.Description.Valid }}{{ .Post.Description.String }}{{ end }}</p>
 <p>User: <a href="/admin/user/{{ .Post.UsersIdusers }}">{{ if .Post.Username.Valid }}{{ .Post.Username.String }}{{ else }}{{ .Post.UsersIdusers }}{{ end }}</a></p>
-<p>Board: <a href="/admin/imagebbs/boards/board/{{ .Post.ImageboardIdimageboard }}">{{ .Post.ImageboardIdimageboard }}</a> | <a href="/imagebbs/board/{{ .Post.ImageboardIdimageboard }}">Public View</a></p>
+<p>Board: <a href="/admin/imagebbs/boards/board/{{ .Post.ImageboardIdimageboard.Int32 }}">{{ .Post.ImageboardIdimageboard.Int32 }}</a> | <a href="/imagebbs/board/{{ .Post.ImageboardIdimageboard.Int32 }}">Public View</a></p>
 <p>Approved: {{ if .Post.Approved }}Yes{{ else }}No{{ end }}</p>
 <p>
     <a href="/admin/user/{{ .Post.UsersIdusers }}/imagebbs/post/{{ .Post.Idimagepost }}/edit">Edit</a> |

--- a/core/templates/site/imagebbs/adminPostEditPage.gohtml
+++ b/core/templates/site/imagebbs/adminPostEditPage.gohtml
@@ -5,7 +5,7 @@
     <label>Board:
         <select name="board">
             {{ range .Boards }}
-            <option value="{{ .Idimageboard }}"{{ if eq .Idimageboard $.Post.ImageboardIdimageboard }} selected{{ end }}>{{ .Title.String }}</option>
+            <option value="{{ .Idimageboard }}"{{ if eq .Idimageboard $.Post.ImageboardIdimageboard.Int32 }} selected{{ end }}>{{ .Title.String }}</option>
             {{ end }}
         </select>
     </label><br>

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 57
+	ExpectedSchemaVersion = 58
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/handlers/imagebbs/imagebbsAdminBoardListPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardListPage.go
@@ -56,7 +56,7 @@ func AdminBoardListPage(w http.ResponseWriter, r *http.Request) {
 	const limit = 50
 	rows, err := cd.Queries().ListImagePostsByBoardForLister(r.Context(), db.ListImagePostsByBoardForListerParams{
 		ListerID:     cd.UserID,
-		BoardID:      board.Idimageboard,
+		BoardID:      sql.NullInt32{Int32: board.Idimageboard, Valid: true},
 		ListerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 		Limit:        limit + 1,
 		Offset:       int32((page - 1) * limit),

--- a/handlers/imagebbs/imagebbsAdminBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardPage.go
@@ -59,14 +59,18 @@ func (ModifyBoardTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	parents := make(map[int32]int32, len(boards))
 	for _, b := range boards {
-		parents[b.Idimageboard] = b.ImageboardIdimageboard
+		if b.ImageboardIdimageboard.Valid {
+			parents[b.Idimageboard] = b.ImageboardIdimageboard.Int32
+		} else {
+			parents[b.Idimageboard] = 0
+		}
 	}
 	if path, loop := algorithms.WouldCreateLoop(parents, int32(bid), int32(parentBoardId)); loop {
 		return common.UserError{ErrorMessage: fmt.Sprintf("invalid parent board: loop %v", path)}
 	}
 
 	err = queries.AdminUpdateImageBoard(r.Context(), db.AdminUpdateImageBoardParams{
-		ImageboardIdimageboard: int32(parentBoardId),
+		ImageboardIdimageboard: sql.NullInt32{Int32: int32(parentBoardId), Valid: parentBoardId != 0},
 		Title:                  sql.NullString{Valid: true, String: name},
 		Description:            sql.NullString{Valid: true, String: desc},
 		Idimageboard:           int32(bid),

--- a/handlers/imagebbs/imagebbsAdminBoardViewPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardViewPage.go
@@ -51,7 +51,7 @@ func AdminBoardViewPage(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := cd.Queries().ListImagePostsByBoardForLister(r.Context(), db.ListImagePostsByBoardForListerParams{
 		ListerID:     cd.UserID,
-		BoardID:      board.Idimageboard,
+		BoardID:      sql.NullInt32{Int32: board.Idimageboard, Valid: true},
 		ListerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 		Limit:        5,
 		Offset:       0,

--- a/handlers/imagebbs/imagebbsAdminBoardsPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardsPage.go
@@ -50,7 +50,7 @@ func AdminBoardsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data := Data{Page: page}
 	for _, b := range boards {
-		threads, err := queries.AdminCountThreadsByBoard(r.Context(), b.Idimageboard)
+		threads, err := queries.AdminCountThreadsByBoard(r.Context(), sql.NullInt32{Int32: b.Idimageboard, Valid: true})
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			log.Printf("countThreads error: %s", err)
 			threads = 0

--- a/handlers/imagebbs/imagebbsAdminNewBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminNewBoardPage.go
@@ -53,14 +53,18 @@ func (NewBoardTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	parents := make(map[int32]int32, len(boards))
 	for _, b := range boards {
-		parents[b.Idimageboard] = b.ImageboardIdimageboard
+		if b.ImageboardIdimageboard.Valid {
+			parents[b.Idimageboard] = b.ImageboardIdimageboard.Int32
+		} else {
+			parents[b.Idimageboard] = 0
+		}
 	}
 	if path, loop := algorithms.WouldCreateLoop(parents, 0, int32(parentBoardId)); loop {
 		return common.UserError{ErrorMessage: fmt.Sprintf("invalid parent board: loop %v", path)}
 	}
 
 	err = queries.AdminCreateImageBoard(r.Context(), db.AdminCreateImageBoardParams{
-		ImageboardIdimageboard: int32(parentBoardId),
+		ImageboardIdimageboard: sql.NullInt32{Int32: int32(parentBoardId), Valid: parentBoardId != 0},
 		Title:                  sql.NullString{Valid: true, String: name},
 		Description:            sql.NullString{Valid: true, String: desc},
 	})

--- a/handlers/imagebbs/imagebbsAdminPostPage.go
+++ b/handlers/imagebbs/imagebbsAdminPostPage.go
@@ -32,7 +32,7 @@ func (ModifyPostTask) Action(w http.ResponseWriter, r *http.Request) any {
 	desc := r.PostFormValue("desc")
 	approved := r.PostFormValue("approved") == "1"
 	if err := cd.Queries().AdminUpdateImagePost(r.Context(), db.AdminUpdateImagePostParams{
-		ImageboardIdimageboard: int32(board),
+		ImageboardIdimageboard: sql.NullInt32{Int32: int32(board), Valid: board != 0},
 		Description:            sql.NullString{Valid: true, String: desc},
 		Approved:               approved,
 		Idimagepost:            int32(pid),

--- a/handlers/imagebbs/imagebbsBoardPage.go
+++ b/handlers/imagebbs/imagebbsBoardPage.go
@@ -161,7 +161,7 @@ func (UploadImageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	approved := !board.ApprovalRequired
 
 	pid, err := queries.CreateImagePostForPoster(r.Context(), db.CreateImagePostForPosterParams{
-		ImageboardID: int32(bid),
+		ImageboardID: sql.NullInt32{Int32: int32(bid), Valid: true},
 		Thumbnail:    sql.NullString{Valid: true, String: relThumb},
 		Fullimage:    sql.NullString{Valid: true, String: relFull},
 		PosterID:     uid,

--- a/handlers/imagebbs/imagebbsBoardPage_test.go
+++ b/handlers/imagebbs/imagebbsBoardPage_test.go
@@ -2,6 +2,7 @@ package imagebbs
 
 import (
 	"context"
+	"database/sql"
 	"net/http/httptest"
 	"regexp"
 	"strings"
@@ -27,13 +28,13 @@ func TestBoardPageRendersSubBoards(t *testing.T) {
 	boardRows := sqlmock.NewRows([]string{"idimageboard", "imageboard_idimageboard", "title", "description", "approval_required"}).
 		AddRow(4, 3, "child", "sub", false)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idimageboard, b.imageboard_idimageboard, b.title")).
-		WithArgs(int32(0), int32(3), sqlmock.AnyArg(), int32(200), int32(0)).
+		WithArgs(int32(0), sql.NullInt32{Int32: 3, Valid: true}, sql.NullInt32{Int32: 3, Valid: true}, sqlmock.AnyArg(), int32(200), int32(0)).
 		WillReturnRows(boardRows)
 
 	postRows := sqlmock.NewRows([]string{"idimagepost", "forumthread_id", "users_idusers", "imageboard_idimageboard", "posted", "description", "thumbnail", "fullimage", "file_size", "approved", "deleted_at", "last_index", "username", "comments"}).
 		AddRow(1, 1, 1, 3, time.Unix(0, 0), "desc", "/t", "/f", 10, true, nil, nil, "alice", 0)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT i.idimagepost, i.forumthread_id, i.users_idusers")).
-		WithArgs(int32(0), int32(3), sqlmock.AnyArg(), int32(200), int32(0)).
+		WithArgs(int32(0), sql.NullInt32{Int32: 3, Valid: true}, sqlmock.AnyArg(), int32(200), int32(0)).
 		WillReturnRows(postRows)
 
 	req := httptest.NewRequest("GET", "/imagebbs/board/3", nil)

--- a/handlers/imagebbs/imagebbsFeed.go
+++ b/handlers/imagebbs/imagebbsFeed.go
@@ -34,7 +34,7 @@ func RssPage(w http.ResponseWriter, r *http.Request) {
 	for _, b := range boards {
 		rows, err := queries.ListImagePostsByBoardForLister(r.Context(), db.ListImagePostsByBoardForListerParams{
 			ListerID:     cd.UserID,
-			BoardID:      b.Idimageboard,
+			BoardID:      sql.NullInt32{Int32: b.Idimageboard, Valid: true},
 			ListerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 			Limit:        200,
 			Offset:       0,
@@ -72,7 +72,7 @@ func AtomPage(w http.ResponseWriter, r *http.Request) {
 	for _, b := range boards {
 		rows, err := queries.ListImagePostsByBoardForLister(r.Context(), db.ListImagePostsByBoardForListerParams{
 			ListerID:     cd.UserID,
-			BoardID:      b.Idimageboard,
+			BoardID:      sql.NullInt32{Int32: b.Idimageboard, Valid: true},
 			ListerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 			Limit:        200,
 			Offset:       0,
@@ -107,7 +107,7 @@ func BoardRssPage(w http.ResponseWriter, r *http.Request) {
 	}
 	rows, err := queries.ListImagePostsByBoardForLister(r.Context(), db.ListImagePostsByBoardForListerParams{
 		ListerID:     cd.UserID,
-		BoardID:      int32(bid),
+		BoardID:      sql.NullInt32{Int32: int32(bid), Valid: true},
 		ListerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 		Limit:        200,
 		Offset:       0,
@@ -157,7 +157,7 @@ func BoardAtomPage(w http.ResponseWriter, r *http.Request) {
 	}
 	rows, err := queries.ListImagePostsByBoardForLister(r.Context(), db.ListImagePostsByBoardForListerParams{
 		ListerID:     cd.UserID,
-		BoardID:      int32(bid),
+		BoardID:      sql.NullInt32{Int32: int32(bid), Valid: true},
 		ListerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 		Limit:        200,
 		Offset:       0,

--- a/internal/app/dbstart/testdata/original.mysql.sql
+++ b/internal/app/dbstart/testdata/original.mysql.sql
@@ -122,7 +122,7 @@ CREATE TABLE `forumtopic` (
 
 CREATE TABLE `imageboard` (
   `idimageboard` int(10) NOT NULL AUTO_INCREMENT,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   `approval_required` tinyint(1) NOT NULL DEFAULT 0,
@@ -134,7 +134,7 @@ CREATE TABLE `imagepost` (
   `idimagepost` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `posted` datetime DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `thumbnail` tinytext DEFAULT NULL,

--- a/internal/app/dbstart/testdata/original.postgres.sql
+++ b/internal/app/dbstart/testdata/original.postgres.sql
@@ -122,7 +122,7 @@ CREATE TABLE `forumtopic` (
 
 CREATE TABLE `imageboard` (
   `idimageboard` int(10) NOT NULL AUTO_INCREMENT,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   `approval_required` tinyint(1) NOT NULL DEFAULT 0,
@@ -134,7 +134,7 @@ CREATE TABLE `imagepost` (
   `idimagepost` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `posted` datetime DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `thumbnail` tinytext DEFAULT NULL,

--- a/internal/app/dbstart/testdata/original.sqlite.sql
+++ b/internal/app/dbstart/testdata/original.sqlite.sql
@@ -122,7 +122,7 @@ CREATE TABLE `forumtopic` (
 
 CREATE TABLE `imageboard` (
   `idimageboard` int(10) NOT NULL AUTO_INCREMENT,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   `approval_required` tinyint(1) NOT NULL DEFAULT 0,
@@ -134,7 +134,7 @@ CREATE TABLE `imagepost` (
   `idimagepost` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `posted` datetime DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `thumbnail` tinytext DEFAULT NULL,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -121,7 +121,7 @@ type DeactivatedImagepost struct {
 	Idimagepost            int32
 	ForumthreadID          int32
 	UsersIdusers           int32
-	ImageboardIdimageboard int32
+	ImageboardIdimageboard sql.NullInt32
 	Posted                 sql.NullTime
 	Description            sql.NullString
 	Thumbnail              sql.NullString
@@ -263,7 +263,7 @@ type Grant struct {
 
 type Imageboard struct {
 	Idimageboard           int32
-	ImageboardIdimageboard int32
+	ImageboardIdimageboard sql.NullInt32
 	Title                  sql.NullString
 	Description            sql.NullString
 	ApprovalRequired       bool
@@ -273,7 +273,7 @@ type Imagepost struct {
 	Idimagepost            int32
 	ForumthreadID          int32
 	UsersIdusers           int32
-	ImageboardIdimageboard int32
+	ImageboardIdimageboard sql.NullInt32
 	Posted                 sql.NullTime
 	Description            sql.NullString
 	Thumbnail              sql.NullString

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -27,7 +27,7 @@ type Querier interface {
 	AdminCountForumThreads(ctx context.Context) (int64, error)
 	AdminCountForumTopics(ctx context.Context) (int64, error)
 	AdminCountLinksByCategory(ctx context.Context, linkerCategoryID int32) (int64, error)
-	AdminCountThreadsByBoard(ctx context.Context, imageboardIdimageboard int32) (int64, error)
+	AdminCountThreadsByBoard(ctx context.Context, imageboardIdimageboard sql.NullInt32) (int64, error)
 	AdminCountWordList(ctx context.Context) (int64, error)
 	AdminCountWordListByPrefix(ctx context.Context, prefix interface{}) (int64, error)
 	AdminCreateFAQCategory(ctx context.Context, name sql.NullString) error

--- a/internal/db/queries-deactivation.sql.go
+++ b/internal/db/queries-deactivation.sql.go
@@ -71,7 +71,7 @@ type AdminArchiveImagepostParams struct {
 	Idimagepost            int32
 	ForumthreadID          int32
 	UsersIdusers           int32
-	ImageboardIdimageboard int32
+	ImageboardIdimageboard sql.NullInt32
 	Posted                 sql.NullTime
 	Description            sql.NullString
 	Thumbnail              sql.NullString

--- a/internal/db/queries-imagebbs.sql
+++ b/internal/db/queries-imagebbs.sql
@@ -7,7 +7,7 @@ UPDATE imageboard SET title = ?, description = ?, imageboard_idimageboard = ?, a
 -- name: SystemListBoardsByParentID :many
 SELECT b.*
 FROM imageboard b
-WHERE b.imageboard_idimageboard = sqlc.arg(parent_id)
+WHERE (b.imageboard_idimageboard = sqlc.narg(parent_id) OR (b.imageboard_idimageboard IS NULL AND sqlc.narg(parent_id) IS NULL))
 LIMIT ? OFFSET ?;
 
 
@@ -95,7 +95,7 @@ WITH role_ids AS (
 )
 SELECT b.*
 FROM imageboard b
-WHERE b.imageboard_idimageboard = sqlc.arg(parent_id)
+WHERE (b.imageboard_idimageboard = sqlc.narg(parent_id) OR (b.imageboard_idimageboard IS NULL AND sqlc.narg(parent_id) IS NULL))
   AND b.deleted_at IS NULL
   AND EXISTS (
     SELECT 1 FROM grants g

--- a/internal/db/queries-stats.sql.go
+++ b/internal/db/queries-stats.sql.go
@@ -39,7 +39,7 @@ FROM imagepost
 WHERE imageboard_idimageboard = ?
 `
 
-func (q *Queries) AdminCountThreadsByBoard(ctx context.Context, imageboardIdimageboard int32) (int64, error) {
+func (q *Queries) AdminCountThreadsByBoard(ctx context.Context, imageboardIdimageboard sql.NullInt32) (int64, error) {
 	row := q.db.QueryRowContext(ctx, adminCountThreadsByBoard, imageboardIdimageboard)
 	var count int64
 	err := row.Scan(&count)

--- a/internal/db/queries_imagebbs_test.go
+++ b/internal/db/queries_imagebbs_test.go
@@ -18,13 +18,13 @@ func TestQueries_ListBoardsByParentIDForLister(t *testing.T) {
 	defer conn.Close()
 	q := New(conn)
 
-	rows := sqlmock.NewRows([]string{"idimageboard", "imageboard_idimageboard", "title", "description", "approval_required"}).AddRow(1, 0, nil, nil, 0)
+	rows := sqlmock.NewRows([]string{"idimageboard", "imageboard_idimageboard", "title", "description", "approval_required"}).AddRow(1, nil, nil, nil, 0)
 	viewer := sql.NullInt32{}
 	mock.ExpectQuery(regexp.QuoteMeta(listBoardsByParentIDForLister)).
-		WithArgs(int32(1), int32(0), viewer, int32(5), int32(0)).
+		WithArgs(int32(1), sql.NullInt32{}, sql.NullInt32{}, viewer, int32(5), int32(0)).
 		WillReturnRows(rows)
 
-	res, err := q.ListBoardsByParentIDForLister(context.Background(), ListBoardsByParentIDForListerParams{ListerID: 1, ParentID: 0, ListerUserID: viewer, Limit: 5, Offset: 0})
+	res, err := q.ListBoardsByParentIDForLister(context.Background(), ListBoardsByParentIDForListerParams{ListerID: 1, ParentID: sql.NullInt32{}, ListerUserID: viewer, Limit: 5, Offset: 0})
 	if err != nil {
 		t.Fatalf("ListBoardsByParentIDForLister: %v", err)
 	}
@@ -52,10 +52,10 @@ func TestQueries_ListImagePostsByBoardForLister_GlobalGrant(t *testing.T) {
 		AddRow(1, 0, 1, 2, nil, nil, nil, nil, 0, true, nil, nil, "alice", 0)
 
 	mock.ExpectQuery(regexp.QuoteMeta(listImagePostsByBoardForLister)).
-		WithArgs(int32(1), int32(2), sql.NullInt32{Int32: 1, Valid: true}, int32(5), int32(0)).
+		WithArgs(int32(1), sql.NullInt32{Int32: 2, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}, int32(5), int32(0)).
 		WillReturnRows(rows)
 
-	res, err := q.ListImagePostsByBoardForLister(context.Background(), ListImagePostsByBoardForListerParams{ListerID: 1, BoardID: 2, ListerUserID: sql.NullInt32{Int32: 1, Valid: true}, Limit: 5, Offset: 0})
+	res, err := q.ListImagePostsByBoardForLister(context.Background(), ListImagePostsByBoardForListerParams{ListerID: 1, BoardID: sql.NullInt32{Int32: 2, Valid: true}, ListerUserID: sql.NullInt32{Int32: 1, Valid: true}, Limit: 5, Offset: 0})
 	if err != nil {
 		t.Fatalf("ListImagePostsByBoardForLister: %v", err)
 	}

--- a/migrations/0058.mysql.sql
+++ b/migrations/0058.mysql.sql
@@ -1,0 +1,11 @@
+-- Allow NULL imageboard references
+ALTER TABLE imageboard MODIFY imageboard_idimageboard INT NULL;
+ALTER TABLE imagepost MODIFY imageboard_idimageboard INT NULL;
+ALTER TABLE deactivated_imageposts MODIFY imageboard_idimageboard INT NULL;
+
+UPDATE imageboard SET imageboard_idimageboard = NULL WHERE imageboard_idimageboard = 0;
+UPDATE imagepost SET imageboard_idimageboard = NULL WHERE imageboard_idimageboard = 0;
+UPDATE deactivated_imageposts SET imageboard_idimageboard = NULL WHERE imageboard_idimageboard = 0;
+
+-- Update schema version
+UPDATE schema_version SET version = 58 WHERE version = 57;

--- a/migrations/0058.postgres.sql
+++ b/migrations/0058.postgres.sql
@@ -1,0 +1,14 @@
+-- Allow NULL imageboard references
+ALTER TABLE imageboard ALTER COLUMN imageboard_idimageboard DROP NOT NULL;
+ALTER TABLE imageboard ALTER COLUMN imageboard_idimageboard DROP DEFAULT;
+ALTER TABLE imagepost ALTER COLUMN imageboard_idimageboard DROP NOT NULL;
+ALTER TABLE imagepost ALTER COLUMN imageboard_idimageboard DROP DEFAULT;
+ALTER TABLE deactivated_imageposts ALTER COLUMN imageboard_idimageboard DROP NOT NULL;
+ALTER TABLE deactivated_imageposts ALTER COLUMN imageboard_idimageboard DROP DEFAULT;
+
+UPDATE imageboard SET imageboard_idimageboard = NULL WHERE imageboard_idimageboard = 0;
+UPDATE imagepost SET imageboard_idimageboard = NULL WHERE imageboard_idimageboard = 0;
+UPDATE deactivated_imageposts SET imageboard_idimageboard = NULL WHERE imageboard_idimageboard = 0;
+
+-- Update schema version
+UPDATE schema_version SET version = 58 WHERE version = 57;

--- a/migrations/0058.sqlite.sql
+++ b/migrations/0058.sqlite.sql
@@ -1,0 +1,11 @@
+-- Allow NULL imageboard references
+ALTER TABLE imageboard MODIFY imageboard_idimageboard INT NULL;
+ALTER TABLE imagepost MODIFY imageboard_idimageboard INT NULL;
+ALTER TABLE deactivated_imageposts MODIFY imageboard_idimageboard INT NULL;
+
+UPDATE imageboard SET imageboard_idimageboard = NULL WHERE imageboard_idimageboard = 0;
+UPDATE imagepost SET imageboard_idimageboard = NULL WHERE imageboard_idimageboard = 0;
+UPDATE deactivated_imageposts SET imageboard_idimageboard = NULL WHERE imageboard_idimageboard = 0;
+
+-- Update schema version
+UPDATE schema_version SET version = 58 WHERE version = 57;

--- a/schema/schema.mysql.sql
+++ b/schema/schema.mysql.sql
@@ -128,7 +128,7 @@ CREATE TABLE `forumtopic` (
 
 CREATE TABLE `imageboard` (
   `idimageboard` int(10) NOT NULL AUTO_INCREMENT,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   `approval_required` tinyint(1) NOT NULL DEFAULT 0,
@@ -140,7 +140,7 @@ CREATE TABLE `imagepost` (
   `idimagepost` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `posted` datetime DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `thumbnail` tinytext DEFAULT NULL,
@@ -154,6 +154,7 @@ CREATE TABLE `imagepost` (
   KEY `imagepost_FKIndex2` (`users_idusers`),
   KEY `imagepost_FKIndex3` (`forumthread_id`)
 );
+
 
 CREATE TABLE `imagepost_search` (
   `image_post_id` int(10) NOT NULL DEFAULT 0,
@@ -564,7 +565,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_imageposts` (
   `idimagepost` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `imageboard_idimageboard` int NOT NULL,
+  `imageboard_idimageboard` int DEFAULT NULL,
   `posted` datetime,
   `description` tinytext,
   `thumbnail` tinytext,

--- a/schema/schema.postgres.sql
+++ b/schema/schema.postgres.sql
@@ -128,7 +128,7 @@ CREATE TABLE `forumtopic` (
 
 CREATE TABLE `imageboard` (
   `idimageboard` int(10) NOT NULL AUTO_INCREMENT,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   `approval_required` tinyint(1) NOT NULL DEFAULT 0,
@@ -140,7 +140,7 @@ CREATE TABLE `imagepost` (
   `idimagepost` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `posted` datetime DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `thumbnail` tinytext DEFAULT NULL,
@@ -564,7 +564,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_imageposts` (
   `idimagepost` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `imageboard_idimageboard` int NOT NULL,
+  `imageboard_idimageboard` int DEFAULT NULL,
   `posted` datetime,
   `description` tinytext,
   `thumbnail` tinytext,

--- a/schema/schema.sqlite.sql
+++ b/schema/schema.sqlite.sql
@@ -128,7 +128,7 @@ CREATE TABLE `forumtopic` (
 
 CREATE TABLE `imageboard` (
   `idimageboard` int(10) NOT NULL AUTO_INCREMENT,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   `approval_required` tinyint(1) NOT NULL DEFAULT 0,
@@ -140,7 +140,7 @@ CREATE TABLE `imagepost` (
   `idimagepost` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `posted` datetime DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `thumbnail` tinytext DEFAULT NULL,
@@ -564,7 +564,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_imageposts` (
   `idimagepost` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `imageboard_idimageboard` int NOT NULL,
+  `imageboard_idimageboard` int DEFAULT NULL,
   `posted` datetime,
   `description` tinytext,
   `thumbnail` tinytext,

--- a/testdata/schema/original.mysql.sql
+++ b/testdata/schema/original.mysql.sql
@@ -122,7 +122,7 @@ CREATE TABLE `forumtopic` (
 
 CREATE TABLE `imageboard` (
   `idimageboard` int(10) NOT NULL AUTO_INCREMENT,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   `approval_required` tinyint(1) NOT NULL DEFAULT 0,
@@ -134,7 +134,7 @@ CREATE TABLE `imagepost` (
   `idimagepost` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `posted` datetime DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `thumbnail` tinytext DEFAULT NULL,

--- a/testdata/schema/original.postgres.sql
+++ b/testdata/schema/original.postgres.sql
@@ -122,7 +122,7 @@ CREATE TABLE `forumtopic` (
 
 CREATE TABLE `imageboard` (
   `idimageboard` int(10) NOT NULL AUTO_INCREMENT,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   `approval_required` tinyint(1) NOT NULL DEFAULT 0,
@@ -134,7 +134,7 @@ CREATE TABLE `imagepost` (
   `idimagepost` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `posted` datetime DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `thumbnail` tinytext DEFAULT NULL,

--- a/testdata/schema/original.sqlite.sql
+++ b/testdata/schema/original.sqlite.sql
@@ -122,7 +122,7 @@ CREATE TABLE `forumtopic` (
 
 CREATE TABLE `imageboard` (
   `idimageboard` int(10) NOT NULL AUTO_INCREMENT,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   `approval_required` tinyint(1) NOT NULL DEFAULT 0,
@@ -134,7 +134,7 @@ CREATE TABLE `imagepost` (
   `idimagepost` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `imageboard_idimageboard` int(10) NOT NULL DEFAULT 0,
+  `imageboard_idimageboard` int(10) DEFAULT NULL,
   `posted` datetime DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `thumbnail` tinytext DEFAULT NULL,


### PR DESCRIPTION
## Summary
- allow NULL parent board references and remove defaults
- update queries, handlers, and templates for nullable board IDs
- regenerate sqlc and bump schema version

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestAdminCategoryPageLinks, TestAdminTopicPage, TestAdminTopicEditFormPage)*

------
https://chatgpt.com/codex/tasks/task_e_6895f1df2160832fbbe9005171c9d4b7