### PR TITLE
Ensure pills extend without remove icon

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -244,7 +244,7 @@ div.title {
 .label.pill {
         display: inline-flex;
         align-items: center;
-        padding-right: 0;
+        padding-right: 8px;
         cursor: default;
         color: #000;
 }
@@ -278,6 +278,7 @@ div.title {
         border: none;
         padding: 4px 8px;
         cursor: pointer;
+        margin-right: -8px;
         border-radius: 0 12px 12px 0;
 }
 


### PR DESCRIPTION
## Summary
- keep label pills a consistent width even when no remove button is present
- offset remove button to account for default pill padding

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: handlers/forum/topic_label_tasks_test.go:19:2: strings redeclared in this block)*
- `golangci-lint run` *(fails: handlers/forum/topic_label_tasks_test.go:19:2: strings redeclared in this block, etc.)*
- `go test ./...` *(fails: TestThreadPageShowsDefaultPrivateLabels and others)*

------
https://chatgpt.com/codex/tasks/task_e_689973244e44832f8161f6262fb92945