### PR TITLE
Style reply boxes like comments

### DIFF
--- a/core/templates/site/blogs/blogReply.gohtml
+++ b/core/templates/site/blogs/blogReply.gohtml
@@ -1,12 +1,37 @@
 {{ define "blogReply" }}
        {{ if cd.SelectedThreadCanReply }}
             {{ $blog := cd.BlogPost }}
-            <font size="4">Reply:</font><br>
-            <form method="post" action="/blogs/blog/{{$blog.Idblogs}}/reply">
-        {{ csrfField }}
-                <textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>
-                {{ template "languageCombobox" }}
-                <input type="submit" name="task" value="Reply">
-            </form>
+            <div class="comment">
+                <aside class="author">
+                    <div class="avatar"></div>
+                    {{ with $u := cd.CurrentUserLoaded }}
+                        <div class="username">{{ $u.Username.String }}</div>
+                    {{ end }}
+                    <div class="meta">
+                        {{ $comments := cd.SelectedSectionThreadComments }}
+                        {{ $num := add (add (len $comments) (cd.Offset)) 1 }}
+                        <div class="comment-id"><a class="comment-id" href="#bottom">#{{ $num }}</a></div>
+                        {{ $now := localTime (now) }}
+                        <div class="date">{{ $now.Format "2006-01-02" }}</div>
+                        <div class="time">{{ $now.Format "15:04 MST" }}</div>
+                        <div class="day">{{ $now.Format "Monday" }}</div>
+                        <div class="zone">{{ cd.Location }}</div>
+                        {{ if gt (len $comments) 0 }}
+                            {{ $prev := index $comments (add (len $comments) -1) }}
+                            <div class="since">{{ since (localTime $prev.Written.Time) $now }}</div>
+                        {{ end }}
+                    </div>
+                </aside>
+                <section class="body">
+                    <a id="bottom"></a>
+                    <font size="4">Reply:</font><br>
+                    <form method="post" action="/blogs/blog/{{$blog.Idblogs}}/reply">
+                {{ csrfField }}
+                        <textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>
+                        {{ template "languageCombobox" }}
+                        <input type="submit" name="task" value="Reply">
+                    </form>
+                </section>
+            </div>
        {{end}}
 {{ end }}

--- a/core/templates/site/forum/reply.gohtml
+++ b/core/templates/site/forum/reply.gohtml
@@ -1,14 +1,39 @@
 {{ define "forumReply" }}
-       {{ if cd.SelectedThreadCanReply }}
-            <font size="4">Reply:</font><br>
-            {{ $base := "/forum" }}
-            {{ with $.BasePath }}{{ $base = . }}{{ end }}
-            <form method="post" action="{{$base}}/topic/{{$.Topic.Idforumtopic}}/thread/{{$.Thread.Idforumthread}}/reply">
-        {{ csrfField }}
-                <textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>
-                {{ template "languageCombobox" }}
-                                <input type="submit" name="task" value="Reply">
-                                <input type="submit" name="task" value="Cancel">
-                        </form>
-               {{end}}
+    {{ if cd.SelectedThreadCanReply }}
+        <div class="comment">
+            <aside class="author">
+                <div class="avatar"></div>
+                {{ with $u := cd.CurrentUserLoaded }}
+                    <div class="username">{{ $u.Username.String }}</div>
+                {{ end }}
+                <div class="meta">
+                    {{ $comments := cd.SelectedSectionThreadComments }}
+                    {{ $num := add (add (len $comments) (cd.Offset)) 1 }}
+                    <div class="comment-id"><a class="comment-id" href="#bottom">#{{ $num }}</a></div>
+                    {{ $now := localTime (now) }}
+                    <div class="date">{{ $now.Format "2006-01-02" }}</div>
+                    <div class="time">{{ $now.Format "15:04 MST" }}</div>
+                    <div class="day">{{ $now.Format "Monday" }}</div>
+                    <div class="zone">{{ cd.Location }}</div>
+                    {{ if gt (len $comments) 0 }}
+                        {{ $prev := index $comments (add (len $comments) -1) }}
+                        <div class="since">{{ since (localTime $prev.Written.Time) $now }}</div>
+                    {{ end }}
+                </div>
+            </aside>
+            <section class="body">
+                <a id="bottom"></a>
+                <font size="4">Reply:</font><br>
+                {{ $base := "/forum" }}
+                {{ with $.BasePath }}{{ $base = . }}{{ end }}
+                <form method="post" action="{{$base}}/topic/{{$.Topic.Idforumtopic}}/thread/{{$.Thread.Idforumthread}}/reply">
+                    {{ csrfField }}
+                    <textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>
+                    {{ template "languageCombobox" }}
+                    <input type="submit" name="task" value="Reply">
+                    <input type="submit" name="task" value="Cancel">
+                </form>
+            </section>
+        </div>
+    {{ end }}
 {{ end }}

