### PR TITLE
refactor: unify a4code quote handlers

### DIFF
--- a/a4code/quote_test.go
+++ b/a4code/quote_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 )
 
-func TestQuoteOf(t *testing.T) {
-	got := QuoteOfText("bob", "hello")
+func TestQuote(t *testing.T) {
+	got := QuoteText("bob", "hello")
 	want := "[quoteof \"bob\" hello]\n"
 	if got != want {
 		t.Errorf("got %q want %q", got, want)
@@ -33,9 +33,9 @@ func TestQuoteOf(t *testing.T) {
 	}
 }
 
-func TestFullQuoteOfParagraphs(t *testing.T) {
+func TestQuoteFullParagraphs(t *testing.T) {
 	text := "foo\n\nbar"
-	got := FullQuoteOf("bob", text)
+	got := QuoteText("bob", text, WithFullQuote())
 	want := "[quoteof \"bob\" foo]\n[quoteof \"bob\" bar]\n"
 	if got != want {
 		t.Errorf("got %q want %q", got, want)
@@ -59,9 +59,9 @@ func TestFullQuoteOfParagraphs(t *testing.T) {
 	}
 }
 
-func TestFullQuoteOfEscaping(t *testing.T) {
+func TestQuoteFullEscaping(t *testing.T) {
 	text := "see \\[bracket\\]"
-	got := FullQuoteOf("bob", text)
+	got := QuoteText("bob", text, WithFullQuote())
 	want := "[quoteof \"bob\" see [bracket]]\n"
 	if got != want {
 		t.Errorf("got %q want %q", got, want)
@@ -86,9 +86,9 @@ func TestFullQuoteOfEscaping(t *testing.T) {
 	}
 }
 
-func TestFullQuoteOfImage(t *testing.T) {
+func TestQuoteFullImage(t *testing.T) {
 	text := "[img http://example.com/foo.jpg]"
-	got := FullQuoteOf("bob", text)
+	got := QuoteText("bob", text, WithFullQuote())
 	want := "[quoteof \"bob\" [img http://example.com/foo.jpg]]\n"
 	if got != want {
 		t.Errorf("got %q want %q", got, want)
@@ -109,5 +109,13 @@ func TestFullQuoteOfImage(t *testing.T) {
 	}
 	if _, ok := q.Children[1].(*Image); !ok {
 		t.Fatalf("expected Image node, got %T", q.Children[1])
+	}
+}
+
+func TestQuoteTrim(t *testing.T) {
+	got := QuoteText("bob", " hello \n", WithTrimSpace())
+	want := "[quoteof \"bob\" hello]\n"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
 	}
 }

--- a/handlers/blogs/blogsBlogPage.go
+++ b/handlers/blogs/blogsBlogPage.go
@@ -53,9 +53,9 @@ func BlogPage(w http.ResponseWriter, r *http.Request) {
 		if comment, err := cd.CommentByID(int32(quoteID)); err == nil {
 			switch replyType {
 			case "full":
-				data.Text = a4code.FullQuoteOf(comment.Username.String, comment.Text.String)
+				data.Text = a4code.QuoteText(comment.Username.String, comment.Text.String, a4code.WithFullQuote())
 			default:
-				data.Text = a4code.QuoteOfText(comment.Username.String, comment.Text.String)
+				data.Text = a4code.QuoteText(comment.Username.String, comment.Text.String)
 			}
 		}
 	}

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -56,9 +56,9 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 		if comment, err := cd.CommentByID(int32(commentId)); err == nil {
 			switch replyType {
 			case "full":
-				data.Text = a4code.FullQuoteOf(comment.Username.String, comment.Text.String)
+				data.Text = a4code.QuoteText(comment.Username.String, comment.Text.String, a4code.WithFullQuote())
 			default:
-				data.Text = a4code.QuoteOfText(comment.Username.String, comment.Text.String)
+				data.Text = a4code.QuoteText(comment.Username.String, comment.Text.String)
 			}
 		}
 	}

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -120,9 +120,9 @@ func ThreadPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 		if c, err := cd.CommentByID(int32(quoteId)); err == nil && c != nil {
 			switch replyType {
 			case "full":
-				data.Text = a4code.FullQuoteOf(c.Username.String, c.Text.String)
+				data.Text = a4code.QuoteText(c.Username.String, c.Text.String, a4code.WithFullQuote())
 			default:
-				data.Text = a4code.QuoteOfText(c.Username.String, c.Text.String)
+				data.Text = a4code.QuoteText(c.Username.String, c.Text.String)
 			}
 		}
 	}

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -158,9 +158,9 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		if c, err := cd.CommentByID(int32(quoteId)); err == nil && c != nil {
 			switch replyType {
 			case "full":
-				data.Text = a4code.FullQuoteOf(c.Username.String, c.Text.String)
+				data.Text = a4code.QuoteText(c.Username.String, c.Text.String, a4code.WithFullQuote())
 			default:
-				data.Text = a4code.QuoteOfText(c.Username.String, c.Text.String)
+				data.Text = a4code.QuoteText(c.Username.String, c.Text.String)
 			}
 		}
 	}
@@ -238,8 +238,8 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
 		ptidi, err := queries.CreateForumTopicForPoster(r.Context(), db.CreateForumTopicForPosterParams{
-                        ForumcategoryID: 0,
-                        ForumLang:       link.LanguageIdlanguage,
+			ForumcategoryID: 0,
+			ForumLang:       link.LanguageIdlanguage,
 			Title: sql.NullString{
 				String: LinkerTopicName,
 				Valid:  true,

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -137,9 +137,9 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		if c, err := cd.CommentByID(int32(quoteId)); err == nil && c != nil {
 			switch replyType {
 			case "full":
-				data.ReplyText = a4code.FullQuoteOf(c.Username.String, c.Text.String)
+				data.ReplyText = a4code.QuoteText(c.Username.String, c.Text.String, a4code.WithFullQuote())
 			default:
-				data.ReplyText = a4code.QuoteOfText(c.Username.String, c.Text.String)
+				data.ReplyText = a4code.QuoteText(c.Username.String, c.Text.String)
 			}
 		}
 	}

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -107,9 +107,9 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		if c, err := cd.CommentByID(int32(quoteId)); err == nil && c != nil {
 			switch replyType {
 			case "full":
-				data.ReplyText = a4code.FullQuoteOf(c.Username.String, c.Text.String)
+				data.ReplyText = a4code.QuoteText(c.Username.String, c.Text.String, a4code.WithFullQuote())
 			default:
-				data.ReplyText = a4code.QuoteOfText(c.Username.String, c.Text.String)
+				data.ReplyText = a4code.QuoteText(c.Username.String, c.Text.String)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- consolidate FullQuoteOf and QuoteOfText into new QuoteText with functional options
- update handlers to use QuoteText for quoting replies
- expand tests for quoting, paragraph handling, escaping, and trimming

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68989b7bf33c832f894cb589f399bca3