### PR TITLE
Rename language id columns to language_id

### DIFF
--- a/cmd/goa4web/blog_create.go
+++ b/cmd/goa4web/blog_create.go
@@ -43,12 +43,12 @@ func (c *blogCreateCmd) Run() error {
 	ctx := context.Background()
 	queries := db.New(conn)
 	_, err = queries.CreateBlogEntryForWriter(ctx, db.CreateBlogEntryForWriterParams{
-		UsersIdusers:       int32(c.UserID),
-		LanguageIdlanguage: sql.NullInt32{Int32: int32(c.LangID), Valid: c.LangID != 0},
-		Blog:               sql.NullString{String: c.Text, Valid: true},
-		Timezone:           sql.NullString{String: time.Local.String(), Valid: true},
-		UserID:             sql.NullInt32{Int32: int32(c.UserID), Valid: true},
-		ListerID:           int32(c.UserID),
+		UsersIdusers: int32(c.UserID),
+		LanguageID:   sql.NullInt32{Int32: int32(c.LangID), Valid: c.LangID != 0},
+		Blog:         sql.NullString{String: c.Text, Valid: true},
+		Timezone:     sql.NullString{String: time.Local.String(), Valid: true},
+		UserID:       sql.NullInt32{Int32: int32(c.UserID), Valid: true},
+		ListerID:     int32(c.UserID),
 	})
 	if err != nil {
 		return fmt.Errorf("create blog: %w", err)

--- a/cmd/goa4web/blog_deactivate.go
+++ b/cmd/goa4web/blog_deactivate.go
@@ -57,13 +57,13 @@ func (c *blogDeactivateCmd) Run() error {
 		threadID = b.ForumthreadID.Int32
 	}
 	if err := queries.AdminArchiveBlog(ctx, db.AdminArchiveBlogParams{
-		Idblogs:            b.Idblogs,
-		ForumthreadID:      threadID,
-		UsersIdusers:       b.UsersIdusers,
-		LanguageIdlanguage: b.LanguageIdlanguage,
-		Blog:               b.Blog,
-		Written:            sql.NullTime{Time: b.Written, Valid: true},
-		Timezone:           b.Timezone,
+		Idblogs:       b.Idblogs,
+		ForumthreadID: threadID,
+		UsersIdusers:  b.UsersIdusers,
+		LanguageID:    b.LanguageID,
+		Blog:          b.Blog,
+		Written:       sql.NullTime{Time: b.Written, Valid: true},
+		Timezone:      b.Timezone,
 	}); err != nil {
 		return fmt.Errorf("archive blog: %w", err)
 	}

--- a/cmd/goa4web/comment_deactivate.go
+++ b/cmd/goa4web/comment_deactivate.go
@@ -48,13 +48,13 @@ func (c *commentDeactivateCmd) Run() error {
 		return fmt.Errorf("comment already deactivated")
 	}
 	if err := queries.AdminArchiveComment(ctx, db.AdminArchiveCommentParams{
-		Idcomments:         cm.Idcomments,
-		ForumthreadID:      cm.ForumthreadID,
-		UsersIdusers:       cm.UsersIdusers,
-		LanguageIdlanguage: cm.LanguageIdlanguage,
-		Written:            cm.Written,
-		Text:               cm.Text,
-		Timezone:           cm.Timezone,
+		Idcomments:    cm.Idcomments,
+		ForumthreadID: cm.ForumthreadID,
+		UsersIdusers:  cm.UsersIdusers,
+		LanguageID:    cm.LanguageID,
+		Written:       cm.Written,
+		Text:          cm.Text,
+		Timezone:      cm.Timezone,
 	}); err != nil {
 		return fmt.Errorf("archive comment: %w", err)
 	}

--- a/cmd/goa4web/lang_list.go
+++ b/cmd/goa4web/lang_list.go
@@ -38,7 +38,7 @@ func (c *langListCmd) Run() error {
 		return fmt.Errorf("list languages: %w", err)
 	}
 	for _, l := range langs {
-		fmt.Printf("%d\t%s\n", l.Idlanguage, l.Nameof.String)
+		fmt.Printf("%d\t%s\n", l.ID, l.Nameof.String)
 	}
 	return nil
 }

--- a/cmd/goa4web/lang_update.go
+++ b/cmd/goa4web/lang_update.go
@@ -39,7 +39,7 @@ func (c *langUpdateCmd) Run() error {
 	}
 	ctx := context.Background()
 	queries := db.New(conn)
-	err = queries.AdminRenameLanguage(ctx, db.AdminRenameLanguageParams{Nameof: sql.NullString{String: c.Name, Valid: true}, Idlanguage: int32(c.ID)})
+	err = queries.AdminRenameLanguage(ctx, db.AdminRenameLanguageParams{Nameof: sql.NullString{String: c.Name, Valid: true}, ID: int32(c.ID)})
 	if err != nil {
 		return fmt.Errorf("update language: %w", err)
 	}

--- a/cmd/goa4web/links_deactivate.go
+++ b/cmd/goa4web/links_deactivate.go
@@ -48,15 +48,15 @@ func (c *linksDeactivateCmd) Run() error {
 		return fmt.Errorf("link already deactivated")
 	}
 	if err := queries.AdminArchiveLink(ctx, db.AdminArchiveLinkParams{
-		Idlinker:           l.Idlinker,
-		LanguageIdlanguage: l.LanguageIdlanguage,
-		UsersIdusers:       l.UsersIdusers,
-		LinkerCategoryID:   l.LinkerCategoryID,
-		ForumthreadID:      l.ForumthreadID,
-		Title:              l.Title,
-		Url:                l.Url,
-		Description:        l.Description,
-		Listed:             l.Listed,
+		Idlinker:         l.Idlinker,
+		LanguageID:       l.LanguageID,
+		UsersIdusers:     l.UsersIdusers,
+		LinkerCategoryID: l.LinkerCategoryID,
+		ForumthreadID:    l.ForumthreadID,
+		Title:            l.Title,
+		Url:              l.Url,
+		Description:      l.Description,
+		Listed:           l.Listed,
 	}); err != nil {
 		return fmt.Errorf("archive link: %w", err)
 	}

--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -88,13 +88,13 @@ func (c *userDeactivateCmd) Run() error {
 			return fmt.Errorf("comment %d already deactivated", cm.Idcomments)
 		}
 		if err := qtx.AdminArchiveComment(ctx, db.AdminArchiveCommentParams{
-			Idcomments:         cm.Idcomments,
-			ForumthreadID:      cm.ForumthreadID,
-			UsersIdusers:       cm.UsersIdusers,
-			LanguageIdlanguage: cm.LanguageIdlanguage,
-			Written:            cm.Written,
-			Text:               cm.Text,
-			Timezone:           cm.Timezone,
+			Idcomments:    cm.Idcomments,
+			ForumthreadID: cm.ForumthreadID,
+			UsersIdusers:  cm.UsersIdusers,
+			LanguageID:    cm.LanguageID,
+			Written:       cm.Written,
+			Text:          cm.Text,
+			Timezone:      cm.Timezone,
 		}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("archive comment: %w", err)
@@ -121,16 +121,16 @@ func (c *userDeactivateCmd) Run() error {
 			return fmt.Errorf("writing %d already deactivated", w.Idwriting)
 		}
 		if err := qtx.AdminArchiveWriting(ctx, db.AdminArchiveWritingParams{
-			Idwriting:          w.Idwriting,
-			UsersIdusers:       w.UsersIdusers,
-			ForumthreadID:      w.ForumthreadID,
-			LanguageIdlanguage: w.LanguageIdlanguage,
-			WritingCategoryID:  w.WritingCategoryID,
-			Title:              w.Title,
-			Published:          w.Published,
-			Writing:            w.Writing,
-			Abstract:           w.Abstract,
-			Private:            w.Private,
+			Idwriting:         w.Idwriting,
+			UsersIdusers:      w.UsersIdusers,
+			ForumthreadID:     w.ForumthreadID,
+			LanguageID:        w.LanguageID,
+			WritingCategoryID: w.WritingCategoryID,
+			Title:             w.Title,
+			Published:         w.Published,
+			Writing:           w.Writing,
+			Abstract:          w.Abstract,
+			Private:           w.Private,
 		}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("archive writing: %w", err)
@@ -165,13 +165,13 @@ func (c *userDeactivateCmd) Run() error {
 			threadID = b.ForumthreadID.Int32
 		}
 		if err := qtx.AdminArchiveBlog(ctx, db.AdminArchiveBlogParams{
-			Idblogs:            b.Idblogs,
-			ForumthreadID:      threadID,
-			UsersIdusers:       b.UsersIdusers,
-			LanguageIdlanguage: b.LanguageIdlanguage,
-			Blog:               b.Blog,
-			Written:            sql.NullTime{Time: b.Written, Valid: true},
-			Timezone:           b.Timezone,
+			Idblogs:       b.Idblogs,
+			ForumthreadID: threadID,
+			UsersIdusers:  b.UsersIdusers,
+			LanguageID:    b.LanguageID,
+			Blog:          b.Blog,
+			Written:       sql.NullTime{Time: b.Written, Valid: true},
+			Timezone:      b.Timezone,
 		}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("archive blog: %w", err)
@@ -233,16 +233,16 @@ func (c *userDeactivateCmd) Run() error {
 			return fmt.Errorf("link %d already deactivated", l.Idlinker)
 		}
 		if err := qtx.AdminArchiveLink(ctx, db.AdminArchiveLinkParams{
-			Idlinker:           l.Idlinker,
-			LanguageIdlanguage: l.LanguageIdlanguage,
-			UsersIdusers:       l.UsersIdusers,
-			LinkerCategoryID:   l.LinkerCategoryID,
-			ForumthreadID:      l.ForumthreadID,
-			Title:              l.Title,
-			Url:                l.Url,
-			Description:        l.Description,
-			Listed:             l.Listed,
-			Timezone:           l.Timezone,
+			Idlinker:         l.Idlinker,
+			LanguageID:       l.LanguageID,
+			UsersIdusers:     l.UsersIdusers,
+			LinkerCategoryID: l.LinkerCategoryID,
+			ForumthreadID:    l.ForumthreadID,
+			Title:            l.Title,
+			Url:              l.Url,
+			Description:      l.Description,
+			Listed:           l.Listed,
+			Timezone:         l.Timezone,
 		}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("archive link: %w", err)

--- a/cmd/goa4web/writing_deactivate.go
+++ b/cmd/goa4web/writing_deactivate.go
@@ -48,16 +48,16 @@ func (c *writingDeactivateCmd) Run() error {
 		return fmt.Errorf("writing already deactivated")
 	}
 	if err := queries.AdminArchiveWriting(ctx, db.AdminArchiveWritingParams{
-		Idwriting:          w.Idwriting,
-		UsersIdusers:       w.UsersIdusers,
-		ForumthreadID:      w.ForumthreadID,
-		LanguageIdlanguage: w.LanguageIdlanguage,
-		WritingCategoryID:  w.WritingCategoryID,
-		Title:              w.Title,
-		Published:          w.Published,
-		Writing:            w.Writing,
-		Abstract:           w.Abstract,
-		Private:            w.Private,
+		Idwriting:         w.Idwriting,
+		UsersIdusers:      w.UsersIdusers,
+		ForumthreadID:     w.ForumthreadID,
+		LanguageID:        w.LanguageID,
+		WritingCategoryID: w.WritingCategoryID,
+		Title:             w.Title,
+		Published:         w.Published,
+		Writing:           w.Writing,
+		Abstract:          w.Abstract,
+		Private:           w.Private,
 	}); err != nil {
 		return fmt.Errorf("archive writing: %w", err)
 	}

--- a/cmd/goa4web/writing_tree.go
+++ b/cmd/goa4web/writing_tree.go
@@ -36,14 +36,14 @@ func (c *writingTreeCmd) Run() error {
 	if err != nil {
 		return fmt.Errorf("tree: %w", err)
 	}
-        children := map[int32][]*db.WritingCategory{}
-        for _, cat := range rows {
-                var parent int32
-                if cat.WritingCategoryID.Valid {
-                        parent = cat.WritingCategoryID.Int32
-                }
-                children[parent] = append(children[parent], cat)
-        }
+	children := map[int32][]*db.WritingCategory{}
+	for _, cat := range rows {
+		var parent int32
+		if cat.WritingCategoryID.Valid {
+			parent = cat.WritingCategoryID.Int32
+		}
+		children[parent] = append(children[parent], cat)
+	}
 	var printTree func(parent int32, prefix string)
 	printTree = func(parent int32, prefix string) {
 		for _, cat := range children[parent] {

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1260,8 +1260,8 @@ func (cd *CoreData) RenameLanguage(oldCode, newCode string) error {
 		return fmt.Errorf("lookup language id: %w", err)
 	}
 	if err := cd.queries.AdminRenameLanguage(cd.ctx, db.AdminRenameLanguageParams{
-		Nameof:     sql.NullString{String: newCode, Valid: true},
-		Idlanguage: id,
+		Nameof: sql.NullString{String: newCode, Valid: true},
+		ID:     id,
 	}); err != nil {
 		return fmt.Errorf("update language: %w", err)
 	}
@@ -1283,7 +1283,7 @@ func (cd *CoreData) DeleteLanguage(code string) (int32, string, error) {
 	var name string
 	if rows, err := cd.Languages(); err == nil {
 		for _, l := range rows {
-			if l.Idlanguage == int32(id) {
+			if l.ID == int32(id) {
 				name = l.Nameof.String
 				break
 			}
@@ -1615,8 +1615,8 @@ func (cd *CoreData) Preference() (*db.Preference, error) {
 func (cd *CoreData) PreferredLanguageID(siteDefault string) int32 {
 	id, err := cd.preferredLanguageID.Load(func() (int32, error) {
 		if pref, err := cd.Preference(); err == nil && pref != nil {
-			if pref.LanguageIdlanguage.Valid {
-				return pref.LanguageIdlanguage.Int32, nil
+			if pref.LanguageID.Valid {
+				return pref.LanguageID.Int32, nil
 			}
 		}
 		if cd.queries == nil || siteDefault == "" {
@@ -2319,16 +2319,16 @@ func (cd *CoreData) SectionThreadComments(section, itemType string, id int32, op
 		out := make([]*db.GetCommentsByThreadIdForUserRow, len(rows))
 		for idx, r := range rows {
 			out[idx] = &db.GetCommentsByThreadIdForUserRow{
-				Idcomments:         r.Idcomments,
-				ForumthreadID:      r.ForumthreadID,
-				UsersIdusers:       r.UsersIdusers,
-				LanguageIdlanguage: r.LanguageIdlanguage,
-				Written:            r.Written,
-				Text:               r.Text,
-				DeletedAt:          r.DeletedAt,
-				LastIndex:          r.LastIndex,
-				Posterusername:     r.Posterusername,
-				IsOwner:            r.IsOwner,
+				Idcomments:     r.Idcomments,
+				ForumthreadID:  r.ForumthreadID,
+				UsersIdusers:   r.UsersIdusers,
+				LanguageID:     r.LanguageID,
+				Written:        r.Written,
+				Text:           r.Text,
+				DeletedAt:      r.DeletedAt,
+				LastIndex:      r.LastIndex,
+				Posterusername: r.Posterusername,
+				IsOwner:        r.IsOwner,
 			}
 		}
 		return out, nil

--- a/core/common/coredata_forum.go
+++ b/core/common/coredata_forum.go
@@ -115,7 +115,7 @@ func (cd *CoreData) ForumTopics(categoryID int32) ([]*db.GetForumTopicsForUserRo
 				Idforumtopic:                 r.Idforumtopic,
 				Lastposter:                   r.Lastposter,
 				ForumcategoryIdforumcategory: r.ForumcategoryIdforumcategory,
-				LanguageIdlanguage:           r.LanguageIdlanguage,
+				LanguageID:                   r.LanguageID,
 				Title:                        r.Title,
 				Description:                  r.Description,
 				Threads:                      r.Threads,

--- a/core/common/coredata_news.go
+++ b/core/common/coredata_news.go
@@ -34,7 +34,7 @@ func (cd *CoreData) ThreadInfo(post *db.GetNewsPostByIdWithWriterIdAndThreadComm
 	if errors.Is(err, sql.ErrNoRows) {
 		id, err := cd.queries.CreateForumTopicForPoster(cd.ctx, db.CreateForumTopicForPosterParams{
 			ForumcategoryID: 0,
-			ForumLang:       post.LanguageIdlanguage,
+			ForumLang:       post.LanguageID,
 			Title:           sql.NullString{String: newsTopicName, Valid: true},
 			Description:     sql.NullString{String: newsTopicDescription, Valid: true},
 			Handler:         "news",

--- a/core/common/coredata_search.go
+++ b/core/common/coredata_search.go
@@ -348,12 +348,12 @@ func (cd *CoreData) blogSearch(r *http.Request, uid int32) ([]*db.Blog, bool, bo
 	blogs := make([]*db.Blog, 0, len(rows))
 	for _, r := range rows {
 		blogs = append(blogs, &db.Blog{
-			Idblogs:            r.Idblogs,
-			ForumthreadID:      r.ForumthreadID,
-			UsersIdusers:       r.UsersIdusers,
-			LanguageIdlanguage: r.LanguageIdlanguage,
-			Blog:               r.Blog,
-			Written:            r.Written,
+			Idblogs:       r.Idblogs,
+			ForumthreadID: r.ForumthreadID,
+			UsersIdusers:  r.UsersIdusers,
+			LanguageID:    r.LanguageID,
+			Blog:          r.Blog,
+			Written:       r.Written,
 		})
 	}
 

--- a/core/common/coredata_test.go
+++ b/core/common/coredata_test.go
@@ -25,7 +25,7 @@ func TestCoreDataLatestNewsLazy(t *testing.T) {
 	queries := db.New(conn)
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
-		"writerName", "writerId", "idsitenews", "forumthread_id", "language_idlanguage",
+		"writerName", "writerId", "idsitenews", "forumthread_id", "language_id",
 		"users_idusers", "news", "occurred", "timezone", "comments",
 	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, time.Local.String(), 0)
 
@@ -173,14 +173,14 @@ func TestPublicWritingsLazy(t *testing.T) {
 
 	queries := db.New(conn)
 	now := time.Now()
-	rows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "Username", "Comments"}).
+	rows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_id", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "Username", "Comments"}).
 		AddRow(1, 1, 0, 1, 0, "t", now, "w", "a", false, now, now, "u", 0)
 
 	mock.ExpectQuery("SELECT w.idwriting").WithArgs(int32(1), int32(0), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows)
 	mock.ExpectQuery("SELECT 1 FROM grants g JOIN roles").WithArgs("user", "administrator").WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery("SELECT 1 FROM grants").WithArgs(int32(1), "writing", sql.NullString{String: "article", Valid: true}, "see", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
-	rows2 := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "Username", "Comments"}).
+	rows2 := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_id", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "Username", "Comments"}).
 		AddRow(2, 1, 0, 1, 1, "t2", now, "w2", "a2", false, now, now, "u", 0)
 
 	mock.ExpectQuery("SELECT w.idwriting").WithArgs(int32(1), int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}, int32(15), int32(0)).WillReturnRows(rows2)
@@ -222,7 +222,7 @@ func TestCoreDataLatestWritingsLazy(t *testing.T) {
 	queries := db.New(conn)
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
-		"idwriting", "users_idusers", "forumthread_id", "language_idlanguage",
+		"idwriting", "users_idusers", "forumthread_id", "language_id",
 		"writing_category_id", "title", "published", "writing", "abstract",
 		"private", "deleted_at", "last_index",
 	}).AddRow(1, 1, 0, 1, 1, "t", now, "w", "a", nil, nil, now)
@@ -327,7 +327,7 @@ func TestBlogListLazy(t *testing.T) {
 
 	queries := db.New(conn)
 	now := time.Now()
-	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "comments", "is_owner"}).
+	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_id", "blog", "written", "timezone", "username", "comments", "is_owner"}).
 		AddRow(1, nil, 1, 0, "b", now, time.Local.String(), "bob", 0, true)
 	mock.ExpectQuery("SELECT b.idblogs").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -361,7 +361,7 @@ func TestBlogListForSelectedAuthorLazy(t *testing.T) {
 
 	queries := db.New(conn)
 	now := time.Now()
-	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "comments", "is_owner"}).
+	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_id", "blog", "written", "timezone", "username", "comments", "is_owner"}).
 		AddRow(1, nil, 1, 0, "b", now, time.Local.String(), "bob", 0, true)
 	mock.ExpectQuery("SELECT b.idblogs").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -395,7 +395,7 @@ func TestSelectedQuestionFromCategory(t *testing.T) {
 	ctx := context.Background()
 	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
 
-	row := sqlmock.NewRows([]string{"id", "faq_category_id", "language_idlanguage", "users_idusers", "answer", "question"}).
+	row := sqlmock.NewRows([]string{"id", "faq_category_id", "language_id", "users_idusers", "answer", "question"}).
 		AddRow(1, 2, 0, 0, sql.NullString{}, sql.NullString{})
 	mock.ExpectQuery("SELECT id, faq_category_id").WithArgs(int32(1)).WillReturnRows(row)
 	mock.ExpectExec("UPDATE faq SET deleted_at").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
@@ -420,7 +420,7 @@ func TestSelectedQuestionFromCategoryWrongCategory(t *testing.T) {
 	ctx := context.Background()
 	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
 
-	row := sqlmock.NewRows([]string{"id", "faq_category_id", "language_idlanguage", "users_idusers", "answer", "question"}).
+	row := sqlmock.NewRows([]string{"id", "faq_category_id", "language_id", "users_idusers", "answer", "question"}).
 		AddRow(1, 3, 0, 0, sql.NullString{}, sql.NullString{})
 	mock.ExpectQuery("SELECT id, faq_category_id").WithArgs(int32(1)).WillReturnRows(row)
 

--- a/core/common/coredata_user.go
+++ b/core/common/coredata_user.go
@@ -173,21 +173,21 @@ func (cd *CoreData) SetUserLanguage(userID, languageID int32) error {
 	pref, err := cd.queries.GetPreferenceForLister(cd.ctx, userID)
 	if err != nil {
 		if err == sql.ErrNoRows {
-                        return cd.queries.InsertPreferenceForLister(cd.ctx, db.InsertPreferenceForListerParams{
-                                LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
-                                ListerID:   userID,
-                                PageSize:   int32(cd.Config.PageSizeDefault),
-                                Timezone:   sql.NullString{},
-                        })
+			return cd.queries.InsertPreferenceForLister(cd.ctx, db.InsertPreferenceForListerParams{
+				LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
+				ListerID:   userID,
+				PageSize:   int32(cd.Config.PageSizeDefault),
+				Timezone:   sql.NullString{},
+			})
 		}
 		return err
 	}
-        return cd.queries.UpdatePreferenceForLister(cd.ctx, db.UpdatePreferenceForListerParams{
-                LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
-                ListerID:   userID,
-                PageSize:   pref.PageSize,
-                Timezone:   pref.Timezone,
-        })
+	return cd.queries.UpdatePreferenceForLister(cd.ctx, db.UpdatePreferenceForListerParams{
+		LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
+		ListerID:   userID,
+		PageSize:   pref.PageSize,
+		Timezone:   pref.Timezone,
+	})
 }
 
 // SetUserLanguages replaces a user's language selections.
@@ -199,7 +199,7 @@ func (cd *CoreData) SetUserLanguages(userID int32, langs []int32) error {
 		return err
 	}
 	for _, l := range langs {
-		if err := cd.queries.InsertUserLang(cd.ctx, db.InsertUserLangParams{UsersIdusers: userID, LanguageIdlanguage: l}); err != nil {
+		if err := cd.queries.InsertUserLang(cd.ctx, db.InsertUserLangParams{UsersIdusers: userID, LanguageID: l}); err != nil {
 			return err
 		}
 	}
@@ -214,17 +214,17 @@ func (cd *CoreData) SetTimezone(userID int32, tz string) error {
 	pref, err := cd.queries.GetPreferenceForLister(cd.ctx, userID)
 	if err != nil {
 		if err == sql.ErrNoRows {
-                        return cd.queries.InsertPreferenceForLister(cd.ctx, db.InsertPreferenceForListerParams{
-                                LanguageID: sql.NullInt32{},
-                                ListerID:   userID,
-                                PageSize:   int32(cd.Config.PageSizeDefault),
-                                Timezone:   sql.NullString{String: tz, Valid: tz != ""},
-                        })
+			return cd.queries.InsertPreferenceForLister(cd.ctx, db.InsertPreferenceForListerParams{
+				LanguageID: sql.NullInt32{},
+				ListerID:   userID,
+				PageSize:   int32(cd.Config.PageSizeDefault),
+				Timezone:   sql.NullString{String: tz, Valid: tz != ""},
+			})
 		}
 		return err
 	}
 	return cd.queries.UpdatePreferenceForLister(cd.ctx, db.UpdatePreferenceForListerParams{
-		LanguageID: pref.LanguageIdlanguage,
+		LanguageID: pref.LanguageID,
 		ListerID:   userID,
 		PageSize:   pref.PageSize,
 		Timezone:   sql.NullString{String: tz, Valid: tz != ""},

--- a/core/common/coredata_writings.go
+++ b/core/common/coredata_writings.go
@@ -151,17 +151,17 @@ func (cd *CoreData) CreateWritingReply(w *db.GetWritingForListerByIDRow, languag
 	pt, err := cd.queries.SystemGetForumTopicByTitle(cd.ctx, sql.NullString{String: WritingTopicName, Valid: true})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
-                ptidi, err := cd.queries.CreateForumTopicForPoster(cd.ctx, db.CreateForumTopicForPosterParams{
-                        ForumcategoryID: 0,
-                        ForumLang:       w.LanguageIdlanguage,
-                        Title:           sql.NullString{String: WritingTopicName, Valid: true},
-                        Description:     sql.NullString{String: WritingTopicDescription, Valid: true},
-                        Handler:         "writing",
-                        Section:         "forum",
-                        GrantCategoryID: sql.NullInt32{},
-                        GranteeID:       sql.NullInt32{},
-                        PosterID:        0,
-                })
+		ptidi, err := cd.queries.CreateForumTopicForPoster(cd.ctx, db.CreateForumTopicForPosterParams{
+			ForumcategoryID: 0,
+			ForumLang:       w.LanguageID,
+			Title:           sql.NullString{String: WritingTopicName, Valid: true},
+			Description:     sql.NullString{String: WritingTopicDescription, Valid: true},
+			Handler:         "writing",
+			Section:         "forum",
+			GrantCategoryID: sql.NullInt32{},
+			GranteeID:       sql.NullInt32{},
+			PosterID:        0,
+		})
 		if err != nil {
 			return 0, 0, 0, err
 		}
@@ -198,7 +198,7 @@ func (cd *CoreData) UpdateWriting(w *db.GetWritingForListerByIDRow, title, abstr
 		Abstract:   sql.NullString{Valid: true, String: abstract},
 		Content:    sql.NullString{Valid: true, String: body},
 		Private:    sql.NullBool{Valid: true, Bool: private},
-                LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
+		LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		WritingID:  w.Idwriting,
 		WriterID:   cd.UserID,
 		GranteeID:  sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
@@ -220,7 +220,7 @@ func (cd *CoreData) CreateWriting(categoryID, languageID int32, title, abstract,
 		Abstract:          sql.NullString{Valid: true, String: abstract},
 		Writing:           sql.NullString{Valid: true, String: body},
 		Private:           sql.NullBool{Valid: true, Bool: private},
-                LanguageID:        sql.NullInt32{Int32: languageID, Valid: languageID != 0},
+		LanguageID:        sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		GrantCategoryID:   sql.NullInt32{Int32: categoryID, Valid: true},
 		GranteeID:         sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	})
@@ -278,19 +278,19 @@ func (cd *CoreData) CreateWritingCategory(parentID int32, name, desc string) err
 	if err != nil {
 		return err
 	}
-        parents := make(map[int32]int32, len(cats))
-        for _, c := range cats {
-                var pid int32
-                if c.WritingCategoryID.Valid {
-                        pid = c.WritingCategoryID.Int32
-                }
-                parents[c.Idwritingcategory] = pid
-        }
+	parents := make(map[int32]int32, len(cats))
+	for _, c := range cats {
+		var pid int32
+		if c.WritingCategoryID.Valid {
+			pid = c.WritingCategoryID.Int32
+		}
+		parents[c.Idwritingcategory] = pid
+	}
 	if path, loop := algorithms.WouldCreateLoop(parents, 0, parentID); loop && len(path) > 0 {
 		return UserError{ErrorMessage: "invalid parent category: loop detected"}
 	}
-        return cd.queries.AdminInsertWritingCategory(cd.ctx, db.AdminInsertWritingCategoryParams{
-                WritingCategoryID: sql.NullInt32{Int32: parentID, Valid: parentID != 0},
+	return cd.queries.AdminInsertWritingCategory(cd.ctx, db.AdminInsertWritingCategoryParams{
+		WritingCategoryID: sql.NullInt32{Int32: parentID, Valid: parentID != 0},
 		Title: sql.NullString{
 			Valid:  true,
 			String: name,
@@ -311,21 +311,21 @@ func (cd *CoreData) ChangeWritingCategory(id, parentID int32, name, desc string)
 	if err != nil {
 		return err
 	}
-        parents := make(map[int32]int32, len(cats))
-        for _, c := range cats {
-                var pid int32
-                if c.WritingCategoryID.Valid {
-                        pid = c.WritingCategoryID.Int32
-                }
-                parents[c.Idwritingcategory] = pid
-        }
+	parents := make(map[int32]int32, len(cats))
+	for _, c := range cats {
+		var pid int32
+		if c.WritingCategoryID.Valid {
+			pid = c.WritingCategoryID.Int32
+		}
+		parents[c.Idwritingcategory] = pid
+	}
 	if path, loop := algorithms.WouldCreateLoop(parents, id, parentID); loop {
 		return UserError{ErrorMessage: fmt.Sprintf("invalid parent category: loop %v", path)}
 	}
-        return cd.queries.AdminUpdateWritingCategory(cd.ctx, db.AdminUpdateWritingCategoryParams{
-                Title:             sql.NullString{Valid: true, String: name},
-                Description:       sql.NullString{Valid: true, String: desc},
-                Idwritingcategory: id,
-                WritingCategoryID: sql.NullInt32{Int32: parentID, Valid: parentID != 0},
-        })
+	return cd.queries.AdminUpdateWritingCategory(cd.ctx, db.AdminUpdateWritingCategoryParams{
+		Title:             sql.NullString{Valid: true, String: name},
+		Description:       sql.NullString{Valid: true, String: desc},
+		Idwritingcategory: id,
+		WritingCategoryID: sql.NullInt32{Int32: parentID, Valid: parentID != 0},
+	})
 }

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -61,7 +61,7 @@ func TestLatestNewsRespectsPermissions(t *testing.T) {
 
 	now := time.Now()
 	rows := sqlmock.NewRows([]string{
-		"writerName", "writerId", "idsitenews", "forumthread_id", "language_idlanguage",
+		"writerName", "writerId", "idsitenews", "forumthread_id", "language_id",
 		"users_idusers", "news", "occurred", "timezone", "comments",
 	}).AddRow("w", 1, 1, 0, 1, 1, "a", now, time.Local.String(), 0).AddRow("w", 1, 2, 0, 1, 1, "b", now, time.Local.String(), 0)
 

--- a/core/templates/email_execute_test.go
+++ b/core/templates/email_execute_test.go
@@ -1,13 +1,13 @@
 package templates_test
 
 import (
-        htemplate "html/template"
-        "io"
-        "strings"
-        "testing"
-        "time"
+	htemplate "html/template"
+	"io"
+	"strings"
+	"testing"
+	"time"
 
-        "github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/core/templates"
 )
 
 type emailData struct {
@@ -47,7 +47,7 @@ func sampleEmailData() emailData {
 		},
 		"ThreadID":           1,
 		"ThreadURL":          "https://example.com/thread",
-                "Time":               time.Now(),
+		"Time":               time.Now(),
 		"Title":              map[string]interface{}{"String": "title"},
 		"TopicTitle":         "topic title",
 		"UnsubURL":           "https://example.com/unsub",

--- a/core/templates/site/admin/languageEditPage.gohtml
+++ b/core/templates/site/admin/languageEditPage.gohtml
@@ -2,14 +2,14 @@
 <h2>Edit Language {{ .Language.Nameof.String }}</h2>
 <form method="post">
     {{ csrfField }}
-    <input type="hidden" name="cid" value="{{ .Language.Idlanguage }}">
+    <input type="hidden" name="cid" value="{{ .Language.ID }}">
     <label>Name:<input name="cname" value="{{ .Language.Nameof.String }}"></label>
     <input type="submit" name="task" value="Rename Language">
 </form>
 <form method="post">
     {{ csrfField }}
-    <input type="hidden" name="cid" value="{{ .Language.Idlanguage }}">
+    <input type="hidden" name="cid" value="{{ .Language.ID }}">
     <input type="submit" name="task" value="Delete Language">
 </form>
-<p><a href="/admin/languages/language/{{ .Language.Idlanguage }}">Back</a></p>
+<p><a href="/admin/languages/language/{{ .Language.ID }}">Back</a></p>
 {{ template "tail" $ }}

--- a/core/templates/site/admin/languagePage.gohtml
+++ b/core/templates/site/admin/languagePage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-[<a href="/admin">Admin:</a> <a href="/admin/languages">Languages</a> <a href="/admin/languages/language/{{ .Language.Idlanguage }}">(This page/Refresh)</a>]<br />
+[<a href="/admin">Admin:</a> <a href="/admin/languages">Languages</a> <a href="/admin/languages/language/{{ .Language.ID }}">(This page/Refresh)</a>]<br />
 <h2>{{ .Language.Nameof.String }}</h2>
 <table>
     <tr><th>Type</th><th>Count</th></tr>
@@ -9,6 +9,6 @@
     <tr><td>News</td><td>{{ .Counts.News }}</td></tr>
     <tr><td>Links</td><td>{{ .Counts.Links }}</td></tr>
 </table>
-<p><a href="/admin/languages/language/{{ .Language.Idlanguage }}/edit">Edit</a></p>
+<p><a href="/admin/languages/language/{{ .Language.ID }}/edit">Edit</a></p>
 <p><a href="/admin/languages">Back to list</a></p>
 {{ template "tail" $ }}

--- a/core/templates/site/admin/languagesPage.gohtml
+++ b/core/templates/site/admin/languagesPage.gohtml
@@ -7,8 +7,8 @@
     </tr>
     {{range cd.Languages}}
     <tr>
-        <td>{{.Idlanguage}}</td>
-        <td><a href="/admin/languages/language/{{.Idlanguage}}">{{.Nameof.String}}</a></td>
+        <td>{{.ID}}</td>
+        <td><a href="/admin/languages/language/{{.ID}}">{{.Nameof.String}}</a></td>
     </tr>
     {{end}}
 </table>

--- a/core/templates/site/admin/userBlogsPage.gohtml
+++ b/core/templates/site/admin/userBlogsPage.gohtml
@@ -7,7 +7,7 @@
         <td><a href="/admin/blogs/blog/{{ .Idblogs }}">{{ .Idblogs }}</a></td>
         <td>{{ localTimeIn .Written .Timezone.String }}</td>
         <td>{{ .Comments }}</td>
-        <td>{{ .LanguageIdlanguage }}</td>
+        <td>{{ .LanguageID }}</td>
         <td>{{if .Idforumcategory.Valid}}<a href="/forum/category/{{ .Idforumcategory.Int32 }}">{{ .ForumcategoryTitle.String }}</a>{{end}}</td>
         <td>{{ left 40 (firstline (a4code2string .Blog.String)) }}</td>
         <td><a href="/blogs/blog/{{ .Idblogs }}">View</a></td>

--- a/core/templates/site/languageCombobox.gohtml
+++ b/core/templates/site/languageCombobox.gohtml
@@ -4,7 +4,7 @@
         <option value="0">Multi-lingual
         {{ $sel := cd.PreferredLanguageID cd.Config.DefaultLanguage }}
         {{range cd.Languages}}
-            <option value="{{.Idlanguage}}"{{if eq .Idlanguage $sel}} selected{{end}}>{{.Nameof.String}}
+            <option value="{{.ID}}"{{if eq .ID $sel}} selected{{end}}>{{.Nameof.String}}
         {{else}}
             <option disabled>No languages</option>
         {{end}}

--- a/handlers/admin/adminCommentPage_test.go
+++ b/handlers/admin/adminCommentPage_test.go
@@ -29,15 +29,15 @@ func TestAdminCommentPage_UsesURLParam(t *testing.T) {
 	threadID := 55
 	topicID := 66
 
-	rows1 := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "username", "is_owner"}).
+	rows1 := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "username", "is_owner"}).
 		AddRow(commentID, threadID, 2, 1, time.Now(), "body", nil, nil, nil, "user", true)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows1)
 
-	rows2 := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner", "idforumthread", "idforumtopic", "forumtopic_title", "thread_title", "idforumcategory", "forumcategory_title"}).
+	rows2 := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner", "idforumthread", "idforumtopic", "forumtopic_title", "thread_title", "idforumcategory", "forumcategory_title"}).
 		AddRow(commentID, threadID, 2, 1, time.Now(), "body", nil, nil, nil, "user", true, threadID, topicID, "topic", "thread", 1, "cat")
 	mock.ExpectQuery("SELECT").WillReturnRows(rows2)
 
-	rows3 := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner"}).
+	rows3 := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner"}).
 		AddRow(commentID, threadID, 2, 1, time.Now(), "body", nil, nil, nil, "user", true)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows3)
 

--- a/handlers/admin/adminCommentTasks.go
+++ b/handlers/admin/adminCommentTasks.go
@@ -74,13 +74,13 @@ func (DeactivateCommentTask) Action(w http.ResponseWriter, r *http.Request) any 
 		return fmt.Errorf("comment already deactivated %w", handlers.ErrRedirectOnSamePageHandler(fmt.Errorf("already deactivated")))
 	}
 	if err := q.AdminArchiveComment(r.Context(), db.AdminArchiveCommentParams{
-		Idcomments:         c.Idcomments,
-		ForumthreadID:      c.ForumthreadID,
-		UsersIdusers:       c.UsersIdusers,
-		LanguageIdlanguage: c.LanguageIdlanguage,
-		Written:            c.Written,
-		Text:               c.Text,
-		Timezone:           c.Timezone,
+		Idcomments:    c.Idcomments,
+		ForumthreadID: c.ForumthreadID,
+		UsersIdusers:  c.UsersIdusers,
+		LanguageID:    c.LanguageID,
+		Written:       c.Written,
+		Text:          c.Text,
+		Timezone:      c.Timezone,
 	}); err != nil {
 		return fmt.Errorf("archive comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/admin/adminCommentTasks_test.go
+++ b/handlers/admin/adminCommentTasks_test.go
@@ -50,7 +50,7 @@ func setupCommentTest(t *testing.T, commentID int, body url.Values) (*httptest.R
 func TestDeleteCommentTask_UsesURLParam(t *testing.T) {
 	rr, req, conn, mock := setupCommentTest(t, 15, nil)
 	defer conn.Close()
-	rows := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "username", "is_owner"}).
+	rows := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "username", "is_owner"}).
 		AddRow(15, 2, 3, 1, time.Now(), "body", nil, nil, nil, "user", true)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectExec("UPDATE").WithArgs(sqlmock.AnyArg(), int32(15)).WillReturnResult(sqlmock.NewResult(0, 1))
@@ -66,7 +66,7 @@ func TestEditCommentTask_UsesURLParam(t *testing.T) {
 	body := url.Values{"replytext": {"updated"}}
 	rr, req, conn, mock := setupCommentTest(t, 22, body)
 	defer conn.Close()
-	rows := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "username", "is_owner"}).
+	rows := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "username", "is_owner"}).
 		AddRow(22, 2, 3, 1, time.Now(), "body", nil, nil, nil, "user", true)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectExec("UPDATE").WithArgs(sqlmock.AnyArg(), int32(22)).WillReturnResult(sqlmock.NewResult(0, 1))
@@ -81,7 +81,7 @@ func TestEditCommentTask_UsesURLParam(t *testing.T) {
 func TestDeactivateCommentTask_UsesURLParam(t *testing.T) {
 	rr, req, conn, mock := setupCommentTest(t, 33, nil)
 	defer conn.Close()
-	rows := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "username", "is_owner"}).
+	rows := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "username", "is_owner"}).
 		AddRow(33, 2, 3, 1, time.Now(), "body", nil, nil, nil, "user", true)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectQuery("SELECT").WithArgs(int32(33)).WillReturnRows(sqlmock.NewRows([]string{"is_deactivated"}).AddRow(false))
@@ -98,7 +98,7 @@ func TestDeactivateCommentTask_UsesURLParam(t *testing.T) {
 func TestRestoreCommentTask_UsesURLParam(t *testing.T) {
 	rr, req, conn, mock := setupCommentTest(t, 44, nil)
 	defer conn.Close()
-	rows := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "username", "is_owner"}).
+	rows := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "username", "is_owner"}).
 		AddRow(44, 2, 3, 1, time.Now(), "", nil, nil, nil, "user", true)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectQuery("SELECT").WithArgs(int32(44)).WillReturnRows(sqlmock.NewRows([]string{"is_deactivated"}).AddRow(true))

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -1,19 +1,19 @@
 package admin
 
 import (
-        "database/sql"
-        "fmt"
-        "log"
-        "net/http"
-        "net/mail"
-        "strconv"
-        "strings"
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"net/mail"
+	"strconv"
+	"strings"
 
-        "github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/core/consts"
 
-        "github.com/arran4/goa4web/core/common"
-        "github.com/arran4/goa4web/handlers"
-        "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 )
 
 func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
@@ -31,10 +31,10 @@ func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	langID, _ := strconv.Atoi(r.URL.Query().Get("lang"))
 	role := r.URL.Query().Get("role")
-        rows, err := queries.AdminListUnsentPendingEmails(r.Context(), db.AdminListUnsentPendingEmailsParams{
-                LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
-                RoleName:   role,
-        })
+	rows, err := queries.AdminListUnsentPendingEmails(r.Context(), db.AdminListUnsentPendingEmailsParams{
+		LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
+		RoleName:   role,
+	})
 	if err != nil {
 		log.Printf("list pending emails: %v", err)
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))

--- a/handlers/admin/adminFailedEmailsPage.go
+++ b/handlers/admin/adminFailedEmailsPage.go
@@ -1,19 +1,19 @@
 package admin
 
 import (
-        "database/sql"
-        "fmt"
-        "log"
-        "net/http"
-        "net/mail"
-        "net/url"
-        "strconv"
-        "strings"
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"net/mail"
+	"net/url"
+	"strconv"
+	"strings"
 
-        "github.com/arran4/goa4web/core/common"
-        "github.com/arran4/goa4web/core/consts"
-        "github.com/arran4/goa4web/handlers"
-        "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 )
 
 // AdminFailedEmailsPage shows queued emails with errors.
@@ -40,12 +40,12 @@ func AdminFailedEmailsPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	langID, _ := strconv.Atoi(r.URL.Query().Get("lang"))
 	role := r.URL.Query().Get("role")
-        rows, err := queries.AdminListFailedEmails(r.Context(), db.AdminListFailedEmailsParams{
-                LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
-                RoleName:   role,
-                Limit:      int32(pageSize + 1),
-                Offset:     int32(offset),
-        })
+	rows, err := queries.AdminListFailedEmails(r.Context(), db.AdminListFailedEmailsParams{
+		LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
+		RoleName:   role,
+		Limit:      int32(pageSize + 1),
+		Offset:     int32(offset),
+	})
 	if err != nil {
 		log.Printf("list failed emails: %v", err)
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))

--- a/handlers/admin/adminSentEmailsPage.go
+++ b/handlers/admin/adminSentEmailsPage.go
@@ -1,19 +1,19 @@
 package admin
 
 import (
-        "database/sql"
-        "fmt"
-        "log"
-        "net/http"
-        "net/mail"
-        "net/url"
-        "strconv"
-        "strings"
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"net/mail"
+	"net/url"
+	"strconv"
+	"strings"
 
-        "github.com/arran4/goa4web/core/common"
-        "github.com/arran4/goa4web/core/consts"
-        "github.com/arran4/goa4web/handlers"
-        "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 )
 
 // AdminSentEmailsPage shows previously sent emails with pagination.
@@ -40,12 +40,12 @@ func AdminSentEmailsPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	langID, _ := strconv.Atoi(r.URL.Query().Get("lang"))
 	role := r.URL.Query().Get("role")
-        rows, err := queries.AdminListSentEmails(r.Context(), db.AdminListSentEmailsParams{
-                LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
-                RoleName:   role,
-                Limit:      int32(pageSize + 1),
-                Offset:     int32(offset),
-        })
+	rows, err := queries.AdminListSentEmails(r.Context(), db.AdminListSentEmailsParams{
+		LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
+		RoleName:   role,
+		Limit:      int32(pageSize + 1),
+		Offset:     int32(offset),
+	})
 	if err != nil {
 		log.Printf("list sent emails: %v", err)
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))

--- a/handlers/admin/adminUserGrantsPage_test.go
+++ b/handlers/admin/adminUserGrantsPage_test.go
@@ -30,7 +30,7 @@ func TestAdminUserGrantsPage_UserIDInjected(t *testing.T) {
 	mock.ExpectQuery("SELECT").WithArgs(int32(userID)).WillReturnRows(sqlmock.NewRows([]string{"iduser_roles", "users_idusers", "role_id", "name"}))
 	mock.ExpectQuery("SELECT").WithArgs(sqlmock.AnyArg()).WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}))
 	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "title", "description"}))
-	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"idlanguage", "nameof"}))
+	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "nameof"}))
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/admin/user/%d/grants", userID), nil)
 	req = mux.SetURLVars(req, map[string]string{"user": strconv.Itoa(userID)})

--- a/handlers/admin/adminUserWritingsPage_test.go
+++ b/handlers/admin/adminUserWritingsPage_test.go
@@ -31,9 +31,9 @@ func TestAdminUserWritingsPage(t *testing.T) {
 		WithArgs(int32(1)).
 		WillReturnRows(userRows)
 
-	writingRows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "username", "comments"}).
+	writingRows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_id", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "username", "comments"}).
 		AddRow(1, 1, 0, 0, 2, "Title", time.Now(), "", "", false, nil, nil, "user", 0)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,\n    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments\nFROM writing w\nLEFT JOIN users u ON w.users_idusers = u.idusers\nWHERE w.users_idusers = ?\nORDER BY w.published DESC")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_id, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,\n    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments\nFROM writing w\nLEFT JOIN users u ON w.users_idusers = u.idusers\nWHERE w.users_idusers = ?\nORDER BY w.published DESC")).
 		WithArgs(int32(1)).
 		WillReturnRows(writingRows)
 

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -91,7 +91,7 @@ func TestAdminListUnsentPendingEmails(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 	rows := sqlmock.NewRows([]string{"id", "to_user_id", "body", "error_count", "created_at", "direct_email"}).AddRow(1, 2, "b", 0, time.Now(), false)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT pe.id, pe.to_user_id, pe.body, pe.error_count, pe.created_at, pe.direct_email FROM pending_emails pe LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers LEFT JOIN roles r ON ur.role_id = r.id WHERE pe.sent_at IS NULL   AND (? IS NULL OR p.language_idlanguage = ?)   AND (? IS NULL OR r.name = ?) ORDER BY pe.id")).WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT pe.id, pe.to_user_id, pe.body, pe.error_count, pe.created_at, pe.direct_email FROM pending_emails pe LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers LEFT JOIN roles r ON ur.role_id = r.id WHERE pe.sent_at IS NULL   AND (? IS NULL OR p.language_id = ?)   AND (? IS NULL OR r.name = ?) ORDER BY pe.id")).WillReturnRows(rows)
 	if _, err := q.AdminListUnsentPendingEmails(context.Background(), db.AdminListUnsentPendingEmailsParams{}); err != nil {
 		t.Fatalf("list: %v", err)
 	}

--- a/handlers/admin/role_grants.go
+++ b/handlers/admin/role_grants.go
@@ -103,7 +103,7 @@ func buildGrantGroupsFromGrants(ctx context.Context, cd *common.CoreData, grants
 	langMap := map[int32]string{}
 	for _, l := range langs {
 		if l.Nameof.Valid {
-			langMap[l.Idlanguage] = l.Nameof.String
+			langMap[l.ID] = l.Nameof.String
 		}
 	}
 
@@ -194,7 +194,7 @@ func buildGrantGroupsFromGrants(ctx context.Context, cd *common.CoreData, grants
 					if w, err := queries.GetWritingForListerByID(ctx, db.GetWritingForListerByIDParams{ListerID: cd.UserID, Idwriting: g.ItemID.Int32, ListerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0}}); err == nil {
 						if w.Title.Valid {
 							info := w.Title.String
-							if name, ok := langMap[w.LanguageIdlanguage.Int32]; ok && name != "" {
+							if name, ok := langMap[w.LanguageID.Int32]; ok && name != "" {
 								info = fmt.Sprintf("[%s] %s", name, info)
 							}
 							gi.Info = info
@@ -220,8 +220,8 @@ func buildGrantGroupsFromGrants(ctx context.Context, cd *common.CoreData, grants
 						if len(text) > 40 {
 							text = text[:40] + "..."
 						}
-						if qrow.LanguageIdlanguage.Valid {
-							if name, ok := langMap[qrow.LanguageIdlanguage.Int32]; ok && name != "" {
+						if qrow.LanguageID.Valid {
+							if name, ok := langMap[qrow.LanguageID.Int32]; ok && name != "" {
 								text = fmt.Sprintf("[%s] %s", name, text)
 							}
 						}

--- a/handlers/admin/role_grants_build_test.go
+++ b/handlers/admin/role_grants_build_test.go
@@ -27,11 +27,11 @@ func TestBuildGrantGroupsIncludesAvailableActionsWithoutGrants(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants WHERE role_id = ? ORDER BY id\n")).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_idlanguage, f.title, f.description\nFROM forumcategory f\nWHERE (")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_id, f.title, f.description\nFROM forumcategory f\nWHERE (")).
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language\n")).
-		WillReturnRows(sqlmock.NewRows([]string{"idlanguage", "nameof"}))
+		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof\nFROM language\n")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "nameof"}))
 
 	groups, err := buildGrantGroups(context.Background(), cd, 1)
 	if err != nil {
@@ -83,11 +83,11 @@ func TestBuildGrantGroupsSkipsInvalidItemIDGrants(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants WHERE role_id = ? ORDER BY id\n")).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(rows)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_idlanguage, f.title, f.description\nFROM forumcategory f\nWHERE (")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_id, f.title, f.description\nFROM forumcategory f\nWHERE (")).
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language\n")).
-		WillReturnRows(sqlmock.NewRows([]string{"idlanguage", "nameof"}))
+		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof\nFROM language\n")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "nameof"}))
 
 	groups, err := buildGrantGroups(context.Background(), cd, 1)
 	if err != nil {

--- a/handlers/admin/user_grants_build_test.go
+++ b/handlers/admin/user_grants_build_test.go
@@ -24,11 +24,11 @@ func TestBuildUserGrantGroupsIncludesAvailableActionsWithoutGrants(t *testing.T)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants WHERE user_id = ? ORDER BY id\n")).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_idlanguage, f.title, f.description\nFROM forumcategory f\nWHERE (\nf.language_idlanguage = 0\nOR f.language_idlanguage IS NULL\nOR EXISTS (\nSELECT 1 FROM user_language ul\nWHERE ul.users_idusers = ?\nAND ul.language_idlanguage = f.language_idlanguage\n)\nOR NOT EXISTS (\nSELECT 1 FROM user_language ul WHERE ul.users_idusers = ?\n)\n)\n")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_id, f.title, f.description\nFROM forumcategory f\nWHERE (\nf.language_id = 0\nOR f.language_id IS NULL\nOR EXISTS (\nSELECT 1 FROM user_language ul\nWHERE ul.users_idusers = ?\nAND ul.language_id = f.language_id\n)\nOR NOT EXISTS (\nSELECT 1 FROM user_language ul WHERE ul.users_idusers = ?\n)\n)\n")).
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language\n")).
-		WillReturnRows(sqlmock.NewRows([]string{"idlanguage", "nameof"}))
+		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof\nFROM language\n")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "nameof"}))
 
 	groups, err := buildGrantGroupsForUser(context.Background(), cd, 1)
 	if err != nil {

--- a/handlers/blogs/blogsAdminBlogCommentsPage_test.go
+++ b/handlers/blogs/blogsAdminBlogCommentsPage_test.go
@@ -27,7 +27,7 @@ func TestAdminBlogCommentsPage_UsesURLParam(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	blogID := 9
-	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "comments", "is_owner"}).
+	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_id", "blog", "written", "timezone", "username", "comments", "is_owner"}).
 		AddRow(blogID, sql.NullInt32{Int32: 1, Valid: true}, 1, 1, "body", time.Now(), time.Local.String(), "user", 0, true)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectQuery("SELECT").WillReturnError(sql.ErrNoRows)

--- a/handlers/blogs/blogsAdminBlogPage_test.go
+++ b/handlers/blogs/blogsAdminBlogPage_test.go
@@ -26,7 +26,7 @@ func TestAdminBlogPage_UsesURLParam(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	blogID := 7
-	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "comments", "is_owner"}).
+	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_id", "blog", "written", "timezone", "username", "comments", "is_owner"}).
 		AddRow(blogID, nil, 1, 1, "body", time.Now(), time.Local.String(), "user", 0, true)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}))

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -75,8 +75,8 @@ func (AddBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 	uid, _ := session.Values["UID"].(int32)
 
 	id, err := queries.CreateBlogEntryForWriter(r.Context(), db.CreateBlogEntryForWriterParams{
-		UsersIdusers:       uid,
-		LanguageIdlanguage: sql.NullInt32{Int32: int32(languageId), Valid: languageId != 0},
+		UsersIdusers: uid,
+		LanguageID:   sql.NullInt32{Int32: int32(languageId), Valid: languageId != 0},
 		Blog: sql.NullString{
 			String: text,
 			Valid:  true,

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -138,7 +138,7 @@ func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if errors.Is(err, sql.ErrNoRows) {
 		ptidi, err := queries.CreateForumTopicForPoster(r.Context(), db.CreateForumTopicForPosterParams{
 			ForumcategoryID: 0,
-			ForumLang:       sql.NullInt32{Int32: blog.LanguageIdlanguage.Int32, Valid: blog.LanguageIdlanguage.Valid},
+			ForumLang:       sql.NullInt32{Int32: blog.LanguageID.Int32, Valid: blog.LanguageID.Valid},
 			Title: sql.NullString{
 				String: BloggerTopicName,
 				Valid:  true,

--- a/handlers/blogs/blogsCommentPage_replyable_test.go
+++ b/handlers/blogs/blogsCommentPage_replyable_test.go
@@ -55,14 +55,14 @@ func TestCommentPageLockedThreadDisablesReply(t *testing.T) {
 
 	req, _ := setupCommentRequest(t, queries, store, 1)
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof FROM language")).
-		WillReturnRows(sqlmock.NewRows([]string{"idlanguage", "nameof"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof FROM language")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "nameof"}))
 	cd := req.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if _, err := cd.Languages(); err != nil {
 		t.Fatalf("languages: %v", err)
 	}
 
-	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "coalesce(th.comments, 0)", "is_owner"}).
+	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_id", "blog", "written", "timezone", "username", "coalesce(th.comments, 0)", "is_owner"}).
 		AddRow(1, 1, 2, 1, "hi", time.Unix(0, 0), time.Local.String(), "bob", 0, false)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(blogRows)
 
@@ -78,7 +78,7 @@ func TestCommentPageLockedThreadDisablesReply(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
 		WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), "blogs", sql.NullString{String: "entry", Valid: true}, sql.NullInt32{Int32: 2, Valid: true}).
-		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner"}))
+		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner"}))
 
 	threadRows2 := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked"}).
 		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), true)
@@ -118,14 +118,14 @@ func TestCommentPageUnlockedThreadShowsReply(t *testing.T) {
 
 	req, _ := setupCommentRequest(t, queries, store, 1)
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof FROM language")).
-		WillReturnRows(sqlmock.NewRows([]string{"idlanguage", "nameof"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof FROM language")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "nameof"}))
 	cd := req.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if _, err := cd.Languages(); err != nil {
 		t.Fatalf("languages: %v", err)
 	}
 
-	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "coalesce(th.comments, 0)", "is_owner"}).
+	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_id", "blog", "written", "timezone", "username", "coalesce(th.comments, 0)", "is_owner"}).
 		AddRow(1, 1, 2, 1, "hi", time.Unix(0, 0), time.Local.String(), "bob", 0, false)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(blogRows)
 
@@ -141,7 +141,7 @@ func TestCommentPageUnlockedThreadShowsReply(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
 		WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), "blogs", sql.NullString{String: "entry", Valid: true}, sql.NullInt32{Int32: 2, Valid: true}).
-		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner"}))
+		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner"}))
 
 	threadRows2 := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked"}).
 		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), false)
@@ -181,14 +181,14 @@ func TestCommentPageNoThreadShowsReply(t *testing.T) {
 
 	req, _ := setupCommentRequest(t, queries, store, 1)
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof FROM language")).
-		WillReturnRows(sqlmock.NewRows([]string{"idlanguage", "nameof"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof FROM language")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "nameof"}))
 	cd := req.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	if _, err := cd.Languages(); err != nil {
 		t.Fatalf("languages: %v", err)
 	}
 
-	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "coalesce(th.comments, 0)", "is_owner"}).
+	blogRows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_id", "blog", "written", "timezone", "username", "coalesce(th.comments, 0)", "is_owner"}).
 		AddRow(1, nil, 2, 1, "hi", time.Unix(0, 0), time.Local.String(), "bob", 0, false)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), sql.NullInt32{Int32: 2, Valid: true}).WillReturnRows(blogRows)
 

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -66,7 +66,7 @@ func TestBlogsBloggerPostsPage(t *testing.T) {
 
 	blogRows := sqlmock.NewRows([]string{
 		"idblogs", "forumthread_id", "users_idusers",
-		"language_idlanguage", "blog", "written", "username", "coalesce(th.comments, 0)", "is_owner",
+		"language_id", "blog", "written", "username", "coalesce(th.comments, 0)", "is_owner",
 	}).AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), "bob", 0, true)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).
 		WithArgs(int32(1), int32(1), int32(1), int32(1), int32(1), int32(1), sqlmock.AnyArg(), int32(15), int32(0)).
@@ -97,7 +97,7 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).
 		WithArgs(int32(1), int32(1), int32(1), int32(1), int32(1), int32(1), sqlmock.AnyArg(), int32(15), int32(0)).
-		WillReturnRows(sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_idlanguage", "blog", "written", "timezone", "username", "coalesce(th.comments, 0)", "is_owner"}).
+		WillReturnRows(sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_id", "blog", "written", "timezone", "username", "coalesce(th.comments, 0)", "is_owner"}).
 			AddRow(1, 1, 1, 1, "hello", time.Unix(0, 0), time.Local.String(), "bob", 0, true))
 
 	req := httptest.NewRequest("GET", "http://example.com/blogs/rss?rss=bob", nil)

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 65
+	ExpectedSchemaVersion = 66
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/handlers/forum/forumAdminCategoryPage_test.go
+++ b/handlers/forum/forumAdminCategoryPage_test.go
@@ -39,14 +39,14 @@ func TestAdminCategoryPageLinks(t *testing.T) {
 	queries := db.New(sqlDB)
 	mock.MatchExpectationsInOrder(false)
 
-	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}).
+	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}).
 		AddRow(1, 0, 0, "cat", "desc")
-	mock.ExpectQuery("SELECT idforumcategory, forumcategory_idforumcategory, language_idlanguage, title, description FROM forumcategory").
+	mock.ExpectQuery("SELECT idforumcategory, forumcategory_idforumcategory, language_id, title, description FROM forumcategory").
 		WillReturnRows(catRows)
 
-	topicsRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
+	topicsRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
 		AddRow(1, 0, 1, 0, "t", "d", 0, 0, time.Now(), "", nil)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_idlanguage, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler, lu.username AS LastPosterUsername FROM forumtopic t")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_id, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler, lu.username AS LastPosterUsername FROM forumtopic t")).
 		WillReturnRows(topicsRows)
 
 	req, rr := setupRequest(t, queries, "/admin/forum/categories/category/1", map[string]string{"category": "1"})
@@ -81,14 +81,14 @@ func TestAdminCategoryEditPage(t *testing.T) {
 	queries := db.New(sqlDB)
 	mock.MatchExpectationsInOrder(false)
 
-	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}).
+	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}).
 		AddRow(1, 0, 0, "cat", "desc")
-	mock.ExpectQuery("SELECT idforumcategory, forumcategory_idforumcategory, language_idlanguage, title, description FROM forumcategory").
+	mock.ExpectQuery("SELECT idforumcategory, forumcategory_idforumcategory, language_id, title, description FROM forumcategory").
 		WillReturnRows(catRows)
 
-	allRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}).
+	allRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}).
 		AddRow(1, 0, 0, "cat", "desc")
-	mock.ExpectQuery("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_idlanguage, f.title, f.description\nFROM forumcategory f").
+	mock.ExpectQuery("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_id, f.title, f.description\nFROM forumcategory f").
 		WillReturnRows(allRows)
 
 	req, rr := setupRequest(t, queries, "/admin/forum/categories/category/1/edit", map[string]string{"category": "1"})

--- a/handlers/forum/forumAdminTopicPage_test.go
+++ b/handlers/forum/forumAdminTopicPage_test.go
@@ -27,9 +27,9 @@ func TestAdminTopicPage(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	topicID := 4
-	rows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
+	rows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
 		AddRow(topicID, 0, 1, 0, "t", "d", 2, 3, time.Now(), "", nil)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_idlanguage, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler, lu.username AS LastPosterUsername FROM forumtopic t")).WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_id, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler, lu.username AS LastPosterUsername FROM forumtopic t")).WillReturnRows(rows)
 
 	cd := common.NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
 	r := httptest.NewRequest("GET", "/admin/forum/topics/topic/"+strconv.Itoa(topicID), nil)
@@ -54,11 +54,11 @@ func TestAdminTopicEditFormPage(t *testing.T) {
 	mock.MatchExpectationsInOrder(false)
 
 	topicID := 4
-	topicRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
+	topicRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
 		AddRow(topicID, 0, 1, 0, "t", "d", 2, 3, time.Now(), "", nil)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_idlanguage, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler, lu.username AS LastPosterUsername FROM forumtopic t")).WillReturnRows(topicRows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_id, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler, lu.username AS LastPosterUsername FROM forumtopic t")).WillReturnRows(topicRows)
 
