### PR TITLE
Fix missing writing ID when replying

### DIFF
--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -74,6 +74,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	cd.LoadSelectionsFromRequest(r)
 
 	writing, err := cd.Article()
 	if err != nil {

--- a/handlers/writings/writingsArticlePage_test.go
+++ b/handlers/writings/writingsArticlePage_test.go
@@ -53,7 +53,6 @@ func TestArticleReplyActionPage_UsesWritingParam(t *testing.T) {
 
 	q := db.New(dbconn)
 	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithSession(sess))
-	cd.LoadSelectionsFromRequest(req)
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)


### PR DESCRIPTION
## Summary
- ensure reply task loads selections from the request before retrieving the article
- simplify article reply test to rely on automatic selection loading

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68986d2f493c832fa6b05284f2ced1d8