### PR TITLE
Expand admin breadcrumb and link coverage

### DIFF
--- a/core/common/breadcrumb.go
+++ b/core/common/breadcrumb.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"log"
+	"strings"
 )
 
 // Breadcrumb represents a single navigation step.
@@ -217,6 +218,40 @@ func (cd *CoreData) adminBreadcrumbs() ([]Breadcrumb, error) {
 		} else {
 			crumbs = append(crumbs, Breadcrumb{Title: fmt.Sprintf("Role %d", cd.currentRoleID)})
 		}
+	case cd.currentCategoryID != 0 && strings.HasPrefix(cd.PageTitle, "Linker Category"):
+		crumbs = append(crumbs, Breadcrumb{Title: "Linker Categories", Link: "/admin/linker/categories"})
+		crumbs = append(crumbs, Breadcrumb{Title: cd.PageTitle})
+	case cd.currentCategoryID != 0 && strings.HasPrefix(cd.PageTitle, "Edit Category"):
+		crumbs = append(crumbs, Breadcrumb{Title: "Writing Categories", Link: "/admin/writings/categories"})
+		crumbs = append(crumbs, Breadcrumb{Title: fmt.Sprintf("Writing Category %d", cd.currentCategoryID), Link: fmt.Sprintf("/admin/writings/categories/category/%d", cd.currentCategoryID)})
+		crumbs = append(crumbs, Breadcrumb{Title: cd.PageTitle})
+	case cd.currentCategoryID != 0 && strings.Contains(cd.PageTitle, "Category Grants"):
+		crumbs = append(crumbs, Breadcrumb{Title: "Writing Categories", Link: "/admin/writings/categories"})
+		crumbs = append(crumbs, Breadcrumb{Title: fmt.Sprintf("Writing Category %d", cd.currentCategoryID), Link: fmt.Sprintf("/admin/writings/categories/category/%d", cd.currentCategoryID)})
+		crumbs = append(crumbs, Breadcrumb{Title: cd.PageTitle})
+	case cd.currentCategoryID != 0 && strings.HasPrefix(cd.PageTitle, "Writing Category"):
+		crumbs = append(crumbs, Breadcrumb{Title: "Writing Categories", Link: "/admin/writings/categories"})
+		crumbs = append(crumbs, Breadcrumb{Title: cd.PageTitle})
+	case strings.Contains(cd.PageTitle, "FAQ Category") && !strings.Contains(cd.PageTitle, "FAQ Categories"):
+		crumbs = append(crumbs, Breadcrumb{Title: "FAQ Categories", Link: "/admin/faq/categories"})
+		crumbs = append(crumbs, Breadcrumb{Title: cd.PageTitle})
+	case cd.currentLinkID != 0 && strings.HasPrefix(cd.PageTitle, "Link"):
+		crumbs = append(crumbs, Breadcrumb{Title: "Linker Links", Link: "/admin/linker/links"})
+		crumbs = append(crumbs, Breadcrumb{Title: cd.PageTitle})
+	case cd.currentBoardID != 0 && strings.Contains(cd.PageTitle, "Image Board"):
+		crumbs = append(crumbs, Breadcrumb{Title: "Image Boards", Link: "/admin/imagebbs/boards"})
+		title := fmt.Sprintf("Board %d", cd.currentBoardID)
+		if boards, err := cd.ImageBoards(); err == nil {
+			for _, b := range boards {
+				if b.Idimageboard == cd.currentBoardID {
+					if b.Title.Valid {
+						title = b.Title.String
+					}
+					break
+				}
+			}
+		}
+		crumbs = append(crumbs, Breadcrumb{Title: title})
 	case cd.currentRequestID != 0:
 		crumbs = append(crumbs, Breadcrumb{Title: "Requests", Link: "/admin/requests"})
 		crumbs = append(crumbs, Breadcrumb{Title: fmt.Sprintf("Request %d", cd.currentRequestID)})

