### PR TITLE
feat: show anchors on news comments page

### DIFF
--- a/core/templates/site/news/post.gohtml
+++ b/core/templates/site/news/post.gohtml
@@ -6,7 +6,11 @@
         <tr>
             <td>{{ .News.String | a4code2html }}<br>-<br>{{ .Writername.String }}
             -
-            [<a href="/news/news/{{ .Idsitenews }}">{{ .Comments.Int32 }} COMMENTS</a>]
+            {{ if cd.SelectedThreadID }}
+                {{ .Comments.Int32 }} COMMENTS [<a href="#bottom">BOTTOM</a>]{{ if cd.SelectedThreadCanReply }} [<a href="#reply">REPLY</a>]{{ end }}
+            {{ else }}
+                [<a href="/news/news/{{ .Idsitenews }}">{{ .Comments.Int32 }} COMMENTS</a>]
+            {{ end }}
 
             {{ if cd.ShowEditNews .Idsitenews .UsersIdusers }}
                 [<a href="/news/news/{{ .Idsitenews }}/edit">EDIT</a>]


### PR DESCRIPTION
## Summary
- avoid linking to the current page from news posts
- add anchors for `#bottom` and `#reply` on news comment pages

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestPrivateTopicCreateTask_GrantsBeforeComment)*

------
https://chatgpt.com/codex/tasks/task_e_6898596a8100832fb81c654e053657d5