### PR TITLE
Make writing_category_id nullable

### DIFF
--- a/cmd/goa4web/writing_tree.go
+++ b/cmd/goa4web/writing_tree.go
@@ -38,7 +38,10 @@ func (c *writingTreeCmd) Run() error {
 	}
 	children := map[int32][]*db.WritingCategory{}
 	for _, cat := range rows {
-		parent := cat.WritingCategoryID
+		parent := int32(0)
+		if cat.WritingCategoryID.Valid {
+			parent = cat.WritingCategoryID.Int32
+		}
 		children[parent] = append(children[parent], cat)
 	}
 	var printTree func(parent int32, prefix string)

--- a/core/templates/site/listWritingCategories.gohtml
+++ b/core/templates/site/listWritingCategories.gohtml
@@ -4,7 +4,7 @@
         {{ $cats := cd.VisibleWritingCategories }}
         {{ $found := false }}
         {{ range $cats }}
-            {{ if eq .WritingCategoryID $.WritingCategoryID }}
+            {{ if eq .WritingCategoryID.Int32 $.WritingCategoryID }}
                 {{ $found = true }}
                 {{ $title := .Title.String }}
                 {{ $description := .Description.String }}

--- a/core/templates/site/writings/writingsAdminCategoriesPage.gohtml
+++ b/core/templates/site/writings/writingsAdminCategoriesPage.gohtml
@@ -10,7 +10,7 @@
         {{ range .Categories }}
         <tr>
             <td><a id="wc{{ .Idwritingcategory }}" href="/admin/writings/categories/category/{{ .Idwritingcategory }}">{{ .Idwritingcategory }}</a></td>
-            <td>{{ $fcid := .WritingCategoryID }} <a href="#wc{{ $fcid }}">{{ $fcid }}</a></td>
+            <td>{{ $fcid := .WritingCategoryID.Int32 }} <a href="#wc{{ $fcid }}">{{ $fcid }}</a></td>
             <td>{{ .Title.String }}</td>
             <td>{{ .Description.String }}</td>
             <td>

--- a/core/templates/site/writings/writingsAdminCategoryEditPage.gohtml
+++ b/core/templates/site/writings/writingsAdminCategoryEditPage.gohtml
@@ -6,7 +6,7 @@
     <table>
         <tr>
             <th>Parent</th>
-            <td><select name="pcid"><option value="0">None</option>{{ range .Categories }}<option value="{{ .Idwritingcategory }}" {{ if eq $.Category.WritingCategoryID .Idwritingcategory }}selected{{ end }}>{{ .Title.String }}</option>{{ end }}</select></td>
+            <td><select name="pcid"><option value="0">None</option>{{ range .Categories }}<option value="{{ .Idwritingcategory }}" {{ if eq $.Category.WritingCategoryID.Int32 .Idwritingcategory }}selected{{ end }}>{{ .Title.String }}</option>{{ end }}</select></td>
         </tr>
         <tr>
             <th>Title</th>

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 57
+	ExpectedSchemaVersion = 58
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/handlers/writings/writing_category_change_task.go
+++ b/handlers/writings/writing_category_change_task.go
@@ -52,7 +52,7 @@ func (WritingCategoryChangeTask) Action(w http.ResponseWriter, r *http.Request) 
 			String: desc,
 		},
 		Idwritingcategory: int32(cid),
-		WritingCategoryID: int32(parentID),
+		WritingCategoryID: sql.NullInt32{Int32: int32(parentID), Valid: parentID != 0},
 	}); err != nil {
 		return fmt.Errorf("update writing category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
@@ -69,7 +69,11 @@ func writingCategoryWouldLoop(ctx context.Context, queries db.Querier, cid, pare
 		}
 		parents = make(map[int32]int32, len(cats))
 		for _, c := range cats {
-			parents[c.Idwritingcategory] = c.WritingCategoryID
+			parent := int32(0)
+			if c.WritingCategoryID.Valid {
+				parent = c.WritingCategoryID.Int32
+			}
+			parents[c.Idwritingcategory] = parent
 		}
 	} else {
 		parents = map[int32]int32{}

--- a/handlers/writings/writing_category_change_task_test.go
+++ b/handlers/writings/writing_category_change_task_test.go
@@ -24,11 +24,11 @@ func TestWritingCategoryChangeTask(t *testing.T) {
 	queries := db.New(conn)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
-		AddRow(1, 0, "a", "")
+		AddRow(1, nil, "a", "")
 	mock.ExpectQuery("SELECT wc.idwritingcategory").WillReturnRows(rows)
 
 	mock.ExpectExec("UPDATE writing_category").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), int32(0), int32(1)).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), int32(1)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	form := url.Values{"name": {"A"}, "desc": {"B"}, "pcid": {"0"}, "cid": {"1"}}