-	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}).
+	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}).
 		AddRow(1, 0, 0, "cat", "desc")
 	mock.ExpectQuery("SELECT").WillReturnRows(catRows)
 

--- a/handlers/forum/forumAdminTopicsPage_test.go
+++ b/handlers/forum/forumAdminTopicsPage_test.go
@@ -26,7 +26,7 @@ func TestAdminTopicsPage(t *testing.T) {
 	countRows := sqlmock.NewRows([]string{"count"}).AddRow(1)
 	mock.ExpectQuery(`SELECT COUNT\(`).WillReturnRows(countRows)
 
-	rows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler"}).
+	rows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler"}).
 		AddRow(1, 0, 0, 0, "t", "d", 0, 0, time.Now(), "")
 	mock.ExpectQuery("SELECT t.idforumtopic").WillReturnRows(rows)
 

--- a/handlers/forum/forumThreadPage_quote_test.go
+++ b/handlers/forum/forumThreadPage_quote_test.go
@@ -34,19 +34,19 @@ func TestThreadPageQuotePrefillsReply(t *testing.T) {
 	mock.ExpectQuery(".*").
 		WithArgs(int32(1), int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername",
+			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername",
 		}).AddRow(int32(1), int32(1), int32(1), int32(1), sql.NullString{String: "topic", Valid: true}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullTime{}, "normal", sql.NullString{}))
 
 	mock.ExpectQuery(".*").
 		WithArgs(int32(1), int32(1), int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner",
+			"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner",
 		}))
 
 	mock.ExpectQuery(".*").
 		WithArgs(int32(1), int32(1), int32(2), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "username", "is_owner",
+			"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "username", "is_owner",
 		}).AddRow(int32(2), int32(1), int32(1), int32(1), sql.NullTime{}, sql.NullString{String: "hi", Valid: true}, sql.NullString{}, sql.NullTime{}, sql.NullTime{}, sql.NullString{String: "alice", Valid: true}, false))
 
 	mock.ExpectQuery("SELECT category_path").

