### PR TITLE
Sort topic labels globally

### DIFF
--- a/core/templates/label.go
+++ b/core/templates/label.go
@@ -1,0 +1,8 @@
+package templates
+
+// TopicLabel represents a label attached to a thread or content item.
+// Type is one of "public", "author", or "private".
+type TopicLabel struct {
+	Name string
+	Type string
+}

--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -2,7 +2,7 @@
     {{ $base := "/forum" }}
     {{ with .BasePath }}{{ $base = . }}{{ end }}
     <div class="label-bar">
-        {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
+        {{ template "topicLabels" .Labels }}
         <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" class="mark-read">
             {{ csrfField }}
             <input type="hidden" name="task" value="Mark Topic Read"/>
@@ -24,23 +24,17 @@
             {{ csrfField }}
             <input type="hidden" name="task" value="Set Labels"/>
             <input type="hidden" name="back" value="{{ .BackURL }}"/>
-            <div class="public-labels">
-                {{ range .PublicLabels }}
-                <span class="label pill public">{{ . }}<button type="button" class="remove" data-type="public">x</button><input type="hidden" name="public" value="{{ . }}"/></span>
+            {{ range .Labels }}
+                {{ if eq .Type "public" }}
+                <span class="label pill public">{{ .Name }}<button type="button" class="remove" data-type="public">x</button><input type="hidden" name="public" value="{{ .Name }}"/></span>
+                {{ else if eq .Type "private" }}
+                <span class="label pill private">{{ .Name }}<button type="button" class="remove" data-type="private">x</button><input type="hidden" name="private" value="{{ .Name }}"/></span>
+                {{ else if eq .Type "author" }}
+                <span class="label pill author">{{ .Name }}</span>
                 {{ end }}
-                <input type="text" class="label-input" data-type="public" placeholder="Add public label"/>
-            </div>
-            <div class="author-labels">
-                {{ range .AuthorLabels }}
-                <span class="label pill author">{{ . }}</span>
-                {{ end }}
-            </div>
-            <div class="private-labels">
-                {{ range .PrivateLabels }}
-                <span class="label pill private">{{ . }}<button type="button" class="remove" data-type="private">x</button><input type="hidden" name="private" value="{{ . }}"/></span>
-                {{ end }}
-                <input type="text" class="label-input" data-type="private" placeholder="Add private label"/>
-            </div>
+            {{ end }}
+            <input type="text" class="label-input" data-type="public" placeholder="Add public label"/>
+            <input type="text" class="label-input" data-type="private" placeholder="Add private label"/>
             <input type="submit" value="Save Labels"/>
         </form>
         <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" class="mark-read">

--- a/core/templates/site/forum/topicLabels.gohtml
+++ b/core/templates/site/forum/topicLabels.gohtml
@@ -1,25 +1,7 @@
 {{ define "topicLabels" }}
 <span class="labels">
-    {{ if .Public }}
-    <span class="labels-public">
-        {{ range .Public }}
-        <span class="label pill public" title="public label">{{ . }}</span>
-        {{ end }}
-    </span>
-    {{ end }}
-    {{ if .Author }}
-    <span class="labels-author">
-        {{ range .Author }}
-        <span class="label pill author" title="author label">{{ . }}</span>
-        {{ end }}
-    </span>
-    {{ end }}
-    {{ if .Private }}
-    <span class="labels-private">
-        {{ range .Private }}
-        <span class="label pill private" title="private label">{{ . }}</span>
-        {{ end }}
-    </span>
+    {{ range . }}
+    <span class="label pill {{ .Type }}" title="{{ .Type }} label">{{ .Name }}</span>
     {{ end }}
 </span>
 {{ end }}

--- a/core/templates/site/forum/topicsPage.gohtml
+++ b/core/templates/site/forum/topicsPage.gohtml
@@ -19,9 +19,9 @@
             </form>
         {{- end }}
     </div>
-    {{ if or (gt (len .PublicLabels) 0) (gt (len .AuthorLabels) 0) (gt (len .PrivateLabels) 0) }}
+    {{ if gt (len .Labels) 0 }}
         <h3>Labels</h3>
-        {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
+        {{ template "topicLabels" .Labels }}
     {{ end }}
 
     {{ template "topicThreads" $ }}

--- a/core/templates/site/topicThreads.gohtml
+++ b/core/templates/site/topicThreads.gohtml
@@ -17,11 +17,7 @@
                 At <span class="post-time last">{{ localTime .Lastaddition.Time }}</span>
                 [<a href="{{$base}}/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">
                     {{- .Comments.Int32 }} comments.</a>]{{" "}}
-                {{- template "topicLabels" (dict
-                    "Public" .PublicLabels
-                    "Author" .AuthorLabels
-                    "Private" .PrivateLabels
-                ) }}
+                {{- template "topicLabels" .Labels }}
             </div>
         </div>
     {{- end }}

--- a/core/templates/threadPage_labels_test.go
+++ b/core/templates/threadPage_labels_test.go
@@ -7,23 +7,12 @@ import (
 	"testing"
 )
 
-// dict is a helper for building maps in templates.
-func dict(values ...any) map[string]any {
-	m := make(map[string]any, len(values)/2)
-	for i := 0; i < len(values); i += 2 {
-		key, _ := values[i].(string)
-		m[key] = values[i+1]
-	}
-	return m
-}
-
 func csrfField() template.HTML { return "" }
 
 // TestThreadPageShowsDefaultPrivateLabels ensures that the thread page template
 // renders special private labels like "new" and "unread".
 func TestThreadPageShowsDefaultPrivateLabels(t *testing.T) {
 	funcMap := template.FuncMap{
-		"dict":      dict,
 		"csrfField": csrfField,
 	}
 	tmpl := template.New("test").Funcs(funcMap)
@@ -37,17 +26,15 @@ func TestThreadPageShowsDefaultPrivateLabels(t *testing.T) {
 	}
 
 	data := struct {
-		Topic         struct{ Idforumtopic int32 }
-		Thread        struct{ Idforumthread int32 }
-		PublicLabels  []string
-		AuthorLabels  []string
-		PrivateLabels []string
-		BasePath      string
-		BackURL       string
+		Topic    struct{ Idforumtopic int32 }
+		Thread   struct{ Idforumthread int32 }
+		Labels   []TopicLabel
+		BasePath string
+		BackURL  string
 	}{}
 	data.Topic.Idforumtopic = 1
 	data.Thread.Idforumthread = 3
-	data.PrivateLabels = []string{"new", "unread"}
+	data.Labels = []TopicLabel{{Name: "new", Type: "private"}, {Name: "unread", Type: "private"}}
 	data.BasePath = "/forum"
 	data.BackURL = "/forum/topic/1/thread/1"
 


### PR DESCRIPTION
## Summary
- combine public, author and private labels into one sorted list
- render topic label editor after labels with unified inputs

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689987b44d18832fb8e8510c186a34d8