### PR TITLE
notifications: add send flag to all template providers

### DIFF
--- a/cmd/goa4web/notifications_tasks_data.go
+++ b/cmd/goa4web/notifications_tasks_data.go
@@ -31,7 +31,7 @@ func taskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 		t := e.Task
 		evt := eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}
 		if tp, ok := t.(notif.SelfNotificationTemplateProvider); ok {
-			if et := tp.SelfEmailTemplate(evt); et != nil {
+			if et, _ := tp.SelfEmailTemplate(evt); et != nil {
 				info.SelfEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 			if nt := tp.SelfInternalNotificationTemplate(evt); nt != nil {
@@ -39,12 +39,12 @@ func taskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 			}
 		}
 		if tp, ok := t.(notif.DirectEmailNotificationTemplateProvider); ok {
-			if et := tp.DirectEmailTemplate(evt); et != nil {
+			if et, _ := tp.DirectEmailTemplate(evt); et != nil {
 				info.DirectEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 		}
 		if tp, ok := t.(notif.SubscribersNotificationTemplateProvider); ok {
-			if et := tp.SubscribedEmailTemplate(evt); et != nil {
+			if et, _ := tp.SubscribedEmailTemplate(evt); et != nil {
 				info.SubEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 			if nt := tp.SubscribedInternalNotificationTemplate(evt); nt != nil {
@@ -52,7 +52,7 @@ func taskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 			}
 		}
 		if tp, ok := t.(notif.AdminEmailTemplateProvider); ok {
-			if et := tp.AdminEmailTemplate(evt); et != nil {
+			if et, _ := tp.AdminEmailTemplate(evt); et != nil {
 				info.AdminEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 			if nt := tp.AdminInternalNotificationTemplate(evt); nt != nil {
@@ -60,7 +60,7 @@ func taskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 			}
 		}
 		if tp, ok := t.(notif.TargetUsersNotificationProvider); ok {
-			if et := tp.TargetEmailTemplate(evt); et != nil {
+			if et, _ := tp.TargetEmailTemplate(evt); et != nil {
 				info.TargetEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 			if nt := tp.TargetInternalNotificationTemplate(evt); nt != nil {

--- a/handlers/admin/add_announcement_task.go
+++ b/handlers/admin/add_announcement_task.go
@@ -51,8 +51,8 @@ func (AddAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (AddAnnouncementTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("announcementEmail")
+func (AddAnnouncementTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("announcementEmail"), true
 }
 
 func (AddAnnouncementTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/admin/add_ip_ban_task.go
+++ b/handlers/admin/add_ip_ban_task.go
@@ -67,8 +67,8 @@ func (AddIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (AddIPBanTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminAddIPBanEmail")
+func (AddIPBanTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminAddIPBanEmail"), true
 }
 
 func (AddIPBanTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -34,7 +34,7 @@ func gatherTaskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 		t := e.Task
 		evt := eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}
 		if tp, ok := t.(notif.SelfNotificationTemplateProvider); ok {
-			if et := tp.SelfEmailTemplate(evt); et != nil {
+			if et, _ := tp.SelfEmailTemplate(evt); et != nil {
 				info.SelfEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 			if nt := tp.SelfInternalNotificationTemplate(evt); nt != nil {
@@ -42,12 +42,12 @@ func gatherTaskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 			}
 		}
 		if tp, ok := t.(notif.DirectEmailNotificationTemplateProvider); ok {
-			if et := tp.DirectEmailTemplate(evt); et != nil {
+			if et, _ := tp.DirectEmailTemplate(evt); et != nil {
 				info.DirectEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 		}
 		if tp, ok := t.(notif.SubscribersNotificationTemplateProvider); ok {
-			if et := tp.SubscribedEmailTemplate(evt); et != nil {
+			if et, _ := tp.SubscribedEmailTemplate(evt); et != nil {
 				info.SubEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 			if nt := tp.SubscribedInternalNotificationTemplate(evt); nt != nil {
@@ -55,7 +55,7 @@ func gatherTaskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 			}
 		}
 		if tp, ok := t.(notif.AdminEmailTemplateProvider); ok {
-			if et := tp.AdminEmailTemplate(evt); et != nil {
+			if et, _ := tp.AdminEmailTemplate(evt); et != nil {
 				info.AdminEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 			if nt := tp.AdminInternalNotificationTemplate(evt); nt != nil {
@@ -63,7 +63,7 @@ func gatherTaskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 			}
 		}
 		if tp, ok := t.(notif.TargetUsersNotificationProvider); ok {
-			if et := tp.TargetEmailTemplate(evt); et != nil {
+			if et, _ := tp.TargetEmailTemplate(evt); et != nil {
 				info.TargetEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 			if nt := tp.TargetInternalNotificationTemplate(evt); nt != nil {

--- a/handlers/admin/adminIPBanTemplates_test.go
+++ b/handlers/admin/adminIPBanTemplates_test.go
@@ -30,6 +30,8 @@ func TestAdminIPBanTemplatesExist(t *testing.T) {
 		&DeleteIPBanTask{TaskString: TaskDelete},
 	}
 	for _, p := range admins {
-		checkIPBanEmailTemplates(t, p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		if et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			checkIPBanEmailTemplates(t, et)
+		}
 	}
 }

--- a/handlers/admin/adminUserPasswordReset.go
+++ b/handlers/admin/adminUserPasswordReset.go
@@ -82,8 +82,8 @@ func (UserPasswordResetTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, err
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (UserPasswordResetTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminPasswordResetEmail")
+func (UserPasswordResetTask) TargetEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminPasswordResetEmail"), true
 }
 
 func (UserPasswordResetTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/admin/announcementTemplates_test.go
+++ b/handlers/admin/announcementTemplates_test.go
@@ -40,7 +40,9 @@ func TestAnnouncementTemplatesExist(t *testing.T) {
 		deleteAnnouncementTask,
 	}
 	for _, p := range admins {
-		checkEmailTemplates(t, p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		if et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			checkEmailTemplates(t, et)
+		}
 		checkNotificationTemplate(t, p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/admin/delete_announcement_task.go
+++ b/handlers/admin/delete_announcement_task.go
@@ -51,8 +51,8 @@ func (DeleteAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any
 	return nil
 }
 
-func (DeleteAnnouncementTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("announcementEmail")
+func (DeleteAnnouncementTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("announcementEmail"), true
 }
 
 func (DeleteAnnouncementTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/admin/delete_ip_ban_task.go
+++ b/handlers/admin/delete_ip_ban_task.go
@@ -54,8 +54,8 @@ func (DeleteIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (DeleteIPBanTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminRemoveIPBanEmail")
+func (DeleteIPBanTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminRemoveIPBanEmail"), true
 }
 
 func (DeleteIPBanTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/auth/forgotPassword_test.go
+++ b/handlers/auth/forgotPassword_test.go
@@ -40,7 +40,9 @@ func TestForgotPasswordTemplatesExist(t *testing.T) {
 		emailAssociationRequestTask,
 	}
 	for _, p := range admins {
-		requireEmailTemplates(t, p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		if et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			requireEmailTemplates(t, et)
+		}
 		requireNotificationTemplate(t, p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 
@@ -48,7 +50,11 @@ func TestForgotPasswordTemplatesExist(t *testing.T) {
 		forgotPasswordTask,
 	}
 	for _, p := range selfProviders {
-		requireEmailTemplates(t, p.SelfEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		if et, send := p.SelfEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); send {
+			requireEmailTemplates(t, et)
+		} else {
+			t.Errorf("expected self email to be sent")
+		}
 		requireNotificationTemplate(t, p.SelfInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/auth/forgot_password_task.go
+++ b/handlers/auth/forgot_password_task.go
@@ -103,8 +103,8 @@ func (ForgotPasswordTask) AuditRecord(data map[string]any) string {
 	return "password reset requested"
 }
 
-func (EmailAssociationRequestTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationEmailAssociationRequestEmail")
+func (EmailAssociationRequestTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationEmailAssociationRequestEmail"), true
 }
 
 func (EmailAssociationRequestTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -112,8 +112,8 @@ func (EmailAssociationRequestTask) AdminInternalNotificationTemplate(evt eventbu
 	return &v
 }
 
-func (f ForgotPasswordTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationUserRequestPasswordResetEmail")
+func (f ForgotPasswordTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationUserRequestPasswordResetEmail"), true
 }
 
 func (f ForgotPasswordTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -121,8 +121,8 @@ func (f ForgotPasswordTask) AdminInternalNotificationTemplate(evt eventbus.TaskE
 	return &v
 }
 
-func (f ForgotPasswordTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("passwordResetEmail")
+func (f ForgotPasswordTask) SelfEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("passwordResetEmail"), true
 }
 
 func (f ForgotPasswordTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -30,8 +30,8 @@ var _ notif.SubscribersNotificationTemplateProvider = (*AddBlogTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*AddBlogTask)(nil)
 var _ notif.GrantsRequiredProvider = (*AddBlogTask)(nil)
 
-func (AddBlogTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationBlogAddEmail")
+func (AddBlogTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationBlogAddEmail"), true
 }
 
 func (AddBlogTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -39,8 +39,8 @@ func (AddBlogTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *st
 	return &v
 }
 
-func (AddBlogTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("blogAddEmail")
+func (AddBlogTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("blogAddEmail"), true
 }
 
 func (AddBlogTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -27,8 +27,8 @@ var editBlogTask = &EditBlogTask{TaskString: TaskEdit}
 var _ tasks.Task = (*EditBlogTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*EditBlogTask)(nil)
 
-func (EditBlogTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationBlogEditEmail")
+func (EditBlogTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationBlogEditEmail"), true
 }
 
 func (EditBlogTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -35,11 +35,8 @@ var (
 	_ notif.GrantsRequiredProvider                  = (*ReplyBlogTask)(nil)
 )
 
-func (ReplyBlogTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	if evt.Outcome != eventbus.TaskOutcomeSuccess {
-		return nil
-	}
-	return notif.NewEmailTemplates("replyEmail")
+func (ReplyBlogTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("replyEmail"), evt.Outcome == eventbus.TaskOutcomeSuccess
 }
 
 func (ReplyBlogTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/blogs/blogsCommentEditCancelTask.go
+++ b/handlers/blogs/blogsCommentEditCancelTask.go
@@ -24,8 +24,8 @@ var cancelTask = &CancelTask{TaskString: TaskCancel}
 var _ tasks.Task = (*CancelTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*CancelTask)(nil)
 
-func (CancelTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationBlogCommentCancelEmail")
+func (CancelTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationBlogCommentCancelEmail"), true
 }
 
 func (CancelTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/blogs/blogsCommentEditReplyTask.go
+++ b/handlers/blogs/blogsCommentEditReplyTask.go
@@ -28,8 +28,8 @@ var editReplyTask = &EditReplyTask{TaskString: TaskEditReply}
 var _ tasks.Task = (*EditReplyTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*EditReplyTask)(nil)
 
-func (EditReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationBlogCommentEditEmail")
+func (EditReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationBlogCommentEditEmail"), true
 }
 
 func (EditReplyTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -27,8 +27,8 @@ var askTask = &AskTask{TaskString: TaskAsk}
 var _ tasks.Task = (*AskTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*AskTask)(nil)
 
-func (AskTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationFaqAskEmail")
+func (AskTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationFaqAskEmail"), true
 }
 
 func (AskTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/faq/faqTemplates_test.go
+++ b/handlers/faq/faqTemplates_test.go
@@ -37,7 +37,9 @@ func requireNotificationTemplate(t *testing.T, name *string) {
 
 func TestAskTaskTemplatesCompile(t *testing.T) {
 	var task AskTask
-	requireEmailTemplates(t, task.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+	if et, _ := task.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+		requireEmailTemplates(t, et)
+	}
 	requireNotificationTemplate(t, task.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 }
 

--- a/handlers/forum/category_change_task.go
+++ b/handlers/forum/category_change_task.go
@@ -16,8 +16,8 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*CategoryChangeTask)(nil)
 )
 
-func (CategoryChangeTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationForumCategoryChangeEmail")
+func (CategoryChangeTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationForumCategoryChangeEmail"), true
 }
 
 func (CategoryChangeTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/forum/category_create_task.go
+++ b/handlers/forum/category_create_task.go
@@ -16,8 +16,8 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*CategoryCreateTask)(nil)
 )
 
-func (CategoryCreateTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationForumCategoryCreateEmail")
+func (CategoryCreateTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationForumCategoryCreateEmail"), true
 }
 
 func (CategoryCreateTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/forum/delete_category_task.go
+++ b/handlers/forum/delete_category_task.go
@@ -16,8 +16,8 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*DeleteCategoryTask)(nil)
 )
 
-func (DeleteCategoryTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationForumDeleteCategoryEmail")
+func (DeleteCategoryTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationForumDeleteCategoryEmail"), true
 }
 
 func (DeleteCategoryTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/forum/forumAdminTemplates_test.go
+++ b/handlers/forum/forumAdminTemplates_test.go
@@ -34,6 +34,8 @@ func TestForumAdminTemplatesExist(t *testing.T) {
 		threadDeleteTask,
 	}
 	for _, p := range admins {
-		requireAdminEmailTemplates(t, p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		if et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			requireAdminEmailTemplates(t, et)
+		}
 	}
 }

--- a/handlers/forum/forumTemplates_test.go
+++ b/handlers/forum/forumTemplates_test.go
@@ -40,7 +40,9 @@ func TestForumTemplatesExist(t *testing.T) {
 		replyTask,
 	}
 	for _, p := range providers {
-		checkEmailTemplates(t, p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		if et, _ := p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			checkEmailTemplates(t, et)
+		}
 		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -53,8 +53,8 @@ func (CreateThreadTask) IndexData(data map[string]any) []searchworker.IndexEvent
 	return nil
 }
 
-func (CreateThreadTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("threadEmail")
+func (CreateThreadTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("threadEmail"), true
 }
 
 func (CreateThreadTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -62,8 +62,8 @@ func (CreateThreadTask) SubscribedInternalNotificationTemplate(evt eventbus.Task
 	return &s
 }
 
-func (CreateThreadTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationForumThreadCreateEmail")
+func (CreateThreadTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationForumThreadCreateEmail"), true
 }
 
 func (CreateThreadTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -49,11 +49,8 @@ func (ReplyTask) IndexData(data map[string]any) []searchworker.IndexEventData {
 
 var _ searchworker.IndexedTask = ReplyTask{}
 
-func (ReplyTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	if evt.Outcome != eventbus.TaskOutcomeSuccess {
-		return nil
-	}
-	return notif.NewEmailTemplates("replyEmail")
+func (ReplyTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("replyEmail"), evt.Outcome == eventbus.TaskOutcomeSuccess
 }
 
 func (ReplyTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -64,11 +61,8 @@ func (ReplyTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) 
 	return &s
 }
 
-func (ReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	if evt.Outcome != eventbus.TaskOutcomeSuccess {
-		return nil
-	}
-	return notif.NewEmailTemplates("adminNotificationForumReplyEmail")
+func (ReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationForumReplyEmail"), evt.Outcome == eventbus.TaskOutcomeSuccess
 }
 
 func (ReplyTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/forum/thread_delete_task.go
+++ b/handlers/forum/thread_delete_task.go
@@ -16,8 +16,8 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*ThreadDeleteTask)(nil)
 )
 
-func (ThreadDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationForumThreadDeleteEmail")
+func (ThreadDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationForumThreadDeleteEmail"), true
 }
 
 func (ThreadDeleteTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/forum/topic_change_task.go
+++ b/handlers/forum/topic_change_task.go
@@ -16,8 +16,8 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*TopicChangeTask)(nil)
 )
 
-func (TopicChangeTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationForumTopicChangeEmail")
+func (TopicChangeTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationForumTopicChangeEmail"), true
 }
 
 func (TopicChangeTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/forum/topic_create_task.go
+++ b/handlers/forum/topic_create_task.go
@@ -16,8 +16,8 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*TopicCreateTask)(nil)
 )
 
-func (TopicCreateTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationForumTopicCreateEmail")
+func (TopicCreateTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationForumTopicCreateEmail"), true
 }
 
 func (TopicCreateTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/forum/topic_delete_task.go
+++ b/handlers/forum/topic_delete_task.go
@@ -16,8 +16,8 @@ var (
 	_ notif.AdminEmailTemplateProvider = (*TopicDeleteTask)(nil)
 )
 
-func (TopicDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationForumTopicDeleteEmail")
+func (TopicDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationForumTopicDeleteEmail"), true
 }
 
 func (TopicDeleteTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/imagebbs/imagebbsAdminApprove.go
+++ b/handlers/imagebbs/imagebbsAdminApprove.go
@@ -48,8 +48,8 @@ func (ApprovePostTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (ApprovePostTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("imagePostApprovedEmail")
+func (ApprovePostTask) SelfEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("imagePostApprovedEmail"), true
 }
 
 func (ApprovePostTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/imagebbs/imagebbsAdminBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardPage.go
@@ -30,8 +30,8 @@ var modifyBoardTask = &ModifyBoardTask{TaskString: TaskModifyBoard}
 var _ tasks.Task = (*ModifyBoardTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*ModifyBoardTask)(nil)
 
-func (ModifyBoardTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("imageBoardUpdateEmail")
+func (ModifyBoardTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("imageBoardUpdateEmail"), true
 }
 
 func (ModifyBoardTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/imagebbs/imagebbsAdminNewBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminNewBoardPage.go
@@ -27,8 +27,8 @@ var newBoardTask = &NewBoardTask{TaskString: TaskNewBoard}
 var _ tasks.Task = (*NewBoardTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*NewBoardTask)(nil)
 
-func (NewBoardTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationImageBoardNewEmail")
+func (NewBoardTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationImageBoardNewEmail"), true
 }
 
 func (NewBoardTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -46,11 +46,8 @@ func (ReplyTask) IndexData(data map[string]any) []searchworker.IndexEventData {
 
 var _ searchworker.IndexedTask = ReplyTask{}
 
-func (ReplyTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	if evt.Outcome != eventbus.TaskOutcomeSuccess {
-		return nil
-	}
-	return notif.NewEmailTemplates("replyEmail")
+func (ReplyTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("replyEmail"), evt.Outcome == eventbus.TaskOutcomeSuccess
 }
 
 func (ReplyTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/imagebbs/imagebbsTemplates_test.go
+++ b/handlers/imagebbs/imagebbsTemplates_test.go
@@ -40,7 +40,9 @@ func TestImageBbsTemplatesExist(t *testing.T) {
 		modifyBoardTask,
 	}
 	for _, p := range admins {
-		checkEmailTemplates(t, p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		if et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			checkEmailTemplates(t, et)
+		}
 		if p != newBoardTask {
 			checkNotificationTemplate(t, p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 		}
@@ -50,7 +52,11 @@ func TestImageBbsTemplatesExist(t *testing.T) {
 		approvePostTask,
 	}
 	for _, p := range selfProviders {
-		checkEmailTemplates(t, p.SelfEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		if et, send := p.SelfEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); send {
+			checkEmailTemplates(t, et)
+		} else {
+			t.Errorf("expected self email to be sent")
+		}
 		checkNotificationTemplate(t, p.SelfInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 
@@ -58,7 +64,9 @@ func TestImageBbsTemplatesExist(t *testing.T) {
 		replyTask,
 	}
 	for _, p := range subs {
-		checkEmailTemplates(t, p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		if et, _ := p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			checkEmailTemplates(t, et)
+		}
 		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/languages/create_language_task.go
+++ b/handlers/languages/create_language_task.go
@@ -44,8 +44,8 @@ func (CreateLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (CreateLanguageTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationLanguageCreateEmail")
+func (CreateLanguageTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationLanguageCreateEmail"), true
 }
 
 func (CreateLanguageTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/languages/delete_language_task.go
+++ b/handlers/languages/delete_language_task.go
@@ -45,8 +45,8 @@ func (DeleteLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (DeleteLanguageTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationLanguageDeleteEmail")
+func (DeleteLanguageTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationLanguageDeleteEmail"), true
 }
 
 func (DeleteLanguageTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/languages/languagesTemplates_test.go
+++ b/handlers/languages/languagesTemplates_test.go
@@ -41,7 +41,9 @@ func TestLanguageTaskTemplates(t *testing.T) {
 		createLanguageTask,
 	}
 	for _, a := range admins {
-		requireEmailTemplates(t, a.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		if et, _ := a.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			requireEmailTemplates(t, et)
+		}
 		requireNotificationTemplate(t, a.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/languages/rename_language_task.go
+++ b/handlers/languages/rename_language_task.go
@@ -59,8 +59,8 @@ func (RenameLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (RenameLanguageTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationLanguageRenameEmail")
+func (RenameLanguageTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationLanguageRenameEmail"), true
 }
 
 func (RenameLanguageTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/linker/approve_task.go
+++ b/handlers/linker/approve_task.go
@@ -79,8 +79,8 @@ func (approveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (approveTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("linkerApprovedEmail")
+func (approveTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("linkerApprovedEmail"), true
 }
 
 func (approveTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -88,8 +88,8 @@ func (approveTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent
 	return &s
 }
 
-func (approveTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationLinkerApprovedEmail")
+func (approveTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationLinkerApprovedEmail"), true
 }
 
 func (approveTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/linker/bulk_approve_task.go
+++ b/handlers/linker/bulk_approve_task.go
@@ -86,8 +86,8 @@ func (bulkApproveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (bulkApproveTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("linkerApprovedEmail")
+func (bulkApproveTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("linkerApprovedEmail"), true
 }
 
 func (bulkApproveTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -95,8 +95,8 @@ func (bulkApproveTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskE
 	return &s
 }
 
-func (bulkApproveTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationLinkerApprovedEmail")
+func (bulkApproveTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationLinkerApprovedEmail"), true
 }
 
 func (bulkApproveTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/linker/bulk_delete_task.go
+++ b/handlers/linker/bulk_delete_task.go
@@ -75,8 +75,8 @@ func (bulkDeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (bulkDeleteTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("linkerRejectedEmail")
+func (bulkDeleteTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("linkerRejectedEmail"), true
 }
 
 func (bulkDeleteTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -84,8 +84,8 @@ func (bulkDeleteTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEv
 	return &s
 }
 
-func (bulkDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationLinkerRejectedEmail")
+func (bulkDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationLinkerRejectedEmail"), true
 }
 
 func (bulkDeleteTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/linker/delete_task.go
+++ b/handlers/linker/delete_task.go
@@ -63,8 +63,8 @@ func (deleteTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (deleteTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("linkerRejectedEmail")
+func (deleteTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("linkerRejectedEmail"), true
 }
 
 func (deleteTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -72,8 +72,8 @@ func (deleteTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent)
 	return &s
 }
 
-func (deleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationLinkerRejectedEmail")
+func (deleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationLinkerRejectedEmail"), true
 }
 
 func (deleteTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -106,8 +106,8 @@ func (addTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (addTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("linkerAddEmail")
+func (addTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("linkerAddEmail"), true
 }
 
 func (addTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -115,8 +115,8 @@ func (addTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *s
 	return &s
 }
 
-func (addTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationLinkerAddEmail")
+func (addTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationLinkerAddEmail"), true
 }
 
 func (addTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/news/cancel_edit_task.go
+++ b/handlers/news/cancel_edit_task.go
@@ -22,8 +22,8 @@ var cancelTask = &CancelTask{TaskString: TaskCancel}
 var _ tasks.Task = (*CancelTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*CancelTask)(nil)
 
-func (CancelTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationNewsCommentCancelEmail")
+func (CancelTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationNewsCommentCancelEmail"), true
 }
 
 func (CancelTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/news/edit_reply_task.go
+++ b/handlers/news/edit_reply_task.go
@@ -26,8 +26,8 @@ var editReplyTask = &EditReplyTask{TaskString: TaskEditReply}
 var _ tasks.Task = (*EditReplyTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*EditReplyTask)(nil)
 
-func (EditReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationNewsCommentEditEmail")
+func (EditReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationNewsCommentEditEmail"), true
 }
 
 func (EditReplyTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/news/newsAnnouncementTasks.go
+++ b/handlers/news/newsAnnouncementTasks.go
@@ -9,8 +9,8 @@ import (
 var _ tasks.Task = (*AnnouncementAddTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*AnnouncementAddTask)(nil)
 
-func (AnnouncementAddTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationNewsAddEmail")
+func (AnnouncementAddTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationNewsAddEmail"), true
 }
 
 func (AnnouncementAddTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -21,8 +21,8 @@ func (AnnouncementAddTask) AdminInternalNotificationTemplate(evt eventbus.TaskEv
 var _ tasks.Task = (*AnnouncementDeleteTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*AnnouncementDeleteTask)(nil)
 
-func (AnnouncementDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationNewsDeleteEmail")
+func (AnnouncementDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationNewsDeleteEmail"), true
 }
 
 func (AnnouncementDeleteTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/news/newsEditPostTask.go
+++ b/handlers/news/newsEditPostTask.go
@@ -24,8 +24,8 @@ var editTask = &EditTask{TaskString: TaskEdit}
 var _ tasks.Task = (*EditTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*EditTask)(nil)
 
-func (EditTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationNewsEditEmail")
+func (EditTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationNewsEditEmail"), true
 }
 
 func (EditTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/news/newsNewPostTask.go
+++ b/handlers/news/newsNewPostTask.go
@@ -28,8 +28,8 @@ var (
 	_ notif.AutoSubscribeProvider                   = (*NewPostTask)(nil)
 )
 
-func (NewPostTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationNewsAddEmail")
+func (NewPostTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationNewsAddEmail"), true
 }
 
 func (NewPostTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -37,8 +37,8 @@ func (NewPostTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *st
 	return &v
 }
 
-func (NewPostTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("newsAddEmail")
+func (NewPostTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("newsAddEmail"), true
 }
 
 func (NewPostTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -42,11 +42,8 @@ func (ReplyTask) IndexData(data map[string]any) []searchworker.IndexEventData {
 
 var _ searchworker.IndexedTask = ReplyTask{}
 
-func (ReplyTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	if evt.Outcome != eventbus.TaskOutcomeSuccess {
-		return nil
-	}
-	return notif.NewEmailTemplates("replyEmail")
+func (ReplyTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("replyEmail"), evt.Outcome == eventbus.TaskOutcomeSuccess
 }
 
 func (ReplyTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -57,11 +54,8 @@ func (ReplyTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) 
 	return &s
 }
 
-func (ReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	if evt.Outcome != eventbus.TaskOutcomeSuccess {
-		return nil
-	}
-	return notif.NewEmailTemplates("adminNotificationNewsReplyEmail")
+func (ReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationNewsReplyEmail"), evt.Outcome == eventbus.TaskOutcomeSuccess
 }
 
 func (ReplyTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/news/newsTemplates_test.go
+++ b/handlers/news/newsTemplates_test.go
@@ -40,7 +40,9 @@ func TestNewsTemplatesExist(t *testing.T) {
 		replyTask,
 	}
 	for _, p := range subs {
-		checkEmailTemplates(t, p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		if et, _ := p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			checkEmailTemplates(t, et)
+		}
 		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 
@@ -56,7 +58,9 @@ func TestNewsTemplatesExist(t *testing.T) {
 		announcementDeleteTask,
 	}
 	for _, p := range admins {
-		checkEmailTemplates(t, p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		if et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			checkEmailTemplates(t, et)
+		}
 		checkNotificationTemplate(t, p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/handlers/news/user_allow_task.go
+++ b/handlers/news/user_allow_task.go
@@ -21,8 +21,8 @@ var userAllowTask = &UserAllowTask{TaskString: TaskUserAllow}
 var _ tasks.Task = (*UserAllowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*UserAllowTask)(nil)
 
-func (UserAllowTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationNewsUserAllowEmail")
+func (UserAllowTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationNewsUserAllowEmail"), true
 }
 
 func (UserAllowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/news/user_disallow_task.go
+++ b/handlers/news/user_disallow_task.go
@@ -22,8 +22,8 @@ var userDisallowTask = &UserDisallowTask{TaskString: TaskUserDisallow}
 var _ tasks.Task = (*UserDisallowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*UserDisallowTask)(nil)
 
-func (UserDisallowTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationNewsUserDisallowEmail")
+func (UserDisallowTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationNewsUserDisallowEmail"), true
 }
 
 func (UserDisallowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/search/remakeBlogFinishedTask.go
+++ b/handlers/search/remakeBlogFinishedTask.go
@@ -20,8 +20,8 @@ var _ notif.SelfNotificationTemplateProvider = (*RemakeBlogFinishedTask)(nil)
 
 func (RemakeBlogFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
 
-func (RemakeBlogFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("searchRebuildBlogEmail")
+func (RemakeBlogFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("searchRebuildBlogEmail"), true
 }
 
 func (RemakeBlogFinishedTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -29,8 +29,8 @@ func (RemakeBlogFinishedTask) AdminInternalNotificationTemplate(evt eventbus.Tas
 	return &s
 }
 
-func (RemakeBlogFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("searchRebuildBlogEmail")
+func (RemakeBlogFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("searchRebuildBlogEmail"), true
 }
 
 func (RemakeBlogFinishedTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/search/remakeCommentsFinishedTask.go
+++ b/handlers/search/remakeCommentsFinishedTask.go
@@ -20,8 +20,8 @@ var _ notif.SelfNotificationTemplateProvider = (*RemakeCommentsFinishedTask)(nil
 
 func (RemakeCommentsFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
 
-func (RemakeCommentsFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("searchRebuildCommentsEmail")
+func (RemakeCommentsFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("searchRebuildCommentsEmail"), true
 }
 
 func (RemakeCommentsFinishedTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -29,8 +29,8 @@ func (RemakeCommentsFinishedTask) AdminInternalNotificationTemplate(evt eventbus
 	return &s
 }
 
-func (RemakeCommentsFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("searchRebuildCommentsEmail")
+func (RemakeCommentsFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("searchRebuildCommentsEmail"), true
 }
 
 func (RemakeCommentsFinishedTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/search/remakeImageFinishedTask.go
+++ b/handlers/search/remakeImageFinishedTask.go
@@ -20,8 +20,8 @@ var _ notif.SelfNotificationTemplateProvider = (*RemakeImageFinishedTask)(nil)
 
 func (RemakeImageFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
 
-func (RemakeImageFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("searchRebuildImageEmail")
+func (RemakeImageFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("searchRebuildImageEmail"), true
 }
 
 func (RemakeImageFinishedTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -29,8 +29,8 @@ func (RemakeImageFinishedTask) AdminInternalNotificationTemplate(evt eventbus.Ta
 	return &s
 }
 
-func (RemakeImageFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("searchRebuildImageEmail")
+func (RemakeImageFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("searchRebuildImageEmail"), true
 }
 
 func (RemakeImageFinishedTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/search/remakeLinkerFinishedTask.go
+++ b/handlers/search/remakeLinkerFinishedTask.go
@@ -20,8 +20,8 @@ var _ notif.SelfNotificationTemplateProvider = (*RemakeLinkerFinishedTask)(nil)
 
 func (RemakeLinkerFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
 
-func (RemakeLinkerFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("searchRebuildLinkerEmail")
+func (RemakeLinkerFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("searchRebuildLinkerEmail"), true
 }
 
 func (RemakeLinkerFinishedTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -29,8 +29,8 @@ func (RemakeLinkerFinishedTask) AdminInternalNotificationTemplate(evt eventbus.T
 	return &s
 }
 
-func (RemakeLinkerFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("searchRebuildLinkerEmail")
+func (RemakeLinkerFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("searchRebuildLinkerEmail"), true
 }
 
 func (RemakeLinkerFinishedTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/search/remakeNewsFinishedTask.go
+++ b/handlers/search/remakeNewsFinishedTask.go
@@ -20,8 +20,8 @@ var _ notif.SelfNotificationTemplateProvider = (*RemakeNewsFinishedTask)(nil)
 
 func (RemakeNewsFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
 
-func (RemakeNewsFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("searchRebuildNewsEmail")
+func (RemakeNewsFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("searchRebuildNewsEmail"), true
 }
 
 func (RemakeNewsFinishedTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -29,8 +29,8 @@ func (RemakeNewsFinishedTask) AdminInternalNotificationTemplate(evt eventbus.Tas
 	return &s
 }
 
-func (RemakeNewsFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("searchRebuildNewsEmail")
+func (RemakeNewsFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("searchRebuildNewsEmail"), true
 }
 
 func (RemakeNewsFinishedTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/search/remakeWritingFinishedTask.go
+++ b/handlers/search/remakeWritingFinishedTask.go
@@ -20,8 +20,8 @@ var _ notif.SelfNotificationTemplateProvider = (*RemakeWritingFinishedTask)(nil)
 
 func (RemakeWritingFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }
 
-func (RemakeWritingFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("searchRebuildWritingEmail")
+func (RemakeWritingFinishedTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("searchRebuildWritingEmail"), true
 }
 
 func (RemakeWritingFinishedTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -29,8 +29,8 @@ func (RemakeWritingFinishedTask) AdminInternalNotificationTemplate(evt eventbus.
 	return &s
 }
 
-func (RemakeWritingFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("searchRebuildWritingEmail")
+func (RemakeWritingFinishedTask) SelfEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("searchRebuildWritingEmail"), true
 }
 
 func (RemakeWritingFinishedTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/user/addEmailTask.go
+++ b/handlers/user/addEmailTask.go
@@ -137,8 +137,8 @@ func (AddEmailTask) Notify(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
 }
 
-func (AddEmailTask) DirectEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("verifyEmail")
+func (AddEmailTask) DirectEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("verifyEmail"), true
 }
 
 func (AddEmailTask) DirectEmailAddress(evt eventbus.TaskEvent) (string, error) {

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -27,7 +27,7 @@ func TestPermissionUserTasksTemplates(t *testing.T) {
 		&PermissionUserDisallowTask{TaskString: TaskUserDisallow},
 	}
 	for _, p := range admins {
-		et := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+		et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
 		if et == nil || et.Text == "" || et.HTML == "" || et.Subject == "" {
 			t.Errorf("incomplete templates for %T", p)
 		}

--- a/handlers/user/permissionUpdateTask.go
+++ b/handlers/user/permissionUpdateTask.go
@@ -94,8 +94,8 @@ func (PermissionUpdateTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, erro
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (PermissionUpdateTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("updateUserRoleEmail")
+func (PermissionUpdateTask) TargetEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("updateUserRoleEmail"), true
 }
 
 func (PermissionUpdateTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/user/permissionUserAllowTask.go
+++ b/handlers/user/permissionUserAllowTask.go
@@ -23,8 +23,8 @@ var _ tasks.Task = (*PermissionUserAllowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*PermissionUserAllowTask)(nil)
 var _ notif.TargetUsersNotificationProvider = (*PermissionUserAllowTask)(nil)
 
-func (PermissionUserAllowTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminPermissionAllowEmail")
+func (PermissionUserAllowTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminPermissionAllowEmail"), true
 }
 
 func (PermissionUserAllowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -80,8 +80,8 @@ func (PermissionUserAllowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, e
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (PermissionUserAllowTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("setUserRoleEmail")
+func (PermissionUserAllowTask) TargetEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("setUserRoleEmail"), true
 }
 
 func (PermissionUserAllowTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/user/permissionUserDisallowTask.go
+++ b/handlers/user/permissionUserDisallowTask.go
@@ -23,8 +23,8 @@ var _ tasks.Task = (*PermissionUserDisallowTask)(nil)
 var _ notif.AdminEmailTemplateProvider = (*PermissionUserDisallowTask)(nil)
 var _ notif.TargetUsersNotificationProvider = (*PermissionUserDisallowTask)(nil)
 
-func (PermissionUserDisallowTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminPermissionDisallowEmail")
+func (PermissionUserDisallowTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminPermissionDisallowEmail"), true
 }
 
 func (PermissionUserDisallowTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
@@ -96,8 +96,8 @@ func (PermissionUserDisallowTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32
 	return nil, fmt.Errorf("target user id not provided")
 }
 
-func (PermissionUserDisallowTask) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("deleteUserRoleEmail")
+func (PermissionUserDisallowTask) TargetEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("deleteUserRoleEmail"), true
 }
 
 func (PermissionUserDisallowTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/user/resendVerificationEmailTask.go
+++ b/handlers/user/resendVerificationEmailTask.go
@@ -21,8 +21,8 @@ func (ResendVerificationEmailTask) Action(w http.ResponseWriter, r *http.Request
 	return addEmailTask.Resend(w, r)
 }
 
-func (ResendVerificationEmailTask) DirectEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("verifyEmail")
+func (ResendVerificationEmailTask) DirectEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("verifyEmail"), true
 }
 
 func (ResendVerificationEmailTask) DirectEmailAddress(evt eventbus.TaskEvent) (string, error) {

--- a/handlers/user/testMailTask.go
+++ b/handlers/user/testMailTask.go
@@ -41,8 +41,8 @@ func (TestMailTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return handlers.RefreshDirectHandler{TargetURL: "/usr/email"}
 }
 
-func (TestMailTask) SelfEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("testEmail")
+func (TestMailTask) SelfEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("testEmail"), true
 }
 
 func (TestMailTask) SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/writings/edit_reply_task.go
+++ b/handlers/writings/edit_reply_task.go
@@ -65,8 +65,8 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return handlers.RedirectHandler(fmt.Sprintf("/writings/article/%d", writing.Idwriting))
 }
 
-func (EditReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("adminNotificationNewsCommentEditEmail")
+func (EditReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("adminNotificationNewsCommentEditEmail"), true
 }
 
 func (EditReplyTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -39,11 +39,8 @@ func (ReplyTask) IndexData(data map[string]any) []searchworker.IndexEventData {
 	return nil
 }
 
-func (ReplyTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	if evt.Outcome != eventbus.TaskOutcomeSuccess {
-		return nil
-	}
-	return notif.NewEmailTemplates("replyEmail")
+func (ReplyTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("replyEmail"), evt.Outcome == eventbus.TaskOutcomeSuccess
 }
 
 func (ReplyTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/writings/submit_writing_task.go
+++ b/handlers/writings/submit_writing_task.go
@@ -90,8 +90,8 @@ func (SubmitWritingTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return handlers.RedirectHandler(fmt.Sprintf("/writings/article/%d", articleID))
 }
 
-func (SubmitWritingTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("writingEmail")
+func (SubmitWritingTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("writingEmail"), true
 }
 
 func (SubmitWritingTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/writings/templates_test.go
+++ b/handlers/writings/templates_test.go
@@ -12,7 +12,7 @@ import (
 func TestReplyTemplatesCompile(t *testing.T) {
 	// Ensure the ReplyTask exposes templates that actually exist so users
 	// receive notification emails when someone responds.
-	et := replyTask.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+	et, _ := replyTask.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
 	htmlTmpls := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
 	textTmpls := templates.GetCompiledEmailTextTemplates(map[string]any{})
 	if htmlTmpls.Lookup(et.HTML) == nil {

--- a/handlers/writings/update_writing_task.go
+++ b/handlers/writings/update_writing_task.go
@@ -84,8 +84,8 @@ func (UpdateWritingTask) Action(w http.ResponseWriter, r *http.Request) any {
 	return nil
 }
 
-func (UpdateWritingTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return notif.NewEmailTemplates("writingUpdateEmail")
+func (UpdateWritingTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return notif.NewEmailTemplates("writingUpdateEmail"), true
 }
 
 func (UpdateWritingTask) SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string {

--- a/handlers/writings/writingsTemplates_test.go
+++ b/handlers/writings/writingsTemplates_test.go
@@ -41,7 +41,9 @@ func TestWritingsTemplatesExist(t *testing.T) {
 		replyTask,
 	}
 	for _, p := range providers {
-		checkEmailTemplates(t, p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		if et, _ := p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			checkEmailTemplates(t, et)
+		}
 		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
 	}
 }

--- a/internal/notifications/bus_worker_test.go
+++ b/internal/notifications/bus_worker_test.go
@@ -247,7 +247,9 @@ func (targetTask) Action(http.ResponseWriter, *http.Request) any { return nil }
 
 func (targetTask) TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error) { return []int32{2, 3}, nil }
 
-func (targetTask) TargetEmailTemplate(evt eventbus.TaskEvent) *EmailTemplates { return nil }
+func (targetTask) TargetEmailTemplate(evt eventbus.TaskEvent) (templates *EmailTemplates, send bool) {
+	return nil, false
+}
 
 func (targetTask) TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string {
 	t := NotificationTemplateFilenameGenerator("announcement")
@@ -352,10 +354,10 @@ func TestProcessEventAutoSubscribe(t *testing.T) {
 	q := db.New(conn)
 	n := New(WithQueries(q), WithConfig(cfg))
 
-        prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies", "timezone"}).
-                AddRow(1, 0, 1, nil, 0, true, nil)
-        mock.ExpectQuery(regexp.QuoteMeta("SELECT idpreferences, language_idlanguage, users_idusers, emailforumupdates, page_size, auto_subscribe_replies, timezone FROM preferences WHERE users_idusers = ?")).
-                WithArgs(int32(1)).WillReturnRows(prefRows)
+	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies", "timezone"}).
+		AddRow(1, 0, 1, nil, 0, true, nil)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idpreferences, language_idlanguage, users_idusers, emailforumupdates, page_size, auto_subscribe_replies, timezone FROM preferences WHERE users_idusers = ?")).
+		WithArgs(int32(1)).WillReturnRows(prefRows)
 
 	pattern := buildPatterns(tasks.TaskString("AutoSub"), "/forum/topic/7/thread/42")[0]
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT users_idusers FROM subscriptions WHERE pattern = ? AND method = ?")).

--- a/internal/notifications/permission_tasks_test.go
+++ b/internal/notifications/permission_tasks_test.go
@@ -19,20 +19,22 @@ import (
 
 type allowTaskNoEmail struct{ user.PermissionUserAllowTask }
 
-func (allowTaskNoEmail) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates { return nil }
+func (allowTaskNoEmail) TargetEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return nil, false
+}
 
 type disallowTaskNoEmail struct {
 	user.PermissionUserDisallowTask
 }
 
-func (disallowTaskNoEmail) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return nil
+func (disallowTaskNoEmail) TargetEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return nil, false
 }
 
 type updateTaskNoEmail struct{ user.PermissionUpdateTask }
 
-func (updateTaskNoEmail) TargetEmailTemplate(evt eventbus.TaskEvent) *notif.EmailTemplates {
-	return nil
+func (updateTaskNoEmail) TargetEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
+	return nil, false
 }
 
 func TestProcessEventPermissionTasks(t *testing.T) {

--- a/internal/notifications/reply_templates_test.go
+++ b/internal/notifications/reply_templates_test.go
@@ -16,7 +16,7 @@ func TestReplyTemplatesExist(t *testing.T) {
 	html := templates.GetCompiledEmailHtmlTemplates(map[string]any{})
 	text := templates.GetCompiledEmailTextTemplates(map[string]any{})
 	nt := templates.GetCompiledNotificationTemplates(map[string]any{})
-	et := task.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+	et, _ := task.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
 	if html.Lookup(et.HTML) == nil {
 		t.Errorf("missing html template %s", et.HTML)
 	}

--- a/internal/notifications/subscriptionsinterfaces.go
+++ b/internal/notifications/subscriptionsinterfaces.go
@@ -21,14 +21,14 @@ func NewEmailTemplates(prefix string) *EmailTemplates {
 // AdminEmailTemplateProvider indicates the notification should be sent via
 // email to administrators using the provided templates.
 type AdminEmailTemplateProvider interface {
-	AdminEmailTemplate(evt eventbus.TaskEvent) *EmailTemplates
+	AdminEmailTemplate(evt eventbus.TaskEvent) (templates *EmailTemplates, send bool)
 	AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string
 }
 
 // SelfNotificationTemplateProvider is used for mandatory self notifications such as password
 // resets or verifications.
 type SelfNotificationTemplateProvider interface {
-	SelfEmailTemplate(evt eventbus.TaskEvent) *EmailTemplates
+	SelfEmailTemplate(evt eventbus.TaskEvent) (templates *EmailTemplates, send bool)
 	SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string
 }
 
@@ -44,13 +44,13 @@ type SelfEmailBroadcaster interface {
 // Internal notifications are not supported for this provider.
 type DirectEmailNotificationTemplateProvider interface {
 	DirectEmailAddress(evt eventbus.TaskEvent) (string, error)
-	DirectEmailTemplate(evt eventbus.TaskEvent) *EmailTemplates
+	DirectEmailTemplate(evt eventbus.TaskEvent) (templates *EmailTemplates, send bool)
 }
 
 // SubscribersNotificationTemplateProvider indicates the notification should be delivered to
 // subscribed users.
 type SubscribersNotificationTemplateProvider interface {
-	SubscribedEmailTemplate(evt eventbus.TaskEvent) *EmailTemplates
+	SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *EmailTemplates, send bool)
 	SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string
 }
 
@@ -67,7 +67,7 @@ type AutoSubscribeProvider interface {
 // to the returned user IDs.
 type TargetUsersNotificationProvider interface {
 	TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error)
-	TargetEmailTemplate(evt eventbus.TaskEvent) *EmailTemplates
+	TargetEmailTemplate(evt eventbus.TaskEvent) (templates *EmailTemplates, send bool)
 	TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string
 }
 


### PR DESCRIPTION
## Summary
- add send flag to all notification template provider interfaces
- have notifier and admin tooling honor the send flag across admin, direct, subscriber, and target emails
- update tasks and tests to return templates alongside a send boolean

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689937882d84832fb786612989572a5b