### PR TITLE
Load client scripts only when modules are enabled

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -100,6 +100,8 @@ type CoreData struct {
 	TasksReg          *tasks.Registry
 	SiteTitle         string
 	UserID            int32
+	// routerModules tracks enabled router modules.
+	routerModules map[string]struct{}
 
 	session      *sessions.Session
 	sessionProxy SessionManager
@@ -2564,6 +2566,19 @@ func WithNavRegistry(r NavigationProvider) CoreOption {
 	return func(cd *CoreData) { cd.Nav = r }
 }
 
+// WithRouterModules sets the enabled router modules on CoreData.
+func WithRouterModules(mods []string) CoreOption {
+	return func(cd *CoreData) {
+		if len(mods) == 0 {
+			return
+		}
+		cd.routerModules = make(map[string]struct{}, len(mods))
+		for _, m := range mods {
+			cd.routerModules[m] = struct{}{}
+		}
+	}
+}
+
 // WithCustomQueries sets the db.CustomQueries dependency.
 func WithCustomQueries(cq db.CustomQueries) CoreOption {
 	return func(cd *CoreData) { cd.customQueries = cq }
@@ -2659,6 +2674,15 @@ func ContainsItem(items []IndexItem, name string) bool {
 		}
 	}
 	return false
+}
+
+// HasModule reports whether the named router module is enabled.
+func (cd *CoreData) HasModule(name string) bool {
+	if cd == nil || cd.routerModules == nil {
+		return false
+	}
+	_, ok := cd.routerModules[name]
+	return ok
 }
 
 // LatestWritings returns recent public writings with permission data.

--- a/core/templates/head_template_test.go
+++ b/core/templates/head_template_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 )
 
@@ -20,5 +21,27 @@ func TestHeadTemplateRendersSiteTitle(t *testing.T) {
 	}
 	if !strings.Contains(b.String(), "<title>Page - My Site</title>") {
 		t.Fatalf("unexpected output: %s", b.String())
+	}
+}
+
+func TestHeadTemplateIncludesModuleScripts(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	cd := common.NewCoreData(r.Context(), nil, config.NewRuntimeConfig(),
+		common.WithSiteTitle("My Site"),
+		common.WithRouterModules([]string{"images", "websocket"}),
+	)
+	cd.PageTitle = "Page"
+	tmpl := template.Must(template.New("").Funcs(cd.Funcs(r)).ParseFS(testTemplates,
+		"site/*.gohtml", "site/*/*.gohtml"))
+	var b strings.Builder
+	if err := tmpl.ExecuteTemplate(&b, "head", nil); err != nil {
+		t.Fatalf("execute head: %v", err)
+	}
+	out := b.String()
+	if !strings.Contains(out, `<script src="/images/pasteimg.js"></script>`) {
+		t.Errorf("missing images script: %s", out)
+	}
+	if !strings.Contains(out, `<script src="/websocket/notifications.js"></script>`) {
+		t.Errorf("missing notifications script: %s", out)
 	}
 }

--- a/core/templates/site/head.gohtml
+++ b/core/templates/site/head.gohtml
@@ -13,8 +13,12 @@
                 {{template "headdata"}}
                <link rel="stylesheet" href="/main.css">
                <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+               {{ if cd.HasModule "images" }}
                <script src="/images/pasteimg.js"></script>
+               {{ end }}
+               {{ if and (cd.HasModule "websocket") cd.Config.NotificationsEnabled }}
                <script src="/websocket/notifications.js"></script>
+               {{ end }}
        {{ if cd.AutoRefresh }}
             <meta http-equiv="refresh" content="{{cd.AutoRefresh}}">
         {{ end }}

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -237,6 +237,10 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 			}
 			provider := s.EmailReg.ProviderFromConfig(s.Config)
 			offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+			modules := []string{}
+			if s.RouterReg != nil {
+				modules = s.RouterReg.Names()
+			}
 			cd := common.NewCoreData(r.Context(), queries, s.Config,
 				common.WithImageSigner(s.ImageSigner),
 				common.WithCustomQueries(queries),
@@ -249,6 +253,7 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 				common.WithNavRegistry(s.Nav),
 				common.WithTasksRegistry(s.TasksReg),
 				common.WithDBRegistry(s.DBReg),
+				common.WithRouterModules(modules),
 				common.WithOffset(offset),
 				common.WithSiteTitle("Arran's Site"),
 			)


### PR DESCRIPTION
## Summary
- Track enabled router modules within CoreData and expose `HasModule`
- Pass module list from server and load paste image and notifications scripts conditionally
- Cover head template scripts with a unit test

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689871911238832faaef803ce455c3a2