### PR TITLE
Avoid redundant grant checks for section thread replies

### DIFF
--- a/handlers/blogs/blogsCommentPage_replyable_test.go
+++ b/handlers/blogs/blogsCommentPage_replyable_test.go
@@ -66,13 +66,32 @@ func TestCommentPageLockedThreadDisablesReply(t *testing.T) {
 		AddRow(1, 1, 2, 1, "hi", time.Unix(0, 0), "bob", 0, false)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(blogRows)
 
-	threadRows := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername"}).
+	threadRows1 := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername"}).
 		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), true, "bob")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(threadRows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(
+		int32(2),
+		int32(1),
+		int32(2),
+		int32(2),
+		sql.NullInt32{Int32: 2, Valid: true},
+	).WillReturnRows(threadRows1)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
 		WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), "blogs", sql.NullString{String: "entry", Valid: true}, sql.NullInt32{Int32: 2, Valid: true}).
 		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "deleted_at", "posterusername"}))
+
+	threadRows2 := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked"}).
+		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), true)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(
+		int32(2),
+		int32(1),
+		int32(2),
+		int32(2),
+		"blogs",
+		sql.NullString{String: "entry", Valid: true},
+		sql.NullInt32{Int32: 1, Valid: true},
+		sql.NullInt32{Int32: 2, Valid: true},
+	).WillReturnRows(threadRows2)
 
 	rr := httptest.NewRecorder()
 	CommentPage(rr, req)
@@ -110,13 +129,32 @@ func TestCommentPageUnlockedThreadShowsReply(t *testing.T) {
 		AddRow(1, 1, 2, 1, "hi", time.Unix(0, 0), "bob", 0, false)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(blogRows)
 
-	threadRows := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername"}).
+	threadRows1 := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername"}).
 		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), false, "bob")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(threadRows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(
+		int32(2),
+		int32(1),
+		int32(2),
+		int32(2),
+		sql.NullInt32{Int32: 2, Valid: true},
+	).WillReturnRows(threadRows1)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
 		WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), "blogs", sql.NullString{String: "entry", Valid: true}, sql.NullInt32{Int32: 2, Valid: true}).
 		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "deleted_at", "posterusername"}))
+
+	threadRows2 := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked"}).
+		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), false)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT th.idforumthread")).WithArgs(
+		int32(2),
+		int32(1),
+		int32(2),
+		int32(2),
+		"blogs",
+		sql.NullString{String: "entry", Valid: true},
+		sql.NullInt32{Int32: 1, Valid: true},
+		sql.NullInt32{Int32: 2, Valid: true},
+	).WillReturnRows(threadRows2)
 
 	rr := httptest.NewRecorder()
 	CommentPage(rr, req)

--- a/handlers/forum/forumThreadPage_quote_test.go
+++ b/handlers/forum/forumThreadPage_quote_test.go
@@ -25,7 +25,7 @@ func TestThreadPageQuotePrefillsReply(t *testing.T) {
 	}
 	defer dbconn.Close()
 
-	mock.ExpectQuery(".*").
+	mock.ExpectQuery("SELECT th.idforumthread").
 		WithArgs(int32(1), int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername",
@@ -52,6 +52,21 @@ func TestThreadPageQuotePrefillsReply(t *testing.T) {
 	mock.ExpectQuery("SELECT category_path").
 		WithArgs(int32(1)).
 		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "title"}))
+
+	mock.ExpectQuery("SELECT th.idforumthread").
+		WithArgs(
+			int32(1),
+			int32(1),
+			int32(1),
+			int32(1),
+			"forum",
+			sql.NullString{String: "topic", Valid: true},
+			sql.NullInt32{Int32: 1, Valid: true},
+			sql.NullInt32{Int32: 1, Valid: true},
+		).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked",
+		}).AddRow(int32(1), int32(1), int32(1), int32(1), sql.NullInt32{}, sql.NullTime{}, sql.NullBool{}))
 
 	store := sessions.NewCookieStore([]byte("test"))
 	core.Store = store

--- a/handlers/privateforum/topic_create_task_test.go
+++ b/handlers/privateforum/topic_create_task_test.go
@@ -32,6 +32,7 @@ func TestPrivateTopicCreateTask_GrantsBeforeComment(t *testing.T) {
 	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO comments").WillReturnResult(sqlmock.NewResult(3, 1))
 	mock.ExpectExec("INSERT INTO subscriptions").WillReturnResult(sqlmock.NewResult(0, 1))
 

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -318,6 +318,7 @@ type Querier interface {
 	GetPreferenceForLister(ctx context.Context, listerID int32) (*Preference, error)
 	GetPublicProfileRoleForUser(ctx context.Context, usersIdusers int32) (int32, error)
 	GetPublicWritings(ctx context.Context, arg GetPublicWritingsParams) ([]*Writing, error)
+	GetThreadBySectionThreadIDForReplier(ctx context.Context, arg GetThreadBySectionThreadIDForReplierParams) (*Forumthread, error)
 	GetThreadLastPosterAndPerms(ctx context.Context, arg GetThreadLastPosterAndPermsParams) (*GetThreadLastPosterAndPermsRow, error)
 	// GetUnreadNotificationCountForLister returns the number of unread notifications for a
 	// lister.


### PR DESCRIPTION
## Summary
- use a section-aware thread lookup to verify reply access
- drop redundant grant check in `sectionThreadCanReply`
- cover reply permission flow with updated tests

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68985f813aa0832f9a083d06e780b963