### PR TITLE
fix: keep topic labels inline with comment count

### DIFF
--- a/core/templates/site/forum/topicLabels.gohtml
+++ b/core/templates/site/forum/topicLabels.gohtml
@@ -1,25 +1,25 @@
 {{ define "topicLabels" }}
-<div class="labels">
+<span class="labels">
     {{ if .Public }}
-    <div class="labels-public">
+    <span class="labels-public">
         {{ range .Public }}
         <span class="label public" title="public label">{{ . }}</span>
         {{ end }}
-    </div>
+    </span>
     {{ end }}
     {{ if .Author }}
-    <div class="labels-author">
+    <span class="labels-author">
         {{ range .Author }}
         <span class="label author" title="author label">{{ . }}</span>
         {{ end }}
-    </div>
+    </span>
     {{ end }}
     {{ if .Private }}
-    <div class="labels-private">
+    <span class="labels-private">
         {{ range .Private }}
         <span class="label private" title="private label">{{ . }}</span>
         {{ end }}
-    </div>
+    </span>
     {{ end }}
-</div>
+</span>
 {{ end }}

--- a/core/templates/site/topicThreads.gohtml
+++ b/core/templates/site/topicThreads.gohtml
@@ -15,8 +15,13 @@
             <div class="thread-meta">
                 Lastposter: <span class="poster-name last">{{ .Lastposterusername.String }}</span>
                 At <span class="post-time last">{{ localTime .Lastaddition.Time }}</span>
-                {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
-                [<a href="{{$base}}/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">{{ .Comments.Int32 }} comments.</a>]
+                [<a href="{{$base}}/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">
+                    {{- .Comments.Int32 }} comments.</a>]{{" "}}
+                {{- template "topicLabels" (dict
+                    "Public" .PublicLabels
+                    "Author" .AuthorLabels
+                    "Private" .PrivateLabels
+                ) }}
             </div>
         </div>
     {{- end }}


### PR DESCRIPTION
## Summary
- render topic labels with spans so they don't force line breaks
- place topic labels after comment count in thread listings
- format thread template markup with whitespace control for readability

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689969a16ca8832f918f35c8afe64736