--- a/core/templates/site/admin/userWritingsPage.gohtml
+++ b/core/templates/site/admin/userWritingsPage.gohtml
@@ -6,7 +6,7 @@
     <tr>
         <td><a href="/admin/writings/article/{{ .Idwriting }}">{{ .Idwriting }}</a></td>
         <td>{{ .Title.String }}</td>
-        <td><a href="/admin/writings/category/{{ .WritingCategoryID }}">{{ .WritingCategoryID }}</a></td>
+        <td><a href="/admin/writings/categories/category/{{ .WritingCategoryID }}">{{ .WritingCategoryID }}</a></td>
         <td>{{ if .Published.Valid }}{{ localTime .Published.Time }}{{ end }}</td>
         <td>{{ .Comments }}</td>
         <td><a href="/writings/article/{{ .Idwriting }}">View</a> | <a href="/writings/article/{{ .Idwriting }}/edit">Edit</a></td>

--- a/core/templates/site/faq/faqAdminCategoryEditPage.gohtml
+++ b/core/templates/site/faq/faqAdminCategoryEditPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-<h1>Edit Category</h1>
+<h1>Edit Category <a href="/admin/faq/categories/category/{{ .Category.Idfaqcategories }}">{{ .Category.Idfaqcategories }}</a></h1>
 <form method="post" action="/admin/faq/categories">
 {{ csrfField }}
 <input type="hidden" name="cid" value="{{ .Category.Idfaqcategories }}">

--- a/core/templates/site/faq/faqAdminCategoryPage.gohtml
+++ b/core/templates/site/faq/faqAdminCategoryPage.gohtml
@@ -7,7 +7,7 @@
 <h2>Latest Questions</h2>
 <ul>
     {{- range .Latest }}
-    <li>{{ .Question }}</li>
+    <li><a href="/admin/faq/question/{{ .Idfaq }}/edit">{{ .Question }}</a></li>
     {{- end }}
 </ul>
 {{- end }}

--- a/core/templates/site/faq/faqAdminCategoryQuestionsPage.gohtml
+++ b/core/templates/site/faq/faqAdminCategoryQuestionsPage.gohtml
@@ -8,9 +8,9 @@
     </tr>
     {{- range .Questions }}
     <tr>
-        <td>{{ .Idfaq }}</td>
+        <td><a href="/admin/faq/question/{{ .Idfaq }}/edit">{{ .Idfaq }}</a></td>
         <td>{{ .Question }}</td>
-        <td><a href="/admin/faq/question/{{ .Idfaq }}/edit">Edit</a></td>
+        <td><a href="/faq">View</a> | <a href="/admin/faq/question/{{ .Idfaq }}/edit">Edit</a></td>
     </tr>
     {{- end }}
 </table>

--- a/core/templates/site/imagebbs/adminBoardViewPage.gohtml
+++ b/core/templates/site/imagebbs/adminBoardViewPage.gohtml
@@ -12,13 +12,14 @@
 
 <h3>Recent Posts</h3>
 <table border="1">
-<tr><th>ID<th>User<th>Description<th>Posted</tr>
+<tr><th>ID</th><th>User</th><th>Description</th><th>Posted</th><th>View</th></tr>
 {{ range .Posts }}
 <tr>
-<td>{{ .Idimagepost }}</td>
+<td><a href="/admin/user/{{ .UsersIdusers }}/imagebbs/post/{{ .Idimagepost }}">{{ .Idimagepost }}</a></td>
 <td>{{ .Username.String }}</td>
 <td>{{ .Description.String }}</td>
 <td>{{ if .Posted.Valid }}{{ localTime .Posted.Time }}{{ end }}</td>
+<td><a href="/imagebbs/post/{{ .Idimagepost }}">View</a></td>
 </tr>
 {{ end }}
 </table>

--- a/core/templates/site/linker/linkerAdminCategoryPage.gohtml
+++ b/core/templates/site/linker/linkerAdminCategoryPage.gohtml
@@ -14,17 +14,19 @@
         <th>Title</th>
         <th>URL</th>
         <th>Poster</th>
+        <th>View</th>
     </tr>
     {{ range cd.LinkerLinksByCategoryID .CategoryID }}
     <tr>
