### PR TITLE
Toggle and strike out removed topic labels

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -281,6 +281,11 @@ div.title {
         border-radius: 0 12px 12px 0;
 }
 
+.label.pill.removed {
+        text-decoration: line-through;
+        opacity: 0.5;
+}
+
 tr.unsupported td {
         background: #f3e5f5;
 }

--- a/core/templates/assets/topic_labels.js
+++ b/core/templates/assets/topic_labels.js
@@ -2,7 +2,19 @@
     document.addEventListener('click', function(e) {
         if (e.target.classList.contains('remove')) {
             var span = e.target.parentElement;
-            span.parentElement.removeChild(span);
+            var hidden = span.querySelector('input[type="hidden"]');
+            if (span.classList.contains('unsaved') && !span.classList.contains('removed')) {
+                span.parentElement.removeChild(span);
+                return;
+            }
+            span.classList.toggle('removed');
+            if (span.classList.contains('removed')) {
+                span.classList.add('unsaved');
+                if (hidden) { hidden.disabled = true; }
+            } else {
+                span.classList.remove('unsaved');
+                if (hidden) { hidden.disabled = false; }
+            }
         }
     });
     document.querySelectorAll('.label-input').forEach(function(input) {


### PR DESCRIPTION
## Summary
- Allow removing existing topic labels by toggling a strikethrough instead of immediate deletion
- Style removed labels with a line-through and reduced opacity

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: handlers/forum/topic_label_tasks_test.go: strings redeclared)*
- `golangci-lint run ./...`
- `go test ./...` *(fails: handlers/forum build, privateforum tests)*

------
https://chatgpt.com/codex/tasks/task_e_68997302948c832f860e527fd314facc