### PR TITLE
Fix private forum label routes and adjust label display

### DIFF
--- a/core/templates/assets/topic_labels.js
+++ b/core/templates/assets/topic_labels.js
@@ -1,0 +1,40 @@
+(function() {
+    document.addEventListener('click', function(e) {
+        if (e.target.classList.contains('remove')) {
+            var span = e.target.parentElement;
+            span.parentElement.removeChild(span);
+        }
+    });
+    document.querySelectorAll('.label-input').forEach(function(input) {
+        input.addEventListener('keydown', function(e) {
+            if (e.key === ' ') {
+                e.preventDefault();
+                var val = input.value.trim();
+                if (!val) {
+                    return;
+                }
+                var name = input.dataset.type;
+                var exists = Array.from(document.querySelectorAll('input[name="' + name + '"]')).some(function(n) { return n.value === val; });
+                if (exists) {
+                    input.value = '';
+                    return;
+                }
+                var span = document.createElement('span');
+                span.className = 'label ' + name;
+                span.textContent = val + ' ';
+                var btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'remove';
+                btn.textContent = 'x';
+                span.appendChild(btn);
+                var hidden = document.createElement('input');
+                hidden.type = 'hidden';
+                hidden.name = name;
+                hidden.value = val;
+                span.appendChild(hidden);
+                input.parentElement.insertBefore(span, input);
+                input.value = '';
+            }
+        });
+    });
+})();

--- a/core/templates/embedded.go
+++ b/core/templates/embedded.go
@@ -33,6 +33,8 @@ var (
 	roleGrantsEditorJSData []byte
 	//go:embed "assets/private_forum.js"
 	privateForumJSData []byte
+	//go:embed "assets/topic_labels.js"
+	topicLabelsJSData []byte
 )
 
 func init() {
@@ -107,3 +109,6 @@ func GetRoleGrantsEditorJSData() []byte { return roleGrantsEditorJSData }
 
 // GetPrivateForumJSData returns the JavaScript for private forum pages.
 func GetPrivateForumJSData() []byte { return privateForumJSData }
+
+// GetTopicLabelsJSData returns the JavaScript for topic label editing.
+func GetTopicLabelsJSData() []byte { return topicLabelsJSData }

--- a/core/templates/live.go
+++ b/core/templates/live.go
@@ -93,3 +93,12 @@ func GetPrivateForumJSData() []byte {
 	}
 	return b
 }
