### PR TITLE
Fix thread mark-read redirect and inverse labels

### DIFF
--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -5,6 +5,7 @@
         {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
         <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/labels" class="mark-read">
             <input type="hidden" name="task" value="Mark Topic Read"/>
+            <input type="hidden" name="redirect" value="{{$base}}/topic/{{.Topic.Idforumtopic}}/thread/{{.Thread.Idforumthread}}"/>
             <button type="submit">Mark as read</button>
         </form>
     </div>

--- a/handlers/forum/topic_label_tasks.go
+++ b/handlers/forum/topic_label_tasks.go
@@ -163,11 +163,18 @@ func (MarkTopicReadTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	vars := mux.Vars(r)
 	topicID, _ := strconv.Atoi(vars["topic"])
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
 	if err := cd.SetTopicPrivateLabelStatus(int32(topicID), false, false); err != nil {
 		log.Printf("mark read: %v", err)
 		return fmt.Errorf("mark read %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	return handlers.RefreshDirectHandler{TargetURL: r.Header.Get("Referer")}
+	target := r.PostFormValue("redirect")
+	if target == "" {
+		target = r.Header.Get("Referer")
+	}
+	return handlers.RefreshDirectHandler{TargetURL: target}
 }
 
 // SetLabelsTask replaces public and private labels on a topic.

--- a/handlers/forum/topic_label_tasks_test.go
+++ b/handlers/forum/topic_label_tasks_test.go
@@ -1,0 +1,58 @@
+package forum
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/gorilla/mux"
+)
+
+func TestMarkTopicReadTaskAddsInverseLabels(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	q := db.New(conn)
+	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd.UserID = 2
+
+	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO forumtopic_private_labels")).
+		WithArgs(int32(1), cd.UserID, "new", true).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO forumtopic_private_labels")).
+		WithArgs(int32(1), cd.UserID, "unread", true).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	form := url.Values{}
+	form.Set("redirect", "/private/topic/1/thread/3")
+	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
+
+	res := MarkTopicReadTask{}.Action(httptest.NewRecorder(), req)
+	rdh, ok := res.(handlers.RefreshDirectHandler)
+	if !ok {
+		t.Fatalf("expected RefreshDirectHandler, got %T", res)
+	}
+	if rdh.TargetURL != "/private/topic/1/thread/3" {
+		t.Fatalf("redirect %q, want /private/topic/1/thread/3", rdh.TargetURL)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- include a redirect target in thread mark-read form
- have mark-read task parse the form, update label status, and redirect accordingly
- add unit test verifying inverse label writes and redirect

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689969dc940c832f9d09e66f59953d50