### PR TITLE
Fix forum mark-as-read redirect

### DIFF
--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -6,8 +6,14 @@
         <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/labels" class="mark-read">
             {{ csrfField }}
             <input type="hidden" name="task" value="Mark Topic Read"/>
-            <input type="hidden" name="back" value="{{ .BackURL }}"/>
+            <input type="hidden" name="redirect" value="{{ .BackURL }}"/>
             <button type="submit">Mark as read</button>
+        </form>
+        <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/labels" class="mark-read">
+            {{ csrfField }}
+            <input type="hidden" name="task" value="Mark Topic Read"/>
+            <input type="hidden" name="redirect" value="{{$base}}/topic/{{.Topic.Idforumtopic}}"/>
+            <button type="submit">Mark as read and go back</button>
         </form>
     </div>
     {{ template "threadComments" }}

--- a/core/templates/threadPage_labels_test.go
+++ b/core/templates/threadPage_labels_test.go
@@ -42,10 +42,12 @@ func TestThreadPageShowsDefaultPrivateLabels(t *testing.T) {
 		AuthorLabels  []string
 		PrivateLabels []string
 		BasePath      string
+		BackURL       string
 	}{}
 	data.Topic.Idforumtopic = 1
 	data.PrivateLabels = []string{"new", "unread"}
 	data.BasePath = "/forum"
+	data.BackURL = "/forum/topic/1/thread/1"
 
 	var buf bytes.Buffer
 	if err := tmpl.ExecuteTemplate(&buf, "threadPage.gohtml", data); err != nil {

--- a/handlers/forum/topic_label_tasks.go
+++ b/handlers/forum/topic_label_tasks.go
@@ -197,9 +197,12 @@ func (MarkTopicReadTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("mark read %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-  target := r.PostFormValue("redirect")
+	target := r.PostFormValue("redirect")
 	if target == "" {
 		target = r.Header.Get("Referer")
+	}
+	if target == "" {
+		target = strings.TrimSuffix(r.URL.Path, "/labels")
 	}
 	return handlers.RefreshDirectHandler{TargetURL: target}
 }
@@ -235,7 +238,7 @@ func (SetLabelsTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("set private labels %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-  if err := cd.SetTopicPrivateLabelStatus(int32(topicID), inverse["new"], inverse["unread"]); err != nil {
+	if err := cd.SetTopicPrivateLabelStatus(int32(topicID), inverse["new"], inverse["unread"]); err != nil {
 		log.Printf("set private label status: %v", err)
 		return fmt.Errorf("set private label status %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/forum/topic_label_tasks_test.go
+++ b/handlers/forum/topic_label_tasks_test.go
@@ -7,68 +7,43 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"github.com/DATA-DOG/go-sqlmock"
 
-	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/core/consts"
-	"github.com/arran4/goa4web/internal/db"
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
 
-	"regexp"
-	"strings"
-	"testing"
-
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 )
 
 func TestMarkTopicReadTaskRedirect(t *testing.T) {
 	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
 	form := url.Values{}
-	form.Set("redirect", "/private/topic/1")
-	form.Set("task", string(TaskMarkTopicRead))
+	form.Set("redirect", "/private/topic/1/thread/2")
 	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Referer", "/private/topic/1/thread/51")
+	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
-	rr := httptest.NewRecorder()
 
-	res := MarkTopicReadTaskHandler.Action(rr, req)
+	res := MarkTopicReadTask{}.Action(httptest.NewRecorder(), req)
 	rdh, ok := res.(handlers.RefreshDirectHandler)
 	if !ok {
 		t.Fatalf("expected RefreshDirectHandler, got %T", res)
 	}
-	if rdh.TargetURL != "/private/topic/1/thread/3" {
-		t.Fatalf("redirect %q, want /private/topic/1/thread/3", rdh.TargetURL)
+	if rdh.TargetURL != "/private/topic/1/thread/2" {
+		t.Fatalf("redirect %q, want /private/topic/1/thread/2", rdh.TargetURL)
 	}
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-  }
 }
 
-func TestSetLabelsTaskUpdatesSpecialLabels(t *testing.T) {
-	q := db.New(conn)
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
-	cd.UserID = 2
-
-	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO forumtopic_private_labels")).
-		WithArgs(int32(1), cd.UserID, "new", true).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO forumtopic_private_labels")).
-		WithArgs(int32(1), cd.UserID, "unread", true).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-
-	form := url.Values{}
-	form.Set("redirect", "/private/topic/1/thread/3")
-	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", strings.NewReader(form.Encode()))
+func TestMarkTopicReadTaskRefererFallback(t *testing.T) {
+	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
+	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", nil)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+	req.Header.Set("Referer", "/private/topic/1")
 	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
 
 	res := MarkTopicReadTask{}.Action(httptest.NewRecorder(), req)
 	rdh, ok := res.(handlers.RefreshDirectHandler)
@@ -76,12 +51,11 @@ func TestSetLabelsTaskUpdatesSpecialLabels(t *testing.T) {
 		t.Fatalf("expected RefreshDirectHandler, got %T", res)
 	}
 	if rdh.TargetURL != "/private/topic/1" {
-		t.Fatalf("expected redirect to /private/topic/1 got %s", rdh.TargetURL)
-
-  }
+		t.Fatalf("redirect %q, want /private/topic/1", rdh.TargetURL)
+	}
 }
 
-func TestMarkTopicReadTaskAddsInverseLabels(t *testing.T) {
+func TestSetLabelsTaskAddsInverseLabels(t *testing.T) {
 	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
@@ -113,9 +87,10 @@ func TestMarkTopicReadTaskAddsInverseLabels(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
-	rr := httptest.NewRecorder()
 
+	rr := httptest.NewRecorder()
 	setLabelsTask.Action(rr, req)
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}

--- a/handlers/privateforum/labels_test.go
+++ b/handlers/privateforum/labels_test.go
@@ -21,11 +21,11 @@ func TestPrivateLabelRoutes(t *testing.T) {
 	nav := navpkg.NewRegistry()
 	RegisterRoutes(r, config.NewRuntimeConfig(), nav)
 
-	t.Run("uses back parameter", func(t *testing.T) {
+	t.Run("uses redirect parameter", func(t *testing.T) {
 		cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
 		cd.ForumBasePath = "/private"
 
-		body := "task=" + url.QueryEscape(string(forumhandlers.TaskMarkTopicRead)) + "&back=" + url.QueryEscape("/private/topic/1/thread/2")
+		body := "task=" + url.QueryEscape(string(forumhandlers.TaskMarkTopicRead)) + "&redirect=" + url.QueryEscape("/private/topic/1/thread/2")
 		req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
@@ -40,7 +40,7 @@ func TestPrivateLabelRoutes(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back without back parameter", func(t *testing.T) {
+	t.Run("falls back without redirect parameter", func(t *testing.T) {
 		cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
 		cd.ForumBasePath = "/private"
 


### PR DESCRIPTION
## Summary
- ensure thread "Mark as read" stays on the same page and add a "Mark as read and go back" option
- default mark-as-read redirects to the referer or topic when no redirect is provided
- add tests covering mark-as-read redirect behavior

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899740da2f4832fb4f7e0e05152921b