### PR TITLE
Handle private forum topic display

### DIFF
--- a/core/templates/site/forum/topicsPage.gohtml
+++ b/core/templates/site/forum/topicsPage.gohtml
@@ -3,7 +3,7 @@
     {{ if .Category }}
         <h1>Category: {{ .Category.Title.String }}</h1>
     {{ end }}
-    <h2>Topic: {{ .Topic.Title.String }}</h2>
+    <h2>Topic: {{ if .Topic.DisplayTitle }}{{ .Topic.DisplayTitle }}{{ else }}{{ .Topic.Title.String }}{{ end }}</h2>
 
     <div class="topic-actions">
         <a href="/forum/topic/{{.Topic.Idforumtopic}}/thread">New Thread</a>

--- a/handlers/forum/forumTopicPage_private_test.go
+++ b/handlers/forum/forumTopicPage_private_test.go
@@ -1,0 +1,72 @@
+package forum
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestTopicsPage_PrivateTopic(t *testing.T) {
+	core.Store = sessions.NewCookieStore([]byte("test"))
+	core.SessionName = "test-session"
+
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+	queries := db.New(conn)
+
+	cd := common.NewCoreData(context.Background(), queries, config.NewRuntimeConfig())
+
+	req := httptest.NewRequest(http.MethodGet, "/forum/topic/1", nil)
+	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+
+	mock.ExpectQuery("SELECT .* FROM forumcategory").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}))
+
+	mock.ExpectQuery("SELECT t.* FROM forumtopic t").
+		WithArgs(sqlmock.AnyArg(), 1, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
+			AddRow(1, 0, 1, 0, "Topic: old is now Private chat with: Bob", "", 0, 0, time.Now(), "private", ""))
+
+	mock.ExpectQuery("SELECT u.idusers, u.username FROM grants").
+		WithArgs(1, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"idusers", "username"}).AddRow(1, "Alice").AddRow(2, "Bob"))
+
+	mock.ExpectQuery("SELECT .* FROM forumthread").
+		WithArgs(sqlmock.AnyArg(), 1, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "lastposterusername", "lastposterid", "firstpostusername", "firstpostwritten", "firstposttext"}))
+
+	w := httptest.NewRecorder()
+	TopicsPage(w, req)
+
+	body := w.Body.String()
+	if strings.Contains(body, "is now Private chat with") {
+		t.Fatalf("unexpected conversion message in output: %q", body)
+	}
+	if strings.Contains(body, "Category:") {
+		t.Fatalf("unexpected category heading: %q", body)
+	}
+	if !strings.Contains(body, "Topic: Alice, Bob") {
+		t.Fatalf("expected participant names, got %q", body)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure private forum topics show participant names instead of conversion message
- avoid attaching category breadcrumbs for private topics
- cover private topic rendering with regression test

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895ffe8eee0832fa5e299a6c085282e