### PR TITLE
Add CSRF to forum thread mark-as-read form

### DIFF
--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -4,6 +4,7 @@
     <div class="label-bar">
         {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
         <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/labels" class="mark-read">
+            {{ csrfField }}
             <input type="hidden" name="task" value="Mark Topic Read"/>
             <button type="submit">Mark as read</button>
         </form>

--- a/core/templates/thread_page_test.go
+++ b/core/templates/thread_page_test.go
@@ -1,0 +1,17 @@
+package templates
+
+import (
+	_ "embed"
+	"regexp"
+	"testing"
+)
+
+//go:embed site/forum/threadPage.gohtml
+var threadPageTemplate string
+
+func TestThreadPageMarkReadIncludesCSRF(t *testing.T) {
+	re := regexp.MustCompile(`(?s)<form[^>]*class="mark-read"[^>]*>.*{{ csrfField }}`)
+	if !re.MatchString(threadPageTemplate) {
+		t.Fatalf("mark-read form missing csrfField")
+	}
+}


### PR DESCRIPTION
## Summary
- ensure thread "Mark as read" form includes CSRF protection
- add test verifying mark-read form contains CSRF field

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689969dc940c832f9d09e66f59953d50