### PR TITLE
refactor: use semantic classes for topic threads

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -339,6 +339,38 @@ tr.unsupported td {
        flex: 1;
 }
 
+/* Thread list styles */
+.thread-list {
+        width: 100%;
+}
+
+.thread {
+        border: 1px solid #000;
+        margin-bottom: 1em;
+}
+
+.thread-meta {
+        padding: 0.25em;
+}
+
+.thread-header {
+        background-color: lightgrey;
+}
+
+.thread-content {
+        padding: 0.25em;
+}
+
+.poster-name.first,
+.post-time.first {
+        color: green;
+}
+
+.poster-name.last,
+.post-time.last {
+        color: blue;
+}
+
 
 .comments {
        display: flex;

--- a/core/templates/site/topicThreads.gohtml
+++ b/core/templates/site/topicThreads.gohtml
@@ -1,25 +1,21 @@
 {{ define "topicThreads" }}
     <h2>Threads</h2>
+    <div class="thread-list">
     {{- range .Threads }}
-        <table width="100%" border=1>
-            <tr>
-                <td bgcolor="lightgrey">
-                    First poster: <font color="green">{{ .Firstpostusername.String }}</font> At <font color="green">{{ localTime .Firstpostwritten.Time }}</font>
-                </td>
-            </tr>
-            <tr>
-                <td bgcolor="">
-                    {{ .Firstposttext.String | a4code2html }}<br>
-                </td>
-            </tr>
-            <tr>
-                <td bgcolor="">
-                    Lastposter: <font color="blue">{{ .Lastposterusername.String }}</font>
-                    At <font color="blue">{{ localTime .Lastaddition.Time }}</font>
-                    [<a href="/forum/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">{{ .Comments.Int32 }} comments.</a>]
-                </td>
-            </tr>
-        </table>
-        <br />
+        <div class="thread">
+            <div class="thread-meta thread-header">
+                First poster: <span class="poster-name first">{{ .Firstpostusername.String }}</span>
+                At <span class="post-time first">{{ localTime .Firstpostwritten.Time }}</span>
+            </div>
+            <div class="thread-content">
+                {{ .Firstposttext.String | a4code2html }}<br>
+            </div>
+            <div class="thread-meta">
+                Lastposter: <span class="poster-name last">{{ .Lastposterusername.String }}</span>
+                At <span class="post-time last">{{ localTime .Lastaddition.Time }}</span>
+                [<a href="/forum/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">{{ .Comments.Int32 }} comments.</a>]
+            </div>
+        </div>
     {{- end }}
+    </div>
 {{ end }}


### PR DESCRIPTION
## Summary
- replace inline styling in topic thread template with semantic elements and classes
- define thread list classes in main stylesheet for centralized theming

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot use sql.NullInt32 as int32 in core/common/coredata_writings.go)*
- `golangci-lint run ./...` *(fails: typecheck errors and unused import)*
- `go test ./...` *(fails: build errors in core/common/coredata_writings.go and related packages)*

------
https://chatgpt.com/codex/tasks/task_e_6896ab5415cc832f942301d20a6cf4b3