### PR TITLE
Handle nullable blog forum thread IDs

### DIFF
--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -328,7 +328,7 @@ func TestBlogListLazy(t *testing.T) {
 	queries := db.New(conn)
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "username", "comments", "is_owner"}).
-		AddRow(1, 0, 1, 0, "b", now, "bob", 0, true)
+		AddRow(1, nil, 1, 0, "b", now, "bob", 0, true)
 	mock.ExpectQuery("SELECT b.idblogs").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(rows)
@@ -362,7 +362,7 @@ func TestBlogListForSelectedAuthorLazy(t *testing.T) {
 	queries := db.New(conn)
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "username", "comments", "is_owner"}).
-		AddRow(1, 0, 1, 0, "b", now, "bob", 0, true)
+		AddRow(1, nil, 1, 0, "b", now, "bob", 0, true)
 	mock.ExpectQuery("SELECT b.idblogs").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(rows)

--- a/handlers/admin/adminUserWritingsPage_test.go
+++ b/handlers/admin/adminUserWritingsPage_test.go
@@ -32,8 +32,8 @@ func TestAdminUserWritingsPage(t *testing.T) {
 		WillReturnRows(userRows)
 
 	writingRows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "username", "comments"}).
-		AddRow(1, 1, 0, 0, 2, "Title", time.Now(), "", "", false, nil, nil, "user", 0)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,\n    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments\nFROM writing w\nLEFT JOIN users u ON w.users_idusers = u.idusers\nWHERE w.users_idusers = ?\nORDER BY w.published DESC")).
+		AddRow(1, 1, nil, 0, 2, "Title", time.Now(), "", "", false, nil, nil, "user", 0)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,\n    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments\nFROM writing w\nLEFT JOIN users u ON w.users_idusers = u.idusers\nWHERE w.users_idusers = ?\nORDER BY w.published DESC")).
 		WithArgs(int32(1)).
 		WillReturnRows(writingRows)
 

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -65,7 +65,7 @@ func TestBlogsBloggerPostsPage(t *testing.T) {
 		WillReturnRows(userRows)
 
 	blogRows := sqlmock.NewRows([]string{
-		"idblogs", "forumthread_idforumthread", "users_idusers",
+		"idblogs", "forumthread_id", "users_idusers",
 		"language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)", "is_owner",
 	}).AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), "bob", 0, true)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).
@@ -97,7 +97,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).
 		WithArgs(int32(1), int32(1), int32(1), int32(1), int32(1), int32(1), sqlmock.AnyArg(), int32(15), int32(0)).
-		WillReturnRows(sqlmock.NewRows([]string{"idblogs", "forumthread_idforumthread", "users_idusers", "language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)", "is_owner"}).
+		WillReturnRows(sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)", "is_owner"}).
 			AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), "bob", 0, true))
 
 	req := httptest.NewRequest("GET", "http://example.com/blogs/rss?rss=bob", nil)

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 59
+	ExpectedSchemaVersion = 60
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -124,7 +124,7 @@ LEFT JOIN forumthread th ON c.forumthread_id=th.idforumthread
 LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
 LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.forumthread_id=sqlc.arg(thread_id)
-  AND c.forumthread_id!=0
+  AND c.forumthread_id IS NOT NULL
   AND (
       c.language_idlanguage = 0
       OR c.language_idlanguage IS NULL
@@ -162,7 +162,7 @@ LEFT JOIN forumthread th ON c.forumthread_id=th.idforumthread
 LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
 LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.forumthread_id=sqlc.arg(thread_id)
-  AND c.forumthread_id!=0
+  AND c.forumthread_id IS NOT NULL
   AND (
       c.language_idlanguage = 0
       OR c.language_idlanguage IS NULL

--- a/internal/db/queries-comments.sql.go
+++ b/internal/db/queries-comments.sql.go
@@ -445,7 +445,7 @@ LEFT JOIN forumthread th ON c.forumthread_id=th.idforumthread
 LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
 LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.forumthread_id=?
-  AND c.forumthread_id!=0
+  AND c.forumthread_id IS NOT NULL
   AND (
       c.language_idlanguage = 0
       OR c.language_idlanguage IS NULL
@@ -548,7 +548,7 @@ LEFT JOIN forumthread th ON c.forumthread_id=th.idforumthread
 LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
 LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.forumthread_id=?
-  AND c.forumthread_id!=0
+  AND c.forumthread_id IS NOT NULL
   AND (
       c.language_idlanguage = 0
       OR c.language_idlanguage IS NULL

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -8,7 +8,7 @@ LIMIT ? OFFSET ?
 
 -- name: SystemListPublicWritingsByAuthor :many
 SELECT w.*, u.username,
-    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.private = 0 AND w.users_idusers = sqlc.arg(author_id)
@@ -25,7 +25,7 @@ WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT w.*, u.username,
-    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.private = 0 AND w.users_idusers = sqlc.arg(author_id)
@@ -56,7 +56,7 @@ LIMIT ? OFFSET ?;
 
 -- name: SystemListPublicWritingsInCategory :many
 SELECT w.*, u.Username,
-    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) as Comments
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) as Comments
 FROM writing w
 LEFT JOIN users u ON w.Users_Idusers = u.idusers
 WHERE w.private = 0 AND w.writing_category_id = sqlc.arg(category_id)
@@ -68,7 +68,7 @@ WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT w.*, u.Username,
-    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) as Comments
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) as Comments
 FROM writing w
 LEFT JOIN users u ON w.Users_Idusers=u.idusers
 WHERE w.private = 0 AND w.writing_category_id = sqlc.arg(writing_category_id)
