### PR TITLE
Add comment counts to admin usage stats

### DIFF
--- a/core/templates/site/admin/usageStatsPage.gohtml
+++ b/core/templates/site/admin/usageStatsPage.gohtml
@@ -11,33 +11,35 @@
 
 <h3>Threads per Forum Topic</h3>
 <table border="1">
-    <tr><th>ID</th><th>Topic</th><th>Handler</th><th>Threads</th></tr>
+    <tr><th>ID</th><th>Topic</th><th>Handler</th><th>Threads</th><th>Comments</th></tr>
     {{- range .ForumTopics }}
     <tr>
         <td><a href="/admin/forum/topics/topic/{{ .Idforumtopic }}/edit">{{ .Idforumtopic }}</a></td>
         <td><a href="/forum/topic/{{ .Idforumtopic }}">{{ .Title.String }}</a></td>
         <td>{{ .Handler }}</td>
-        <td>{{ .Count }}</td>
+        <td>{{ .Threads }}</td>
+        <td>{{ .Comments }}</td>
     </tr>
     {{- end }}
 </table>
 
 <h3>Threads per Forum Handler</h3>
 <table border="1">
-    <tr><th>Handler</th><th>Threads</th></tr>
+    <tr><th>Handler</th><th>Threads</th><th>Comments</th></tr>
     {{- range .ForumHandlers }}
-    <tr><td>{{ .Handler }}</td><td>{{ .Count }}</td></tr>
+    <tr><td>{{ .Handler }}</td><td>{{ .Threads }}</td><td>{{ .Comments }}</td></tr>
     {{- end }}
 </table>
 
 <h3>Threads per Forum Category</h3>
 <table border="1">
-    <tr><th>ID</th><th>Category</th><th>Threads</th></tr>
+    <tr><th>ID</th><th>Category</th><th>Threads</th><th>Comments</th></tr>
     {{- range .ForumCategories }}
     <tr>
         <td><a href="/admin/forum/categories/category/{{ .Idforumcategory }}">{{ .Idforumcategory }}</a></td>
         <td><a href="/forum/category/{{ .Idforumcategory }}">{{ .Title.String }}</a></td>
-        <td>{{ .Count }}</td>
+        <td>{{ .Threads }}</td>
+        <td>{{ .Comments }}</td>
     </tr>
     {{- end }}
 </table>

--- a/handlers/admin/adminUsageStatsPage.go
+++ b/handlers/admin/adminUsageStatsPage.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 
@@ -194,6 +195,19 @@ func AdminUsageStatsPage(w http.ResponseWriter, r *http.Request) {
 
 	log.Print("wait for goroutines")
 	wg.Wait()
+
+	ensureHandler := func(h string) {
+		for _, r := range data.ForumHandlers {
+			if r.Handler == h {
+				return
+			}
+		}
+		data.ForumHandlers = append(data.ForumHandlers, &db.AdminForumHandlerThreadCountsRow{Handler: h, Threads: 0, Comments: 0})
+	}
+	ensureHandler("private")
+	ensureHandler("all")
+	sort.Slice(data.ForumHandlers, func(i, j int) bool { return data.ForumHandlers[i].Handler < data.ForumHandlers[j].Handler })
+
 	log.Print("close error channel")
 	close(errCh)
 	errWG.Wait()

--- a/internal/db/queries-stats.sql
+++ b/internal/db/queries-stats.sql
@@ -4,24 +4,33 @@ FROM imagepost
 WHERE imageboard_idimageboard = ?;
 
 -- name: AdminForumTopicThreadCounts :many
-SELECT t.idforumtopic, t.title, t.handler, COUNT(th.idforumthread) AS count
+SELECT t.idforumtopic, t.title, t.handler,
+       COUNT(DISTINCT th.idforumthread) AS threads,
+       COUNT(c.idcomments) AS comments
 FROM forumtopic t
 LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
+LEFT JOIN comments c ON c.forumthread_idforumthread = th.idforumthread
 GROUP BY t.idforumtopic, t.title, t.handler
 ORDER BY t.title;
 
 -- name: AdminForumCategoryThreadCounts :many
-SELECT c.idforumcategory, c.title, COUNT(th.idforumthread) AS count
+SELECT c.idforumcategory, c.title,
+       COUNT(DISTINCT th.idforumthread) AS threads,
+       COUNT(cm.idcomments) AS comments
 FROM forumcategory c
 LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
 LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
+LEFT JOIN comments cm ON cm.forumthread_idforumthread = th.idforumthread
 GROUP BY c.idforumcategory
 ORDER BY c.title;
 
 -- name: AdminForumHandlerThreadCounts :many
-SELECT t.handler, COUNT(th.idforumthread) AS count
+SELECT t.handler,
+       COUNT(DISTINCT th.idforumthread) AS threads,
+       COUNT(c.idcomments) AS comments
 FROM forumtopic t
 LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
+LEFT JOIN comments c ON c.forumthread_idforumthread = th.idforumthread
 GROUP BY t.handler
 ORDER BY t.handler;
 


### PR DESCRIPTION
## Summary
- Track both thread and comment totals for forum topics, handlers and categories
- Always show "private" and "all" forum handler sections in the admin usage stats
- Display comment counts in the admin usage stats page

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68988481df3c832f829886a09f15212f