### PR TITLE
feat: add drag-and-drop topic role grants

### DIFF
--- a/core/templates/site/forum/adminTopicGrantsPage.gohtml
+++ b/core/templates/site/forum/adminTopicGrantsPage.gohtml
@@ -1,48 +1,32 @@
 {{ template "head" $ }}
 <h3>Topic {{ .TopicID }} Grants</h3>
+<button id="commit-all" class="hidden">Commit All</button>
 <table border="1">
-    <tr>
-        <th>ID</th>
-        <th>User / Role</th>
-        <th>Action</th>
-        <th>Delete?</th>
-    </tr>
-    {{- range .Grants }}
-    <tr>
-        <td>{{ .ID }}</td>
-        <td>
-            {{- if .Username.Valid }}User: {{ .Username.String }}{{ end -}}
-            {{- if and .Username.Valid .RoleName.Valid }}<br>{{ end -}}
-            {{- if .RoleName.Valid }}Role: {{ .RoleName.String }}{{ end -}}
-        </td>
+    <tr><th>Action</th><th>Has</th><th>Disabled</th><th>Can Have</th><th>Commit</th></tr>
+    {{- range .GrantGroups }}
+    <tr data-action="{{ .Action }}">
         <td>{{ .Action }}</td>
+        <td class="have">
+            {{- range .Have }}<span class="pill" draggable="true" data-default="have">{{ . }}</span>{{- end }}
+        </td>
+        <td class="disabled">
+            {{- range .Disabled }}<span class="pill" draggable="true" data-default="disabled">{{ . }}</span>{{- end }}
+        </td>
+        <td class="available">
+            {{- range .Available }}<span class="pill" draggable="true" data-default="available">{{ . }}</span>{{- end }}
+        </td>
         <td>
-            <form method="post" action="/admin/forum/topics/topic/{{ $.TopicID }}/grant/delete">
-        {{ csrfField }}
-                <input type="hidden" name="grantid" value="{{ .ID }}">
-                <input type="submit" name="task" value="Delete grant">
+            <form method="post" action="{{ $.UpdateURL }}" class="commit-form">
+                {{ csrfField }}
+                <input type="hidden" name="task" value="Update grants">
+                <input type="hidden" name="action" value="{{ .Action }}">
+                <input type="hidden" name="actions" value="">
+                <input type="hidden" name="disabled_actions" value="">
+                <input type="submit" value="Commit" class="hidden">
             </form>
         </td>
     </tr>
     {{- end }}
-    <tr>
-        <form method="post" action="/admin/forum/topics/topic/{{ $.TopicID }}/grant">
-        {{ csrfField }}
-            <td>NEW</td>
-            <td>
-                <input name="username" placeholder="username"><br>
-                <select name="role">
-                    <option value="">None</option>
-                    {{- range $.Roles }}<option value="{{ .Name }}">{{ .Name }}</option>{{- end }}
-                </select>
-            </td>
-            <td>
-                {{- range $.Actions }}
-                <label><input type="checkbox" name="action" value="{{ . }}">{{ . }}</label>
-                {{- end }}
-            </td>
-            <td><input type="submit" name="task" value="Create grant"></td>
-        </form>
-    </tr>
 </table>
+<script src="/admin/role-grants-editor.js"></script>
 {{ template "tail" $ }}

--- a/handlers/forum/routes_admin.go
+++ b/handlers/forum/routes_admin.go
@@ -37,6 +37,7 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	far.HandleFunc("/topics/topic/{topic}/delete", AdminTopicDeletePage).Methods("POST").MatcherFunc(topicDeleteTask.Matcher())
 	far.HandleFunc("/topics/topic/{topic}/grants", AdminTopicGrantsPage).Methods("GET")
 	far.HandleFunc("/topics/topic/{topic}/grant", handlers.TaskHandler(topicGrantCreateTask)).Methods("POST").MatcherFunc(topicGrantCreateTask.Matcher())
+	far.HandleFunc("/topics/topic/{topic}/grant/update", handlers.TaskHandler(topicGrantUpdateTask)).Methods("POST").MatcherFunc(topicGrantUpdateTask.Matcher())
 	far.HandleFunc("/topics/topic/{topic}/grant/delete", handlers.TaskHandler(topicGrantDeleteTask)).Methods("POST").MatcherFunc(topicGrantDeleteTask.Matcher())
 	far.HandleFunc("/topic/{topic}", AdminTopicPage).Methods("GET")
 	far.HandleFunc("/topic/{topic}/edit", AdminTopicEditFormPage).Methods("GET")
