### PR TITLE
Allow blog comments without existing thread

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1928,13 +1928,16 @@ func (cd *CoreData) SelectedThreadCanReply() bool {
 }
 
 func (cd *CoreData) sectionThreadCanReply(section string, itemID int32) bool {
-	if section == "" || itemID == 0 || cd.currentThreadID == 0 {
+	if section == "" || itemID == 0 {
 		return false
+	}
+	it := sectionItemType(section)
+	if cd.currentThreadID == 0 {
+		return cd.HasGrant(section, it, "reply", itemID)
 	}
 	if cd.queries == nil {
 		return false
 	}
-	it := sectionItemType(section)
 	th, err := cd.queries.GetThreadBySectionThreadIDForReplier(cd.ctx, db.GetThreadBySectionThreadIDForReplierParams{
 		ReplierID:      cd.UserID,
 		ThreadID:       cd.currentThreadID,


### PR DESCRIPTION
## Summary
- allow replying to blogs without an existing comment thread
- add tests for grant fallback when no thread

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68989d644880832facaf8a28b5ee0b92