@@ -236,7 +236,7 @@ WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
 SELECT w.*, u.username,
-    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.users_idusers = sqlc.arg(author_id)
@@ -254,7 +254,7 @@ ORDER BY w.published DESC;
 
 -- name: AdminGetAllWritingsByAuthor :many
 SELECT w.*, u.username,
-    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.users_idusers = sqlc.arg(author_id)

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -13,7 +13,7 @@ import (
 
 const adminGetAllWritingsByAuthor = `-- name: AdminGetAllWritingsByAuthor :many
 SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
-    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.users_idusers = ?
@@ -228,7 +228,7 @@ WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
-    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.users_idusers = ?
@@ -512,7 +512,7 @@ WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
-    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.private = 0 AND w.users_idusers = ?
@@ -618,7 +618,7 @@ WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
 SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.Username,
-    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) as Comments
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) as Comments
 FROM writing w
 LEFT JOIN users u ON w.Users_Idusers=u.idusers
 WHERE w.private = 0 AND w.writing_category_id = ?
@@ -1111,7 +1111,7 @@ func (q *Queries) SystemGetWritingByID(ctx context.Context, idwriting int32) (in
 
 const systemListPublicWritingsByAuthor = `-- name: SystemListPublicWritingsByAuthor :many
 SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
-    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) AS Comments
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.private = 0 AND w.users_idusers = ?
@@ -1182,7 +1182,7 @@ func (q *Queries) SystemListPublicWritingsByAuthor(ctx context.Context, arg Syst
 
 const systemListPublicWritingsInCategory = `-- name: SystemListPublicWritingsInCategory :many
 SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.Username,
-    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id != 0) as Comments
+    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) as Comments
 FROM writing w
 LEFT JOIN users u ON w.Users_Idusers = u.idusers
 WHERE w.private = 0 AND w.writing_category_id = ?

--- a/migrations/0060.mysql.sql
+++ b/migrations/0060.mysql.sql
@@ -1,0 +1,7 @@
+UPDATE blogs SET forumthread_id = NULL WHERE forumthread_id = 0;
+
+ALTER TABLE blogs
+    MODIFY COLUMN forumthread_id int(10) DEFAULT NULL;
+
+-- Update schema version
+UPDATE schema_version SET version = 60 WHERE version = 59;

--- a/migrations/0060.postgres.sql
+++ b/migrations/0060.postgres.sql
@@ -1,0 +1,8 @@
+UPDATE blogs SET forumthread_id = NULL WHERE forumthread_id = 0;
+
+ALTER TABLE blogs
+    ALTER COLUMN forumthread_id DROP DEFAULT,
+    ALTER COLUMN forumthread_id DROP NOT NULL;
+
+-- Update schema version
+UPDATE schema_version SET version = 60 WHERE version = 59;

--- a/migrations/0060.sqlite.sql
+++ b/migrations/0060.sqlite.sql
@@ -1,0 +1,7 @@
+UPDATE blogs SET forumthread_id = NULL WHERE forumthread_id = 0;
+
+ALTER TABLE blogs
+    MODIFY COLUMN forumthread_id int(10) DEFAULT NULL;
+
+-- Update schema version
+UPDATE schema_version SET version = 60 WHERE version = 59;


### PR DESCRIPTION
## Summary
- allow blog forum threads to be NULL and drop checks for id=0
- update queries and tests to treat missing forum threads as NULL
- add migration converting 0 blog thread ids to NULL and bump schema version

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` (fails: cannot use sql.NullInt32 as int32 in coredata_writings.go)
- `golangci-lint run` (fails: typecheck errors in core/common and related packages)
- `go test ./...` (fails: build failed in multiple packages due to sql.NullInt32 vs int32)


------
https://chatgpt.com/codex/tasks/task_e_6896ab417ba4832f97fe31f11f05536f