--- a/core/templates/site/forum/threadNewPage.gohtml
+++ b/core/templates/site/forum/threadNewPage.gohtml
@@ -1,11 +1,36 @@
 {{ template "head" $ }}
-    <font size="4">New Thread:</font><br>
-    <form method="post" action="">
-        {{ csrfField }}
-        <textarea id="reply" name="replytext" cols="40" rows="20"></textarea><br>
-        {{ template "languageCombobox" }}
-        <input type="submit" name="task" value="Create Thread">
-        <input type="submit" name="task" formaction="cancel" value="Cancel">
-    </form>
+    <div class="comment">
+        <aside class="author">
+            <div class="avatar"></div>
+            {{ with $u := cd.CurrentUserLoaded }}
+                <div class="username">{{ $u.Username.String }}</div>
+            {{ end }}
+            <div class="meta">
+                {{ $comments := cd.SelectedSectionThreadComments }}
+                {{ $num := add (add (len $comments) (cd.Offset)) 1 }}
+                <div class="comment-id"><a class="comment-id" href="#bottom">#{{ $num }}</a></div>
+                {{ $now := localTime (now) }}
+                <div class="date">{{ $now.Format "2006-01-02" }}</div>
+                <div class="time">{{ $now.Format "15:04 MST" }}</div>
+                <div class="day">{{ $now.Format "Monday" }}</div>
+                <div class="zone">{{ cd.Location }}</div>
+                {{ if gt (len $comments) 0 }}
+                    {{ $prev := index $comments (add (len $comments) -1) }}
+                    <div class="since">{{ since (localTime $prev.Written.Time) $now }}</div>
+                {{ end }}
+            </div>
+        </aside>
+        <section class="body">
+            <a id="bottom"></a>
+            <font size="4">New Thread:</font><br>
+            <form method="post" action="">
+                {{ csrfField }}
+                <textarea id="reply" name="replytext" cols="40" rows="20"></textarea><br>
+                {{ template "languageCombobox" }}
+                <input type="submit" name="task" value="Create Thread">
+                <input type="submit" name="task" formaction="cancel" value="Cancel">
+            </form>
+        </section>
+    </div>
 
 {{ template "tail" $ }}

--- a/core/templates/site/imagebbs/boardThreadPage.gohtml
+++ b/core/templates/site/imagebbs/boardThreadPage.gohtml
@@ -9,14 +9,39 @@
     {{ end }}
     {{ template "threadComments" }}
     {{ if cd.SelectedThreadCanReply }}
-        <font size="4">Reply:</font><br>
-        <form method="post" action="?board={{ .BoardID }}">
-        {{ csrfField }}
-            <input type="hidden" name="replyTo" value="{{ .ForumThreadID }}">
-            <input type="hidden" name="ipid" value="{{ .ImagePost.Idimagepost }}">
-            <textarea name="replytext" cols="40" rows="20"></textarea><br>
-            {{ template "languageCombobox" }}
-            <input type="submit" name="task" value="Reply">
-        </form>
+        <div class="comment">
+            <aside class="author">
+                <div class="avatar"></div>
+                {{ with $u := cd.CurrentUserLoaded }}
+                    <div class="username">{{ $u.Username.String }}</div>
+                {{ end }}
+                <div class="meta">
+                    {{ $comments := cd.SelectedSectionThreadComments }}
+                    {{ $num := add (add (len $comments) (cd.Offset)) 1 }}
+                    <div class="comment-id"><a class="comment-id" href="#bottom">#{{ $num }}</a></div>
+                    {{ $now := localTime (now) }}
+                    <div class="date">{{ $now.Format "2006-01-02" }}</div>
+                    <div class="time">{{ $now.Format "15:04 MST" }}</div>
+                    <div class="day">{{ $now.Format "Monday" }}</div>
+                    <div class="zone">{{ cd.Location }}</div>
+                    {{ if gt (len $comments) 0 }}
+                        {{ $prev := index $comments (add (len $comments) -1) }}
+                        <div class="since">{{ since (localTime $prev.Written.Time) $now }}</div>
+                    {{ end }}
+                </div>
+            </aside>
+            <section class="body">
+                <a id="bottom"></a>
+                <font size="4">Reply:</font><br>
+                <form method="post" action="?board={{ .BoardID }}">
+                {{ csrfField }}
+                    <input type="hidden" name="replyTo" value="{{ .ForumThreadID }}">
+                    <input type="hidden" name="ipid" value="{{ .ImagePost.Idimagepost }}">
+                    <textarea name="replytext" cols="40" rows="20"></textarea><br>
+                    {{ template "languageCombobox" }}
+                    <input type="submit" name="task" value="Reply">
+                </form>
+            </section>
+        </div>
     {{ end }}
 {{ template "tail" $ }}