@@ -56,7 +56,7 @@ func TestWritingCategoryWouldLoop(t *testing.T) {
 	queries := db.New(conn)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
-		AddRow(1, 0, "a", "").
+		AddRow(1, nil, "a", "").
 		AddRow(2, 1, "b", "")
 	mock.ExpectQuery("SELECT wc.idwritingcategory").WillReturnRows(rows)
 
@@ -92,7 +92,7 @@ func TestWritingCategoryWouldLoopHeadToTail(t *testing.T) {
 	queries := db.New(conn)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
-		AddRow(1, 0, "a", "").
+		AddRow(1, nil, "a", "").
 		AddRow(2, 1, "b", "").
 		AddRow(3, 2, "c", "").
 		AddRow(4, 3, "d", "")
@@ -120,7 +120,7 @@ func TestWritingCategoryWouldLoopAfterNode(t *testing.T) {
 	queries := db.New(conn)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
-		AddRow(1, 0, "a", "").
+		AddRow(1, nil, "a", "").
 		AddRow(2, 3, "b", "").
 		AddRow(3, 2, "c", "")
 	mock.ExpectQuery("SELECT wc.idwritingcategory").WillReturnRows(rows)

--- a/handlers/writings/writing_category_create_task.go
+++ b/handlers/writings/writing_category_create_task.go
@@ -37,13 +37,17 @@ func (WritingCategoryCreateTask) Action(w http.ResponseWriter, r *http.Request) 
 	}
 	parents := make(map[int32]int32, len(cats))
 	for _, c := range cats {
-		parents[c.Idwritingcategory] = c.WritingCategoryID
+		parent := int32(0)
+		if c.WritingCategoryID.Valid {
+			parent = c.WritingCategoryID.Int32
+		}
+		parents[c.Idwritingcategory] = parent
 	}
 	if path, loop := algorithms.WouldCreateLoop(parents, 0, int32(pcid)); loop && len(path) > 0 {
 		return common.UserError{ErrorMessage: "invalid parent category: loop detected"}
 	}
 	if err := queries.AdminInsertWritingCategory(r.Context(), db.AdminInsertWritingCategoryParams{
-		WritingCategoryID: int32(pcid),
+		WritingCategoryID: sql.NullInt32{Int32: int32(pcid), Valid: pcid != 0},
 		Title: sql.NullString{
 			Valid:  true,
 			String: name,

--- a/handlers/writings/writingsAdminCategoriesPage.go
+++ b/handlers/writings/writingsAdminCategoriesPage.go
@@ -58,7 +58,11 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	data.Categories = categoryRows[offset:end]
 	children := map[int32][]*db.WritingCategory{}
 	for _, c := range categoryRows {
-		children[c.WritingCategoryID] = append(children[c.WritingCategoryID], c)
+		parent := int32(0)
+		if c.WritingCategoryID.Valid {
+			parent = c.WritingCategoryID.Int32
+		}
+		children[parent] = append(children[parent], c)
 	}
 	var build func(parent int32) string
 	build = func(parent int32) string {

--- a/handlers/writings/writingsAdminCategoriesPage_test.go
+++ b/handlers/writings/writingsAdminCategoriesPage_test.go
@@ -24,7 +24,7 @@ func TestWritingsAdminCategoriesPage(t *testing.T) {
 	queries := db.New(sqlDB)
 
 	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
-		AddRow(1, 0, "a", "b")
+		AddRow(1, nil, "a", "b")
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT wc.idwritingcategory, wc.writing_category_id, wc.title, wc.description\nFROM writing_category wc")).WillReturnRows(rows)
 
 	req := httptest.NewRequest("GET", "/admin/writings/categories", nil)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -507,7 +507,7 @@ type Writing struct {
 
 type WritingCategory struct {
 	Idwritingcategory int32
-	WritingCategoryID int32
+	WritingCategoryID sql.NullInt32
 	Title             sql.NullString
 	Description       sql.NullString
 }

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -142,7 +142,7 @@ VALUES (?, ?, ?)
 `
 
 type AdminInsertWritingCategoryParams struct {
-	WritingCategoryID int32
+	WritingCategoryID sql.NullInt32
 	Title             sql.NullString
 	Description       sql.NullString
 }
@@ -161,7 +161,7 @@ WHERE idwritingCategory = ?
 type AdminUpdateWritingCategoryParams struct {
 	Title             sql.NullString
 	Description       sql.NullString
-	WritingCategoryID int32
+	WritingCategoryID sql.NullInt32
 	Idwritingcategory int32
 }
 

--- a/migrations/0058.mysql.sql
+++ b/migrations/0058.mysql.sql
@@ -1,0 +1,6 @@
+ALTER TABLE writing_category
+    MODIFY COLUMN writing_category_id INT DEFAULT NULL;
+UPDATE writing_category SET writing_category_id = NULL WHERE writing_category_id = 0;
+
+-- Record upgrade to schema version 58
+UPDATE schema_version SET version = 58 WHERE version = 57;

--- a/migrations/0058.postgres.sql
+++ b/migrations/0058.postgres.sql
@@ -1,0 +1,6 @@
+ALTER TABLE writing_category
+    ALTER COLUMN writing_category_id DROP NOT NULL;
+UPDATE writing_category SET writing_category_id = NULL WHERE writing_category_id = 0;
+
+-- Record upgrade to schema version 58
+UPDATE schema_version SET version = 58 WHERE version = 57;

--- a/migrations/0058.sqlite.sql
+++ b/migrations/0058.sqlite.sql
@@ -1,0 +1,6 @@
+ALTER TABLE writing_category
+    MODIFY COLUMN writing_category_id INT DEFAULT NULL;
+UPDATE writing_category SET writing_category_id = NULL WHERE writing_category_id = 0;
+
+-- Record upgrade to schema version 58
+UPDATE schema_version SET version = 58 WHERE version = 57;

--- a/schema/schema.mysql.sql
+++ b/schema/schema.mysql.sql
@@ -372,7 +372,7 @@ CREATE TABLE `writing` (
 
 CREATE TABLE `writing_category` (
   `idwritingCategory` int(10) NOT NULL AUTO_INCREMENT,
-  `writing_category_id` int(10) NOT NULL DEFAULT 0,
+  `writing_category_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   PRIMARY KEY (`idwritingCategory`),

--- a/schema/schema.postgres.sql
+++ b/schema/schema.postgres.sql
@@ -372,7 +372,7 @@ CREATE TABLE `writing` (
 
 CREATE TABLE `writing_category` (
   `idwritingCategory` int(10) NOT NULL AUTO_INCREMENT,
-  `writing_category_id` int(10) NOT NULL DEFAULT 0,
+  `writing_category_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   PRIMARY KEY (`idwritingCategory`),

--- a/schema/schema.sqlite.sql
+++ b/schema/schema.sqlite.sql
@@ -372,7 +372,7 @@ CREATE TABLE `writing` (
 
 CREATE TABLE `writing_category` (
   `idwritingCategory` int(10) NOT NULL AUTO_INCREMENT,
-  `writing_category_id` int(10) NOT NULL DEFAULT 0,
+  `writing_category_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   PRIMARY KEY (`idwritingCategory`),


### PR DESCRIPTION
## Summary
- allow parent `writing_category_id` to be NULL and migrate existing `0` values
- regenerate sqlc and update admin category handlers and templates for nullable parents
- bump expected schema version to 58

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: unmatched expectations in handlers/forum tests)*

------
https://chatgpt.com/codex/tasks/task_e_6895f1cf6154832f8727764d2e3a898d