--- a/handlers/forum/forumTopicPage_links_test.go
+++ b/handlers/forum/forumTopicPage_links_test.go
@@ -37,11 +37,11 @@ func TestTopicsPage_ThreadLinks(t *testing.T) {
 
 	mock.ExpectQuery("SELECT .* FROM forumcategory").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}))
+		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}))
 
 	mock.ExpectQuery("SELECT t.* FROM forumtopic t").
 		WithArgs(sqlmock.AnyArg(), 1, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
 			AddRow(1, 0, 1, 0, "Topic", "", 0, 0, time.Now(), "", ""))
 
 	mock.ExpectQuery("SELECT .* FROM forumthread").

--- a/handlers/forum/forumTopicPage_private_test.go
+++ b/handlers/forum/forumTopicPage_private_test.go
@@ -38,11 +38,11 @@ func TestTopicsPage_PrivateTopic(t *testing.T) {
 
 	mock.ExpectQuery("SELECT .* FROM forumcategory").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}))
+		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}))
 
 	mock.ExpectQuery("SELECT t.* FROM forumtopic t").
 		WithArgs(sqlmock.AnyArg(), 1, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
 			AddRow(1, 0, 1, 0, "Topic: old is now Private chat with: Bob", "", 0, 0, time.Now(), "private", ""))
 
 	mock.ExpectQuery("SELECT u.idusers, u.username FROM grants").

--- a/handlers/forum/matchers_test.go
+++ b/handlers/forum/matchers_test.go
@@ -32,7 +32,7 @@ func TestRequireThreadAndTopicTrue(t *testing.T) {
 	mock.ExpectQuery("SELECT t.idforumtopic").
 		WithArgs(int32(0), int32(1), int32(0), int32(0), sql.NullInt32{Int32: 0, Valid: false}).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername",
+			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername",
 		}).AddRow(1, 0, 0, 0, sql.NullString{}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullTime{}, "", sql.NullString{}))
 
 		// handler will trigger another load
@@ -90,7 +90,7 @@ func TestRequireThreadAndTopicFalse(t *testing.T) {
 	mock.ExpectQuery("SELECT t.idforumtopic").
 		WithArgs(int32(0), int32(3), int32(0), int32(0), sql.NullInt32{Int32: 0, Valid: false}).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername",
+			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername",
 		}).AddRow(3, 0, 0, 0, sql.NullString{}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullTime{}, "", sql.NullString{}))
 
 	req := httptest.NewRequest("GET", "/forum/topic/1/thread/2", nil)

