### PR TITLE
Add mark read and back option

### DIFF
--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -39,6 +39,11 @@
         </form>
     </div>
     <script src="{{$base}}/topic_labels.js"></script>
+    <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/labels" class="mark-read">
+        <input type="hidden" name="task" value="Mark Topic Read"/>
+        <input type="hidden" name="redirect" value="{{$base}}/topic/{{.Topic.Idforumtopic}}"/>
+        <button type="submit">Mark as read and go back</button>
+    </form>
     <a href="{{$base}}/topic/{{.Topic.Idforumtopic}}">Back</a>
 
 {{ template "tail" $ }}

--- a/handlers/forum/topic_label_tasks_test.go
+++ b/handlers/forum/topic_label_tasks_test.go
@@ -1,0 +1,36 @@
+package forum
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+)
+
+func TestMarkTopicReadTaskRedirect(t *testing.T) {
+	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
+	form := url.Values{}
+	form.Set("redirect", "/private/topic/1")
+	form.Set("task", string(TaskMarkTopicRead))
+	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Referer", "/private/topic/1/thread/51")
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+	rr := httptest.NewRecorder()
+
+	res := MarkTopicReadTaskHandler.Action(rr, req)
+	rdh, ok := res.(handlers.RefreshDirectHandler)
+	if !ok {
+		t.Fatalf("expected RefreshDirectHandler, got %T", res)
+	}
+	if rdh.TargetURL != "/private/topic/1" {
+		t.Fatalf("expected redirect to /private/topic/1 got %s", rdh.TargetURL)
+	}
+}


### PR DESCRIPTION
## Summary
- add bottom-of-thread button to mark topic read and return to topic view
- support optional redirect in MarkTopicReadTask and assert tasks implement the interface
- test MarkTopicReadTask redirect behavior

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68996a1327d4832fa4b52a61fd421da9