### PR TITLE
Display default private labels in thread editor

### DIFF
--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -29,9 +29,7 @@
             </div>
             <div class="private-labels">
                 {{ range .PrivateLabels }}
-                {{ if and (ne . "new") (ne . "unread") }}
                 <span class="label private">{{ . }}<button type="button" class="remove" data-type="private">x</button><input type="hidden" name="private" value="{{ . }}"/></span>
-                {{ end }}
                 {{ end }}
                 <input type="text" class="label-input" data-type="private" placeholder="Add private label"/>
             </div>

--- a/core/templates/threadPage_labels_test.go
+++ b/core/templates/threadPage_labels_test.go
@@ -1,0 +1,58 @@
+package templates
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+	"testing"
+)
+
+// dict is a helper for building maps in templates.
+func dict(values ...any) map[string]any {
+	m := make(map[string]any, len(values)/2)
+	for i := 0; i < len(values); i += 2 {
+		key, _ := values[i].(string)
+		m[key] = values[i+1]
+	}
+	return m
+}
+
+func csrfField() template.HTML { return "" }
+
+// TestThreadPageShowsDefaultPrivateLabels ensures that the thread page template
+// renders special private labels like "new" and "unread".
+func TestThreadPageShowsDefaultPrivateLabels(t *testing.T) {
+	funcMap := template.FuncMap{
+		"dict":      dict,
+		"csrfField": csrfField,
+	}
+	tmpl := template.New("test").Funcs(funcMap)
+
+	// Provide stub templates used by threadPage.gohtml.
+	if _, err := tmpl.Parse(`{{define "head"}}{{end}}{{define "tail"}}{{end}}{{define "threadComments"}}{{end}}{{define "forumReply"}}{{end}}`); err != nil {
+		t.Fatalf("parse stubs: %v", err)
+	}
+	if _, err := tmpl.ParseFiles("site/forum/topicLabels.gohtml", "site/forum/threadPage.gohtml"); err != nil {
+		t.Fatalf("parse templates: %v", err)
+	}
+
+	data := struct {
+		Topic         struct{ Idforumtopic int32 }
+		PublicLabels  []string
+		AuthorLabels  []string
+		PrivateLabels []string
+		BasePath      string
+	}{}
+	data.Topic.Idforumtopic = 1
+	data.PrivateLabels = []string{"new", "unread"}
+	data.BasePath = "/forum"
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "threadPage.gohtml", data); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `value="new"`) || !strings.Contains(out, `value="unread"`) {
+		t.Fatalf("expected new and unread labels in output: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure Save Labels form includes default "new" and "unread" private labels
- add test covering default private label rendering

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68996923f678832f882f37a91c1a7d3d