### PR TITLE
Fix template comparison for writing categories

### DIFF
--- a/core/templates/site/listWritingCategories.gohtml
+++ b/core/templates/site/listWritingCategories.gohtml
@@ -4,7 +4,7 @@
         {{ $cats := cd.VisibleWritingCategories }}
         {{ $found := false }}
         {{ range $cats }}
-            {{ if eq .WritingCategoryID $.WritingCategoryID }}
+            {{ if eq .WritingCategoryID.Int32 $.WritingCategoryID }}
                 {{ $found = true }}
                 {{ $title := .Title.String }}
                 {{ $description := .Description.String }}


### PR DESCRIPTION
## Summary
- fix writing categories template to compare `sql.NullInt32` IDs correctly

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: hung, terminated)*
- `golangci-lint run` *(fails: hung, terminated)*
- `go test ./...` *(fails: TestPrivateTopicCreateTask_GrantsBeforeComment)*

------
https://chatgpt.com/codex/tasks/task_e_68985c8cecb4832fbc54fb2635d3d9e0