### PR TITLE
Fix thread label task compile errors and update tests

### DIFF
--- a/handlers/forum/thread_label_tasks.go
+++ b/handlers/forum/thread_label_tasks.go
@@ -70,7 +70,7 @@ var (
 	_ tasks.Task = (*RemovePrivateLabelTask)(nil)
 	_ tasks.Task = (*AddAuthorLabelTask)(nil)
 	_ tasks.Task = (*RemoveAuthorLabelTask)(nil)
-	_ tasks.Task = (*MarkTopicReadTask)(nil)
+	_ tasks.Task = (*MarkThreadReadTask)(nil)
 	_ tasks.Task = (*SetLabelsTask)(nil)
 )
 
@@ -238,7 +238,7 @@ func (SetLabelsTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("set private labels %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if err := cd.SetTopicPrivateLabelStatus(int32(threadID), inverse["new"], inverse["unread"]); err != nil {
+	if err := cd.SetThreadPrivateLabelStatus(int32(threadID), inverse["new"], inverse["unread"]); err != nil {
 		log.Printf("set private label status: %v", err)
 		return fmt.Errorf("set private label status %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/forum/thread_label_tasks_test.go
+++ b/handlers/forum/thread_label_tasks_test.go
@@ -19,16 +19,16 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 )
 
-func TestMarkTopicReadTaskRedirect(t *testing.T) {
+func TestMarkThreadReadTaskRedirect(t *testing.T) {
 	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
 	form := url.Values{}
 	form.Set("redirect", "/private/topic/1/thread/2")
-	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/thread/1/labels", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
+	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "1"})
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
 
-	res := MarkTopicReadTask{}.Action(httptest.NewRecorder(), req)
+	res := MarkThreadReadTask{}.Action(httptest.NewRecorder(), req)
 	rdh, ok := res.(handlers.RefreshDirectHandler)
 	if !ok {
 		t.Fatalf("expected RefreshDirectHandler, got %T", res)
@@ -38,21 +38,21 @@ func TestMarkTopicReadTaskRedirect(t *testing.T) {
 	}
 }
 
-func TestMarkTopicReadTaskRefererFallback(t *testing.T) {
+func TestMarkThreadReadTaskRefererFallback(t *testing.T) {
 	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
-	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", nil)
+	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/thread/1/labels", nil)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Referer", "/private/topic/1")
-	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
+	req.Header.Set("Referer", "/private/topic/1/thread/1")
+	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "1"})
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
 
-	res := MarkTopicReadTask{}.Action(httptest.NewRecorder(), req)
+	res := MarkThreadReadTask{}.Action(httptest.NewRecorder(), req)
 	rdh, ok := res.(handlers.RefreshDirectHandler)
 	if !ok {
 		t.Fatalf("expected RefreshDirectHandler, got %T", res)
 	}
-	if rdh.TargetURL != "/private/topic/1" {
-		t.Fatalf("redirect %q, want /private/topic/1", rdh.TargetURL)
+	if rdh.TargetURL != "/private/topic/1/thread/1" {
+		t.Fatalf("redirect %q, want /private/topic/1/thread/1", rdh.TargetURL)
 	}
 }
 
@@ -66,20 +66,20 @@ func TestSetLabelsTaskAddsInverseLabels(t *testing.T) {
 	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
 	cd.UserID = 1
 
-	mock.ExpectQuery("SELECT .* FROM forumtopic_public_labels").
-		WithArgs(int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"forumtopic_idforumtopic", "label"}))
-	mock.ExpectQuery("SELECT .* FROM content_label_status").
-		WithArgs("forumtopic", int32(1)).
+	mock.ExpectQuery("SELECT .* FROM content_public_labels").
+		WithArgs("thread", int32(1)).
 		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "label"}))
