### PR TITLE
Add private forum topic and thread pages

### DIFF
--- a/core/common/breadcrumb.go
+++ b/core/common/breadcrumb.go
@@ -23,7 +23,7 @@ func (cd *CoreData) Breadcrumbs() []Breadcrumb {
 		err    error
 	)
 	switch cd.currentSection {
-	case "forum":
+	case "forum", "privateforum":
 		crumbs, err = cd.forumBreadcrumbs()
 	case "writings":
 		crumbs, err = cd.writingBreadcrumbs()
@@ -46,7 +46,11 @@ func (cd *CoreData) Breadcrumbs() []Breadcrumb {
 }
 
 func (cd *CoreData) forumBreadcrumbs() ([]Breadcrumb, error) {
-	crumbs := []Breadcrumb{{Title: "Forum", Link: "/forum"}}
+	base := cd.ForumBasePath
+	if base == "" {
+		base = "/forum"
+	}
+	crumbs := []Breadcrumb{{Title: "Forum", Link: base}}
 	catID := cd.currentCategoryID
 	topicID := cd.currentTopicID
 	threadID := cd.currentThreadID
@@ -71,7 +75,7 @@ func (cd *CoreData) forumBreadcrumbs() ([]Breadcrumb, error) {
 			if row.Title.Valid {
 				title = row.Title.String
 			}
-			link := fmt.Sprintf("/forum/category/%d", row.Idforumcategory)
+			link := fmt.Sprintf("%s/category/%d", base, row.Idforumcategory)
 			if row.Idforumcategory == catID && topicID == 0 && threadID == 0 {
 				crumbs = append(crumbs, Breadcrumb{Title: title})
 			} else {
@@ -85,7 +89,7 @@ func (cd *CoreData) forumBreadcrumbs() ([]Breadcrumb, error) {
 			if topic.Title.Valid {
 				title = topic.Title.String
 			}
-			link := fmt.Sprintf("/forum/topic/%d", topicID)
+			link := fmt.Sprintf("%s/topic/%d", base, topicID)
 			if threadID == 0 {
 				crumbs = append(crumbs, Breadcrumb{Title: title})
 			} else {

--- a/core/common/breadcrumb_private_test.go
+++ b/core/common/breadcrumb_private_test.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+)
+
+func TestPrivateForumBreadcrumbBasePath(t *testing.T) {
+	cd := NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
+	cd.SetCurrentSection("privateforum")
+	cd.ForumBasePath = "/private"
+	crumbs, err := cd.forumBreadcrumbs()
+	if err != nil {
+		t.Fatalf("forumBreadcrumbs error: %v", err)
+	}
+	if len(crumbs) == 0 || crumbs[0].Link != "/private" {
+		t.Fatalf("crumbs=%v", crumbs)
+	}
+}

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -99,6 +99,7 @@ type CoreData struct {
 	StartLink         string
 	TasksReg          *tasks.Registry
 	SiteTitle         string
+	ForumBasePath     string // ForumBasePath holds the URL prefix for forum links.
 	UserID            int32
 
 	session      *sessions.Session
@@ -1611,11 +1612,11 @@ func (cd *CoreData) Preference() (*db.Preference, error) {
 // otherwise it resolves the site's default language name to an ID.
 func (cd *CoreData) PreferredLanguageID(siteDefault string) int32 {
 	id, err := cd.preferredLanguageID.Load(func() (int32, error) {
-                if pref, err := cd.Preference(); err == nil && pref != nil {
-                        if pref.LanguageIdlanguage.Valid {
-                                return pref.LanguageIdlanguage.Int32, nil
-                        }
-                }
+		if pref, err := cd.Preference(); err == nil && pref != nil {
+			if pref.LanguageIdlanguage.Valid {
+				return pref.LanguageIdlanguage.Int32, nil
+			}
+		}
 		if cd.queries == nil || siteDefault == "" {
 			return 0, nil
 		}

--- a/core/templates/site/forum/reply.gohtml
+++ b/core/templates/site/forum/reply.gohtml
@@ -1,7 +1,9 @@
 {{ define "forumReply" }}
        {{ if cd.SelectedThreadCanReply }}
             <font size="4">Reply:</font><br>
-            <form method="post" action="/forum/topic/{{$.Topic.Idforumtopic}}/thread/{{$.Thread.Idforumthread}}/reply">
+            {{ $base := "/forum" }}
+            {{ with $.BasePath }}{{ $base = . }}{{ end }}
+            <form method="post" action="{{$base}}/topic/{{$.Topic.Idforumtopic}}/thread/{{$.Thread.Idforumthread}}/reply">
         {{ csrfField }}
                 <textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>
                 {{ template "languageCombobox" }}

--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -2,6 +2,8 @@
     {{ template "threadComments" }}
     {{ template "forumReply" $ }}
 
-    <a href="/forum/topic/{{.Topic.Idforumtopic}}">Back</a>
+    {{ $base := "/forum" }}
+    {{ with .BasePath }}{{ $base = . }}{{ end }}
+    <a href="{{$base}}/topic/{{.Topic.Idforumtopic}}">Back</a>
 
 {{ template "tail" $ }}

--- a/core/templates/site/forum/topicsPage.gohtml
+++ b/core/templates/site/forum/topicsPage.gohtml
@@ -5,14 +5,16 @@
     {{ end }}
     <h2>Topic: {{ if .Topic.DisplayTitle }}{{ .Topic.DisplayTitle }}{{ else }}{{ .Topic.Title.String }}{{ end }}</h2>
 
+    {{ $base := "/forum" }}
+    {{ with .BasePath }}{{ $base = . }}{{ end }}
     <div class="topic-actions">
-        <a href="/forum/topic/{{.Topic.Idforumtopic}}/thread">New Thread</a>
+        <a href="{{$base}}/topic/{{.Topic.Idforumtopic}}/thread">New Thread</a>
         {{- if and cd.IsAdmin cd.IsAdminMode }} | [<a href="/admin/forum/topics/topic/{{.Topic.Idforumtopic}}/edit">ADMIN</a>]{{ end }}
-        {{- if .Subscribed }} | <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/unsubscribe">
+        {{- if .Subscribed }} | <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/unsubscribe">
                 <input type="hidden" name="task" value="Unsubscribe From Topic"/>
                 <input type="submit" value="Unsubscribe"/>
             </form>
-        {{- else }} | <form method="post" action="/forum/topic/{{.Topic.Idforumtopic}}/subscribe">
+        {{- else }} | <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/subscribe">
                 <input type="hidden" name="task" value="Subscribe To Topic"/>
                 <input type="submit" value="Subscribe"/>
             </form>

--- a/core/templates/site/privateForumPage.gohtml
+++ b/core/templates/site/privateForumPage.gohtml
@@ -1,7 +1,7 @@
 {{ define "privateForumPage" }}
     {{ template "head" $ }}
     <h1>Private Topics</h1>
-    {{ template "tableTopics" (dict "Topics" cd.PrivateTopics) }}
+    {{ template "tableTopics" (dict "Topics" cd.PrivateTopics "BasePath" "/private") }}
     {{ if cd.HasGrant "privateforum" "topic" "create" 0 }}
         <h2>Start group discussion</h2>
         <p>Add people to start a shared conversation.</p>

--- a/core/templates/site/tableTopics.gohtml
+++ b/core/templates/site/tableTopics.gohtml
@@ -1,4 +1,6 @@
 {{ define "tableTopics" }}
+    {{ $base := "/forum" }}
+    {{ with .BasePath }}{{ $base = . }}{{ end }}
     <table>
         <tr>
             <th width="400px">Topic name<br>Description
@@ -11,7 +13,7 @@
             <td>
                 {{ $title := .Title.String }}
                 {{ if .DisplayTitle }}{{ $title = .DisplayTitle }}{{ end }}
-                <a href="/forum/topic/{{ .Idforumtopic }}">{{ $title | a4code2html }}</a>{{ if and cd.IsAdmin cd.IsAdminMode }} [<a href="/admin/forum/topics/topic/{{ .Idforumtopic }}/edit">ADMIN</a>]{{ end }}<br>
+                <a href="{{$base}}/topic/{{ .Idforumtopic }}">{{ $title | a4code2html }}</a>{{ if and cd.IsAdmin cd.IsAdminMode }} [<a href="/admin/forum/topics/topic/{{ .Idforumtopic }}/edit">ADMIN</a>]{{ end }}<br>
                 {{ with .Description.String }}<i>{{ . | a4code2html }}</i>{{ end }}
             </td>
             <td align="center">{{ localTime .Lastaddition.Time }}<br>{{ .Lastposterusername.String }}</td>

--- a/core/templates/site/topicThreads.gohtml
+++ b/core/templates/site/topicThreads.gohtml
@@ -1,4 +1,6 @@
 {{ define "topicThreads" }}
+    {{ $base := "/forum" }}
+    {{ with .BasePath }}{{ $base = . }}{{ end }}
     <h2>Threads</h2>
     {{- range .Threads }}
         <table width="100%" border=1>
@@ -16,7 +18,7 @@
                 <td bgcolor="">
                     Lastposter: <font color="blue">{{ .Lastposterusername.String }}</font>
                     At <font color="blue">{{ localTime .Lastaddition.Time }}</font>
-                    [<a href="/forum/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">{{ .Comments.Int32 }} comments.</a>]
+                    [<a href="{{$base}}/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">{{ .Comments.Int32 }} comments.</a>]
                 </td>
             </tr>
         </table>

--- a/handlers/forum/basepath.go
+++ b/handlers/forum/basepath.go
@@ -1,0 +1,22 @@
+package forum
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+)
+
+// BasePathMiddleware sets the forum base path on CoreData for downstream handlers.
+func BasePathMiddleware(base string) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+				cd.ForumBasePath = base
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/handlers/forum/comment_edit_action_cancel_task.go
+++ b/handlers/forum/comment_edit_action_cancel_task.go
@@ -15,6 +15,9 @@ type topicThreadCommentEditActionCancelTask struct{ tasks.TaskString }
 
 var topicThreadCommentEditActionCancel = &topicThreadCommentEditActionCancelTask{TaskString: TaskCancel}
 
+// TopicThreadCommentEditActionCancelHandler aborts editing a comment. Exported for reuse.
+var TopicThreadCommentEditActionCancelHandler = topicThreadCommentEditActionCancel
+
 var _ tasks.Task = (*topicThreadCommentEditActionCancelTask)(nil)
 
 func (topicThreadCommentEditActionCancelTask) Action(w http.ResponseWriter, r *http.Request) any {
@@ -28,6 +31,10 @@ func (topicThreadCommentEditActionCancelTask) Action(w http.ResponseWriter, r *h
 	if err != nil || topicRow == nil {
 		return fmt.Errorf("topic fetch %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	endURL := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
+	base := cd.ForumBasePath
+	if base == "" {
+		base = "/forum"
+	}
+	endURL := fmt.Sprintf("%s/topic/%d/thread/%d#bottom", base, topicRow.Idforumtopic, threadRow.Idforumthread)
 	return handlers.RedirectHandler(endURL)
 }

--- a/handlers/forum/comment_edit_action_task.go
+++ b/handlers/forum/comment_edit_action_task.go
@@ -18,6 +18,9 @@ type topicThreadCommentEditActionTask struct{ tasks.TaskString }
 
 var topicThreadCommentEditAction = &topicThreadCommentEditActionTask{TaskString: TaskEditReply}
 
+// TopicThreadCommentEditActionHandler updates a comment. Exported for reuse.
+var TopicThreadCommentEditActionHandler = topicThreadCommentEditAction
+
 var _ tasks.Task = (*topicThreadCommentEditActionTask)(nil)
 
 func (topicThreadCommentEditActionTask) Action(w http.ResponseWriter, r *http.Request) any {
@@ -52,5 +55,9 @@ func (topicThreadCommentEditActionTask) Action(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	return handlers.RedirectHandler(fmt.Sprintf("/forum/topic/%d/thread/%d#comment-%d", topicRow.Idforumtopic, threadRow.Idforumthread, commentID))
+	base := cd.ForumBasePath
+	if base == "" {
+		base = "/forum"
+	}
+	return handlers.RedirectHandler(fmt.Sprintf("%s/topic/%d/thread/%d#comment-%d", base, topicRow.Idforumtopic, threadRow.Idforumthread, commentID))
 }

--- a/handlers/forum/forumTopicPage.go
+++ b/handlers/forum/forumTopicPage.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func TopicsPage(w http.ResponseWriter, r *http.Request) {
+func TopicsPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath string) {
 	type Data struct {
 		Admin                   bool
 		Back                    bool
@@ -28,6 +28,7 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 		Categories              []*ForumcategoryPlus
 		Category                *ForumcategoryPlus
 		CopyDataToSubCategories func(rootCategory *ForumcategoryPlus) *Data
+		BasePath                string
 	}
 
 	if _, ok := core.GetSessionOrFail(w, r); !ok {
@@ -38,8 +39,10 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cd.LoadSelectionsFromRequest(r)
+	cd.ForumBasePath = basePath
 	data := &Data{
-		Admin: cd.IsAdmin() && cd.IsAdminMode(),
+		Admin:    cd.IsAdmin() && cd.IsAdminMode(),
+		BasePath: basePath,
 	}
 
 	copyDataToSubCategories := func(rootCategory *ForumcategoryPlus) *Data {
@@ -129,4 +132,9 @@ func TopicsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	handlers.TemplateHandler(w, r, "topicsPage.gohtml", data)
+}
+
+// TopicsPage serves the forum topic page at the default /forum prefix.
+func TopicsPage(w http.ResponseWriter, r *http.Request) {
+	TopicsPageWithBasePath(w, r, "/forum")
 }

--- a/handlers/forum/subscribe_topic_task.go
+++ b/handlers/forum/subscribe_topic_task.go
@@ -20,6 +20,9 @@ type subscribeTopicTask struct{ tasks.TaskString }
 
 var subscribeTopicTaskAction = &subscribeTopicTask{TaskString: TaskSubscribeToTopic}
 
+// SubscribeTopicTaskHandler subscribes a user to a topic. Exported for reuse.
+var SubscribeTopicTaskHandler = subscribeTopicTaskAction
+
 var _ tasks.Task = (*subscribeTopicTask)(nil)
 
 func (subscribeTopicTask) Action(w http.ResponseWriter, r *http.Request) any {
@@ -34,5 +37,9 @@ func (subscribeTopicTask) Action(w http.ResponseWriter, r *http.Request) any {
 		log.Printf("insert subscription: %v", err)
 		return fmt.Errorf("insert subscription %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	return handlers.RedirectHandler(fmt.Sprintf("/forum/topic/%d", topicID))
+	base := cd.ForumBasePath
+	if base == "" {
+		base = "/forum"
+	}
+	return handlers.RedirectHandler(fmt.Sprintf("%s/topic/%d", base, topicID))
 }

--- a/handlers/forum/thread_new_cancel_task.go
+++ b/handlers/forum/thread_new_cancel_task.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/gorilla/mux"
@@ -15,9 +17,18 @@ type threadNewCancelTask struct{ tasks.TaskString }
 
 var threadNewCancelAction = &threadNewCancelTask{TaskString: TaskCancel}
 
+// ThreadNewCancelHandler aborts creating a new thread. Exported for reuse.
+var ThreadNewCancelHandler = threadNewCancelAction
+
 var _ tasks.Task = (*threadNewCancelTask)(nil)
 
 func (threadNewCancelTask) Action(w http.ResponseWriter, r *http.Request) any {
 	topicID, _ := strconv.Atoi(mux.Vars(r)["topic"])
-	return handlers.RedirectHandler(fmt.Sprintf("/forum/topic/%d", topicID))
+	base := "/forum"
+	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+		if cd.ForumBasePath != "" {
+			base = cd.ForumBasePath
+		}
+	}
+	return handlers.RedirectHandler(fmt.Sprintf("%s/topic/%d", base, topicID))
 }

--- a/handlers/forum/topic_thread_reply_cancel_task.go
+++ b/handlers/forum/topic_thread_reply_cancel_task.go
@@ -15,6 +15,9 @@ type topicThreadReplyCancelTask struct{ tasks.TaskString }
 
 var topicThreadReplyCancel = &topicThreadReplyCancelTask{TaskString: TaskCancel}
 
+// TopicThreadReplyCancelHandler cancels replying to a thread. Exported for reuse.
+var TopicThreadReplyCancelHandler = topicThreadReplyCancel
+
 var _ tasks.Task = (*topicThreadReplyCancelTask)(nil)
 
 func (topicThreadReplyCancelTask) Action(w http.ResponseWriter, r *http.Request) any {
@@ -28,6 +31,10 @@ func (topicThreadReplyCancelTask) Action(w http.ResponseWriter, r *http.Request)
 	if err != nil || topicRow == nil {
 		return fmt.Errorf("topic fetch %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	endURL := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
+	base := cd.ForumBasePath
+	if base == "" {
+		base = "/forum"
+	}
+	endURL := fmt.Sprintf("%s/topic/%d/thread/%d#bottom", base, topicRow.Idforumtopic, threadRow.Idforumthread)
 	return handlers.RedirectHandler(endURL)
 }

--- a/handlers/forum/topic_thread_reply_cancel_task_test.go
+++ b/handlers/forum/topic_thread_reply_cancel_task_test.go
@@ -1,0 +1,42 @@
+package forum
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/lazy"
+	"github.com/gorilla/mux"
+)
+
+func TestTopicThreadReplyCancel_BasePath(t *testing.T) {
+	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
+	cd.ForumBasePath = "/private"
+	thread := &db.GetThreadLastPosterAndPermsRow{Idforumthread: 2, ForumtopicIdforumtopic: 1}
+	topic := &db.GetForumTopicByIdForUserRow{Idforumtopic: 1}
+	if _, err := cd.ForumThreadByID(2, lazy.Set(thread)); err != nil {
+		t.Fatalf("set thread: %v", err)
+	}
+	if _, err := cd.ForumTopicByID(1, lazy.Set(topic)); err != nil {
+		t.Fatalf("set topic: %v", err)
+	}
+	cd.SetCurrentThreadAndTopic(2, 1)
+	req := httptest.NewRequest("POST", "/private/topic/1/thread/2/reply", nil)
+	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "2"})
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+	cd.LoadSelectionsFromRequest(req)
+
+	res := TopicThreadReplyCancelHandler.Action(httptest.NewRecorder(), req)
+	rh, ok := res.(handlers.RedirectHandler)
+	if !ok {
+		t.Fatalf("expected RedirectHandler, got %T", res)
+	}
+	if string(rh) != "/private/topic/1/thread/2#bottom" {
+		t.Fatalf("redirect=%s", rh)
+	}
+}

--- a/handlers/forum/unsubscribe_topic_task.go
+++ b/handlers/forum/unsubscribe_topic_task.go
@@ -20,6 +20,9 @@ type unsubscribeTopicTask struct{ tasks.TaskString }
 
 var unsubscribeTopicTaskAction = &unsubscribeTopicTask{TaskString: TaskUnsubscribeFromTopic}
 
+// UnsubscribeTopicTaskHandler removes a topic subscription. Exported for reuse.
+var UnsubscribeTopicTaskHandler = unsubscribeTopicTaskAction
+
 var _ tasks.Task = (*unsubscribeTopicTask)(nil)
 
 func (unsubscribeTopicTask) Action(w http.ResponseWriter, r *http.Request) any {
@@ -34,5 +37,9 @@ func (unsubscribeTopicTask) Action(w http.ResponseWriter, r *http.Request) any {
 		log.Printf("delete subscription: %v", err)
 		return fmt.Errorf("delete subscription %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	return handlers.RedirectHandler(fmt.Sprintf("/forum/topic/%d", topicID))
+	base := cd.ForumBasePath
+	if base == "" {
+		base = "/forum"
+	}
+	return handlers.RedirectHandler(fmt.Sprintf("%s/topic/%d", base, topicID))
 }

--- a/handlers/privateforum/routes.go
+++ b/handlers/privateforum/routes.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers"
+	forumhandlers "github.com/arran4/goa4web/handlers/forum"
+	forumcomments "github.com/arran4/goa4web/handlers/forum/comments"
 	navpkg "github.com/arran4/goa4web/internal/navigation"
 	"github.com/arran4/goa4web/internal/router"
 )
@@ -15,10 +17,27 @@ import (
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
 	navReg.RegisterIndexLink("Private", "/private", SectionWeight)
 	pr := r.PathPrefix("/private").Subrouter()
-	pr.Use(handlers.IndexMiddleware(CustomIndex), handlers.SectionMiddleware("privateforum"))
+	pr.Use(handlers.IndexMiddleware(CustomIndex), handlers.SectionMiddleware("privateforum"), forumhandlers.BasePathMiddleware("/private"))
 	pr.HandleFunc("", Page).Methods(http.MethodGet)
 	pr.HandleFunc("", handlers.TaskHandler(privateTopicCreateTask)).Methods(http.MethodPost).MatcherFunc(privateTopicCreateTask.Matcher())
 	pr.HandleFunc("/private_forum.js", handlers.PrivateForumJS).Methods(http.MethodGet)
+	pr.HandleFunc("/topic/{topic}", TopicPage).Methods(http.MethodGet)
+
+	pr.HandleFunc("/topic/{topic}/subscribe", handlers.TaskHandler(forumhandlers.SubscribeTopicTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.SubscribeTopicTaskHandler.Matcher())
+	pr.HandleFunc("/topic/{topic}/unsubscribe", handlers.TaskHandler(forumhandlers.UnsubscribeTopicTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.UnsubscribeTopicTaskHandler.Matcher())
+
+	pr.HandleFunc("/topic/{topic}/thread", forumhandlers.CreateThreadTaskHandler.Page).Methods(http.MethodGet)
+	pr.HandleFunc("/topic/{topic}/thread", handlers.TaskHandler(forumhandlers.CreateThreadTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.CreateThreadTaskHandler.Matcher())
+	pr.HandleFunc("/topic/{topic}/thread/cancel", forumhandlers.ThreadNewCancelPage).Methods(http.MethodGet)
+	pr.HandleFunc("/topic/{topic}/thread/cancel", handlers.TaskHandler(forumhandlers.ThreadNewCancelHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.ThreadNewCancelHandler.Matcher())
+	pr.HandleFunc("/topic/{topic}/thread", handlers.TaskHandler(forumhandlers.ThreadNewCancelHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.ThreadNewCancelHandler.Matcher())
+
+	pr.Handle("/topic/{topic}/thread/{thread}", forumhandlers.RequireThreadAndTopic(http.HandlerFunc(ThreadPage))).Methods(http.MethodGet)
+	pr.Handle("/topic/{topic}/thread/{thread}", forumhandlers.RequireThreadAndTopic(http.HandlerFunc(handlers.TaskDoneAutoRefreshPage))).Methods(http.MethodPost)
+	pr.Handle("/topic/{topic}/thread/{thread}/reply", forumhandlers.RequireThreadAndTopic(http.HandlerFunc(handlers.TaskHandler(forumhandlers.ReplyTaskHandler)))).Methods(http.MethodPost).MatcherFunc(forumhandlers.ReplyTaskHandler.Matcher())
+	pr.Handle("/topic/{topic}/thread/{thread}/reply", forumhandlers.RequireThreadAndTopic(http.HandlerFunc(handlers.TaskHandler(forumhandlers.TopicThreadReplyCancelHandler)))).Methods(http.MethodPost).MatcherFunc(forumhandlers.TopicThreadReplyCancelHandler.Matcher())
+	pr.Handle("/topic/{topic}/thread/{thread}/comment/{comment}", forumhandlers.RequireThreadAndTopic(forumcomments.RequireCommentAuthor(http.HandlerFunc(handlers.TaskHandler(forumhandlers.TopicThreadCommentEditActionHandler))))).Methods(http.MethodPost).MatcherFunc(forumhandlers.TopicThreadCommentEditActionHandler.Matcher())
+	pr.Handle("/topic/{topic}/thread/{thread}/comment/{comment}", forumhandlers.RequireThreadAndTopic(forumcomments.RequireCommentAuthor(http.HandlerFunc(handlers.TaskHandler(forumhandlers.TopicThreadCommentEditActionCancelHandler))))).Methods(http.MethodPost).MatcherFunc(forumhandlers.TopicThreadCommentEditActionCancelHandler.Matcher())
 }
 
 // Register registers the private forum router module.

--- a/handlers/privateforum/thread.go
+++ b/handlers/privateforum/thread.go
@@ -1,0 +1,12 @@
+package privateforum
+
+import (
+	"net/http"
+
+	forumhandlers "github.com/arran4/goa4web/handlers/forum"
+)
+
+// ThreadPage displays a thread within a private topic.
+func ThreadPage(w http.ResponseWriter, r *http.Request) {
+	forumhandlers.ThreadPageWithBasePath(w, r, "/private")
+}

--- a/handlers/privateforum/topic.go
+++ b/handlers/privateforum/topic.go
@@ -1,0 +1,12 @@
+package privateforum
+
+import (
+	"net/http"
+
+	forumhandlers "github.com/arran4/goa4web/handlers/forum"
+)
+
+// TopicPage displays a private topic with thread listings.
+func TopicPage(w http.ResponseWriter, r *http.Request) {
+	forumhandlers.TopicsPageWithBasePath(w, r, "/private")
+}

--- a/handlers/privateforum/topic_create_task_test.go
+++ b/handlers/privateforum/topic_create_task_test.go
@@ -32,6 +32,7 @@ func TestPrivateTopicCreateTask_GrantsBeforeComment(t *testing.T) {
 	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO grants").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO comments").WillReturnResult(sqlmock.NewResult(3, 1))
 	mock.ExpectExec("INSERT INTO subscriptions").WillReturnResult(sqlmock.NewResult(0, 1))
 

--- a/handlers/privateforum/topic_page_test.go
+++ b/handlers/privateforum/topic_page_test.go
@@ -1,0 +1,72 @@
+package privateforum
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestTopicPage_Prefix(t *testing.T) {
+	core.Store = sessions.NewCookieStore([]byte("test"))
+	core.SessionName = "test-session"
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+	queries := db.New(conn)
+	cd := common.NewCoreData(context.Background(), queries, config.NewRuntimeConfig())
+
+	req := httptest.NewRequest(http.MethodGet, "/private/topic/1", nil)
+	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
+	cd.ForumBasePath = "/private"
+	cd.SetCurrentSection("privateforum")
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+
+	mock.ExpectQuery("SELECT .* FROM forumcategory").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}))
+
+	mock.ExpectQuery("SELECT t.* FROM forumtopic t").
+		WithArgs(sqlmock.AnyArg(), 1, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
+			AddRow(1, 0, 0, 0, "topic", "", 0, 0, time.Now(), "private", ""))
+
+	mock.ExpectQuery("SELECT u.idusers, u.username FROM grants").
+		WithArgs(1, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"idusers", "username"}).AddRow(1, "Alice"))
+
+	mock.ExpectQuery("SELECT .* FROM forumthread").
+		WithArgs(sqlmock.AnyArg(), 1, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "lastposterusername", "lastposterid", "firstpostusername", "firstpostwritten", "firstposttext"}).
+			AddRow(1, 1, 1, 1, sql.NullInt32{Int32: 0, Valid: true}, sql.NullTime{}, sql.NullBool{}, sql.NullString{String: "Bob", Valid: true}, sql.NullInt32{Int32: 1, Valid: true}, sql.NullString{String: "Alice", Valid: true}, sql.NullTime{}, sql.NullString{String: "hi", Valid: true}))
+
+	w := httptest.NewRecorder()
+	TopicPage(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "/private/topic/1/thread") {
+		t.Fatalf("expected private thread link, got %q", body)
+	}
+	if !strings.Contains(body, `<nav class="breadcrumbs"`) || !strings.Contains(body, `href="/private">Forum</a>`) {
+		t.Fatalf("expected private breadcrumb, got %q", body)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Propagate forum base path so breadcrumbs and links use `/private` for private forum views
- Register private forum routes and tasks for subscribing, thread creation, replies, and comment edits
- Ensure reply and cancel handlers respect custom prefixes and add tests for private paths

## Testing
- `go mod tidy`
- `go vet ./handlers/privateforum/... ./handlers/forum/...`
- `golangci-lint run handlers/privateforum/... handlers/forum/...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68985ab379c4832fbd9a25b157ed65be