### PR TITLE
Auto-subscribe creators to private topics

### DIFF
--- a/handlers/privateforum/auto_subscribe_test.go
+++ b/handlers/privateforum/auto_subscribe_test.go
@@ -1,0 +1,13 @@
+package privateforum
+
+import (
+	"testing"
+
+	notif "github.com/arran4/goa4web/internal/notifications"
+)
+
+func TestPrivateTopicCreateTaskAutoSubscribe(t *testing.T) {
+	if _, ok := interface{}(privateTopicCreateTask).(notif.AutoSubscribeProvider); !ok {
+		t.Fatalf("PrivateTopicCreateTask should implement AutoSubscribeProvider so creators follow replies")
+	}
+}

--- a/handlers/privateforum/topic_create_task_test.go
+++ b/handlers/privateforum/topic_create_task_test.go
@@ -33,6 +33,7 @@ func TestPrivateTopicCreateTask_GrantsBeforeComment(t *testing.T) {
 	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO comments").WillReturnResult(sqlmock.NewResult(3, 1))
+	mock.ExpectExec("INSERT INTO subscriptions").WillReturnResult(sqlmock.NewResult(0, 1))
 
 	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
 	cd.UserID = 1


### PR DESCRIPTION
## Summary
- ensure private topic creation subscribes the creator to the topic and thread
- add coverage for private topic auto-subscribe behavior

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68960006a864832f92796b123427b315