### PR TITLE
Clarify private forum message textarea

### DIFF
--- a/core/templates/site/privateForumPage.gohtml
+++ b/core/templates/site/privateForumPage.gohtml
@@ -11,7 +11,7 @@
             <button type="button" id="add-participant">Add</button>
             <ul id="participants"></ul>
             <input type="hidden" name="participants" id="participants-field">
-            <textarea name="body" id="message-field" placeholder="Message" style="display:none"></textarea>
+            <textarea name="body" id="message-field" cols="60" rows="5" placeholder="Message" style="display:none"></textarea>
             <button type="submit" id="create-button" style="display:none">Create</button>
         </form>
         <script src="/private/private_forum.js"></script>


### PR DESCRIPTION
## Summary
- ensure the private forum creation message field is shown with explicit size for easier typing

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestPrivateTopicCreateTask_GrantsBeforeComment: unexpected error: create private topic create reply grant ExecQuery: could not match actual sql)*

------
https://chatgpt.com/codex/tasks/task_e_68985a54d074832f95afb58565533526