### PR TITLE
Fix go vet and go test

### DIFF
--- a/core/templates/threadPage_labels_test.go
+++ b/core/templates/threadPage_labels_test.go
@@ -38,12 +38,14 @@ func TestThreadPageShowsDefaultPrivateLabels(t *testing.T) {
 
 	data := struct {
 		Topic         struct{ Idforumtopic int32 }
+		Thread        struct{ Idforumthread int32 }
 		PublicLabels  []string
 		AuthorLabels  []string
 		PrivateLabels []string
 		BasePath      string
 	}{}
 	data.Topic.Idforumtopic = 1
+	data.Thread.Idforumthread = 3
 	data.PrivateLabels = []string{"new", "unread"}
 	data.BasePath = "/forum"
 


### PR DESCRIPTION
## Summary
- add missing thread field in thread page template test
- simplify mark topic read task tests to assert redirect behavior

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899712c2e48832fb36228d99a1b3c25