--- a/core/templates/site/news/post.gohtml
+++ b/core/templates/site/news/post.gohtml
@@ -7,7 +7,7 @@
             <td>{{ .News.String | a4code2html }}<br>-<br>{{ .Writername.String }}
             -
             {{ if cd.SelectedThreadID }}
-                {{ .Comments.Int32 }} COMMENTS [<a href="#bottom">BOTTOM</a>]{{ if cd.SelectedThreadCanReply }} [<a href="#reply">REPLY</a>]{{ end }}
+                {{ .Comments.Int32 }} COMMENTS [<a href="#bottom">BOTTOM</a>]{{ if cd.SelectedThreadCanReply }} [<a href="#bottom">REPLY</a>]{{ end }}
             {{ else }}
                 [<a href="/news/news/{{ .Idsitenews }}">{{ .Comments.Int32 }} COMMENTS</a>]
             {{ end }}

--- a/core/templates/site/news/postPage.gohtml
+++ b/core/templates/site/news/postPage.gohtml
@@ -2,15 +2,39 @@
     {{ template "newsPost" $.Post }}
     <hr><font size=4>Replies:</font>
     {{ template "threadComments" }}
-    <a id="reply"></a>
     {{ if cd.SelectedThreadCanReply }}
-        <font size=4>Reply:</font>
-        <form method="post" action="?#reply">
-        {{ csrfField }}
-            <input type="hidden" name="replyto" value="{{ .Thread.Idforumthread }}">
-            <textarea name="replytext" cols=40 rows=20>{{.ReplyText}}</textarea><br>
-            {{ template "languageCombobox" }}
-            <input type="submit" name="task" value="Reply">
-        </form>
+        <div class="comment">
+            <aside class="author">
+                <div class="avatar"></div>
+                {{ with $u := cd.CurrentUserLoaded }}
+                    <div class="username">{{ $u.Username.String }}</div>
+                {{ end }}
+                <div class="meta">
+                    {{ $comments := cd.SelectedSectionThreadComments }}
+                    {{ $num := add (add (len $comments) (cd.Offset)) 1 }}
+                    <div class="comment-id"><a class="comment-id" href="#bottom">#{{ $num }}</a></div>
+                    {{ $now := localTime (now) }}
+                    <div class="date">{{ $now.Format "2006-01-02" }}</div>
+                    <div class="time">{{ $now.Format "15:04 MST" }}</div>
+                    <div class="day">{{ $now.Format "Monday" }}</div>
+                    <div class="zone">{{ cd.Location }}</div>
+                    {{ if gt (len $comments) 0 }}
+                        {{ $prev := index $comments (add (len $comments) -1) }}
+                        <div class="since">{{ since (localTime $prev.Written.Time) $now }}</div>
+                    {{ end }}
+                </div>
+            </aside>
+            <section class="body">
+                <a id="bottom"></a>
+                <font size=4>Reply:</font><br>
+                <form method="post" action="?#bottom">
+                {{ csrfField }}
+                    <input type="hidden" name="replyto" value="{{ .Thread.Idforumthread }}">
+                    <textarea name="replytext" cols=40 rows=20>{{.ReplyText}}</textarea><br>
+                    {{ template "languageCombobox" }}
+                    <input type="submit" name="task" value="Reply">
+                </form>
+            </section>
+        </div>
     {{ end }}
 {{ template "tail" $ }}

--- a/core/templates/site/showLinkComments.gohtml
+++ b/core/templates/site/showLinkComments.gohtml
@@ -18,15 +18,40 @@
         {{ end }}
 
         {{ if cd.SelectedThreadCanReply }}
