### PR TITLE
Fix tests for timezone field

### DIFF
--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -26,8 +26,8 @@ func TestCoreDataLatestNewsLazy(t *testing.T) {
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
 		"writerName", "writerId", "idsitenews", "forumthread_id", "language_idlanguage",
-		"users_idusers", "news", "occurred", "comments",
-	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, 0)
+		"users_idusers", "news", "occurred", "timezone", "comments",
+	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, time.Local.String(), 0)
 
 	mock.ExpectQuery("SELECT u.username").WithArgs(int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
 	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
@@ -59,15 +59,16 @@ func TestUpdateFAQQuestion(t *testing.T) {
 	}
 	defer conn.Close()
 
+	cfg := config.NewRuntimeConfig()
 	queries := db.New(conn)
 	mock.ExpectExec("UPDATE faq").
 		WithArgs(sql.NullString{String: "a", Valid: true}, sql.NullString{String: "q", Valid: true}, sql.NullInt32{Int32: 2, Valid: true}, int32(1)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("INSERT INTO faq_revisions").
-		WithArgs(int32(1), int32(3), sql.NullString{String: "q", Valid: true}, sql.NullString{String: "a", Valid: true}, sql.NullString{String: time.Local.String(), Valid: true}, sql.NullInt32{Int32: 3, Valid: true}, int32(3)).
+		WithArgs(int32(1), int32(3), sql.NullString{String: "q", Valid: true}, sql.NullString{String: "a", Valid: true}, sql.NullString{String: cfg.Timezone, Valid: true}, sql.NullInt32{Int32: 3, Valid: true}, int32(3)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	cd := common.NewCoreData(context.Background(), queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), queries, cfg)
 	if err := cd.UpdateFAQQuestion("q", "a", 2, 1, 3); err != nil {
 		t.Fatalf("UpdateFAQQuestion: %v", err)
 	}
@@ -326,8 +327,8 @@ func TestBlogListLazy(t *testing.T) {
 
 	queries := db.New(conn)
 	now := time.Now()
-	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "username", "comments", "is_owner"}).
-		AddRow(1, nil, 1, 0, "b", now, "bob", 0, true)
+	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "comments", "is_owner"}).
+		AddRow(1, nil, 1, 0, "b", now, time.Local.String(), "bob", 0, true)
 	mock.ExpectQuery("SELECT b.idblogs").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(rows)
@@ -360,8 +361,8 @@ func TestBlogListForSelectedAuthorLazy(t *testing.T) {
 
 	queries := db.New(conn)
 	now := time.Now()
-	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "username", "comments", "is_owner"}).
-		AddRow(1, nil, 1, 0, "b", now, "bob", 0, true)
+	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "comments", "is_owner"}).
+		AddRow(1, nil, 1, 0, "b", now, time.Local.String(), "bob", 0, true)
 	mock.ExpectQuery("SELECT b.idblogs").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(rows)

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -62,8 +62,8 @@ func TestLatestNewsRespectsPermissions(t *testing.T) {
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
 		"writerName", "writerId", "idsitenews", "forumthread_id", "language_idlanguage",
-		"users_idusers", "news", "occurred", "comments",
-	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, 0).AddRow("w", 1, 2, 0, 1, 1, "b", now, 0)
+		"users_idusers", "news", "occurred", "timezone", "comments",
+	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, time.Local.String(), 0).AddRow("w", 1, 2, 0, 1, 1, "b", now, time.Local.String(), 0)
 
 	mock.ExpectQuery("SELECT u.username").WithArgs(int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
 

--- a/handlers/blogs/blogsAdminBlogCommentsPage_test.go
+++ b/handlers/blogs/blogsAdminBlogCommentsPage_test.go
@@ -27,10 +27,10 @@ func TestAdminBlogCommentsPage_UsesURLParam(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	blogID := 9
-	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "username", "comments", "is_owner"}).
-		AddRow(blogID, sql.NullInt32{Int32: 1, Valid: true}, 1, 1, "body", time.Now(), "user", 0, true)
+	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "comments", "is_owner"}).
+		AddRow(blogID, sql.NullInt32{Int32: 1, Valid: true}, 1, 1, "body", time.Now(), time.Local.String(), "user", 0, true)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"idcomments", "posterusername", "text"}))
+	mock.ExpectQuery("SELECT").WillReturnError(sql.ErrNoRows)
 
 	req := httptest.NewRequest("GET", "/admin/blogs/blog/"+strconv.Itoa(blogID)+"/comments", nil)
 	req = mux.SetURLVars(req, map[string]string{"blog": strconv.Itoa(blogID)})

--- a/handlers/blogs/blogsAdminBlogPage_test.go
+++ b/handlers/blogs/blogsAdminBlogPage_test.go
@@ -26,8 +26,8 @@ func TestAdminBlogPage_UsesURLParam(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	blogID := 7
-	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "username", "comments", "is_owner"}).
-		AddRow(blogID, nil, 1, 1, "body", time.Now(), "user", 0, true)
+	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "comments", "is_owner"}).
+		AddRow(blogID, nil, 1, 1, "body", time.Now(), time.Local.String(), "user", 0, true)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}))
 	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}))