--- a/handlers/languages/admin.go
+++ b/handlers/languages/admin.go
@@ -37,7 +37,7 @@ func adminLanguagePage(w http.ResponseWriter, r *http.Request) {
 	var lang *db.Language
 	if rows, err := cd.Languages(); err == nil {
 		for _, l := range rows {
-			if l.Idlanguage == int32(id) {
+			if l.ID == int32(id) {
 				lang = l
 				break
 			}
@@ -74,7 +74,7 @@ func adminLanguageEditPage(w http.ResponseWriter, r *http.Request) {
 	var lang *db.Language
 	if rows, err := cd.Languages(); err == nil {
 		for _, l := range rows {
-			if l.Idlanguage == int32(id) {
+			if l.ID == int32(id) {
 				lang = l
 				break
 			}

--- a/handlers/languages/delete_language_task_test.go
+++ b/handlers/languages/delete_language_task_test.go
@@ -36,11 +36,11 @@ func TestDeleteLanguageTask_PreventDeletion(t *testing.T) {
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 
-	langRows := sqlmock.NewRows([]string{"idlanguage", "nameof"}).AddRow(1, "en")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language")).WillReturnRows(langRows)
+	langRows := sqlmock.NewRows([]string{"id", "nameof"}).AddRow(1, "en")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof\nFROM language")).WillReturnRows(langRows)
 
 	countRows := sqlmock.NewRows([]string{"comments", "writings", "blogs", "news", "links"}).AddRow(1, 0, 0, 0, 0)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT\n    (SELECT COUNT(*) FROM comments WHERE comments.language_idlanguage = ?) AS comments,\n    (SELECT COUNT(*) FROM writing WHERE writing.language_idlanguage = ?) AS writings,\n    (SELECT COUNT(*) FROM blogs WHERE blogs.language_idlanguage = ?) AS blogs,\n    (SELECT COUNT(*) FROM site_news WHERE site_news.language_idlanguage = ?) AS news,\n    (SELECT COUNT(*) FROM linker WHERE linker.language_idlanguage = ?) AS links")).WithArgs(int32(1), int32(1), int32(1), int32(1), int32(1)).WillReturnRows(countRows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT\n    (SELECT COUNT(*) FROM comments WHERE comments.language_id = ?) AS comments,\n    (SELECT COUNT(*) FROM writing WHERE writing.language_id = ?) AS writings,\n    (SELECT COUNT(*) FROM blogs WHERE blogs.language_id = ?) AS blogs,\n    (SELECT COUNT(*) FROM site_news WHERE site_news.language_id = ?) AS news,\n    (SELECT COUNT(*) FROM linker WHERE linker.language_id = ?) AS links")).WithArgs(int32(1), int32(1), int32(1), int32(1), int32(1)).WillReturnRows(countRows)
 
 	result := deleteLanguageTask.Action(rr, req)
 	if result == nil {

--- a/handlers/languages/rename_language_task.go
+++ b/handlers/languages/rename_language_task.go
@@ -38,7 +38,7 @@ func (RenameLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {
 	var oldName string
 	if rows, err := cd.Languages(); err == nil {
 		for _, l := range rows {
-			if l.Idlanguage == int32(cid) {
+			if l.ID == int32(cid) {
 				oldName = l.Nameof.String
 				break
 			}

--- a/handlers/languages/rename_language_task_test.go
+++ b/handlers/languages/rename_language_task_test.go
@@ -37,13 +37,13 @@ func TestRenameLanguageTask_Action(t *testing.T) {
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 
-	langRows := sqlmock.NewRows([]string{"idlanguage", "nameof"}).AddRow(1, "en")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language")).WillReturnRows(langRows)
+	langRows := sqlmock.NewRows([]string{"id", "nameof"}).AddRow(1, "en")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof\nFROM language")).WillReturnRows(langRows)
 
-	idRow := sqlmock.NewRows([]string{"idlanguage"}).AddRow(1)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage FROM language WHERE nameof = ?")).WithArgs("en").WillReturnRows(idRow)
+	idRow := sqlmock.NewRows([]string{"id"}).AddRow(1)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM language WHERE nameof = ?")).WithArgs("en").WillReturnRows(idRow)
 
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE language\nSET nameof = ?\nWHERE idlanguage = ?")).WithArgs("fr", int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE language\nSET nameof = ?\nWHERE id = ?")).WithArgs("fr", int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	result := renameLanguageTask.Action(rr, req)
 	if result != nil {

--- a/handlers/linker/linkerAdminLinkPage.go
+++ b/handlers/linker/linkerAdminLinkPage.go
@@ -35,8 +35,8 @@ func adminLinkPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int
 	}{
 		Link:               link,
-                Selected:           int(link.LinkerCategoryID.Int32),
-                SelectedLanguageId: int(link.LanguageIdlanguage.Int32),
+		Selected:           int(link.LinkerCategoryID.Int32),
+		SelectedLanguageId: int(link.LanguageID.Int32),
 	}
 
 	handlers.TemplateHandler(w, r, "adminLinkPage.gohtml", data)
@@ -65,12 +65,12 @@ func (editLinkTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := cd.Queries()
 
 	if err := queries.AdminUpdateLinkerItem(r.Context(), db.AdminUpdateLinkerItemParams{
-		Title:              sql.NullString{Valid: true, String: title},
-		Url:                sql.NullString{Valid: true, String: URL},
-		Description:        sql.NullString{Valid: true, String: desc},
-                LinkerCategoryID:   sql.NullInt32{Int32: int32(cat), Valid: cat != 0},
-                LanguageIdlanguage: sql.NullInt32{Int32: int32(lang), Valid: lang != 0},
-		Idlinker:           id,
+		Title:            sql.NullString{Valid: true, String: title},
+		Url:              sql.NullString{Valid: true, String: URL},
+		Description:      sql.NullString{Valid: true, String: desc},
+		LinkerCategoryID: sql.NullInt32{Int32: int32(cat), Valid: cat != 0},
+		LanguageID:       sql.NullInt32{Int32: int32(lang), Valid: lang != 0},
+		Idlinker:         id,
 	}); err != nil {
 		return fmt.Errorf("update linker item fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/linker/linkerAdminLinkViewPage_test.go
+++ b/handlers/linker/linkerAdminLinkViewPage_test.go
@@ -35,7 +35,7 @@ func TestAdminLinkViewPage(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT l.idlinker")).
 		WithArgs(int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"idlinker", "language_idlanguage", "users_idusers", "linker_category_id", "forumthread_id", "title", "url", "description", "listed", "username", "title_2"}).
+		WillReturnRows(sqlmock.NewRows([]string{"idlinker", "language_id", "users_idusers", "linker_category_id", "forumthread_id", "title", "url", "description", "listed", "username", "title_2"}).
 			AddRow(1, 1, 2, 1, 0, "t", "http://u", "d", time.Unix(0, 0), "bob", "cat"))
 
 	adminLinkViewPage(w, req)

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -239,7 +239,7 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if errors.Is(err, sql.ErrNoRows) {
 		ptidi, err := queries.CreateForumTopicForPoster(r.Context(), db.CreateForumTopicForPosterParams{
 			ForumcategoryID: 0,
-			ForumLang:       link.LanguageIdlanguage,
+			ForumLang:       link.LanguageID,
 			Title: sql.NullString{
 				String: LinkerTopicName,
 				Valid:  true,

--- a/handlers/linker/linkerCommentsPage_test.go
+++ b/handlers/linker/linkerCommentsPage_test.go
@@ -48,12 +48,12 @@ func TestCommentsPageAllowsGlobalViewGrant(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT l.idlinker")).
 		WithArgs(int32(2), sqlmock.AnyArg(), int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"idlinker", "language_idlanguage", "users_idusers", "linker_category_id", "forumthread_id", "title", "url", "description", "listed", "timezone", "username", "title"}).
+		WillReturnRows(sqlmock.NewRows([]string{"idlinker", "language_id", "users_idusers", "linker_category_id", "forumthread_id", "title", "url", "description", "listed", "timezone", "username", "title"}).
 			AddRow(1, 1, 2, 1, 1, "t", "http://u", "d", time.Unix(0, 0), time.Local.String(), "bob", "cat"))
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).
 		WithArgs(int32(2), int32(2), int32(1), int32(2), int32(2), "linker", sql.NullString{String: "link", Valid: true}, sql.NullInt32{Int32: 2, Valid: true}).
-		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_idlanguage", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner"}))
+		WillReturnRows(sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner"}))
 
 	threadRows := sqlmock.NewRows([]string{"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername"}).
 		AddRow(1, 1, 1, 1, 0, time.Unix(0, 0), false, "bob")

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -58,7 +58,7 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 		WithArgs(int32(1)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	rows := sqlmock.NewRows([]string{"idlinker", "language_idlanguage", "users_idusers", "linkercategory_idlinkerCategory", "forumthread_idforumthread", "title", "url", "description", "listed", "username", "title_2"}).
+	rows := sqlmock.NewRows([]string{"idlinker", "language_id", "users_idusers", "linkercategory_idlinkerCategory", "forumthread_idforumthread", "title", "url", "description", "listed", "username", "title_2"}).
 		AddRow(1, 1, 1, 1, 0, "Foo", "http://foo", "Bar", time.Now(), "u", "c")
 	mock.ExpectQuery("SELECT l.idlinker").WithArgs(int32(0), int32(1), sqlmock.AnyArg()).WillReturnRows(rows)
 

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -114,9 +114,9 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 	})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
-                ptidi, err := queries.CreateForumTopicForPoster(r.Context(), db.CreateForumTopicForPosterParams{
-                        ForumcategoryID: 0,
-                        ForumLang:       link.LanguageIdlanguage,
+		ptidi, err := queries.CreateForumTopicForPoster(r.Context(), db.CreateForumTopicForPosterParams{
+			ForumcategoryID: 0,
+			ForumLang:       link.LanguageID,
 			Title: sql.NullString{
 				String: LinkerTopicName,
 				Valid:  true,

--- a/handlers/news/admin_pages.go
+++ b/handlers/news/admin_pages.go
@@ -177,7 +177,7 @@ func adminNewsEditFormPage(w http.ResponseWriter, r *http.Request) {
 	}{
 		Languages:          langs,
 		Post:               post,
-                SelectedLanguageId: int(post.LanguageIdlanguage.Int32),
+		SelectedLanguageId: int(post.LanguageID.Int32),
 	}
 	if err := cd.ExecuteSiteTemplate(w, r, "adminNewsEditPage.gohtml", data); err != nil {
 		handlers.RenderErrorPage(w, r, err)

--- a/handlers/news/newsReplyTask_event_test.go
+++ b/handlers/news/newsReplyTask_event_test.go
@@ -38,12 +38,12 @@ func TestNewsReplyTaskEventData(t *testing.T) {
 
 	mock.ExpectQuery("SELECT u.username AS writerName").
 		WithArgs(uid, int32(pid), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"writerName", "writerId", "idsiteNews", "forumthread_id", "language_idlanguage", "users_idusers", "news", "occurred", "timezone", "comments"}).
+		WillReturnRows(sqlmock.NewRows([]string{"writerName", "writerId", "idsiteNews", "forumthread_id", "language_id", "users_idusers", "news", "occurred", "timezone", "comments"}).
 			AddRow("writer", uid, pid, pthid, 1, uid, "txt", time.Now(), time.Local.String(), 0))
 
 	mock.ExpectQuery("SELECT idforumtopic").
 		WithArgs(sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler"}).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler"}).
 			AddRow(4, int32(0), 0, 0, NewsTopicName, "", 0, 0, sql.NullTime{}, "news"))
 
 	mock.ExpectExec("INSERT INTO comments").

--- a/handlers/news/search_test.go
+++ b/handlers/news/search_test.go
@@ -32,7 +32,7 @@ func TestNewsSearchFiltersUnauthorized(t *testing.T) {
 
 	newsRows := sqlmock.NewRows([]string{
 		"writerName", "writerId", "idsitenews", "forumthread_id",
-		"language_idlanguage", "users_idusers", "news", "occurred", "timezone",
+		"language_id", "users_idusers", "news", "occurred", "timezone",
 		"Comments",
 	}).AddRow("bob", 1, 1, 0, 1, 1, "text", time.Unix(0, 0), time.Local.String(), 0)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.username AS writerName")).

--- a/handlers/privateforum/topic_page_test.go
+++ b/handlers/privateforum/topic_page_test.go
@@ -39,11 +39,11 @@ func TestTopicPage_Prefix(t *testing.T) {
 
 	mock.ExpectQuery("SELECT .* FROM forumcategory").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_idlanguage", "title", "description"}))
+		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}))
 
 	mock.ExpectQuery("SELECT t.* FROM forumtopic t").
 		WithArgs(sqlmock.AnyArg(), 1, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_idlanguage", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler", "lastposterusername"}).
 			AddRow(1, 0, 0, 0, "topic", "", 0, 0, time.Now(), "private", ""))
 
 	mock.ExpectQuery("SELECT u.idusers, u.username FROM grants").

--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -55,27 +55,27 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 	selected := make(map[int32]bool)
 	if len(userLangs) == 0 {
 		for _, l := range langs {
-			selected[l.Idlanguage] = true
+			selected[l.ID] = true
 		}
 	} else {
 		for _, ul := range userLangs {
-			selected[ul.LanguageIdlanguage] = true
+			selected[ul.LanguageID] = true
 		}
 	}
 
 	var opts []LanguageOption
 	for _, l := range langs {
-		opt := LanguageOption{ID: l.Idlanguage, Name: l.Nameof.String}
-		if selected[l.Idlanguage] {
+		opt := LanguageOption{ID: l.ID, Name: l.Nameof.String}
+		if selected[l.ID] {
 			opt.IsSelected = true
 		}
-                if pref != nil && pref.LanguageIdlanguage.Valid && pref.LanguageIdlanguage.Int32 == l.Idlanguage {
-                        opt.IsDefault = true
-                }
+		if pref != nil && pref.LanguageID.Valid && pref.LanguageID.Int32 == l.ID {
+			opt.IsDefault = true
+		}
 		opts = append(opts, opt)
 	}
 
-        defaultIsMulti := pref == nil || !pref.LanguageIdlanguage.Valid
+	defaultIsMulti := pref == nil || !pref.LanguageID.Valid
 	data := Data{
 		LanguageOptions:       opts,
 		DefaultIsMultilingual: defaultIsMulti,
@@ -97,8 +97,8 @@ func updateLanguageSelections(r *http.Request, cd *common.CoreData, queries db.Q
 	}
 
 	for _, l := range langs {
-		if r.PostFormValue(fmt.Sprintf("language%d", l.Idlanguage)) != "" {
-			if err := queries.InsertUserLang(r.Context(), db.InsertUserLangParams{UsersIdusers: uid, LanguageIdlanguage: l.Idlanguage}); err != nil {
+		if r.PostFormValue(fmt.Sprintf("language%d", l.ID)) != "" {
+			if err := queries.InsertUserLang(r.Context(), db.InsertUserLangParams{UsersIdusers: uid, LanguageID: l.ID}); err != nil {
 				return err
 			}
 		}
@@ -120,17 +120,17 @@ func updateDefaultLanguage(r *http.Request, queries db.Querier, uid int32) error
 	}
 
 	if errors.Is(err, sql.ErrNoRows) {
-                return queries.InsertPreferenceForLister(r.Context(), db.InsertPreferenceForListerParams{
-                        LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
-                        ListerID:   uid,
-                        PageSize:   int32(cd.Config.PageSizeDefault),
-                        Timezone:   sql.NullString{},
-                })
+		return queries.InsertPreferenceForLister(r.Context(), db.InsertPreferenceForListerParams{
+			LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
+			ListerID:   uid,
+			PageSize:   int32(cd.Config.PageSizeDefault),
+			Timezone:   sql.NullString{},
+		})
 	}
 
-        pref.LanguageIdlanguage = sql.NullInt32{Int32: int32(langID), Valid: langID != 0}
+	pref.LanguageID = sql.NullInt32{Int32: int32(langID), Valid: langID != 0}
 	return queries.UpdatePreferenceForLister(r.Context(), db.UpdatePreferenceForListerParams{
-		LanguageID: pref.LanguageIdlanguage,
+		LanguageID: pref.LanguageID,
 		ListerID:   uid,
 		PageSize:   pref.PageSize,
 		Timezone:   pref.Timezone,

--- a/handlers/user/userPagingPage.go
+++ b/handlers/user/userPagingPage.go
@@ -56,16 +56,16 @@ func (PagingSaveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if errors.Is(err, sql.ErrNoRows) {
-                err = queries.InsertPreferenceForLister(r.Context(), db.InsertPreferenceForListerParams{
-                        LanguageID: sql.NullInt32{},
-                        ListerID:   uid,
-                        PageSize:   int32(size),
-                        Timezone:   sql.NullString{},
-                })
+		err = queries.InsertPreferenceForLister(r.Context(), db.InsertPreferenceForListerParams{
+			LanguageID: sql.NullInt32{},
+			ListerID:   uid,
+			PageSize:   int32(size),
+			Timezone:   sql.NullString{},
+		})
 	} else {
 		pref.PageSize = int32(size)
 		err = queries.UpdatePreferenceForLister(r.Context(), db.UpdatePreferenceForListerParams{
-			LanguageID: pref.LanguageIdlanguage,
+			LanguageID: pref.LanguageID,
 			ListerID:   uid,
 			PageSize:   pref.PageSize,
 			Timezone:   pref.Timezone,

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -222,9 +222,9 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
-	rows := sqlmock.NewRows([]string{"idlanguage", "nameof"}).AddRow(1, "en").AddRow(2, "fr")
+	rows := sqlmock.NewRows([]string{"id", "nameof"}).AddRow(1, "en").AddRow(2, "fr")
 	mock.ExpectExec("DELETE FROM user_language").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language")).WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof\nFROM language")).WillReturnRows(rows)
 	mock.ExpectExec("INSERT INTO user_language").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectQuery("SELECT idpreferences").WithArgs(int32(1)).WillReturnError(sql.ErrNoRows)
 	mock.ExpectExec("INSERT INTO preferences").WithArgs(int32(2), int32(1), int32(cfg.PageSizeDefault), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -271,9 +271,9 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
-	rows := sqlmock.NewRows([]string{"idlanguage", "nameof"}).AddRow(1, "en")
+	rows := sqlmock.NewRows([]string{"id", "nameof"}).AddRow(1, "en")
 	mock.ExpectExec("DELETE FROM user_language").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language")).WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof\nFROM language")).WillReturnRows(rows)
 	mock.ExpectExec("INSERT INTO user_language").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	saveLanguagesTask.Action(rr, req)
@@ -322,7 +322,7 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
-	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies", "timezone"}).
+	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_id", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies", "timezone"}).
 		AddRow(1, 1, 1, nil, cfg.PageSizeDefault, true, nil)
 	mock.ExpectQuery("SELECT idpreferences").WithArgs(int32(1)).WillReturnRows(prefRows)
 	mock.ExpectExec("UPDATE preferences").WithArgs(int32(2), int32(cfg.PageSizeDefault), sqlmock.AnyArg(), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/handlers/writings/matchers_test.go
+++ b/handlers/writings/matchers_test.go
@@ -44,7 +44,7 @@ func TestRequireWritingAuthorWritingVar(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	rows := sqlmock.NewRows([]string{
-		"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "WriterId", "WriterUsername",
+		"idwriting", "users_idusers", "forumthread_id", "language_id", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "WriterId", "WriterUsername",
 	}).AddRow(2, 1, 0, 1, 1, sql.NullString{}, sql.NullTime{}, sql.NullString{}, sql.NullString{}, sql.NullBool{}, sql.NullTime{}, sql.NullTime{}, 1, sql.NullString{})
 	mock.ExpectQuery("SELECT w.idwriting").
 		WithArgs(int32(1), int32(2), sql.NullInt32{Int32: 1, Valid: true}).

--- a/handlers/writings/writing_category_change_task.go
+++ b/handlers/writings/writing_category_change_task.go
@@ -50,14 +50,14 @@ func writingCategoryWouldLoop(ctx context.Context, queries db.Querier, cid, pare
 		if err != nil {
 			return nil, false, err
 		}
-                parents = make(map[int32]int32, len(cats))
-                for _, c := range cats {
-                        var pid int32
-                        if c.WritingCategoryID.Valid {
-                                pid = c.WritingCategoryID.Int32
-                        }
-                        parents[c.Idwritingcategory] = pid
-                }
+		parents = make(map[int32]int32, len(cats))
+		for _, c := range cats {
+			var pid int32
+			if c.WritingCategoryID.Valid {
+				pid = c.WritingCategoryID.Int32
+			}
+			parents[c.Idwritingcategory] = pid
+		}
 	} else {
 		parents = map[int32]int32{}
 	}

--- a/handlers/writings/writing_category_change_task_test.go
+++ b/handlers/writings/writing_category_change_task_test.go
@@ -23,13 +23,13 @@ func TestWritingCategoryChangeTask(t *testing.T) {
 
 	queries := db.New(conn)
 
-        rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
-                AddRow(1, nil, "a", "")
+	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
+		AddRow(1, nil, "a", "")
 	mock.ExpectQuery("SELECT wc.idwritingcategory").WillReturnRows(rows)
 
-        mock.ExpectExec("UPDATE writing_category").
-                WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), int32(1)).
-                WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE writing_category").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), int32(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	form := url.Values{"name": {"A"}, "desc": {"B"}, "pcid": {"0"}, "cid": {"1"}}
 	req := httptest.NewRequest("POST", "/admin/writings/categories/category/1/edit", strings.NewReader(form.Encode()))

--- a/handlers/writings/writingsAdminCategoriesPage.go
+++ b/handlers/writings/writingsAdminCategoriesPage.go
@@ -56,14 +56,14 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.AllCategories = categoryRows
 	data.Categories = categoryRows[offset:end]
-        children := map[int32][]*db.WritingCategory{}
-        for _, c := range categoryRows {
-                var pid int32
-                if c.WritingCategoryID.Valid {
-                        pid = c.WritingCategoryID.Int32
-                }
-                children[pid] = append(children[pid], c)
-        }
+	children := map[int32][]*db.WritingCategory{}
+	for _, c := range categoryRows {
+		var pid int32
+		if c.WritingCategoryID.Valid {
+			pid = c.WritingCategoryID.Int32
+		}
+		children[pid] = append(children[pid], c)
+	}
 	var build func(parent int32) string
 	build = func(parent int32) string {
 		var sb strings.Builder

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -56,15 +56,15 @@ type BannedIp struct {
 }
 
 type Blog struct {
-	Idblogs            int32
-	ForumthreadID      sql.NullInt32
-	UsersIdusers       int32
-	LanguageIdlanguage sql.NullInt32
-	Blog               sql.NullString
-	Written            time.Time
-	Timezone           sql.NullString
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
+	Idblogs       int32
+	ForumthreadID sql.NullInt32
+	UsersIdusers  int32
+	LanguageID    sql.NullInt32
+	Blog          sql.NullString
+	Written       time.Time
+	Timezone      sql.NullString
+	DeletedAt     sql.NullTime
+	LastIndex     sql.NullTime
 }
 
 type BlogsSearch struct {
@@ -80,15 +80,15 @@ type Bookmark struct {
 }
 
 type Comment struct {
-	Idcomments         int32
-	ForumthreadID      int32
-	UsersIdusers       int32
-	LanguageIdlanguage sql.NullInt32
-	Written            sql.NullTime
-	Text               sql.NullString
-	Timezone           sql.NullString
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
+	Idcomments    int32
+	ForumthreadID int32
+	UsersIdusers  int32
+	LanguageID    sql.NullInt32
+	Written       sql.NullTime
+	Text          sql.NullString
+	Timezone      sql.NullString
+	DeletedAt     sql.NullTime
+	LastIndex     sql.NullTime
 }
 
 type CommentsSearch struct {
@@ -121,27 +121,27 @@ type ContentPublicLabel struct {
 }
 
 type DeactivatedBlog struct {
-	Idblogs            int32
-	ForumthreadID      int32
-	UsersIdusers       int32
-	LanguageIdlanguage sql.NullInt32
-	Blog               sql.NullString
-	Written            sql.NullTime
-	Timezone           sql.NullString
-	DeletedAt          sql.NullTime
-	RestoredAt         sql.NullTime
+	Idblogs       int32
+	ForumthreadID int32
+	UsersIdusers  int32
+	LanguageID    sql.NullInt32
+	Blog          sql.NullString
+	Written       sql.NullTime
+	Timezone      sql.NullString
+	DeletedAt     sql.NullTime
+	RestoredAt    sql.NullTime
 }
 
 type DeactivatedComment struct {
-	Idcomments         int32
-	ForumthreadID      int32
-	UsersIdusers       int32
-	LanguageIdlanguage sql.NullInt32
-	Written            sql.NullTime
-	Text               sql.NullString
-	Timezone           sql.NullString
-	DeletedAt          sql.NullTime
-	RestoredAt         sql.NullTime
+	Idcomments    int32
+	ForumthreadID int32
+	UsersIdusers  int32
+	LanguageID    sql.NullInt32
+	Written       sql.NullTime
+	Text          sql.NullString
+	Timezone      sql.NullString
+	DeletedAt     sql.NullTime
+	RestoredAt    sql.NullTime
 }
 
 type DeactivatedImagepost struct {
@@ -161,18 +161,18 @@ type DeactivatedImagepost struct {
 }
 
 type DeactivatedLinker struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	DeletedAt          sql.NullTime
-	RestoredAt         sql.NullTime
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
+	DeletedAt        sql.NullTime
+	RestoredAt       sql.NullTime
 }
 
 type DeactivatedUser struct {
@@ -186,18 +186,18 @@ type DeactivatedUser struct {
 }
 
 type DeactivatedWriting struct {
-	Idwriting          int32
-	UsersIdusers       int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	WritingCategoryID  int32
-	Title              sql.NullString
-	Published          sql.NullTime
-	Writing            sql.NullString
-	Abstract           sql.NullString
-	Private            sql.NullBool
-	DeletedAt          sql.NullTime
-	RestoredAt         sql.NullTime
+	Idwriting         int32
+	UsersIdusers      int32
+	ForumthreadID     int32
+	LanguageID        sql.NullInt32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Published         sql.NullTime
+	Writing           sql.NullString
+	Abstract          sql.NullString
+	Private           sql.NullBool
+	DeletedAt         sql.NullTime
+	RestoredAt        sql.NullTime
 }
 
 type DeadLetter struct {
@@ -221,12 +221,12 @@ type ExternalLink struct {
 }
 
 type Faq struct {
-	ID                 int32
-	FaqCategoryID      sql.NullInt32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	Answer             sql.NullString
-	Question           sql.NullString
+	ID            int32
+	FaqCategoryID sql.NullInt32
+	LanguageID    sql.NullInt32
+	UsersIdusers  int32
+	Answer        sql.NullString
+	Question      sql.NullString
 }
 
 type FaqCategory struct {
@@ -247,7 +247,7 @@ type FaqRevision struct {
 type Forumcategory struct {
 	Idforumcategory              int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           sql.NullInt32
+	LanguageID                   sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 }
@@ -266,7 +266,7 @@ type Forumtopic struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           sql.NullInt32
+	LanguageID                   sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -322,23 +322,23 @@ type ImagepostSearch struct {
 }
 
 type Language struct {
-	Idlanguage int32
-	Nameof     sql.NullString
+	ID     int32
+	Nameof sql.NullString
 }
 
 type Linker struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
+	DeletedAt        sql.NullTime
+	LastIndex        sql.NullTime
 }
 
 type LinkerCategory struct {
@@ -349,14 +349,14 @@ type LinkerCategory struct {
 }
 
 type LinkerQueue struct {
-	Idlinkerqueue      int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Timezone           sql.NullString
+	Idlinkerqueue    int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Timezone         sql.NullString
 }
 
 type LinkerSearch struct {
@@ -411,7 +411,7 @@ type PendingPassword struct {
 
 type Preference struct {
 	Idpreferences        int32
-	LanguageIdlanguage   sql.NullInt32
+	LanguageID           sql.NullInt32
 	UsersIdusers         int32
 	Emailforumupdates    sql.NullBool
 	PageSize             int32
@@ -455,14 +455,14 @@ type SiteAnnouncement struct {
 }
 
 type SiteNews struct {
-	Idsitenews         int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	News               sql.NullString
-	Occurred           sql.NullTime
-	Timezone           sql.NullString
-	LastIndex          sql.NullTime
+	Idsitenews    int32
+	ForumthreadID int32
+	LanguageID    sql.NullInt32
+	UsersIdusers  int32
+	News          sql.NullString
+	Occurred      sql.NullTime
+	Timezone      sql.NullString
+	LastIndex     sql.NullTime
 }
 
 type SiteNewsSearch struct {
@@ -513,9 +513,9 @@ type UserEmail struct {
 }
 
 type UserLanguage struct {
-	Iduserlang         int32
-	UsersIdusers       int32
-	LanguageIdlanguage int32
+	Iduserlang   int32
+	UsersIdusers int32
+	LanguageID   int32
 }
 
 type UserRole struct {
@@ -525,18 +525,18 @@ type UserRole struct {
 }
 
 type Writing struct {
-	Idwriting          int32
-	UsersIdusers       int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	WritingCategoryID  int32
-	Title              sql.NullString
-	Published          sql.NullTime
-	Writing            sql.NullString
-	Abstract           sql.NullString
-	Private            sql.NullBool
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
+	Idwriting         int32
+	UsersIdusers      int32
+	ForumthreadID     int32
+	LanguageID        sql.NullInt32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Published         sql.NullTime
+	Writing           sql.NullString
+	Abstract          sql.NullString
+	Private           sql.NullBool
+	DeletedAt         sql.NullTime
+	LastIndex         sql.NullTime
 }
 
 type WritingCategory struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -56,7 +56,7 @@ type Querier interface {
 	// AdminDeleteLanguage removes a language entry.
 	// Parameters:
 	//   ? - Language ID to be deleted (int)
-	AdminDeleteLanguage(ctx context.Context, idlanguage int32) error
+	AdminDeleteLanguage(ctx context.Context, id int32) error
 	// AdminDeleteLinkerCategory removes a linker category.
 	AdminDeleteLinkerCategory(ctx context.Context, idlinkercategory int32) error
 	AdminDeleteLinkerQueuedItem(ctx context.Context, idlinkerqueue int32) error

--- a/internal/db/queries-announcements.sql
+++ b/internal/db/queries-announcements.sql
@@ -29,10 +29,10 @@ WHERE a.active = 1
       NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
       )
-      OR n.language_idlanguage = 0
-      OR n.language_idlanguage IS NULL
-      OR n.language_idlanguage IN (
-          SELECT ul.language_idlanguage
+      OR n.language_id = 0
+      OR n.language_id IS NULL
+      OR n.language_id IN (
+          SELECT ul.language_id
           FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
       )

--- a/internal/db/queries-announcements.sql.go
+++ b/internal/db/queries-announcements.sql.go
@@ -103,10 +103,10 @@ WHERE a.active = 1
       NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
       )
-      OR n.language_idlanguage = 0
-      OR n.language_idlanguage IS NULL
-      OR n.language_idlanguage IN (
-          SELECT ul.language_idlanguage
+      OR n.language_id = 0
+      OR n.language_id IS NULL
+      OR n.language_id IN (
+          SELECT ul.language_id
           FROM user_language ul
           WHERE ul.users_idusers = ?
       )

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -1,6 +1,6 @@
 -- name: UpdateBlogEntryForWriter :exec
 UPDATE blogs b
-SET language_idlanguage = sqlc.narg(language_id), blog = sqlc.arg(blog)
+SET language_id = sqlc.narg(language_id), blog = sqlc.arg(blog)
 WHERE b.idblogs = sqlc.arg(entry_id)
   AND b.users_idusers = sqlc.arg(writer_id)
   AND EXISTS (
@@ -17,8 +17,8 @@ WHERE b.idblogs = sqlc.arg(entry_id)
   );
 
 -- name: CreateBlogEntryForWriter :execlastid
-INSERT INTO blogs (users_idusers, language_idlanguage, blog, written, timezone)
-SELECT sqlc.arg(users_idusers), sqlc.narg(language_idlanguage), sqlc.arg(blog), CURRENT_TIMESTAMP, sqlc.arg(timezone)
+INSERT INTO blogs (users_idusers, language_id, blog, written, timezone)
+SELECT sqlc.arg(users_idusers), sqlc.narg(language_id), sqlc.arg(blog), CURRENT_TIMESTAMP, sqlc.arg(timezone)
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section = 'blogs'
@@ -46,7 +46,7 @@ WHERE idblogs = ?;
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
-SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, b.timezone, u.username, coalesce(th.comments, 0),
+SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_id, b.blog, b.written, b.timezone, u.username, coalesce(th.comments, 0),
        b.users_idusers = sqlc.arg(lister_id) AS is_owner
 FROM blogs b
 JOIN grants g ON (g.item_id = b.idblogs OR g.item_id IS NULL)
@@ -59,12 +59,12 @@ JOIN grants g ON (g.item_id = b.idblogs OR g.item_id IS NULL)
 LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE (
-    b.language_idlanguage = 0
-    OR b.language_idlanguage IS NULL
+    b.language_id = 0
+    OR b.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
-          AND ul.language_idlanguage = b.language_idlanguage
+          AND ul.language_id = b.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -77,19 +77,19 @@ LIMIT ? OFFSET ?;
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
-SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, b.timezone, u.username, coalesce(th.comments, 0),
+SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_id, b.blog, b.written, b.timezone, u.username, coalesce(th.comments, 0),
        b.users_idusers = sqlc.arg(lister_id) AS is_owner
 FROM blogs b
 LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE (b.users_idusers = sqlc.arg(author_id) OR sqlc.arg(author_id) = 0)
 AND (
-    b.language_idlanguage = 0
-    OR b.language_idlanguage IS NULL
+    b.language_id = 0
+    OR b.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
-          AND ul.language_idlanguage = b.language_idlanguage
+          AND ul.language_id = b.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -112,16 +112,16 @@ LIMIT ? OFFSET ?;
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
-SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, b.timezone
+SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_id, b.blog, b.written, b.timezone
 FROM blogs b
 WHERE b.idblogs IN (sqlc.slice(blogIds))
   AND (
-      b.language_idlanguage = 0
-      OR b.language_idlanguage IS NULL
+      b.language_id = 0
+      OR b.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = b.language_idlanguage
+            AND ul.language_id = b.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -144,19 +144,19 @@ LIMIT ? OFFSET ?;
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(lister_id)
 )
-SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_idlanguage, b.blog, b.written, b.timezone, u.username, coalesce(th.comments, 0),
+SELECT b.idblogs, b.forumthread_id, b.users_idusers, b.language_id, b.blog, b.written, b.timezone, u.username, coalesce(th.comments, 0),
        b.users_idusers = sqlc.arg(lister_id) AS is_owner
 FROM blogs b
 LEFT JOIN users u ON b.users_idusers=u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 WHERE b.idblogs = sqlc.arg(id)
   AND (
-      b.language_idlanguage = 0
-      OR b.language_idlanguage IS NULL
+      b.language_id = 0
+      OR b.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = b.language_idlanguage
+            AND ul.language_id = b.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -184,12 +184,12 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN blogs b ON b.idblogs = cs.blog_id
 WHERE swl.word = ?
   AND (
-      b.language_idlanguage = 0
-      OR b.language_idlanguage IS NULL
+      b.language_id = 0
+      OR b.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = b.language_idlanguage
+            AND ul.language_id = b.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -217,12 +217,12 @@ JOIN blogs b ON b.idblogs = cs.blog_id
 WHERE swl.word = ?
   AND cs.blog_id IN (sqlc.slice('ids'))
   AND (
-      b.language_idlanguage = 0
-      OR b.language_idlanguage IS NULL
+      b.language_id = 0
+      OR b.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = b.language_idlanguage
+            AND ul.language_id = b.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -249,12 +249,12 @@ SELECT u.username, COUNT(b.idblogs) AS count
 FROM blogs b
 JOIN users u ON b.users_idusers = u.idusers
 WHERE (
-    b.language_idlanguage = 0
-    OR b.language_idlanguage IS NULL
+    b.language_id = 0
+    OR b.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
-          AND ul.language_idlanguage = b.language_idlanguage
+          AND ul.language_id = b.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -283,12 +283,12 @@ FROM blogs b
 JOIN users u ON b.users_idusers = u.idusers
 WHERE (LOWER(u.username) LIKE LOWER(sqlc.arg(query)) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(sqlc.arg(query)))
   AND (
-    b.language_idlanguage = 0
-    OR b.language_idlanguage IS NULL
+    b.language_id = 0
+    OR b.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
-          AND ul.language_idlanguage = b.language_idlanguage
+          AND ul.language_id = b.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -311,7 +311,7 @@ LIMIT ? OFFSET ?;
 SELECT b.idblogs,
        b.forumthread_id,
        b.users_idusers,
-       b.language_idlanguage,
+       b.language_id,
        b.blog,
        b.written,
        b.timezone,

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -10,12 +10,12 @@ LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
 LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.idcomments = sqlc.arg(id)
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+      c.language_id = 0
+      OR c.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -35,7 +35,7 @@ LIMIT 1;
 
 -- name: UpdateCommentForEditor :exec
 UPDATE comments c
-SET language_idlanguage = sqlc.narg(language_id), text = sqlc.arg(text)
+SET language_id = sqlc.narg(language_id), text = sqlc.arg(text)
 WHERE c.idcomments = sqlc.arg(comment_id)
   AND c.users_idusers = sqlc.arg(commenter_id)
   AND EXISTS (
@@ -73,12 +73,12 @@ LEFT JOIN users pu ON pu.idusers = c.users_idusers
 LEFT JOIN forumcategory fc ON t.forumcategory_idforumcategory = fc.idforumcategory
 WHERE c.Idcomments IN (sqlc.slice('ids'))
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+      c.language_id = 0
+      OR c.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -98,7 +98,7 @@ ORDER BY c.written DESC
 ;
 
 -- name: CreateCommentInSectionForCommenter :execlastid
-INSERT INTO comments (language_idlanguage, users_idusers, forumthread_id, text, written, timezone)
+INSERT INTO comments (language_id, users_idusers, forumthread_id, text, written, timezone)
 SELECT sqlc.narg(language_id), sqlc.narg(commenter_id), sqlc.arg(forumthread_id), sqlc.arg(text), NOW(), sqlc.arg(timezone)
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -126,12 +126,12 @@ LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.forumthread_id=sqlc.arg(thread_id)
   AND c.forumthread_id IS NOT NULL
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+      c.language_id = 0
+      OR c.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -164,12 +164,12 @@ LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.forumthread_id=sqlc.arg(thread_id)
   AND c.forumthread_id IS NOT NULL
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+      c.language_id = 0
+      OR c.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -189,7 +189,7 @@ ORDER BY c.written;
 
 
 -- name: AdminGetAllCommentsByUser :many
-SELECT c.idcomments, c.forumthread_id, c.users_idusers, c.language_idlanguage,
+SELECT c.idcomments, c.forumthread_id, c.users_idusers, c.language_id,
        c.written, c.text, c.deleted_at, c.last_index, c.timezone,
        th.forumtopic_idforumtopic, t.title AS forumtopic_title,
        fp.text AS thread_title

--- a/internal/db/queries-deactivation.sql
+++ b/internal/db/queries-deactivation.sql
@@ -10,7 +10,7 @@ UPDATE users SET username = ?, email = '', passwd = '', passwd_algorithm = '', d
 WHERE idusers = ?;
 
 -- name: AdminArchiveComment :exec
-INSERT INTO deactivated_comments (idcomments, forumthread_id, users_idusers, language_idlanguage, written, text, timezone, deleted_at)
+INSERT INTO deactivated_comments (idcomments, forumthread_id, users_idusers, language_id, written, text, timezone, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, NOW());
 
 -- name: AdminScrubComment :exec
@@ -39,7 +39,7 @@ WHERE restored_at IS NULL
 LIMIT ? OFFSET ?;
 
 -- name: AdminArchiveWriting :exec
-INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_id, language_idlanguage, writing_category_id, title, published, writing, abstract, private, deleted_at)
+INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_id, language_id, writing_category_id, title, published, writing, abstract, private, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
 
 -- name: AdminScrubWriting :exec
@@ -68,7 +68,7 @@ WHERE restored_at IS NULL
 LIMIT ? OFFSET ?;
 
 -- name: AdminArchiveBlog :exec
-INSERT INTO deactivated_blogs (idblogs, forumthread_id, users_idusers, language_idlanguage, blog, written, timezone, deleted_at)
+INSERT INTO deactivated_blogs (idblogs, forumthread_id, users_idusers, language_id, blog, written, timezone, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, NOW());
 
 -- name: AdminScrubBlog :exec
@@ -124,7 +124,7 @@ WHERE restored_at IS NULL
 LIMIT ? OFFSET ?;
 
 -- name: AdminArchiveLink :exec
-INSERT INTO deactivated_linker (idlinker, language_idlanguage, users_idusers, linker_category_id, forumthread_id, title, url, description, listed, timezone, deleted_at)
+INSERT INTO deactivated_linker (idlinker, language_id, users_idusers, linker_category_id, forumthread_id, title, url, description, listed, timezone, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
 
 -- name: AdminScrubLink :exec

--- a/internal/db/queries-deactivation.sql.go
+++ b/internal/db/queries-deactivation.sql.go
@@ -11,18 +11,18 @@ import (
 )
 
 const adminArchiveBlog = `-- name: AdminArchiveBlog :exec
-INSERT INTO deactivated_blogs (idblogs, forumthread_id, users_idusers, language_idlanguage, blog, written, timezone, deleted_at)
+INSERT INTO deactivated_blogs (idblogs, forumthread_id, users_idusers, language_id, blog, written, timezone, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
 type AdminArchiveBlogParams struct {
-	Idblogs            int32
-	ForumthreadID      int32
-	UsersIdusers       int32
-	LanguageIdlanguage sql.NullInt32
-	Blog               sql.NullString
-	Written            sql.NullTime
-	Timezone           sql.NullString
+	Idblogs       int32
+	ForumthreadID int32
+	UsersIdusers  int32
+	LanguageID    sql.NullInt32
+	Blog          sql.NullString
+	Written       sql.NullTime
+	Timezone      sql.NullString
 }
 
 func (q *Queries) AdminArchiveBlog(ctx context.Context, arg AdminArchiveBlogParams) error {
@@ -30,7 +30,7 @@ func (q *Queries) AdminArchiveBlog(ctx context.Context, arg AdminArchiveBlogPara
 		arg.Idblogs,
 		arg.ForumthreadID,
 		arg.UsersIdusers,
-		arg.LanguageIdlanguage,
+		arg.LanguageID,
 		arg.Blog,
 		arg.Written,
 		arg.Timezone,
@@ -39,18 +39,18 @@ func (q *Queries) AdminArchiveBlog(ctx context.Context, arg AdminArchiveBlogPara
 }
 
 const adminArchiveComment = `-- name: AdminArchiveComment :exec
-INSERT INTO deactivated_comments (idcomments, forumthread_id, users_idusers, language_idlanguage, written, text, timezone, deleted_at)
+INSERT INTO deactivated_comments (idcomments, forumthread_id, users_idusers, language_id, written, text, timezone, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
 type AdminArchiveCommentParams struct {
-	Idcomments         int32
-	ForumthreadID      int32
-	UsersIdusers       int32
-	LanguageIdlanguage sql.NullInt32
-	Written            sql.NullTime
-	Text               sql.NullString
-	Timezone           sql.NullString
+	Idcomments    int32
+	ForumthreadID int32
+	UsersIdusers  int32
+	LanguageID    sql.NullInt32
+	Written       sql.NullTime
+	Text          sql.NullString
+	Timezone      sql.NullString
 }
 
 func (q *Queries) AdminArchiveComment(ctx context.Context, arg AdminArchiveCommentParams) error {
@@ -58,7 +58,7 @@ func (q *Queries) AdminArchiveComment(ctx context.Context, arg AdminArchiveComme
 		arg.Idcomments,
 		arg.ForumthreadID,
 		arg.UsersIdusers,
-		arg.LanguageIdlanguage,
+		arg.LanguageID,
 		arg.Written,
 		arg.Text,
 		arg.Timezone,
@@ -103,27 +103,27 @@ func (q *Queries) AdminArchiveImagepost(ctx context.Context, arg AdminArchiveIma
 }
 
 const adminArchiveLink = `-- name: AdminArchiveLink :exec
-INSERT INTO deactivated_linker (idlinker, language_idlanguage, users_idusers, linker_category_id, forumthread_id, title, url, description, listed, timezone, deleted_at)
+INSERT INTO deactivated_linker (idlinker, language_id, users_idusers, linker_category_id, forumthread_id, title, url, description, listed, timezone, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
 type AdminArchiveLinkParams struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
 }
 
 func (q *Queries) AdminArchiveLink(ctx context.Context, arg AdminArchiveLinkParams) error {
 	_, err := q.db.ExecContext(ctx, adminArchiveLink,
 		arg.Idlinker,
-		arg.LanguageIdlanguage,
+		arg.LanguageID,
 		arg.UsersIdusers,
 		arg.LinkerCategoryID,
 		arg.ForumthreadID,
@@ -150,21 +150,21 @@ func (q *Queries) AdminArchiveUser(ctx context.Context, idusers int32) error {
 }
 
 const adminArchiveWriting = `-- name: AdminArchiveWriting :exec
-INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_id, language_idlanguage, writing_category_id, title, published, writing, abstract, private, deleted_at)
+INSERT INTO deactivated_writings (idwriting, users_idusers, forumthread_id, language_id, writing_category_id, title, published, writing, abstract, private, deleted_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 `
 
 type AdminArchiveWritingParams struct {
-	Idwriting          int32
-	UsersIdusers       int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	WritingCategoryID  int32
-	Title              sql.NullString
-	Published          sql.NullTime
-	Writing            sql.NullString
-	Abstract           sql.NullString
-	Private            sql.NullBool
+	Idwriting         int32
+	UsersIdusers      int32
+	ForumthreadID     int32
+	LanguageID        sql.NullInt32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Published         sql.NullTime
+	Writing           sql.NullString
+	Abstract          sql.NullString
+	Private           sql.NullBool
 }
 
 func (q *Queries) AdminArchiveWriting(ctx context.Context, arg AdminArchiveWritingParams) error {
@@ -172,7 +172,7 @@ func (q *Queries) AdminArchiveWriting(ctx context.Context, arg AdminArchiveWriti
 		arg.Idwriting,
 		arg.UsersIdusers,
 		arg.ForumthreadID,
-		arg.LanguageIdlanguage,
+		arg.LanguageID,
 		arg.WritingCategoryID,
 		arg.Title,
 		arg.Published,

--- a/internal/db/queries-faq.sql
+++ b/internal/db/queries-faq.sql
@@ -7,17 +7,17 @@ WHERE faq_category_id IS NULL OR answer IS NULL;
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
-SELECT faq.id, faq.faq_category_id, faq.language_idlanguage, faq.users_idusers, faq.answer, faq.question
+SELECT faq.id, faq.faq_category_id, faq.language_id, faq.users_idusers, faq.answer, faq.question
 FROM faq
 WHERE answer IS NOT NULL
   AND deleted_at IS NULL
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+      language_id = 0
+      OR language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = faq.language_idlanguage
+            AND ul.language_id = faq.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -35,7 +35,7 @@ WHERE answer IS NOT NULL
   );
 
 -- name: AdminGetFAQDismissedQuestions :many
-SELECT id, faq_category_id, language_idlanguage, users_idusers, answer, question
+SELECT id, faq_category_id, language_id, users_idusers, answer, question
 FROM faq
 WHERE deleted_at IS NOT NULL;
 
@@ -56,7 +56,7 @@ WHERE id = ?;
 INSERT INTO faq_categories (name) VALUES (sqlc.arg(name));
 
 -- name: CreateFAQQuestionForWriter :exec
-INSERT INTO faq (question, users_idusers, language_idlanguage)
+INSERT INTO faq (question, users_idusers, language_id)
 SELECT sqlc.arg(question), sqlc.arg(writer_id), sqlc.narg(language_id)
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -71,7 +71,7 @@ WHERE EXISTS (
 );
 
 -- name: InsertFAQQuestionForWriter :execresult
-INSERT INTO faq (question, answer, faq_category_id, users_idusers, language_idlanguage)
+INSERT INTO faq (question, answer, faq_category_id, users_idusers, language_id)
 SELECT sqlc.arg(question), sqlc.arg(answer), sqlc.arg(category_id), sqlc.arg(writer_id), sqlc.narg(language_id)
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -102,18 +102,18 @@ FROM faq_categories;
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
-SELECT c.id AS category_id, c.name, f.id AS faq_id, f.faq_category_id, f.language_idlanguage, f.users_idusers, f.answer, f.question
+SELECT c.id AS category_id, c.name, f.id AS faq_id, f.faq_category_id, f.language_id, f.users_idusers, f.answer, f.question
 FROM faq f
 LEFT JOIN faq_categories c ON c.id = f.faq_category_id
 WHERE c.id IS NOT NULL
   AND f.answer IS NOT NULL
   AND (
-      f.language_idlanguage = 0
-      OR f.language_idlanguage IS NULL
+      f.language_id = 0
+      OR f.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = f.language_idlanguage
+            AND ul.language_id = f.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -145,17 +145,17 @@ SELECT * FROM faq WHERE id = ?;
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
-SELECT faq.id, faq.faq_category_id, faq.language_idlanguage, faq.users_idusers, faq.answer, faq.question
+SELECT faq.id, faq.faq_category_id, faq.language_id, faq.users_idusers, faq.answer, faq.question
 FROM faq
 WHERE faq.id = sqlc.arg(faq_id)
   AND deleted_at IS NULL
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+      language_id = 0
+      OR language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = faq.language_idlanguage
+            AND ul.language_id = faq.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -204,17 +204,17 @@ SELECT * FROM faq WHERE faq_category_id = ?;
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
-SELECT faq.id, faq.faq_category_id, faq.language_idlanguage, faq.users_idusers, faq.answer, faq.question
+SELECT faq.id, faq.faq_category_id, faq.language_id, faq.users_idusers, faq.answer, faq.question
 FROM faq
 WHERE faq.faq_category_id = sqlc.arg(category_id)
   AND deleted_at IS NULL
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+      language_id = 0
+      OR language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = faq.language_idlanguage
+            AND ul.language_id = faq.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)

--- a/internal/db/queries-faq.sql.go
+++ b/internal/db/queries-faq.sql.go
@@ -40,7 +40,7 @@ func (q *Queries) AdminDeleteFAQCategory(ctx context.Context, id int32) error {
 }
 
 const adminGetFAQByID = `-- name: AdminGetFAQByID :one
-SELECT id, faq_category_id, language_idlanguage, users_idusers, answer, question FROM faq WHERE id = ?
+SELECT id, faq_category_id, language_id, users_idusers, answer, question FROM faq WHERE id = ?
 `
 
 func (q *Queries) AdminGetFAQByID(ctx context.Context, id int32) (*Faq, error) {
@@ -49,7 +49,7 @@ func (q *Queries) AdminGetFAQByID(ctx context.Context, id int32) (*Faq, error) {
 	err := row.Scan(
 		&i.ID,
 		&i.FaqCategoryID,
-		&i.LanguageIdlanguage,
+		&i.LanguageID,
 		&i.UsersIdusers,
 		&i.Answer,
 		&i.Question,
@@ -143,7 +143,7 @@ func (q *Queries) AdminGetFAQCategoryWithQuestionCountByID(ctx context.Context, 
 }
 
 const adminGetFAQDismissedQuestions = `-- name: AdminGetFAQDismissedQuestions :many
-SELECT id, faq_category_id, language_idlanguage, users_idusers, answer, question
+SELECT id, faq_category_id, language_id, users_idusers, answer, question
 FROM faq
 WHERE deleted_at IS NOT NULL
 `
@@ -160,7 +160,7 @@ func (q *Queries) AdminGetFAQDismissedQuestions(ctx context.Context) ([]*Faq, er
 		if err := rows.Scan(
 			&i.ID,
 			&i.FaqCategoryID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.Answer,
 			&i.Question,
@@ -179,7 +179,7 @@ func (q *Queries) AdminGetFAQDismissedQuestions(ctx context.Context) ([]*Faq, er
 }
 
 const adminGetFAQQuestionsByCategory = `-- name: AdminGetFAQQuestionsByCategory :many
-SELECT id, faq_category_id, language_idlanguage, users_idusers, answer, question FROM faq WHERE faq_category_id = ?
+SELECT id, faq_category_id, language_id, users_idusers, answer, question FROM faq WHERE faq_category_id = ?
 `
 
 func (q *Queries) AdminGetFAQQuestionsByCategory(ctx context.Context, faqCategoryID sql.NullInt32) ([]*Faq, error) {
@@ -194,7 +194,7 @@ func (q *Queries) AdminGetFAQQuestionsByCategory(ctx context.Context, faqCategor
 		if err := rows.Scan(
 			&i.ID,
 			&i.FaqCategoryID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.Answer,
 			&i.Question,
@@ -213,7 +213,7 @@ func (q *Queries) AdminGetFAQQuestionsByCategory(ctx context.Context, faqCategor
 }
 
 const adminGetFAQUnansweredQuestions = `-- name: AdminGetFAQUnansweredQuestions :many
-SELECT id, faq_category_id, language_idlanguage, users_idusers, answer, question
+SELECT id, faq_category_id, language_id, users_idusers, answer, question
 FROM faq
 WHERE faq_category_id IS NULL OR answer IS NULL
 `
@@ -230,7 +230,7 @@ func (q *Queries) AdminGetFAQUnansweredQuestions(ctx context.Context) ([]*Faq, e
 		if err := rows.Scan(
 			&i.ID,
 			&i.FaqCategoryID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.Answer,
 			&i.Question,
@@ -288,7 +288,7 @@ func (q *Queries) AdminUpdateFAQQuestionAnswer(ctx context.Context, arg AdminUpd
 }
 
 const createFAQQuestionForWriter = `-- name: CreateFAQQuestionForWriter :exec
-INSERT INTO faq (question, users_idusers, language_idlanguage)
+INSERT INTO faq (question, users_idusers, language_id)
 SELECT ?, ?, ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -325,18 +325,18 @@ const getAllAnsweredFAQWithFAQCategoriesForUser = `-- name: GetAllAnsweredFAQWit
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT c.id AS category_id, c.name, f.id AS faq_id, f.faq_category_id, f.language_idlanguage, f.users_idusers, f.answer, f.question
+SELECT c.id AS category_id, c.name, f.id AS faq_id, f.faq_category_id, f.language_id, f.users_idusers, f.answer, f.question
 FROM faq f
 LEFT JOIN faq_categories c ON c.id = f.faq_category_id
 WHERE c.id IS NOT NULL
   AND f.answer IS NOT NULL
   AND (
-      f.language_idlanguage = 0
-      OR f.language_idlanguage IS NULL
+      f.language_id = 0
+      OR f.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = f.language_idlanguage
+            AND ul.language_id = f.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -361,14 +361,14 @@ type GetAllAnsweredFAQWithFAQCategoriesForUserParams struct {
 }
 
 type GetAllAnsweredFAQWithFAQCategoriesForUserRow struct {
-	CategoryID         sql.NullInt32
-	Name               sql.NullString
-	FaqID              int32
-	FaqCategoryID      sql.NullInt32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	Answer             sql.NullString
-	Question           sql.NullString
+	CategoryID    sql.NullInt32
+	Name          sql.NullString
+	FaqID         int32
+	FaqCategoryID sql.NullInt32
+	LanguageID    sql.NullInt32
+	UsersIdusers  int32
+	Answer        sql.NullString
+	Question      sql.NullString
 }
 
 func (q *Queries) GetAllAnsweredFAQWithFAQCategoriesForUser(ctx context.Context, arg GetAllAnsweredFAQWithFAQCategoriesForUserParams) ([]*GetAllAnsweredFAQWithFAQCategoriesForUserRow, error) {
@@ -390,7 +390,7 @@ func (q *Queries) GetAllAnsweredFAQWithFAQCategoriesForUser(ctx context.Context,
 			&i.Name,
 			&i.FaqID,
 			&i.FaqCategoryID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.Answer,
 			&i.Question,
@@ -412,17 +412,17 @@ const getFAQAnsweredQuestions = `-- name: GetFAQAnsweredQuestions :many
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT faq.id, faq.faq_category_id, faq.language_idlanguage, faq.users_idusers, faq.answer, faq.question
+SELECT faq.id, faq.faq_category_id, faq.language_id, faq.users_idusers, faq.answer, faq.question
 FROM faq
 WHERE answer IS NOT NULL
   AND deleted_at IS NULL
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+      language_id = 0
+      OR language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = faq.language_idlanguage
+            AND ul.language_id = faq.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -462,7 +462,7 @@ func (q *Queries) GetFAQAnsweredQuestions(ctx context.Context, arg GetFAQAnswere
 		if err := rows.Scan(
 			&i.ID,
 			&i.FaqCategoryID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.Answer,
 			&i.Question,
@@ -484,17 +484,17 @@ const getFAQByID = `-- name: GetFAQByID :one
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT faq.id, faq.faq_category_id, faq.language_idlanguage, faq.users_idusers, faq.answer, faq.question
+SELECT faq.id, faq.faq_category_id, faq.language_id, faq.users_idusers, faq.answer, faq.question
 FROM faq
 WHERE faq.id = ?
   AND deleted_at IS NULL
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+      language_id = 0
+      OR language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = faq.language_idlanguage
+            AND ul.language_id = faq.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -530,7 +530,7 @@ func (q *Queries) GetFAQByID(ctx context.Context, arg GetFAQByIDParams) (*Faq, e
 	err := row.Scan(
 		&i.ID,
 		&i.FaqCategoryID,
-		&i.LanguageIdlanguage,
+		&i.LanguageID,
 		&i.UsersIdusers,
 		&i.Answer,
 		&i.Question,
@@ -542,17 +542,17 @@ const getFAQQuestionsByCategory = `-- name: GetFAQQuestionsByCategory :many
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT faq.id, faq.faq_category_id, faq.language_idlanguage, faq.users_idusers, faq.answer, faq.question
+SELECT faq.id, faq.faq_category_id, faq.language_id, faq.users_idusers, faq.answer, faq.question
 FROM faq
 WHERE faq.faq_category_id = ?
   AND deleted_at IS NULL
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+      language_id = 0
+      OR language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = faq.language_idlanguage
+            AND ul.language_id = faq.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -594,7 +594,7 @@ func (q *Queries) GetFAQQuestionsByCategory(ctx context.Context, arg GetFAQQuest
 		if err := rows.Scan(
 			&i.ID,
 			&i.FaqCategoryID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.Answer,
 			&i.Question,
@@ -648,7 +648,7 @@ func (q *Queries) GetFAQRevisionsForAdmin(ctx context.Context, faqID int32) ([]*
 }
 
 const insertFAQQuestionForWriter = `-- name: InsertFAQQuestionForWriter :execresult
-INSERT INTO faq (question, answer, faq_category_id, users_idusers, language_idlanguage)
+INSERT INTO faq (question, answer, faq_category_id, users_idusers, language_id)
 SELECT ?, ?, ?, ?, ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -724,7 +724,7 @@ func (q *Queries) InsertFAQRevisionForUser(ctx context.Context, arg InsertFAQRev
 }
 
 const systemGetFAQQuestions = `-- name: SystemGetFAQQuestions :many
-SELECT id, faq_category_id, language_idlanguage, users_idusers, answer, question
+SELECT id, faq_category_id, language_id, users_idusers, answer, question
 FROM faq
 `
 
@@ -740,7 +740,7 @@ func (q *Queries) SystemGetFAQQuestions(ctx context.Context) ([]*Faq, error) {
 		if err := rows.Scan(
 			&i.ID,
 			&i.FaqCategoryID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.Answer,
 			&i.Question,

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -1,4 +1,4 @@
-UPDATE forumcategory SET title = ?, description = ?, forumcategory_idforumcategory = ?, language_idlanguage = sqlc.narg(category_language_id) WHERE idforumcategory = ?;
+UPDATE forumcategory SET title = ?, description = ?, forumcategory_idforumcategory = ?, language_id = sqlc.narg(category_language_id) WHERE idforumcategory = ?;
 
 -- name: GetAllForumCategoriesWithSubcategoryCount :many
 SELECT c.*, COUNT(c2.idforumcategory) as SubcategoryCount,
@@ -7,12 +7,12 @@ FROM forumcategory c
 LEFT JOIN forumcategory c2 ON c.idforumcategory = c2.forumcategory_idforumcategory
 LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_id = 0
+    OR c.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
-          AND ul.language_idlanguage = c.language_idlanguage
+          AND ul.language_id = c.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -24,12 +24,12 @@ GROUP BY c.idforumcategory;
 SELECT COUNT(*)
 FROM forumcategory c
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_id = 0
+    OR c.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
-          AND ul.language_idlanguage = c.language_idlanguage
+          AND ul.language_id = c.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -43,12 +43,12 @@ FROM forumcategory c
 LEFT JOIN forumcategory c2 ON c.idforumcategory = c2.forumcategory_idforumcategory
 LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_id = 0
+    OR c.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
-          AND ul.language_idlanguage = c.language_idlanguage
+          AND ul.language_id = c.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -62,12 +62,12 @@ LIMIT ? OFFSET ?;
 SELECT t.*
 FROM forumtopic t
 WHERE (
-    t.language_idlanguage = 0
-    OR t.language_idlanguage IS NULL
+    t.language_id = 0
+    OR t.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
-          AND ul.language_idlanguage = t.language_idlanguage
+          AND ul.language_id = t.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -81,7 +81,7 @@ FROM forumtopic t
 ORDER BY t.idforumtopic
 LIMIT ? OFFSET ?;
 
-UPDATE forumtopic SET title = ?, description = ?, forumcategory_idforumcategory = ?, language_idlanguage = sqlc.narg(topic_language_id) WHERE idforumtopic = ?;
+UPDATE forumtopic SET title = ?, description = ?, forumcategory_idforumcategory = ?, language_id = sqlc.narg(topic_language_id) WHERE idforumtopic = ?;
 
 -- name: GetAllForumTopicsByCategoryIdForUserWithLastPosterName :many
 WITH role_ids AS (
@@ -92,12 +92,12 @@ FROM forumtopic t
 LEFT JOIN users lu ON lu.idusers = t.lastposter
 WHERE t.forumcategory_idforumcategory = sqlc.arg(category_id)
   AND (
-      t.language_idlanguage = 0
-      OR t.language_idlanguage IS NULL
+      t.language_id = 0
+      OR t.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = t.language_idlanguage
+            AND ul.language_id = t.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -166,12 +166,12 @@ FROM forumtopic t
 LEFT JOIN users lu ON lu.idusers = t.lastposter
 WHERE t.handler <> 'private'
   AND (
-    t.language_idlanguage = 0
-    OR t.language_idlanguage IS NULL
+    t.language_id = 0
+    OR t.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
-          AND ul.language_idlanguage = t.language_idlanguage
+          AND ul.language_id = t.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -198,12 +198,12 @@ FROM forumtopic t
 LEFT JOIN users lu ON lu.idusers = t.lastposter
 WHERE t.idforumtopic = sqlc.arg(idforumtopic)
   AND (
-      t.language_idlanguage = 0
-      OR t.language_idlanguage IS NULL
+      t.language_id = 0
+      OR t.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = t.language_idlanguage
+            AND ul.language_id = t.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -226,24 +226,24 @@ ORDER BY t.lastaddition DESC;
 SELECT f.*
 FROM forumcategory f
 WHERE (
-    f.language_idlanguage = 0
-    OR f.language_idlanguage IS NULL
+    f.language_id = 0
+    OR f.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
-          AND ul.language_idlanguage = f.language_idlanguage
+          AND ul.language_id = f.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
     )
 );
 
-INSERT INTO forumcategory (forumcategory_idforumcategory, language_idlanguage, title, description) VALUES (?, sqlc.narg(category_language_id), ?, ?);
+INSERT INTO forumcategory (forumcategory_idforumcategory, language_id, title, description) VALUES (?, sqlc.narg(category_language_id), ?, ?);
 
-INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description, handler) VALUES (?, sqlc.narg(topic_language_id), ?, ?, ?);
+INSERT INTO forumtopic (forumcategory_idforumcategory, language_id, title, description, handler) VALUES (?, sqlc.narg(topic_language_id), ?, ?, ?);
 
 -- name: CreateForumTopicForPoster :execlastid
-INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description, handler)
+INSERT INTO forumtopic (forumcategory_idforumcategory, language_id, title, description, handler)
 SELECT sqlc.arg(forumcategory_id), sqlc.arg(forum_lang), sqlc.arg(title), sqlc.arg(description), sqlc.arg(handler)
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -295,7 +295,7 @@ ORDER BY th.lastaddition DESC;
 SELECT t.idforumtopic,
        t.lastposter,
        t.forumcategory_idforumcategory,
-       t.language_idlanguage,
+       t.language_id,
        t.title,
        t.description,
        t.threads,
@@ -381,12 +381,12 @@ ORDER BY t.idforumtopic, th.lastaddition DESC;
 SELECT * FROM forumcategory
 WHERE idforumcategory = sqlc.arg(idforumcategory)
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+      language_id = 0
+      OR language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = language_idlanguage
+            AND ul.language_id = language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -397,12 +397,12 @@ WHERE idforumcategory = sqlc.arg(idforumcategory)
 SELECT * FROM forumtopic
 WHERE forumcategory_idforumcategory = sqlc.arg(category_id)
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+      language_id = 0
+      OR language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = language_idlanguage
+            AND ul.language_id = language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)

--- a/internal/db/queries-forum.sql.go
+++ b/internal/db/queries-forum.sql.go
@@ -14,12 +14,12 @@ const adminCountForumCategories = `-- name: AdminCountForumCategories :one
 SELECT COUNT(*)
 FROM forumcategory c
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_id = 0
+    OR c.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
-          AND ul.language_idlanguage = c.language_idlanguage
+          AND ul.language_id = c.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -58,18 +58,18 @@ func (q *Queries) AdminDeleteForumTopic(ctx context.Context, idforumtopic int32)
 }
 
 const adminListForumCategoriesWithCounts = `-- name: AdminListForumCategoriesWithCounts :many
-SELECT c.idforumcategory, c.forumcategory_idforumcategory, c.language_idlanguage, c.title, c.description, COUNT(c2.idforumcategory) AS SubcategoryCount,
+SELECT c.idforumcategory, c.forumcategory_idforumcategory, c.language_id, c.title, c.description, COUNT(c2.idforumcategory) AS SubcategoryCount,
        COUNT(t.idforumtopic) AS TopicCount
 FROM forumcategory c
 LEFT JOIN forumcategory c2 ON c.idforumcategory = c2.forumcategory_idforumcategory
 LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_id = 0
+    OR c.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
-          AND ul.language_idlanguage = c.language_idlanguage
+          AND ul.language_id = c.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -89,7 +89,7 @@ type AdminListForumCategoriesWithCountsParams struct {
 type AdminListForumCategoriesWithCountsRow struct {
 	Idforumcategory              int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           sql.NullInt32
+	LanguageID                   sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Subcategorycount             int64
@@ -113,7 +113,7 @@ func (q *Queries) AdminListForumCategoriesWithCounts(ctx context.Context, arg Ad
 		if err := rows.Scan(
 			&i.Idforumcategory,
 			&i.ForumcategoryIdforumcategory,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.Title,
 			&i.Description,
 			&i.Subcategorycount,
@@ -133,7 +133,7 @@ func (q *Queries) AdminListForumCategoriesWithCounts(ctx context.Context, arg Ad
 }
 
 const adminListForumTopics = `-- name: AdminListForumTopics :many
-SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_idlanguage, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler
+SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_id, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler
 FROM forumtopic t
 ORDER BY t.idforumtopic
 LIMIT ? OFFSET ?
@@ -157,7 +157,7 @@ func (q *Queries) AdminListForumTopics(ctx context.Context, arg AdminListForumTo
 			&i.Idforumtopic,
 			&i.Lastposter,
 			&i.ForumcategoryIdforumcategory,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.Title,
 			&i.Description,
 			&i.Threads,
@@ -257,7 +257,7 @@ func (q *Queries) AdminRebuildAllForumTopicMetaColumns(ctx context.Context) erro
 }
 
 const createForumTopicForPoster = `-- name: CreateForumTopicForPoster :execlastid
-INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description, handler)
+INSERT INTO forumtopic (forumcategory_idforumcategory, language_id, title, description, handler)
 SELECT ?, ?, ?, ?, ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -304,15 +304,15 @@ func (q *Queries) CreateForumTopicForPoster(ctx context.Context, arg CreateForum
 }
 
 const getAllForumCategories = `-- name: GetAllForumCategories :many
-SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_idlanguage, f.title, f.description
+SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_id, f.title, f.description
 FROM forumcategory f
 WHERE (
-    f.language_idlanguage = 0
-    OR f.language_idlanguage IS NULL
+    f.language_id = 0
+    OR f.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
-          AND ul.language_idlanguage = f.language_idlanguage
+          AND ul.language_id = f.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -336,7 +336,7 @@ func (q *Queries) GetAllForumCategories(ctx context.Context, arg GetAllForumCate
 		if err := rows.Scan(
 			&i.Idforumcategory,
 			&i.ForumcategoryIdforumcategory,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.Title,
 			&i.Description,
 		); err != nil {
@@ -354,18 +354,18 @@ func (q *Queries) GetAllForumCategories(ctx context.Context, arg GetAllForumCate
 }
 
 const getAllForumCategoriesWithSubcategoryCount = `-- name: GetAllForumCategoriesWithSubcategoryCount :many
-SELECT c.idforumcategory, c.forumcategory_idforumcategory, c.language_idlanguage, c.title, c.description, COUNT(c2.idforumcategory) as SubcategoryCount,
+SELECT c.idforumcategory, c.forumcategory_idforumcategory, c.language_id, c.title, c.description, COUNT(c2.idforumcategory) as SubcategoryCount,
        COUNT(t.idforumtopic)   as TopicCount
 FROM forumcategory c
 LEFT JOIN forumcategory c2 ON c.idforumcategory = c2.forumcategory_idforumcategory
 LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_id = 0
+    OR c.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
-          AND ul.language_idlanguage = c.language_idlanguage
+          AND ul.language_id = c.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -381,7 +381,7 @@ type GetAllForumCategoriesWithSubcategoryCountParams struct {
 type GetAllForumCategoriesWithSubcategoryCountRow struct {
 	Idforumcategory              int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           sql.NullInt32
+	LanguageID                   sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Subcategorycount             int64
@@ -400,7 +400,7 @@ func (q *Queries) GetAllForumCategoriesWithSubcategoryCount(ctx context.Context,
 		if err := rows.Scan(
 			&i.Idforumcategory,
 			&i.ForumcategoryIdforumcategory,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.Title,
 			&i.Description,
 			&i.Subcategorycount,
@@ -470,15 +470,15 @@ func (q *Queries) GetAllForumThreadsWithTopic(ctx context.Context) ([]*GetAllFor
 }
 
 const getAllForumTopics = `-- name: GetAllForumTopics :many
-SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_idlanguage, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler
+SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_id, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler
 FROM forumtopic t
 WHERE (
-    t.language_idlanguage = 0
-    OR t.language_idlanguage IS NULL
+    t.language_id = 0
+    OR t.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
-          AND ul.language_idlanguage = t.language_idlanguage
+          AND ul.language_id = t.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -504,7 +504,7 @@ func (q *Queries) GetAllForumTopics(ctx context.Context, arg GetAllForumTopicsPa
 			&i.Idforumtopic,
 			&i.Lastposter,
 			&i.ForumcategoryIdforumcategory,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.Title,
 			&i.Description,
 			&i.Threads,
@@ -529,17 +529,17 @@ const getAllForumTopicsByCategoryIdForUserWithLastPosterName = `-- name: GetAllF
 WITH role_ids AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_idlanguage, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler, lu.username AS LastPosterUsername
+SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_id, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler, lu.username AS LastPosterUsername
 FROM forumtopic t
 LEFT JOIN users lu ON lu.idusers = t.lastposter
 WHERE t.forumcategory_idforumcategory = ?
   AND (
-      t.language_idlanguage = 0
-      OR t.language_idlanguage IS NULL
+      t.language_id = 0
+      OR t.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = t.language_idlanguage
+            AND ul.language_id = t.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -568,7 +568,7 @@ type GetAllForumTopicsByCategoryIdForUserWithLastPosterNameRow struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           sql.NullInt32
+	LanguageID                   sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -597,7 +597,7 @@ func (q *Queries) GetAllForumTopicsByCategoryIdForUserWithLastPosterName(ctx con
 			&i.Idforumtopic,
 			&i.Lastposter,
 			&i.ForumcategoryIdforumcategory,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.Title,
 			&i.Description,
 			&i.Threads,
@@ -620,15 +620,15 @@ func (q *Queries) GetAllForumTopicsByCategoryIdForUserWithLastPosterName(ctx con
 }
 
 const getForumCategoryById = `-- name: GetForumCategoryById :one
-SELECT idforumcategory, forumcategory_idforumcategory, language_idlanguage, title, description FROM forumcategory
+SELECT idforumcategory, forumcategory_idforumcategory, language_id, title, description FROM forumcategory
 WHERE idforumcategory = ?
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+      language_id = 0
+      OR language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = language_idlanguage
+            AND ul.language_id = language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -647,7 +647,7 @@ func (q *Queries) GetForumCategoryById(ctx context.Context, arg GetForumCategory
 	err := row.Scan(
 		&i.Idforumcategory,
 		&i.ForumcategoryIdforumcategory,
-		&i.LanguageIdlanguage,
+		&i.LanguageID,
 		&i.Title,
 		&i.Description,
 	)
@@ -736,7 +736,7 @@ func (q *Queries) GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndF
 }
 
 const getForumTopicById = `-- name: GetForumTopicById :one
-SELECT idforumtopic, lastposter, forumcategory_idforumcategory, language_idlanguage, title, description, threads, comments, lastaddition, handler
+SELECT idforumtopic, lastposter, forumcategory_idforumcategory, language_id, title, description, threads, comments, lastaddition, handler
 FROM forumtopic
 WHERE idforumtopic = ?
 `
@@ -748,7 +748,7 @@ func (q *Queries) GetForumTopicById(ctx context.Context, idforumtopic int32) (*F
 		&i.Idforumtopic,
 		&i.Lastposter,
 		&i.ForumcategoryIdforumcategory,
-		&i.LanguageIdlanguage,
+		&i.LanguageID,
 		&i.Title,
 		&i.Description,
 		&i.Threads,
@@ -763,17 +763,17 @@ const getForumTopicByIdForUser = `-- name: GetForumTopicByIdForUser :one
 WITH role_ids AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_idlanguage, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler, lu.username AS LastPosterUsername
+SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_id, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler, lu.username AS LastPosterUsername
 FROM forumtopic t
 LEFT JOIN users lu ON lu.idusers = t.lastposter
 WHERE t.idforumtopic = ?
   AND (
-      t.language_idlanguage = 0
-      OR t.language_idlanguage IS NULL
+      t.language_id = 0
+      OR t.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = t.language_idlanguage
+            AND ul.language_id = t.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -802,7 +802,7 @@ type GetForumTopicByIdForUserRow struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           sql.NullInt32
+	LanguageID                   sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -825,7 +825,7 @@ func (q *Queries) GetForumTopicByIdForUser(ctx context.Context, arg GetForumTopi
 		&i.Idforumtopic,
 		&i.Lastposter,
 		&i.ForumcategoryIdforumcategory,
-		&i.LanguageIdlanguage,
+		&i.LanguageID,
 		&i.Title,
 		&i.Description,
 		&i.Threads,
@@ -838,15 +838,15 @@ func (q *Queries) GetForumTopicByIdForUser(ctx context.Context, arg GetForumTopi
 }
 
 const getForumTopicsByCategoryId = `-- name: GetForumTopicsByCategoryId :many
-SELECT idforumtopic, lastposter, forumcategory_idforumcategory, language_idlanguage, title, description, threads, comments, lastaddition, handler FROM forumtopic
+SELECT idforumtopic, lastposter, forumcategory_idforumcategory, language_id, title, description, threads, comments, lastaddition, handler FROM forumtopic
 WHERE forumcategory_idforumcategory = ?
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+      language_id = 0
+      OR language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = language_idlanguage
+            AND ul.language_id = language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -873,7 +873,7 @@ func (q *Queries) GetForumTopicsByCategoryId(ctx context.Context, arg GetForumTo
 			&i.Idforumtopic,
 			&i.Lastposter,
 			&i.ForumcategoryIdforumcategory,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.Title,
 			&i.Description,
 			&i.Threads,
@@ -898,17 +898,17 @@ const getForumTopicsForUser = `-- name: GetForumTopicsForUser :many
 WITH role_ids AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_idlanguage, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler, lu.username AS LastPosterUsername
+SELECT t.idforumtopic, t.lastposter, t.forumcategory_idforumcategory, t.language_id, t.title, t.description, t.threads, t.comments, t.lastaddition, t.handler, lu.username AS LastPosterUsername
 FROM forumtopic t
 LEFT JOIN users lu ON lu.idusers = t.lastposter
 WHERE t.handler <> 'private'
   AND (
-    t.language_idlanguage = 0
-    OR t.language_idlanguage IS NULL
+    t.language_id = 0
+    OR t.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
-          AND ul.language_idlanguage = t.language_idlanguage
+          AND ul.language_id = t.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -936,7 +936,7 @@ type GetForumTopicsForUserRow struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           sql.NullInt32
+	LanguageID                   sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -964,7 +964,7 @@ func (q *Queries) GetForumTopicsForUser(ctx context.Context, arg GetForumTopicsF
 			&i.Idforumtopic,
 			&i.Lastposter,
 			&i.ForumcategoryIdforumcategory,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.Title,
 			&i.Description,
 			&i.Threads,
@@ -1087,7 +1087,7 @@ const listPrivateTopicsByUserID = `-- name: ListPrivateTopicsByUserID :many
 SELECT t.idforumtopic,
        t.lastposter,
        t.forumcategory_idforumcategory,
-       t.language_idlanguage,
+       t.language_id,
        t.title,
        t.description,
        t.threads,
@@ -1111,7 +1111,7 @@ type ListPrivateTopicsByUserIDRow struct {
 	Idforumtopic                 int32
 	Lastposter                   int32
 	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           sql.NullInt32
+	LanguageID                   sql.NullInt32
 	Title                        sql.NullString
 	Description                  sql.NullString
 	Threads                      sql.NullInt32
@@ -1134,7 +1134,7 @@ func (q *Queries) ListPrivateTopicsByUserID(ctx context.Context, userID sql.Null
 			&i.Idforumtopic,
 			&i.Lastposter,
 			&i.ForumcategoryIdforumcategory,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.Title,
 			&i.Description,
 			&i.Threads,
@@ -1157,7 +1157,7 @@ func (q *Queries) ListPrivateTopicsByUserID(ctx context.Context, userID sql.Null
 }
 
 const systemGetForumTopicByTitle = `-- name: SystemGetForumTopicByTitle :one
-SELECT idforumtopic, lastposter, forumcategory_idforumcategory, language_idlanguage, title, description, threads, comments, lastaddition, handler
+SELECT idforumtopic, lastposter, forumcategory_idforumcategory, language_id, title, description, threads, comments, lastaddition, handler
 FROM forumtopic
 WHERE title=?
 `
@@ -1169,7 +1169,7 @@ func (q *Queries) SystemGetForumTopicByTitle(ctx context.Context, title sql.Null
 		&i.Idforumtopic,
 		&i.Lastposter,
 		&i.ForumcategoryIdforumcategory,
-		&i.LanguageIdlanguage,
+		&i.LanguageID,
 		&i.Title,
 		&i.Description,
 		&i.Threads,

--- a/internal/db/queries-languages.sql
+++ b/internal/db/queries-languages.sql
@@ -5,14 +5,14 @@
 -- name: AdminRenameLanguage :exec
 UPDATE language
 SET nameof = ?
-WHERE idlanguage = ?;
+WHERE id = ?;
 
 -- AdminDeleteLanguage removes a language entry.
 -- Parameters:
 --   ? - Language ID to be deleted (int)
 -- name: AdminDeleteLanguage :exec
 DELETE FROM language
-WHERE idlanguage = ?;
+WHERE id = ?;
 
 -- AdminCreateLanguage adds a new language.
 -- Parameters:
@@ -33,7 +33,7 @@ FROM language;
 
 -- SystemGetLanguageIDByName resolves a language ID by name.
 -- name: SystemGetLanguageIDByName :one
-SELECT idlanguage FROM language WHERE nameof = ?;
+SELECT id FROM language WHERE nameof = ?;
 
 
 -- SystemCountLanguages counts all languages.
@@ -43,8 +43,8 @@ SELECT COUNT(*) FROM language;
 -- AdminLanguageUsageCounts returns counts of content referencing a language.
 -- name: AdminLanguageUsageCounts :one
 SELECT
-    (SELECT COUNT(*) FROM comments WHERE comments.language_idlanguage = sqlc.narg(lang_id)) AS comments,
-    (SELECT COUNT(*) FROM writing WHERE writing.language_idlanguage = sqlc.narg(lang_id)) AS writings,
-    (SELECT COUNT(*) FROM blogs WHERE blogs.language_idlanguage = sqlc.narg(lang_id)) AS blogs,
-    (SELECT COUNT(*) FROM site_news WHERE site_news.language_idlanguage = sqlc.narg(lang_id)) AS news,
-    (SELECT COUNT(*) FROM linker WHERE linker.language_idlanguage = sqlc.narg(lang_id)) AS links;
+    (SELECT COUNT(*) FROM comments WHERE comments.language_id = sqlc.narg(lang_id)) AS comments,
+    (SELECT COUNT(*) FROM writing WHERE writing.language_id = sqlc.narg(lang_id)) AS writings,
+    (SELECT COUNT(*) FROM blogs WHERE blogs.language_id = sqlc.narg(lang_id)) AS blogs,
+    (SELECT COUNT(*) FROM site_news WHERE site_news.language_id = sqlc.narg(lang_id)) AS news,
+    (SELECT COUNT(*) FROM linker WHERE linker.language_id = sqlc.narg(lang_id)) AS links;

--- a/internal/db/queries-languages.sql.go
+++ b/internal/db/queries-languages.sql.go
@@ -26,15 +26,15 @@ func (q *Queries) AdminCreateLanguage(ctx context.Context, nameof sql.NullString
 
 const adminDeleteLanguage = `-- name: AdminDeleteLanguage :exec
 DELETE FROM language
-WHERE idlanguage = ?
+WHERE id = ?
 `
 
 // AdminDeleteLanguage removes a language entry.
 // Parameters:
 //
 //	? - Language ID to be deleted (int)
-func (q *Queries) AdminDeleteLanguage(ctx context.Context, idlanguage int32) error {
-	_, err := q.db.ExecContext(ctx, adminDeleteLanguage, idlanguage)
+func (q *Queries) AdminDeleteLanguage(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, adminDeleteLanguage, id)
 	return err
 }
 
@@ -50,11 +50,11 @@ func (q *Queries) AdminInsertLanguage(ctx context.Context, nameof sql.NullString
 
 const adminLanguageUsageCounts = `-- name: AdminLanguageUsageCounts :one
 SELECT
-    (SELECT COUNT(*) FROM comments WHERE comments.language_idlanguage = ?) AS comments,
-    (SELECT COUNT(*) FROM writing WHERE writing.language_idlanguage = ?) AS writings,
-    (SELECT COUNT(*) FROM blogs WHERE blogs.language_idlanguage = ?) AS blogs,
-    (SELECT COUNT(*) FROM site_news WHERE site_news.language_idlanguage = ?) AS news,
-    (SELECT COUNT(*) FROM linker WHERE linker.language_idlanguage = ?) AS links
+    (SELECT COUNT(*) FROM comments WHERE comments.language_id = ?) AS comments,
+    (SELECT COUNT(*) FROM writing WHERE writing.language_id = ?) AS writings,
+    (SELECT COUNT(*) FROM blogs WHERE blogs.language_id = ?) AS blogs,
+    (SELECT COUNT(*) FROM site_news WHERE site_news.language_id = ?) AS news,
+    (SELECT COUNT(*) FROM linker WHERE linker.language_id = ?) AS links
 `
 
 type AdminLanguageUsageCountsParams struct {
@@ -92,12 +92,12 @@ func (q *Queries) AdminLanguageUsageCounts(ctx context.Context, arg AdminLanguag
 const adminRenameLanguage = `-- name: AdminRenameLanguage :exec
 UPDATE language
 SET nameof = ?
-WHERE idlanguage = ?
+WHERE id = ?
 `
 
 type AdminRenameLanguageParams struct {
-	Nameof     sql.NullString
-	Idlanguage int32
+	Nameof sql.NullString
+	ID     int32
 }
 
 // AdminRenameLanguage updates the language name.
@@ -106,7 +106,7 @@ type AdminRenameLanguageParams struct {
 //	? - New name for the language (string)
 //	? - Language ID to be updated (int)
 func (q *Queries) AdminRenameLanguage(ctx context.Context, arg AdminRenameLanguageParams) error {
-	_, err := q.db.ExecContext(ctx, adminRenameLanguage, arg.Nameof, arg.Idlanguage)
+	_, err := q.db.ExecContext(ctx, adminRenameLanguage, arg.Nameof, arg.ID)
 	return err
 }
 
@@ -123,19 +123,19 @@ func (q *Queries) SystemCountLanguages(ctx context.Context) (int64, error) {
 }
 
 const systemGetLanguageIDByName = `-- name: SystemGetLanguageIDByName :one
-SELECT idlanguage FROM language WHERE nameof = ?
+SELECT id FROM language WHERE nameof = ?
 `
 
 // SystemGetLanguageIDByName resolves a language ID by name.
 func (q *Queries) SystemGetLanguageIDByName(ctx context.Context, nameof sql.NullString) (int32, error) {
 	row := q.db.QueryRowContext(ctx, systemGetLanguageIDByName, nameof)
-	var idlanguage int32
-	err := row.Scan(&idlanguage)
-	return idlanguage, err
+	var id int32
+	err := row.Scan(&id)
+	return id, err
 }
 
 const systemListLanguages = `-- name: SystemListLanguages :many
-SELECT idlanguage, nameof
+SELECT id, nameof
 FROM language
 `
 
@@ -149,7 +149,7 @@ func (q *Queries) SystemListLanguages(ctx context.Context) ([]*Language, error) 
 	var items []*Language
 	for rows.Next() {
 		var i Language
-		if err := rows.Scan(&i.Idlanguage, &i.Nameof); err != nil {
+		if err := rows.Scan(&i.ID, &i.Nameof); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/internal/db/queries-linker.sql
+++ b/internal/db/queries-linker.sql
@@ -95,8 +95,8 @@ JOIN users u ON l.users_idusers = u.idusers
 JOIN linker_category c ON l.linker_category_id = c.idlinkerCategory
 ;
 -- name: AdminInsertQueuedLinkFromQueue :execlastid
-INSERT INTO linker (users_idusers, linker_category_id, language_idlanguage, title, `url`, description, timezone)
-SELECT l.users_idusers, l.linker_category_id, l.language_idlanguage, l.title, l.url, l.description, l.timezone
+INSERT INTO linker (users_idusers, linker_category_id, language_id, title, `url`, description, timezone)
+SELECT l.users_idusers, l.linker_category_id, l.language_id, l.title, l.url, l.description, l.timezone
 FROM linker_queue l
 WHERE l.idlinkerQueue = ?;
 
@@ -105,14 +105,14 @@ INSERT INTO linker (users_idusers, linker_category_id, title, url, description, 
 VALUES (sqlc.arg(users_idusers), sqlc.arg(linker_category_id), sqlc.arg(title), sqlc.arg(url), sqlc.arg(description), NOW(), sqlc.arg(timezone));
 
 -- name: AdminUpdateLinkerItem :exec
-UPDATE linker SET title = ?, url = ?, description = ?, linker_category_id = ?, language_idlanguage = ?
+UPDATE linker SET title = ?, url = ?, description = ?, linker_category_id = ?, language_id = ?
 WHERE idlinker = ?;
 
 -- name: SystemAssignLinkerThreadID :exec
 UPDATE linker SET forumthread_id = ? WHERE idlinker = ?;
 
 -- name: GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -134,7 +134,7 @@ grants_for_viewer AS (
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -153,7 +153,7 @@ WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercate
 ORDER BY l.listed DESC;
 
 -- name: GetLinkerItemsByUserDescending :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -174,7 +174,7 @@ grants_for_viewer AS (
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -205,7 +205,7 @@ grants_for_viewer AS (
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -225,7 +225,7 @@ ORDER BY l.listed DESC
 LIMIT ? OFFSET ?;
 
 -- name: GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending :one
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
 JOIN users u ON l.users_idusers = u.idusers
 JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -243,7 +243,7 @@ grants_for_viewer AS (
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
 JOIN users u ON l.users_idusers = u.idusers
 JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -261,7 +261,7 @@ WHERE l.idlinker = sqlc.arg(idlinker)
 LIMIT 1;
 
 -- name: GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescending :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
 JOIN users u ON l.users_idusers = u.idusers
 JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -279,7 +279,7 @@ grants_for_viewer AS (
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
 JOIN users u ON l.users_idusers = u.idusers
 JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -315,7 +315,7 @@ UPDATE linker SET last_index = NOW() WHERE idlinker = ?;
 
 
 -- name: GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -336,7 +336,7 @@ grants_for_viewer AS (
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory

--- a/internal/db/queries-linker.sql.go
+++ b/internal/db/queries-linker.sql.go
@@ -84,8 +84,8 @@ func (q *Queries) AdminDeleteLinkerQueuedItem(ctx context.Context, idlinkerqueue
 }
 
 const adminInsertQueuedLinkFromQueue = `-- name: AdminInsertQueuedLinkFromQueue :execlastid
-INSERT INTO linker (users_idusers, linker_category_id, language_idlanguage, title, ` + "`" + `url` + "`" + `, description, timezone)
-SELECT l.users_idusers, l.linker_category_id, l.language_idlanguage, l.title, l.url, l.description, l.timezone
+INSERT INTO linker (users_idusers, linker_category_id, language_id, title, ` + "`" + `url` + "`" + `, description, timezone)
+SELECT l.users_idusers, l.linker_category_id, l.language_id, l.title, l.url, l.description, l.timezone
 FROM linker_queue l
 WHERE l.idlinkerQueue = ?
 `
@@ -130,17 +130,17 @@ func (q *Queries) AdminUpdateLinkerCategorySortOrder(ctx context.Context, arg Ad
 }
 
 const adminUpdateLinkerItem = `-- name: AdminUpdateLinkerItem :exec
-UPDATE linker SET title = ?, url = ?, description = ?, linker_category_id = ?, language_idlanguage = ?
+UPDATE linker SET title = ?, url = ?, description = ?, linker_category_id = ?, language_id = ?
 WHERE idlinker = ?
 `
 
 type AdminUpdateLinkerItemParams struct {
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	LinkerCategoryID   sql.NullInt32
-	LanguageIdlanguage sql.NullInt32
-	Idlinker           int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	LinkerCategoryID sql.NullInt32
+	LanguageID       sql.NullInt32
+	Idlinker         int32
 }
 
 func (q *Queries) AdminUpdateLinkerItem(ctx context.Context, arg AdminUpdateLinkerItemParams) error {
@@ -149,7 +149,7 @@ func (q *Queries) AdminUpdateLinkerItem(ctx context.Context, arg AdminUpdateLink
 		arg.Url,
 		arg.Description,
 		arg.LinkerCategoryID,
-		arg.LanguageIdlanguage,
+		arg.LanguageID,
 		arg.Idlinker,
 	)
 	return err
@@ -329,7 +329,7 @@ func (q *Queries) GetAllLinkerCategoriesForUser(ctx context.Context, arg GetAllL
 }
 
 const getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending = `-- name: GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -345,19 +345,19 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 }
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
+	Comments         sql.NullInt32
+	CategoryTitle    sql.NullString
+	Posterusername   sql.NullString
 }
 
 func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow, error) {
@@ -371,7 +371,7 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 		var i GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow
 		if err := rows.Scan(
 			&i.Idlinker,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.LinkerCategoryID,
 			&i.ForumthreadID,
@@ -409,7 +409,7 @@ grants_for_viewer AS (
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -435,19 +435,19 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 }
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
+	Comments         sql.NullInt32
+	CategoryTitle    sql.NullString
+	Posterusername   sql.NullString
 }
 
 func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUser(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserRow, error) {
@@ -466,7 +466,7 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 		var i GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserRow
 		if err := rows.Scan(
 			&i.Idlinker,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.LinkerCategoryID,
 			&i.ForumthreadID,
@@ -504,7 +504,7 @@ grants_for_viewer AS (
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -531,19 +531,19 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 }
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
+	Comments         sql.NullInt32
+	CategoryTitle    sql.NullString
+	Posterusername   sql.NullString
 }
 
 func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginated(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow, error) {
@@ -564,7 +564,7 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 		var i GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow
 		if err := rows.Scan(
 			&i.Idlinker,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.LinkerCategoryID,
 			&i.ForumthreadID,
@@ -602,7 +602,7 @@ grants_for_viewer AS (
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -631,19 +631,19 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 }
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRowRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
+	Comments         sql.NullInt32
+	CategoryTitle    sql.NullString
+	Posterusername   sql.NullString
 }
 
 func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRowParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRowRow, error) {
@@ -664,7 +664,7 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 		var i GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRowRow
 		if err := rows.Scan(
 			&i.Idlinker,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.LinkerCategoryID,
 			&i.ForumthreadID,
@@ -691,7 +691,7 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 }
 
 const getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated = `-- name: GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -708,19 +708,19 @@ type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending
 }
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
+	Comments         sql.NullInt32
+	CategoryTitle    sql.NullString
+	Posterusername   sql.NullString
 }
 
 func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow, error) {
@@ -739,7 +739,7 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 		var i GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow
 		if err := rows.Scan(
 			&i.Idlinker,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.LinkerCategoryID,
 			&i.ForumthreadID,
@@ -766,24 +766,24 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 }
 
 const getAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails = `-- name: GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails :many
-SELECT l.idlinkerqueue, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.title, l.url, l.description, l.timezone, u.username, c.title as category_title, c.idlinkerCategory
+SELECT l.idlinkerqueue, l.language_id, l.users_idusers, l.linker_category_id, l.title, l.url, l.description, l.timezone, u.username, c.title as category_title, c.idlinkerCategory
 FROM linker_queue l
 JOIN users u ON l.users_idusers = u.idusers
 JOIN linker_category c ON l.linker_category_id = c.idlinkerCategory
 `
 
 type GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetailsRow struct {
-	Idlinkerqueue      int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Timezone           sql.NullString
-	Username           sql.NullString
-	CategoryTitle      sql.NullString
-	Idlinkercategory   int32
+	Idlinkerqueue    int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Timezone         sql.NullString
+	Username         sql.NullString
+	CategoryTitle    sql.NullString
+	Idlinkercategory int32
 }
 
 func (q *Queries) GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails(ctx context.Context) ([]*GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetailsRow, error) {
@@ -797,7 +797,7 @@ func (q *Queries) GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails(ctx co
 		var i GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetailsRow
 		if err := rows.Scan(
 			&i.Idlinkerqueue,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.LinkerCategoryID,
 			&i.Title,
@@ -957,7 +957,7 @@ func (q *Queries) GetLinkerCategoryLinkCounts(ctx context.Context) ([]*GetLinker
 }
 
 const getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending = `-- name: GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending :one
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
 JOIN users u ON l.users_idusers = u.idusers
 JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -965,18 +965,18 @@ WHERE l.idlinker = ?
 `
 
 type GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Username           sql.NullString
-	Title_2            sql.NullString
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
+	Username         sql.NullString
+	Title_2          sql.NullString
 }
 
 func (q *Queries) GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(ctx context.Context, idlinker int32) (*GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow, error) {
@@ -984,7 +984,7 @@ func (q *Queries) GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(
 	var i GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow
 	err := row.Scan(
 		&i.Idlinker,
-		&i.LanguageIdlanguage,
+		&i.LanguageID,
 		&i.UsersIdusers,
 		&i.LinkerCategoryID,
 		&i.ForumthreadID,
@@ -1011,7 +1011,7 @@ grants_for_viewer AS (
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
 JOIN users u ON l.users_idusers = u.idusers
 JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -1036,18 +1036,18 @@ type GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams 
 }
 
 type GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Username           sql.NullString
-	Title_2            sql.NullString
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
+	Username         sql.NullString
+	Title_2          sql.NullString
 }
 
 func (q *Queries) GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUser(ctx context.Context, arg GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams) (*GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow, error) {
@@ -1055,7 +1055,7 @@ func (q *Queries) GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingF
 	var i GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow
 	err := row.Scan(
 		&i.Idlinker,
-		&i.LanguageIdlanguage,
+		&i.LanguageID,
 		&i.UsersIdusers,
 		&i.LinkerCategoryID,
 		&i.ForumthreadID,
@@ -1071,7 +1071,7 @@ func (q *Queries) GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingF
 }
 
 const getLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescending = `-- name: GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescending :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
 JOIN users u ON l.users_idusers = u.idusers
 JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -1079,18 +1079,18 @@ WHERE l.idlinker IN (/*SLICE:linkerids*/?)
 `
 
 type GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Username           sql.NullString
-	Title_2            sql.NullString
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
+	Username         sql.NullString
+	Title_2          sql.NullString
 }
 
 func (q *Queries) GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescending(ctx context.Context, linkerids []int32) ([]*GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow, error) {
@@ -1114,7 +1114,7 @@ func (q *Queries) GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendin
 		var i GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow
 		if err := rows.Scan(
 			&i.Idlinker,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.LinkerCategoryID,
 			&i.ForumthreadID,
@@ -1151,7 +1151,7 @@ grants_for_viewer AS (
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
 JOIN users u ON l.users_idusers = u.idusers
 JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -1175,18 +1175,18 @@ type GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserParam
 }
 
 type GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Username           sql.NullString
-	Title_2            sql.NullString
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
+	Username         sql.NullString
+	Title_2          sql.NullString
 }
 
 func (q *Queries) GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUser(ctx context.Context, arg GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserParams) ([]*GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserRow, error) {
@@ -1212,7 +1212,7 @@ func (q *Queries) GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendin
 		var i GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserRow
 		if err := rows.Scan(
 			&i.Idlinker,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.LinkerCategoryID,
 			&i.ForumthreadID,
@@ -1238,7 +1238,7 @@ func (q *Queries) GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendin
 }
 
 const getLinkerItemsByUserDescending = `-- name: GetLinkerItemsByUserDescending :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -1255,19 +1255,19 @@ type GetLinkerItemsByUserDescendingParams struct {
 }
 
 type GetLinkerItemsByUserDescendingRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
+	Comments         sql.NullInt32
+	CategoryTitle    sql.NullString
+	Posterusername   sql.NullString
 }
 
 func (q *Queries) GetLinkerItemsByUserDescending(ctx context.Context, arg GetLinkerItemsByUserDescendingParams) ([]*GetLinkerItemsByUserDescendingRow, error) {
@@ -1281,7 +1281,7 @@ func (q *Queries) GetLinkerItemsByUserDescending(ctx context.Context, arg GetLin
 		var i GetLinkerItemsByUserDescendingRow
 		if err := rows.Scan(
 			&i.Idlinker,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.LinkerCategoryID,
 			&i.ForumthreadID,
@@ -1319,7 +1319,7 @@ grants_for_viewer AS (
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
+SELECT l.idlinker, l.language_id, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
@@ -1348,19 +1348,19 @@ type GetLinkerItemsByUserDescendingForUserParams struct {
 }
 
 type GetLinkerItemsByUserDescendingForUserRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	Idlinker         int32
+	LanguageID       sql.NullInt32
+	UsersIdusers     int32
+	LinkerCategoryID sql.NullInt32
+	ForumthreadID    int32
+	Title            sql.NullString
+	Url              sql.NullString
+	Description      sql.NullString
+	Listed           sql.NullTime
+	Timezone         sql.NullString
+	Comments         sql.NullInt32
+	CategoryTitle    sql.NullString
+	Posterusername   sql.NullString
 }
 
 func (q *Queries) GetLinkerItemsByUserDescendingForUser(ctx context.Context, arg GetLinkerItemsByUserDescendingForUserParams) ([]*GetLinkerItemsByUserDescendingForUserRow, error) {
@@ -1380,7 +1380,7 @@ func (q *Queries) GetLinkerItemsByUserDescendingForUser(ctx context.Context, arg
 		var i GetLinkerItemsByUserDescendingForUserRow
 		if err := rows.Scan(
 			&i.Idlinker,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.LinkerCategoryID,
 			&i.ForumthreadID,

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -1,5 +1,5 @@
 -- name: CreateNewsPostForWriter :execlastid
-INSERT INTO site_news (news, users_idusers, occurred, timezone, language_idlanguage)
+INSERT INTO site_news (news, users_idusers, occurred, timezone, language_id)
 SELECT sqlc.arg(news), sqlc.arg(writer_id), NOW(), sqlc.arg(timezone), sqlc.narg(language_id)
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -16,7 +16,7 @@ WHERE EXISTS (
 
 -- name: UpdateNewsPostForWriter :exec
 UPDATE site_news s
-SET news = sqlc.arg(news), language_idlanguage = sqlc.narg(language_id)
+SET news = sqlc.arg(news), language_id = sqlc.narg(language_id)
 WHERE s.idsiteNews = sqlc.arg(post_id)
   AND s.users_idusers = sqlc.arg(writer_id)
   AND EXISTS (
@@ -53,7 +53,7 @@ WHERE idsiteNews = ?;
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_id, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
@@ -74,7 +74,7 @@ LIMIT 1;
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_id, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
@@ -83,10 +83,10 @@ WHERE s.Idsitenews IN (sqlc.slice(newsIds))
       NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
       )
-      OR s.language_idlanguage = 0
-      OR s.language_idlanguage IS NULL
-      OR s.language_idlanguage IN (
-          SELECT ul.language_idlanguage
+      OR s.language_id = 0
+      OR s.language_id IS NULL
+      OR s.language_id IN (
+          SELECT ul.language_id
           FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
       )
@@ -107,7 +107,7 @@ ORDER BY s.occurred DESC;
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_id, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
@@ -115,10 +115,10 @@ WHERE (
     NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
     )
-    OR s.language_idlanguage = 0
-    OR s.language_idlanguage IS NULL
-    OR s.language_idlanguage IN (
-        SELECT ul.language_idlanguage FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
+    OR s.language_id = 0
+    OR s.language_id IS NULL
+    OR s.language_id IN (
+        SELECT ul.language_id FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
     )
 )
   AND EXISTS (
@@ -136,7 +136,7 @@ LIMIT ? OFFSET ?;
 
 
 -- name: AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescending :many
-SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers,
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_id, s.users_idusers,
 s.news, s.occurred, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const adminListNewsPostsWithWriterUsernameAndThreadCommentCountDescending = `-- name: AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescending :many
-SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers,
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_id, s.users_idusers,
 s.news, s.occurred, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
@@ -27,15 +27,15 @@ type AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams s
 }
 
 type AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow struct {
-	Writername         sql.NullString
-	Writerid           sql.NullInt32
-	Idsitenews         int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	News               sql.NullString
-	Occurred           sql.NullTime
-	Comments           sql.NullInt32
+	Writername    sql.NullString
+	Writerid      sql.NullInt32
+	Idsitenews    int32
+	ForumthreadID int32
+	LanguageID    sql.NullInt32
+	UsersIdusers  int32
+	News          sql.NullString
+	Occurred      sql.NullTime
+	Comments      sql.NullInt32
 }
 
 func (q *Queries) AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescending(ctx context.Context, arg AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams) ([]*AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow, error) {
@@ -52,7 +52,7 @@ func (q *Queries) AdminListNewsPostsWithWriterUsernameAndThreadCommentCountDesce
 			&i.Writerid,
 			&i.Idsitenews,
 			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.News,
 			&i.Occurred,
@@ -87,7 +87,7 @@ func (q *Queries) AdminReplaceSiteNewsURL(ctx context.Context, arg AdminReplaceS
 }
 
 const createNewsPostForWriter = `-- name: CreateNewsPostForWriter :execlastid
-INSERT INTO site_news (news, users_idusers, occurred, timezone, language_idlanguage)
+INSERT INTO site_news (news, users_idusers, occurred, timezone, language_id)
 SELECT ?, ?, NOW(), ?, ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -190,7 +190,7 @@ const getNewsPostByIdWithWriterIdAndThreadCommentCount = `-- name: GetNewsPostBy
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_id, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
@@ -214,16 +214,16 @@ type GetNewsPostByIdWithWriterIdAndThreadCommentCountParams struct {
 }
 
 type GetNewsPostByIdWithWriterIdAndThreadCommentCountRow struct {
-	Writername         sql.NullString
-	Writerid           sql.NullInt32
-	Idsitenews         int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	News               sql.NullString
-	Occurred           sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
+	Writername    sql.NullString
+	Writerid      sql.NullInt32
+	Idsitenews    int32
+	ForumthreadID int32
+	LanguageID    sql.NullInt32
+	UsersIdusers  int32
+	News          sql.NullString
+	Occurred      sql.NullTime
+	Timezone      sql.NullString
+	Comments      sql.NullInt32
 }
 
 func (q *Queries) GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx context.Context, arg GetNewsPostByIdWithWriterIdAndThreadCommentCountParams) (*GetNewsPostByIdWithWriterIdAndThreadCommentCountRow, error) {
@@ -234,7 +234,7 @@ func (q *Queries) GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx context.C
 		&i.Writerid,
 		&i.Idsitenews,
 		&i.ForumthreadID,
-		&i.LanguageIdlanguage,
+		&i.LanguageID,
 		&i.UsersIdusers,
 		&i.News,
 		&i.Occurred,
@@ -248,7 +248,7 @@ const getNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount = `-- name: GetN
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_id, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
@@ -257,10 +257,10 @@ WHERE s.Idsitenews IN (/*SLICE:newsids*/?)
       NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
       )
-      OR s.language_idlanguage = 0
-      OR s.language_idlanguage IS NULL
-      OR s.language_idlanguage IN (
-          SELECT ul.language_idlanguage
+      OR s.language_id = 0
+      OR s.language_id IS NULL
+      OR s.language_id IN (
+          SELECT ul.language_id
           FROM user_language ul
           WHERE ul.users_idusers = ?
       )
@@ -285,16 +285,16 @@ type GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountParams struct {
 }
 
 type GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow struct {
-	Writername         sql.NullString
-	Writerid           sql.NullInt32
-	Idsitenews         int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	News               sql.NullString
-	Occurred           sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
+	Writername    sql.NullString
+	Writerid      sql.NullInt32
+	Idsitenews    int32
+	ForumthreadID int32
+	LanguageID    sql.NullInt32
+	UsersIdusers  int32
+	News          sql.NullString
+	Occurred      sql.NullTime
+	Timezone      sql.NullString
+	Comments      sql.NullInt32
 }
 
 func (q *Queries) GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount(ctx context.Context, arg GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountParams) ([]*GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow, error) {
@@ -325,7 +325,7 @@ func (q *Queries) GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount(ctx 
 			&i.Writerid,
 			&i.Idsitenews,
 			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.News,
 			&i.Occurred,
@@ -349,7 +349,7 @@ const getNewsPostsWithWriterUsernameAndThreadCommentCountDescending = `-- name: 
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
+SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_id, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
 LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
@@ -357,10 +357,10 @@ WHERE (
     NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
     )
-    OR s.language_idlanguage = 0
-    OR s.language_idlanguage IS NULL
-    OR s.language_idlanguage IN (
-        SELECT ul.language_idlanguage FROM user_language ul WHERE ul.users_idusers = ?
+    OR s.language_id = 0
+    OR s.language_id IS NULL
+    OR s.language_id IN (
+        SELECT ul.language_id FROM user_language ul WHERE ul.users_idusers = ?
     )
 )
   AND EXISTS (
@@ -385,16 +385,16 @@ type GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams struct 
 }
 
 type GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow struct {
-	Writername         sql.NullString
-	Writerid           sql.NullInt32
-	Idsitenews         int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	News               sql.NullString
-	Occurred           sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
+	Writername    sql.NullString
+	Writerid      sql.NullInt32
+	Idsitenews    int32
+	ForumthreadID int32
+	LanguageID    sql.NullInt32
+	UsersIdusers  int32
+	News          sql.NullString
+	Occurred      sql.NullTime
+	Timezone      sql.NullString
+	Comments      sql.NullInt32
 }
 
 func (q *Queries) GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(ctx context.Context, arg GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingParams) ([]*GetNewsPostsWithWriterUsernameAndThreadCommentCountDescendingRow, error) {
@@ -418,7 +418,7 @@ func (q *Queries) GetNewsPostsWithWriterUsernameAndThreadCommentCountDescending(
 			&i.Writerid,
 			&i.Idsitenews,
 			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.UsersIdusers,
 			&i.News,
 			&i.Occurred,
@@ -476,7 +476,7 @@ func (q *Queries) SystemSetSiteNewsLastIndex(ctx context.Context, idsitenews int
 
 const updateNewsPostForWriter = `-- name: UpdateNewsPostForWriter :exec
 UPDATE site_news s
-SET news = ?, language_idlanguage = ?
+SET news = ?, language_id = ?
 WHERE s.idsiteNews = ?
   AND s.users_idusers = ?
   AND EXISTS (

--- a/internal/db/queries-pending_emails.sql
+++ b/internal/db/queries-pending_emails.sql
@@ -20,7 +20,7 @@ LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers
 LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers
 LEFT JOIN roles r ON ur.role_id = r.id
 WHERE pe.sent_at IS NULL
-  AND (sqlc.narg(language_id) IS NULL OR p.language_idlanguage = sqlc.narg(language_id))
+  AND (sqlc.narg(language_id) IS NULL OR p.language_id = sqlc.narg(language_id))
   AND (sqlc.arg(role_name) IS NULL OR r.name = sqlc.arg(role_name))
 ORDER BY pe.id;
 
@@ -48,7 +48,7 @@ LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers
 LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers
 LEFT JOIN roles r ON ur.role_id = r.id
 WHERE pe.sent_at IS NOT NULL
-  AND (sqlc.narg(language_id) IS NULL OR p.language_idlanguage = sqlc.narg(language_id))
+  AND (sqlc.narg(language_id) IS NULL OR p.language_id = sqlc.narg(language_id))
   AND (sqlc.arg(role_name) IS NULL OR r.name = sqlc.arg(role_name))
 ORDER BY pe.sent_at DESC
 LIMIT ? OFFSET ?;
@@ -61,7 +61,7 @@ LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers
 LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers
 LEFT JOIN roles r ON ur.role_id = r.id
 WHERE pe.sent_at IS NULL AND pe.error_count > 0
-  AND (sqlc.narg(language_id) IS NULL OR p.language_idlanguage = sqlc.narg(language_id))
+  AND (sqlc.narg(language_id) IS NULL OR p.language_id = sqlc.narg(language_id))
   AND (sqlc.arg(role_name) IS NULL OR r.name = sqlc.arg(role_name))
 ORDER BY pe.id
 LIMIT ? OFFSET ?;

--- a/internal/db/queries-pending_emails.sql.go
+++ b/internal/db/queries-pending_emails.sql.go
@@ -56,7 +56,7 @@ LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers
 LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers
 LEFT JOIN roles r ON ur.role_id = r.id
 WHERE pe.sent_at IS NULL AND pe.error_count > 0
-  AND (? IS NULL OR p.language_idlanguage = ?)
+  AND (? IS NULL OR p.language_id = ?)
   AND (? IS NULL OR r.name = ?)
 ORDER BY pe.id
 LIMIT ? OFFSET ?
@@ -123,7 +123,7 @@ LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers
 LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers
 LEFT JOIN roles r ON ur.role_id = r.id
 WHERE pe.sent_at IS NOT NULL
-  AND (? IS NULL OR p.language_idlanguage = ?)
+  AND (? IS NULL OR p.language_id = ?)
   AND (? IS NULL OR r.name = ?)
 ORDER BY pe.sent_at DESC
 LIMIT ? OFFSET ?
@@ -192,7 +192,7 @@ LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers
 LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers
 LEFT JOIN roles r ON ur.role_id = r.id
 WHERE pe.sent_at IS NULL
-  AND (? IS NULL OR p.language_idlanguage = ?)
+  AND (? IS NULL OR p.language_id = ?)
   AND (? IS NULL OR r.name = ?)
 ORDER BY pe.id
 `

--- a/internal/db/queries-preferences.sql
+++ b/internal/db/queries-preferences.sql
@@ -13,16 +13,16 @@ SET auto_subscribe_replies = sqlc.arg(auto_subscribe_replies)
 WHERE users_idusers = sqlc.arg(lister_id);
 
 -- name: GetPreferenceForLister :one
-SELECT idpreferences, language_idlanguage, users_idusers, emailforumupdates, page_size, auto_subscribe_replies, timezone
+SELECT idpreferences, language_id, users_idusers, emailforumupdates, page_size, auto_subscribe_replies, timezone
 FROM preferences
 WHERE users_idusers = sqlc.arg(lister_id);
 
 -- name: InsertPreferenceForLister :exec
-INSERT INTO preferences (language_idlanguage, users_idusers, page_size, timezone)
+INSERT INTO preferences (language_id, users_idusers, page_size, timezone)
 VALUES (sqlc.narg(language_id), sqlc.arg(lister_id), sqlc.arg(page_size), sqlc.arg(timezone));
 
 -- name: UpdatePreferenceForLister :exec
-UPDATE preferences SET language_idlanguage = sqlc.narg(language_id), page_size = sqlc.arg(page_size), timezone = sqlc.arg(timezone) WHERE users_idusers = sqlc.arg(lister_id);
+UPDATE preferences SET language_id = sqlc.narg(language_id), page_size = sqlc.arg(page_size), timezone = sqlc.arg(timezone) WHERE users_idusers = sqlc.arg(lister_id);
 
 -- name: UpdateTimezoneForLister :exec
 UPDATE preferences

--- a/internal/db/queries-preferences.sql.go
+++ b/internal/db/queries-preferences.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const getPreferenceForLister = `-- name: GetPreferenceForLister :one
-SELECT idpreferences, language_idlanguage, users_idusers, emailforumupdates, page_size, auto_subscribe_replies, timezone
+SELECT idpreferences, language_id, users_idusers, emailforumupdates, page_size, auto_subscribe_replies, timezone
 FROM preferences
 WHERE users_idusers = ?
 `
@@ -21,7 +21,7 @@ func (q *Queries) GetPreferenceForLister(ctx context.Context, listerID int32) (*
 	var i Preference
 	err := row.Scan(
 		&i.Idpreferences,
-		&i.LanguageIdlanguage,
+		&i.LanguageID,
 		&i.UsersIdusers,
 		&i.Emailforumupdates,
 		&i.PageSize,
@@ -48,7 +48,7 @@ func (q *Queries) InsertEmailPreferenceForLister(ctx context.Context, arg Insert
 }
 
 const insertPreferenceForLister = `-- name: InsertPreferenceForLister :exec
-INSERT INTO preferences (language_idlanguage, users_idusers, page_size, timezone)
+INSERT INTO preferences (language_id, users_idusers, page_size, timezone)
 VALUES (?, ?, ?, ?)
 `
 
@@ -102,7 +102,7 @@ func (q *Queries) UpdateEmailForumUpdatesForLister(ctx context.Context, arg Upda
 }
 
 const updatePreferenceForLister = `-- name: UpdatePreferenceForLister :exec
-UPDATE preferences SET language_idlanguage = ?, page_size = ?, timezone = ? WHERE users_idusers = ?
+UPDATE preferences SET language_id = ?, page_size = ?, timezone = ? WHERE users_idusers = ?
 `
 
 type UpdatePreferenceForListerParams struct {

--- a/internal/db/queries-search.sql
+++ b/internal/db/queries-search.sql
@@ -98,12 +98,12 @@ LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
 WHERE swl.word=sqlc.arg(word)
   AND ft.forumcategory_idforumcategory!=0
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+      c.language_id = 0
+      OR c.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -134,12 +134,12 @@ WHERE swl.word=sqlc.arg(word)
   AND cs.comment_id IN (sqlc.slice('ids'))
   AND ft.forumcategory_idforumcategory!=0
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+      c.language_id = 0
+      OR c.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -169,12 +169,12 @@ LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
 WHERE swl.word=sqlc.arg(word)
   AND fth.forumtopic_idforumtopic IN (sqlc.slice('ftids'))
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+      c.language_id = 0
+      OR c.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -205,12 +205,12 @@ WHERE swl.word=sqlc.arg(word)
   AND cs.comment_id IN (sqlc.slice('ids'))
   AND fth.forumtopic_idforumtopic IN (sqlc.slice('ftids'))
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+      c.language_id = 0
+      OR c.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -264,12 +264,12 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN writing w ON w.idwriting = cs.writing_id
 WHERE swl.word = sqlc.arg(word)
   AND (
-      w.language_idlanguage = 0
-      OR w.language_idlanguage IS NULL
+      w.language_id = 0
+      OR w.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = w.language_idlanguage
+            AND ul.language_id = w.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -297,12 +297,12 @@ JOIN writing w ON w.idwriting = cs.writing_id
 WHERE swl.word = sqlc.arg(word)
   AND cs.writing_id IN (sqlc.slice('ids'))
   AND (
-      w.language_idlanguage = 0
-      OR w.language_idlanguage IS NULL
+      w.language_id = 0
+      OR w.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = w.language_idlanguage
+            AND ul.language_id = w.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -329,12 +329,12 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN site_news sn ON sn.idsiteNews = cs.site_news_id
 WHERE swl.word = sqlc.arg(word)
   AND (
-      sn.language_idlanguage = 0
-      OR sn.language_idlanguage IS NULL
+      sn.language_id = 0
+      OR sn.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = sn.language_idlanguage
+            AND ul.language_id = sn.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -362,12 +362,12 @@ JOIN site_news sn ON sn.idsiteNews = cs.site_news_id
 WHERE swl.word = sqlc.arg(word)
   AND cs.site_news_id IN (sqlc.slice('ids'))
   AND (
-      sn.language_idlanguage = 0
-      OR sn.language_idlanguage IS NULL
+      sn.language_id = 0
+      OR sn.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = sn.language_idlanguage
+            AND ul.language_id = sn.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -396,12 +396,12 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN linker l ON l.idlinker = cs.linker_id
 WHERE swl.word = sqlc.arg(word)
   AND (
-      l.language_idlanguage = 0
-      OR l.language_idlanguage IS NULL
+      l.language_id = 0
+      OR l.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = l.language_idlanguage
+            AND ul.language_id = l.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -429,12 +429,12 @@ JOIN linker l ON l.idlinker = cs.linker_id
 WHERE swl.word = sqlc.arg(word)
   AND cs.linker_id IN (sqlc.slice('ids'))
   AND (
-      l.language_idlanguage = 0
-      OR l.language_idlanguage IS NULL
+      l.language_id = 0
+      OR l.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = l.language_idlanguage
+            AND ul.language_id = l.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)

--- a/internal/db/queries-search.sql.go
+++ b/internal/db/queries-search.sql.go
@@ -170,12 +170,12 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN linker l ON l.idlinker = cs.linker_id
 WHERE swl.word = ?
   AND (
-      l.language_idlanguage = 0
-      OR l.language_idlanguage IS NULL
+      l.language_id = 0
+      OR l.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = l.language_idlanguage
+            AND ul.language_id = l.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -239,12 +239,12 @@ JOIN linker l ON l.idlinker = cs.linker_id
 WHERE swl.word = ?
   AND cs.linker_id IN (/*SLICE:ids*/?)
   AND (
-      l.language_idlanguage = 0
-      OR l.language_idlanguage IS NULL
+      l.language_id = 0
+      OR l.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = l.language_idlanguage
+            AND ul.language_id = l.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -320,12 +320,12 @@ LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
 WHERE swl.word=?
   AND fth.forumtopic_idforumtopic IN (/*SLICE:ftids*/?)
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+      c.language_id = 0
+      OR c.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -401,12 +401,12 @@ LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
 WHERE swl.word=?
   AND ft.forumcategory_idforumcategory!=0
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+      c.language_id = 0
+      OR c.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -473,12 +473,12 @@ WHERE swl.word=?
   AND cs.comment_id IN (/*SLICE:ids*/?)
   AND fth.forumtopic_idforumtopic IN (/*SLICE:ftids*/?)
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+      c.language_id = 0
+      OR c.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -564,12 +564,12 @@ WHERE swl.word=?
   AND cs.comment_id IN (/*SLICE:ids*/?)
   AND ft.forumcategory_idforumcategory!=0
   AND (
-      c.language_idlanguage = 0
-      OR c.language_idlanguage IS NULL
+      c.language_id = 0
+      OR c.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -642,12 +642,12 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN site_news sn ON sn.idsiteNews = cs.site_news_id
 WHERE swl.word = ?
   AND (
-      sn.language_idlanguage = 0
-      OR sn.language_idlanguage IS NULL
+      sn.language_id = 0
+      OR sn.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = sn.language_idlanguage
+            AND ul.language_id = sn.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -711,12 +711,12 @@ JOIN site_news sn ON sn.idsiteNews = cs.site_news_id
 WHERE swl.word = ?
   AND cs.site_news_id IN (/*SLICE:ids*/?)
   AND (
-      sn.language_idlanguage = 0
-      OR sn.language_idlanguage IS NULL
+      sn.language_id = 0
+      OR sn.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = sn.language_idlanguage
+            AND ul.language_id = sn.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -789,12 +789,12 @@ LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearc
 JOIN writing w ON w.idwriting = cs.writing_id
 WHERE swl.word = ?
   AND (
-      w.language_idlanguage = 0
-      OR w.language_idlanguage IS NULL
+      w.language_id = 0
+      OR w.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = w.language_idlanguage
+            AND ul.language_id = w.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -858,12 +858,12 @@ JOIN writing w ON w.idwriting = cs.writing_id
 WHERE swl.word = ?
   AND cs.writing_id IN (/*SLICE:ids*/?)
   AND (
-      w.language_idlanguage = 0
-      OR w.language_idlanguage IS NULL
+      w.language_id = 0
+      OR w.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = w.language_idlanguage
+            AND ul.language_id = w.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?

--- a/internal/db/queries-threads.sql
+++ b/internal/db/queries-threads.sql
@@ -60,12 +60,12 @@ LEFT JOIN users lu ON lu.idusers = t.lastposter
 LEFT JOIN comments fc ON th.firstpost = fc.idcomments
 WHERE th.idforumthread=sqlc.arg(thread_id)
   AND (
-      fc.language_idlanguage = 0
-      OR fc.language_idlanguage IS NULL
+      fc.language_id = 0
+      OR fc.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = fc.language_idlanguage
+            AND ul.language_id = fc.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -119,12 +119,12 @@ FROM forumthread th
 LEFT JOIN comments fc ON th.firstpost = fc.idcomments
 WHERE th.idforumthread = sqlc.arg(thread_id)
   AND (
-      fc.language_idlanguage = 0
-      OR fc.language_idlanguage IS NULL
+      fc.language_id = 0
+      OR fc.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(replier_id)
-            AND ul.language_idlanguage = fc.language_idlanguage
+            AND ul.language_id = fc.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(replier_id)

--- a/internal/db/queries-threads.sql.go
+++ b/internal/db/queries-threads.sql.go
@@ -198,12 +198,12 @@ FROM forumthread th
 LEFT JOIN comments fc ON th.firstpost = fc.idcomments
 WHERE th.idforumthread = ?
   AND (
-      fc.language_idlanguage = 0
-      OR fc.language_idlanguage IS NULL
+      fc.language_id = 0
+      OR fc.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = fc.language_idlanguage
+            AND ul.language_id = fc.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -265,12 +265,12 @@ LEFT JOIN users lu ON lu.idusers = t.lastposter
 LEFT JOIN comments fc ON th.firstpost = fc.idcomments
 WHERE th.idforumthread=?
   AND (
-      fc.language_idlanguage = 0
-      OR fc.language_idlanguage IS NULL
+      fc.language_id = 0
+      OR fc.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = fc.language_idlanguage
+            AND ul.language_id = fc.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?

--- a/internal/db/queries-user_languages.sql
+++ b/internal/db/queries-user_languages.sql
@@ -1,5 +1,5 @@
 -- name: GetUserLanguages :many
-SELECT iduserlang, users_idusers, language_idlanguage
+SELECT iduserlang, users_idusers, language_id
 FROM user_language
 WHERE users_idusers = ?;
 
@@ -7,5 +7,5 @@ WHERE users_idusers = ?;
 DELETE FROM user_language WHERE users_idusers = sqlc.arg(user_id);
 
 -- name: InsertUserLang :exec
-INSERT INTO user_language (users_idusers, language_idlanguage)
+INSERT INTO user_language (users_idusers, language_id)
 VALUES (?, ?);

--- a/internal/db/queries-user_languages.sql.go
+++ b/internal/db/queries-user_languages.sql.go
@@ -19,7 +19,7 @@ func (q *Queries) DeleteUserLanguagesForUser(ctx context.Context, userID int32) 
 }
 
 const getUserLanguages = `-- name: GetUserLanguages :many
-SELECT iduserlang, users_idusers, language_idlanguage
+SELECT iduserlang, users_idusers, language_id
 FROM user_language
 WHERE users_idusers = ?
 `
@@ -33,7 +33,7 @@ func (q *Queries) GetUserLanguages(ctx context.Context, usersIdusers int32) ([]*
 	var items []*UserLanguage
 	for rows.Next() {
 		var i UserLanguage
-		if err := rows.Scan(&i.Iduserlang, &i.UsersIdusers, &i.LanguageIdlanguage); err != nil {
+		if err := rows.Scan(&i.Iduserlang, &i.UsersIdusers, &i.LanguageID); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -48,16 +48,16 @@ func (q *Queries) GetUserLanguages(ctx context.Context, usersIdusers int32) ([]*
 }
 
 const insertUserLang = `-- name: InsertUserLang :exec
-INSERT INTO user_language (users_idusers, language_idlanguage)
+INSERT INTO user_language (users_idusers, language_id)
 VALUES (?, ?)
 `
 
 type InsertUserLangParams struct {
-	UsersIdusers       int32
-	LanguageIdlanguage int32
+	UsersIdusers int32
+	LanguageID   int32
 }
 
 func (q *Queries) InsertUserLang(ctx context.Context, arg InsertUserLangParams) error {
-	_, err := q.db.ExecContext(ctx, insertUserLang, arg.UsersIdusers, arg.LanguageIdlanguage)
+	_, err := q.db.ExecContext(ctx, insertUserLang, arg.UsersIdusers, arg.LanguageID)
 	return err
 }

--- a/internal/db/queries-writings.sql
+++ b/internal/db/queries-writings.sql
@@ -30,12 +30,12 @@ FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.private = 0 AND w.users_idusers = sqlc.arg(author_id)
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_id = 0
+    OR w.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
-          AND ul.language_idlanguage = w.language_idlanguage
+          AND ul.language_id = w.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -73,12 +73,12 @@ FROM writing w
 LEFT JOIN users u ON w.Users_Idusers=u.idusers
 WHERE w.private = 0 AND w.writing_category_id = sqlc.arg(writing_category_id)
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_id = 0
+    OR w.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
-          AND ul.language_idlanguage = w.language_idlanguage
+          AND ul.language_id = w.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -104,7 +104,7 @@ SET title = sqlc.arg(title),
     abstract = sqlc.arg(abstract),
     writing = sqlc.arg(content),
     private = sqlc.arg(private),
-    language_idlanguage = sqlc.narg(language_id)
+    language_id = sqlc.narg(language_id)
 WHERE w.idwriting = sqlc.arg(writing_id)
   AND w.users_idusers = sqlc.arg(writer_id)
   AND EXISTS (
@@ -121,11 +121,11 @@ WHERE w.idwriting = sqlc.arg(writing_id)
   );
 
 -- name: InsertWriting :execlastid
-INSERT INTO writing (writing_category_id, title, abstract, writing, private, language_idlanguage, published, users_idusers)
+INSERT INTO writing (writing_category_id, title, abstract, writing, private, language_id, published, users_idusers)
 VALUES (?, ?, ?, ?, ?, ?, NOW(), ?);
 
 -- name: CreateWritingForWriter :execlastid
-INSERT INTO writing (writing_category_id, title, abstract, writing, private, language_idlanguage, published, users_idusers)
+INSERT INTO writing (writing_category_id, title, abstract, writing, private, language_id, published, users_idusers)
 SELECT sqlc.arg(writing_category_id), sqlc.arg(title), sqlc.arg(abstract), sqlc.arg(writing), sqlc.arg(private), sqlc.narg(language_id), NOW(), sqlc.arg(writer_id)
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -170,12 +170,12 @@ FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 WHERE w.idwriting IN (sqlc.slice(writing_ids))
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_id = 0
+    OR w.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
-          AND ul.language_idlanguage = w.language_idlanguage
+          AND ul.language_id = w.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -267,12 +267,12 @@ SELECT u.username, COUNT(w.idwriting) AS count
 FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 WHERE (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_id = 0
+    OR w.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
-          AND ul.language_idlanguage = w.language_idlanguage
+          AND ul.language_id = w.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -301,12 +301,12 @@ FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 WHERE (LOWER(u.username) LIKE LOWER(sqlc.arg(query)) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(sqlc.arg(query)))
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_id = 0
+    OR w.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(lister_id)
-          AND ul.language_idlanguage = w.language_idlanguage
+          AND ul.language_id = w.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)

--- a/internal/db/queries-writings.sql.go
+++ b/internal/db/queries-writings.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const adminGetAllWritingsByAuthor = `-- name: AdminGetAllWritingsByAuthor :many
-SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
+SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_id, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
@@ -21,20 +21,20 @@ ORDER BY w.published DESC
 `
 
 type AdminGetAllWritingsByAuthorRow struct {
-	Idwriting          int32
-	UsersIdusers       int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	WritingCategoryID  int32
-	Title              sql.NullString
-	Published          sql.NullTime
-	Writing            sql.NullString
-	Abstract           sql.NullString
-	Private            sql.NullBool
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
-	Username           sql.NullString
-	Comments           int64
+	Idwriting         int32
+	UsersIdusers      int32
+	ForumthreadID     int32
+	LanguageID        sql.NullInt32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Published         sql.NullTime
+	Writing           sql.NullString
+	Abstract          sql.NullString
+	Private           sql.NullBool
+	DeletedAt         sql.NullTime
+	LastIndex         sql.NullTime
+	Username          sql.NullString
+	Comments          int64
 }
 
 func (q *Queries) AdminGetAllWritingsByAuthor(ctx context.Context, authorID int32) ([]*AdminGetAllWritingsByAuthorRow, error) {
@@ -50,7 +50,7 @@ func (q *Queries) AdminGetAllWritingsByAuthor(ctx context.Context, authorID int3
 			&i.Idwriting,
 			&i.UsersIdusers,
 			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
@@ -76,7 +76,7 @@ func (q *Queries) AdminGetAllWritingsByAuthor(ctx context.Context, authorID int3
 }
 
 const adminGetWritingsByCategoryId = `-- name: AdminGetWritingsByCategoryId :many
-SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username
+SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_id, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.writing_category_id = ?
@@ -84,19 +84,19 @@ ORDER BY w.published DESC
 `
 
 type AdminGetWritingsByCategoryIdRow struct {
-	Idwriting          int32
-	UsersIdusers       int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	WritingCategoryID  int32
-	Title              sql.NullString
-	Published          sql.NullTime
-	Writing            sql.NullString
-	Abstract           sql.NullString
-	Private            sql.NullBool
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
-	Username           sql.NullString
+	Idwriting         int32
+	UsersIdusers      int32
+	ForumthreadID     int32
+	LanguageID        sql.NullInt32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Published         sql.NullTime
+	Writing           sql.NullString
+	Abstract          sql.NullString
+	Private           sql.NullBool
+	DeletedAt         sql.NullTime
+	LastIndex         sql.NullTime
+	Username          sql.NullString
 }
 
 func (q *Queries) AdminGetWritingsByCategoryId(ctx context.Context, writingCategoryID int32) ([]*AdminGetWritingsByCategoryIdRow, error) {
@@ -112,7 +112,7 @@ func (q *Queries) AdminGetWritingsByCategoryId(ctx context.Context, writingCateg
 			&i.Idwriting,
 			&i.UsersIdusers,
 			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
@@ -176,7 +176,7 @@ func (q *Queries) AdminUpdateWritingCategory(ctx context.Context, arg AdminUpdat
 }
 
 const createWritingForWriter = `-- name: CreateWritingForWriter :execlastid
-INSERT INTO writing (writing_category_id, title, abstract, writing, private, language_idlanguage, published, users_idusers)
+INSERT INTO writing (writing_category_id, title, abstract, writing, private, language_id, published, users_idusers)
 SELECT ?, ?, ?, ?, ?, ?, NOW(), ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -227,7 +227,7 @@ const getAllWritingsByAuthorForLister = `-- name: GetAllWritingsByAuthorForListe
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
+SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_id, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
@@ -252,20 +252,20 @@ type GetAllWritingsByAuthorForListerParams struct {
 }
 
 type GetAllWritingsByAuthorForListerRow struct {
-	Idwriting          int32
-	UsersIdusers       int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	WritingCategoryID  int32
-	Title              sql.NullString
-	Published          sql.NullTime
-	Writing            sql.NullString
-	Abstract           sql.NullString
-	Private            sql.NullBool
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
-	Username           sql.NullString
-	Comments           int64
+	Idwriting         int32
+	UsersIdusers      int32
+	ForumthreadID     int32
+	LanguageID        sql.NullInt32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Published         sql.NullTime
+	Writing           sql.NullString
+	Abstract          sql.NullString
+	Private           sql.NullBool
+	DeletedAt         sql.NullTime
+	LastIndex         sql.NullTime
+	Username          sql.NullString
+	Comments          int64
 }
 
 func (q *Queries) GetAllWritingsByAuthorForLister(ctx context.Context, arg GetAllWritingsByAuthorForListerParams) ([]*GetAllWritingsByAuthorForListerRow, error) {
@@ -281,7 +281,7 @@ func (q *Queries) GetAllWritingsByAuthorForLister(ctx context.Context, arg GetAl
 			&i.Idwriting,
 			&i.UsersIdusers,
 			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
@@ -346,7 +346,7 @@ func (q *Queries) GetAllWritingsForIndex(ctx context.Context) ([]*GetAllWritings
 }
 
 const getPublicWritings = `-- name: GetPublicWritings :many
-SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index
+SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_id, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index
 FROM writing w
 WHERE w.private = 0
 ORDER BY w.published DESC
@@ -371,7 +371,7 @@ func (q *Queries) GetPublicWritings(ctx context.Context, arg GetPublicWritingsPa
 			&i.Idwriting,
 			&i.UsersIdusers,
 			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
@@ -414,7 +414,7 @@ const getWritingForListerByID = `-- name: GetWritingForListerByID :one
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.idusers AS WriterId, u.Username AS WriterUsername
+SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_id, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.idusers AS WriterId, u.Username AS WriterUsername
 FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 WHERE w.idwriting = ?
@@ -438,20 +438,20 @@ type GetWritingForListerByIDParams struct {
 }
 
 type GetWritingForListerByIDRow struct {
-	Idwriting          int32
-	UsersIdusers       int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	WritingCategoryID  int32
-	Title              sql.NullString
-	Published          sql.NullTime
-	Writing            sql.NullString
-	Abstract           sql.NullString
-	Private            sql.NullBool
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
-	Writerid           int32
-	Writerusername     sql.NullString
+	Idwriting         int32
+	UsersIdusers      int32
+	ForumthreadID     int32
+	LanguageID        sql.NullInt32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Published         sql.NullTime
+	Writing           sql.NullString
+	Abstract          sql.NullString
+	Private           sql.NullBool
+	DeletedAt         sql.NullTime
+	LastIndex         sql.NullTime
+	Writerid          int32
+	Writerusername    sql.NullString
 }
 
 func (q *Queries) GetWritingForListerByID(ctx context.Context, arg GetWritingForListerByIDParams) (*GetWritingForListerByIDRow, error) {
@@ -461,7 +461,7 @@ func (q *Queries) GetWritingForListerByID(ctx context.Context, arg GetWritingFor
 		&i.Idwriting,
 		&i.UsersIdusers,
 		&i.ForumthreadID,
-		&i.LanguageIdlanguage,
+		&i.LanguageID,
 		&i.WritingCategoryID,
 		&i.Title,
 		&i.Published,
@@ -477,18 +477,18 @@ func (q *Queries) GetWritingForListerByID(ctx context.Context, arg GetWritingFor
 }
 
 const insertWriting = `-- name: InsertWriting :execlastid
-INSERT INTO writing (writing_category_id, title, abstract, writing, private, language_idlanguage, published, users_idusers)
+INSERT INTO writing (writing_category_id, title, abstract, writing, private, language_id, published, users_idusers)
 VALUES (?, ?, ?, ?, ?, ?, NOW(), ?)
 `
 
 type InsertWritingParams struct {
-	WritingCategoryID  int32
-	Title              sql.NullString
-	Abstract           sql.NullString
-	Writing            sql.NullString
-	Private            sql.NullBool
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Abstract          sql.NullString
+	Writing           sql.NullString
+	Private           sql.NullBool
+	LanguageID        sql.NullInt32
+	UsersIdusers      int32
 }
 
 func (q *Queries) InsertWriting(ctx context.Context, arg InsertWritingParams) (int64, error) {
@@ -498,7 +498,7 @@ func (q *Queries) InsertWriting(ctx context.Context, arg InsertWritingParams) (i
 		arg.Abstract,
 		arg.Writing,
 		arg.Private,
-		arg.LanguageIdlanguage,
+		arg.LanguageID,
 		arg.UsersIdusers,
 	)
 	if err != nil {
@@ -511,18 +511,18 @@ const listPublicWritingsByUserForLister = `-- name: ListPublicWritingsByUserForL
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
+SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_id, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
 WHERE w.private = 0 AND w.users_idusers = ?
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_id = 0
+    OR w.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
-          AND ul.language_idlanguage = w.language_idlanguage
+          AND ul.language_id = w.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -551,20 +551,20 @@ type ListPublicWritingsByUserForListerParams struct {
 }
 
 type ListPublicWritingsByUserForListerRow struct {
-	Idwriting          int32
-	UsersIdusers       int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	WritingCategoryID  int32
-	Title              sql.NullString
-	Published          sql.NullTime
-	Writing            sql.NullString
-	Abstract           sql.NullString
-	Private            sql.NullBool
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
-	Username           sql.NullString
-	Comments           int64
+	Idwriting         int32
+	UsersIdusers      int32
+	ForumthreadID     int32
+	LanguageID        sql.NullInt32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Published         sql.NullTime
+	Writing           sql.NullString
+	Abstract          sql.NullString
+	Private           sql.NullBool
+	DeletedAt         sql.NullTime
+	LastIndex         sql.NullTime
+	Username          sql.NullString
+	Comments          int64
 }
 
 func (q *Queries) ListPublicWritingsByUserForLister(ctx context.Context, arg ListPublicWritingsByUserForListerParams) ([]*ListPublicWritingsByUserForListerRow, error) {
@@ -588,7 +588,7 @@ func (q *Queries) ListPublicWritingsByUserForLister(ctx context.Context, arg Lis
 			&i.Idwriting,
 			&i.UsersIdusers,
 			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
@@ -617,18 +617,18 @@ const listPublicWritingsInCategoryForLister = `-- name: ListPublicWritingsInCate
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.Username,
+SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_id, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.Username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) as Comments
 FROM writing w
 LEFT JOIN users u ON w.Users_Idusers=u.idusers
 WHERE w.private = 0 AND w.writing_category_id = ?
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_id = 0
+    OR w.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
-          AND ul.language_idlanguage = w.language_idlanguage
+          AND ul.language_id = w.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -657,20 +657,20 @@ type ListPublicWritingsInCategoryForListerParams struct {
 }
 
 type ListPublicWritingsInCategoryForListerRow struct {
-	Idwriting          int32
-	UsersIdusers       int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	WritingCategoryID  int32
-	Title              sql.NullString
-	Published          sql.NullTime
-	Writing            sql.NullString
-	Abstract           sql.NullString
-	Private            sql.NullBool
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
-	Username           sql.NullString
-	Comments           int64
+	Idwriting         int32
+	UsersIdusers      int32
+	ForumthreadID     int32
+	LanguageID        sql.NullInt32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Published         sql.NullTime
+	Writing           sql.NullString
+	Abstract          sql.NullString
+	Private           sql.NullBool
+	DeletedAt         sql.NullTime
+	LastIndex         sql.NullTime
+	Username          sql.NullString
+	Comments          int64
 }
 
 func (q *Queries) ListPublicWritingsInCategoryForLister(ctx context.Context, arg ListPublicWritingsInCategoryForListerParams) ([]*ListPublicWritingsInCategoryForListerRow, error) {
@@ -694,7 +694,7 @@ func (q *Queries) ListPublicWritingsInCategoryForLister(ctx context.Context, arg
 			&i.Idwriting,
 			&i.UsersIdusers,
 			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
@@ -727,12 +727,12 @@ SELECT u.username, COUNT(w.idwriting) AS count
 FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 WHERE (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_id = 0
+    OR w.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
-          AND ul.language_idlanguage = w.language_idlanguage
+          AND ul.language_id = w.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -804,12 +804,12 @@ FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 WHERE (LOWER(u.username) LIKE LOWER(?) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(?))
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_id = 0
+    OR w.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
-          AND ul.language_idlanguage = w.language_idlanguage
+          AND ul.language_id = w.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -973,17 +973,17 @@ const listWritingsByIDsForLister = `-- name: ListWritingsByIDsForLister :many
 WITH role_ids AS (
     SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?
 )
-SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.idusers AS WriterId, u.username AS WriterUsername
+SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_id, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.idusers AS WriterId, u.username AS WriterUsername
 FROM writing w
 JOIN users u ON w.users_idusers = u.idusers
 WHERE w.idwriting IN (/*SLICE:writing_ids*/?)
   AND (
-    w.language_idlanguage = 0
-    OR w.language_idlanguage IS NULL
+    w.language_id = 0
+    OR w.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = ?
-          AND ul.language_idlanguage = w.language_idlanguage
+          AND ul.language_id = w.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -1012,20 +1012,20 @@ type ListWritingsByIDsForListerParams struct {
 }
 
 type ListWritingsByIDsForListerRow struct {
-	Idwriting          int32
-	UsersIdusers       int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	WritingCategoryID  int32
-	Title              sql.NullString
-	Published          sql.NullTime
-	Writing            sql.NullString
-	Abstract           sql.NullString
-	Private            sql.NullBool
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
-	Writerid           int32
-	Writerusername     sql.NullString
+	Idwriting         int32
+	UsersIdusers      int32
+	ForumthreadID     int32
+	LanguageID        sql.NullInt32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Published         sql.NullTime
+	Writing           sql.NullString
+	Abstract          sql.NullString
+	Private           sql.NullBool
+	DeletedAt         sql.NullTime
+	LastIndex         sql.NullTime
+	Writerid          int32
+	Writerusername    sql.NullString
 }
 
 func (q *Queries) ListWritingsByIDsForLister(ctx context.Context, arg ListWritingsByIDsForListerParams) ([]*ListWritingsByIDsForListerRow, error) {
@@ -1057,7 +1057,7 @@ func (q *Queries) ListWritingsByIDsForLister(ctx context.Context, arg ListWritin
 			&i.Idwriting,
 			&i.UsersIdusers,
 			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
@@ -1110,7 +1110,7 @@ func (q *Queries) SystemGetWritingByID(ctx context.Context, idwriting int32) (in
 }
 
 const systemListPublicWritingsByAuthor = `-- name: SystemListPublicWritingsByAuthor :many
-SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
+SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_id, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments
 FROM writing w
 LEFT JOIN users u ON w.users_idusers = u.idusers
@@ -1126,20 +1126,20 @@ type SystemListPublicWritingsByAuthorParams struct {
 }
 
 type SystemListPublicWritingsByAuthorRow struct {
-	Idwriting          int32
-	UsersIdusers       int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	WritingCategoryID  int32
-	Title              sql.NullString
-	Published          sql.NullTime
-	Writing            sql.NullString
-	Abstract           sql.NullString
-	Private            sql.NullBool
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
-	Username           sql.NullString
-	Comments           int64
+	Idwriting         int32
+	UsersIdusers      int32
+	ForumthreadID     int32
+	LanguageID        sql.NullInt32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Published         sql.NullTime
+	Writing           sql.NullString
+	Abstract          sql.NullString
+	Private           sql.NullBool
+	DeletedAt         sql.NullTime
+	LastIndex         sql.NullTime
+	Username          sql.NullString
+	Comments          int64
 }
 
 func (q *Queries) SystemListPublicWritingsByAuthor(ctx context.Context, arg SystemListPublicWritingsByAuthorParams) ([]*SystemListPublicWritingsByAuthorRow, error) {
@@ -1155,7 +1155,7 @@ func (q *Queries) SystemListPublicWritingsByAuthor(ctx context.Context, arg Syst
 			&i.Idwriting,
 			&i.UsersIdusers,
 			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
@@ -1181,7 +1181,7 @@ func (q *Queries) SystemListPublicWritingsByAuthor(ctx context.Context, arg Syst
 }
 
 const systemListPublicWritingsInCategory = `-- name: SystemListPublicWritingsInCategory :many
-SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_idlanguage, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.Username,
+SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_id, w.writing_category_id, w.title, w.published, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.Username,
     (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) as Comments
 FROM writing w
 LEFT JOIN users u ON w.Users_Idusers = u.idusers
@@ -1197,20 +1197,20 @@ type SystemListPublicWritingsInCategoryParams struct {
 }
 
 type SystemListPublicWritingsInCategoryRow struct {
-	Idwriting          int32
-	UsersIdusers       int32
-	ForumthreadID      int32
-	LanguageIdlanguage sql.NullInt32
-	WritingCategoryID  int32
-	Title              sql.NullString
-	Published          sql.NullTime
-	Writing            sql.NullString
-	Abstract           sql.NullString
-	Private            sql.NullBool
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
-	Username           sql.NullString
-	Comments           int64
+	Idwriting         int32
+	UsersIdusers      int32
+	ForumthreadID     int32
+	LanguageID        sql.NullInt32
+	WritingCategoryID int32
+	Title             sql.NullString
+	Published         sql.NullTime
+	Writing           sql.NullString
+	Abstract          sql.NullString
+	Private           sql.NullBool
+	DeletedAt         sql.NullTime
+	LastIndex         sql.NullTime
+	Username          sql.NullString
+	Comments          int64
 }
 
 func (q *Queries) SystemListPublicWritingsInCategory(ctx context.Context, arg SystemListPublicWritingsInCategoryParams) ([]*SystemListPublicWritingsInCategoryRow, error) {
@@ -1226,7 +1226,7 @@ func (q *Queries) SystemListPublicWritingsInCategory(ctx context.Context, arg Sy
 			&i.Idwriting,
 			&i.UsersIdusers,
 			&i.ForumthreadID,
-			&i.LanguageIdlanguage,
+			&i.LanguageID,
 			&i.WritingCategoryID,
 			&i.Title,
 			&i.Published,
@@ -1306,7 +1306,7 @@ SET title = ?,
     abstract = ?,
     writing = ?,
     private = ?,
-    language_idlanguage = ?
+    language_id = ?
 WHERE w.idwriting = ?
   AND w.users_idusers = ?
   AND EXISTS (

--- a/internal/db/queries_writers_test.go
+++ b/internal/db/queries_writers_test.go
@@ -74,7 +74,7 @@ func TestQueries_GetWritingForListerByID_GlobalGrant(t *testing.T) {
 	defer conn.Close()
 	q := New(conn)
 
-	rows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_idlanguage", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "WriterId", "WriterUsername"}).
+	rows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_id", "writing_category_id", "title", "published", "writing", "abstract", "private", "deleted_at", "last_index", "WriterId", "WriterUsername"}).
 		AddRow(1, 1, 0, 0, 0, nil, nil, nil, nil, false, nil, nil, 1, "bob")
 
 	mock.ExpectQuery(regexp.QuoteMeta(getWritingForListerByID)).

--- a/internal/notifications/bus_worker_test.go
+++ b/internal/notifications/bus_worker_test.go
@@ -354,9 +354,9 @@ func TestProcessEventAutoSubscribe(t *testing.T) {
 	q := db.New(conn)
 	n := New(WithQueries(q), WithConfig(cfg))
 
-	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_idlanguage", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies", "timezone"}).
+	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_id", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies", "timezone"}).
 		AddRow(1, 0, 1, nil, 0, true, nil)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idpreferences, language_idlanguage, users_idusers, emailforumupdates, page_size, auto_subscribe_replies, timezone FROM preferences WHERE users_idusers = ?")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idpreferences, language_id, users_idusers, emailforumupdates, page_size, auto_subscribe_replies, timezone FROM preferences WHERE users_idusers = ?")).
 		WithArgs(int32(1)).WillReturnRows(prefRows)
 
 	pattern := buildPatterns(tasks.TaskString("AutoSub"), "/forum/topic/7/thread/42")[0]

--- a/migrations/0066.mysql.sql
+++ b/migrations/0066.mysql.sql
@@ -1,0 +1,19 @@
+ALTER TABLE language CHANGE COLUMN idlanguage id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE blogs CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE comments CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE faq CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE forumcategory CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE forumtopic CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE linker CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE linker_queue CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE preferences CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE site_news CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE writing CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE deactivated_comments CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE deactivated_writings CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE deactivated_blogs CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE deactivated_linker CHANGE COLUMN language_idlanguage language_id INT NULL;
+ALTER TABLE user_language CHANGE COLUMN language_idlanguage language_id INT NOT NULL DEFAULT 0;
+
+-- Update schema version
+UPDATE schema_version SET version = 66 WHERE version = 65;

--- a/migrations/0066.postgres.sql
+++ b/migrations/0066.postgres.sql
@@ -1,0 +1,19 @@
+ALTER TABLE language RENAME COLUMN idlanguage TO id;
+ALTER TABLE blogs RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE comments RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE faq RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE forumcategory RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE forumtopic RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE linker RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE linker_queue RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE preferences RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE site_news RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE writing RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE deactivated_comments RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE deactivated_writings RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE deactivated_blogs RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE deactivated_linker RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE user_language RENAME COLUMN language_idlanguage TO language_id;
+
+-- Update schema version
+UPDATE schema_version SET version = 66 WHERE version = 65;

--- a/migrations/0066.sqlite.sql
+++ b/migrations/0066.sqlite.sql
@@ -1,0 +1,19 @@
+ALTER TABLE language RENAME COLUMN idlanguage TO id;
+ALTER TABLE blogs RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE comments RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE faq RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE forumcategory RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE forumtopic RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE linker RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE linker_queue RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE preferences RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE site_news RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE writing RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE deactivated_comments RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE deactivated_writings RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE deactivated_blogs RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE deactivated_linker RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE user_language RENAME COLUMN language_idlanguage TO language_id;
+
+-- Update schema version
+UPDATE schema_version SET version = 66 WHERE version = 65;

--- a/schema/schema.mysql.sql
+++ b/schema/schema.mysql.sql
@@ -2,14 +2,14 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `timezone` tinytext DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
   `last_index` datetime DEFAULT NULL,
   PRIMARY KEY (`idblogs`),
-  KEY `blogs_FKIndex1` (`language_idlanguage`),
+  KEY `blogs_FKIndex1` (`language_id`),
   KEY `blogs_FKIndex2` (`users_idusers`),
   KEY `blogs_FKIndex3` (`forumthread_id`)
 );
@@ -35,14 +35,14 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   `timezone` tinytext DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
   `last_index` datetime DEFAULT NULL,
   PRIMARY KEY (`idcomments`),
-  KEY `comments_FKIndex1` (`language_idlanguage`),
+  KEY `comments_FKIndex1` (`language_id`),
   KEY `comments_FKIndex2` (`users_idusers`),
   KEY `comments_FKIndex3` (`forumthread_id`)
 );
@@ -59,13 +59,13 @@ CREATE TABLE `comments_search` (
 CREATE TABLE `faq` (
   `id` int(10) NOT NULL AUTO_INCREMENT,
   `faq_category_id` int(10) DEFAULT NULL,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `Table_21_FKIndex1` (`users_idusers`),
-  KEY `Table_21_FKIndex2` (`language_idlanguage`),
+  KEY `Table_21_FKIndex2` (`language_id`),
   KEY `Table_21_FKIndex3` (`faq_category_id`)
 );
 
@@ -90,12 +90,12 @@ CREATE TABLE IF NOT EXISTS `faq_revisions` (
 CREATE TABLE `forumcategory` (
   `idforumcategory` int(10) NOT NULL AUTO_INCREMENT,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   PRIMARY KEY (`idforumcategory`),
   KEY `forumcategory_FKIndex1` (`forumcategory_idforumcategory`),
-  KEY `forumcategory_FKIndex2` (`language_idlanguage`)
+  KEY `forumcategory_FKIndex2` (`language_id`)
 );
 
 CREATE TABLE `forumthread` (
@@ -116,7 +116,7 @@ CREATE TABLE `forumtopic` (
   `idforumtopic` int(10) NOT NULL AUTO_INCREMENT,
   `lastposter` int(10) NOT NULL DEFAULT 0,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `threads` int(10) DEFAULT NULL,
@@ -126,7 +126,7 @@ CREATE TABLE `forumtopic` (
   PRIMARY KEY (`idforumtopic`),
   KEY `forumtopic_FKIndex1` (`forumcategory_idforumcategory`),
   KEY `forumtopic_FKIndex2` (`lastposter`),
-  KEY `forumtopic_FKIndex3` (`language_idlanguage`)
+  KEY `forumtopic_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `imageboard` (
@@ -170,14 +170,14 @@ CREATE TABLE `imagepost_search` (
 );
 
 CREATE TABLE `language` (
-  `idlanguage` int(10) NOT NULL AUTO_INCREMENT,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
   `nameof` tinytext DEFAULT NULL,
-  PRIMARY KEY (`idlanguage`)
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) DEFAULT NULL,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
@@ -192,7 +192,7 @@ CREATE TABLE `linker` (
   KEY `linker_FKIndex1` (`forumthread_id`),
   KEY `linker_FKIndex2` (`linker_category_id`),
   KEY `linker_FKIndex3` (`users_idusers`),
-  KEY `linker_FKIndex4` (`language_idlanguage`)
+  KEY `linker_FKIndex4` (`language_id`)
 );
 
 CREATE TABLE `linker_category` (
@@ -205,7 +205,7 @@ CREATE TABLE `linker_category` (
 
 CREATE TABLE `linker_queue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
@@ -215,7 +215,7 @@ CREATE TABLE `linker_queue` (
   PRIMARY KEY (`idlinkerQueue`),
   KEY `linkerQueue_FKIndex1` (`linker_category_id`),
   KEY `linkerQueue_FKIndex2` (`users_idusers`),
-  KEY `linkerQueue_FKIndex3` (`language_idlanguage`)
+  KEY `linkerQueue_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `linker_search` (
@@ -265,7 +265,7 @@ CREATE TABLE `grants` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -273,7 +273,7 @@ CREATE TABLE `preferences` (
   `timezone` tinytext DEFAULT NULL,
   PRIMARY KEY (`idpreferences`),
   KEY `preferences_FKIndex1` (`users_idusers`),
-  KEY `preferences_FKIndex2` (`language_idlanguage`)
+  KEY `preferences_FKIndex2` (`language_id`)
 );
 
 CREATE TABLE `searchwordlist` (
@@ -294,7 +294,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `site_news` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occurred` datetime DEFAULT NULL,
@@ -302,7 +302,7 @@ CREATE TABLE `site_news` (
   `last_index` datetime DEFAULT NULL,
   PRIMARY KEY (`idsiteNews`),
   KEY `siteNews_FKIndex1` (`users_idusers`),
-  KEY `siteNews_FKIndex2` (`language_idlanguage`),
+  KEY `siteNews_FKIndex2` (`language_id`),
   KEY `siteNews_FKIndex3` (`forumthread_id`)
 );
 
@@ -319,9 +319,9 @@ CREATE TABLE `site_news_search` (
 CREATE TABLE `user_language` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   PRIMARY KEY (`iduserlang`),
-  KEY `userpref_FKIndex1` (`language_idlanguage`),
+  KEY `userpref_FKIndex1` (`language_id`),
   KEY `userpref_FKIndex2` (`users_idusers`)
 );
 
@@ -362,7 +362,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `writing_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,
@@ -373,7 +373,7 @@ CREATE TABLE `writing` (
   `last_index` datetime DEFAULT NULL,
   PRIMARY KEY (`idwriting`),
   KEY `writing_FKIndex1` (`writing_category_id`),
-  KEY `writing_FKIndex2` (`language_idlanguage`),
+  KEY `writing_FKIndex2` (`language_id`),
   KEY `writing_FKIndex3` (`forumthread_id`),
   KEY `writing_FKIndex4` (`users_idusers`)
 );
@@ -532,7 +532,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_comments` (
   `idcomments` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int DEFAULT NULL,
+  `language_id` int DEFAULT NULL,
   `written` datetime,
   `text` longtext,
   `timezone` tinytext DEFAULT NULL,
@@ -545,7 +545,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_writings` (
   `idwriting` int NOT NULL,
   `users_idusers` int NOT NULL,
   `forumthread_id` int NOT NULL,
-  `language_idlanguage` int DEFAULT NULL,
+  `language_id` int DEFAULT NULL,
   `writing_category_id` int NOT NULL,
   `title` tinytext,
   `published` datetime,
@@ -561,7 +561,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_blogs` (
   `idblogs` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int DEFAULT NULL,
+  `language_id` int DEFAULT NULL,
   `blog` longtext,
   `written` datetime,
   `timezone` tinytext DEFAULT NULL,
@@ -589,7 +589,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_imageposts` (
 
 CREATE TABLE IF NOT EXISTS `deactivated_linker` (
   `idlinker` int NOT NULL,
-  `language_idlanguage` int DEFAULT NULL,
+  `language_id` int DEFAULT NULL,
   `users_idusers` int NOT NULL,
   `linker_category_id` int DEFAULT NULL,
   `forumthread_id` int NOT NULL,

--- a/schema/schema.postgres.sql
+++ b/schema/schema.postgres.sql
@@ -2,14 +2,14 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `timezone` text DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
   `last_index` datetime DEFAULT NULL,
   PRIMARY KEY (`idblogs`),
-  KEY `blogs_FKIndex1` (`language_idlanguage`),
+  KEY `blogs_FKIndex1` (`language_id`),
   KEY `blogs_FKIndex2` (`users_idusers`),
   KEY `blogs_FKIndex3` (`forumthread_id`)
 );
@@ -35,14 +35,14 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   `timezone` text DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
   `last_index` datetime DEFAULT NULL,
   PRIMARY KEY (`idcomments`),
-  KEY `comments_FKIndex1` (`language_idlanguage`),
+  KEY `comments_FKIndex1` (`language_id`),
   KEY `comments_FKIndex2` (`users_idusers`),
   KEY `comments_FKIndex3` (`forumthread_id`)
 );
@@ -59,13 +59,13 @@ CREATE TABLE `comments_search` (
 CREATE TABLE `faq` (
   `id` int(10) NOT NULL AUTO_INCREMENT,
   `faq_category_id` int(10) DEFAULT NULL,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `Table_21_FKIndex1` (`users_idusers`),
-  KEY `Table_21_FKIndex2` (`language_idlanguage`),
+  KEY `Table_21_FKIndex2` (`language_id`),
   KEY `Table_21_FKIndex3` (`faq_category_id`)
 );
 
@@ -90,12 +90,12 @@ CREATE TABLE IF NOT EXISTS `faq_revisions` (
 CREATE TABLE `forumcategory` (
   `idforumcategory` int(10) NOT NULL AUTO_INCREMENT,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   PRIMARY KEY (`idforumcategory`),
   KEY `forumcategory_FKIndex1` (`forumcategory_idforumcategory`),
-  KEY `forumcategory_FKIndex2` (`language_idlanguage`)
+  KEY `forumcategory_FKIndex2` (`language_id`)
 );
 
 CREATE TABLE `forumthread` (
@@ -116,7 +116,7 @@ CREATE TABLE `forumtopic` (
   `idforumtopic` int(10) NOT NULL AUTO_INCREMENT,
   `lastposter` int(10) NOT NULL DEFAULT 0,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `threads` int(10) DEFAULT NULL,
@@ -126,7 +126,7 @@ CREATE TABLE `forumtopic` (
   PRIMARY KEY (`idforumtopic`),
   KEY `forumtopic_FKIndex1` (`forumcategory_idforumcategory`),
   KEY `forumtopic_FKIndex2` (`lastposter`),
-  KEY `forumtopic_FKIndex3` (`language_idlanguage`)
+  KEY `forumtopic_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `imageboard` (
@@ -169,14 +169,14 @@ CREATE TABLE `imagepost_search` (
 );
 
 CREATE TABLE `language` (
-  `idlanguage` int(10) NOT NULL AUTO_INCREMENT,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
   `nameof` tinytext DEFAULT NULL,
-  PRIMARY KEY (`idlanguage`)
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) DEFAULT NULL,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
@@ -191,7 +191,7 @@ CREATE TABLE `linker` (
   KEY `linker_FKIndex1` (`forumthread_id`),
   KEY `linker_FKIndex2` (`linker_category_id`),
   KEY `linker_FKIndex3` (`users_idusers`),
-  KEY `linker_FKIndex4` (`language_idlanguage`)
+  KEY `linker_FKIndex4` (`language_id`)
 );
 
 CREATE TABLE `linker_category` (
@@ -204,7 +204,7 @@ CREATE TABLE `linker_category` (
 
 CREATE TABLE `linker_queue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
@@ -214,7 +214,7 @@ CREATE TABLE `linker_queue` (
   PRIMARY KEY (`idlinkerQueue`),
   KEY `linkerQueue_FKIndex1` (`linker_category_id`),
   KEY `linkerQueue_FKIndex2` (`users_idusers`),
-  KEY `linkerQueue_FKIndex3` (`language_idlanguage`)
+  KEY `linkerQueue_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `linker_search` (
@@ -264,7 +264,7 @@ CREATE TABLE `grants` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -272,7 +272,7 @@ CREATE TABLE `preferences` (
   `timezone` text DEFAULT NULL,
   PRIMARY KEY (`idpreferences`),
   KEY `preferences_FKIndex1` (`users_idusers`),
-  KEY `preferences_FKIndex2` (`language_idlanguage`)
+  KEY `preferences_FKIndex2` (`language_id`)
 );
 
 CREATE TABLE `searchwordlist` (
@@ -293,7 +293,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `site_news` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occurred` datetime DEFAULT NULL,
@@ -301,7 +301,7 @@ CREATE TABLE `site_news` (
   `last_index` datetime DEFAULT NULL,
   PRIMARY KEY (`idsiteNews`),
   KEY `siteNews_FKIndex1` (`users_idusers`),
-  KEY `siteNews_FKIndex2` (`language_idlanguage`),
+  KEY `siteNews_FKIndex2` (`language_id`),
   KEY `siteNews_FKIndex3` (`forumthread_id`)
 );
 
@@ -318,9 +318,9 @@ CREATE TABLE `site_news_search` (
 CREATE TABLE `user_language` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   PRIMARY KEY (`iduserlang`),
-  KEY `userpref_FKIndex1` (`language_idlanguage`),
+  KEY `userpref_FKIndex1` (`language_id`),
   KEY `userpref_FKIndex2` (`users_idusers`)
 );
 
@@ -361,7 +361,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `writing_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,
@@ -372,7 +372,7 @@ CREATE TABLE `writing` (
   `last_index` datetime DEFAULT NULL,
   PRIMARY KEY (`idwriting`),
   KEY `writing_FKIndex1` (`writing_category_id`),
-  KEY `writing_FKIndex2` (`language_idlanguage`),
+  KEY `writing_FKIndex2` (`language_id`),
   KEY `writing_FKIndex3` (`forumthread_id`),
   KEY `writing_FKIndex4` (`users_idusers`)
 );
@@ -531,7 +531,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_comments` (
   `idcomments` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int DEFAULT NULL,
+  `language_id` int DEFAULT NULL,
   `written` datetime,
   `text` longtext,
   `timezone` text DEFAULT NULL,
@@ -544,7 +544,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_writings` (
   `idwriting` int NOT NULL,
   `users_idusers` int NOT NULL,
   `forumthread_id` int NOT NULL,
-  `language_idlanguage` int DEFAULT NULL,
+  `language_id` int DEFAULT NULL,
   `writing_category_id` int NOT NULL,
   `title` tinytext,
   `published` datetime,
@@ -560,7 +560,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_blogs` (
   `idblogs` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int DEFAULT NULL,
+  `language_id` int DEFAULT NULL,
   `blog` longtext,
   `written` datetime,
   `timezone` text DEFAULT NULL,
@@ -588,7 +588,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_imageposts` (
 
 CREATE TABLE IF NOT EXISTS `deactivated_linker` (
   `idlinker` int NOT NULL,
-  `language_idlanguage` int DEFAULT NULL,
+  `language_id` int DEFAULT NULL,
   `users_idusers` int NOT NULL,
   `linker_category_id` int DEFAULT NULL,
   `forumthread_id` int NOT NULL,

--- a/schema/schema.sqlite.sql
+++ b/schema/schema.sqlite.sql
@@ -2,14 +2,14 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `timezone` text,
   `deleted_at` datetime DEFAULT NULL,
   `last_index` datetime DEFAULT NULL,
   PRIMARY KEY (`idblogs`),
-  KEY `blogs_FKIndex1` (`language_idlanguage`),
+  KEY `blogs_FKIndex1` (`language_id`),
   KEY `blogs_FKIndex2` (`users_idusers`),
   KEY `blogs_FKIndex3` (`forumthread_id`)
 );
@@ -35,14 +35,14 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   `timezone` text,
   `deleted_at` datetime DEFAULT NULL,
   `last_index` datetime DEFAULT NULL,
   PRIMARY KEY (`idcomments`),
-  KEY `comments_FKIndex1` (`language_idlanguage`),
+  KEY `comments_FKIndex1` (`language_id`),
   KEY `comments_FKIndex2` (`users_idusers`),
   KEY `comments_FKIndex3` (`forumthread_id`)
 );
@@ -59,13 +59,13 @@ CREATE TABLE `comments_search` (
 CREATE TABLE `faq` (
   `id` int(10) NOT NULL AUTO_INCREMENT,
   `faq_category_id` int(10) DEFAULT NULL,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `Table_21_FKIndex1` (`users_idusers`),
-  KEY `Table_21_FKIndex2` (`language_idlanguage`),
+  KEY `Table_21_FKIndex2` (`language_id`),
   KEY `Table_21_FKIndex3` (`faq_category_id`)
 );
 
@@ -90,12 +90,12 @@ CREATE TABLE IF NOT EXISTS `faq_revisions` (
 CREATE TABLE `forumcategory` (
   `idforumcategory` int(10) NOT NULL AUTO_INCREMENT,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   PRIMARY KEY (`idforumcategory`),
   KEY `forumcategory_FKIndex1` (`forumcategory_idforumcategory`),
-  KEY `forumcategory_FKIndex2` (`language_idlanguage`)
+  KEY `forumcategory_FKIndex2` (`language_id`)
 );
 
 CREATE TABLE `forumthread` (
@@ -116,7 +116,7 @@ CREATE TABLE `forumtopic` (
   `idforumtopic` int(10) NOT NULL AUTO_INCREMENT,
   `lastposter` int(10) NOT NULL DEFAULT 0,
   `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `threads` int(10) DEFAULT NULL,
@@ -126,7 +126,7 @@ CREATE TABLE `forumtopic` (
   PRIMARY KEY (`idforumtopic`),
   KEY `forumtopic_FKIndex1` (`forumcategory_idforumcategory`),
   KEY `forumtopic_FKIndex2` (`lastposter`),
-  KEY `forumtopic_FKIndex3` (`language_idlanguage`)
+  KEY `forumtopic_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `imageboard` (
@@ -169,14 +169,14 @@ CREATE TABLE `imagepost_search` (
 );
 
 CREATE TABLE `language` (
-  `idlanguage` int(10) NOT NULL AUTO_INCREMENT,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
   `nameof` tinytext DEFAULT NULL,
-  PRIMARY KEY (`idlanguage`)
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) DEFAULT NULL,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
@@ -191,7 +191,7 @@ CREATE TABLE `linker` (
   KEY `linker_FKIndex1` (`forumthread_id`),
   KEY `linker_FKIndex2` (`linker_category_id`),
   KEY `linker_FKIndex3` (`users_idusers`),
-  KEY `linker_FKIndex4` (`language_idlanguage`)
+  KEY `linker_FKIndex4` (`language_id`)
 );
 
 CREATE TABLE `linker_category` (
@@ -204,7 +204,7 @@ CREATE TABLE `linker_category` (
 
 CREATE TABLE `linker_queue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linker_category_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
@@ -214,7 +214,7 @@ CREATE TABLE `linker_queue` (
   PRIMARY KEY (`idlinkerQueue`),
   KEY `linkerQueue_FKIndex1` (`linker_category_id`),
   KEY `linkerQueue_FKIndex2` (`users_idusers`),
-  KEY `linkerQueue_FKIndex3` (`language_idlanguage`)
+  KEY `linkerQueue_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `linker_search` (
@@ -264,7 +264,7 @@ CREATE TABLE `grants` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
@@ -272,7 +272,7 @@ CREATE TABLE `preferences` (
   `timezone` text DEFAULT NULL,
   PRIMARY KEY (`idpreferences`),
   KEY `preferences_FKIndex1` (`users_idusers`),
-  KEY `preferences_FKIndex2` (`language_idlanguage`)
+  KEY `preferences_FKIndex2` (`language_id`)
 );
 
 CREATE TABLE `searchwordlist` (
@@ -293,7 +293,7 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `site_news` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occurred` datetime DEFAULT NULL,
@@ -301,7 +301,7 @@ CREATE TABLE `site_news` (
   `last_index` datetime DEFAULT NULL,
   PRIMARY KEY (`idsiteNews`),
   KEY `siteNews_FKIndex1` (`users_idusers`),
-  KEY `siteNews_FKIndex2` (`language_idlanguage`),
+  KEY `siteNews_FKIndex2` (`language_id`),
   KEY `siteNews_FKIndex3` (`forumthread_id`)
 );
 
@@ -318,9 +318,9 @@ CREATE TABLE `site_news_search` (
 CREATE TABLE `user_language` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   PRIMARY KEY (`iduserlang`),
-  KEY `userpref_FKIndex1` (`language_idlanguage`),
+  KEY `userpref_FKIndex1` (`language_id`),
   KEY `userpref_FKIndex2` (`users_idusers`)
 );
 
@@ -361,7 +361,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_id` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `language_id` int(10) DEFAULT NULL,
   `writing_category_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,
@@ -372,7 +372,7 @@ CREATE TABLE `writing` (
   `last_index` datetime DEFAULT NULL,
   PRIMARY KEY (`idwriting`),
   KEY `writing_FKIndex1` (`writing_category_id`),
-  KEY `writing_FKIndex2` (`language_idlanguage`),
+  KEY `writing_FKIndex2` (`language_id`),
   KEY `writing_FKIndex3` (`forumthread_id`),
   KEY `writing_FKIndex4` (`users_idusers`)
 );
@@ -531,7 +531,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_comments` (
   `idcomments` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int DEFAULT NULL,
+  `language_id` int DEFAULT NULL,
   `written` datetime,
   `text` longtext,
   `timezone` text,
@@ -544,7 +544,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_writings` (
   `idwriting` int NOT NULL,
   `users_idusers` int NOT NULL,
   `forumthread_id` int NOT NULL,
-  `language_idlanguage` int DEFAULT NULL,
+  `language_id` int DEFAULT NULL,
   `writing_category_id` int NOT NULL,
   `title` tinytext,
   `published` datetime,
@@ -560,7 +560,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_blogs` (
   `idblogs` int NOT NULL,
   `forumthread_id` int NOT NULL,
   `users_idusers` int NOT NULL,
-  `language_idlanguage` int DEFAULT NULL,
+  `language_id` int DEFAULT NULL,
   `blog` longtext,
   `written` datetime,
   `timezone` text,
@@ -588,7 +588,7 @@ CREATE TABLE IF NOT EXISTS `deactivated_imageposts` (
 
 CREATE TABLE IF NOT EXISTS `deactivated_linker` (
   `idlinker` int NOT NULL,
-  `language_idlanguage` int DEFAULT NULL,
+  `language_id` int DEFAULT NULL,
   `users_idusers` int NOT NULL,
   `linker_category_id` int DEFAULT NULL,
   `forumthread_id` int NOT NULL,

--- a/testdata/schema/original.mysql.sql
+++ b/testdata/schema/original.mysql.sql
@@ -18,11 +18,11 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT NOW(),
   PRIMARY KEY (`idblogs`),
-  KEY `blogs_FKIndex1` (`language_idlanguage`),
+  KEY `blogs_FKIndex1` (`language_id`),
   KEY `blogs_FKIndex2` (`users_idusers`),
   KEY `blogs_FKIndex3` (`forumthread_idforumthread`)
 );
@@ -47,11 +47,11 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   PRIMARY KEY (`idcomments`),
-  KEY `comments_FKIndex1` (`language_idlanguage`),
+  KEY `comments_FKIndex1` (`language_id`),
   KEY `comments_FKIndex2` (`users_idusers`),
   KEY `comments_FKIndex3` (`forumthread_idforumthread`)
 );
@@ -67,13 +67,13 @@ CREATE TABLE `commentsSearch` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
   PRIMARY KEY (`idfaq`),
   KEY `Table_21_FKIndex1` (`users_idusers`),
-  KEY `Table_21_FKIndex2` (`language_idlanguage`),
+  KEY `Table_21_FKIndex2` (`language_id`),
   KEY `Table_21_FKIndex3` (`faqCategories_idfaqCategories`)
 );
 
@@ -156,14 +156,14 @@ CREATE TABLE `imagepostSearch` (
 );
 
 CREATE TABLE `language` (
-  `idlanguage` int(10) NOT NULL AUTO_INCREMENT,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
   `nameof` tinytext DEFAULT NULL,
-  PRIMARY KEY (`idlanguage`)
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
@@ -175,7 +175,7 @@ CREATE TABLE `linker` (
   KEY `linker_FKIndex1` (`forumthread_idforumthread`),
   KEY `linker_FKIndex2` (`linkerCategory_idlinkerCategory`),
   KEY `linker_FKIndex3` (`users_idusers`),
-  KEY `linker_FKIndex4` (`language_idlanguage`)
+  KEY `linker_FKIndex4` (`language_id`)
 );
 
 CREATE TABLE `linkerCategory` (
@@ -188,7 +188,7 @@ CREATE TABLE `linkerCategory` (
 
 CREATE TABLE `linkerQueue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -197,7 +197,7 @@ CREATE TABLE `linkerQueue` (
   PRIMARY KEY (`idlinkerQueue`),
   KEY `linkerQueue_FKIndex1` (`linkerCategory_idlinkerCategory`),
   KEY `linkerQueue_FKIndex2` (`users_idusers`),
-  KEY `linkerQueue_FKIndex3` (`language_idlanguage`)
+  KEY `linkerQueue_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `linkerSearch` (
@@ -219,13 +219,13 @@ CREATE TABLE `permissions` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
   PRIMARY KEY (`idpreferences`),
   KEY `preferences_FKIndex1` (`users_idusers`),
-  KEY `preferences_FKIndex2` (`language_idlanguage`)
+  KEY `preferences_FKIndex2` (`language_id`)
 );
 
 CREATE TABLE `searchwordlist` (
@@ -245,13 +245,13 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `siteNews` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occured` datetime DEFAULT NULL,
   PRIMARY KEY (`idsiteNews`),
   KEY `siteNews_FKIndex1` (`users_idusers`),
-  KEY `siteNews_FKIndex2` (`language_idlanguage`),
+  KEY `siteNews_FKIndex2` (`language_id`),
   KEY `siteNews_FKIndex3` (`forumthread_idforumthread`)
 );
 
@@ -279,9 +279,9 @@ CREATE TABLE `topicrestrictions` (
 CREATE TABLE `userlang` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   PRIMARY KEY (`iduserlang`),
-  KEY `userpref_FKIndex1` (`language_idlanguage`),
+  KEY `userpref_FKIndex1` (`language_id`),
   KEY `userpref_FKIndex2` (`users_idusers`)
 );
 
@@ -309,7 +309,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `writingCategory_idwritingCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,
@@ -318,7 +318,7 @@ CREATE TABLE `writing` (
   `private` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`idwriting`),
   KEY `writing_FKIndex1` (`writingCategory_idwritingCategory`),
-  KEY `writing_FKIndex2` (`language_idlanguage`),
+  KEY `writing_FKIndex2` (`language_id`),
   KEY `writing_FKIndex3` (`forumthread_idforumthread`),
   KEY `writing_FKIndex4` (`users_idusers`)
 );

--- a/testdata/schema/original.postgres.sql
+++ b/testdata/schema/original.postgres.sql
@@ -18,11 +18,11 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT NOW(),
   PRIMARY KEY (`idblogs`),
-  KEY `blogs_FKIndex1` (`language_idlanguage`),
+  KEY `blogs_FKIndex1` (`language_id`),
   KEY `blogs_FKIndex2` (`users_idusers`),
   KEY `blogs_FKIndex3` (`forumthread_idforumthread`)
 );
@@ -47,11 +47,11 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   PRIMARY KEY (`idcomments`),
-  KEY `comments_FKIndex1` (`language_idlanguage`),
+  KEY `comments_FKIndex1` (`language_id`),
   KEY `comments_FKIndex2` (`users_idusers`),
   KEY `comments_FKIndex3` (`forumthread_idforumthread`)
 );
@@ -67,13 +67,13 @@ CREATE TABLE `commentsSearch` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
   PRIMARY KEY (`idfaq`),
   KEY `Table_21_FKIndex1` (`users_idusers`),
-  KEY `Table_21_FKIndex2` (`language_idlanguage`),
+  KEY `Table_21_FKIndex2` (`language_id`),
   KEY `Table_21_FKIndex3` (`faqCategories_idfaqCategories`)
 );
 
@@ -156,14 +156,14 @@ CREATE TABLE `imagepostSearch` (
 );
 
 CREATE TABLE `language` (
-  `idlanguage` int(10) NOT NULL AUTO_INCREMENT,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
   `nameof` tinytext DEFAULT NULL,
-  PRIMARY KEY (`idlanguage`)
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
@@ -175,7 +175,7 @@ CREATE TABLE `linker` (
   KEY `linker_FKIndex1` (`forumthread_idforumthread`),
   KEY `linker_FKIndex2` (`linkerCategory_idlinkerCategory`),
   KEY `linker_FKIndex3` (`users_idusers`),
-  KEY `linker_FKIndex4` (`language_idlanguage`)
+  KEY `linker_FKIndex4` (`language_id`)
 );
 
 CREATE TABLE `linkerCategory` (
@@ -188,7 +188,7 @@ CREATE TABLE `linkerCategory` (
 
 CREATE TABLE `linkerQueue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -197,7 +197,7 @@ CREATE TABLE `linkerQueue` (
   PRIMARY KEY (`idlinkerQueue`),
   KEY `linkerQueue_FKIndex1` (`linkerCategory_idlinkerCategory`),
   KEY `linkerQueue_FKIndex2` (`users_idusers`),
-  KEY `linkerQueue_FKIndex3` (`language_idlanguage`)
+  KEY `linkerQueue_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `linkerSearch` (
@@ -219,13 +219,13 @@ CREATE TABLE `permissions` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
   PRIMARY KEY (`idpreferences`),
   KEY `preferences_FKIndex1` (`users_idusers`),
-  KEY `preferences_FKIndex2` (`language_idlanguage`)
+  KEY `preferences_FKIndex2` (`language_id`)
 );
 
 CREATE TABLE `searchwordlist` (
@@ -245,13 +245,13 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `siteNews` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occured` datetime DEFAULT NULL,
   PRIMARY KEY (`idsiteNews`),
   KEY `siteNews_FKIndex1` (`users_idusers`),
-  KEY `siteNews_FKIndex2` (`language_idlanguage`),
+  KEY `siteNews_FKIndex2` (`language_id`),
   KEY `siteNews_FKIndex3` (`forumthread_idforumthread`)
 );
 
@@ -279,9 +279,9 @@ CREATE TABLE `topicrestrictions` (
 CREATE TABLE `userlang` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   PRIMARY KEY (`iduserlang`),
-  KEY `userpref_FKIndex1` (`language_idlanguage`),
+  KEY `userpref_FKIndex1` (`language_id`),
   KEY `userpref_FKIndex2` (`users_idusers`)
 );
 
@@ -309,7 +309,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `writingCategory_idwritingCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,
@@ -318,7 +318,7 @@ CREATE TABLE `writing` (
   `private` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`idwriting`),
   KEY `writing_FKIndex1` (`writingCategory_idwritingCategory`),
-  KEY `writing_FKIndex2` (`language_idlanguage`),
+  KEY `writing_FKIndex2` (`language_id`),
   KEY `writing_FKIndex3` (`forumthread_idforumthread`),
   KEY `writing_FKIndex4` (`users_idusers`)
 );

--- a/testdata/schema/original.sqlite.sql
+++ b/testdata/schema/original.sqlite.sql
@@ -18,11 +18,11 @@ CREATE TABLE `blogs` (
   `idblogs` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `blog` longtext DEFAULT NULL,
   `written` DATETIME NOT NULL DEFAULT NOW(),
   PRIMARY KEY (`idblogs`),
-  KEY `blogs_FKIndex1` (`language_idlanguage`),
+  KEY `blogs_FKIndex1` (`language_id`),
   KEY `blogs_FKIndex2` (`users_idusers`),
   KEY `blogs_FKIndex3` (`forumthread_idforumthread`)
 );
@@ -47,11 +47,11 @@ CREATE TABLE `comments` (
   `idcomments` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `written` datetime DEFAULT NULL,
   `text` longtext DEFAULT NULL,
   PRIMARY KEY (`idcomments`),
-  KEY `comments_FKIndex1` (`language_idlanguage`),
+  KEY `comments_FKIndex1` (`language_id`),
   KEY `comments_FKIndex2` (`users_idusers`),
   KEY `comments_FKIndex3` (`forumthread_idforumthread`)
 );
@@ -67,13 +67,13 @@ CREATE TABLE `commentsSearch` (
 CREATE TABLE `faq` (
   `idfaq` int(10) NOT NULL AUTO_INCREMENT,
   `faqCategories_idfaqCategories` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `answer` mediumtext DEFAULT NULL,
   `question` mediumtext DEFAULT NULL,
   PRIMARY KEY (`idfaq`),
   KEY `Table_21_FKIndex1` (`users_idusers`),
-  KEY `Table_21_FKIndex2` (`language_idlanguage`),
+  KEY `Table_21_FKIndex2` (`language_id`),
   KEY `Table_21_FKIndex3` (`faqCategories_idfaqCategories`)
 );
 
@@ -156,14 +156,14 @@ CREATE TABLE `imagepostSearch` (
 );
 
 CREATE TABLE `language` (
-  `idlanguage` int(10) NOT NULL AUTO_INCREMENT,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
   `nameof` tinytext DEFAULT NULL,
-  PRIMARY KEY (`idlanguage`)
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `linker` (
   `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
@@ -175,7 +175,7 @@ CREATE TABLE `linker` (
   KEY `linker_FKIndex1` (`forumthread_idforumthread`),
   KEY `linker_FKIndex2` (`linkerCategory_idlinkerCategory`),
   KEY `linker_FKIndex3` (`users_idusers`),
-  KEY `linker_FKIndex4` (`language_idlanguage`)
+  KEY `linker_FKIndex4` (`language_id`)
 );
 
 CREATE TABLE `linkerCategory` (
@@ -188,7 +188,7 @@ CREATE TABLE `linkerCategory` (
 
 CREATE TABLE `linkerQueue` (
   `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `linkerCategory_idlinkerCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
@@ -197,7 +197,7 @@ CREATE TABLE `linkerQueue` (
   PRIMARY KEY (`idlinkerQueue`),
   KEY `linkerQueue_FKIndex1` (`linkerCategory_idlinkerCategory`),
   KEY `linkerQueue_FKIndex2` (`users_idusers`),
-  KEY `linkerQueue_FKIndex3` (`language_idlanguage`)
+  KEY `linkerQueue_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `linkerSearch` (
@@ -219,13 +219,13 @@ CREATE TABLE `permissions` (
 
 CREATE TABLE `preferences` (
   `idpreferences` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `emailforumupdates` tinyint(1) DEFAULT 0,
   `page_size` int(10) NOT NULL DEFAULT 15,
   PRIMARY KEY (`idpreferences`),
   KEY `preferences_FKIndex1` (`users_idusers`),
-  KEY `preferences_FKIndex2` (`language_idlanguage`)
+  KEY `preferences_FKIndex2` (`language_id`)
 );
 
 CREATE TABLE `searchwordlist` (
@@ -245,13 +245,13 @@ CREATE TABLE `searchwordlist_has_linker` (
 CREATE TABLE `siteNews` (
   `idsiteNews` int(10) NOT NULL AUTO_INCREMENT,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `news` longtext DEFAULT NULL,
   `occured` datetime DEFAULT NULL,
   PRIMARY KEY (`idsiteNews`),
   KEY `siteNews_FKIndex1` (`users_idusers`),
-  KEY `siteNews_FKIndex2` (`language_idlanguage`),
+  KEY `siteNews_FKIndex2` (`language_id`),
   KEY `siteNews_FKIndex3` (`forumthread_idforumthread`)
 );
 
@@ -279,9 +279,9 @@ CREATE TABLE `topicrestrictions` (
 CREATE TABLE `userlang` (
   `iduserlang` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   PRIMARY KEY (`iduserlang`),
-  KEY `userpref_FKIndex1` (`language_idlanguage`),
+  KEY `userpref_FKIndex1` (`language_id`),
   KEY `userpref_FKIndex2` (`users_idusers`)
 );
 
@@ -309,7 +309,7 @@ CREATE TABLE `writing` (
   `idwriting` int(10) NOT NULL AUTO_INCREMENT,
   `users_idusers` int(10) NOT NULL DEFAULT 0,
   `forumthread_idforumthread` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) NOT NULL DEFAULT 0,
   `writingCategory_idwritingCategory` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `published` datetime DEFAULT NULL,
@@ -318,7 +318,7 @@ CREATE TABLE `writing` (
   `private` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`idwriting`),
   KEY `writing_FKIndex1` (`writingCategory_idwritingCategory`),
-  KEY `writing_FKIndex2` (`language_idlanguage`),
+  KEY `writing_FKIndex2` (`language_id`),
   KEY `writing_FKIndex3` (`forumthread_idforumthread`),
   KEY `writing_FKIndex4` (`users_idusers`)
 );


### PR DESCRIPTION
## Summary
- rename language primary key to `id` and update references to `language_id`
- adjust schema and SQL queries for new column names
- bump expected schema version and regenerate sqlc models

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689989bc35bc832fa6feceb4a835b168