-            <font size="4">Reply:</font><br>
-            <form method="post">
-        {{ csrfField }}
-                <input type="hidden" name="replyTo" value="{{ .ForumthreadID }}">
-                <input type="hidden" name="lpid" value="{{ .Idlinker }}">
-                <textarea name="replytext" cols="40" rows="20">{{ $.Text }}</textarea><br>
-                {{ template "languageCombobox" }}
-                <input type="submit" name="task" value="Reply">
-            </form>
+            <div class="comment">
+                <aside class="author">
+                    <div class="avatar"></div>
+                    {{ with $u := cd.CurrentUserLoaded }}
+                        <div class="username">{{ $u.Username.String }}</div>
+                    {{ end }}
+                    <div class="meta">
+                        {{ $comments := cd.SelectedSectionThreadComments }}
+                        {{ $num := add (add (len $comments) (cd.Offset)) 1 }}
+                        <div class="comment-id"><a class="comment-id" href="#bottom">#{{ $num }}</a></div>
+                        {{ $now := localTime (now) }}
+                        <div class="date">{{ $now.Format "2006-01-02" }}</div>
+                        <div class="time">{{ $now.Format "15:04 MST" }}</div>
+                        <div class="day">{{ $now.Format "Monday" }}</div>
+                        <div class="zone">{{ cd.Location }}</div>
+                        {{ if gt (len $comments) 0 }}
+                            {{ $prev := index $comments (add (len $comments) -1) }}
+                            <div class="since">{{ since (localTime $prev.Written.Time) $now }}</div>
+                        {{ end }}
+                    </div>
+                </aside>
+                <section class="body">
+                    <a id="bottom"></a>
+                    <font size="4">Reply:</font><br>
+                    <form method="post">
+                {{ csrfField }}
+                        <input type="hidden" name="replyTo" value="{{ .ForumthreadID }}">
+                        <input type="hidden" name="lpid" value="{{ .Idlinker }}">
+                        <textarea name="replytext" cols="40" rows="20">{{ $.Text }}</textarea><br>
+                        {{ template "languageCombobox" }}
+                        <input type="submit" name="task" value="Reply">
+                    </form>
+                </section>
+            </div>
         {{ else }}
             {{ if cd.UserID }}
                 You do not have permission to write a reply.<br>

--- a/core/templates/site/writings/articlePage.gohtml
+++ b/core/templates/site/writings/articlePage.gohtml
@@ -13,13 +13,38 @@
         <hr>Comments:<br>
         {{ template "threadComments" }}
         {{ if cd.SelectedThreadCanReply }}
-            <hr><font size="4">Reply:</font><br>
-            <form method="post">
-        {{ csrfField }}
-                <textarea name="replytext" cols="40" rows="20">{{ .ReplyText }}</textarea><br>
-                {{ template "languageCombobox" }}
-                <input type="submit" name="task" value="Reply">
-            </form>
+            <div class="comment">
+                <aside class="author">
+                    <div class="avatar"></div>
+                    {{ with $u := cd.CurrentUserLoaded }}
+                        <div class="username">{{ $u.Username.String }}</div>
+                    {{ end }}
+                    <div class="meta">
+                        {{ $comments := cd.SelectedSectionThreadComments }}
+                        {{ $num := add (add (len $comments) (cd.Offset)) 1 }}
+                        <div class="comment-id"><a class="comment-id" href="#bottom">#{{ $num }}</a></div>
+                        {{ $now := localTime (now) }}
+                        <div class="date">{{ $now.Format "2006-01-02" }}</div>
+                        <div class="time">{{ $now.Format "15:04 MST" }}</div>
+                        <div class="day">{{ $now.Format "Monday" }}</div>
+                        <div class="zone">{{ cd.Location }}</div>
+                        {{ if gt (len $comments) 0 }}
+                            {{ $prev := index $comments (add (len $comments) -1) }}
+                            <div class="since">{{ since (localTime $prev.Written.Time) $now }}</div>
+                        {{ end }}
+                    </div>
+                </aside>
+                <section class="body">
+                    <a id="bottom"></a>
+                    <hr><font size="4">Reply:</font><br>
+                    <form method="post">
+                    {{ csrfField }}
+                        <textarea name="replytext" cols="40" rows="20">{{ .ReplyText }}</textarea><br>
+                        {{ template "languageCombobox" }}
+                        <input type="submit" name="task" value="Reply">
+                    </form>
+                </section>
+            </div>
         {{ else }}
             {{ if cd.UserID }}
                 You do not have permission to write a reply.<br>


### PR DESCRIPTION
## Summary
- Mirror comment layout for reply forms with author sidebar, user name, and timestamp details
- Apply comment-style reply boxes across news, blogs, image boards, and link pages, linking anchors to `#bottom`
- Point news post reply shortcut to bottom anchor

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68989b22c614832f845f92089ecdba80