### PR TITLE
Fix forumtopic label migrations

### DIFF
--- a/migrations/0065.mysql.sql
+++ b/migrations/0065.mysql.sql
@@ -1,17 +1,17 @@
-RENAME TABLE forumthread_public_labels TO content_public_labels;
+RENAME TABLE forumtopic_public_labels TO content_public_labels;
 ALTER TABLE content_public_labels
-    CHANGE COLUMN forumthread_idforumthread item_id INT NOT NULL,
+    CHANGE COLUMN forumtopic_idforumtopic item_id INT NOT NULL,
     ADD COLUMN item VARCHAR(64) NOT NULL DEFAULT 'thread' AFTER id,
-    DROP INDEX forumthread_public_labels_uq,
+    DROP INDEX forumtopic_public_labels_uq,
     ADD UNIQUE INDEX content_public_labels_uq (item, item_id, label(255));
 ALTER TABLE content_public_labels MODIFY item VARCHAR(64) NOT NULL;
 
-RENAME TABLE forumthread_private_labels TO content_private_labels;
+RENAME TABLE forumtopic_private_labels TO content_private_labels;
 ALTER TABLE content_private_labels
-    CHANGE COLUMN forumthread_idforumthread item_id INT NOT NULL,
+    CHANGE COLUMN forumtopic_idforumtopic item_id INT NOT NULL,
     CHANGE COLUMN users_idusers user_id INT NOT NULL,
     ADD COLUMN item VARCHAR(64) NOT NULL DEFAULT 'thread' AFTER id,
-    DROP INDEX forumthread_private_labels_uq,
+    DROP INDEX forumtopic_private_labels_uq,
     ADD UNIQUE INDEX content_private_labels_uq (item, item_id, user_id, label(255));
 ALTER TABLE content_private_labels MODIFY item VARCHAR(64) NOT NULL;
 

--- a/migrations/0065.postgres.sql
+++ b/migrations/0065.postgres.sql
@@ -1,15 +1,15 @@
-ALTER TABLE forumthread_public_labels RENAME TO content_public_labels;
-ALTER TABLE content_public_labels RENAME COLUMN forumthread_idforumthread TO item_id;
+ALTER TABLE forumtopic_public_labels RENAME TO content_public_labels;
+ALTER TABLE content_public_labels RENAME COLUMN forumtopic_idforumtopic TO item_id;
 ALTER TABLE content_public_labels ADD COLUMN item TEXT NOT NULL DEFAULT 'thread';
-ALTER TABLE content_public_labels DROP CONSTRAINT forumthread_public_labels_uq;
+ALTER TABLE content_public_labels DROP CONSTRAINT forumtopic_public_labels_uq;
 ALTER TABLE content_public_labels ADD CONSTRAINT content_public_labels_uq UNIQUE (item, item_id, label);
 ALTER TABLE content_public_labels ALTER COLUMN item DROP DEFAULT;
 
-ALTER TABLE forumthread_private_labels RENAME TO content_private_labels;
-ALTER TABLE content_private_labels RENAME COLUMN forumthread_idforumthread TO item_id;
+ALTER TABLE forumtopic_private_labels RENAME TO content_private_labels;
+ALTER TABLE content_private_labels RENAME COLUMN forumtopic_idforumtopic TO item_id;
 ALTER TABLE content_private_labels RENAME COLUMN users_idusers TO user_id;
 ALTER TABLE content_private_labels ADD COLUMN item TEXT NOT NULL DEFAULT 'thread';
-ALTER TABLE content_private_labels DROP CONSTRAINT forumthread_private_labels_uq;
+ALTER TABLE content_private_labels DROP CONSTRAINT forumtopic_private_labels_uq;
 ALTER TABLE content_private_labels ADD CONSTRAINT content_private_labels_uq UNIQUE (item, item_id, user_id, label);
 ALTER TABLE content_private_labels ALTER COLUMN item DROP DEFAULT;
 

--- a/migrations/0065.sqlite.sql
+++ b/migrations/0065.sqlite.sql
@@ -1,15 +1,15 @@
-ALTER TABLE forumthread_public_labels RENAME TO content_public_labels;
-ALTER TABLE content_public_labels RENAME COLUMN forumthread_idforumthread TO item_id;
+ALTER TABLE forumtopic_public_labels RENAME TO content_public_labels;
+ALTER TABLE content_public_labels RENAME COLUMN forumtopic_idforumtopic TO item_id;
 ALTER TABLE content_public_labels ADD COLUMN item TEXT NOT NULL DEFAULT 'thread';
 CREATE UNIQUE INDEX content_public_labels_uq ON content_public_labels (item, item_id, label);
-DROP INDEX forumthread_public_labels_uq;
+DROP INDEX forumtopic_public_labels_uq;
 
-ALTER TABLE forumthread_private_labels RENAME TO content_private_labels;
-ALTER TABLE content_private_labels RENAME COLUMN forumthread_idforumthread TO item_id;
+ALTER TABLE forumtopic_private_labels RENAME TO content_private_labels;
+ALTER TABLE content_private_labels RENAME COLUMN forumtopic_idforumtopic TO item_id;
 ALTER TABLE content_private_labels RENAME COLUMN users_idusers TO user_id;
 ALTER TABLE content_private_labels ADD COLUMN item TEXT NOT NULL DEFAULT 'thread';
 CREATE UNIQUE INDEX content_private_labels_uq ON content_private_labels (item, item_id, user_id, label);
-DROP INDEX forumthread_private_labels_uq;
+DROP INDEX forumtopic_private_labels_uq;
 
 -- Update schema version
 UPDATE schema_version SET version = 65 WHERE version = 64;


### PR DESCRIPTION
## Summary
- rename forumtopic label tables to content_* in migration 0065
- align item_id and user_id columns and unique indexes

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689988bfae08832fa06d3a882b5dfb9e