### PR TITLE
Fix writing categories template comparison

### DIFF
--- a/core/templates/site/listWritingCategories.gohtml
+++ b/core/templates/site/listWritingCategories.gohtml
@@ -4,7 +4,7 @@
         {{ $cats := cd.VisibleWritingCategories }}
         {{ $found := false }}
         {{ range $cats }}
-            {{ if eq .WritingCategoryID $.WritingCategoryID }}
+            {{ if eq .WritingCategoryID.Int32 $.WritingCategoryID }}
                 {{ $found = true }}
                 {{ $title := .Title.String }}
                 {{ $description := .Description.String }}


### PR DESCRIPTION
## Summary
- prevent type mismatch in listWritingCategories template by comparing int32 values

## Testing
- `go mod tidy`
- `go fmt ./...` (reverted unrelated changes)
- `go vet ./...` (hung, aborted)
- `golangci-lint run` (hung, aborted)
- `go test ./...` *(fails: TestPrivateTopicCreateTask_GrantsBeforeComment)*


------
https://chatgpt.com/codex/tasks/task_e_6898591a0bd8832f9696774ef31e6264