### PR TITLE
Display thread counts by forum handler on admin usage page

### DIFF
--- a/core/templates/site/admin/usageStatsPage.gohtml
+++ b/core/templates/site/admin/usageStatsPage.gohtml
@@ -11,13 +11,22 @@
 
 <h3>Threads per Forum Topic</h3>
 <table border="1">
-    <tr><th>ID</th><th>Topic</th><th>Threads</th></tr>
+    <tr><th>ID</th><th>Topic</th><th>Handler</th><th>Threads</th></tr>
     {{- range .ForumTopics }}
     <tr>
         <td><a href="/admin/forum/topics/topic/{{ .Idforumtopic }}/edit">{{ .Idforumtopic }}</a></td>
         <td><a href="/forum/topic/{{ .Idforumtopic }}">{{ .Title.String }}</a></td>
+        <td>{{ .Handler }}</td>
         <td>{{ .Count }}</td>
     </tr>
+    {{- end }}
+</table>
+
+<h3>Threads per Forum Handler</h3>
+<table border="1">
+    <tr><th>Handler</th><th>Threads</th></tr>
+    {{- range .ForumHandlers }}
+    <tr><td>{{ .Handler }}</td><td>{{ .Count }}</td></tr>
     {{- end }}
 </table>
 

--- a/handlers/admin/adminUsageStatsPage.go
+++ b/handlers/admin/adminUsageStatsPage.go
@@ -24,6 +24,7 @@ func AdminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
 		Errors            []string
 		ForumTopics       []*db.AdminForumTopicThreadCountsRow
+		ForumHandlers     []*db.AdminForumHandlerThreadCountsRow
 		ForumCategories   []*db.AdminForumCategoryThreadCountsRow
 		WritingCategories []*db.AdminWritingCategoryCountsRow
 		LinkerCategories  []*db.GetLinkerCategoryLinkCountsRow
@@ -74,6 +75,20 @@ func AdminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 			data.ForumTopics = rows
 		} else {
 			addErr("forum topic counts", err)
+		}
+	}()
+
+	log.Print("start forum handler counts")
+	wg.Add(1)
+	go func() {
+		defer func() {
+			log.Print("stop forum handler counts")
+			wg.Done()
+		}()
+		if rows, err := queries.AdminForumHandlerThreadCounts(ctx); err == nil {
+			data.ForumHandlers = rows
+		} else {
+			addErr("forum handler counts", err)
 		}
 	}()
 

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -69,6 +69,7 @@ type Querier interface {
 	// admin task
 	AdminDemoteAnnouncement(ctx context.Context, id int32) error
 	AdminForumCategoryThreadCounts(ctx context.Context) ([]*AdminForumCategoryThreadCountsRow, error)
+	AdminForumHandlerThreadCounts(ctx context.Context) ([]*AdminForumHandlerThreadCountsRow, error)
 	AdminForumTopicThreadCounts(ctx context.Context) ([]*AdminForumTopicThreadCountsRow, error)
 	AdminGetAllBlogEntriesByUser(ctx context.Context, authorID int32) ([]*AdminGetAllBlogEntriesByUserRow, error)
 	AdminGetAllCommentsByUser(ctx context.Context, userID int32) ([]*AdminGetAllCommentsByUserRow, error)

--- a/internal/db/queries-stats.sql
+++ b/internal/db/queries-stats.sql
@@ -4,10 +4,10 @@ FROM imagepost
 WHERE imageboard_idimageboard = ?;
 
 -- name: AdminForumTopicThreadCounts :many
-SELECT t.idforumtopic, t.title, COUNT(th.idforumthread) AS count
+SELECT t.idforumtopic, t.title, t.handler, COUNT(th.idforumthread) AS count
 FROM forumtopic t
 LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
-GROUP BY t.idforumtopic
+GROUP BY t.idforumtopic, t.title, t.handler
 ORDER BY t.title;
 
 -- name: AdminForumCategoryThreadCounts :many
@@ -17,6 +17,13 @@ LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
 LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
 GROUP BY c.idforumcategory
 ORDER BY c.title;
+
+-- name: AdminForumHandlerThreadCounts :many
+SELECT t.handler, COUNT(th.idforumthread) AS count
+FROM forumtopic t
+LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
+GROUP BY t.handler
+ORDER BY t.handler;
 
 -- name: AdminImageboardPostCounts :many
 SELECT ib.idimageboard, ib.title, COUNT(ip.idimagepost) AS count


### PR DESCRIPTION
## Summary
- track forum thread counts per topic handler and expose via `AdminForumHandlerThreadCounts`
- show handler column for each forum topic and add a handler summary table on `/admin/usage`

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68987cd87288832fa094dd0f0a15c406