### PR TITLE
Fix missing new/unread labels after saving

### DIFF
--- a/handlers/forum/topic_label_tasks.go
+++ b/handlers/forum/topic_label_tasks.go
@@ -182,11 +182,15 @@ func (SetLabelsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 	pub := r.PostForm["public"]
 	priv := r.PostForm["private"]
+	// Special inverse private labels: show unless stored in the database.
+	inverse := map[string]bool{"new": false, "unread": false}
 	filteredPriv := make([]string, 0, len(priv))
 	for _, l := range priv {
-		if l != "new" && l != "unread" {
-			filteredPriv = append(filteredPriv, l)
+		if _, ok := inverse[l]; ok {
+			inverse[l] = true
+			continue
 		}
+		filteredPriv = append(filteredPriv, l)
 	}
 	if err := cd.SetTopicPublicLabels(int32(topicID), pub); err != nil {
 		log.Printf("set public labels: %v", err)
@@ -195,6 +199,10 @@ func (SetLabelsTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err := cd.SetTopicPrivateLabels(int32(topicID), filteredPriv); err != nil {
 		log.Printf("set private labels: %v", err)
 		return fmt.Errorf("set private labels %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+	if err := cd.SetTopicPrivateLabelStatus(int32(topicID), inverse["new"], inverse["unread"]); err != nil {
+		log.Printf("set private label status: %v", err)
+		return fmt.Errorf("set private label status %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	return handlers.RefreshDirectHandler{TargetURL: r.Header.Get("Referer")}
 }

--- a/handlers/forum/topic_label_tasks_test.go
+++ b/handlers/forum/topic_label_tasks_test.go
@@ -1,0 +1,58 @@
+package forum
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/gorilla/mux"
+)
+
+func TestSetLabelsTaskUpdatesSpecialLabels(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+	q := db.New(conn)
+	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd.UserID = 1
+
+	mock.ExpectQuery("SELECT .* FROM forumtopic_public_labels").
+		WithArgs(int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"forumtopic_idforumtopic", "label"}))
+	mock.ExpectQuery("SELECT .* FROM content_label_status").
+		WithArgs("forumtopic", int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "label"}))
+	mock.ExpectQuery("SELECT .* FROM forumtopic_private_labels").
+		WithArgs(int32(1), int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"forumtopic_idforumtopic", "users_idusers", "label", "invert"}))
+	mock.ExpectExec("INSERT IGNORE INTO forumtopic_private_labels").
+		WithArgs(int32(1), int32(1), "new", true).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT IGNORE INTO forumtopic_private_labels").
+		WithArgs(int32(1), int32(1), "unread", true).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	form := url.Values{}
+	form.Set("task", string(TaskSetLabels))
+	req := httptest.NewRequest(http.MethodPost, "/forum/topic/1/labels", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+	rr := httptest.NewRecorder()
+
+	setLabelsTask.Action(rr, req)
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- update SetLabelsTask to record special `new` and `unread` labels via SetTopicPrivateLabelStatus
- add regression test for SetLabelsTask ensuring inverse labels are stored
- refine special label detection using a map to track inverse private labels

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68996923f678832f882f37a91c1a7d3d