### PR TITLE
Fix comment deactivation type and admin writings test

### DIFF
--- a/cmd/goa4web/comment_deactivate.go
+++ b/cmd/goa4web/comment_deactivate.go
@@ -47,15 +47,11 @@ func (c *commentDeactivateCmd) Run() error {
 	if deactivated {
 		return fmt.Errorf("comment already deactivated")
 	}
-	var langID int32
-	if cm.LanguageIdlanguage.Valid {
-		langID = cm.LanguageIdlanguage.Int32
-	}
 	if err := queries.AdminArchiveComment(ctx, db.AdminArchiveCommentParams{
 		Idcomments:         cm.Idcomments,
 		ForumthreadID:      cm.ForumthreadID,
 		UsersIdusers:       cm.UsersIdusers,
-		LanguageIdlanguage: langID,
+		LanguageIdlanguage: cm.LanguageIdlanguage,
 		Written:            cm.Written,
 		Text:               cm.Text,
 	}); err != nil {

--- a/handlers/admin/adminUserWritingsPage_test.go
+++ b/handlers/admin/adminUserWritingsPage_test.go
@@ -32,7 +32,7 @@ func TestAdminUserWritingsPage(t *testing.T) {
 		WillReturnRows(userRows)
 
 	writingRows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "username", "comments"}).
-		AddRow(1, 1, nil, 0, 2, "Title", time.Now(), "", "", false, nil, nil, "user", 0)
+		AddRow(1, 1, 0, 0, 2, "Title", time.Now(), "", "", false, nil, nil, "user", 0)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,\n    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments\nFROM writing w\nLEFT JOIN users u ON w.users_idusers = u.idusers\nWHERE w.users_idusers = ?\nORDER BY w.published DESC")).
 		WithArgs(int32(1)).
 		WillReturnRows(writingRows)


### PR DESCRIPTION
## Summary
- fix AdminArchiveComment call to use sql.NullInt32 language id
- correct admin user writings page test data

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68985206f81c832faa6f7390bcf30574