### PR TITLE
Style forum labels as pill tags

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -241,6 +241,46 @@ div.title {
         background: #d1c4e9;
 }
 
+.label.pill {
+        display: inline-flex;
+        align-items: center;
+        padding-right: 0;
+        cursor: default;
+        color: #000;
+}
+
+.label.pill.public {
+        background: #c8e6c9;
+}
+
+.label.pill.public.unsaved {
+        background: #e8f5e9;
+}
+
+.label.pill.author {
+        background: #bbdefb;
+}
+
+.label.pill.author.unsaved {
+        background: #e3f2fd;
+}
+
+.label.pill.private {
+        background: #ffe0b2;
+}
+
+.label.pill.private.unsaved {
+        background: #fff3e0;
+}
+
+.label.pill .remove {
+        background: inherit;
+        border: none;
+        padding: 4px 8px;
+        cursor: pointer;
+        border-radius: 0 12px 12px 0;
+}
+
 tr.unsupported td {
         background: #f3e5f5;
 }

--- a/core/templates/assets/topic_labels.js
+++ b/core/templates/assets/topic_labels.js
@@ -20,8 +20,8 @@
                     return;
                 }
                 var span = document.createElement('span');
-                span.className = 'label ' + name;
-                span.textContent = val + ' ';
+                span.className = 'label pill ' + name + ' unsaved';
+                span.textContent = val;
                 var btn = document.createElement('button');
                 btn.type = 'button';
                 btn.className = 'remove';

--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -18,19 +18,19 @@
             <input type="hidden" name="task" value="Set Labels"/>
             <div class="public-labels">
                 {{ range .PublicLabels }}
-                <span class="label public">{{ . }}<button type="button" class="remove" data-type="public">x</button><input type="hidden" name="public" value="{{ . }}"/></span>
+                <span class="label pill public">{{ . }}<button type="button" class="remove" data-type="public">x</button><input type="hidden" name="public" value="{{ . }}"/></span>
                 {{ end }}
                 <input type="text" class="label-input" data-type="public" placeholder="Add public label"/>
             </div>
             <div class="author-labels">
                 {{ range .AuthorLabels }}
-                <span class="label author">{{ . }}</span>
+                <span class="label pill author">{{ . }}</span>
                 {{ end }}
             </div>
             <div class="private-labels">
                 {{ range .PrivateLabels }}
                 {{ if and (ne . "new") (ne . "unread") }}
-                <span class="label private">{{ . }}<button type="button" class="remove" data-type="private">x</button><input type="hidden" name="private" value="{{ . }}"/></span>
+                <span class="label pill private">{{ . }}<button type="button" class="remove" data-type="private">x</button><input type="hidden" name="private" value="{{ . }}"/></span>
                 {{ end }}
                 {{ end }}
                 <input type="text" class="label-input" data-type="private" placeholder="Add private label"/>

--- a/core/templates/site/forum/topicLabels.gohtml
+++ b/core/templates/site/forum/topicLabels.gohtml
@@ -3,21 +3,21 @@
     {{ if .Public }}
     <div class="labels-public">
         {{ range .Public }}
-        <span class="label public" title="public label">{{ . }}</span>
+        <span class="label pill public" title="public label">{{ . }}</span>
         {{ end }}
     </div>
     {{ end }}
     {{ if .Author }}
     <div class="labels-author">
         {{ range .Author }}
-        <span class="label author" title="author label">{{ . }}</span>
+        <span class="label pill author" title="author label">{{ . }}</span>
         {{ end }}
     </div>
     {{ end }}
     {{ if .Private }}
     <div class="labels-private">
         {{ range .Private }}
-        <span class="label private" title="private label">{{ . }}</span>
+        <span class="label pill private" title="private label">{{ . }}</span>
         {{ end }}
     </div>
     {{ end }}


### PR DESCRIPTION
## Summary
- Render topic labels with the existing `pill` style
- Embed close button inside pill with curved right edge
- Update label editor JS to produce pill-styled tags
- Color code public, author, and private labels with lighter shades for unsaved tags

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689968b23d04832f9a2eb0eeec16efc0