### PR TITLE
Fix forum category route

### DIFF
--- a/core/templates/site/admin/usageStatsPage.gohtml
+++ b/core/templates/site/admin/usageStatsPage.gohtml
@@ -27,7 +27,7 @@
     {{- range .ForumCategories }}
     <tr>
         <td><a href="/admin/forum/categories/category/{{ .Idforumcategory }}">{{ .Idforumcategory }}</a></td>
-        <td><a href="/forum/categories/category/{{ .Idforumcategory }}">{{ .Title.String }}</a></td>
+        <td><a href="/forum/category/{{ .Idforumcategory }}">{{ .Title.String }}</a></td>
         <td>{{ .Count }}</td>
     </tr>
     {{- end }}

--- a/core/templates/site/commentSearchReslts.gohtml
+++ b/core/templates/site/commentSearchReslts.gohtml
@@ -8,7 +8,7 @@
     {{- else }}
         <ul>
         {{- range $i, $result := $cd.SearchComments }}
-            <li>{{ $i }}: <a href="/forum/categories/category/{{$result.Idforumcategory}}">{{ $result.ForumcategoryTitle.String}}</a>: <a href="/forum/topic/{{$result.Idforumtopic}}">{{ $result.ForumtopicTitle.String }}</a>: {{$result.Posterusername.String}} on {{ localTime $result.Written.Time }}: <a href="/forum/topic/{{$result.Idforumtopic}}/thread/{{$result.Idforumthread}}">{{ $result.Text.String | a4code2html}}</a></li>
+            <li>{{ $i }}: <a href="/forum/category/{{$result.Idforumcategory}}">{{ $result.ForumcategoryTitle.String}}</a>: <a href="/forum/topic/{{$result.Idforumtopic}}">{{ $result.ForumtopicTitle.String }}</a>: {{$result.Posterusername.String}} on {{ localTime $result.Written.Time }}: <a href="/forum/topic/{{$result.Idforumtopic}}/thread/{{$result.Idforumthread}}">{{ $result.Text.String | a4code2html}}</a></li>
         {{- end }}
         </ul>
     {{ end }}

--- a/core/templates/site/forum/categories.gohtml
+++ b/core/templates/site/forum/categories.gohtml
@@ -18,7 +18,7 @@
                             {{ end }}
                         </form>
                     {{ else }}
-                        <strong><a href="/forum/categories/category/{{ .Idforumcategory }}">{{ .Title.String }}</a></strong> - {{ .Description.String }} ({{ len .Topics }})<br>
+                        <strong><a href="/forum/category/{{ .Idforumcategory }}">{{ .Title.String }}</a></strong> - {{ .Description.String }} ({{ len .Topics }})<br>
                     {{ end }}
                 </td>
             </tr>

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -21,6 +21,7 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Regis
 	fr.HandleFunc("/topic/{topic}.rss", TopicRssPage).Methods("GET")
 	fr.HandleFunc("/topic/{topic}.atom", TopicAtomPage).Methods("GET")
 	fr.HandleFunc("", Page).Methods("GET")
+	fr.HandleFunc("/category/{category}", Page).Methods("GET")
 	fr.HandleFunc("/categories/category/{category}", Page).Methods("GET")
 	fr.HandleFunc("/topic/{topic}", TopicsPage).Methods("GET")
 	fr.HandleFunc("/topic/{topic}/subscribe", handlers.TaskHandler(subscribeTopicTaskAction)).Methods("POST").MatcherFunc(subscribeTopicTaskAction.Matcher())

--- a/handlers/forum/routes_test.go
+++ b/handlers/forum/routes_test.go
@@ -1,0 +1,21 @@
+package forum
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
+	"github.com/gorilla/mux"
+)
+
+// TestCategoryRoute verifies that the public category route exists.
+func TestCategoryRoute(t *testing.T) {
+	r := mux.NewRouter()
+	RegisterRoutes(r, &config.RuntimeConfig{}, navpkg.NewRegistry())
+	req := httptest.NewRequest("GET", "/forum/category/1", nil)
+	m := &mux.RouteMatch{}
+	if !r.Match(req, m) || m.Handler == nil {
+		t.Fatalf("route /forum/category/{id} not registered")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `/forum/category/{category}` route for forum categories
- Update templates and links to use the new category path
- Add test ensuring the category route is registered

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: create private topic create reply grant ExecQuery: could not match actual sql)*

------
https://chatgpt.com/codex/tasks/task_e_6898689ce804832fa80fdf2c62bc1450