### PR TITLE
style: highlight label inputs with pill colors

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -273,6 +273,18 @@ div.title {
         background: #fff3e0;
 }
 
+.label-input[data-type="public"] {
+        background: #e8f5e9;
+}
+
+.label-input[data-type="author"] {
+        background: #e3f2fd;
+}
+
+.label-input[data-type="private"] {
+        background: #fff3e0;
+}
+
 .label.pill .remove {
         background: inherit;
         border: none;


### PR DESCRIPTION
## Summary
- color topic label input backgrounds to match the resulting pill color for public, author, and private labels

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestSetLabelsTaskUpdatesSpecialLabels in handlers/forum)*

------
https://chatgpt.com/codex/tasks/task_e_68997af3c090832fb5bd01bf196f835e