### PR TITLE
Sort labels alphabetically across types

### DIFF
--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -2,7 +2,7 @@
     {{ $base := "/forum" }}
     {{ with .BasePath }}{{ $base = . }}{{ end }}
     <div class="label-bar">
-        {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
+        {{ template "topicLabels" .Labels }}
         <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" class="mark-read">
             {{ csrfField }}
             <input type="hidden" name="task" value="Mark Topic Read"/>
@@ -24,21 +24,11 @@
             {{ csrfField }}
             <input type="hidden" name="task" value="Set Labels"/>
             <input type="hidden" name="back" value="{{ .BackURL }}"/>
-            <div class="public-labels">
-                {{ range .PublicLabels }}
-                <span class="label pill public">{{ . }}<button type="button" class="remove" data-type="public">x</button><input type="hidden" name="public" value="{{ . }}"/></span>
+            <div class="labels">
+                {{ range .Labels }}
+                <span class="label pill {{ .Type }}">{{ .Text }}{{ if or (eq .Type "public") (eq .Type "private") }}<button type="button" class="remove" data-type="{{ .Type }}">x</button><input type="hidden" name="{{ .Type }}" value="{{ .Text }}"/>{{ end }}</span>
                 {{ end }}
                 <input type="text" class="label-input" data-type="public" placeholder="Add public label"/>
-            </div>
-            <div class="author-labels">
-                {{ range .AuthorLabels }}
-                <span class="label pill author">{{ . }}</span>
-                {{ end }}
-            </div>
-            <div class="private-labels">
-                {{ range .PrivateLabels }}
-                <span class="label pill private">{{ . }}<button type="button" class="remove" data-type="private">x</button><input type="hidden" name="private" value="{{ . }}"/></span>
-                {{ end }}
                 <input type="text" class="label-input" data-type="private" placeholder="Add private label"/>
             </div>
             <input type="submit" value="Save Labels"/>

--- a/core/templates/site/forum/topicLabels.gohtml
+++ b/core/templates/site/forum/topicLabels.gohtml
@@ -1,25 +1,7 @@
 {{ define "topicLabels" }}
 <span class="labels">
-    {{ if .Public }}
-    <span class="labels-public">
-        {{ range .Public }}
-        <span class="label pill public" title="public label">{{ . }}</span>
-        {{ end }}
-    </span>
-    {{ end }}
-    {{ if .Author }}
-    <span class="labels-author">
-        {{ range .Author }}
-        <span class="label pill author" title="author label">{{ . }}</span>
-        {{ end }}
-    </span>
-    {{ end }}
-    {{ if .Private }}
-    <span class="labels-private">
-        {{ range .Private }}
-        <span class="label pill private" title="private label">{{ . }}</span>
-        {{ end }}
-    </span>
+    {{ range . }}
+    <span class="label pill {{ .Type }}" title="{{ .Type }} label">{{ .Text }}</span>
     {{ end }}
 </span>
 {{ end }}

--- a/core/templates/site/forum/topicsPage.gohtml
+++ b/core/templates/site/forum/topicsPage.gohtml
@@ -19,9 +19,9 @@
             </form>
         {{- end }}
     </div>
-    {{ if or (gt (len .PublicLabels) 0) (gt (len .AuthorLabels) 0) (gt (len .PrivateLabels) 0) }}
+    {{ if gt (len .Labels) 0 }}
         <h3>Labels</h3>
-        {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
+        {{ template "topicLabels" .Labels }}
     {{ end }}
 
     {{ template "topicThreads" $ }}

--- a/core/templates/site/topicThreads.gohtml
+++ b/core/templates/site/topicThreads.gohtml
@@ -15,13 +15,9 @@
             <div class="thread-meta">
                 Lastposter: <span class="poster-name last">{{ .Lastposterusername.String }}</span>
                 At <span class="post-time last">{{ localTime .Lastaddition.Time }}</span>
-                [<a href="{{$base}}/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">
+               [<a href="{{$base}}/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">
                     {{- .Comments.Int32 }} comments.</a>]{{" "}}
-                {{- template "topicLabels" (dict
-                    "Public" .PublicLabels
-                    "Author" .AuthorLabels
-                    "Private" .PrivateLabels
-                ) }}
+                {{- template "topicLabels" .Labels }}
             </div>
         </div>
     {{- end }}

--- a/core/templates/threadPage_labels_test.go
+++ b/core/templates/threadPage_labels_test.go
@@ -7,26 +7,12 @@ import (
 	"testing"
 )
 
-// dict is a helper for building maps in templates.
-func dict(values ...any) map[string]any {
-	m := make(map[string]any, len(values)/2)
-	for i := 0; i < len(values); i += 2 {
-		key, _ := values[i].(string)
-		m[key] = values[i+1]
-	}
-	return m
-}
-
 func csrfField() template.HTML { return "" }
 
 // TestThreadPageShowsDefaultPrivateLabels ensures that the thread page template
 // renders special private labels like "new" and "unread".
 func TestThreadPageShowsDefaultPrivateLabels(t *testing.T) {
-	funcMap := template.FuncMap{
-		"dict":      dict,
-		"csrfField": csrfField,
-	}
-	tmpl := template.New("test").Funcs(funcMap)
+	tmpl := template.New("test").Funcs(template.FuncMap{"csrfField": csrfField})
 
 	// Provide stub templates used by threadPage.gohtml.
 	if _, err := tmpl.Parse(`{{define "head"}}{{end}}{{define "tail"}}{{end}}{{define "threadComments"}}{{end}}{{define "forumReply"}}{{end}}`); err != nil {
@@ -37,17 +23,18 @@ func TestThreadPageShowsDefaultPrivateLabels(t *testing.T) {
 	}
 
 	data := struct {
-		Topic         struct{ Idforumtopic int32 }
-		Thread        struct{ Idforumthread int32 }
-		PublicLabels  []string
-		AuthorLabels  []string
-		PrivateLabels []string
-		BasePath      string
-		BackURL       string
+		Topic    struct{ Idforumtopic int32 }
+		Thread   struct{ Idforumthread int32 }
+		Labels   []struct{ Text, Type string }
+		BasePath string
+		BackURL  string
 	}{}
 	data.Topic.Idforumtopic = 1
 	data.Thread.Idforumthread = 3
-	data.PrivateLabels = []string{"new", "unread"}
+	data.Labels = []struct{ Text, Type string }{
+		{Text: "new", Type: "private"},
+		{Text: "unread", Type: "private"},
+	}
 	data.BasePath = "/forum"
 	data.BackURL = "/forum/topic/1/thread/1"
 

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -30,9 +30,7 @@ func ThreadPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 		AdminURL       func(*db.GetCommentsByThreadIdForUserRow) string
 		CanReply       bool
 		BasePath       string
-		PublicLabels   []string
-		AuthorLabels   []string
-		PrivateLabels  []string
+		Labels         []Label
 		BackURL        string
 	}
 
@@ -120,17 +118,20 @@ func ThreadPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 		Edit:                         false,
 	}
 
-	if pub, author, err := cd.ThreadPublicLabels(threadRow.Idforumthread); err == nil {
-		data.PublicLabels = pub
-		data.AuthorLabels = author
+	var pub, author []string
+	if p, a, err := cd.ThreadPublicLabels(threadRow.Idforumthread); err == nil {
+		pub = p
+		author = a
 	} else {
 		log.Printf("list public labels: %v", err)
 	}
-	if priv, err := cd.ThreadPrivateLabels(threadRow.Idforumthread); err == nil {
-		data.PrivateLabels = priv
+	var priv []string
+	if p, err := cd.ThreadPrivateLabels(threadRow.Idforumthread); err == nil {
+		priv = p
 	} else {
 		log.Printf("list private labels: %v", err)
 	}
+	data.Labels = mergeLabels(pub, author, priv)
 
 	replyType := r.URL.Query().Get("type")
 	if quoteId != 0 {

--- a/handlers/forum/labels.go
+++ b/handlers/forum/labels.go
@@ -1,0 +1,25 @@
+package forum
+
+import "sort"
+
+// Label represents a public, author, or private label.
+type Label struct {
+	Text string // The label value.
+	Type string // Label type: "public", "author", or "private".
+}
+
+// mergeLabels combines public, author, and private labels into one slice sorted by label text.
+func mergeLabels(pub, author, priv []string) []Label {
+	labels := make([]Label, 0, len(pub)+len(author)+len(priv))
+	for _, l := range pub {
+		labels = append(labels, Label{Text: l, Type: "public"})
+	}
+	for _, l := range author {
+		labels = append(labels, Label{Text: l, Type: "author"})
+	}
+	for _, l := range priv {
+		labels = append(labels, Label{Text: l, Type: "private"})
+	}
+	sort.Slice(labels, func(i, j int) bool { return labels[i].Text < labels[j].Text })
+	return labels
+}

--- a/handlers/forum/thread_label_tasks.go
+++ b/handlers/forum/thread_label_tasks.go
@@ -70,7 +70,7 @@ var (
 	_ tasks.Task = (*RemovePrivateLabelTask)(nil)
 	_ tasks.Task = (*AddAuthorLabelTask)(nil)
 	_ tasks.Task = (*RemoveAuthorLabelTask)(nil)
-	_ tasks.Task = (*MarkTopicReadTask)(nil)
+	_ tasks.Task = (*MarkThreadReadTask)(nil)
 	_ tasks.Task = (*SetLabelsTask)(nil)
 )
 
@@ -238,7 +238,7 @@ func (SetLabelsTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("set private labels %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if err := cd.SetTopicPrivateLabelStatus(int32(threadID), inverse["new"], inverse["unread"]); err != nil {
+	if err := cd.SetThreadPrivateLabelStatus(int32(threadID), inverse["new"], inverse["unread"]); err != nil {
 		log.Printf("set private label status: %v", err)
 		return fmt.Errorf("set private label status %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/forum/topic_label_tasks_test.go
+++ b/handlers/forum/topic_label_tasks_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 )
 
-func TestMarkTopicReadTaskRedirect(t *testing.T) {
+func TestMarkThreadReadTaskRedirect(t *testing.T) {
 	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
 	form := url.Values{}
 	form.Set("redirect", "/private/topic/1/thread/2")
@@ -28,7 +28,7 @@ func TestMarkTopicReadTaskRedirect(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
 
-	res := MarkTopicReadTask{}.Action(httptest.NewRecorder(), req)
+	res := MarkThreadReadTask{}.Action(httptest.NewRecorder(), req)
 	rdh, ok := res.(handlers.RefreshDirectHandler)
 	if !ok {
 		t.Fatalf("expected RefreshDirectHandler, got %T", res)
@@ -38,7 +38,7 @@ func TestMarkTopicReadTaskRedirect(t *testing.T) {
 	}
 }
 
-func TestMarkTopicReadTaskRefererFallback(t *testing.T) {
+func TestMarkThreadReadTaskRefererFallback(t *testing.T) {
 	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
 	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", nil)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -46,7 +46,7 @@ func TestMarkTopicReadTaskRefererFallback(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
 
-	res := MarkTopicReadTask{}.Action(httptest.NewRecorder(), req)
+	res := MarkThreadReadTask{}.Action(httptest.NewRecorder(), req)
 	rdh, ok := res.(handlers.RefreshDirectHandler)
 	if !ok {
 		t.Fatalf("expected RefreshDirectHandler, got %T", res)
@@ -66,20 +66,20 @@ func TestSetLabelsTaskAddsInverseLabels(t *testing.T) {
 	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
 	cd.UserID = 1
 
-	mock.ExpectQuery("SELECT .* FROM forumtopic_public_labels").
-		WithArgs(int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"forumtopic_idforumtopic", "label"}))
-	mock.ExpectQuery("SELECT .* FROM content_label_status").
-		WithArgs("forumtopic", int32(1)).
+	mock.ExpectQuery("SELECT .* FROM content_public_labels").
+		WithArgs("thread", int32(1)).
 		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "label"}))
-	mock.ExpectQuery("SELECT .* FROM forumtopic_private_labels").
-		WithArgs(int32(1), int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"forumtopic_idforumtopic", "users_idusers", "label", "invert"}))
-	mock.ExpectExec("INSERT IGNORE INTO forumtopic_private_labels").
-		WithArgs(int32(1), int32(1), "new", true).
+	mock.ExpectQuery("SELECT .* FROM content_label_status").
+		WithArgs("thread", int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "label"}))
+	mock.ExpectQuery("SELECT .* FROM content_private_labels").
+		WithArgs("thread", int32(1), int32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "user_id", "label", "invert"}))
+	mock.ExpectExec("INSERT IGNORE INTO content_private_labels").
+		WithArgs("thread", int32(1), int32(1), "new", true).
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("INSERT IGNORE INTO forumtopic_private_labels").
-		WithArgs(int32(1), int32(1), "unread", true).
+	mock.ExpectExec("INSERT IGNORE INTO content_private_labels").
+		WithArgs("thread", int32(1), int32(1), "unread", true).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	form := url.Values{}
@@ -108,40 +108,40 @@ func TestSetLabelsTaskUpdatesSpecialLabels(t *testing.T) {
 	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
 	cd.UserID = 2
 
-	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO forumtopic_private_labels")).
-		WithArgs(int32(1), cd.UserID, "new", true).
+	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO content_private_labels")).
+		WithArgs("thread", int32(1), cd.UserID, "new", true).
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO forumtopic_private_labels")).
-		WithArgs(int32(1), cd.UserID, "unread", true).
+	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO content_private_labels")).
+		WithArgs("thread", int32(1), cd.UserID, "unread", true).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	form := url.Values{}
 	form.Set("redirect", "/private/topic/1/thread/3")
-	form.Set("task", string(TaskMarkTopicRead))
+	form.Set("task", string(TaskMarkThreadRead))
 	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
 
 	// Execute the mark-as-read task, which should upsert the inverse labels.
-	_ = MarkTopicReadTask{}.Action(httptest.NewRecorder(), req)
+	_ = MarkThreadReadTask{}.Action(httptest.NewRecorder(), req)
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}
 }
 
-func TestMarkTopicReadTaskRedirectWithThread(t *testing.T) {
+func TestMarkThreadReadTaskRedirectWithThread(t *testing.T) {
 	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
 	form := url.Values{}
 	form.Set("redirect", "/private/topic/1/thread/3")
-	form.Set("task", string(TaskMarkTopicRead))
+	form.Set("task", string(TaskMarkThreadRead))
 	req := httptest.NewRequest(http.MethodPost, "/private/topic/1/labels", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
 	req = mux.SetURLVars(req, map[string]string{"topic": "1"})
 
-	res := MarkTopicReadTask{}.Action(httptest.NewRecorder(), req)
+	res := MarkThreadReadTask{}.Action(httptest.NewRecorder(), req)
 	rdh, ok := res.(handlers.RefreshDirectHandler)
 	if !ok {
 		t.Fatalf("expected RefreshDirectHandler, got %T", res)

--- a/handlers/privateforum/labels_test.go
+++ b/handlers/privateforum/labels_test.go
@@ -25,7 +25,7 @@ func TestPrivateLabelRoutes(t *testing.T) {
 		cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
 		cd.ForumBasePath = "/private"
 
-		body := "task=" + url.QueryEscape(string(forumhandlers.TaskMarkTopicRead)) + "&redirect=" + url.QueryEscape("/private/topic/1/thread/2")
+		body := "task=" + url.QueryEscape(string(forumhandlers.TaskMarkThreadRead)) + "&redirect=" + url.QueryEscape("/private/topic/1/thread/2")
 		req := httptest.NewRequest(http.MethodPost, "/private/thread/1/labels", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))


### PR DESCRIPTION
## Summary
- Merge public, author, and private labels into a single list sorted alphabetically
- Move label inputs to the end of the thread label editor
- Fix outdated task references and adjust tests for new label handling

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: expectation mismatch in handlers/forum tests)*

------
https://chatgpt.com/codex/tasks/task_e_689982d643dc832fb3cda82ebda9c7d7