-	mock.ExpectQuery("SELECT .* FROM forumtopic_private_labels").
-		WithArgs(int32(1), int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"forumtopic_idforumtopic", "users_idusers", "label", "invert"}))
-	mock.ExpectExec("INSERT IGNORE INTO forumtopic_private_labels").
-		WithArgs(int32(1), int32(1), "new", true).
+	mock.ExpectQuery("SELECT .* FROM content_label_status").
+		WithArgs("thread", int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "label"}))
+	mock.ExpectQuery("SELECT .* FROM content_private_labels").
+		WithArgs("thread", int32(1), int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "user_id", "label", "invert"}))
+	mock.ExpectExec("INSERT IGNORE INTO content_private_labels").
+		WithArgs("thread", int32(1), int32(1), "new", true).
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("INSERT IGNORE INTO forumtopic_private_labels").
-		WithArgs(int32(1), int32(1), "unread", true).
+	mock.ExpectExec("INSERT IGNORE INTO content_private_labels").
+		WithArgs("thread", int32(1), int32(1), "unread", true).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	form := url.Values{}
@@ -108,40 +108,40 @@ func TestSetLabelsTaskUpdatesSpecialLabels(t *testing.T) {
 	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
 	cd.UserID = 2
 
-	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO forumtopic_private_labels")).
-		WithArgs(int32(1), cd.UserID, "new", true).
+	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO content_private_labels")).
+		WithArgs("thread", int32(1), cd.UserID, "new", true).
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO forumtopic_private_labels")).
-		WithArgs(int32(1), cd.UserID, "unread", true).
+	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO content_private_labels")).
+		WithArgs("thread", int32(1), cd.UserID, "unread", true).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	form := url.Values{}
 	form.Set("redirect", "/private/topic/1/thread/3")
-	form.Set("task", string(TaskMarkTopicRead))
-	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", strings.NewReader(form.Encode()))
+	form.Set("task", string(TaskMarkThreadRead))
+	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/thread/1/labels", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
+	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "1"})
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
 
 	// Execute the mark-as-read task, which should upsert the inverse labels.
-	_ = MarkTopicReadTask{}.Action(httptest.NewRecorder(), req)
+	_ = MarkThreadReadTask{}.Action(httptest.NewRecorder(), req)
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}
 }
 
-func TestMarkTopicReadTaskRedirectWithThread(t *testing.T) {
+func TestMarkThreadReadTaskRedirectWithThread(t *testing.T) {
 	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
 	form := url.Values{}
 	form.Set("redirect", "/private/topic/1/thread/3")
-	form.Set("task", string(TaskMarkTopicRead))
-	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", strings.NewReader(form.Encode()))
+	form.Set("task", string(TaskMarkThreadRead))
+	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/thread/1/labels", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
-	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
+	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "1"})
 
-	res := MarkTopicReadTask{}.Action(httptest.NewRecorder(), req)
+	res := MarkThreadReadTask{}.Action(httptest.NewRecorder(), req)
 	rdh, ok := res.(handlers.RefreshDirectHandler)
 	if !ok {
 		t.Fatalf("expected RefreshDirectHandler, got %T", res)

--- a/handlers/privateforum/labels_test.go
+++ b/handlers/privateforum/labels_test.go
@@ -25,7 +25,7 @@ func TestPrivateLabelRoutes(t *testing.T) {
 		cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
 		cd.ForumBasePath = "/private"
 
-		body := "task=" + url.QueryEscape(string(forumhandlers.TaskMarkTopicRead)) + "&redirect=" + url.QueryEscape("/private/topic/1/thread/2")
+		body := "task=" + url.QueryEscape(string(forumhandlers.TaskMarkThreadRead)) + "&redirect=" + url.QueryEscape("/private/topic/1/thread/2")
 		req := httptest.NewRequest(http.MethodPost, "/private/thread/1/labels", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))


### PR DESCRIPTION
## Summary
- switch thread label tasks to use MarkThreadReadTask and SetThreadPrivateLabelStatus
- align tests with thread label behavior and content_* tables
- update private forum label tests to use TaskMarkThreadRead

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68998330270c832faf0548f4cba0e84e