### PR TITLE
Allow nullable writing category parent

### DIFF
--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 58
+	ExpectedSchemaVersion = 59
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/migrations/0059.mysql.sql
+++ b/migrations/0059.mysql.sql
@@ -1,0 +1,7 @@
+ALTER TABLE writing_category
+    MODIFY COLUMN writing_category_id int(10) DEFAULT NULL;
+
+UPDATE writing_category SET writing_category_id = NULL WHERE writing_category_id = 0;
+
+-- Update schema version
+UPDATE schema_version SET version = 59 WHERE version = 58;

--- a/migrations/0059.postgres.sql
+++ b/migrations/0059.postgres.sql
@@ -1,0 +1,7 @@
+ALTER TABLE writing_category ALTER COLUMN writing_category_id DROP DEFAULT;
+ALTER TABLE writing_category ALTER COLUMN writing_category_id DROP NOT NULL;
+
+UPDATE writing_category SET writing_category_id = NULL WHERE writing_category_id = 0;
+
+-- Update schema version
+UPDATE schema_version SET version = 59 WHERE version = 58;

--- a/migrations/0059.sqlite.sql
+++ b/migrations/0059.sqlite.sql
@@ -1,0 +1,7 @@
+ALTER TABLE writing_category
+    MODIFY COLUMN writing_category_id int(10) DEFAULT NULL;
+
+UPDATE writing_category SET writing_category_id = NULL WHERE writing_category_id = 0;
+
+-- Update schema version
+UPDATE schema_version SET version = 59 WHERE version = 58;

--- a/schema/schema.mysql.sql
+++ b/schema/schema.mysql.sql
@@ -373,7 +373,7 @@ CREATE TABLE `writing` (
 
 CREATE TABLE `writing_category` (
   `idwritingCategory` int(10) NOT NULL AUTO_INCREMENT,
-  `writing_category_id` int(10) NOT NULL DEFAULT 0,
+  `writing_category_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   PRIMARY KEY (`idwritingCategory`),

--- a/schema/schema.postgres.sql
+++ b/schema/schema.postgres.sql
@@ -372,7 +372,7 @@ CREATE TABLE `writing` (
 
 CREATE TABLE `writing_category` (
   `idwritingCategory` int(10) NOT NULL AUTO_INCREMENT,
-  `writing_category_id` int(10) NOT NULL DEFAULT 0,
+  `writing_category_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   PRIMARY KEY (`idwritingCategory`),

--- a/schema/schema.sqlite.sql
+++ b/schema/schema.sqlite.sql
@@ -372,7 +372,7 @@ CREATE TABLE `writing` (
 
 CREATE TABLE `writing_category` (
   `idwritingCategory` int(10) NOT NULL AUTO_INCREMENT,
-  `writing_category_id` int(10) NOT NULL DEFAULT 0,
+  `writing_category_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
   PRIMARY KEY (`idwritingCategory`),


### PR DESCRIPTION
## Summary
- allow `writing_category.writing_category_id` to be NULL instead of 0
- bump expected schema version to 59
- document nullable parent in schema files

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot use languageID as sql.NullInt32 value)*
- `golangci-lint run` *(fails: typecheck errors in core/common and other packages)*
- `go test ./...` *(fails: build errors in core/common)*

------
https://chatgpt.com/codex/tasks/task_e_6896035a8ae8832f83c77d9609f8cd43