### PR TITLE
feat: highlight admin in email subjects

### DIFF
--- a/internal/notifications/email_test.go
+++ b/internal/notifications/email_test.go
@@ -1,0 +1,34 @@
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"mime"
+	"net/mail"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+)
+
+func TestRenderEmailFromTemplates_AdminSubject(t *testing.T) {
+	cfg := config.NewRuntimeConfig()
+	cfg.EmailEnabled = true
+	cfg.EmailFrom = "from@example.com"
+	n := New(WithConfig(cfg))
+	msg, err := n.RenderEmailFromTemplates(context.Background(), "to@example.com", &EmailTemplates{}, nil, WithAdmin())
+	if err != nil {
+		t.Fatalf("RenderEmailFromTemplates: %v", err)
+	}
+	m, err := mail.ReadMessage(bytes.NewReader(msg))
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	subj, err := new(mime.WordDecoder).DecodeHeader(m.Header.Get("Subject"))
+	if err != nil {
+		t.Fatalf("DecodeHeader: %v", err)
+	}
+	want := "[goa4web Admin] Website Update Notification"
+	if subj != want {
+		t.Fatalf("subject=%q want %q", subj, want)
+	}
+}

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -141,7 +141,7 @@ func (n *Notifier) notifyAdmins(ctx context.Context, et *EmailTemplates, nt *str
 			log.Printf("notify admin %s: %v", addr, err)
 		}
 		if et != nil {
-			if err := n.renderAndQueueEmailFromTemplates(ctx, uid, addr, et, data); err != nil {
+			if err := n.renderAndQueueEmailFromTemplates(ctx, uid, addr, et, data, WithAdmin()); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary
- replace boolean admin argument with functional email options and a WithAdmin helper so subject prefixes are tagged generically
- apply new options in RenderEmailFromTemplates and notifier admin paths
- adjust unit test to use WithAdmin and confirm admin subjects

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689924119074832f97686a548247ef16