@@ -44,6 +45,7 @@ func RegisterAdminRoutes(ar *mux.Router) {
 	far.HandleFunc("/topic/{topic}/delete", AdminTopicDeletePage).Methods("POST").MatcherFunc(topicDeleteTask.Matcher())
 	far.HandleFunc("/topic/{topic}/grants", AdminTopicGrantsPage).Methods("GET")
 	far.HandleFunc("/topic/{topic}/grant", handlers.TaskHandler(topicGrantCreateTask)).Methods("POST").MatcherFunc(topicGrantCreateTask.Matcher())
+	far.HandleFunc("/topic/{topic}/grant/update", handlers.TaskHandler(topicGrantUpdateTask)).Methods("POST").MatcherFunc(topicGrantUpdateTask.Matcher())
 	far.HandleFunc("/topic/{topic}/grant/delete", handlers.TaskHandler(topicGrantDeleteTask)).Methods("POST").MatcherFunc(topicGrantDeleteTask.Matcher())
 
 	far.HandleFunc("/categories/category/{category}/grants", AdminCategoryGrantsPage).Methods("GET")

--- a/handlers/forum/tasks.go
+++ b/handlers/forum/tasks.go
@@ -75,6 +75,9 @@ const (
 	// TaskTopicGrantDelete removes an existing forum topic grant.
 	TaskTopicGrantDelete tasks.TaskString = "Delete grant"
 
+	// TaskTopicGrantUpdate updates grants for a forum topic action.
+	TaskTopicGrantUpdate tasks.TaskString = "Update grants"
+
 	// TaskCategoryGrantCreate adds a new grant to a forum category.
 	TaskCategoryGrantCreate tasks.TaskString = "Create grant"
 

--- a/handlers/forum/tasks_register.go
+++ b/handlers/forum/tasks_register.go
@@ -11,6 +11,7 @@ func RegisterTasks() []tasks.NamedTask {
 		topicChangeTask,
 		topicDeleteTask,
 		topicGrantCreateTask,
+		topicGrantUpdateTask,
 		topicGrantDeleteTask,
 		categoryGrantCreateTask,
 		categoryGrantDeleteTask,

--- a/handlers/forum/topic_grant_update_task.go
+++ b/handlers/forum/topic_grant_update_task.go
@@ -1,0 +1,140 @@
+package forum
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/tasks"
+	"github.com/gorilla/mux"
+)
+
+// TopicGrantUpdateTask updates role grants for a forum topic action.
+type TopicGrantUpdateTask struct{ tasks.TaskString }
+
+var topicGrantUpdateTask = &TopicGrantUpdateTask{TaskString: TaskTopicGrantUpdate}
+
+var _ tasks.Task = (*TopicGrantUpdateTask)(nil)
+
+func (TopicGrantUpdateTask) Action(w http.ResponseWriter, r *http.Request) any {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	queries := cd.Queries()
+	tid, err := strconv.Atoi(mux.Vars(r)["topic"])
+	if err != nil {
+		return fmt.Errorf("topic id parse fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	action := r.PostFormValue("action")
+	activeStr := r.PostFormValue("actions")
+	disabledStr := r.PostFormValue("disabled_actions")
+	desiredActive := map[string]struct{}{}
+	for _, n := range strings.Split(activeStr, ",") {
+		if n != "" {
+			desiredActive[n] = struct{}{}
+		}
+	}
+	desiredDisabled := map[string]struct{}{}
+	for _, n := range strings.Split(disabledStr, ",") {
+		if n != "" {
+			desiredDisabled[n] = struct{}{}
+		}
+	}
+	roles, err := cd.AllRoles()
+	if err != nil {
+		return fmt.Errorf("list roles %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	roleIDs := map[string]int32{}
+	idToName := map[int32]string{}
+	for _, ro := range roles {
+		roleIDs[ro.Name] = ro.ID
+		idToName[ro.ID] = ro.Name
+	}
+	grants, err := queries.ListGrants(r.Context())
+	if err != nil {
+		return fmt.Errorf("list grants %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	existing := map[int32]*db.Grant{}
+	for _, g := range grants {
+		if g.Section == "forum" && g.Item.Valid && g.Item.String == "topic" && g.ItemID.Valid && g.ItemID.Int32 == int32(tid) && g.Action == action && !g.UserID.Valid {
+			rid := int32(0)
+			if g.RoleID.Valid {
+				rid = g.RoleID.Int32
+			}
+			existing[rid] = g
+		}
+	}
+	for name := range desiredActive {
+		rid, ok := roleIDs[name]
+		if !ok {
+			continue
+		}
+		g, ok := existing[rid]
+		if !ok {
+			id, err := queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
+				RoleID:   sql.NullInt32{Int32: rid, Valid: rid != 0},
+				Section:  "forum",
+				Item:     sql.NullString{String: "topic", Valid: true},
+				RuleType: "allow",
+				ItemID:   sql.NullInt32{Int32: int32(tid), Valid: true},
+				Action:   action,
+			})
+			if err != nil {
+				return fmt.Errorf("create grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+			}
+			g = &db.Grant{ID: int32(id)}
+		}
+		if g != nil && !g.Active {
+			if err := queries.AdminUpdateGrantActive(r.Context(), db.AdminUpdateGrantActiveParams{Active: true, ID: g.ID}); err != nil {
+				return fmt.Errorf("activate grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+			}
+		}
+	}
+	for name := range desiredDisabled {
+		rid, ok := roleIDs[name]
+		if !ok {
+			continue
+		}
+		g, ok := existing[rid]
+		if !ok {
+			id, err := queries.AdminCreateGrant(r.Context(), db.AdminCreateGrantParams{
+				RoleID:   sql.NullInt32{Int32: rid, Valid: rid != 0},
+				Section:  "forum",
+				Item:     sql.NullString{String: "topic", Valid: true},
+				RuleType: "allow",
+				ItemID:   sql.NullInt32{Int32: int32(tid), Valid: true},
+				Action:   action,
+			})
+			if err != nil {
+				return fmt.Errorf("create grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+			}
+			if err := queries.AdminUpdateGrantActive(r.Context(), db.AdminUpdateGrantActiveParams{Active: false, ID: int32(id)}); err != nil {
+				return fmt.Errorf("deactivate grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+			}
+		} else if g.Active {
+			if err := queries.AdminUpdateGrantActive(r.Context(), db.AdminUpdateGrantActiveParams{Active: false, ID: g.ID}); err != nil {
+				return fmt.Errorf("deactivate grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+			}
+		}
+	}
+	for id, g := range existing {
+		name := idToName[id]
+		if _, ok := desiredActive[name]; ok {
+			continue
+		}
+		if _, ok := desiredDisabled[name]; ok {
+			continue
+		}
+		if err := queries.AdminDeleteGrant(r.Context(), g.ID); err != nil {
+			return fmt.Errorf("delete grant %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+	}
+	return handlers.RefreshDirectHandler{TargetURL: fmt.Sprintf("/admin/forum/topics/topic/%d/grants", tid)}
+}

--- a/handlers/forum/topic_grants.go
+++ b/handlers/forum/topic_grants.go
@@ -1,0 +1,81 @@
+package forum
+
+import (
+	"context"
+	"sort"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// TopicGrantGroup represents roles assigned to an action on a topic.
+type TopicGrantGroup struct {
+	Action    string
+	Have      []string
+	Disabled  []string
+	Available []string
+}
+
+// buildTopicGrantGroups organises topic grants for editing.
+func buildTopicGrantGroups(ctx context.Context, cd *common.CoreData, topicID int32) ([]TopicGrantGroup, error) {
+	queries := cd.Queries()
+	roles, err := cd.AllRoles()
+	if err != nil {
+		return nil, err
+	}
+	roleNames := map[int32]string{}
+	for _, r := range roles {
+		roleNames[r.ID] = r.Name
+	}
+	grants, err := queries.ListGrants(ctx)
+	if err != nil {
+		return nil, err
+	}
+	byAction := map[string]map[int32]*db.Grant{}
+	for _, g := range grants {
+		if g.Section != "forum" || !g.Item.Valid || g.Item.String != "topic" || !g.ItemID.Valid || g.ItemID.Int32 != topicID {
+			continue
+		}
+		if g.UserID.Valid {
+			continue // only role grants
+		}
+		rid := int32(0)
+		if g.RoleID.Valid {
+			rid = g.RoleID.Int32
+		}
+		if byAction[g.Action] == nil {
+			byAction[g.Action] = map[int32]*db.Grant{}
+		}
+		byAction[g.Action][rid] = g
+	}
+	actions := []string{"see", "view", "reply", "post", "edit"}
+	var groups []TopicGrantGroup
+	for _, act := range actions {
+		gg := TopicGrantGroup{Action: act}
+		used := map[int32]bool{}
+		if m, ok := byAction[act]; ok {
+			for rid, g := range m {
+				name, ok := roleNames[rid]
+				if !ok {
+					continue
+				}
+				used[rid] = true
+				if g.Active {
+					gg.Have = append(gg.Have, name)
+				} else {
+					gg.Disabled = append(gg.Disabled, name)
+				}
+			}
+		}
+		for rid, name := range roleNames {
+			if !used[rid] {
+				gg.Available = append(gg.Available, name)
+			}
+		}
+		sort.Strings(gg.Have)
+		sort.Strings(gg.Disabled)
+		sort.Strings(gg.Available)
+		groups = append(groups, gg)
+	}
+	return groups, nil
+}

--- a/handlers/forum/topic_grants_build_test.go
+++ b/handlers/forum/topic_grants_build_test.go
@@ -1,0 +1,47 @@
+package forum
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// TestBuildTopicGrantGroupsIncludesAllRoles ensures groups are returned for each action when no grants exist.
+func TestBuildTopicGrantGroupsIncludesAllRoles(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+	q := db.New(conn)
+	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id\n")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).
+			AddRow(1, "member", true, false, time.Now()))
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants ORDER BY id\n")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}))
+
+	groups, err := buildTopicGrantGroups(context.Background(), cd, 1)
+	if err != nil {
+		t.Fatalf("buildTopicGrantGroups: %v", err)
+	}
+	if len(groups) != 5 {
+		t.Fatalf("expected 5 groups, got %d", len(groups))
+	}
+	for _, g := range groups {
+		if len(g.Have) != 0 || len(g.Disabled) != 0 || len(g.Available) != 2 {
+			t.Fatalf("unexpected group %+v", g)
+		}
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add drag-and-drop editor for forum topic role grants
- support updating topic grants via new task and route
- cover topic grant grouping with unit tests

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68993a775160832f816a8324380cd185