--- a/handlers/blogs/blogsCommentPage_replyable_test.go
+++ b/handlers/blogs/blogsCommentPage_replyable_test.go
@@ -62,8 +62,8 @@ func TestCommentPageLockedThreadDisablesReply(t *testing.T) {
 		t.Fatalf("languages: %v", err)
 	}
 
-	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)", "is_owner"}).
-		AddRow(1, 1, 2, 1, "hi", time.Unix(0, 0), "bob", 0, false)
+	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "coalesce(th.comments, 0)", "is_owner"}).
+		AddRow(1, 1, 2, 1, "hi", time.Unix(0, 0), time.Local.String(), "bob", 0, false)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(blogRows)
 
 	threadRows1 := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername"}).
@@ -78,7 +78,7 @@ func TestCommentPageLockedThreadDisablesReply(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
 		WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), "blogs", sql.NullString{String: "entry", Valid: true}, sql.NullInt32{Int32: 2, Valid: true}).
-		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "deleted_at", "posterusername"}))
+		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner"}))
 
 	threadRows2 := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked"}).
 		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), true)
@@ -125,8 +125,8 @@ func TestCommentPageUnlockedThreadShowsReply(t *testing.T) {
 		t.Fatalf("languages: %v", err)
 	}
 
-	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)", "is_owner"}).
-		AddRow(1, 1, 2, 1, "hi", time.Unix(0, 0), "bob", 0, false)
+	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "coalesce(th.comments, 0)", "is_owner"}).
+		AddRow(1, 1, 2, 1, "hi", time.Unix(0, 0), time.Local.String(), "bob", 0, false)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(blogRows)
 
 	threadRows1 := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername"}).
@@ -141,7 +141,7 @@ func TestCommentPageUnlockedThreadShowsReply(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
 		WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), "blogs", sql.NullString{String: "entry", Valid: true}, sql.NullInt32{Int32: 2, Valid: true}).
-		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "deleted_at", "posterusername"}))
+		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner"}))
 
 	threadRows2 := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked"}).
 		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), false)
@@ -188,8 +188,8 @@ func TestCommentPageNoThreadShowsReply(t *testing.T) {
 		t.Fatalf("languages: %v", err)
 	}
 
-	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)", "is_owner"}).
-		AddRow(1, nil, 2, 1, "hi", time.Unix(0, 0), "bob", 0, false)
+	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "coalesce(th.comments, 0)", "is_owner"}).
+		AddRow(1, nil, 2, 1, "hi", time.Unix(0, 0), time.Local.String(), "bob", 0, false)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(blogRows)
 
 	rr := httptest.NewRecorder()

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -97,8 +97,8 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).
 		WithArgs(int32(1), int32(1), int32(1), int32(1), int32(1), int32(1), sqlmock.AnyArg(), int32(15), int32(0)).
-		WillReturnRows(sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)", "is_owner"}).
-			AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), "bob", 0, true))
+		WillReturnRows(sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "coalesce(th.comments, 0)", "is_owner"}).
+			AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), time.Local.String(), "bob", 0, true))
 
 	req := httptest.NewRequest("GET", "http://example.com/blogs/rss?rss=bob", nil)
 	q := db.New(conn)

--- a/handlers/imagebbs/imagebbsBoardPage_test.go
+++ b/handlers/imagebbs/imagebbsBoardPage_test.go
@@ -31,8 +31,8 @@ func TestBoardPageRendersSubBoards(t *testing.T) {
 		WithArgs(int32(0), sql.NullInt32{Int32: 3, Valid: true}, sql.NullInt32{Int32: 3, Valid: true}, sqlmock.AnyArg(), int32(200), int32(0)).
 		WillReturnRows(boardRows)
 
-	postRows := sqlmock.NewRows([]string{"idimagepost", "forumthread_id", "users_idusers", "imageboard_idimageboard", "posted", "description", "thumbnail", "fullimage", "file_size", "approved", "deleted_at", "last_index", "username", "comments"}).
-		AddRow(1, 1, 1, 3, time.Unix(0, 0), "desc", "/t", "/f", 10, true, nil, nil, "alice", 0)
+	postRows := sqlmock.NewRows([]string{"idimagepost", "forumthread_id", "users_idusers", "imageboard_idimageboard", "posted", "timezone", "description", "thumbnail", "fullimage", "file_size", "approved", "deleted_at", "last_index", "username", "comments"}).
+		AddRow(1, 1, 1, 3, time.Unix(0, 0), time.Local.String(), "desc", "/t", "/f", 10, true, nil, nil, "alice", 0)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT i.idimagepost, i.forumthread_id, i.users_idusers")).
 		WithArgs(int32(0), sql.NullInt32{Int32: 3, Valid: true}, sqlmock.AnyArg(), int32(200), int32(0)).
 		WillReturnRows(postRows)

--- a/handlers/linker/linkerCommentsPage_test.go
+++ b/handlers/linker/linkerCommentsPage_test.go
@@ -48,12 +48,12 @@ func TestCommentsPageAllowsGlobalViewGrant(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT l.idlinker")).
 		WithArgs(int32(2), sqlmock.AnyArg(), int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"idlinker", "language_idlanguage", "users_idusers", "linker_category_id", "forumthread_id", "title", "url", "description", "listed", "username", "title_2"}).
-			AddRow(1, 1, 2, 1, 1, "t", "http://u", "d", time.Unix(0, 0), "bob", "cat"))
+		WillReturnRows(sqlmock.NewRows([]string{"idlinker", "language_idlanguage", "users_idusers", "linker_category_id", "forumthread_id", "title", "url", "description", "listed", "timezone", "username", "title"}).
+			AddRow(1, 1, 2, 1, 1, "t", "http://u", "d", time.Unix(0, 0), time.Local.String(), "bob", "cat"))
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
 		WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), "linker", sql.NullString{String: "link", Valid: true}, sql.NullInt32{Int32: 2, Valid: true}).
