### PR TITLE
Allow nullable language references

### DIFF
--- a/cmd/goa4web/blog_create.go
+++ b/cmd/goa4web/blog_create.go
@@ -43,7 +43,7 @@ func (c *blogCreateCmd) Run() error {
 	queries := db.New(conn)
 	_, err = queries.CreateBlogEntryForWriter(ctx, db.CreateBlogEntryForWriterParams{
 		UsersIdusers:       int32(c.UserID),
-		LanguageIdlanguage: int32(c.LangID),
+		LanguageIdlanguage: sql.NullInt32{Int32: int32(c.LangID), Valid: c.LangID != 0},
 		Blog:               sql.NullString{String: c.Text, Valid: true},
 		UserID:             sql.NullInt32{Int32: int32(c.UserID), Valid: true},
 		ListerID:           int32(c.UserID),

--- a/cmd/goa4web/blog_update.go
+++ b/cmd/goa4web/blog_update.go
@@ -42,7 +42,7 @@ func (c *blogUpdateCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(conn)
 	err = queries.UpdateBlogEntryForWriter(ctx, db.UpdateBlogEntryForWriterParams{
-		LanguageID:   int32(c.LangID),
+		LanguageID:   sql.NullInt32{Int32: int32(c.LangID), Valid: c.LangID != 0},
 		Blog:         sql.NullString{String: c.Text, Valid: c.Text != ""},
 		EntryID:      int32(c.ID),
 		WriterID:     0,

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1286,7 +1286,7 @@ func (cd *CoreData) DeleteLanguage(code string) (int32, string, error) {
 			}
 		}
 	}
-	counts, err := cd.queries.AdminLanguageUsageCounts(cd.ctx, db.AdminLanguageUsageCountsParams{ID: int32(id)})
+	counts, err := cd.queries.AdminLanguageUsageCounts(cd.ctx, db.AdminLanguageUsageCountsParams{ID: sql.NullInt32{Int32: int32(id), Valid: true}})
 	if err != nil {
 		return int32(id), name, err
 	}
@@ -1612,8 +1612,8 @@ func (cd *CoreData) Preference() (*db.Preference, error) {
 func (cd *CoreData) PreferredLanguageID(siteDefault string) int32 {
 	id, err := cd.preferredLanguageID.Load(func() (int32, error) {
 		if pref, err := cd.Preference(); err == nil && pref != nil {
-			if pref.LanguageIdlanguage != 0 {
-				return pref.LanguageIdlanguage, nil
+			if pref.LanguageIdlanguage.Valid {
+				return pref.LanguageIdlanguage.Int32, nil
 			}
 		}
 		if cd.queries == nil || siteDefault == "" {
@@ -1970,7 +1970,7 @@ func (cd *CoreData) CreateCommentInSectionForCommenter(section, itemType string,
 		return 0, nil
 	}
 	return cd.queries.CreateCommentInSectionForCommenter(cd.ctx, db.CreateCommentInSectionForCommenterParams{
-		LanguageID:    languageID,
+		LanguageID:    sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		CommenterID:   sql.NullInt32{Int32: commenterID, Valid: commenterID != 0},
 		ForumthreadID: threadID,
 		Text:          sql.NullString{String: text, Valid: text != ""},

--- a/core/common/coredata_blogs.go
+++ b/core/common/coredata_blogs.go
@@ -65,7 +65,7 @@ func (cd *CoreData) UpdateBlogReply(commentID, commenterID, languageID int32, te
 		return nil
 	}
 	return cd.queries.UpdateCommentForEditor(cd.ctx, db.UpdateCommentForEditorParams{
-		LanguageID:  languageID,
+		LanguageID:  sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		Text:        sql.NullString{String: text, Valid: true},
 		CommentID:   commentID,
 		CommenterID: commenterID,

--- a/core/common/coredata_forum.go
+++ b/core/common/coredata_forum.go
@@ -152,7 +152,7 @@ func (cd *CoreData) UpdateForumComment(commentID, languageID int32, text string)
 		return nil
 	}
 	return cd.queries.UpdateCommentForEditor(cd.ctx, db.UpdateCommentForEditorParams{
-		LanguageID:  languageID,
+		LanguageID:  sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		Text:        sql.NullString{String: text, Valid: true},
 		CommentID:   commentID,
 		CommenterID: cd.UserID,
@@ -166,7 +166,7 @@ func (cd *CoreData) EditForumComment(commentID, commenterID, languageID int32, t
 		return nil
 	}
 	return cd.queries.UpdateCommentForEditor(cd.ctx, db.UpdateCommentForEditorParams{
-		LanguageID:  languageID,
+		LanguageID:  sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		Text:        sql.NullString{String: text, Valid: true},
 		CommentID:   commentID,
 		CommenterID: commenterID,

--- a/core/common/coredata_misc.go
+++ b/core/common/coredata_misc.go
@@ -35,7 +35,7 @@ func (cd *CoreData) CreatePrivateTopic(p CreatePrivateTopicParams) (topicID, thr
 	tid, err := cd.queries.CreateForumTopicForPoster(cd.ctx, db.CreateForumTopicForPosterParams{
 		PosterID:        p.CreatorID,
 		ForumcategoryID: PrivateForumCategoryID,
-		LanguageID:      0,
+		LanguageID:      sql.NullInt32{},
 		Title:           sql.NullString{},
 		Description:     sql.NullString{},
 		Handler:         "private",

--- a/core/common/coredata_news.go
+++ b/core/common/coredata_news.go
@@ -105,7 +105,7 @@ func (cd *CoreData) UpdateNewsReply(commentID, editorID, languageID int32, text 
 		return ThreadInfo{}, fmt.Errorf("thread fetch: %w", err)
 	}
 	if err := cd.queries.UpdateCommentForEditor(cd.ctx, db.UpdateCommentForEditorParams{
-		LanguageID:  languageID,
+		LanguageID:  sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		Text:        sql.NullString{String: text, Valid: true},
 		CommentID:   commentID,
 		CommenterID: editorID,
@@ -124,7 +124,7 @@ func (cd *CoreData) UpdateNewsPost(postID, languageID, userID int32, text string
 	return cd.queries.UpdateNewsPostForWriter(cd.ctx, db.UpdateNewsPostForWriterParams{
 		PostID:      postID,
 		GrantPostID: sql.NullInt32{Int32: postID, Valid: true},
-		LanguageID:  languageID,
+		LanguageID:  sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		News:        sql.NullString{String: text, Valid: true},
 		GranteeID:   sql.NullInt32{Int32: userID, Valid: userID != 0},
 		WriterID:    userID,
@@ -145,7 +145,7 @@ func (cd *CoreData) CreateNewsPost(languageID, userID int32, text string) (int64
 		return 0, nil
 	}
 	id, err := cd.queries.CreateNewsPostForWriter(cd.ctx, db.CreateNewsPostForWriterParams{
-		LanguageID: languageID,
+		LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		News:       sql.NullString{String: text, Valid: true},
 		WriterID:   userID,
 		GranteeID:  sql.NullInt32{Int32: userID, Valid: true},

--- a/core/common/coredata_user.go
+++ b/core/common/coredata_user.go
@@ -174,7 +174,7 @@ func (cd *CoreData) SetUserLanguage(userID, languageID int32) error {
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return cd.queries.InsertPreferenceForLister(cd.ctx, db.InsertPreferenceForListerParams{
-				LanguageID: languageID,
+				LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 				ListerID:   userID,
 				PageSize:   int32(cd.Config.PageSizeDefault),
 				Timezone:   sql.NullString{},
@@ -183,7 +183,7 @@ func (cd *CoreData) SetUserLanguage(userID, languageID int32) error {
 		return err
 	}
 	return cd.queries.UpdatePreferenceForLister(cd.ctx, db.UpdatePreferenceForListerParams{
-		LanguageID: languageID,
+		LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		ListerID:   userID,
 		PageSize:   pref.PageSize,
 		Timezone:   pref.Timezone,
@@ -199,7 +199,7 @@ func (cd *CoreData) SetUserLanguages(userID int32, langs []int32) error {
 		return err
 	}
 	for _, l := range langs {
-		if err := cd.queries.InsertUserLang(cd.ctx, db.InsertUserLangParams{UsersIdusers: userID, LanguageIdlanguage: l}); err != nil {
+		if err := cd.queries.InsertUserLang(cd.ctx, db.InsertUserLangParams{UsersIdusers: userID, LanguageIdlanguage: sql.NullInt32{Int32: l, Valid: l != 0}}); err != nil {
 			return err
 		}
 	}
@@ -215,7 +215,7 @@ func (cd *CoreData) SetTimezone(userID int32, tz string) error {
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return cd.queries.InsertPreferenceForLister(cd.ctx, db.InsertPreferenceForListerParams{
-				LanguageID: 0,
+				LanguageID: sql.NullInt32{},
 				ListerID:   userID,
 				PageSize:   int32(cd.Config.PageSizeDefault),
 				Timezone:   sql.NullString{String: tz, Valid: tz != ""},

--- a/core/common/coredata_writings.go
+++ b/core/common/coredata_writings.go
@@ -63,7 +63,7 @@ func (cd *CoreData) ArticleComment(r *http.Request, ops ...lazy.Option[*db.GetCo
 func (cd *CoreData) UpdateArticleComment(commentID, languageID int32, text string) error {
 	uid := cd.UserID
 	return cd.queries.UpdateCommentForEditor(cd.ctx, db.UpdateCommentForEditorParams{
-		LanguageID:  languageID,
+		LanguageID:  sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		Text:        sql.NullString{String: text, Valid: true},
 		CommentID:   commentID,
 		CommenterID: uid,
@@ -131,7 +131,7 @@ func (cd *CoreData) UpdateWritingReply(commentID, languageID int32, text string)
 		return nil, err
 	}
 	if err := cd.queries.UpdateCommentForEditor(cd.ctx, db.UpdateCommentForEditorParams{
-		LanguageID:  languageID,
+		LanguageID:  sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		Text:        sql.NullString{String: text, Valid: true},
 		CommentID:   cmt.Idcomments,
 		CommenterID: uid,
@@ -194,7 +194,7 @@ func (cd *CoreData) UpdateWriting(w *db.GetWritingForListerByIDRow, title, abstr
 		Abstract:   sql.NullString{Valid: true, String: abstract},
 		Content:    sql.NullString{Valid: true, String: body},
 		Private:    sql.NullBool{Valid: true, Bool: private},
-		LanguageID: languageID,
+		LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		WritingID:  w.Idwriting,
 		WriterID:   cd.UserID,
 		GranteeID:  sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
@@ -216,7 +216,7 @@ func (cd *CoreData) CreateWriting(categoryID, languageID int32, title, abstract,
 		Abstract:          sql.NullString{Valid: true, String: abstract},
 		Writing:           sql.NullString{Valid: true, String: body},
 		Private:           sql.NullBool{Valid: true, Bool: private},
-		LanguageID:        languageID,
+		LanguageID:        sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		GrantCategoryID:   sql.NullInt32{Int32: categoryID, Valid: true},
 		GranteeID:         sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	})

--- a/core/common/faq.go
+++ b/core/common/faq.go
@@ -74,7 +74,6 @@ func (cd *CoreData) RenameFAQCategory(id int32, name string) error {
 	})
 }
 
-
 // CreateFAQQuestionParams groups input for CreateFAQQuestion.
 type CreateFAQQuestionParams struct {
 	Question   string
@@ -94,7 +93,7 @@ func (cd *CoreData) CreateFAQQuestion(p CreateFAQQuestionParams) (int64, error) 
 		Answer:     sql.NullString{String: p.Answer, Valid: p.Answer != ""},
 		CategoryID: p.CategoryID,
 		WriterID:   p.WriterID,
-		LanguageID: p.LanguageID,
+		LanguageID: sql.NullInt32{Int32: p.LanguageID, Valid: p.LanguageID != 0},
 		GranteeID:  sql.NullInt32{Int32: p.WriterID, Valid: p.WriterID != 0},
 	})
 	if err != nil {
@@ -116,4 +115,3 @@ func (cd *CoreData) CreateFAQQuestion(p CreateFAQQuestionParams) (int64, error) 
 	}
 	return id, nil
 }
-

--- a/core/templates/email_execute_test.go
+++ b/core/templates/email_execute_test.go
@@ -1,13 +1,13 @@
 package templates_test
 
 import (
-        htemplate "html/template"
-        "io"
-        "strings"
-        "testing"
-        "time"
+	htemplate "html/template"
+	"io"
+	"strings"
+	"testing"
+	"time"
 
-        "github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/core/templates"
 )
 
 type emailData struct {
@@ -47,7 +47,7 @@ func sampleEmailData() emailData {
 		},
 		"ThreadID":           1,
 		"ThreadURL":          "https://example.com/thread",
-                "Time":               time.Now(),
+		"Time":               time.Now(),
 		"Title":              map[string]interface{}{"String": "title"},
 		"TopicTitle":         "topic title",
 		"UnsubURL":           "https://example.com/unsub",

--- a/core/templates/text_templates_test.go
+++ b/core/templates/text_templates_test.go
@@ -1,13 +1,13 @@
 package templates_test
 
 import (
-        "embed"
-        "io/fs"
-        "path/filepath"
-        "strings"
-        "testing"
-        "text/template"
-        "time"
+	"embed"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
 
 	"github.com/arran4/goa4web/core/templates"
 )
@@ -23,12 +23,12 @@ func TestParseGoTxtTemplates(t *testing.T) {
 		if d.IsDir() || !strings.HasSuffix(path, ".gotxt") {
 			return nil
 		}
-                t.Run(filepath.Base(path), func(t *testing.T) {
-                        tmpl := template.New("").Funcs(template.FuncMap{"localTime": func(t time.Time) time.Time { return t }})
-                        if _, err := tmpl.ParseFS(textTemplates, path); err != nil {
-                                t.Errorf("failed to parse %s: %v", path, err)
-                        }
-                })
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			tmpl := template.New("").Funcs(template.FuncMap{"localTime": func(t time.Time) time.Time { return t }})
+			if _, err := tmpl.ParseFS(textTemplates, path); err != nil {
+				t.Errorf("failed to parse %s: %v", path, err)
+			}
+		})
 		return nil
 	})
 	if err != nil {

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"net/http"
@@ -31,7 +32,7 @@ func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 	langID, _ := strconv.Atoi(r.URL.Query().Get("lang"))
 	role := r.URL.Query().Get("role")
 	rows, err := queries.AdminListUnsentPendingEmails(r.Context(), db.AdminListUnsentPendingEmailsParams{
-		LanguageID: int32(langID),
+		LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
 		RoleName:   role,
 	})
 	if err != nil {

--- a/handlers/admin/adminFailedEmailsPage.go
+++ b/handlers/admin/adminFailedEmailsPage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"net/http"
@@ -40,7 +41,7 @@ func AdminFailedEmailsPage(w http.ResponseWriter, r *http.Request) {
 	langID, _ := strconv.Atoi(r.URL.Query().Get("lang"))
 	role := r.URL.Query().Get("role")
 	rows, err := queries.AdminListFailedEmails(r.Context(), db.AdminListFailedEmailsParams{
-		LanguageID: int32(langID),
+		LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
 		RoleName:   role,
 		Limit:      int32(pageSize + 1),
 		Offset:     int32(offset),

--- a/handlers/admin/adminSentEmailsPage.go
+++ b/handlers/admin/adminSentEmailsPage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"net/http"
@@ -40,7 +41,7 @@ func AdminSentEmailsPage(w http.ResponseWriter, r *http.Request) {
 	langID, _ := strconv.Atoi(r.URL.Query().Get("lang"))
 	role := r.URL.Query().Get("role")
 	rows, err := queries.AdminListSentEmails(r.Context(), db.AdminListSentEmailsParams{
-		LanguageID: int32(langID),
+		LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
 		RoleName:   role,
 		Limit:      int32(pageSize + 1),
 		Offset:     int32(offset),

--- a/handlers/admin/role_grants.go
+++ b/handlers/admin/role_grants.go
@@ -194,8 +194,10 @@ func buildGrantGroupsFromGrants(ctx context.Context, cd *common.CoreData, grants
 					if w, err := queries.GetWritingForListerByID(ctx, db.GetWritingForListerByIDParams{ListerID: cd.UserID, Idwriting: g.ItemID.Int32, ListerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0}}); err == nil {
 						if w.Title.Valid {
 							info := w.Title.String
-							if name, ok := langMap[w.LanguageIdlanguage]; ok && name != "" {
-								info = fmt.Sprintf("[%s] %s", name, info)
+							if w.LanguageIdlanguage.Valid {
+								if name, ok := langMap[w.LanguageIdlanguage.Int32]; ok && name != "" {
+									info = fmt.Sprintf("[%s] %s", name, info)
+								}
 							}
 							gi.Info = info
 						}
@@ -220,8 +222,10 @@ func buildGrantGroupsFromGrants(ctx context.Context, cd *common.CoreData, grants
 						if len(text) > 40 {
 							text = text[:40] + "..."
 						}
-						if name, ok := langMap[qrow.LanguageIdlanguage]; ok && name != "" {
-							text = fmt.Sprintf("[%s] %s", name, text)
+						if qrow.LanguageIdlanguage.Valid {
+							if name, ok := langMap[qrow.LanguageIdlanguage.Int32]; ok && name != "" {
+								text = fmt.Sprintf("[%s] %s", name, text)
+							}
 						}
 						gi.Info = text
 					}

--- a/handlers/admin/user_grants_build_test.go
+++ b/handlers/admin/user_grants_build_test.go
@@ -24,7 +24,7 @@ func TestBuildUserGrantGroupsIncludesAvailableActionsWithoutGrants(t *testing.T)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants WHERE user_id = ? ORDER BY id\n")).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_idlanguage, f.title, f.description\nFROM forumcategory f\nWHERE (\nf.language_idlanguage = 0\nOR f.language_idlanguage IS NULL\nOR EXISTS (\nSELECT 1 FROM user_language ul\nWHERE ul.users_idusers = ?\nAND ul.language_idlanguage = f.language_idlanguage\n)\nOR NOT EXISTS (\nSELECT 1 FROM user_language ul WHERE ul.users_idusers = ?\n)\n)\n")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_idlanguage, f.title, f.description\nFROM forumcategory f\nWHERE (\nf.language_idlanguage IS NULL\nOR EXISTS (\nSELECT 1 FROM user_language ul\nWHERE ul.users_idusers = ?\nAND ul.language_idlanguage = f.language_idlanguage\n)\nOR NOT EXISTS (\nSELECT 1 FROM user_language ul WHERE ul.users_idusers = ?\n)\n)\n")).
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language\n")).

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -75,7 +75,7 @@ func (AddBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	id, err := queries.CreateBlogEntryForWriter(r.Context(), db.CreateBlogEntryForWriterParams{
 		UsersIdusers:       uid,
-		LanguageIdlanguage: int32(languageId),
+		LanguageIdlanguage: sql.NullInt32{Int32: int32(languageId), Valid: languageId != 0},
 		Blog: sql.NullString{
 			String: text,
 			Valid:  true,

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -50,7 +50,7 @@ func (EditBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err = queries.UpdateBlogEntryForWriter(r.Context(), db.UpdateBlogEntryForWriterParams{
 		EntryID:      row.Idblogs,
 		GrantEntryID: sql.NullInt32{Int32: row.Idblogs, Valid: true},
-		LanguageID:   int32(languageId),
+		LanguageID:   sql.NullInt32{Int32: int32(languageId), Valid: languageId != 0},
 		Blog: sql.NullString{
 			String: text,
 			Valid:  true,

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 58
+	ExpectedSchemaVersion = 59
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -93,7 +93,7 @@ func (AskTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err := queries.CreateFAQQuestionForWriter(r.Context(), db.CreateFAQQuestionForWriterParams{
 		Question:   sql.NullString{String: text, Valid: true},
 		WriterID:   uid,
-		LanguageID: int32(languageId),
+		LanguageID: sql.NullInt32{Int32: int32(languageId), Valid: languageId != 0},
 		GranteeID:  sql.NullInt32{Int32: uid, Valid: true},
 	}); err != nil {
 		return fmt.Errorf("faq fetch fail: %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/forum/forumAdminCategoryCreatePage.go
+++ b/handlers/forum/forumAdminCategoryCreatePage.go
@@ -59,7 +59,7 @@ func AdminCategoryCreateSubmit(w http.ResponseWriter, r *http.Request) {
 	languageID, _ := strconv.Atoi(r.PostFormValue("language"))
 	if err := queries.AdminCreateForumCategory(r.Context(), db.AdminCreateForumCategoryParams{
 		ForumcategoryIdforumcategory: int32(pcid),
-		LanguageIdlanguage:           int32(languageID),
+		LanguageIdlanguage:           sql.NullInt32{Int32: int32(languageID), Valid: languageID != 0},
 		Title:                        sql.NullString{Valid: true, String: name},
 		Description:                  sql.NullString{Valid: true, String: desc},
 	}); err != nil {

--- a/handlers/forum/forumAdminCategoryEditPage.go
+++ b/handlers/forum/forumAdminCategoryEditPage.go
@@ -82,7 +82,7 @@ func AdminCategoryEditSubmit(w http.ResponseWriter, r *http.Request) {
 		Description:                  sql.NullString{Valid: true, String: desc},
 		Idforumcategory:              int32(categoryId),
 		ForumcategoryIdforumcategory: int32(pcid),
-		LanguageIdlanguage:           int32(languageID),
+		LanguageIdlanguage:           sql.NullInt32{Int32: int32(languageID), Valid: languageID != 0},
 	}); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return

--- a/handlers/forum/forumAdminCategoryPage_test.go
+++ b/handlers/forum/forumAdminCategoryPage_test.go
@@ -40,14 +40,12 @@ func TestAdminCategoryPageLinks(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}).
-		AddRow(1, 0, 0, "cat", "desc")
-	mock.ExpectQuery("SELECT idforumcategory, forumcategory_idforumcategory, language_idlanguage, title, description FROM forumcategory").
-		WillReturnRows(catRows)
+		AddRow(1, 0, nil, "cat", "desc")
+	mock.ExpectQuery("SELECT idforumcategory").WillReturnRows(catRows)
 
-	topicsRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler"}).
-		AddRow(1, 0, 1, 0, "t", "d", 0, 0, time.Now(), "")
-	mock.ExpectQuery("SELECT idforumtopic, lastposter, forumcategory_idforumcategory, language_idlanguage, title, description, threads, comments, lastaddition, handler FROM forumtopic").
-		WillReturnRows(topicsRows)
+	topicsRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername"}).
+		AddRow(1, 0, 1, nil, "t", "d", 0, 0, time.Now(), "", "")
+	mock.ExpectQuery("SELECT t.idforumtopic").WillReturnRows(topicsRows)
 
 	req, rr := setupRequest(t, queries, "/admin/forum/categories/category/1", map[string]string{"category": "1"})
 
@@ -82,14 +80,12 @@ func TestAdminCategoryEditPage(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}).
-		AddRow(1, 0, 0, "cat", "desc")
-	mock.ExpectQuery("SELECT idforumcategory, forumcategory_idforumcategory, language_idlanguage, title, description FROM forumcategory").
-		WillReturnRows(catRows)
+		AddRow(1, 0, nil, "cat", "desc")
+	mock.ExpectQuery("SELECT idforumcategory").WillReturnRows(catRows)
 
 	allRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}).
-		AddRow(1, 0, 0, "cat", "desc")
-	mock.ExpectQuery("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_idlanguage, f.title, f.description\nFROM forumcategory f").
-		WillReturnRows(allRows)
+		AddRow(1, 0, nil, "cat", "desc")
+	mock.ExpectQuery("SELECT f.idforumcategory").WillReturnRows(allRows)
 
 	req, rr := setupRequest(t, queries, "/admin/forum/categories/category/1/edit", map[string]string{"category": "1"})
 

--- a/handlers/forum/forumAdminTopicPage_test.go
+++ b/handlers/forum/forumAdminTopicPage_test.go
@@ -26,9 +26,9 @@ func TestAdminTopicPage(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	topicID := 4
-	rows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler"}).
-		AddRow(topicID, 0, 1, 0, "t", "d", 2, 3, time.Now(), "")
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+	rows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername"}).
+		AddRow(topicID, 0, 1, nil, "t", "d", 2, 3, time.Now(), "", "")
+	mock.ExpectQuery("SELECT t.idforumtopic").WillReturnRows(rows)
 
 	cd := common.NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
 	r := httptest.NewRequest("GET", "/admin/forum/topics/topic/"+strconv.Itoa(topicID), nil)
@@ -53,17 +53,17 @@ func TestAdminTopicEditFormPage(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	topicID := 4
-	topicRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler"}).
-		AddRow(topicID, 0, 1, 0, "t", "d", 2, 3, time.Now(), "")
-	mock.ExpectQuery("SELECT").WillReturnRows(topicRows)
+	topicRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername"}).
+		AddRow(topicID, 0, 1, nil, "t", "d", 2, 3, time.Now(), "", "")
+	mock.ExpectQuery("SELECT t.idforumtopic").WillReturnRows(topicRows)
 
 	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}).
-		AddRow(1, 0, 0, "cat", "desc")
-	mock.ExpectQuery("SELECT").WillReturnRows(catRows)
+		AddRow(1, 0, nil, "cat", "desc")
+	mock.ExpectQuery("SELECT f.idforumcategory").WillReturnRows(catRows)
 
 	roleRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).
 		AddRow(1, "role", true, false, nil)
-	mock.ExpectQuery("SELECT").WillReturnRows(roleRows)
+	mock.ExpectQuery("SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id").WillReturnRows(roleRows)
 
 	cd := common.NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
 	r := httptest.NewRequest("GET", "/admin/forum/topics/topic/"+strconv.Itoa(topicID)+"/edit", nil)

--- a/handlers/forum/forumAdminTopicsPage.go
+++ b/handlers/forum/forumAdminTopicsPage.go
@@ -75,7 +75,7 @@ func AdminTopicEditPage(w http.ResponseWriter, r *http.Request) {
 		Title:                        sql.NullString{String: name, Valid: true},
 		Description:                  sql.NullString{String: desc, Valid: true},
 		ForumcategoryIdforumcategory: int32(cid),
-		LanguageIdlanguage:           int32(languageID),
+		LanguageIdlanguage:           sql.NullInt32{Int32: int32(languageID), Valid: languageID != 0},
 		Idforumtopic:                 int32(tid),
 	}); err != nil {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
@@ -114,7 +114,7 @@ func AdminTopicCreatePage(w http.ResponseWriter, r *http.Request) {
 	topicID, err := cd.Queries().CreateForumTopicForPoster(r.Context(), db.CreateForumTopicForPosterParams{
 		PosterID:        uid,
 		ForumcategoryID: int32(pcid),
-		LanguageID:      int32(languageID),
+		LanguageID:      sql.NullInt32{Int32: int32(languageID), Valid: languageID != 0},
 		Title:           sql.NullString{String: name, Valid: true},
 		Description:     sql.NullString{String: desc, Valid: true},
 		Handler:         "",

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -153,7 +153,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if errors.Is(err, sql.ErrNoRows) {
 		ptidi, err := queries.SystemCreateForumTopic(r.Context(), db.SystemCreateForumTopicParams{
 			ForumcategoryIdforumcategory: 0,
-			LanguageIdlanguage:           0,
+			LanguageIdlanguage:           sql.NullInt32{},
 			Title: sql.NullString{
 				String: ImageBBSTopicName,
 				Valid:  true,

--- a/handlers/languages/admin.go
+++ b/handlers/languages/admin.go
@@ -1,6 +1,7 @@
 package languages
 
 import (
+	"database/sql"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -46,7 +47,7 @@ func adminLanguagePage(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Not Found"))
 		return
 	}
-	counts, err := cd.Queries().AdminLanguageUsageCounts(r.Context(), db.AdminLanguageUsageCountsParams{ID: int32(id)})
+	counts, err := cd.Queries().AdminLanguageUsageCounts(r.Context(), db.AdminLanguageUsageCountsParams{ID: sql.NullInt32{Int32: int32(id), Valid: true}})
 	if err != nil {
 		handlers.RenderErrorPage(w, r, err)
 		return

--- a/handlers/linker/edit_reply_task.go
+++ b/handlers/linker/edit_reply_task.go
@@ -65,7 +65,7 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if err = queries.UpdateCommentForEditor(r.Context(), db.UpdateCommentForEditorParams{
-		LanguageID: int32(languageId),
+		LanguageID: sql.NullInt32{Int32: int32(languageId), Valid: languageId != 0},
 		Text: sql.NullString{
 			String: text,
 			Valid:  true,

--- a/handlers/linker/linkerAdminLinkPage.go
+++ b/handlers/linker/linkerAdminLinkPage.go
@@ -36,7 +36,7 @@ func adminLinkPage(w http.ResponseWriter, r *http.Request) {
 	}{
 		Link:               link,
 		Selected:           int(link.LinkerCategoryID),
-		SelectedLanguageId: int(link.LanguageIdlanguage),
+		SelectedLanguageId: int(link.LanguageIdlanguage.Int32),
 	}
 
 	handlers.TemplateHandler(w, r, "adminLinkPage.gohtml", data)
@@ -69,7 +69,7 @@ func (editLinkTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Url:                sql.NullString{Valid: true, String: URL},
 		Description:        sql.NullString{Valid: true, String: desc},
 		LinkerCategoryID:   int32(cat),
-		LanguageIdlanguage: int32(lang),
+		LanguageIdlanguage: sql.NullInt32{Int32: int32(lang), Valid: lang != 0},
 		Idlinker:           id,
 	}); err != nil {
 		return fmt.Errorf("update linker item fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/news/admin_pages.go
+++ b/handlers/news/admin_pages.go
@@ -177,7 +177,7 @@ func adminNewsEditFormPage(w http.ResponseWriter, r *http.Request) {
 	}{
 		Languages:          langs,
 		Post:               post,
-		SelectedLanguageId: int(post.LanguageIdlanguage),
+		SelectedLanguageId: int(post.LanguageIdlanguage.Int32),
 	}
 	if err := cd.ExecuteSiteTemplate(w, r, "adminNewsEditPage.gohtml", data); err != nil {
 		handlers.RenderErrorPage(w, r, err)

--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -59,7 +59,9 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		for _, ul := range userLangs {
-			selected[ul.LanguageIdlanguage] = true
+			if ul.LanguageIdlanguage.Valid {
+				selected[ul.LanguageIdlanguage.Int32] = true
+			}
 		}
 	}
 
@@ -69,13 +71,13 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 		if selected[l.Idlanguage] {
 			opt.IsSelected = true
 		}
-		if pref != nil && pref.LanguageIdlanguage == l.Idlanguage {
+		if pref != nil && pref.LanguageIdlanguage.Valid && pref.LanguageIdlanguage.Int32 == l.Idlanguage {
 			opt.IsDefault = true
 		}
 		opts = append(opts, opt)
 	}
 
-	defaultIsMulti := pref == nil || pref.LanguageIdlanguage == 0
+	defaultIsMulti := pref == nil || !pref.LanguageIdlanguage.Valid
 	data := Data{
 		LanguageOptions:       opts,
 		DefaultIsMultilingual: defaultIsMulti,
@@ -98,7 +100,7 @@ func updateLanguageSelections(r *http.Request, cd *common.CoreData, queries db.Q
 
 	for _, l := range langs {
 		if r.PostFormValue(fmt.Sprintf("language%d", l.Idlanguage)) != "" {
-			if err := queries.InsertUserLang(r.Context(), db.InsertUserLangParams{UsersIdusers: uid, LanguageIdlanguage: l.Idlanguage}); err != nil {
+			if err := queries.InsertUserLang(r.Context(), db.InsertUserLangParams{UsersIdusers: uid, LanguageIdlanguage: sql.NullInt32{Int32: l.Idlanguage, Valid: true}}); err != nil {
 				return err
 			}
 		}
@@ -121,14 +123,14 @@ func updateDefaultLanguage(r *http.Request, queries db.Querier, uid int32) error
 
 	if errors.Is(err, sql.ErrNoRows) {
 		return queries.InsertPreferenceForLister(r.Context(), db.InsertPreferenceForListerParams{
-			LanguageID: int32(langID),
+			LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
 			ListerID:   uid,
 			PageSize:   int32(cd.Config.PageSizeDefault),
 			Timezone:   sql.NullString{},
 		})
 	}
 
-	pref.LanguageIdlanguage = int32(langID)
+	pref.LanguageIdlanguage = sql.NullInt32{Int32: int32(langID), Valid: langID != 0}
 	return queries.UpdatePreferenceForLister(r.Context(), db.UpdatePreferenceForListerParams{
 		LanguageID: pref.LanguageIdlanguage,
 		ListerID:   uid,

--- a/handlers/user/userPagingPage.go
+++ b/handlers/user/userPagingPage.go
@@ -57,7 +57,7 @@ func (PagingSaveTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	if errors.Is(err, sql.ErrNoRows) {
 		err = queries.InsertPreferenceForLister(r.Context(), db.InsertPreferenceForListerParams{
-			LanguageID: 0,
+			LanguageID: sql.NullInt32{},
 			ListerID:   uid,
 			PageSize:   int32(size),
 			Timezone:   sql.NullString{},

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -59,7 +59,7 @@ type Blog struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            time.Time
 	DeletedAt          sql.NullTime
@@ -82,7 +82,7 @@ type Comment struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 	DeletedAt          sql.NullTime
@@ -99,7 +99,7 @@ type DeactivatedBlog struct {
 	Idblogs            int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            sql.NullTime
 	DeletedAt          sql.NullTime
@@ -110,7 +110,7 @@ type DeactivatedComment struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 	DeletedAt          sql.NullTime
@@ -134,7 +134,7 @@ type DeactivatedImagepost struct {
 
 type DeactivatedLinker struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -160,7 +160,7 @@ type DeactivatedWriting struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -194,7 +194,7 @@ type ExternalLink struct {
 type Faq struct {
 	Idfaq                        int32
 	FaqcategoriesIdfaqcategories int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	UsersIdusers                 int32
 	Answer                       sql.NullString
 	Question                     sql.NullString
@@ -217,7 +217,7 @@ type FaqRevision struct {
 type Forumcategory struct {
 	Idforumcategory              int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 }
@@ -236,7 +236,7 @@ type Forumtopic struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -297,7 +297,7 @@ type Language struct {
 
 type Linker struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -318,7 +318,7 @@ type LinkerCategory struct {
 
 type LinkerQueue struct {
 	Idlinkerqueue      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	Title              sql.NullString
@@ -378,7 +378,7 @@ type PendingPassword struct {
 
 type Preference struct {
 	Idpreferences        int32
-	LanguageIdlanguage   int32
+	LanguageIdlanguage   sql.NullInt32
 	UsersIdusers         int32
 	Emailforumupdates    sql.NullBool
 	PageSize             int32
@@ -424,7 +424,7 @@ type SiteAnnouncement struct {
 type SiteNews struct {
 	Idsitenews         int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
@@ -481,7 +481,7 @@ type UserEmail struct {
 type UserLanguage struct {
 	Iduserlang         int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 }
 
 type UserRole struct {
@@ -494,7 +494,7 @@ type Writing struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -29,8 +29,7 @@ WHERE a.active = 1
       NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
       )
-      OR n.language_idlanguage = 0
-      OR n.language_idlanguage IS NULL
+    OR n.language_idlanguage IS NULL
       OR n.language_idlanguage IN (
           SELECT ul.language_idlanguage
           FROM user_language ul

--- a/internal/db/queries-announcements.sql.go
+++ b/internal/db/queries-announcements.sql.go
@@ -103,8 +103,7 @@ WHERE a.active = 1
       NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
       )
-      OR n.language_idlanguage = 0
-      OR n.language_idlanguage IS NULL
+    OR n.language_idlanguage IS NULL
       OR n.language_idlanguage IN (
           SELECT ul.language_idlanguage
           FROM user_language ul

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -59,8 +59,7 @@ JOIN grants g ON (g.item_id = b.idblogs OR g.item_id IS NULL)
 LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE (
-    b.language_idlanguage = 0
-    OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -84,8 +83,7 @@ LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE (b.users_idusers = sqlc.arg(author_id) OR sqlc.arg(author_id) = 0)
 AND (
-    b.language_idlanguage = 0
-    OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -116,8 +114,7 @@ SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.bl
 FROM blogs b
 WHERE b.idblogs IN (sqlc.slice(blogIds))
   AND (
-      b.language_idlanguage = 0
-      OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -151,8 +148,7 @@ LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE b.idblogs = sqlc.arg(id)
   AND (
-      b.language_idlanguage = 0
-      OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -184,8 +180,7 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN blogs b ON b.idblogs = cs.blog_id
 WHERE swl.word = ?
   AND (
-      b.language_idlanguage = 0
-      OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -217,8 +212,7 @@ JOIN blogs b ON b.idblogs = cs.blog_id
 WHERE swl.word = ?
   AND cs.blog_id IN (sqlc.slice('ids'))
   AND (
-      b.language_idlanguage = 0
-      OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -249,8 +243,7 @@ SELECT u.username, COUNT(b.idblogs) AS count
 FROM blogs b
 JOIN users u ON b.users_idusers = u.idusers
 WHERE (
-    b.language_idlanguage = 0
-    OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -283,8 +276,7 @@ FROM blogs b
 JOIN users u ON b.users_idusers = u.idusers
 WHERE (LOWER(u.username) LIKE LOWER(sqlc.arg(query)) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(sqlc.arg(query)))
   AND (
-    b.language_idlanguage = 0
-    OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -36,7 +36,7 @@ type AdminGetAllBlogEntriesByUserRow struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            time.Time
 	Username           sql.NullString
@@ -98,7 +98,7 @@ WHERE EXISTS (
 
 type CreateBlogEntryForWriterParams struct {
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	UserID             sql.NullInt32
 	ListerID           int32
@@ -129,8 +129,7 @@ LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE b.idblogs = ?
   AND (
-      b.language_idlanguage = 0
-      OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -163,7 +162,7 @@ type GetBlogEntryForListerByIDRow struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            time.Time
 	Username           sql.NullString
@@ -206,8 +205,7 @@ LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE (b.users_idusers = ? OR ? = 0)
 AND (
-    b.language_idlanguage = 0
-    OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -243,7 +241,7 @@ type ListBlogEntriesByAuthorForListerRow struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            time.Time
 	Username           sql.NullString
@@ -302,8 +300,7 @@ SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.bl
 FROM blogs b
 WHERE b.idblogs IN (/*SLICE:blogids*/?)
   AND (
-      b.language_idlanguage = 0
-      OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -339,7 +336,7 @@ type ListBlogEntriesByIDsForListerRow struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            time.Time
 }
@@ -407,8 +404,7 @@ JOIN grants g ON (g.item_id = b.idblogs OR g.item_id IS NULL)
 LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE (
-    b.language_idlanguage = 0
-    OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -433,7 +429,7 @@ type ListBlogEntriesForListerRow struct {
 	Idblogs            int32
 	ForumthreadID      sql.NullInt32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            time.Time
 	Username           sql.NullString
@@ -492,8 +488,7 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN blogs b ON b.idblogs = cs.blog_id
 WHERE swl.word = ?
   AND (
-      b.language_idlanguage = 0
-      OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -561,8 +556,7 @@ JOIN blogs b ON b.idblogs = cs.blog_id
 WHERE swl.word = ?
   AND cs.blog_id IN (/*SLICE:ids*/?)
   AND (
-      b.language_idlanguage = 0
-      OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -637,8 +631,7 @@ SELECT u.username, COUNT(b.idblogs) AS count
 FROM blogs b
 JOIN users u ON b.users_idusers = u.idusers
 WHERE (
-    b.language_idlanguage = 0
-    OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -714,8 +707,7 @@ FROM blogs b
 JOIN users u ON b.users_idusers = u.idusers
 WHERE (LOWER(u.username) LIKE LOWER(?) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(?))
   AND (
-    b.language_idlanguage = 0
-    OR b.language_idlanguage IS NULL
+    b.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -880,7 +872,7 @@ WHERE b.idblogs = ?
 `
 
 type UpdateBlogEntryForWriterParams struct {
-	LanguageID   int32
+	LanguageID   sql.NullInt32
 	Blog         sql.NullString
 	EntryID      int32
 	WriterID     int32

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -10,8 +10,7 @@ LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
 LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.idcomments = sqlc.arg(id)
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -73,8 +72,7 @@ LEFT JOIN users pu ON pu.idusers = c.users_idusers
 LEFT JOIN forumcategory fc ON t.forumcategory_idforumcategory = fc.idforumcategory
 WHERE c.Idcomments IN (sqlc.slice('ids'))
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -126,8 +124,7 @@ LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.forumthread_id=sqlc.arg(thread_id)
   AND c.forumthread_id!=0
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -164,8 +161,7 @@ LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.forumthread_id=sqlc.arg(thread_id)
   AND c.forumthread_id!=0
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)

--- a/internal/db/queries-comments.sql.go
+++ b/internal/db/queries-comments.sql.go
@@ -28,7 +28,7 @@ type AdminGetAllCommentsByUserRow struct {
 	Idcomments             int32
 	ForumthreadID          int32
 	UsersIdusers           int32
-	LanguageIdlanguage     int32
+	LanguageIdlanguage     sql.NullInt32
 	Written                sql.NullTime
 	Text                   sql.NullString
 	DeletedAt              sql.NullTime
@@ -153,7 +153,7 @@ WHERE EXISTS (
 `
 
 type CreateCommentInSectionForCommenterParams struct {
-	LanguageID    int32
+	LanguageID    sql.NullInt32
 	CommenterID   sql.NullInt32
 	ForumthreadID int32
 	Text          sql.NullString
@@ -246,8 +246,7 @@ LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
 LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.idcomments = ?
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -280,7 +279,7 @@ type GetCommentByIdForUserRow struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 	DeletedAt          sql.NullTime
@@ -330,8 +329,7 @@ LEFT JOIN users pu ON pu.idusers = c.users_idusers
 LEFT JOIN forumcategory fc ON t.forumcategory_idforumcategory = fc.idforumcategory
 WHERE c.Idcomments IN (/*SLICE:ids*/?)
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -364,7 +362,7 @@ type GetCommentsByIdsForUserWithThreadInfoRow struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 	DeletedAt          sql.NullTime
@@ -447,8 +445,7 @@ LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.forumthread_id=?
   AND c.forumthread_id!=0
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -483,7 +480,7 @@ type GetCommentsBySectionThreadIdForUserRow struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 	DeletedAt          sql.NullTime
@@ -550,8 +547,7 @@ LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.forumthread_id=?
   AND c.forumthread_id!=0
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -584,7 +580,7 @@ type GetCommentsByThreadIdForUserRow struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 	DeletedAt          sql.NullTime
@@ -698,7 +694,7 @@ WHERE c.idcomments = ?
 `
 
 type UpdateCommentForEditorParams struct {
-	LanguageID  int32
+	LanguageID  sql.NullInt32
 	Text        sql.NullString
 	CommentID   int32
 	CommenterID int32

--- a/internal/db/queries-deactivation.sql.go
+++ b/internal/db/queries-deactivation.sql.go
@@ -19,7 +19,7 @@ type AdminArchiveBlogParams struct {
 	Idblogs            int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Blog               sql.NullString
 	Written            sql.NullTime
 }
@@ -45,7 +45,7 @@ type AdminArchiveCommentParams struct {
 	Idcomments         int32
 	ForumthreadID      int32
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Written            sql.NullTime
 	Text               sql.NullString
 }
@@ -103,7 +103,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 
 type AdminArchiveLinkParams struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -150,7 +150,7 @@ type AdminArchiveWritingParams struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime

--- a/internal/db/queries-faq.sql
+++ b/internal/db/queries-faq.sql
@@ -12,8 +12,7 @@ FROM faq
 WHERE answer IS NOT NULL
   AND deleted_at IS NULL
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+    language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -108,8 +107,7 @@ LEFT JOIN faq_categories c ON c.idfaqCategories = f.faqCategories_idfaqCategorie
 WHERE c.idfaqCategories <> 0
   AND f.answer IS NOT NULL
   AND (
-      f.language_idlanguage = 0
-      OR f.language_idlanguage IS NULL
+    f.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -150,8 +148,7 @@ FROM faq
 WHERE idfaq = sqlc.arg(faq_id)
   AND deleted_at IS NULL
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+    language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -209,8 +206,7 @@ FROM faq
 WHERE faqCategories_idfaqCategories = sqlc.arg(category_id)
   AND deleted_at IS NULL
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+    language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)

--- a/internal/db/queries-faq.sql.go
+++ b/internal/db/queries-faq.sql.go
@@ -306,7 +306,7 @@ WHERE EXISTS (
 type CreateFAQQuestionForWriterParams struct {
 	Question   sql.NullString
 	WriterID   int32
-	LanguageID int32
+	LanguageID sql.NullInt32
 	GranteeID  sql.NullInt32
 }
 
@@ -331,8 +331,7 @@ LEFT JOIN faq_categories c ON c.idfaqCategories = f.faqCategories_idfaqCategorie
 WHERE c.idfaqCategories <> 0
   AND f.answer IS NOT NULL
   AND (
-      f.language_idlanguage = 0
-      OR f.language_idlanguage IS NULL
+    f.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -365,7 +364,7 @@ type GetAllAnsweredFAQWithFAQCategoriesForUserRow struct {
 	Name                         sql.NullString
 	Idfaq                        int32
 	FaqcategoriesIdfaqcategories int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	UsersIdusers                 int32
 	Answer                       sql.NullString
 	Question                     sql.NullString
@@ -417,8 +416,7 @@ FROM faq
 WHERE answer IS NOT NULL
   AND deleted_at IS NULL
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+    language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -489,8 +487,7 @@ FROM faq
 WHERE idfaq = ?
   AND deleted_at IS NULL
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+    language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -547,8 +544,7 @@ FROM faq
 WHERE faqCategories_idfaqCategories = ?
   AND deleted_at IS NULL
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+    language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -667,7 +663,7 @@ type InsertFAQQuestionForWriterParams struct {
 	Answer     sql.NullString
 	CategoryID int32
 	WriterID   int32
-	LanguageID int32
+	LanguageID sql.NullInt32
 	GranteeID  sql.NullInt32
 }
 

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -8,8 +8,7 @@ FROM forumcategory c
 LEFT JOIN forumcategory c2 ON c.idforumcategory = c2.forumcategory_idforumcategory
 LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -25,8 +24,7 @@ GROUP BY c.idforumcategory;
 SELECT COUNT(*)
 FROM forumcategory c
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -44,8 +42,7 @@ FROM forumcategory c
 LEFT JOIN forumcategory c2 ON c.idforumcategory = c2.forumcategory_idforumcategory
 LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -63,8 +60,7 @@ LIMIT ? OFFSET ?;
 SELECT t.*
 FROM forumtopic t
 WHERE (
-    t.language_idlanguage = 0
-    OR t.language_idlanguage IS NULL
+    t.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -94,8 +90,7 @@ FROM forumtopic t
 LEFT JOIN users lu ON lu.idusers = t.lastposter
 WHERE t.forumcategory_idforumcategory = sqlc.arg(category_id)
   AND (
-      t.language_idlanguage = 0
-      OR t.language_idlanguage IS NULL
+    t.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -168,8 +163,7 @@ FROM forumtopic t
 LEFT JOIN users lu ON lu.idusers = t.lastposter
 WHERE t.handler <> 'private'
   AND (
-    t.language_idlanguage = 0
-    OR t.language_idlanguage IS NULL
+    t.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -200,8 +194,7 @@ FROM forumtopic t
 LEFT JOIN users lu ON lu.idusers = t.lastposter
 WHERE t.idforumtopic = sqlc.arg(idforumtopic)
   AND (
-      t.language_idlanguage = 0
-      OR t.language_idlanguage IS NULL
+    t.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -228,8 +221,7 @@ ORDER BY t.lastaddition DESC;
 SELECT f.*
 FROM forumcategory f
 WHERE (
-    f.language_idlanguage = 0
-    OR f.language_idlanguage IS NULL
+    f.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -385,8 +377,7 @@ ORDER BY t.idforumtopic, th.lastaddition DESC;
 SELECT * FROM forumcategory
 WHERE idforumcategory = sqlc.arg(idforumcategory)
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+    language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -401,8 +392,7 @@ WHERE idforumcategory = sqlc.arg(idforumcategory)
 SELECT * FROM forumtopic
 WHERE forumcategory_idforumcategory = sqlc.arg(category_id)
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+    language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)

--- a/internal/db/queries-forum.sql.go
+++ b/internal/db/queries-forum.sql.go
@@ -14,8 +14,7 @@ const adminCountForumCategories = `-- name: AdminCountForumCategories :one
 SELECT COUNT(*)
 FROM forumcategory c
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -44,7 +43,7 @@ INSERT INTO forumcategory (forumcategory_idforumcategory, language_idlanguage, t
 
 type AdminCreateForumCategoryParams struct {
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 }
@@ -85,8 +84,7 @@ FROM forumcategory c
 LEFT JOIN forumcategory c2 ON c.idforumcategory = c2.forumcategory_idforumcategory
 LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -110,7 +108,7 @@ type AdminListForumCategoriesWithCountsParams struct {
 type AdminListForumCategoriesWithCountsRow struct {
 	Idforumcategory              int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Subcategorycount             int64
@@ -285,7 +283,7 @@ type AdminUpdateForumCategoryParams struct {
 	Title                        sql.NullString
 	Description                  sql.NullString
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Idforumcategory              int32
 }
 
@@ -308,7 +306,7 @@ type AdminUpdateForumTopicParams struct {
 	Title                        sql.NullString
 	Description                  sql.NullString
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Idforumtopic                 int32
 }
 
@@ -342,7 +340,7 @@ WHERE EXISTS (
 
 type CreateForumTopicForPosterParams struct {
 	ForumcategoryID int32
-	LanguageID      int32
+	LanguageID      sql.NullInt32
 	Title           sql.NullString
 	Description     sql.NullString
 	Handler         string
@@ -374,8 +372,7 @@ const getAllForumCategories = `-- name: GetAllForumCategories :many
 SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_idlanguage, f.title, f.description
 FROM forumcategory f
 WHERE (
-    f.language_idlanguage = 0
-    OR f.language_idlanguage IS NULL
+    f.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -427,8 +424,7 @@ FROM forumcategory c
 LEFT JOIN forumcategory c2 ON c.idforumcategory = c2.forumcategory_idforumcategory
 LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -448,7 +444,7 @@ type GetAllForumCategoriesWithSubcategoryCountParams struct {
 type GetAllForumCategoriesWithSubcategoryCountRow struct {
 	Idforumcategory              int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Subcategorycount             int64
@@ -540,8 +536,7 @@ const getAllForumTopics = `-- name: GetAllForumTopics :many
 SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_idlanguage, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler
 FROM forumtopic t
 WHERE (
-    t.language_idlanguage = 0
-    OR t.language_idlanguage IS NULL
+    t.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -601,8 +596,7 @@ FROM forumtopic t
 LEFT JOIN users lu ON lu.idusers = t.lastposter
 WHERE t.forumcategory_idforumcategory = ?
   AND (
-      t.language_idlanguage = 0
-      OR t.language_idlanguage IS NULL
+    t.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -635,7 +629,7 @@ type GetAllForumTopicsByCategoryIdForUserWithLastPosterNameRow struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -690,8 +684,7 @@ const getForumCategoryById = `-- name: GetForumCategoryById :one
 SELECT idforumcategory, forumcategory_idforumcategory, language_idlanguage, title, description FROM forumcategory
 WHERE idforumcategory = ?
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+    language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -835,8 +828,7 @@ FROM forumtopic t
 LEFT JOIN users lu ON lu.idusers = t.lastposter
 WHERE t.idforumtopic = ?
   AND (
-      t.language_idlanguage = 0
-      OR t.language_idlanguage IS NULL
+    t.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -869,7 +861,7 @@ type GetForumTopicByIdForUserRow struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -908,8 +900,7 @@ const getForumTopicsByCategoryId = `-- name: GetForumTopicsByCategoryId :many
 SELECT idforumtopic, lastposter, forumcategory_idforumcategory, language_idlanguage, title, description, threads, comments, lastaddition, handler FROM forumtopic
 WHERE forumcategory_idforumcategory = ?
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+    language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -970,8 +961,7 @@ FROM forumtopic t
 LEFT JOIN users lu ON lu.idusers = t.lastposter
 WHERE t.handler <> 'private'
   AND (
-    t.language_idlanguage = 0
-    OR t.language_idlanguage IS NULL
+    t.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -1003,7 +993,7 @@ type GetForumTopicsForUserRow struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -1178,7 +1168,7 @@ type ListPrivateTopicsByUserIDRow struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -1229,7 +1219,7 @@ INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, titl
 
 type SystemCreateForumTopicParams struct {
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           int32
+	LanguageIdlanguage           sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Handler                      string

--- a/internal/db/queries-languages.sql.go
+++ b/internal/db/queries-languages.sql.go
@@ -58,7 +58,7 @@ SELECT
 `
 
 type AdminLanguageUsageCountsParams struct {
-	ID int32
+	ID sql.NullInt32
 }
 
 type AdminLanguageUsageCountsRow struct {

--- a/internal/db/queries-linker.sql.go
+++ b/internal/db/queries-linker.sql.go
@@ -137,7 +137,7 @@ type AdminUpdateLinkerItemParams struct {
 	Url                sql.NullString
 	Description        sql.NullString
 	LinkerCategoryID   int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	Idlinker           int32
 }
 
@@ -342,7 +342,7 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -430,7 +430,7 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -524,7 +524,7 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -622,7 +622,7 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRowRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -697,7 +697,7 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -760,7 +760,7 @@ JOIN linker_category c ON l.linker_category_id = c.idlinkerCategory
 
 type GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetailsRow struct {
 	Idlinkerqueue      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	Title              sql.NullString
@@ -950,7 +950,7 @@ WHERE l.idlinker = ?
 
 type GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -1019,7 +1019,7 @@ type GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams 
 
 type GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -1060,7 +1060,7 @@ WHERE l.idlinker IN (/*SLICE:linkerids*/?)
 
 type GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -1154,7 +1154,7 @@ type GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserParam
 
 type GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -1232,7 +1232,7 @@ type GetLinkerItemsByUserDescendingParams struct {
 
 type GetLinkerItemsByUserDescendingRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32
@@ -1323,7 +1323,7 @@ type GetLinkerItemsByUserDescendingForUserParams struct {
 
 type GetLinkerItemsByUserDescendingForUserRow struct {
 	Idlinker           int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	LinkerCategoryID   int32
 	ForumthreadID      int32

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -83,8 +83,7 @@ WHERE s.Idsitenews IN (sqlc.slice(newsIds))
       NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
       )
-      OR s.language_idlanguage = 0
-      OR s.language_idlanguage IS NULL
+    OR s.language_idlanguage IS NULL
       OR s.language_idlanguage IN (
           SELECT ul.language_idlanguage
           FROM user_language ul
@@ -115,7 +114,6 @@ WHERE (
     NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
     )
-    OR s.language_idlanguage = 0
     OR s.language_idlanguage IS NULL
     OR s.language_idlanguage IN (
         SELECT ul.language_idlanguage FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -31,7 +31,7 @@ type AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow stru
 	Writerid           sql.NullInt32
 	Idsitenews         int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
@@ -106,7 +106,7 @@ WHERE EXISTS (
 type CreateNewsPostForWriterParams struct {
 	News       sql.NullString
 	WriterID   int32
-	LanguageID int32
+	LanguageID sql.NullInt32
 	GranteeID  sql.NullInt32
 }
 
@@ -216,7 +216,7 @@ type GetNewsPostByIdWithWriterIdAndThreadCommentCountRow struct {
 	Writerid           sql.NullInt32
 	Idsitenews         int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
@@ -253,8 +253,7 @@ WHERE s.Idsitenews IN (/*SLICE:newsids*/?)
       NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
       )
-      OR s.language_idlanguage = 0
-      OR s.language_idlanguage IS NULL
+    OR s.language_idlanguage IS NULL
       OR s.language_idlanguage IN (
           SELECT ul.language_idlanguage
           FROM user_language ul
@@ -285,7 +284,7 @@ type GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow struct {
 	Writerid           sql.NullInt32
 	Idsitenews         int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
@@ -351,7 +350,6 @@ WHERE (
     NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
     )
-    OR s.language_idlanguage = 0
     OR s.language_idlanguage IS NULL
     OR s.language_idlanguage IN (
         SELECT ul.language_idlanguage FROM user_language ul WHERE ul.users_idusers = ?
@@ -383,7 +381,7 @@ type GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow struct {
 	Writerid           sql.NullInt32
 	Idsitenews         int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 	News               sql.NullString
 	Occurred           sql.NullTime
@@ -487,7 +485,7 @@ WHERE s.idsiteNews = ?
 
 type UpdateNewsPostForWriterParams struct {
 	News        sql.NullString
-	LanguageID  int32
+	LanguageID  sql.NullInt32
 	PostID      int32
 	WriterID    int32
 	GrantPostID sql.NullInt32

--- a/internal/db/queries-pending_emails.sql.go
+++ b/internal/db/queries-pending_emails.sql.go
@@ -63,7 +63,7 @@ LIMIT ? OFFSET ?
 `
 
 type AdminListFailedEmailsParams struct {
-	LanguageID int32
+	LanguageID sql.NullInt32
 	RoleName   string
 	Limit      int32
 	Offset     int32
@@ -130,7 +130,7 @@ LIMIT ? OFFSET ?
 `
 
 type AdminListSentEmailsParams struct {
-	LanguageID int32
+	LanguageID sql.NullInt32
 	RoleName   string
 	Limit      int32
 	Offset     int32
@@ -198,7 +198,7 @@ ORDER BY pe.id
 `
 
 type AdminListUnsentPendingEmailsParams struct {
-	LanguageID int32
+	LanguageID sql.NullInt32
 	RoleName   string
 }
 

--- a/internal/db/queries-preferences.sql.go
+++ b/internal/db/queries-preferences.sql.go
@@ -53,7 +53,7 @@ VALUES (?, ?, ?, ?)
 `
 
 type InsertPreferenceForListerParams struct {
-	LanguageID int32
+	LanguageID sql.NullInt32
 	ListerID   int32
 	PageSize   int32
 	Timezone   sql.NullString
@@ -106,7 +106,7 @@ UPDATE preferences SET language_idlanguage = ?, page_size = ?, timezone = ? WHER
 `
 
 type UpdatePreferenceForListerParams struct {
-	LanguageID int32
+	LanguageID sql.NullInt32
 	PageSize   int32
 	Timezone   sql.NullString
 	ListerID   int32

--- a/internal/db/queries-search.sql
+++ b/internal/db/queries-search.sql
@@ -98,8 +98,7 @@ LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
 WHERE swl.word=sqlc.arg(word)
   AND ft.forumcategory_idforumcategory!=0
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -134,8 +133,7 @@ WHERE swl.word=sqlc.arg(word)
   AND cs.comment_id IN (sqlc.slice('ids'))
   AND ft.forumcategory_idforumcategory!=0
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -169,8 +167,7 @@ LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
 WHERE swl.word=sqlc.arg(word)
   AND fth.forumtopic_idforumtopic IN (sqlc.slice('ftids'))
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -205,8 +202,7 @@ WHERE swl.word=sqlc.arg(word)
   AND cs.comment_id IN (sqlc.slice('ids'))
   AND fth.forumtopic_idforumtopic IN (sqlc.slice('ftids'))
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -264,8 +260,7 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN writing w ON w.idwriting = cs.writing_id
 WHERE swl.word = sqlc.arg(word)
   AND (
-      w.language_idlanguage = 0
-      OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -297,8 +292,7 @@ JOIN writing w ON w.idwriting = cs.writing_id
 WHERE swl.word = sqlc.arg(word)
   AND cs.writing_id IN (sqlc.slice('ids'))
   AND (
-      w.language_idlanguage = 0
-      OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -329,8 +323,7 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN site_news sn ON sn.idsiteNews = cs.site_news_id
 WHERE swl.word = sqlc.arg(word)
   AND (
-      sn.language_idlanguage = 0
-      OR sn.language_idlanguage IS NULL
+    sn.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -362,8 +355,7 @@ JOIN site_news sn ON sn.idsiteNews = cs.site_news_id
 WHERE swl.word = sqlc.arg(word)
   AND cs.site_news_id IN (sqlc.slice('ids'))
   AND (
-      sn.language_idlanguage = 0
-      OR sn.language_idlanguage IS NULL
+    sn.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -396,8 +388,7 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN linker l ON l.idlinker = cs.linker_id
 WHERE swl.word = sqlc.arg(word)
   AND (
-      l.language_idlanguage = 0
-      OR l.language_idlanguage IS NULL
+    l.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -429,8 +420,7 @@ JOIN linker l ON l.idlinker = cs.linker_id
 WHERE swl.word = sqlc.arg(word)
   AND cs.linker_id IN (sqlc.slice('ids'))
   AND (
-      l.language_idlanguage = 0
-      OR l.language_idlanguage IS NULL
+    l.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)

--- a/internal/db/queries-search.sql.go
+++ b/internal/db/queries-search.sql.go
@@ -170,8 +170,7 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN linker l ON l.idlinker = cs.linker_id
 WHERE swl.word = ?
   AND (
-      l.language_idlanguage = 0
-      OR l.language_idlanguage IS NULL
+    l.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -239,8 +238,7 @@ JOIN linker l ON l.idlinker = cs.linker_id
 WHERE swl.word = ?
   AND cs.linker_id IN (/*SLICE:ids*/?)
   AND (
-      l.language_idlanguage = 0
-      OR l.language_idlanguage IS NULL
+    l.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -320,8 +318,7 @@ LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
 WHERE swl.word=?
   AND fth.forumtopic_idforumtopic IN (/*SLICE:ftids*/?)
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -401,8 +398,7 @@ LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
 WHERE swl.word=?
   AND ft.forumcategory_idforumcategory!=0
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -473,8 +469,7 @@ WHERE swl.word=?
   AND cs.comment_id IN (/*SLICE:ids*/?)
   AND fth.forumtopic_idforumtopic IN (/*SLICE:ftids*/?)
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -564,8 +559,7 @@ WHERE swl.word=?
   AND cs.comment_id IN (/*SLICE:ids*/?)
   AND ft.forumcategory_idforumcategory!=0
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+    c.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -642,8 +636,7 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN site_news sn ON sn.idsiteNews = cs.site_news_id
 WHERE swl.word = ?
   AND (
-      sn.language_idlanguage = 0
-      OR sn.language_idlanguage IS NULL
+    sn.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -711,8 +704,7 @@ JOIN site_news sn ON sn.idsiteNews = cs.site_news_id
 WHERE swl.word = ?
   AND cs.site_news_id IN (/*SLICE:ids*/?)
   AND (
-      sn.language_idlanguage = 0
-      OR sn.language_idlanguage IS NULL
+    sn.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -789,8 +781,7 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN writing w ON w.idwriting = cs.writing_id
 WHERE swl.word = ?
   AND (
-      w.language_idlanguage = 0
-      OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
@@ -858,8 +849,7 @@ JOIN writing w ON w.idwriting = cs.writing_id
 WHERE swl.word = ?
   AND cs.writing_id IN (/*SLICE:ids*/?)
   AND (
-      w.language_idlanguage = 0
-      OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?

--- a/internal/db/queries-threads.sql
+++ b/internal/db/queries-threads.sql
@@ -60,8 +60,7 @@ LEFT JOIN users lu ON lu.idusers = t.lastposter
 LEFT JOIN comments fc ON th.firstpost = fc.idcomments
 WHERE th.idforumthread=sqlc.arg(thread_id)
   AND (
-      fc.language_idlanguage = 0
-      OR fc.language_idlanguage IS NULL
+    fc.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)

--- a/internal/db/queries-threads.sql.go
+++ b/internal/db/queries-threads.sql.go
@@ -200,8 +200,7 @@ LEFT JOIN users lu ON lu.idusers = t.lastposter
 LEFT JOIN comments fc ON th.firstpost = fc.idcomments
 WHERE th.idforumthread=?
   AND (
-      fc.language_idlanguage = 0
-      OR fc.language_idlanguage IS NULL
+    fc.language_idlanguage IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?

--- a/internal/db/queries-user_languages.sql.go
+++ b/internal/db/queries-user_languages.sql.go
@@ -7,6 +7,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 )
 
 const deleteUserLanguagesForUser = `-- name: DeleteUserLanguagesForUser :exec
@@ -54,7 +55,7 @@ VALUES (?, ?)
 
 type InsertUserLangParams struct {
 	UsersIdusers       int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 }
 
 func (q *Queries) InsertUserLang(ctx context.Context, arg InsertUserLangParams) error {

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -30,8 +30,7 @@ FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.private = 0 AND w.users_idusers = sqlc.arg(author_id)
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -73,8 +72,7 @@ FROM writing w
 LEFT JOIN users u ON w.Users_Idusers=u.idusers
 WHERE w.private = 0 AND w.writing_category_id = sqlc.arg(writing_category_id)
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -170,8 +168,7 @@ FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 WHERE w.idwriting IN (sqlc.slice(writing_ids))
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -267,8 +264,7 @@ SELECT u.username, COUNT(w.idwriting) AS count
 FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 WHERE (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -301,8 +297,7 @@ FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 WHERE (LOWER(u.username) LIKE LOWER(sqlc.arg(query)) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(sqlc.arg(query)))
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -24,7 +24,7 @@ type AdminGetAllWritingsByAuthorRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -87,7 +87,7 @@ type AdminGetWritingsByCategoryIdRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -198,7 +198,7 @@ type CreateWritingForWriterParams struct {
 	Abstract          sql.NullString
 	Writing           sql.NullString
 	Private           sql.NullBool
-	LanguageID        int32
+	LanguageID        sql.NullInt32
 	WriterID          int32
 	GrantCategoryID   sql.NullInt32
 	GranteeID         sql.NullInt32
@@ -255,7 +255,7 @@ type GetAllWritingsByAuthorForListerRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -441,7 +441,7 @@ type GetWritingForListerByIDRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -487,7 +487,7 @@ type InsertWritingParams struct {
 	Abstract           sql.NullString
 	Writing            sql.NullString
 	Private            sql.NullBool
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	UsersIdusers       int32
 }
 
@@ -517,8 +517,7 @@ FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.private = 0 AND w.users_idusers = ?
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -554,7 +553,7 @@ type ListPublicWritingsByUserForListerRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -623,8 +622,7 @@ FROM writing w
 LEFT JOIN users u ON w.Users_Idusers=u.idusers
 WHERE w.private = 0 AND w.writing_category_id = ?
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -660,7 +658,7 @@ type ListPublicWritingsInCategoryForListerRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -727,8 +725,7 @@ SELECT u.username, COUNT(w.idwriting) AS count
 FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 WHERE (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -804,8 +801,7 @@ FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 WHERE (LOWER(u.username) LIKE LOWER(?) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(?))
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -978,8 +974,7 @@ FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 WHERE w.idwriting IN (/*SLICE:writing_ids*/?)
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_idlanguage IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
@@ -1015,7 +1010,7 @@ type ListWritingsByIDsForListerRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -1129,7 +1124,7 @@ type SystemListPublicWritingsByAuthorRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -1200,7 +1195,7 @@ type SystemListPublicWritingsInCategoryRow struct {
 	Idwriting          int32
 	UsersIdusers       int32
 	ForumthreadID      int32
-	LanguageIdlanguage int32
+	LanguageIdlanguage sql.NullInt32
 	WritingCategoryID  int32
 	Title              sql.NullString
 	Published          sql.NullTime
@@ -1328,7 +1323,7 @@ type UpdateWritingForWriterParams struct {
 	Abstract   sql.NullString
 	Content    sql.NullString
 	Private    sql.NullBool
-	LanguageID int32
+	LanguageID sql.NullInt32
 	WritingID  int32
 	WriterID   int32
 	GranteeID  sql.NullInt32

--- a/internal/db/queries_faq_test.go
+++ b/internal/db/queries_faq_test.go
@@ -19,7 +19,7 @@ func TestQueries_InsertFAQQuestionForWriter(t *testing.T) {
 	q := New(conn)
 
 	mock.ExpectExec(regexp.QuoteMeta(insertFAQQuestionForWriter)).
-		WithArgs(sql.NullString{String: "q", Valid: true}, sql.NullString{String: "a", Valid: true}, int32(1), int32(2), int32(1), sql.NullInt32{Int32: 2, Valid: true}, int32(2)).
+		WithArgs(sql.NullString{String: "q", Valid: true}, sql.NullString{String: "a", Valid: true}, int32(1), int32(2), sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 2, Valid: true}, int32(2)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	if _, err := q.InsertFAQQuestionForWriter(context.Background(), InsertFAQQuestionForWriterParams{
@@ -27,7 +27,7 @@ func TestQueries_InsertFAQQuestionForWriter(t *testing.T) {
 		Answer:     sql.NullString{String: "a", Valid: true},
 		CategoryID: 1,
 		WriterID:   2,
-		LanguageID: 1,
+		LanguageID: sql.NullInt32{Int32: 1, Valid: true},
 		GranteeID:  sql.NullInt32{Int32: 2, Valid: true},
 	}); err != nil {
 		t.Fatalf("InsertFAQQuestionForWriter: %v", err)

--- a/internal/notifications/bus_worker_test.go
+++ b/internal/notifications/bus_worker_test.go
@@ -352,10 +352,10 @@ func TestProcessEventAutoSubscribe(t *testing.T) {
 	q := db.New(conn)
 	n := New(WithQueries(q), WithConfig(cfg))
 
-        prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies", "timezone"}).
-                AddRow(1, 0, 1, nil, 0, true, nil)
-        mock.ExpectQuery(regexp.QuoteMeta("SELECT idpreferences, language_idlanguage, users_idusers, emailforumupdates, page_size, auto_subscribe_replies, timezone FROM preferences WHERE users_idusers = ?")).
-                WithArgs(int32(1)).WillReturnRows(prefRows)
+	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies", "timezone"}).
+		AddRow(1, 0, 1, nil, 0, true, nil)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idpreferences, language_idlanguage, users_idusers, emailforumupdates, page_size, auto_subscribe_replies, timezone FROM preferences WHERE users_idusers = ?")).
+		WithArgs(int32(1)).WillReturnRows(prefRows)
 
 	pattern := buildPatterns(tasks.TaskString("AutoSub"), "/forum/topic/7/thread/42")[0]
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT users_idusers FROM subscriptions WHERE pattern = ? AND method = ?")).

--- a/migrations/0059.mysql.sql
+++ b/migrations/0059.mysql.sql
@@ -1,0 +1,35 @@
+-- Allow NULL language references
+ALTER TABLE blogs MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE comments MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE faq MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE forumcategory MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE forumtopic MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE linker MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE linker_queue MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE preferences MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE site_news MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE user_language MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE writing MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE deactivated_comments MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE deactivated_writings MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE deactivated_blogs MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE deactivated_linker MODIFY language_idlanguage INT NULL DEFAULT NULL;
+
+UPDATE blogs SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE comments SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE faq SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE forumcategory SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE forumtopic SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE linker SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE linker_queue SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE preferences SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE site_news SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE user_language SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE writing SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE deactivated_comments SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE deactivated_writings SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE deactivated_blogs SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE deactivated_linker SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+-- Update schema version
+UPDATE schema_version SET version = 59 WHERE version = 58;

--- a/migrations/0059.postgres.sql
+++ b/migrations/0059.postgres.sql
@@ -1,0 +1,50 @@
+-- Allow NULL language references
+ALTER TABLE blogs ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE blogs ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE comments ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE comments ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE faq ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE faq ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE forumcategory ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE forumcategory ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE forumtopic ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE forumtopic ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE linker ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE linker ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE linker_queue ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE linker_queue ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE preferences ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE preferences ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE site_news ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE site_news ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE user_language ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE user_language ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE writing ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE writing ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE deactivated_comments ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE deactivated_comments ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE deactivated_writings ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE deactivated_writings ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE deactivated_blogs ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE deactivated_blogs ALTER COLUMN language_idlanguage DROP DEFAULT;
+ALTER TABLE deactivated_linker ALTER COLUMN language_idlanguage DROP NOT NULL;
+ALTER TABLE deactivated_linker ALTER COLUMN language_idlanguage DROP DEFAULT;
+
+UPDATE blogs SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE comments SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE faq SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE forumcategory SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE forumtopic SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE linker SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE linker_queue SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE preferences SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE site_news SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE user_language SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE writing SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE deactivated_comments SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE deactivated_writings SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE deactivated_blogs SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE deactivated_linker SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+-- Update schema version
+UPDATE schema_version SET version = 59 WHERE version = 58;

--- a/migrations/0059.sqlite.sql
+++ b/migrations/0059.sqlite.sql
@@ -1,0 +1,35 @@
+-- Allow NULL language references
+ALTER TABLE blogs MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE comments MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE faq MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE forumcategory MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE forumtopic MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE linker MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE linker_queue MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE preferences MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE site_news MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE user_language MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE writing MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE deactivated_comments MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE deactivated_writings MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE deactivated_blogs MODIFY language_idlanguage INT NULL DEFAULT NULL;
+ALTER TABLE deactivated_linker MODIFY language_idlanguage INT NULL DEFAULT NULL;
+
+UPDATE blogs SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE comments SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE faq SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE forumcategory SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE forumtopic SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE linker SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE linker_queue SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE preferences SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE site_news SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE user_language SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE writing SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE deactivated_comments SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE deactivated_writings SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE deactivated_blogs SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+UPDATE deactivated_linker SET language_idlanguage = NULL WHERE language_idlanguage = 0;
+
+-- Update schema version
+UPDATE schema_version SET version = 59 WHERE version = 58;

--- a/schema/schema.mysql.sql
+++ b/schema/schema.mysql.sql
@@ -2,7 +2,7 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `deleted_at` datetime DEFAULT NULL,
@@ -34,7 +34,7 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
@@ -57,7 +57,7 @@ CREATE TABLE `comments_search` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
@@ -87,7 +87,7 @@ CREATE TABLE IF NOT EXISTS `faq_revisions` (
 CREATE TABLE `forumcategory` (
   `idforumcategory` int(10) NOT NULL AUTO_INCREMENT,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   PRIMARY KEY (`idforumcategory`),
@@ -113,7 +113,7 @@ CREATE TABLE `forumtopic` (
   `idforumtopic` int(10) NOT NULL AUTO_INCREMENT,
   `lastposter` int(10) NOT NULL DEFAULT 0,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `threads` int(10) DEFAULT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE `language` (
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
@@ -200,7 +200,7 @@ CREATE TABLE `linker_category` (
 
 CREATE TABLE `linker_queue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -259,7 +259,7 @@ CREATE TABLE `grants` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -288,7 +288,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `site_news` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occurred` datetime DEFAULT NULL,
@@ -312,7 +312,7 @@ CREATE TABLE `site_news_search` (
 CREATE TABLE `user_language` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   PRIMARY KEY (`iduserlang`),
   KEY `userpref_FKIndex1` (`language_idlanguage`),
   KEY `userpref_FKIndex2` (`users_idusers`)
@@ -355,7 +355,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `writing_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,
@@ -525,7 +525,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_comments` (
   `idcomments` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `written` datetime,
   `text` longtext,
   `deleted_at` datetime DEFAULT NULL,
@@ -537,7 +537,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_writings` (
   `idwriting` int NOT NULL,
   `users_idusers` int NOT NULL,
   `forumthread_id` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `writing_category_id` int NOT NULL,
   `title` tinytext,
   `published` datetime,
@@ -553,7 +553,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_blogs` (
   `idblogs` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `blog` longtext,
   `written` datetime,
   `deleted_at` datetime DEFAULT NULL,
@@ -579,7 +579,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_imageposts` (
 
 CREATE TABLE IF NOT EXISTS `deactivated_linker` (
   `idlinker` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `users_idusers` int NOT NULL,
   `linker_category_id` int NOT NULL,
   `forumthread_id` int NOT NULL,

--- a/schema/schema.postgres.sql
+++ b/schema/schema.postgres.sql
@@ -2,7 +2,7 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `deleted_at` datetime DEFAULT NULL,
@@ -34,7 +34,7 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
@@ -57,7 +57,7 @@ CREATE TABLE `comments_search` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
@@ -87,7 +87,7 @@ CREATE TABLE IF NOT EXISTS `faq_revisions` (
 CREATE TABLE `forumcategory` (
   `idforumcategory` int(10) NOT NULL AUTO_INCREMENT,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   PRIMARY KEY (`idforumcategory`),
@@ -113,7 +113,7 @@ CREATE TABLE `forumtopic` (
   `idforumtopic` int(10) NOT NULL AUTO_INCREMENT,
   `lastposter` int(10) NOT NULL DEFAULT 0,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `threads` int(10) DEFAULT NULL,
@@ -172,7 +172,7 @@ CREATE TABLE `language` (
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
@@ -199,7 +199,7 @@ CREATE TABLE `linker_category` (
 
 CREATE TABLE `linker_queue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -258,7 +258,7 @@ CREATE TABLE `grants` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -287,7 +287,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `site_news` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occurred` datetime DEFAULT NULL,
@@ -311,7 +311,7 @@ CREATE TABLE `site_news_search` (
 CREATE TABLE `user_language` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   PRIMARY KEY (`iduserlang`),
   KEY `userpref_FKIndex1` (`language_idlanguage`),
   KEY `userpref_FKIndex2` (`users_idusers`)
@@ -354,7 +354,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `writing_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,
@@ -524,7 +524,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_comments` (
   `idcomments` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `written` datetime,
   `text` longtext,
   `deleted_at` datetime DEFAULT NULL,
@@ -536,7 +536,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_writings` (
   `idwriting` int NOT NULL,
   `users_idusers` int NOT NULL,
   `forumthread_id` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `writing_category_id` int NOT NULL,
   `title` tinytext,
   `published` datetime,
@@ -552,7 +552,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_blogs` (
   `idblogs` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `blog` longtext,
   `written` datetime,
   `deleted_at` datetime DEFAULT NULL,
@@ -578,7 +578,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_imageposts` (
 
 CREATE TABLE IF NOT EXISTS `deactivated_linker` (
   `idlinker` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `users_idusers` int NOT NULL,
   `linker_category_id` int NOT NULL,
   `forumthread_id` int NOT NULL,

--- a/schema/schema.sqlite.sql
+++ b/schema/schema.sqlite.sql
@@ -2,7 +2,7 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `deleted_at` datetime DEFAULT NULL,
@@ -34,7 +34,7 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
@@ -57,7 +57,7 @@ CREATE TABLE `comments_search` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
@@ -87,7 +87,7 @@ CREATE TABLE IF NOT EXISTS `faq_revisions` (
 CREATE TABLE `forumcategory` (
   `idforumcategory` int(10) NOT NULL AUTO_INCREMENT,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   PRIMARY KEY (`idforumcategory`),
@@ -113,7 +113,7 @@ CREATE TABLE `forumtopic` (
   `idforumtopic` int(10) NOT NULL AUTO_INCREMENT,
   `lastposter` int(10) NOT NULL DEFAULT 0,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `threads` int(10) DEFAULT NULL,
@@ -172,7 +172,7 @@ CREATE TABLE `language` (
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
@@ -199,7 +199,7 @@ CREATE TABLE `linker_category` (
 
 CREATE TABLE `linker_queue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -258,7 +258,7 @@ CREATE TABLE `grants` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -287,7 +287,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `site_news` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occurred` datetime DEFAULT NULL,
@@ -311,7 +311,7 @@ CREATE TABLE `site_news_search` (
 CREATE TABLE `user_language` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   PRIMARY KEY (`iduserlang`),
   KEY `userpref_FKIndex1` (`language_idlanguage`),
   KEY `userpref_FKIndex2` (`users_idusers`)
@@ -354,7 +354,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_idlanguage` int(10) DEFAULT NULL,
   `writing_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,
@@ -524,7 +524,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_comments` (
   `idcomments` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `written` datetime,
   `text` longtext,
   `deleted_at` datetime DEFAULT NULL,
@@ -536,7 +536,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_writings` (
   `idwriting` int NOT NULL,
   `users_idusers` int NOT NULL,
   `forumthread_id` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `writing_category_id` int NOT NULL,
   `title` tinytext,
   `published` datetime,
@@ -552,7 +552,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_blogs` (
   `idblogs` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `blog` longtext,
   `written` datetime,
   `deleted_at` datetime DEFAULT NULL,
@@ -578,7 +578,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_imageposts` (
 
 CREATE TABLE IF NOT EXISTS `deactivated_linker` (
   `idlinker` int NOT NULL,
-  `language_idlanguage` int NOT NULL,
+  `language_idlanguage` int DEFAULT NULL,
   `users_idusers` int NOT NULL,
   `linker_category_id` int NOT NULL,
   `forumthread_id` int NOT NULL,


### PR DESCRIPTION
## Summary
- allow `language_idlanguage` columns to be NULL with default NULL and convert existing zero values
- update schemas, SQL queries and Go code to use nullable language references
- bump expected schema version
- restore forum admin category and topic tests with updated language-aware expectations
- reuse existing `CoreData` when exporting user data

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895fb60a978832fabb8de77a8c025bd