+
+// GetTopicLabelsJSData returns the JavaScript for topic label editing.
+func GetTopicLabelsJSData() []byte {
+	b, err := os.ReadFile("core/templates/assets/topic_labels.js")
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -1,11 +1,13 @@
 {{ template "head" $ }}
     {{ $base := "/forum" }}
     {{ with .BasePath }}{{ $base = . }}{{ end }}
-    {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
-    <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/labels">
-        <input type="hidden" name="task" value="Mark Topic Read"/>
-        <button type="submit">Mark as read</button>
-    </form>
+    <div class="label-bar">
+        {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
+        <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/labels" class="mark-read">
+            <input type="hidden" name="task" value="Mark Topic Read"/>
+            <button type="submit">Mark as read</button>
+        </form>
+    </div>
     {{ template "threadComments" }}
     {{ template "forumReply" $ }}
 
@@ -36,52 +38,7 @@
             <input type="submit" value="Save Labels"/>
         </form>
     </div>
-    <script>
-    (function() {
-        document.addEventListener('click', function(e) {
-            if (e.target.classList.contains('remove')) {
-                var span = e.target.parentElement;
-                span.parentElement.removeChild(span);
-            }
-        });
-        document.querySelectorAll('.label-input').forEach(function(input) {
-            input.addEventListener('keydown', function(e) {
-                if (e.key === ' ') {
-                    e.preventDefault();
-                    var val = input.value.trim();
-                    if (!val) {
-                        return;
-                    }
-                    var name = input.dataset.type;
-                    var exists = Array.from(document.querySelectorAll('input[name="' + name + '"]')).some(function(n) { return n.value === val; });
-                    if (exists) {
-                        input.value = '';
-                        return;
-                    }
-                    var span = document.createElement('span');
-                    span.className = 'label ' + name;
-                    span.textContent = val + ' ';
-                    var btn = document.createElement('button');
-                    btn.type = 'button';
-                    btn.className = 'remove';
-                    btn.textContent = 'x';
-                    span.appendChild(btn);
-                    var hidden = document.createElement('input');
-                    hidden.type = 'hidden';
-                    hidden.name = name;
-                    hidden.value = val;
-                    span.appendChild(hidden);
-                    input.parentElement.insertBefore(span, input);
-                    input.value = '';
-                }
-            });
-        });
-    })();
-    </script>
-    <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/labels">
-        <input type="hidden" name="task" value="Mark Topic Read"/>
-        <button type="submit">Mark as read</button>
-    </form>
+    <script src="{{$base}}/topic_labels.js"></script>
     <a href="{{$base}}/topic/{{.Topic.Idforumtopic}}">Back</a>
 
 {{ template "tail" $ }}

--- a/core/templates/site/forum/topicsPage.gohtml
+++ b/core/templates/site/forum/topicsPage.gohtml
@@ -4,8 +4,6 @@
         <h1>Category: {{ .Category.Title.String }}</h1>
     {{ end }}
     <h2>Topic: {{ if .Topic.DisplayTitle }}{{ .Topic.DisplayTitle }}{{ else }}{{ .Topic.Title.String }}{{ end }}</h2>
-    {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
-
     {{ $base := "/forum" }}
     {{ with .BasePath }}{{ $base = . }}{{ end }}
     <div class="topic-actions">
@@ -21,6 +19,10 @@
             </form>
         {{- end }}
     </div>
+    {{ if or (gt (len .PublicLabels) 0) (gt (len .AuthorLabels) 0) (gt (len .PrivateLabels) 0) }}
+        <h3>Labels</h3>
+        {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
+    {{ end }}
 
     {{ template "topicThreads" $ }}
 {{ template "tail" $ }}

--- a/core/templates/site/topicThreads.gohtml
+++ b/core/templates/site/topicThreads.gohtml
@@ -12,10 +12,10 @@
             <div class="thread-content">
                 {{ .Firstposttext.String | a4code2html }}<br>
             </div>
-            {{ template "topicLabels" (dict "Public" $.PublicLabels "Author" $.AuthorLabels "Private" $.PrivateLabels) }}
             <div class="thread-meta">
                 Lastposter: <span class="poster-name last">{{ .Lastposterusername.String }}</span>
                 At <span class="post-time last">{{ localTime .Lastaddition.Time }}</span>
+                {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
                 [<a href="{{$base}}/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">{{ .Comments.Int32 }} comments.</a>]
             </div>
         </div>

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -118,13 +118,13 @@ func ThreadPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 		Edit:                         false,
 	}
 
-	if pub, author, err := cd.TopicPublicLabels(topicRow.Idforumtopic); err == nil {
+	if pub, author, err := cd.TopicPublicLabels(threadRow.Idforumthread); err == nil {
 		data.PublicLabels = pub
 		data.AuthorLabels = author
 	} else {
 		log.Printf("list public labels: %v", err)
 	}
-	if priv, err := cd.TopicPrivateLabels(topicRow.Idforumtopic); err == nil {
+	if priv, err := cd.TopicPrivateLabels(threadRow.Idforumthread); err == nil {
 		data.PrivateLabels = priv
 	} else {
 		log.Printf("list private labels: %v", err)

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -26,6 +26,7 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Regis
 	fr.HandleFunc("/topic/{topic}", TopicsPage).Methods("GET")
 	fr.HandleFunc("/topic/{topic}/subscribe", handlers.TaskHandler(subscribeTopicTaskAction)).Methods("POST").MatcherFunc(subscribeTopicTaskAction.Matcher())
 	fr.HandleFunc("/topic/{topic}/unsubscribe", handlers.TaskHandler(unsubscribeTopicTaskAction)).Methods("POST").MatcherFunc(unsubscribeTopicTaskAction.Matcher())
+	fr.HandleFunc("/topic_labels.js", handlers.TopicLabelsJS).Methods(http.MethodGet)
 	fr.HandleFunc("/topic/{topic}/labels", handlers.TaskHandler(setLabelsTask)).Methods("POST").MatcherFunc(setLabelsTask.Matcher())
 	fr.HandleFunc("/topic/{topic}/labels", handlers.TaskHandler(addPublicLabelTask)).Methods("POST").MatcherFunc(addPublicLabelTask.Matcher())
 	fr.HandleFunc("/topic/{topic}/labels", handlers.TaskHandler(removePublicLabelTask)).Methods("POST").MatcherFunc(removePublicLabelTask.Matcher())

--- a/handlers/forum/topic_label_tasks.go
+++ b/handlers/forum/topic_label_tasks.go
@@ -36,6 +36,18 @@ var (
 	setLabelsTask          = &SetLabelsTask{TaskString: TaskSetLabels}
 )
 
+// Exported task handlers for reuse outside the forum package.
+var (
+	AddPublicLabelTaskHandler     = addPublicLabelTask
+	RemovePublicLabelTaskHandler  = removePublicLabelTask
+	AddPrivateLabelTaskHandler    = addPrivateLabelTask
+	RemovePrivateLabelTaskHandler = removePrivateLabelTask
+	AddAuthorLabelTaskHandler     = addAuthorLabelTask
+	RemoveAuthorLabelTaskHandler  = removeAuthorLabelTask
+	MarkTopicReadTaskHandler      = markTopicReadTask
+	SetLabelsTaskHandler          = setLabelsTask
+)
+
 func (AddPublicLabelTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	vars := mux.Vars(r)

--- a/handlers/privateforum/labels_test.go
+++ b/handlers/privateforum/labels_test.go
@@ -1,0 +1,36 @@
+package privateforum
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	forumhandlers "github.com/arran4/goa4web/handlers/forum"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
+	"github.com/gorilla/mux"
+)
+
+func TestPrivateLabelRoutes(t *testing.T) {
+	r := mux.NewRouter()
+	nav := navpkg.NewRegistry()
+	RegisterRoutes(r, config.NewRuntimeConfig(), nav)
+
+	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
+	cd.ForumBasePath = "/private"
+
+	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", strings.NewReader("task="+url.QueryEscape(string(forumhandlers.TaskMarkTopicRead))))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+	rr := httptest.NewRecorder()
+
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+}

--- a/handlers/privateforum/routes.go
+++ b/handlers/privateforum/routes.go
@@ -21,10 +21,20 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Regis
 	pr.HandleFunc("", Page).Methods(http.MethodGet)
 	pr.HandleFunc("", handlers.TaskHandler(privateTopicCreateTask)).Methods(http.MethodPost).MatcherFunc(privateTopicCreateTask.Matcher())
 	pr.HandleFunc("/private_forum.js", handlers.PrivateForumJS).Methods(http.MethodGet)
+	pr.HandleFunc("/topic_labels.js", handlers.TopicLabelsJS).Methods(http.MethodGet)
 	pr.HandleFunc("/topic/{topic}", TopicPage).Methods(http.MethodGet)
 
 	pr.HandleFunc("/topic/{topic}/subscribe", handlers.TaskHandler(forumhandlers.SubscribeTopicTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.SubscribeTopicTaskHandler.Matcher())
 	pr.HandleFunc("/topic/{topic}/unsubscribe", handlers.TaskHandler(forumhandlers.UnsubscribeTopicTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.UnsubscribeTopicTaskHandler.Matcher())
+
+	pr.HandleFunc("/topic/{topic}/labels", handlers.TaskHandler(forumhandlers.SetLabelsTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.SetLabelsTaskHandler.Matcher())
+	pr.HandleFunc("/topic/{topic}/labels", handlers.TaskHandler(forumhandlers.AddPublicLabelTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.AddPublicLabelTaskHandler.Matcher())
+	pr.HandleFunc("/topic/{topic}/labels", handlers.TaskHandler(forumhandlers.RemovePublicLabelTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.RemovePublicLabelTaskHandler.Matcher())
+	pr.HandleFunc("/topic/{topic}/labels", handlers.TaskHandler(forumhandlers.AddAuthorLabelTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.AddAuthorLabelTaskHandler.Matcher())
+	pr.HandleFunc("/topic/{topic}/labels", handlers.TaskHandler(forumhandlers.RemoveAuthorLabelTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.RemoveAuthorLabelTaskHandler.Matcher())
+	pr.HandleFunc("/topic/{topic}/labels", handlers.TaskHandler(forumhandlers.AddPrivateLabelTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.AddPrivateLabelTaskHandler.Matcher())
+	pr.HandleFunc("/topic/{topic}/labels", handlers.TaskHandler(forumhandlers.RemovePrivateLabelTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.RemovePrivateLabelTaskHandler.Matcher())
+	pr.HandleFunc("/topic/{topic}/labels", handlers.TaskHandler(forumhandlers.MarkTopicReadTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.MarkTopicReadTaskHandler.Matcher())
 
 	pr.HandleFunc("/topic/{topic}/thread", forumhandlers.CreateThreadTaskHandler.Page).Methods(http.MethodGet)
 	pr.HandleFunc("/topic/{topic}/thread", handlers.TaskHandler(forumhandlers.CreateThreadTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.CreateThreadTaskHandler.Matcher())

--- a/handlers/static.go
+++ b/handlers/static.go
@@ -38,6 +38,12 @@ func PrivateForumJS(w http.ResponseWriter, r *http.Request) {
 	http.ServeContent(w, r, "private_forum.js", time.Time{}, bytes.NewReader(templates.GetPrivateForumJSData()))
 }
 
+// TopicLabelsJS serves the JavaScript for topic label editing.
+func TopicLabelsJS(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/javascript")
+	http.ServeContent(w, r, "topic_labels.js", time.Time{}, bytes.NewReader(templates.GetTopicLabelsJSData()))
+}
+
 // RedirectPermanent returns a handler that redirects to the provided path using StatusPermanentRedirect.
 func RedirectPermanent(to string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- expose label editor script as /topic_labels.js and wire into forum and private forum routes
- render thread-specific labels in topic listings and fetch labels by thread ID
- show topic labels below actions with heading and use external JS for label editor

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: sql expected destination arguments, multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68995b8f8ec4832fa46674b22c0bb490