### PR TITLE
Streamline thread label controls

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -287,6 +287,28 @@ div.title {
         opacity: 0.5;
 }
 
+.label-editor {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+}
+
+.label-editor form {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin: 0;
+}
+
+.label-editor .public-labels,
+.label-editor .author-labels,
+.label-editor .private-labels {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+}
+
 tr.unsupported td {
         background: #f3e5f5;
 }

--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -20,7 +20,6 @@
     {{ template "forumReply" $ }}
 
     <div class="label-editor">
-        <h3>Labels</h3>
         <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" id="label-form">
             {{ csrfField }}
             <input type="hidden" name="task" value="Set Labels"/>
@@ -44,13 +43,15 @@
             </div>
             <input type="submit" value="Save Labels"/>
         </form>
+        <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" class="mark-read">
+            <input type="hidden" name="task" value="Mark Topic Read"/>
+            <input type="hidden" name="redirect" value="{{$base}}/topic/{{.Topic.Idforumtopic}}"/>
+            <button type="submit">Mark as read and go back</button>
+        </form>
+        <form method="get" action="{{$base}}/topic/{{.Topic.Idforumtopic}}">
+            <button type="submit">Go to topic</button>
+        </form>
     </div>
     <script src="{{$base}}/topic_labels.js"></script>
-    <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" class="mark-read">
-        <input type="hidden" name="task" value="Mark Topic Read"/>
-        <input type="hidden" name="redirect" value="{{$base}}/topic/{{.Topic.Idforumtopic}}"/>
-        <button type="submit">Mark as read and go back</button>
-    </form>
-    <a href="{{$base}}/topic/{{.Topic.Idforumtopic}}">Back</a>
 
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- Present thread labels, editing inputs and navigation buttons on a single line
- Remove redundant "Labels" header and replace back link with "Go to topic" button

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: expectations not met in TestSetLabelsTaskUpdatesSpecialLabels)*


------
https://chatgpt.com/codex/tasks/task_e_68997adcefa8832f822c3854ee3a4b15