### PR TITLE
Include writings in monthly usage stats

### DIFF
--- a/core/templates/site/admin/usageStatsPage.gohtml
+++ b/core/templates/site/admin/usageStatsPage.gohtml
@@ -83,9 +83,9 @@
 
 <h3>Monthly Usage (from {{ .StartYear }})</h3>
 <table border="1">
-    <tr><th>Year</th><th>Month</th><th>Blogs</th><th>News</th><th>Comments</th><th>Images</th><th>Links</th></tr>
+    <tr><th>Year</th><th>Month</th><th>Blogs</th><th>News</th><th>Comments</th><th>Images</th><th>Links</th><th>Writings</th></tr>
     {{- range .Monthly }}
-    <tr><td>{{ .Year }}</td><td>{{ .Month }}</td><td>{{ .Blogs }}</td><td>{{ .News }}</td><td>{{ .Comments }}</td><td>{{ .Images }}</td><td>{{ .Links }}</td></tr>
+    <tr><td>{{ .Year }}</td><td>{{ .Month }}</td><td>{{ .Blogs }}</td><td>{{ .News }}</td><td>{{ .Comments }}</td><td>{{ .Images }}</td><td>{{ .Links }}</td><td>{{ .Writings }}</td></tr>
     {{- end }}
 </table>
 

--- a/internal/db/queries_dynamic.go
+++ b/internal/db/queries_dynamic.go
@@ -122,6 +122,7 @@ type MonthlyUsageRow struct {
 	Comments int64
 	Images   int64
 	Links    int64
+	Writings int64
 }
 
 // UserMonthlyUsageRow aggregates monthly post counts for a single user.
@@ -196,6 +197,7 @@ func (q *Queries) MonthlyUsageCounts(ctx context.Context, startYear int32) ([]*M
 		{"comments", "written", func(r *MonthlyUsageRow, n int64) { r.Comments = n }},
 		{"imagepost", "posted", func(r *MonthlyUsageRow, n int64) { r.Images = n }},
 		{"linker", "listed", func(r *MonthlyUsageRow, n int64) { r.Links = n }},
+		{"writing", "published", func(r *MonthlyUsageRow, n int64) { r.Writings = n }},
 	}
 
 	data := make(map[[2]int32]*MonthlyUsageRow)

--- a/internal/db/usage_counts_test.go
+++ b/internal/db/usage_counts_test.go
@@ -1,0 +1,51 @@
+package db
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// TestMonthlyUsageCounts ensures that writing statistics are included in the
+// monthly usage aggregation.
+func TestMonthlyUsageCounts(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	queries := New(sqlDB)
+
+	startYear := int32(2024)
+	expect := func(table, column string) {
+		q := "SELECT YEAR(" + column + "), MONTH(" + column + "), COUNT(*) FROM " + table + " WHERE YEAR(" + column + ") >= ? GROUP BY YEAR(" + column + "), MONTH(" + column + ")"
+		rows := sqlmock.NewRows([]string{"year", "month", "count"}).AddRow(int32(2024), int32(1), int64(1))
+		mock.ExpectQuery(regexp.QuoteMeta(q)).
+			WithArgs(startYear).
+			WillReturnRows(rows)
+	}
+
+	expect("blogs", "written")
+	expect("site_news", "occurred")
+	expect("comments", "written")
+	expect("imagepost", "posted")
+	expect("linker", "listed")
+	expect("writing", "published")
+
+	rows, err := queries.MonthlyUsageCounts(context.Background(), startYear)
+	if err != nil {
+		t.Fatalf("MonthlyUsageCounts: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].Writings != 1 {
+		t.Fatalf("expected writings=1, got %d", rows[0].Writings)
+	}
+}


### PR DESCRIPTION
## Summary
- track monthly writing publication counts
- show writing stats on admin usage page
- test monthly usage aggregation includes writings

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./internal/db -run TestMonthlyUsageCounts -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68987cd87288832fa094dd0f0a15c406