-        <td>{{ .Idlinker }}</td>
+        <td><a href="/admin/linker/links/link/{{ .Idlinker }}">{{ .Idlinker }}</a></td>
         <td>{{ .Title.String }}</td>
         <td><a href="{{ .Url.String }}">{{ .Url.String }}</a></td>
         <td>{{ .Posterusername.String }}</td>
+        <td><a href="/linker/show/{{ .Idlinker }}">View</a></td>
     </tr>
     {{ else }}
     <tr>
-        <td colspan="4">No links found.</td>
+        <td colspan="5">No links found.</td>
     </tr>
     {{ end }}
 </table>

--- a/core/templates/site/linker/linkerAdminLinksPage.gohtml
+++ b/core/templates/site/linker/linkerAdminLinksPage.gohtml
@@ -3,16 +3,17 @@
 {{- range cd.LinkerCategories }}
 <h3>{{ .Title.String }} ({{ .Idlinkercategory }})</h3>
 <table border="1">
-    <tr><th>ID</th><th>Title</th><th>URL</th><th>Poster</th></tr>
+    <tr><th>ID</th><th>Title</th><th>URL</th><th>Poster</th><th>View</th></tr>
     {{- range cd.LinkerLinksByCategoryID .Idlinkercategory }}
     <tr>
         <td><a href="/admin/linker/links/link/{{ .Idlinker }}">{{ .Idlinker }}</a></td>
         <td>{{ .Title.String }}</td>
         <td><a href="{{ .Url.String }}">{{ .Url.String }}</a></td>
         <td>{{ .Posterusername.String }}</td>
+        <td><a href="/linker/show/{{ .Idlinker }}">View</a></td>
     </tr>
     {{- else }}
-    <tr><td colspan="4">No links.</td></tr>
+    <tr><td colspan="5">No links.</td></tr>
     {{- end }}
 </table>
 {{- end }}

--- a/core/templates/site/writings/adminCategoryGrantsPage.gohtml
+++ b/core/templates/site/writings/adminCategoryGrantsPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-<h3>Category {{ .CategoryID }} Grants</h3>
+<h3>Category <a href="/admin/writings/categories/category/{{ .CategoryID }}">{{ .CategoryID }}</a> Grants</h3>
 <table border="1">
     <tr>
         <th>ID</th>

--- a/core/templates/site/writings/writingsAdminCategoryEditPage.gohtml
+++ b/core/templates/site/writings/writingsAdminCategoryEditPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-<h2>Edit Category {{ .Category.Idwritingcategory }}</h2>
+<h2>Edit Category <a href="/admin/writings/categories/category/{{ .Category.Idwritingcategory }}">{{ .Category.Idwritingcategory }}</a></h2>
 <form method="post" action="/admin/writings/categories/category/{{ .Category.Idwritingcategory }}/edit">
 {{ csrfField }}
     <input type="hidden" name="cid" value="{{ .Category.Idwritingcategory }}">

--- a/core/templates/site/writings/writingsAdminCategoryPage.gohtml
+++ b/core/templates/site/writings/writingsAdminCategoryPage.gohtml
@@ -12,11 +12,11 @@
     </tr>
     {{ range .Writings }}
     <tr>
-        <td>{{ .Idwriting }}</td>
+        <td><a href="/admin/writings/article/{{ .Idwriting }}">{{ .Idwriting }}</a></td>
         <td>{{ .Title.String }}</td>
         <td>{{ .Username.String }}</td>
         <td>{{ localTime .Published.Time }}</td>
-        <td><a href="/writings/{{ .Idwriting }}">View</a></td>
+        <td><a href="/writings/article/{{ .Idwriting }}">View</a></td>
     </tr>
     {{ end }}
 </table>


### PR DESCRIPTION
## Summary
- extend admin breadcrumb generation to writing category edit/grants and FAQ category pages
- link writing category grant/edit headings to their admin category pages
- connect FAQ admin pages to question editors and public FAQ view links

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68989aaaa5a4832fbc89cdd660138dd8