### PR TITLE
Move comment reply links to footer

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -336,8 +336,15 @@ tr.unsupported td {
        margin-bottom: 0.2em;
 }
 
-.body {
+.comment .body {
        flex: 1;
+       display: flex;
+       flex-direction: column;
+}
+
+.comment .body footer {
+       margin-top: auto;
+       padding-top: 0.5em;
 }
 
 /* Thread list styles */

--- a/core/templates/site/comment.gohtml
+++ b/core/templates/site/comment.gohtml
@@ -28,12 +28,14 @@
                 </form>
             {{ else }}
                 {{ $cmt.Text.String | a4code2html}}
-                {{ if cd.SelectedThreadCanReply }}
-                    [<a href="?quote={{ $cmt.Idcomments }}&type=full#reply">FULL REPLY</a>]
-                    [<a href="?quote={{ $cmt.Idcomments }}#reply">PARAGRAPH REPLY</a>]
-                {{ end }}
-                {{ if cd.CanEditComment $cmt }}[<a href="{{ cd.CommentEditURL $cmt }}">EDIT</a>]{{ end }}
-                {{ $admin := cd.CommentAdminURL $cmt }}{{ if $admin }}[<a href="{{ $admin }}">ADMIN</a>]{{ end }}
+                <footer>
+                    {{ if cd.SelectedThreadCanReply }}
+                        [<a href="?quote={{ $cmt.Idcomments }}&type=full#bottom">FULL REPLY</a>]
+                        [<a href="?quote={{ $cmt.Idcomments }}#bottom">PARAGRAPH REPLY</a>]
+                    {{ end }}
+                    {{ if cd.CanEditComment $cmt }}[<a href="{{ cd.CommentEditURL $cmt }}">EDIT</a>]{{ end }}
+                    {{ $admin := cd.CommentAdminURL $cmt }}{{ if $admin }}[<a href="{{ $admin }}">ADMIN</a>]{{ end }}
+                </footer>
             {{ end }}
         </section>
     </div>


### PR DESCRIPTION
## Summary
- Render full and paragraph reply links in a footer area for each comment
- Anchor reply links to the bottom of the page for consistent navigation
- Pin comment footers to the bottom of the comment body with flex layout and spacing

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689870cffacc832f9fd6a019f8b92726