### PR TITLE
Rename FAQ keys to generic ids

### DIFF
--- a/cmd/goa4web/faq_read.go
+++ b/cmd/goa4web/faq_read.go
@@ -48,7 +48,7 @@ func (c *faqReadCmd) Run() error {
 		return fmt.Errorf("get faq: %w", err)
 	}
 	for _, q := range rows {
-		if int(q.Idfaq) == c.ID {
+		if int(q.ID) == c.ID {
 			fmt.Printf("Q: %s\n", q.Question.String)
 			fmt.Printf("A: %s\n", q.Answer.String)
 			return nil

--- a/cmd/goa4web/faq_tree.go
+++ b/cmd/goa4web/faq_tree.go
@@ -38,11 +38,11 @@ func (c *faqTreeCmd) Run() error {
 	}
 	var lastCat int32 = -1
 	for _, r := range rows {
-		if r.Idfaqcategories.Valid && r.Idfaqcategories.Int32 != lastCat {
-			fmt.Printf("%d\t%s\n", r.Idfaqcategories.Int32, r.Name.String)
-			lastCat = r.Idfaqcategories.Int32
+		if r.CategoryID.Valid && r.CategoryID.Int32 != lastCat {
+			fmt.Printf("%d\t%s\n", r.CategoryID.Int32, r.Name.String)
+			lastCat = r.CategoryID.Int32
 		}
-		fmt.Printf("  %d\t%s\n", r.Idfaq, r.Question.String)
+		fmt.Printf("  %d\t%s\n", r.FaqID, r.Question.String)
 	}
 	return nil
 }

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1705,7 +1705,7 @@ func (cd *CoreData) SelectedQuestionFromCategory(questionID, categoryID int32) e
 	if err != nil {
 		return err
 	}
-	if !question.FaqcategoriesIdfaqcategories.Valid || question.FaqcategoriesIdfaqcategories.Int32 != categoryID {
+	if !question.FaqCategoryID.Valid || question.FaqCategoryID.Int32 != categoryID {
 		return fmt.Errorf("question %d not in category %d", questionID, categoryID)
 	}
 	return cd.queries.AdminDeleteFAQ(cd.ctx, questionID)
@@ -1718,10 +1718,10 @@ func (cd *CoreData) UpdateFAQQuestion(question, answer string, categoryID, faqID
 		return nil
 	}
 	if err := cd.queries.AdminUpdateFAQQuestionAnswer(cd.ctx, db.AdminUpdateFAQQuestionAnswerParams{
-		Answer:                       sql.NullString{String: answer, Valid: true},
-		Question:                     sql.NullString{String: question, Valid: true},
-		FaqcategoriesIdfaqcategories: sql.NullInt32{Int32: categoryID, Valid: categoryID != 0},
-		Idfaq:                        faqID,
+		Answer:        sql.NullString{String: answer, Valid: true},
+		Question:      sql.NullString{String: question, Valid: true},
+		FaqCategoryID: sql.NullInt32{Int32: categoryID, Valid: categoryID != 0},
+		ID:            faqID,
 	}); err != nil {
 		return err
 	}

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -394,9 +394,9 @@ func TestSelectedQuestionFromCategory(t *testing.T) {
 	ctx := context.Background()
 	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
 
-	row := sqlmock.NewRows([]string{"idfaq", "faqcategories_idfaqcategories", "language_idlanguage", "users_idusers", "answer", "question"}).
+	row := sqlmock.NewRows([]string{"id", "faq_category_id", "language_idlanguage", "users_idusers", "answer", "question"}).
 		AddRow(1, 2, 0, 0, sql.NullString{}, sql.NullString{})
-	mock.ExpectQuery("SELECT idfaq, faqcategories_idfaqcategories").WithArgs(int32(1)).WillReturnRows(row)
+	mock.ExpectQuery("SELECT id, faq_category_id").WithArgs(int32(1)).WillReturnRows(row)
 	mock.ExpectExec("UPDATE faq SET deleted_at").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	if err := cd.SelectedQuestionFromCategory(1, 2); err != nil {
@@ -419,9 +419,9 @@ func TestSelectedQuestionFromCategoryWrongCategory(t *testing.T) {
 	ctx := context.Background()
 	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
 
-	row := sqlmock.NewRows([]string{"idfaq", "faqcategories_idfaqcategories", "language_idlanguage", "users_idusers", "answer", "question"}).
+	row := sqlmock.NewRows([]string{"id", "faq_category_id", "language_idlanguage", "users_idusers", "answer", "question"}).
 		AddRow(1, 3, 0, 0, sql.NullString{}, sql.NullString{})
-	mock.ExpectQuery("SELECT idfaq, faqcategories_idfaqcategories").WithArgs(int32(1)).WillReturnRows(row)
+	mock.ExpectQuery("SELECT id, faq_category_id").WithArgs(int32(1)).WillReturnRows(row)
 
 	if err := cd.SelectedQuestionFromCategory(1, 2); err == nil {
 		t.Fatalf("expected error")

--- a/core/common/faq.go
+++ b/core/common/faq.go
@@ -44,19 +44,19 @@ func (cd *CoreData) AllAnsweredFAQ() ([]*CategoryFAQs, error) {
 			current CategoryFAQs
 		)
 		for _, row := range faqRows {
-			if current.Category == nil || current.Category.Idfaqcategories.Int32 != row.Idfaqcategories.Int32 {
-				if current.Category != nil && current.Category.Idfaqcategories.Int32 != 0 {
+			if current.Category == nil || current.Category.CategoryID.Int32 != row.CategoryID.Int32 {
+				if current.Category != nil && current.Category.CategoryID.Int32 != 0 {
 					result = append(result, &current)
 				}
 				current = CategoryFAQs{Category: row}
 			}
 			current.FAQs = append(current.FAQs, &FAQ{
-				CategoryID: int(row.Idfaqcategories.Int32),
+				CategoryID: int(row.CategoryID.Int32),
 				Question:   row.Question.String,
 				Answer:     row.Answer.String,
 			})
 		}
-		if current.Category != nil && current.Category.Idfaqcategories.Int32 != 0 {
+		if current.Category != nil && current.Category.CategoryID.Int32 != 0 {
 			result = append(result, &current)
 		}
 		return result, nil
@@ -69,8 +69,8 @@ func (cd *CoreData) RenameFAQCategory(id int32, name string) error {
 		return nil
 	}
 	return cd.queries.AdminRenameFAQCategory(cd.ctx, db.AdminRenameFAQCategoryParams{
-		Name:            sql.NullString{String: name, Valid: true},
-		Idfaqcategories: id,
+		Name: sql.NullString{String: name, Valid: true},
+		ID:   id,
 	})
 }
 

--- a/core/templates/site/faq/adminFaqRevisionPage.gohtml
+++ b/core/templates/site/faq/adminFaqRevisionPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-<h4>Revision History for FAQ {{ .Faq.Idfaq }}</h4>
+<h4>Revision History for FAQ {{ .Faq.ID }}</h4>
 <table>
 <tr><th>Date</th><th>User ID</th><th>Question</th><th>Answer</th></tr>
 {{- range .Revisions }}

--- a/core/templates/site/faq/adminQuestionEditPage.gohtml
+++ b/core/templates/site/faq/adminQuestionEditPage.gohtml
@@ -1,18 +1,18 @@
 {{ template "head" $ }}
-<h4>{{ if eq .Faq.Idfaq 0 }}Create FAQ Entry{{ else }}Edit FAQ Entry{{ end }}</h4>
+<h4>{{ if eq .Faq.ID 0 }}Create FAQ Entry{{ else }}Edit FAQ Entry{{ end }}</h4>
 <form method="post" action="/admin/faq/questions">
 {{ csrfField }}
 <textarea name="question" cols="80" rows="15">{{ .Faq.Question.String }}</textarea><br>
 <textarea name="answer" cols="80" rows="15">{{ .Faq.Answer.String }}</textarea><br>
 <select name="category">
     <option value="0">Hidden</option>
-    {{$cat := .Faq.FaqcategoriesIdfaqcategories.Int32}}
+    {{$cat := .Faq.FaqCategoryID.Int32}}
     {{- range .Categories }}
-    <option value="{{ .Idfaqcategories }}" {{if eq $cat .Idfaqcategories}}selected{{end}}>{{ .Name.String }}</option>
+    <option value="{{ .ID }}" {{if eq $cat .ID}}selected{{end}}>{{ .Name.String }}</option>
     {{- end }}
 </select><br>
-<input type="hidden" name="faq" value="{{ .Faq.Idfaq }}">
-{{ if eq .Faq.Idfaq 0 }}
+<input type="hidden" name="faq" value="{{ .Faq.ID }}">
+{{ if eq .Faq.ID 0 }}
 <input type="submit" name="task" value="Create">
 {{ else }}
 <input type="submit" name="task" value="Edit">

--- a/core/templates/site/faq/adminQuestionTable.gohtml
+++ b/core/templates/site/faq/adminQuestionTable.gohtml
@@ -4,13 +4,13 @@
 {{- range .Rows }}
 <tr>
     <td>{{ .Question.String }}</td>
-    <td>{{ $cat := .FaqcategoriesIdfaqcategories.Int32 }}{{ range $.Categories }}{{ if eq $cat .Idfaqcategories }}{{ .Name.String }}{{ end }}{{ end }}</td>
+    <td>{{ $cat := .FaqCategoryID.Int32 }}{{ range $.Categories }}{{ if eq $cat .ID }}{{ .Name.String }}{{ end }}{{ end }}</td>
     <td>
-        <a href="/admin/faq/question/{{ .Idfaq }}/edit">Edit</a> |
-        <a href="/admin/faq/revisions/{{ .Idfaq }}">History</a>
+        <a href="/admin/faq/question/{{ .ID }}/edit">Edit</a> |
+        <a href="/admin/faq/revisions/{{ .ID }}">History</a>
         <form method="post" action="" style="display:inline;">
             {{ csrfField }}
-            <input type="hidden" name="faq" value="{{ .Idfaq }}">
+            <input type="hidden" name="faq" value="{{ .ID }}">
             <input type="submit" name="task" value="Remove">
         </form>
     </td>

--- a/core/templates/site/faq/askPage.gohtml
+++ b/core/templates/site/faq/askPage.gohtml
@@ -6,7 +6,7 @@
             Please select a category:
             <select name="category">
                 {{- range (cd).FAQCategories }}
-                    <option value="{{ .Idfaqcategories }}">{{ .Name.String }}</option>
+                    <option value="{{ .ID }}">{{ .Name.String }}</option>
                 {{- else }}
                     <option disabled>No categories</option>
                 {{- end }}

--- a/core/templates/site/faq/faqAdminCategoriesPage.gohtml
+++ b/core/templates/site/faq/faqAdminCategoriesPage.gohtml
@@ -7,7 +7,7 @@
     </tr>
     {{- range .Rows }}
     <tr>
-        <td><a href="/admin/faq/categories/category/{{ .Idfaqcategories }}">{{ .Idfaqcategories }}</a></td>
+        <td><a href="/admin/faq/categories/category/{{ .ID }}">{{ .ID }}</a></td>
         <td>{{ .Name.String }}</td>
         <td>{{ .Questioncount }}</td>
     </tr>

--- a/core/templates/site/faq/faqAdminCategoryEditPage.gohtml
+++ b/core/templates/site/faq/faqAdminCategoryEditPage.gohtml
@@ -2,7 +2,7 @@
 <h1>Edit Category</h1>
 <form method="post" action="/admin/faq/categories">
 {{ csrfField }}
-<input type="hidden" name="cid" value="{{ .Category.Idfaqcategories }}">
+<input type="hidden" name="cid" value="{{ .Category.ID }}">
 <input name="cname" value="{{ .Category.Name.String }}">
 <p>
     <input type="submit" name="task" value="Rename Category">

--- a/core/templates/site/faq/faqAdminCategoryPage.gohtml
+++ b/core/templates/site/faq/faqAdminCategoryPage.gohtml
@@ -1,8 +1,8 @@
 {{ template "head" $ }}
 <h1>{{ .Category.Name.String }}</h1>
 <p>Question count: {{ .Category.Questioncount }}</p>
-<p><a href="/admin/faq/categories/category/{{ .Category.Idfaqcategories }}/edit">Edit Category</a></p>
-<p><a href="/admin/faq/categories/category/{{ .Category.Idfaqcategories }}/questions">View Questions</a></p>
+<p><a href="/admin/faq/categories/category/{{ .Category.ID }}/edit">Edit Category</a></p>
+<p><a href="/admin/faq/categories/category/{{ .Category.ID }}/questions">View Questions</a></p>
 {{- if .Latest }}
 <h2>Latest Questions</h2>
 <ul>

--- a/core/templates/site/faq/faqAdminCategoryQuestionsPage.gohtml
+++ b/core/templates/site/faq/faqAdminCategoryQuestionsPage.gohtml
@@ -8,9 +8,9 @@
     </tr>
     {{- range .Questions }}
     <tr>
-        <td>{{ .Idfaq }}</td>
+        <td>{{ .ID }}</td>
         <td>{{ .Question }}</td>
-        <td><a href="/admin/faq/question/{{ .Idfaq }}/edit">Edit</a></td>
+        <td><a href="/admin/faq/question/{{ .ID }}/edit">Edit</a></td>
     </tr>
     {{- end }}
 </table>

--- a/handlers/admin/role_grants.go
+++ b/handlers/admin/role_grants.go
@@ -194,7 +194,7 @@ func buildGrantGroupsFromGrants(ctx context.Context, cd *common.CoreData, grants
 					if w, err := queries.GetWritingForListerByID(ctx, db.GetWritingForListerByIDParams{ListerID: cd.UserID, Idwriting: g.ItemID.Int32, ListerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0}}); err == nil {
 						if w.Title.Valid {
 							info := w.Title.String
-                                                        if name, ok := langMap[w.LanguageIdlanguage.Int32]; ok && name != "" {
+							if name, ok := langMap[w.LanguageIdlanguage.Int32]; ok && name != "" {
 								info = fmt.Sprintf("[%s] %s", name, info)
 							}
 							gi.Info = info
@@ -206,7 +206,7 @@ func buildGrantGroupsFromGrants(ctx context.Context, cd *common.CoreData, grants
 				case "category":
 					if cats, err := queries.AdminGetFAQCategories(ctx); err == nil {
 						for _, c := range cats {
-							if c.Idfaqcategories == g.ItemID.Int32 {
+							if c.ID == g.ItemID.Int32 {
 								if c.Name.Valid {
 									gi.Info = c.Name.String
 								}

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 60
+	ExpectedSchemaVersion = 61
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/handlers/faq/admin_edit_question_page.go
+++ b/handlers/faq/admin_edit_question_page.go
@@ -40,7 +40,7 @@ func AdminEditQuestionPage(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		faq = &db.Faq{Idfaq: 0}
+		faq = &db.Faq{ID: 0}
 	}
 	cats, _ := queries.AdminGetFAQCategories(r.Context())
 	type Data struct {

--- a/internal/db/global_permissions_test.go
+++ b/internal/db/global_permissions_test.go
@@ -15,7 +15,7 @@ func TestGlobalGrantsNews(t *testing.T) {
 }
 
 func TestGlobalGrantsFAQ(t *testing.T) {
-	if !strings.Contains(getFAQAnsweredQuestions, "g.item_id = faq.idfaq OR g.item_id IS NULL") {
+	if !strings.Contains(getFAQAnsweredQuestions, "g.item_id = faq.id OR g.item_id IS NULL") {
 		t.Errorf("global grant missing in GetFAQAnsweredQuestions")
 	}
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -192,17 +192,17 @@ type ExternalLink struct {
 }
 
 type Faq struct {
-	Idfaq                        int32
-	FaqcategoriesIdfaqcategories sql.NullInt32
-	LanguageIdlanguage           sql.NullInt32
-	UsersIdusers                 int32
-	Answer                       sql.NullString
-	Question                     sql.NullString
+	ID                 int32
+	FaqCategoryID      sql.NullInt32
+	LanguageIdlanguage sql.NullInt32
+	UsersIdusers       int32
+	Answer             sql.NullString
+	Question           sql.NullString
 }
 
 type FaqCategory struct {
-	Idfaqcategories int32
-	Name            sql.NullString
+	ID   int32
+	Name sql.NullString
 }
 
 type FaqRevision struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -41,8 +41,8 @@ type Querier interface {
 	AdminCreateLinkerItem(ctx context.Context, arg AdminCreateLinkerItemParams) error
 	AdminDeleteExternalLink(ctx context.Context, id int32) error
 	AdminDeleteExternalLinkByURL(ctx context.Context, url string) error
-	AdminDeleteFAQ(ctx context.Context, idfaq int32) error
-	AdminDeleteFAQCategory(ctx context.Context, idfaqcategories int32) error
+	AdminDeleteFAQ(ctx context.Context, id int32) error
+	AdminDeleteFAQCategory(ctx context.Context, id int32) error
 	AdminDeleteForumCategory(ctx context.Context, idforumcategory int32) error
 	AdminDeleteForumThread(ctx context.Context, idforumthread int32) error
 	// Removes a forum topic by ID.
@@ -75,12 +75,12 @@ type Querier interface {
 	AdminGetAllCommentsByUser(ctx context.Context, userID int32) ([]*AdminGetAllCommentsByUserRow, error)
 	AdminGetAllWritingsByAuthor(ctx context.Context, authorID int32) ([]*AdminGetAllWritingsByAuthorRow, error)
 	AdminGetDashboardStats(ctx context.Context) (*AdminGetDashboardStatsRow, error)
-	AdminGetFAQByID(ctx context.Context, idfaq int32) (*Faq, error)
+	AdminGetFAQByID(ctx context.Context, id int32) (*Faq, error)
 	AdminGetFAQCategories(ctx context.Context) ([]*FaqCategory, error)
 	AdminGetFAQCategoriesWithQuestionCount(ctx context.Context) ([]*AdminGetFAQCategoriesWithQuestionCountRow, error)
-	AdminGetFAQCategoryWithQuestionCountByID(ctx context.Context, idfaqcategories int32) (*AdminGetFAQCategoryWithQuestionCountByIDRow, error)
+	AdminGetFAQCategoryWithQuestionCountByID(ctx context.Context, id int32) (*AdminGetFAQCategoryWithQuestionCountByIDRow, error)
 	AdminGetFAQDismissedQuestions(ctx context.Context) ([]*Faq, error)
-	AdminGetFAQQuestionsByCategory(ctx context.Context, faqcategoriesIdfaqcategories sql.NullInt32) ([]*Faq, error)
+	AdminGetFAQQuestionsByCategory(ctx context.Context, faqCategoryID sql.NullInt32) ([]*Faq, error)
 	AdminGetFAQUnansweredQuestions(ctx context.Context) ([]*Faq, error)
 	AdminGetForumStats(ctx context.Context) (*AdminGetForumStatsRow, error)
 	AdminGetImagePost(ctx context.Context, idimagepost int32) (*AdminGetImagePostRow, error)

--- a/internal/db/queries-faq.sql.go
+++ b/internal/db/queries-faq.sql.go
@@ -21,34 +21,34 @@ func (q *Queries) AdminCreateFAQCategory(ctx context.Context, name sql.NullStrin
 
 const adminDeleteFAQ = `-- name: AdminDeleteFAQ :exec
 UPDATE faq SET deleted_at = NOW()
-WHERE idfaq = ?
+WHERE id = ?
 `
 
-func (q *Queries) AdminDeleteFAQ(ctx context.Context, idfaq int32) error {
-	_, err := q.db.ExecContext(ctx, adminDeleteFAQ, idfaq)
+func (q *Queries) AdminDeleteFAQ(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, adminDeleteFAQ, id)
 	return err
 }
 
 const adminDeleteFAQCategory = `-- name: AdminDeleteFAQCategory :exec
 UPDATE faq_categories SET deleted_at = NOW()
-WHERE idfaqCategories = ?
+WHERE id = ?
 `
 
-func (q *Queries) AdminDeleteFAQCategory(ctx context.Context, idfaqcategories int32) error {
-	_, err := q.db.ExecContext(ctx, adminDeleteFAQCategory, idfaqcategories)
+func (q *Queries) AdminDeleteFAQCategory(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, adminDeleteFAQCategory, id)
 	return err
 }
 
 const adminGetFAQByID = `-- name: AdminGetFAQByID :one
-SELECT idfaq, faqcategories_idfaqcategories, language_idlanguage, users_idusers, answer, question FROM faq WHERE idfaq = ?
+SELECT id, faq_category_id, language_idlanguage, users_idusers, answer, question FROM faq WHERE id = ?
 `
 
-func (q *Queries) AdminGetFAQByID(ctx context.Context, idfaq int32) (*Faq, error) {
-	row := q.db.QueryRowContext(ctx, adminGetFAQByID, idfaq)
+func (q *Queries) AdminGetFAQByID(ctx context.Context, id int32) (*Faq, error) {
+	row := q.db.QueryRowContext(ctx, adminGetFAQByID, id)
 	var i Faq
 	err := row.Scan(
-		&i.Idfaq,
-		&i.FaqcategoriesIdfaqcategories,
+		&i.ID,
+		&i.FaqCategoryID,
 		&i.LanguageIdlanguage,
 		&i.UsersIdusers,
 		&i.Answer,
@@ -58,7 +58,7 @@ func (q *Queries) AdminGetFAQByID(ctx context.Context, idfaq int32) (*Faq, error
 }
 
 const adminGetFAQCategories = `-- name: AdminGetFAQCategories :many
-SELECT idfaqcategories, name
+SELECT id, name
 FROM faq_categories
 `
 
@@ -71,7 +71,7 @@ func (q *Queries) AdminGetFAQCategories(ctx context.Context) ([]*FaqCategory, er
 	var items []*FaqCategory
 	for rows.Next() {
 		var i FaqCategory
-		if err := rows.Scan(&i.Idfaqcategories, &i.Name); err != nil {
+		if err := rows.Scan(&i.ID, &i.Name); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -86,16 +86,16 @@ func (q *Queries) AdminGetFAQCategories(ctx context.Context) ([]*FaqCategory, er
 }
 
 const adminGetFAQCategoriesWithQuestionCount = `-- name: AdminGetFAQCategoriesWithQuestionCount :many
-SELECT c.idfaqcategories, c.name, COUNT(f.idfaq) AS QuestionCount
+SELECT c.id, c.name, COUNT(f.id) AS QuestionCount
 FROM faq_categories c
-LEFT JOIN faq f ON f.faqCategories_idfaqCategories = c.idfaqCategories
-GROUP BY c.idfaqCategories
+LEFT JOIN faq f ON f.faq_category_id = c.id
+GROUP BY c.id
 `
 
 type AdminGetFAQCategoriesWithQuestionCountRow struct {
-	Idfaqcategories int32
-	Name            sql.NullString
-	Questioncount   int64
+	ID            int32
+	Name          sql.NullString
+	Questioncount int64
 }
 
 func (q *Queries) AdminGetFAQCategoriesWithQuestionCount(ctx context.Context) ([]*AdminGetFAQCategoriesWithQuestionCountRow, error) {
@@ -107,7 +107,7 @@ func (q *Queries) AdminGetFAQCategoriesWithQuestionCount(ctx context.Context) ([
 	var items []*AdminGetFAQCategoriesWithQuestionCountRow
 	for rows.Next() {
 		var i AdminGetFAQCategoriesWithQuestionCountRow
-		if err := rows.Scan(&i.Idfaqcategories, &i.Name, &i.Questioncount); err != nil {
+		if err := rows.Scan(&i.ID, &i.Name, &i.Questioncount); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -122,28 +122,28 @@ func (q *Queries) AdminGetFAQCategoriesWithQuestionCount(ctx context.Context) ([
 }
 
 const adminGetFAQCategoryWithQuestionCountByID = `-- name: AdminGetFAQCategoryWithQuestionCountByID :one
-SELECT c.idfaqcategories, c.name, COUNT(f.idfaq) AS QuestionCount
+SELECT c.id, c.name, COUNT(f.id) AS QuestionCount
 FROM faq_categories c
-LEFT JOIN faq f ON f.faqCategories_idfaqCategories = c.idfaqCategories
-WHERE c.idfaqCategories = ?
-GROUP BY c.idfaqCategories
+LEFT JOIN faq f ON f.faq_category_id = c.id
+WHERE c.id = ?
+GROUP BY c.id
 `
 
 type AdminGetFAQCategoryWithQuestionCountByIDRow struct {
-	Idfaqcategories int32
-	Name            sql.NullString
-	Questioncount   int64
+	ID            int32
+	Name          sql.NullString
+	Questioncount int64
 }
 
-func (q *Queries) AdminGetFAQCategoryWithQuestionCountByID(ctx context.Context, idfaqcategories int32) (*AdminGetFAQCategoryWithQuestionCountByIDRow, error) {
-	row := q.db.QueryRowContext(ctx, adminGetFAQCategoryWithQuestionCountByID, idfaqcategories)
+func (q *Queries) AdminGetFAQCategoryWithQuestionCountByID(ctx context.Context, id int32) (*AdminGetFAQCategoryWithQuestionCountByIDRow, error) {
+	row := q.db.QueryRowContext(ctx, adminGetFAQCategoryWithQuestionCountByID, id)
 	var i AdminGetFAQCategoryWithQuestionCountByIDRow
-	err := row.Scan(&i.Idfaqcategories, &i.Name, &i.Questioncount)
+	err := row.Scan(&i.ID, &i.Name, &i.Questioncount)
 	return &i, err
 }
 
 const adminGetFAQDismissedQuestions = `-- name: AdminGetFAQDismissedQuestions :many
-SELECT idfaq, faqCategories_idfaqCategories, language_idlanguage, users_idusers, answer, question
+SELECT id, faq_category_id, language_idlanguage, users_idusers, answer, question
 FROM faq
 WHERE deleted_at IS NOT NULL
 `
@@ -158,8 +158,8 @@ func (q *Queries) AdminGetFAQDismissedQuestions(ctx context.Context) ([]*Faq, er
 	for rows.Next() {
 		var i Faq
 		if err := rows.Scan(
-			&i.Idfaq,
-			&i.FaqcategoriesIdfaqcategories,
+			&i.ID,
+			&i.FaqCategoryID,
 			&i.LanguageIdlanguage,
 			&i.UsersIdusers,
 			&i.Answer,
@@ -179,11 +179,11 @@ func (q *Queries) AdminGetFAQDismissedQuestions(ctx context.Context) ([]*Faq, er
 }
 
 const adminGetFAQQuestionsByCategory = `-- name: AdminGetFAQQuestionsByCategory :many
-SELECT idfaq, faqcategories_idfaqcategories, language_idlanguage, users_idusers, answer, question FROM faq WHERE faqCategories_idfaqCategories = ?
+SELECT id, faq_category_id, language_idlanguage, users_idusers, answer, question FROM faq WHERE faq_category_id = ?
 `
 
-func (q *Queries) AdminGetFAQQuestionsByCategory(ctx context.Context, faqcategoriesIdfaqcategories sql.NullInt32) ([]*Faq, error) {
-	rows, err := q.db.QueryContext(ctx, adminGetFAQQuestionsByCategory, faqcategoriesIdfaqcategories)
+func (q *Queries) AdminGetFAQQuestionsByCategory(ctx context.Context, faqCategoryID sql.NullInt32) ([]*Faq, error) {
+	rows, err := q.db.QueryContext(ctx, adminGetFAQQuestionsByCategory, faqCategoryID)
 	if err != nil {
 		return nil, err
 	}
@@ -192,8 +192,8 @@ func (q *Queries) AdminGetFAQQuestionsByCategory(ctx context.Context, faqcategor
 	for rows.Next() {
 		var i Faq
 		if err := rows.Scan(
-			&i.Idfaq,
-			&i.FaqcategoriesIdfaqcategories,
+			&i.ID,
+			&i.FaqCategoryID,
 			&i.LanguageIdlanguage,
 			&i.UsersIdusers,
 			&i.Answer,
@@ -213,9 +213,9 @@ func (q *Queries) AdminGetFAQQuestionsByCategory(ctx context.Context, faqcategor
 }
 
 const adminGetFAQUnansweredQuestions = `-- name: AdminGetFAQUnansweredQuestions :many
-SELECT idfaq, faqcategories_idfaqcategories, language_idlanguage, users_idusers, answer, question
+SELECT id, faq_category_id, language_idlanguage, users_idusers, answer, question
 FROM faq
-WHERE faqCategories_idfaqCategories IS NULL OR answer IS NULL
+WHERE faq_category_id IS NULL OR answer IS NULL
 `
 
 func (q *Queries) AdminGetFAQUnansweredQuestions(ctx context.Context) ([]*Faq, error) {
@@ -228,8 +228,8 @@ func (q *Queries) AdminGetFAQUnansweredQuestions(ctx context.Context) ([]*Faq, e
 	for rows.Next() {
 		var i Faq
 		if err := rows.Scan(
-			&i.Idfaq,
-			&i.FaqcategoriesIdfaqcategories,
+			&i.ID,
+			&i.FaqCategoryID,
 			&i.LanguageIdlanguage,
 			&i.UsersIdusers,
 			&i.Answer,
@@ -251,38 +251,38 @@ func (q *Queries) AdminGetFAQUnansweredQuestions(ctx context.Context) ([]*Faq, e
 const adminRenameFAQCategory = `-- name: AdminRenameFAQCategory :exec
 UPDATE faq_categories
 SET name = ?
-WHERE idfaqCategories = ?
+WHERE id = ?
 `
 
 type AdminRenameFAQCategoryParams struct {
-	Name            sql.NullString
-	Idfaqcategories int32
+	Name sql.NullString
+	ID   int32
 }
 
 func (q *Queries) AdminRenameFAQCategory(ctx context.Context, arg AdminRenameFAQCategoryParams) error {
-	_, err := q.db.ExecContext(ctx, adminRenameFAQCategory, arg.Name, arg.Idfaqcategories)
+	_, err := q.db.ExecContext(ctx, adminRenameFAQCategory, arg.Name, arg.ID)
 	return err
 }
 
 const adminUpdateFAQQuestionAnswer = `-- name: AdminUpdateFAQQuestionAnswer :exec
 UPDATE faq
-SET answer = ?, question = ?, faqCategories_idfaqCategories = ?
-WHERE idfaq = ?
+SET answer = ?, question = ?, faq_category_id = ?
+WHERE id = ?
 `
 
 type AdminUpdateFAQQuestionAnswerParams struct {
-	Answer                       sql.NullString
-	Question                     sql.NullString
-	FaqcategoriesIdfaqcategories sql.NullInt32
-	Idfaq                        int32
+	Answer        sql.NullString
+	Question      sql.NullString
+	FaqCategoryID sql.NullInt32
+	ID            int32
 }
 
 func (q *Queries) AdminUpdateFAQQuestionAnswer(ctx context.Context, arg AdminUpdateFAQQuestionAnswerParams) error {
 	_, err := q.db.ExecContext(ctx, adminUpdateFAQQuestionAnswer,
 		arg.Answer,
 		arg.Question,
-		arg.FaqcategoriesIdfaqcategories,
-		arg.Idfaq,
+		arg.FaqCategoryID,
+		arg.ID,
 	)
 	return err
 }
@@ -325,10 +325,10 @@ const getAllAnsweredFAQWithFAQCategoriesForUser = `-- name: GetAllAnsweredFAQWit
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT c.idfaqCategories, c.name, f.idfaq, f.faqCategories_idfaqCategories, f.language_idlanguage, f.users_idusers, f.answer, f.question
+SELECT c.id AS category_id, c.name, f.id AS faq_id, f.faq_category_id, f.language_idlanguage, f.users_idusers, f.answer, f.question
 FROM faq f
-LEFT JOIN faq_categories c ON c.idfaqCategories = f.faqCategories_idfaqCategories
-WHERE c.idfaqCategories IS NOT NULL
+LEFT JOIN faq_categories c ON c.id = f.faq_category_id
+WHERE c.id IS NOT NULL
   AND f.answer IS NOT NULL
   AND (
       f.language_idlanguage = 0
@@ -348,11 +348,11 @@ WHERE c.idfaqCategories IS NOT NULL
         AND (g.item='question/answer' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = f.idfaq OR g.item_id IS NULL)
+        AND (g.item_id = f.id OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
-ORDER BY c.idfaqCategories, f.idfaq
+ORDER BY c.id, f.id
 `
 
 type GetAllAnsweredFAQWithFAQCategoriesForUserParams struct {
@@ -361,14 +361,14 @@ type GetAllAnsweredFAQWithFAQCategoriesForUserParams struct {
 }
 
 type GetAllAnsweredFAQWithFAQCategoriesForUserRow struct {
-	Idfaqcategories              sql.NullInt32
-	Name                         sql.NullString
-	Idfaq                        int32
-	FaqcategoriesIdfaqcategories sql.NullInt32
-	LanguageIdlanguage           sql.NullInt32
-	UsersIdusers                 int32
-	Answer                       sql.NullString
-	Question                     sql.NullString
+	CategoryID         sql.NullInt32
+	Name               sql.NullString
+	FaqID              int32
+	FaqCategoryID      sql.NullInt32
+	LanguageIdlanguage sql.NullInt32
+	UsersIdusers       int32
+	Answer             sql.NullString
+	Question           sql.NullString
 }
 
 func (q *Queries) GetAllAnsweredFAQWithFAQCategoriesForUser(ctx context.Context, arg GetAllAnsweredFAQWithFAQCategoriesForUserParams) ([]*GetAllAnsweredFAQWithFAQCategoriesForUserRow, error) {
@@ -386,10 +386,10 @@ func (q *Queries) GetAllAnsweredFAQWithFAQCategoriesForUser(ctx context.Context,
 	for rows.Next() {
 		var i GetAllAnsweredFAQWithFAQCategoriesForUserRow
 		if err := rows.Scan(
-			&i.Idfaqcategories,
+			&i.CategoryID,
 			&i.Name,
-			&i.Idfaq,
-			&i.FaqcategoriesIdfaqcategories,
+			&i.FaqID,
+			&i.FaqCategoryID,
 			&i.LanguageIdlanguage,
 			&i.UsersIdusers,
 			&i.Answer,
@@ -412,7 +412,7 @@ const getFAQAnsweredQuestions = `-- name: GetFAQAnsweredQuestions :many
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT idfaq, faqCategories_idfaqCategories, language_idlanguage, users_idusers, answer, question
+SELECT faq.id, faq.faq_category_id, faq.language_idlanguage, faq.users_idusers, faq.answer, faq.question
 FROM faq
 WHERE answer IS NOT NULL
   AND deleted_at IS NULL
@@ -434,7 +434,7 @@ WHERE answer IS NOT NULL
         AND (g.item='question/answer' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = faq.idfaq OR g.item_id IS NULL)
+        AND (g.item_id = faq.id OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -460,8 +460,8 @@ func (q *Queries) GetFAQAnsweredQuestions(ctx context.Context, arg GetFAQAnswere
 	for rows.Next() {
 		var i Faq
 		if err := rows.Scan(
-			&i.Idfaq,
-			&i.FaqcategoriesIdfaqcategories,
+			&i.ID,
+			&i.FaqCategoryID,
 			&i.LanguageIdlanguage,
 			&i.UsersIdusers,
 			&i.Answer,
@@ -484,9 +484,9 @@ const getFAQByID = `-- name: GetFAQByID :one
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT idfaq, faqCategories_idfaqCategories, language_idlanguage, users_idusers, answer, question
+SELECT faq.id, faq.faq_category_id, faq.language_idlanguage, faq.users_idusers, faq.answer, faq.question
 FROM faq
-WHERE idfaq = ?
+WHERE faq.id = ?
   AND deleted_at IS NULL
   AND (
       language_idlanguage = 0
@@ -506,7 +506,7 @@ WHERE idfaq = ?
         AND (g.item='question/answer' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = faq.idfaq OR g.item_id IS NULL)
+        AND (g.item_id = faq.id OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -528,8 +528,8 @@ func (q *Queries) GetFAQByID(ctx context.Context, arg GetFAQByIDParams) (*Faq, e
 	)
 	var i Faq
 	err := row.Scan(
-		&i.Idfaq,
-		&i.FaqcategoriesIdfaqcategories,
+		&i.ID,
+		&i.FaqCategoryID,
 		&i.LanguageIdlanguage,
 		&i.UsersIdusers,
 		&i.Answer,
@@ -542,9 +542,9 @@ const getFAQQuestionsByCategory = `-- name: GetFAQQuestionsByCategory :many
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT idfaq, faqCategories_idfaqCategories, language_idlanguage, users_idusers, answer, question
+SELECT faq.id, faq.faq_category_id, faq.language_idlanguage, faq.users_idusers, faq.answer, faq.question
 FROM faq
-WHERE faqCategories_idfaqCategories = ?
+WHERE faq.faq_category_id = ?
   AND deleted_at IS NULL
   AND (
       language_idlanguage = 0
@@ -564,7 +564,7 @@ WHERE faqCategories_idfaqCategories = ?
         AND (g.item='question/answer' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = faq.idfaq OR g.item_id IS NULL)
+        AND (g.item_id = faq.id OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -592,8 +592,8 @@ func (q *Queries) GetFAQQuestionsByCategory(ctx context.Context, arg GetFAQQuest
 	for rows.Next() {
 		var i Faq
 		if err := rows.Scan(
-			&i.Idfaq,
-			&i.FaqcategoriesIdfaqcategories,
+			&i.ID,
+			&i.FaqCategoryID,
 			&i.LanguageIdlanguage,
 			&i.UsersIdusers,
 			&i.Answer,
@@ -647,7 +647,7 @@ func (q *Queries) GetFAQRevisionsForAdmin(ctx context.Context, faqID int32) ([]*
 }
 
 const insertFAQQuestionForWriter = `-- name: InsertFAQQuestionForWriter :execresult
-INSERT INTO faq (question, answer, faqCategories_idfaqCategories, users_idusers, language_idlanguage)
+INSERT INTO faq (question, answer, faq_category_id, users_idusers, language_idlanguage)
 SELECT ?, ?, ?, ?, ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -721,7 +721,7 @@ func (q *Queries) InsertFAQRevisionForUser(ctx context.Context, arg InsertFAQRev
 }
 
 const systemGetFAQQuestions = `-- name: SystemGetFAQQuestions :many
-SELECT idfaq, faqcategories_idfaqcategories, language_idlanguage, users_idusers, answer, question
+SELECT id, faq_category_id, language_idlanguage, users_idusers, answer, question
 FROM faq
 `
 
@@ -735,8 +735,8 @@ func (q *Queries) SystemGetFAQQuestions(ctx context.Context) ([]*Faq, error) {
 	for rows.Next() {
 		var i Faq
 		if err := rows.Scan(
-			&i.Idfaq,
-			&i.FaqcategoriesIdfaqcategories,
+			&i.ID,
+			&i.FaqCategoryID,
 			&i.LanguageIdlanguage,
 			&i.UsersIdusers,
 			&i.Answer,

--- a/migrations/0061.mysql.sql
+++ b/migrations/0061.mysql.sql
@@ -1,0 +1,6 @@
+ALTER TABLE faq CHANGE COLUMN idfaq id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE faq CHANGE COLUMN faqCategories_idfaqCategories faq_category_id INT NULL DEFAULT NULL;
+ALTER TABLE faq_categories CHANGE COLUMN idfaqCategories id INT NOT NULL AUTO_INCREMENT;
+
+-- Update schema version
+UPDATE schema_version SET version = 61 WHERE version = 60;

--- a/migrations/0061.postgres.sql
+++ b/migrations/0061.postgres.sql
@@ -1,0 +1,6 @@
+ALTER TABLE faq CHANGE COLUMN idfaq id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE faq CHANGE COLUMN faqCategories_idfaqCategories faq_category_id INT NULL DEFAULT NULL;
+ALTER TABLE faq_categories CHANGE COLUMN idfaqCategories id INT NOT NULL AUTO_INCREMENT;
+
+-- Update schema version
+UPDATE schema_version SET version = 61 WHERE version = 60;

--- a/migrations/0061.sqlite.sql
+++ b/migrations/0061.sqlite.sql
@@ -1,0 +1,6 @@
+ALTER TABLE faq CHANGE COLUMN idfaq id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE faq CHANGE COLUMN faqCategories_idfaqCategories faq_category_id INT NULL DEFAULT NULL;
+ALTER TABLE faq_categories CHANGE COLUMN idfaqCategories id INT NOT NULL AUTO_INCREMENT;
+
+-- Update schema version
+UPDATE schema_version SET version = 61 WHERE version = 60;

--- a/schema/schema.mysql.sql
+++ b/schema/schema.mysql.sql
@@ -55,22 +55,22 @@ CREATE TABLE `comments_search` (
 );
 
 CREATE TABLE `faq` (
-  `idfaq` int(10) NOT NULL AUTO_INCREMENT,
-  `faqCategories_idfaqCategories` int(10) DEFAULT NULL,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `faq_category_id` int(10) DEFAULT NULL,
   `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
-  PRIMARY KEY (`idfaq`),
+  PRIMARY KEY (`id`),
   KEY `Table_21_FKIndex1` (`users_idusers`),
   KEY `Table_21_FKIndex2` (`language_idlanguage`),
-  KEY `Table_21_FKIndex3` (`faqCategories_idfaqCategories`)
+  KEY `Table_21_FKIndex3` (`faq_category_id`)
 );
 
 CREATE TABLE `faq_categories` (
-  `idfaqCategories` int(10) NOT NULL AUTO_INCREMENT,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
   `name` tinytext DEFAULT NULL,
-  PRIMARY KEY (`idfaqCategories`)
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE IF NOT EXISTS `faq_revisions` (

--- a/schema/schema.postgres.sql
+++ b/schema/schema.postgres.sql
@@ -55,22 +55,22 @@ CREATE TABLE `comments_search` (
 );
 
 CREATE TABLE `faq` (
-  `idfaq` int(10) NOT NULL AUTO_INCREMENT,
-  `faqCategories_idfaqCategories` int(10) DEFAULT NULL,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `faq_category_id` int(10) DEFAULT NULL,
   `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
-  PRIMARY KEY (`idfaq`),
+  PRIMARY KEY (`id`),
   KEY `Table_21_FKIndex1` (`users_idusers`),
   KEY `Table_21_FKIndex2` (`language_idlanguage`),
-  KEY `Table_21_FKIndex3` (`faqCategories_idfaqCategories`)
+  KEY `Table_21_FKIndex3` (`faq_category_id`)
 );
 
 CREATE TABLE `faq_categories` (
-  `idfaqCategories` int(10) NOT NULL AUTO_INCREMENT,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
   `name` tinytext DEFAULT NULL,
-  PRIMARY KEY (`idfaqCategories`)
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE IF NOT EXISTS `faq_revisions` (

--- a/schema/schema.sqlite.sql
+++ b/schema/schema.sqlite.sql
@@ -55,22 +55,22 @@ CREATE TABLE `comments_search` (
 );
 
 CREATE TABLE `faq` (
-  `idfaq` int(10) NOT NULL AUTO_INCREMENT,
-  `faqCategories_idfaqCategories` int(10) DEFAULT NULL,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `faq_category_id` int(10) DEFAULT NULL,
   `language_idlanguage` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
-  PRIMARY KEY (`idfaq`),
+  PRIMARY KEY (`id`),
   KEY `Table_21_FKIndex1` (`users_idusers`),
   KEY `Table_21_FKIndex2` (`language_idlanguage`),
-  KEY `Table_21_FKIndex3` (`faqCategories_idfaqCategories`)
+  KEY `Table_21_FKIndex3` (`faq_category_id`)
 );
 
 CREATE TABLE `faq_categories` (
-  `idfaqCategories` int(10) NOT NULL AUTO_INCREMENT,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
   `name` tinytext DEFAULT NULL,
-  PRIMARY KEY (`idfaqCategories`)
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE IF NOT EXISTS `faq_revisions` (


### PR DESCRIPTION
## Summary
- rename `idfaq` and `idfaqCategories` columns to generic `id` with `faq_category_id`
- update queries, Go code and templates to new field names and bump schema version
- regenerate sqlc and adjust admin/FAQ logic accordingly

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689899d1d31c832f990a7557a1154727