### PR TITLE
Fix thread mark read forms

### DIFF
--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -5,13 +5,13 @@
         {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
         <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" class="mark-read">
             {{ csrfField }}
-            <input type="hidden" name="task" value="Mark Topic Read"/>
+            <input type="hidden" name="task" value="Mark Thread Read"/>
             <input type="hidden" name="redirect" value="{{ .BackURL }}"/>
             <button type="submit">Mark as read</button>
         </form>
-        <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/labels" class="mark-read">
+        <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" class="mark-read">
             {{ csrfField }}
-            <input type="hidden" name="task" value="Mark Topic Read"/>
+            <input type="hidden" name="task" value="Mark Thread Read"/>
             <input type="hidden" name="redirect" value="{{$base}}/topic/{{.Topic.Idforumtopic}}"/>
             <button type="submit">Mark as read and go back</button>
         </form>
@@ -44,7 +44,7 @@
             <input type="submit" value="Save Labels"/>
         </form>
         <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" class="mark-read">
-            <input type="hidden" name="task" value="Mark Topic Read"/>
+            <input type="hidden" name="task" value="Mark Thread Read"/>
             <input type="hidden" name="redirect" value="{{$base}}/topic/{{.Topic.Idforumtopic}}"/>
             <button type="submit">Mark as read and go back</button>
         </form>

--- a/core/templates/thread_page_test.go
+++ b/core/templates/thread_page_test.go
@@ -3,6 +3,7 @@ package templates
 import (
 	_ "embed"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -13,5 +14,17 @@ func TestThreadPageMarkReadIncludesCSRF(t *testing.T) {
 	re := regexp.MustCompile(`(?s)<form[^>]*class="mark-read"[^>]*>.*{{ csrfField }}`)
 	if !re.MatchString(threadPageTemplate) {
 		t.Fatalf("mark-read form missing csrfField")
+	}
+}
+
+func TestThreadPageUsesThreadMarkReadTask(t *testing.T) {
+	if strings.Contains(threadPageTemplate, "Mark Topic Read") {
+		t.Fatalf("template uses deprecated Mark Topic Read task")
+	}
+	if c := strings.Count(threadPageTemplate, "Mark Thread Read"); c != 3 {
+		t.Fatalf("expected 3 Mark Thread Read tasks, got %d", c)
+	}
+	if strings.Contains(threadPageTemplate, "/topic/{{.Topic.Idforumtopic}}/labels") {
+		t.Fatalf("mark-read form posts to topic labels endpoint")
 	}
 }


### PR DESCRIPTION
## Summary
- use correct task and endpoint for mark-read forms
- test that templates reference `Mark Thread Read`

## Testing
- `go mod tidy`
- `go fmt ./...` *(reverted unrelated changes)*
- `go vet ./core/...`
- `golangci-lint run ./core/templates/...`
- `go test ./core/templates -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899898e6e90832f8522a3623222c615