-		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "deleted_at", "last_index", "posterusername", "is_owner"}))
+		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner"}))
 
 	threadRows := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername"}).
 		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), false, "bob")

--- a/handlers/news/newsReplyTask_event_test.go
+++ b/handlers/news/newsReplyTask_event_test.go
@@ -38,8 +38,8 @@ func TestNewsReplyTaskEventData(t *testing.T) {
 
 	mock.ExpectQuery("SELECT u.username AS writerName").
 		WithArgs(uid, int32(pid), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"writerName", "writerId", "idsiteNews", "forumthread_id", "language_idlanguage", "users_idusers", "news", "occurred", "comments"}).
-			AddRow("writer", uid, pid, pthid, 1, uid, "txt", time.Now(), 0))
+		WillReturnRows(sqlmock.NewRows([]string{"writerName", "writerId", "idsiteNews", "forumthread_id", "language_idlanguage", "users_idusers", "news", "occurred", "timezone", "comments"}).
+			AddRow("writer", uid, pid, pthid, 1, uid, "txt", time.Now(), time.Local.String(), 0))
 
 	mock.ExpectQuery("SELECT idforumtopic").
 		WithArgs(sqlmock.AnyArg()).

--- a/handlers/news/search_test.go
+++ b/handlers/news/search_test.go
@@ -32,9 +32,9 @@ func TestNewsSearchFiltersUnauthorized(t *testing.T) {
 
 	newsRows := sqlmock.NewRows([]string{
 		"writerName", "writerId", "idsitenews", "forumthread_id",
-		"language_idlanguage", "users_idusers", "news", "occurred",
+		"language_idlanguage", "users_idusers", "news", "occurred", "timezone",
 		"Comments",
-	}).AddRow("bob", 1, 1, 0, 1, 1, "text", time.Unix(0, 0), 0)
+	}).AddRow("bob", 1, 1, 0, 1, 1, "text", time.Unix(0, 0), time.Local.String(), 0)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.username AS writerName")).
 		WithArgs(int32(1), int32(1), int32(2), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
 		WillReturnRows(newsRows)

--- a/internal/db/queries_imagebbs_test.go
+++ b/internal/db/queries_imagebbs_test.go
@@ -48,8 +48,8 @@ func TestQueries_ListImagePostsByBoardForLister_GlobalGrant(t *testing.T) {
 	defer conn.Close()
 	q := New(conn)
 
-	rows := sqlmock.NewRows([]string{"idimagepost", "forumthread_id", "users_idusers", "imageboard_idimageboard", "posted", "description", "thumbnail", "fullimage", "file_size", "approved", "deleted_at", "last_index", "username", "comments"}).
-		AddRow(1, 0, 1, 2, nil, nil, nil, nil, 0, true, nil, nil, "alice", 0)
+	rows := sqlmock.NewRows([]string{"idimagepost", "forumthread_id", "users_idusers", "imageboard_idimageboard", "posted", "timezone", "description", "thumbnail", "fullimage", "file_size", "approved", "deleted_at", "last_index", "username", "comments"}).
+		AddRow(1, 0, 1, 2, nil, nil, nil, nil, nil, 0, true, nil, nil, "alice", 0)
 
 	mock.ExpectQuery(regexp.QuoteMeta(listImagePostsByBoardForLister)).
 		WithArgs(int32(1), sql.NullInt32{Int32: 2, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}, int32(5), int32(0)).


### PR DESCRIPTION
## Summary
- adjust SQL mock rows to account for timezone column
- respect configured default timezone in FAQ revision test

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689959a75af4832fa491e016a47719e4