### PR TITLE
Fix forum stats comments join to match schema

### DIFF
--- a/internal/db/queries-stats.sql
+++ b/internal/db/queries-stats.sql
@@ -9,7 +9,7 @@ SELECT t.idforumtopic, t.title, t.handler,
        COUNT(c.idcomments) AS comments
 FROM forumtopic t
 LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN comments c ON c.forumthread_idforumthread = th.idforumthread
+LEFT JOIN comments c ON c.forumthread_id = th.idforumthread
 GROUP BY t.idforumtopic, t.title, t.handler
 ORDER BY t.title;
 
@@ -20,7 +20,7 @@ SELECT c.idforumcategory, c.title,
 FROM forumcategory c
 LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
 LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN comments cm ON cm.forumthread_idforumthread = th.idforumthread
+LEFT JOIN comments cm ON cm.forumthread_id = th.idforumthread
 GROUP BY c.idforumcategory
 ORDER BY c.title;
 
@@ -30,7 +30,7 @@ SELECT t.handler,
        COUNT(c.idcomments) AS comments
 FROM forumtopic t
 LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN comments c ON c.forumthread_idforumthread = th.idforumthread
+LEFT JOIN comments c ON c.forumthread_id = th.idforumthread
 GROUP BY t.handler
 ORDER BY t.handler;
 

--- a/internal/db/queries-stats.sql.go
+++ b/internal/db/queries-stats.sql.go
@@ -62,7 +62,7 @@ SELECT c.idforumcategory, c.title,
 FROM forumcategory c
 LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
 LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN comments cm ON cm.forumthread_idforumthread = th.idforumthread
+LEFT JOIN comments cm ON cm.forumthread_id = th.idforumthread
 GROUP BY c.idforumcategory
 ORDER BY c.title
 `
@@ -108,7 +108,7 @@ SELECT t.handler,
        COUNT(c.idcomments) AS comments
 FROM forumtopic t
 LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN comments c ON c.forumthread_idforumthread = th.idforumthread
+LEFT JOIN comments c ON c.forumthread_id = th.idforumthread
 GROUP BY t.handler
 ORDER BY t.handler
 `
@@ -148,7 +148,7 @@ SELECT t.idforumtopic, t.title, t.handler,
        COUNT(c.idcomments) AS comments
 FROM forumtopic t
 LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN comments c ON c.forumthread_idforumthread = th.idforumthread
+LEFT JOIN comments c ON c.forumthread_id = th.idforumthread
 GROUP BY t.idforumtopic, t.title, t.handler
 ORDER BY t.title
 `


### PR DESCRIPTION
## Summary
- use `comments.forumthread_id` in forum stats joins
- regenerate sqlc bindings

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689889d14dd4832fbc3a82bf920b202f