### PR TITLE
Add spacing before unsubscribe link in text emails

### DIFF
--- a/core/templates/email/adminAddIPBanEmail.gotxt
+++ b/core/templates/email/adminAddIPBanEmail.gotxt
@@ -1,3 +1,4 @@
 Moderator {{.Item.Moderator}} banned {{.Item.IP}}.
 {{- if .Item.Reason}} Reason: {{.Item.Reason}}{{- end}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationBlogAddEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogAddEmail.gotxt
@@ -2,4 +2,5 @@ User {{.Item.Username}} added a new blog post.
 
 View post:
 {{.Item.PostURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationBlogCommentCancelEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogCommentCancelEmail.gotxt
@@ -2,5 +2,6 @@ User {{.Item.Username}} canceled editing a blog comment.
 
 View comment:
 {{.Item.CommentURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogCommentEditEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogCommentEditEmail.gotxt
@@ -2,5 +2,6 @@ User {{.Item.Username}} edited a blog comment.
 
 View comment:
 {{.Item.CommentURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogEditEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogEditEmail.gotxt
@@ -2,5 +2,6 @@ User {{.Item.Username}} edited a blog post.
 
 View post:
 {{.Item.PostURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogReplyEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogReplyEmail.gotxt
@@ -2,5 +2,6 @@ User {{.Item.Username}} replied to a blog post.
 
 View post:
 {{.Item.PostURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogUserAllowEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogUserAllowEmail.gotxt
@@ -2,5 +2,6 @@ User {{.Item.Username}} granted blog permissions.
 
 Blog section:
 {{.Item.BlogURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogUserDisallowEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogUserDisallowEmail.gotxt
@@ -2,5 +2,6 @@ User {{.Item.Username}} revoked blog permissions.
 
 Blog section:
 {{.Item.BlogURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogUsersAllowEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogUsersAllowEmail.gotxt
@@ -2,5 +2,6 @@ Multiple users were granted blog permissions.
 
 Blog section:
 {{.Item.BlogURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationBlogUsersDisallowEmail.gotxt
+++ b/core/templates/email/adminNotificationBlogUsersDisallowEmail.gotxt
@@ -2,5 +2,6 @@ Multiple users had blog permissions revoked.
 
 Blog section:
 {{.Item.BlogURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationEmailAssociationRequestEmail.gotxt
+++ b/core/templates/email/adminNotificationEmailAssociationRequestEmail.gotxt
@@ -4,4 +4,5 @@ Reason: {{.Item.Reason}}
 
 User page:
 {{.Item.UserURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationFaqAskEmail.gotxt
+++ b/core/templates/email/adminNotificationFaqAskEmail.gotxt
@@ -2,4 +2,5 @@ New FAQ question submitted.
 
 {{.Item.Question}}
 Review it: {{.URL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationForumCategoryChangeEmail.gotxt
+++ b/core/templates/email/adminNotificationForumCategoryChangeEmail.gotxt
@@ -1,3 +1,4 @@
 User {{.Item.Username}} renamed a forum category.
 
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationForumCategoryCreateEmail.gotxt
+++ b/core/templates/email/adminNotificationForumCategoryCreateEmail.gotxt
@@ -1,3 +1,4 @@
 User {{.Item.Username}} created a new forum category.
 
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationForumDeleteCategoryEmail.gotxt
+++ b/core/templates/email/adminNotificationForumDeleteCategoryEmail.gotxt
@@ -1,3 +1,4 @@
 User {{.Item.Username}} deleted a forum category.
 
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationForumReplyEmail.gotxt
+++ b/core/templates/email/adminNotificationForumReplyEmail.gotxt
@@ -2,4 +2,5 @@ User {{.Item.Username}} replied to a forum thread.
 
 View comment:
 {{.Item.CommentURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationForumThreadCreateEmail.gotxt
+++ b/core/templates/email/adminNotificationForumThreadCreateEmail.gotxt
@@ -1,4 +1,5 @@
 User {{.Item.Username}} created a new forum thread.
 
 View thread: {{.Item.ThreadURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationForumThreadDeleteEmail.gotxt
+++ b/core/templates/email/adminNotificationForumThreadDeleteEmail.gotxt
@@ -1,3 +1,4 @@
 User {{.Item.Username}} deleted a forum thread.
 
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationImageBoardNewEmail.gotxt
+++ b/core/templates/email/adminNotificationImageBoardNewEmail.gotxt
@@ -2,4 +2,5 @@ User {{.Item.Username}} created a new image board.
 
 Board link:
 {{.Item.BoardURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationLanguageCreateEmail.gotxt
+++ b/core/templates/email/adminNotificationLanguageCreateEmail.gotxt
@@ -1,4 +1,5 @@
 User {{.Item.Username}} created a new language {{.Item.LanguageName}} (ID {{.Item.LanguageID}}).
 
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationLanguageDeleteEmail.gotxt
+++ b/core/templates/email/adminNotificationLanguageDeleteEmail.gotxt
@@ -1,4 +1,5 @@
 User {{.Item.Username}} deleted language {{.Item.LanguageName}} (ID {{.Item.LanguageID}}).
 
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationLanguageRenameEmail.gotxt
+++ b/core/templates/email/adminNotificationLanguageRenameEmail.gotxt
@@ -1,4 +1,5 @@
 User {{.Item.Username}} renamed language {{.Item.LanguageID}} to {{.Item.LanguageName}}.
 
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationLinkerAddEmail.gotxt
+++ b/core/templates/email/adminNotificationLinkerAddEmail.gotxt
@@ -2,4 +2,5 @@ User {{.Item.Username}} added a new link.
 
 View link:
 {{.Item.LinkURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminNotificationLinkerApprovedEmail.gotxt
+++ b/core/templates/email/adminNotificationLinkerApprovedEmail.gotxt
@@ -2,4 +2,5 @@ Moderator {{.Item.Moderator}} approved the link "{{.Item.Title}}".
 
 View link:
 {{.Item.LinkURL}}
+
 Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/adminNotificationLinkerRejectedEmail.gotxt
+++ b/core/templates/email/adminNotificationLinkerRejectedEmail.gotxt
@@ -2,4 +2,5 @@ Moderator {{.Item.Moderator}} rejected the link "{{.Item.Title}}".
 
 View link:
 {{.Item.LinkURL}}
+
 Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/adminNotificationNewsAddEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsAddEmail.gotxt
@@ -2,5 +2,6 @@ User {{.Item.Username}} added a news post.
 
 View post:
 {{.Item.PostURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsCommentCancelEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsCommentCancelEmail.gotxt
@@ -2,5 +2,6 @@ Comment edit cancelled by {{.Item.Username}}.
 
 View comment:
 {{.Item.CommentURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsCommentEditEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsCommentEditEmail.gotxt
@@ -2,5 +2,6 @@ Comment edited by {{.Item.Username}}.
 
 View comment:
 {{.Item.CommentURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsDeleteEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsDeleteEmail.gotxt
@@ -2,5 +2,6 @@ Announcement removed by {{.Item.Username}}.
 
 View post:
 {{.Item.PostURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsEditEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsEditEmail.gotxt
@@ -2,5 +2,6 @@ News post edited by {{.Item.Username}}.
 
 View post:
 {{.Item.PostURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsReplyEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsReplyEmail.gotxt
@@ -2,5 +2,6 @@ User {{.Item.Username}} replied to a news post.
 
 View post:
 {{.Item.PostURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsUserAllowEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsUserAllowEmail.gotxt
@@ -2,5 +2,6 @@ User {{.Item.Username}} was granted news permissions.
 
 Permissions:
 {{.Item.UserPermissionsURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationNewsUserDisallowEmail.gotxt
+++ b/core/templates/email/adminNotificationNewsUserDisallowEmail.gotxt
@@ -2,5 +2,6 @@ User {{.Item.Username}} had news permissions revoked.
 
 Permissions:
 {{.Item.UserPermissionsURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/adminNotificationUserRequestPasswordResetEmail.gotxt
+++ b/core/templates/email/adminNotificationUserRequestPasswordResetEmail.gotxt
@@ -3,4 +3,5 @@ Is attempting a password reset.
 
 User page:
 {{.Item.UserURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminPasswordResetEmail.gotxt
+++ b/core/templates/email/adminPasswordResetEmail.gotxt
@@ -2,4 +2,5 @@ Hi {{.Item.Username}},
 An administrator has reset your password.
 Your new password is {{.Item.Password}}.
 
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/adminPermissionAllowEmail.gotxt
+++ b/core/templates/email/adminPermissionAllowEmail.gotxt
@@ -1,3 +1,4 @@
 User {{.Item.Username}} granted the {{.Item.Permission}} permission.
 
+
 Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/adminPermissionDisallowEmail.gotxt
+++ b/core/templates/email/adminPermissionDisallowEmail.gotxt
@@ -1,3 +1,4 @@
 User {{.Item.Username}} revoked the {{.Item.Permission}} permission.
 
+
 Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/adminRemoveIPBanEmail.gotxt
+++ b/core/templates/email/adminRemoveIPBanEmail.gotxt
@@ -1,2 +1,3 @@
 Moderator {{.Item.Moderator}} removed ban for {{.Item.IP}}.
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/announcementEmail.gotxt
+++ b/core/templates/email/announcementEmail.gotxt
@@ -1,3 +1,4 @@
 Announcement updated by {{.Item.Username}}.
 
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/blogAddEmail.gotxt
+++ b/core/templates/email/blogAddEmail.gotxt
@@ -3,4 +3,5 @@ Your blog post has been created successfully.
 
 View post:
 {{.Item.PostURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/blogCommentCancelEmail.gotxt
+++ b/core/templates/email/blogCommentCancelEmail.gotxt
@@ -3,5 +3,6 @@ Your comment edit was canceled.
 
 View comment:
 {{.Item.CommentURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogCommentEditEmail.gotxt
+++ b/core/templates/email/blogCommentEditEmail.gotxt
@@ -3,5 +3,6 @@ Your comment has been updated.
 
 View comment:
 {{.Item.CommentURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogEditEmail.gotxt
+++ b/core/templates/email/blogEditEmail.gotxt
@@ -3,5 +3,6 @@ Your blog post has been updated successfully.
 
 View post:
 {{.Item.PostURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogEmail.gotxt
+++ b/core/templates/email/blogEmail.gotxt
@@ -5,6 +5,7 @@ A new blog post was published by {{.Item.Author}}.
 Read it here:
 {{.URL}}
 
+
 Manage notifications: {{.UnsubscribeUrl}}
 {{- if .SignOff}}
 {{.SignOff}}

--- a/core/templates/email/blogReplyEmail.gotxt
+++ b/core/templates/email/blogReplyEmail.gotxt
@@ -3,5 +3,6 @@ Your comment has been posted.
 
 View comment:
 {{.Item.CommentURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogUserAllowEmail.gotxt
+++ b/core/templates/email/blogUserAllowEmail.gotxt
@@ -3,5 +3,6 @@ You have been granted blog permissions.
 
 Blog section:
 {{.Item.BlogURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogUserDisallowEmail.gotxt
+++ b/core/templates/email/blogUserDisallowEmail.gotxt
@@ -3,5 +3,6 @@ Your blog permissions were revoked.
 
 Blog section:
 {{.Item.BlogURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogUsersAllowEmail.gotxt
+++ b/core/templates/email/blogUsersAllowEmail.gotxt
@@ -3,5 +3,6 @@ Multiple users have been granted blog permissions.
 
 Blog section:
 {{.Item.BlogURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/blogUsersDisallowEmail.gotxt
+++ b/core/templates/email/blogUsersDisallowEmail.gotxt
@@ -3,5 +3,6 @@ Multiple users had blog permissions revoked.
 
 Blog section:
 {{.Item.BlogURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/deleteUserRoleEmail.gotxt
+++ b/core/templates/email/deleteUserRoleEmail.gotxt
@@ -1,4 +1,5 @@
 Hi {{.Item.Username}},
 The "{{.Item.Role}}" role has been removed from your account.
 
+
 Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/dlqMultiFailure.gotxt
+++ b/core/templates/email/dlqMultiFailure.gotxt
@@ -1,3 +1,4 @@
 Multiple background tasks have failed.
 Latest error: {{.Item.Message}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/faqAnsweredEmail.gotxt
+++ b/core/templates/email/faqAnsweredEmail.gotxt
@@ -1,4 +1,5 @@
 Hi {{.Item.Username}},
 Your FAQ question has been answered.
 
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/forumReplyEmail.gotxt
+++ b/core/templates/email/forumReplyEmail.gotxt
@@ -3,4 +3,5 @@ Your reply has been posted.
 
 View comment:
 {{.Item.CommentURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/forumThreadCreateEmail.gotxt
+++ b/core/templates/email/forumThreadCreateEmail.gotxt
@@ -3,4 +3,5 @@ Your forum thread has been created successfully.
 
 View thread:
 {{.Item.ThreadURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/imageBoardNewEmail.gotxt
+++ b/core/templates/email/imageBoardNewEmail.gotxt
@@ -2,4 +2,5 @@ A new image board "{{.Item.Title.String}}" has been created.
 
 Board link:
 {{.Item.BoardURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/imageBoardUpdateEmail.gotxt
+++ b/core/templates/email/imageBoardUpdateEmail.gotxt
@@ -1,2 +1,3 @@
 Image board "{{.Item.Title}}" updated.
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/imagePostApprovedEmail.gotxt
+++ b/core/templates/email/imagePostApprovedEmail.gotxt
@@ -3,4 +3,5 @@ Your image post has been approved.
 
 View post:
 {{.Item.PostURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/linkerAddEmail.gotxt
+++ b/core/templates/email/linkerAddEmail.gotxt
@@ -3,4 +3,5 @@ Your link has been submitted successfully.
 
 View link:
 {{.Item.LinkURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/linkerApprovedEmail.gotxt
+++ b/core/templates/email/linkerApprovedEmail.gotxt
@@ -3,4 +3,5 @@ Your link "{{.Item.Title}}" has been approved by {{.Item.Moderator}}.
 
 View link:
 {{.Item.LinkURL}}
+
 Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/linkerRejectedEmail.gotxt
+++ b/core/templates/email/linkerRejectedEmail.gotxt
@@ -3,4 +3,5 @@ Your link "{{.Item.Title}}" was rejected by {{.Item.Moderator}}.
 
 View link:
 {{.Item.LinkURL}}
+
 Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/newsAddEmail.gotxt
+++ b/core/templates/email/newsAddEmail.gotxt
@@ -3,5 +3,6 @@ Your news post has been created.
 
 View post:
 {{.Item.PostURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/newsCommentCancelEmail.gotxt
+++ b/core/templates/email/newsCommentCancelEmail.gotxt
@@ -3,5 +3,6 @@ Your comment edit was cancelled.
 
 View comment:
 {{.Item.CommentURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/newsCommentEditEmail.gotxt
+++ b/core/templates/email/newsCommentEditEmail.gotxt
@@ -3,5 +3,6 @@ Your comment has been updated.
 
 View comment:
 {{.Item.CommentURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/newsCommentEditedEmail.gotxt
+++ b/core/templates/email/newsCommentEditedEmail.gotxt
@@ -2,4 +2,5 @@ Comment edited by {{.Item.Username}}.
 
 View comment:
 {{.Item.CommentURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/newsEditEmail.gotxt
+++ b/core/templates/email/newsEditEmail.gotxt
@@ -3,5 +3,6 @@ Your news post has been updated.
 
 View post:
 {{.Item.PostURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/newsPermissionEmail.gotxt
+++ b/core/templates/email/newsPermissionEmail.gotxt
@@ -1,4 +1,5 @@
 Hi {{.Item.Username}},
 Your news permissions have been updated.
 
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/newsReplyEmail.gotxt
+++ b/core/templates/email/newsReplyEmail.gotxt
@@ -3,5 +3,6 @@ Your comment has been posted.
 
 View comment:
 {{.Item.CommentURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/newsUserAllowEmail.gotxt
+++ b/core/templates/email/newsUserAllowEmail.gotxt
@@ -3,5 +3,6 @@ You have been granted news permissions.
 
 News section:
 {{.Item.NewsURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/newsUserDisallowEmail.gotxt
+++ b/core/templates/email/newsUserDisallowEmail.gotxt
@@ -3,5 +3,6 @@ Your news permissions have been revoked.
 
 News section:
 {{.Item.NewsURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 

--- a/core/templates/email/passwordResetEmail.gotxt
+++ b/core/templates/email/passwordResetEmail.gotxt
@@ -4,4 +4,5 @@ If you didn't request this change, you can ignore this email.
 
 Reset link:
 {{.Item.ResetURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}

--- a/core/templates/email/replyEmail.gotxt
+++ b/core/templates/email/replyEmail.gotxt
@@ -6,6 +6,7 @@ There are now {{.Item.Thread.Comments.Int32}} comments in the discussion.
 View it here:
 {{.URL}}
 
+
 Manage notifications: {{.UnsubscribeUrl}}
 
 {{- if .SignOff}}

--- a/core/templates/email/setUserRoleEmail.gotxt
+++ b/core/templates/email/setUserRoleEmail.gotxt
@@ -1,4 +1,5 @@
 Hi {{.Item.Username}},
 You have been assigned the "{{.Item.Role}}" role.
 
+
 Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/signupEmail.gotxt
+++ b/core/templates/email/signupEmail.gotxt
@@ -6,6 +6,7 @@ Please add them to the user group to approve the account.
 Review the account here:
 {{.URL}}
 
+
 Manage notifications: {{.UnsubscribeUrl}}
 {{- if .SignOff}}
 {{.SignOff}}

--- a/core/templates/email/testEmail.gotxt
+++ b/core/templates/email/testEmail.gotxt
@@ -2,6 +2,7 @@ Hello,
 
 This is a test email confirming your Goa4Web configuration.
 
+
 Manage notifications: {{.UnsubscribeUrl}}
 
 {{- if .SignOff}}

--- a/core/templates/email/threadEmail.gotxt
+++ b/core/templates/email/threadEmail.gotxt
@@ -5,6 +5,7 @@ A new thread "{{.Item.TopicTitle}}" was started at {{.Item.Path}}.
 View it here:
 {{.URL}}
 
+
 Manage notifications: {{.UnsubscribeUrl}}
 {{- if .SignOff}}
 {{.SignOff}}

--- a/core/templates/email/updateEmail.gotxt
+++ b/core/templates/email/updateEmail.gotxt
@@ -5,6 +5,7 @@ Hello,
 {{if .URL}}View details here:
 {{.URL}}
 {{end}}
+
 Manage notifications: {{.UnsubscribeUrl}}
 {{- if .SignOff}}
 {{.SignOff}}

--- a/core/templates/email/updateUserRoleEmail.gotxt
+++ b/core/templates/email/updateUserRoleEmail.gotxt
@@ -1,4 +1,5 @@
 Hi {{.Item.Username}},
 Your role has been updated to "{{.Item.Role}}".
 
+
 Manage notifications: {{.Item.UnsubURL}}

--- a/core/templates/email/writingEmail.gotxt
+++ b/core/templates/email/writingEmail.gotxt
@@ -5,6 +5,7 @@ A new writing "{{.Item.Title}}" was submitted.
 Read it here:
 {{.URL}}
 
+
 Manage notifications: {{.UnsubscribeUrl}}
 {{- if .SignOff}}
 {{.SignOff}}

--- a/core/templates/email/writingUpdateEmail.gotxt
+++ b/core/templates/email/writingUpdateEmail.gotxt
@@ -1,4 +1,5 @@
 Writing "{{.Item.Title}}" was updated.
 View article:
 {{.Item.PostURL}}
+
 Manage notifications: {{.UnsubscribeUrl}}


### PR DESCRIPTION
## Summary
- Add blank line before unsubscribe link in all text email templates to improve readability

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689957ae163c832f89da1a92f1ab5e0e