### PR TITLE
refactor: normalize linker table columns

### DIFF
--- a/cmd/goa4web/links_activate.go
+++ b/cmd/goa4web/links_activate.go
@@ -57,7 +57,7 @@ func (c *linksActivateCmd) Run() error {
 	if found == nil {
 		return fmt.Errorf("link %d not found", c.ID)
 	}
-	if err := queries.AdminRestoreLink(ctx, db.AdminRestoreLinkParams{Title: found.Title, Url: found.Url, Description: found.Description, Idlinker: found.Idlinker}); err != nil {
+	if err := queries.AdminRestoreLink(ctx, db.AdminRestoreLinkParams{Title: found.Title, Url: found.Url, Description: found.Description, ID: found.Idlinker}); err != nil {
 		return fmt.Errorf("restore link: %w", err)
 	}
 	if err := queries.AdminMarkLinkRestored(ctx, found.Idlinker); err != nil {

--- a/cmd/goa4web/links_deactivate.go
+++ b/cmd/goa4web/links_deactivate.go
@@ -40,7 +40,7 @@ func (c *linksDeactivateCmd) Run() error {
 	if err != nil {
 		return fmt.Errorf("fetch link: %w", err)
 	}
-	deactivated, err := queries.AdminIsLinkDeactivated(ctx, l.Idlinker)
+	deactivated, err := queries.AdminIsLinkDeactivated(ctx, l.ID)
 	if err != nil {
 		return fmt.Errorf("check deactivated: %w", err)
 	}
@@ -48,11 +48,11 @@ func (c *linksDeactivateCmd) Run() error {
 		return fmt.Errorf("link already deactivated")
 	}
 	if err := queries.AdminArchiveLink(ctx, db.AdminArchiveLinkParams{
-		Idlinker:           l.Idlinker,
-		LanguageIdlanguage: l.LanguageIdlanguage,
-		UsersIdusers:       l.UsersIdusers,
-		LinkerCategoryID:   l.LinkerCategoryID,
-		ForumthreadID:      l.ForumthreadID,
+		Idlinker:           l.ID,
+		LanguageIdlanguage: l.LanguageID,
+		UsersIdusers:       l.AuthorID,
+		LinkerCategoryID:   l.CategoryID,
+		ForumthreadID:      l.ThreadID,
 		Title:              l.Title,
 		Url:                l.Url,
 		Description:        l.Description,
@@ -60,7 +60,7 @@ func (c *linksDeactivateCmd) Run() error {
 	}); err != nil {
 		return fmt.Errorf("archive link: %w", err)
 	}
-	if err := queries.AdminScrubLink(ctx, db.AdminScrubLinkParams{Title: sql.NullString{String: "", Valid: true}, Idlinker: l.Idlinker}); err != nil {
+	if err := queries.AdminScrubLink(ctx, db.AdminScrubLinkParams{Title: sql.NullString{String: "", Valid: true}, ID: l.ID}); err != nil {
 		return fmt.Errorf("scrub link: %w", err)
 	}
 	return nil

--- a/cmd/goa4web/user_activate.go
+++ b/cmd/goa4web/user_activate.go
@@ -134,7 +134,7 @@ func (c *userActivateCmd) Run() error {
 		return fmt.Errorf("select links: %w", err)
 	}
 	for _, l := range rowsL {
-		if err := qtx.AdminRestoreLink(ctx, db.AdminRestoreLinkParams{Title: l.Title, Url: l.Url, Description: l.Description, Idlinker: l.Idlinker}); err != nil {
+		if err := qtx.AdminRestoreLink(ctx, db.AdminRestoreLinkParams{Title: l.Title, Url: l.Url, Description: l.Description, ID: l.Idlinker}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("restore link: %w", err)
 		}

--- a/cmd/goa4web/user_deactivate.go
+++ b/cmd/goa4web/user_deactivate.go
@@ -217,27 +217,27 @@ func (c *userDeactivateCmd) Run() error {
 			return fmt.Errorf("scrub imagepost: %w", err)
 		}
 	}
-	links, err := qtx.GetLinkerItemsByUserDescending(ctx, db.GetLinkerItemsByUserDescendingParams{UsersIdusers: u.Idusers, Limit: math.MaxInt32, Offset: 0})
+	links, err := qtx.GetLinkerItemsByUserDescending(ctx, db.GetLinkerItemsByUserDescendingParams{AuthorID: u.Idusers, Limit: math.MaxInt32, Offset: 0})
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("list links: %w", err)
 	}
 	for _, l := range links {
-		deactivated, err := qtx.AdminIsLinkDeactivated(ctx, l.Idlinker)
+		deactivated, err := qtx.AdminIsLinkDeactivated(ctx, l.ID)
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("check link deactivated: %w", err)
 		}
 		if deactivated {
 			tx.Rollback()
-			return fmt.Errorf("link %d already deactivated", l.Idlinker)
+			return fmt.Errorf("link %d already deactivated", l.ID)
 		}
 		if err := qtx.AdminArchiveLink(ctx, db.AdminArchiveLinkParams{
-			Idlinker:           l.Idlinker,
-			LanguageIdlanguage: l.LanguageIdlanguage,
-			UsersIdusers:       l.UsersIdusers,
-			LinkerCategoryID:   l.LinkerCategoryID,
-			ForumthreadID:      l.ForumthreadID,
+			Idlinker:           l.ID,
+			LanguageIdlanguage: l.LanguageID,
+			UsersIdusers:       l.AuthorID,
+			LinkerCategoryID:   l.CategoryID,
+			ForumthreadID:      l.ThreadID,
 			Title:              l.Title,
 			Url:                l.Url,
 			Description:        l.Description,
@@ -247,7 +247,7 @@ func (c *userDeactivateCmd) Run() error {
 			tx.Rollback()
 			return fmt.Errorf("archive link: %w", err)
 		}
-		if err := qtx.AdminScrubLink(ctx, db.AdminScrubLinkParams{Title: sql.NullString{String: scrubText(l.Title.String), Valid: l.Title.Valid}, Idlinker: l.Idlinker}); err != nil {
+		if err := qtx.AdminScrubLink(ctx, db.AdminScrubLinkParams{Title: sql.NullString{String: scrubText(l.Title.String), Valid: l.Title.Valid}, ID: l.ID}); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("scrub link: %w", err)
 		}

--- a/core/common/breadcrumb.go
+++ b/core/common/breadcrumb.go
@@ -150,12 +150,12 @@ func (cd *CoreData) linkerBreadcrumbs() ([]Breadcrumb, error) {
 			return nil, err
 		}
 		for _, row := range rows {
-			title := fmt.Sprintf("Category %d", row.Idlinkercategory)
+			title := fmt.Sprintf("Category %d", row.ID)
 			if row.Title.Valid {
 				title = row.Title.String
 			}
-			link := fmt.Sprintf("/linker/category/%d", row.Idlinkercategory)
-			if row.Idlinkercategory == catID {
+			link := fmt.Sprintf("/linker/category/%d", row.ID)
+			if row.ID == catID {
 				crumbs = append(crumbs, Breadcrumb{Title: title})
 			} else {
 				crumbs = append(crumbs, Breadcrumb{Title: title, Link: link})

--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -1432,18 +1432,18 @@ func (cd *CoreData) LinkerItemsForUser(catID, offset int32) ([]*db.GetAllLinkerI
 		return nil, nil
 	}
 	rows, err := cd.queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginated(cd.ctx, db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedParams{
-		ViewerID:         cd.UserID,
-		Idlinkercategory: catID,
-		ViewerUserID:     sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
-		Limit:            int32(cd.PageSize()),
-		Offset:           offset,
+		ViewerID:     cd.UserID,
+		CategoryID:   catID,
+		ViewerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		Limit:        int32(cd.PageSize()),
+		Offset:       offset,
 	})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
 	}
 	var out []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow
 	for _, row := range rows {
-		if cd.HasGrant("linker", "link", "see", row.Idlinker) {
+		if cd.HasGrant("linker", "link", "see", row.ID) {
 			out = append(out, row)
 		}
 	}
@@ -1456,7 +1456,7 @@ func (cd *CoreData) LinkerLinksByCategoryID(id int32, ops ...lazy.Option[[]*db.G
 		if cd.queries == nil {
 			return nil, nil
 		}
-		rows, err := cd.queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(cd.ctx, db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: i})
+		rows, err := cd.queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(cd.ctx, db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{CategoryID: i})
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return nil, err
 		}

--- a/core/templates/site/admin/usageStatsPage.gohtml
+++ b/core/templates/site/admin/usageStatsPage.gohtml
@@ -61,8 +61,8 @@
     <tr><th>ID</th><th>Category</th><th>Links</th></tr>
     {{- range .LinkerCategories }}
     <tr>
-        <td><a href="/admin/linker/categories/category/{{ .Idlinkercategory }}">{{ .Idlinkercategory }}</a></td>
-        <td><a href="/linker/category/{{ .Idlinkercategory }}">{{ .Title.String }}</a></td>
+        <td><a href="/admin/linker/categories/category/{{ .ID }}">{{ .ID }}</a></td>
+        <td><a href="/linker/category/{{ .ID }}">{{ .Title.String }}</a></td>
         <td>{{ .Linkcount }}</td>
     </tr>
     {{- end }}

--- a/core/templates/site/admin/userLinkerPage.gohtml
+++ b/core/templates/site/admin/userLinkerPage.gohtml
@@ -4,11 +4,11 @@
     <tr><th>ID</th><th>Date</th><th>Title</th><th>URL</th><th>View</th></tr>
     {{- range .Links }}
     <tr>
-        <td><a href="/admin/linker/links/link/{{ .Idlinker }}">{{ .Idlinker }}</a></td>
+        <td><a href="/admin/linker/links/link/{{ .ID }}">{{ .ID }}</a></td>
         <td>{{ if .Listed.Valid }}{{ localTimeIn .Listed.Time .Timezone.String }}{{ end }}</td>
         <td>{{ if .Title.Valid }}{{ .Title.String }}{{ end }}</td>
         <td>{{ if .Url.Valid }}<a href="{{ .Url.String }}" target="_blank">{{ .Url.String }}</a>{{ end }}</td>
-        <td><a href="/linker/show/{{ .Idlinker }}">View</a></td>
+        <td><a href="/linker/show/{{ .ID }}">View</a></td>
     </tr>
     {{- end }}
 </table>

--- a/core/templates/site/categoryCombobox.gohtml
+++ b/core/templates/site/categoryCombobox.gohtml
@@ -2,7 +2,7 @@
     Please select appropriate category:
     <select name="category">
         {{- range cd.LinkerCategories }}
-            <option value="{{ .Idlinkercategory }}"{{ if eq .Idlinkercategory $.Selected }} selected{{ end }}>{{ .Title.String }}</option>
+            <option value="{{ .ID }}"{{ if eq .ID $.Selected }} selected{{ end }}>{{ .Title.String }}</option>
         {{- else }}
             <option disabled>No categories</option>
         {{- end }}

--- a/core/templates/site/linker/adminLinkViewPage.gohtml
+++ b/core/templates/site/linker/adminLinkViewPage.gohtml
@@ -6,8 +6,8 @@
     <p><strong>Poster:</strong> {{ .Link.Username.String }}</p>
     <p><strong>Listed:</strong> {{ if .Link.Listed.Valid }}{{ localTimeIn .Link.Listed.Time .Link.Timezone.String }}{{ end }}</p>
     <p>
-        <a href="/admin/linker/links/link/{{ .Link.Idlinker }}/edit">Edit</a> |
-        <a href="/admin/linker/links/link/{{ .Link.Idlinker }}/grants">Permissions</a> |
-        <a href="/admin/linker/links/link/{{ .Link.Idlinker }}/comments">Comments</a>
+        <a href="/admin/linker/links/link/{{ .Link.ID }}/edit">Edit</a> |
+        <a href="/admin/linker/links/link/{{ .Link.ID }}/grants">Permissions</a> |
+        <a href="/admin/linker/links/link/{{ .Link.ID }}/comments">Comments</a>
     </p>
 {{ template "tail" $ }}

--- a/core/templates/site/linker/adminQueuePage.gohtml
+++ b/core/templates/site/linker/adminQueuePage.gohtml
@@ -21,18 +21,18 @@
         </tr>
         {{- range .Queue }}
             <tr>
-                <td><input type="checkbox" name="qid" value="{{ .Idlinkerqueue }}"></td>
-                <td>{{ .Idlinkerqueue }}</td>
-                <td><input name="title" form="u{{ .Idlinkerqueue }}" value="{{ .Title.String }}"></td>
-                <td><input name="URL" form="u{{ .Idlinkerqueue }}" value="{{ .URL.String }}"></td>
-                <td><textarea name="desc" form="u{{ .Idlinkerqueue }}">{{ .Description.String }}</textarea></td>
+                <td><input type="checkbox" name="qid" value="{{ .ID }}"></td>
+                <td>{{ .ID }}</td>
+                <td><input name="title" form="u{{ .ID }}" value="{{ .Title.String }}"></td>
+                <td><input name="URL" form="u{{ .ID }}" value="{{ .URL.String }}"></td>
+                <td><textarea name="desc" form="u{{ .ID }}">{{ .Description.String }}</textarea></td>
                 <td>{{ .Username.String }}</td>
-                <td><input type="hidden" name="category" form="u{{ .Idlinkerqueue }}" value="{{ .IdlinkerCategory }}">{{ .CategoryTitle.String }}</td>
+                <td><input type="hidden" name="category" form="u{{ .ID }}" value="{{ .CategoryID }}">{{ .CategoryTitle.String }}</td>
                 <td>{{ .Preview }}</td>
                 <td>
-                    <form method="post" id="u{{ .Idlinkerqueue }}">
+                    <form method="post" id="u{{ .ID }}">
         {{ csrfField }}
-                        <input type="hidden" name="qid" value="{{ .Idlinkerqueue }}">
+                        <input type="hidden" name="qid" value="{{ .ID }}">
                         <input type="submit" name="task" value="Update">
                     </form>
                 </td>

--- a/core/templates/site/linker/linkerAdminCategoriesPage.gohtml
+++ b/core/templates/site/linker/linkerAdminCategoriesPage.gohtml
@@ -9,11 +9,11 @@
         </tr>
         {{- range .Categories }}
             <tr>
-                <td><a id="lc{{ .Idlinkercategory }}" href="/admin/linker/categories/category/{{ .Idlinkercategory }}">{{ .Idlinkercategory }}</a></td>
+                <td><a id="lc{{ .ID }}" href="/admin/linker/categories/category/{{ .ID }}">{{ .ID }}</a></td>
                 <td>
                     <form method="post">
         {{ csrfField }}
-                        <input type="hidden" name="cid" value="{{ .Idlinkercategory }}">
+                        <input type="hidden" name="cid" value="{{ .ID }}">
                         <input type="number" name="position" value="{{ .Position }}" size="3">
                 </td>
                 <td><input name="title" value="{{ .Title.String }}"></td>
@@ -21,8 +21,8 @@
                 <td>
                     <input type="submit" name="task" value="Update">
                     {{ if eq .Linkcount 0 }}<input type="submit" name="task" value="Delete Category">{{ end }}<br>
-                    <a href="/admin/linker/categories/category/{{ .Idlinkercategory }}/grants">Permissions</a>
-                    <a href="/linker/category/{{ .Idlinkercategory }}">View</a>
+                    <a href="/admin/linker/categories/category/{{ .ID }}/grants">Permissions</a>
+                    <a href="/linker/category/{{ .ID }}">View</a>
                     </form>
                 </td>
             </tr>

--- a/core/templates/site/linker/linkerAdminCategoryEditPage.gohtml
+++ b/core/templates/site/linker/linkerAdminCategoryEditPage.gohtml
@@ -1,9 +1,9 @@
 {{ template "head" $ }}
 {{ with .Category }}
-<h2>Edit Category {{ .Idlinkercategory }}</h2>
+<h2>Edit Category {{ .ID }}</h2>
 <form method="post" action="/admin/linker/categories">
 {{ csrfField }}
-<input type="hidden" name="cid" value="{{ .Idlinkercategory }}">
+<input type="hidden" name="cid" value="{{ .ID }}">
 <label>Title: <input name="title" value="{{ .Title.String }}"></label><br>
 <label>Position: <input type="number" name="position" value="{{ .Position }}"></label><br>
 <label>Order: <input type="number" name="order" value="{{ .Sortorder }}"></label><br>
@@ -11,9 +11,9 @@
 </form>
 <form method="post" action="/admin/linker/categories" style="margin-top:1em;">
 {{ csrfField }}
-<input type="hidden" name="cid" value="{{ .Idlinkercategory }}">
+<input type="hidden" name="cid" value="{{ .ID }}">
 <input type="submit" name="task" value="Delete Category">
 </form>
-<p><a href="/admin/linker/categories/category/{{ .Idlinkercategory }}/grants">Permissions</a></p>
+<p><a href="/admin/linker/categories/category/{{ .ID }}/grants">Permissions</a></p>
 {{ end }}
 {{ template "tail" $ }}

--- a/core/templates/site/linker/linkerAdminCategoryPage.gohtml
+++ b/core/templates/site/linker/linkerAdminCategoryPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 {{ with cd.SelectedLinkerCategory .CategoryID }}
-<h2>Linker Category {{ .Idlinkercategory }} - {{ .Title.String }}</h2>
+<h2>Linker Category {{ .ID }} - {{ .Title.String }}</h2>
 <p>Order: {{ .Position }}</p>
 {{ end }}
 <p>
@@ -18,11 +18,11 @@
     </tr>
     {{ range cd.LinkerLinksByCategoryID .CategoryID }}
     <tr>
-        <td><a href="/admin/linker/links/link/{{ .Idlinker }}">{{ .Idlinker }}</a></td>
+        <td><a href="/admin/linker/links/link/{{ .ID }}">{{ .ID }}</a></td>
         <td>{{ .Title.String }}</td>
         <td><a href="{{ .Url.String }}">{{ .Url.String }}</a></td>
         <td>{{ .Posterusername.String }}</td>
-        <td><a href="/linker/show/{{ .Idlinker }}">View</a></td>
+        <td><a href="/linker/show/{{ .ID }}">View</a></td>
     </tr>
     {{ else }}
     <tr>

--- a/core/templates/site/linker/linkerAdminLinksPage.gohtml
+++ b/core/templates/site/linker/linkerAdminLinksPage.gohtml
@@ -1,16 +1,16 @@
 {{ template "head" $ }}
 <h2>All Links</h2>
 {{- range cd.LinkerCategories }}
-<h3>{{ .Title.String }} ({{ .Idlinkercategory }})</h3>
+<h3>{{ .Title.String }} ({{ .ID }})</h3>
 <table border="1">
     <tr><th>ID</th><th>Title</th><th>URL</th><th>Poster</th><th>View</th></tr>
-    {{- range cd.LinkerLinksByCategoryID .Idlinkercategory }}
+    {{- range cd.LinkerLinksByCategoryID .ID }}
     <tr>
-        <td><a href="/admin/linker/links/link/{{ .Idlinker }}">{{ .Idlinker }}</a></td>
+        <td><a href="/admin/linker/links/link/{{ .ID }}">{{ .ID }}</a></td>
         <td>{{ .Title.String }}</td>
         <td><a href="{{ .Url.String }}">{{ .Url.String }}</a></td>
         <td>{{ .Posterusername.String }}</td>
-        <td><a href="/linker/show/{{ .Idlinker }}">View</a></td>
+        <td><a href="/linker/show/{{ .ID }}">View</a></td>
     </tr>
     {{- else }}
     <tr><td colspan="5">No links.</td></tr>

--- a/core/templates/site/search/resultLinkerActionPage.gohtml
+++ b/core/templates/site/search/resultLinkerActionPage.gohtml
@@ -9,7 +9,7 @@
         {{- else }}
             <ul>
             {{- range $i, $result := . }}
-                <li>{{ $i }}: <a href="/linker/show/{{$result.Idlinker}}">{{ $result.Title.String }}</a></li>
+                <li>{{ $i }}: <a href="/linker/show/{{$result.ID}}">{{ $result.Title.String }}</a></li>
             {{- end }}
             </ul>
         {{ end }}

--- a/core/templates/site/showCategories.gohtml
+++ b/core/templates/site/showCategories.gohtml
@@ -2,7 +2,7 @@
     Please select a category:<br>
     <a href="/linker">All</a><br>
     {{- range cd.LinkerCategoriesForUser }}
-        <a href="/linker/category/{{ .Idlinkercategory }}">{{ .Title.String }}</a><br>
+        <a href="/linker/category/{{ .ID }}">{{ .Title.String }}</a><br>
     {{- else }}
         <em>No categories</em><br>
     {{- end }}

--- a/core/templates/site/showLatestLinks.gohtml
+++ b/core/templates/site/showLatestLinks.gohtml
@@ -8,7 +8,7 @@
                 <tr>
                     <td>
                         {{ .Description.String | a4code2html }}<hr>
-                        {{ .Posterusername.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }} - [<a href="/linker/comments/{{ .Idlinker }}">{{.Comments.Int32}} COMMENTS</a>]<br>
+                        {{ .Posterusername.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }} - [<a href="/linker/comments/{{ .ID }}">{{.Comments.Int32}} COMMENTS</a>]<br>
                     </td>
                 </tr>
             {{- else }}
@@ -30,7 +30,7 @@
                 <tr>
                     <td>
                         {{ .Description.String | a4code2html }}<hr>
-                        {{ .Posterusername.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }} - [<a href="/linker/comments/{{ .Idlinker }}">{{.Comments.Int32}} COMMENTS</a>]<br>
+                        {{ .Posterusername.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }} - [<a href="/linker/comments/{{ .ID }}">{{.Comments.Int32}} COMMENTS</a>]<br>
                     </td>
                 </tr>
             {{- else }}

--- a/core/templates/site/showLinkComments.gohtml
+++ b/core/templates/site/showLinkComments.gohtml
@@ -45,7 +45,7 @@
                     <form method="post">
                 {{ csrfField }}
                         <input type="hidden" name="replyTo" value="{{ .ForumthreadID }}">
-                        <input type="hidden" name="lpid" value="{{ .Idlinker }}">
+                        <input type="hidden" name="lpid" value="{{ .ID }}">
                         <textarea name="replytext" cols="40" rows="20">{{ $.Text }}</textarea><br>
                         {{ template "languageCombobox" }}
                         <input type="submit" name="task" value="Reply">

--- a/handlers/admin/adminUserLinkerPage.go
+++ b/handlers/admin/adminUserLinkerPage.go
@@ -26,9 +26,9 @@ func adminUserLinkerPage(w http.ResponseWriter, r *http.Request) {
 	}
 	queries := cd.Queries()
 	rows, err := queries.GetLinkerItemsByUserDescending(r.Context(), db.GetLinkerItemsByUserDescendingParams{
-		UsersIdusers: cpu.Idusers,
-		Limit:        100,
-		Offset:       0,
+		AuthorID: cpu.Idusers,
+		Limit:    100,
+		Offset:   0,
 	})
 	if err != nil {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 65
+	ExpectedSchemaVersion = 66
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/handlers/languages/delete_language_task_test.go
+++ b/handlers/languages/delete_language_task_test.go
@@ -40,7 +40,7 @@ func TestDeleteLanguageTask_PreventDeletion(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT idlanguage, nameof\nFROM language")).WillReturnRows(langRows)
 
 	countRows := sqlmock.NewRows([]string{"comments", "writings", "blogs", "news", "links"}).AddRow(1, 0, 0, 0, 0)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT\n    (SELECT COUNT(*) FROM comments WHERE comments.language_idlanguage = ?) AS comments,\n    (SELECT COUNT(*) FROM writing WHERE writing.language_idlanguage = ?) AS writings,\n    (SELECT COUNT(*) FROM blogs WHERE blogs.language_idlanguage = ?) AS blogs,\n    (SELECT COUNT(*) FROM site_news WHERE site_news.language_idlanguage = ?) AS news,\n    (SELECT COUNT(*) FROM linker WHERE linker.language_idlanguage = ?) AS links")).WithArgs(int32(1), int32(1), int32(1), int32(1), int32(1)).WillReturnRows(countRows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT\n    (SELECT COUNT(*) FROM comments WHERE comments.language_idlanguage = ?) AS comments,\n    (SELECT COUNT(*) FROM writing WHERE writing.language_idlanguage = ?) AS writings,\n    (SELECT COUNT(*) FROM blogs WHERE blogs.language_idlanguage = ?) AS blogs,\n    (SELECT COUNT(*) FROM site_news WHERE site_news.language_idlanguage = ?) AS news,\n    (SELECT COUNT(*) FROM linker WHERE linker.language_id = ?) AS links")).WithArgs(int32(1), int32(1), int32(1), int32(1), int32(1)).WillReturnRows(countRows)
 
 	result := deleteLanguageTask.Action(rr, req)
 	if result == nil {

--- a/handlers/linker/approve_task.go
+++ b/handlers/linker/approve_task.go
@@ -51,7 +51,7 @@ func (approveTask) Action(w http.ResponseWriter, r *http.Request) any {
 
 	link, err := queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUser(r.Context(), db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams{
 		ViewerID:     cd.UserID,
-		Idlinker:     int32(lid),
+		ID:           int32(lid),
 		ViewerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	})
 	if err != nil {

--- a/handlers/linker/bulk_approve_task.go
+++ b/handlers/linker/bulk_approve_task.go
@@ -55,7 +55,7 @@ func (bulkApproveTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 		link, err := queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUser(r.Context(), db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams{
 			ViewerID:     cd.UserID,
-			Idlinker:     int32(lid),
+			ID:           int32(lid),
 			ViewerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 		})
 		if err != nil {

--- a/handlers/linker/bulk_delete_task.go
+++ b/handlers/linker/bulk_delete_task.go
@@ -37,7 +37,7 @@ func (bulkDeleteTask) Action(w http.ResponseWriter, r *http.Request) any {
 			ids[id] = struct{}{}
 		}
 		for _, it := range rows {
-			if _, ok := ids[int(it.Idlinkerqueue)]; ok {
+			if _, ok := ids[int(it.ID)]; ok {
 				info = append(info, map[string]any{"Title": it.Title.String, "URL": it.Url.String, "Username": it.Username.String})
 			}
 		}

--- a/handlers/linker/delete_category_task.go
+++ b/handlers/linker/delete_category_task.go
@@ -23,7 +23,7 @@ func (deleteCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	rows, _ := cd.LinkerCategoryCounts()
 	for _, c := range rows {
-		if int(c.Idlinkercategory) == cid && c.Linkcount > 0 {
+		if int(c.ID) == cid && c.Linkcount > 0 {
 			handlers.RenderErrorPage(w, r, fmt.Errorf("Category in use"))
 			return nil
 		}

--- a/handlers/linker/delete_task.go
+++ b/handlers/linker/delete_task.go
@@ -33,7 +33,7 @@ func (deleteTask) Action(w http.ResponseWriter, r *http.Request) any {
 	var link *db.GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetailsRow
 	if rows, err := queries.GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails(r.Context()); err == nil {
 		for _, it := range rows {
-			if it.Idlinkerqueue == int32(qid) {
+			if it.ID == int32(qid) {
 				link = it
 				break
 			}

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -94,12 +94,12 @@ func (addTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if err := queries.AdminCreateLinkerItem(r.Context(), db.AdminCreateLinkerItemParams{
-		UsersIdusers:     uid,
-		LinkerCategoryID: sql.NullInt32{Int32: int32(category), Valid: category != 0},
-		Title:            sql.NullString{Valid: true, String: title},
-		Url:              sql.NullString{Valid: true, String: url},
-		Description:      sql.NullString{Valid: true, String: description},
-		Timezone:         sql.NullString{String: cd.Location().String(), Valid: true},
+		AuthorID:    uid,
+		CategoryID:  sql.NullInt32{Int32: int32(category), Valid: category != 0},
+		Title:       sql.NullString{Valid: true, String: title},
+		Url:         sql.NullString{Valid: true, String: url},
+		Description: sql.NullString{Valid: true, String: description},
+		Timezone:    sql.NullString{String: cd.Location().String(), Valid: true},
 	}); err != nil {
 		return fmt.Errorf("create linker item fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/linker/linkerAdminLinkPage.go
+++ b/handlers/linker/linkerAdminLinkPage.go
@@ -32,11 +32,11 @@ func adminLinkPage(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		Link               *db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow
 		Selected           int
-		SelectedLanguageId int
+		SelectedLanguageID int
 	}{
 		Link:               link,
-                Selected:           int(link.LinkerCategoryID.Int32),
-                SelectedLanguageId: int(link.LanguageIdlanguage.Int32),
+		Selected:           int(link.CategoryID.Int32),
+		SelectedLanguageID: int(link.LanguageID.Int32),
 	}
 
 	handlers.TemplateHandler(w, r, "adminLinkPage.gohtml", data)
@@ -65,12 +65,12 @@ func (editLinkTask) Action(w http.ResponseWriter, r *http.Request) any {
 	queries := cd.Queries()
 
 	if err := queries.AdminUpdateLinkerItem(r.Context(), db.AdminUpdateLinkerItemParams{
-		Title:              sql.NullString{Valid: true, String: title},
-		Url:                sql.NullString{Valid: true, String: URL},
-		Description:        sql.NullString{Valid: true, String: desc},
-                LinkerCategoryID:   sql.NullInt32{Int32: int32(cat), Valid: cat != 0},
-                LanguageIdlanguage: sql.NullInt32{Int32: int32(lang), Valid: lang != 0},
-		Idlinker:           id,
+		Title:       sql.NullString{Valid: true, String: title},
+		Url:         sql.NullString{Valid: true, String: URL},
+		Description: sql.NullString{Valid: true, String: desc},
+		CategoryID:  sql.NullInt32{Int32: int32(cat), Valid: cat != 0},
+		LanguageID:  sql.NullInt32{Int32: int32(lang), Valid: lang != 0},
+		ID:          id,
 	}); err != nil {
 		return fmt.Errorf("update linker item fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/linker/linkerAdminLinkViewPage_test.go
+++ b/handlers/linker/linkerAdminLinkViewPage_test.go
@@ -33,9 +33,9 @@ func TestAdminLinkViewPage(t *testing.T) {
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT l.idlinker")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT l.id")).
 		WithArgs(int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"idlinker", "language_idlanguage", "users_idusers", "linker_category_id", "forumthread_id", "title", "url", "description", "listed", "username", "title_2"}).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "language_id", "author_id", "category_id", "thread_id", "title", "url", "description", "listed", "username", "title_2"}).
 			AddRow(1, 1, 2, 1, 0, "t", "http://u", "d", time.Unix(0, 0), "bob", "cat"))
 
 	adminLinkViewPage(w, req)

--- a/handlers/linker/linkerAdminQueuePage.go
+++ b/handlers/linker/linkerAdminQueuePage.go
@@ -58,7 +58,7 @@ func AdminQueuePage(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		if data.Category != "" {
-			if !q.LinkerCategoryID.Valid || strconv.Itoa(int(q.LinkerCategoryID.Int32)) != data.Category {
+			if !q.CategoryID.Valid || strconv.Itoa(int(q.CategoryID.Int32)) != data.Category {
 				continue
 			}
 		}
@@ -115,11 +115,11 @@ func AdminQueueUpdateActionPage(w http.ResponseWriter, r *http.Request) {
 	desc := r.URL.Query().Get("desc")
 	category, _ := strconv.Atoi(r.URL.Query().Get("category"))
 	if err := queries.AdminUpdateLinkerQueuedItem(r.Context(), db.AdminUpdateLinkerQueuedItemParams{
-		LinkerCategoryID: sql.NullInt32{Int32: int32(category), Valid: category != 0},
-		Title:            sql.NullString{Valid: true, String: title},
-		Url:              sql.NullString{Valid: true, String: URL},
-		Description:      sql.NullString{Valid: true, String: desc},
-		Idlinkerqueue:    int32(qid),
+		CategoryID:  sql.NullInt32{Int32: int32(category), Valid: category != 0},
+		Title:       sql.NullString{Valid: true, String: title},
+		Url:         sql.NullString{Valid: true, String: URL},
+		Description: sql.NullString{Valid: true, String: desc},
+		ID:          int32(qid),
 	}); err != nil {
 		log.Printf("updateLinkerQueuedItem Error: %s", err)
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))

--- a/handlers/linker/linkerCommentsPage_test.go
+++ b/handlers/linker/linkerCommentsPage_test.go
@@ -46,9 +46,9 @@ func TestCommentsPageAllowsGlobalViewGrant(t *testing.T) {
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT l.idlinker")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT l.id")).
 		WithArgs(int32(2), sqlmock.AnyArg(), int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"idlinker", "language_idlanguage", "users_idusers", "linker_category_id", "forumthread_id", "title", "url", "description", "listed", "timezone", "username", "title"}).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "language_id", "author_id", "category_id", "thread_id", "title", "url", "description", "listed", "timezone", "username", "title"}).
 			AddRow(1, 1, 2, 1, 1, "t", "http://u", "d", time.Unix(0, 0), time.Local.String(), "bob", "cat"))
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.idcomments")).

--- a/handlers/linker/linkerFeed.go
+++ b/handlers/linker/linkerFeed.go
@@ -37,7 +37,7 @@ func linkerFeed(r *http.Request, rows []*db.GetAllLinkerItemsByCategoryIdWitherP
 			out, _ := io.ReadAll(conv.Process())
 			desc = string(out)
 		}
-		href := fmt.Sprintf("/linker/show/%d", row.Idlinker)
+		href := fmt.Sprintf("/linker/show/%d", row.ID)
 		if row.Url.Valid && row.Url.String != "" {
 			href = row.Url.String
 		}
@@ -63,7 +63,7 @@ func linkerFeed(r *http.Request, rows []*db.GetAllLinkerItemsByCategoryIdWitherP
 func RssPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
-	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(catID)})
+	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{CategoryID: int32(catID)})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
@@ -78,7 +78,7 @@ func RssPage(w http.ResponseWriter, r *http.Request) {
 func AtomPage(w http.ResponseWriter, r *http.Request) {
 	queries := r.Context().Value(consts.KeyCoreData).(*common.CoreData).Queries()
 	catID, _ := strconv.Atoi(r.URL.Query().Get("category"))
-	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{Idlinkercategory: int32(catID)})
+	rows, err := queries.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(r.Context(), db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams{CategoryID: int32(catID)})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -20,7 +20,7 @@ import (
 func TestLinkerFeed(t *testing.T) {
 	rows := []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow{
 		{
-			Idlinker:       1,
+			ID:             1,
 			Title:          sql.NullString{String: "Example", Valid: true},
 			Url:            sql.NullString{String: "http://example.com", Valid: true},
 			Description:    sql.NullString{String: "desc", Valid: true},

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -45,7 +45,7 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 
 	link, err := queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUser(r.Context(), db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams{
 		ViewerID:     cd.UserID,
-		Idlinker:     int32(linkId),
+		ID:           int32(linkId),
 		ViewerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	})
 	if err != nil {
@@ -54,7 +54,7 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !cd.HasGrant("linker", "link", "view", link.Idlinker) {
+	if !cd.HasGrant("linker", "link", "view", link.ID) {
 		handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		return
 	}
@@ -63,7 +63,7 @@ func ShowPage(w http.ResponseWriter, r *http.Request) {
 	if link.Title.Valid {
 		cd.PageTitle = fmt.Sprintf("Link: %s", link.Title.String)
 	} else {
-		cd.PageTitle = fmt.Sprintf("Link %d", link.Idlinker)
+		cd.PageTitle = fmt.Sprintf("Link %d", link.ID)
 	}
 
 	handlers.TemplateHandler(w, r, "showPage.gohtml", data)
@@ -93,7 +93,7 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 
 	link, err := queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUser(r.Context(), db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams{
 		ViewerID:     cd.UserID,
-		Idlinker:     int32(linkId),
+		ID:           int32(linkId),
 		ViewerUserID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	})
 	if err != nil {
@@ -102,21 +102,21 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !cd.HasGrant("linker", "link", "view", link.Idlinker) {
+	if !cd.HasGrant("linker", "link", "view", link.ID) {
 		handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
 		return
 	}
 
-	var pthid int32 = link.ForumthreadID
+	var pthid int32 = link.ThreadID
 	pt, err := queries.SystemGetForumTopicByTitle(r.Context(), sql.NullString{
 		String: LinkerTopicName,
 		Valid:  true,
 	})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
-                ptidi, err := queries.CreateForumTopicForPoster(r.Context(), db.CreateForumTopicForPosterParams{
-                        ForumcategoryID: 0,
-                        ForumLang:       link.LanguageIdlanguage,
+		ptidi, err := queries.CreateForumTopicForPoster(r.Context(), db.CreateForumTopicForPosterParams{
+			ForumcategoryID: 0,
+			ForumLang:       link.LanguageID,
 			Title: sql.NullString{
 				String: LinkerTopicName,
 				Valid:  true,
@@ -153,8 +153,8 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		}
 		pthid = int32(pthidi)
 		if err := queries.SystemAssignLinkerThreadID(r.Context(), db.SystemAssignLinkerThreadIDParams{
-			ForumthreadID: pthid,
-			Idlinker:      int32(linkId),
+			ThreadID: pthid,
+			ID:            int32(linkId),
 		}); err != nil {
 			log.Printf("Error: assignThreadIdToBlogEntry: %s", err)
 			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -81,14 +81,14 @@ func (SuggestTask) Action(w http.ResponseWriter, r *http.Request) any {
 	category, _ := strconv.Atoi(r.PostFormValue("category"))
 
 	if err := queries.CreateLinkerQueuedItemForWriter(r.Context(), db.CreateLinkerQueuedItemForWriterParams{
-		WriterID:         uid,
-		LinkerCategoryID: sql.NullInt32{Int32: int32(category), Valid: category != 0},
-		Title:            sql.NullString{Valid: true, String: title},
-		Url:              sql.NullString{Valid: true, String: url},
-		Description:      sql.NullString{Valid: true, String: description},
-		Timezone:         sql.NullString{String: cd.Location().String(), Valid: true},
-		GrantCategoryID:  sql.NullInt32{Int32: int32(category), Valid: category != 0},
-		GranteeID:        sql.NullInt32{Int32: uid, Valid: true},
+		WriterID:        uid,
+		CategoryID:      sql.NullInt32{Int32: int32(category), Valid: category != 0},
+		Title:           sql.NullString{Valid: true, String: title},
+		Url:             sql.NullString{Valid: true, String: url},
+		Description:     sql.NullString{Valid: true, String: description},
+		Timezone:        sql.NullString{String: cd.Location().String(), Valid: true},
+		GrantCategoryID: sql.NullInt32{Int32: int32(category), Valid: category != 0},
+		GranteeID:       sql.NullInt32{Int32: uid, Valid: true},
 	}); err != nil {
 		return fmt.Errorf("create linker queued item fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/linker/linkerUserPage.go
+++ b/handlers/linker/linkerUserPage.go
@@ -58,7 +58,7 @@ func UserPage(w http.ResponseWriter, r *http.Request) {
 	data := Data{Username: username, HasOffset: offset != 0}
 	cd.PageTitle = fmt.Sprintf("Links by %s", username)
 	for _, row := range rows {
-		if !cd.HasGrant("linker", "link", "see", row.Idlinker) {
+		if !cd.HasGrant("linker", "link", "see", row.ID) {
 			continue
 		}
 		data.Links = append(data.Links, row)

--- a/handlers/linker/rename_category_task.go
+++ b/handlers/linker/rename_category_task.go
@@ -24,9 +24,9 @@ func (renameCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	title := r.PostFormValue("title")
 	pos, _ := strconv.Atoi(r.PostFormValue("position"))
 	if err := queries.AdminRenameLinkerCategory(r.Context(), db.AdminRenameLinkerCategoryParams{
-		Title:            sql.NullString{Valid: true, String: title},
-		Position:         int32(pos),
-		Idlinkercategory: int32(cid),
+		Title:    sql.NullString{Valid: true, String: title},
+		Position: int32(pos),
+		ID:       int32(cid),
 	}); err != nil {
 		return fmt.Errorf("rename linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/linker/update_category_task.go
+++ b/handlers/linker/update_category_task.go
@@ -24,16 +24,16 @@ func (updateCategoryTask) Action(w http.ResponseWriter, r *http.Request) any {
 	title := r.PostFormValue("title")
 	pos, _ := strconv.Atoi(r.PostFormValue("position"))
 	if err := queries.AdminRenameLinkerCategory(r.Context(), db.AdminRenameLinkerCategoryParams{
-		Title:            sql.NullString{Valid: true, String: title},
-		Position:         int32(pos),
-		Idlinkercategory: int32(cid),
+		Title:    sql.NullString{Valid: true, String: title},
+		Position: int32(pos),
+		ID:       int32(cid),
 	}); err != nil {
 		return fmt.Errorf("rename linker category fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	order, _ := strconv.Atoi(r.PostFormValue("order"))
 	if err := queries.AdminUpdateLinkerCategorySortOrder(r.Context(), db.AdminUpdateLinkerCategorySortOrderParams{
-		Sortorder:        int32(order),
-		Idlinkercategory: int32(cid),
+		Sortorder: int32(order),
+		ID:        int32(cid),
 	}); err != nil {
 		return fmt.Errorf("update linker category sort order fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}

--- a/handlers/search/remakeLinkerTask.go
+++ b/handlers/search/remakeLinkerTask.go
@@ -46,14 +46,14 @@ func (RemakeLinkerTask) BackgroundTask(ctx context.Context, q db.Querier) (tasks
 		}
 		if err := indexText(ctx, q, cache, text, func(c context.Context, wid int64, count int32) error {
 			return q.SystemAddToLinkerSearch(c, db.SystemAddToLinkerSearchParams{
-				LinkerID:                       row.Idlinker,
+				LinkerID:                       row.ID,
 				SearchwordlistIdsearchwordlist: int32(wid),
 				WordCount:                      count,
 			})
 		}); err != nil {
 			return nil, err
 		}
-		if err := q.SystemSetLinkerLastIndex(ctx, row.Idlinker); err != nil {
+		if err := q.SystemSetLinkerLastIndex(ctx, row.ID); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/db/global_permissions_test.go
+++ b/internal/db/global_permissions_test.go
@@ -36,7 +36,7 @@ func TestGlobalGrantsThreads(t *testing.T) {
 }
 
 func TestGlobalGrantsLinker(t *testing.T) {
-	if !strings.Contains(getLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUser, "g.item_id = l.idlinker OR g.item_id IS NULL") {
+	if !strings.Contains(getLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUser, "g.item_id = l.id OR g.item_id IS NULL") {
 		t.Errorf("global grant missing in GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUser")
 	}
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -327,36 +327,36 @@ type Language struct {
 }
 
 type Linker struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	DeletedAt          sql.NullTime
-	LastIndex          sql.NullTime
+	ID          int32
+	LanguageID  sql.NullInt32
+	AuthorID    int32
+	CategoryID  sql.NullInt32
+	ThreadID    int32
+	Title       sql.NullString
+	Url         sql.NullString
+	Description sql.NullString
+	Listed      sql.NullTime
+	Timezone    sql.NullString
+	DeletedAt   sql.NullTime
+	LastIndex   sql.NullTime
 }
 
 type LinkerCategory struct {
-	Idlinkercategory int32
-	Position         int32
-	Title            sql.NullString
-	Sortorder        int32
+	ID        int32
+	Position  int32
+	Title     sql.NullString
+	Sortorder int32
 }
 
 type LinkerQueue struct {
-	Idlinkerqueue      int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Timezone           sql.NullString
+	ID          int32
+	LanguageID  sql.NullInt32
+	SubmitterID int32
+	CategoryID  sql.NullInt32
+	Title       sql.NullString
+	Url         sql.NullString
+	Description sql.NullString
+	Timezone    sql.NullString
 }
 
 type LinkerSearch struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -29,7 +29,7 @@ type Querier interface {
 	AdminCountForumCategories(ctx context.Context, arg AdminCountForumCategoriesParams) (int64, error)
 	AdminCountForumThreads(ctx context.Context) (int64, error)
 	AdminCountForumTopics(ctx context.Context) (int64, error)
-	AdminCountLinksByCategory(ctx context.Context, linkerCategoryID sql.NullInt32) (int64, error)
+	AdminCountLinksByCategory(ctx context.Context, categoryID sql.NullInt32) (int64, error)
 	AdminCountThreadsByBoard(ctx context.Context, imageboardIdimageboard sql.NullInt32) (int64, error)
 	AdminCountWordList(ctx context.Context) (int64, error)
 	AdminCountWordListByPrefix(ctx context.Context, prefix interface{}) (int64, error)
@@ -58,8 +58,8 @@ type Querier interface {
 	//   ? - Language ID to be deleted (int)
 	AdminDeleteLanguage(ctx context.Context, idlanguage int32) error
 	// AdminDeleteLinkerCategory removes a linker category.
-	AdminDeleteLinkerCategory(ctx context.Context, idlinkercategory int32) error
-	AdminDeleteLinkerQueuedItem(ctx context.Context, idlinkerqueue int32) error
+	AdminDeleteLinkerCategory(ctx context.Context, id int32) error
+	AdminDeleteLinkerQueuedItem(ctx context.Context, id int32) error
 	AdminDeleteNotification(ctx context.Context, id int32) error
 	// admin task
 	AdminDeletePendingEmail(ctx context.Context, id int32) error
@@ -103,7 +103,7 @@ type Querier interface {
 	AdminInsertBannedIp(ctx context.Context, arg AdminInsertBannedIpParams) error
 	// AdminInsertLanguage adds a new language returning a result.
 	AdminInsertLanguage(ctx context.Context, nameof sql.NullString) (sql.Result, error)
-	AdminInsertQueuedLinkFromQueue(ctx context.Context, idlinkerqueue int32) (int64, error)
+	AdminInsertQueuedLinkFromQueue(ctx context.Context, id int32) (int64, error)
 	AdminInsertRequestComment(ctx context.Context, arg AdminInsertRequestCommentParams) error
 	AdminInsertRequestQueue(ctx context.Context, arg AdminInsertRequestQueueParams) (sql.Result, error)
 	AdminInsertWritingCategory(ctx context.Context, arg AdminInsertWritingCategoryParams) error
@@ -298,9 +298,9 @@ type Querier interface {
 	GetImagePostsByUserDescendingAll(ctx context.Context, arg GetImagePostsByUserDescendingAllParams) ([]*GetImagePostsByUserDescendingAllRow, error)
 	GetLatestAnnouncementByNewsID(ctx context.Context, siteNewsID int32) (*SiteAnnouncement, error)
 	GetLinkerCategoriesWithCount(ctx context.Context) ([]*GetLinkerCategoriesWithCountRow, error)
-	GetLinkerCategoryById(ctx context.Context, idlinkercategory int32) (*LinkerCategory, error)
+	GetLinkerCategoryById(ctx context.Context, id int32) (*LinkerCategory, error)
 	GetLinkerCategoryLinkCounts(ctx context.Context) ([]*GetLinkerCategoryLinkCountsRow, error)
-	GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(ctx context.Context, idlinker int32) (*GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow, error)
+	GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(ctx context.Context, id int32) (*GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow, error)
 	GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUser(ctx context.Context, arg GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams) (*GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow, error)
 	GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescending(ctx context.Context, linkerids []int32) ([]*GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow, error)
 	GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUser(ctx context.Context, arg GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserParams) ([]*GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserRow, error)
@@ -507,7 +507,7 @@ type Querier interface {
 	SystemSetCommentLastIndex(ctx context.Context, idcomments int32) error
 	SystemSetForumTopicHandlerByID(ctx context.Context, arg SystemSetForumTopicHandlerByIDParams) error
 	SystemSetImagePostLastIndex(ctx context.Context, idimagepost int32) error
-	SystemSetLinkerLastIndex(ctx context.Context, idlinker int32) error
+	SystemSetLinkerLastIndex(ctx context.Context, id int32) error
 	SystemSetSiteNewsLastIndex(ctx context.Context, idsitenews int32) error
 	SystemSetWritingLastIndex(ctx context.Context, idwriting int32) error
 	UpdateAutoSubscribeRepliesForLister(ctx context.Context, arg UpdateAutoSubscribeRepliesForListerParams) error

--- a/internal/db/queries-deactivation.sql
+++ b/internal/db/queries-deactivation.sql
@@ -128,14 +128,14 @@ INSERT INTO deactivated_linker (idlinker, language_idlanguage, users_idusers, li
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW());
 
 -- name: AdminScrubLink :exec
-UPDATE linker SET title = ?, url = '', description = '', deleted_at = NOW() WHERE idlinker = ?;
+UPDATE linker SET title = ?, url = '', description = '', deleted_at = NOW() WHERE id = ?;
 
 -- name: AdminListPendingDeactivatedLinks :many
 SELECT idlinker, title, url, description FROM deactivated_linker WHERE users_idusers = ? AND restored_at IS NULL
 LIMIT ? OFFSET ?;
 
 -- name: AdminRestoreLink :exec
-UPDATE linker SET title = ?, url = ?, description = ?, deleted_at = NULL WHERE idlinker = ?;
+UPDATE linker SET title = ?, url = ?, description = ?, deleted_at = NULL WHERE id = ?;
 
 -- name: AdminMarkLinkRestored :exec
 UPDATE deactivated_linker SET restored_at = NOW() WHERE idlinker = ?;

--- a/internal/db/queries-deactivation.sql.go
+++ b/internal/db/queries-deactivation.sql.go
@@ -840,14 +840,14 @@ func (q *Queries) AdminRestoreImagepost(ctx context.Context, arg AdminRestoreIma
 }
 
 const adminRestoreLink = `-- name: AdminRestoreLink :exec
-UPDATE linker SET title = ?, url = ?, description = ?, deleted_at = NULL WHERE idlinker = ?
+UPDATE linker SET title = ?, url = ?, description = ?, deleted_at = NULL WHERE id = ?
 `
 
 type AdminRestoreLinkParams struct {
 	Title       sql.NullString
 	Url         sql.NullString
 	Description sql.NullString
-	Idlinker    int32
+	ID          int32
 }
 
 func (q *Queries) AdminRestoreLink(ctx context.Context, arg AdminRestoreLinkParams) error {
@@ -855,7 +855,7 @@ func (q *Queries) AdminRestoreLink(ctx context.Context, arg AdminRestoreLinkPara
 		arg.Title,
 		arg.Url,
 		arg.Description,
-		arg.Idlinker,
+		arg.ID,
 	)
 	return err
 }
@@ -932,16 +932,16 @@ func (q *Queries) AdminScrubImagepost(ctx context.Context, idimagepost int32) er
 }
 
 const adminScrubLink = `-- name: AdminScrubLink :exec
-UPDATE linker SET title = ?, url = '', description = '', deleted_at = NOW() WHERE idlinker = ?
+UPDATE linker SET title = ?, url = '', description = '', deleted_at = NOW() WHERE id = ?
 `
 
 type AdminScrubLinkParams struct {
-	Title    sql.NullString
-	Idlinker int32
+	Title sql.NullString
+	ID    int32
 }
 
 func (q *Queries) AdminScrubLink(ctx context.Context, arg AdminScrubLinkParams) error {
-	_, err := q.db.ExecContext(ctx, adminScrubLink, arg.Title, arg.Idlinker)
+	_, err := q.db.ExecContext(ctx, adminScrubLink, arg.Title, arg.ID)
 	return err
 }
 

--- a/internal/db/queries-languages.sql
+++ b/internal/db/queries-languages.sql
@@ -47,4 +47,4 @@ SELECT
     (SELECT COUNT(*) FROM writing WHERE writing.language_idlanguage = sqlc.narg(lang_id)) AS writings,
     (SELECT COUNT(*) FROM blogs WHERE blogs.language_idlanguage = sqlc.narg(lang_id)) AS blogs,
     (SELECT COUNT(*) FROM site_news WHERE site_news.language_idlanguage = sqlc.narg(lang_id)) AS news,
-    (SELECT COUNT(*) FROM linker WHERE linker.language_idlanguage = sqlc.narg(lang_id)) AS links;
+    (SELECT COUNT(*) FROM linker WHERE linker.language_id = sqlc.narg(lang_id)) AS links;

--- a/internal/db/queries-languages.sql.go
+++ b/internal/db/queries-languages.sql.go
@@ -54,7 +54,7 @@ SELECT
     (SELECT COUNT(*) FROM writing WHERE writing.language_idlanguage = ?) AS writings,
     (SELECT COUNT(*) FROM blogs WHERE blogs.language_idlanguage = ?) AS blogs,
     (SELECT COUNT(*) FROM site_news WHERE site_news.language_idlanguage = ?) AS news,
-    (SELECT COUNT(*) FROM linker WHERE linker.language_idlanguage = ?) AS links
+    (SELECT COUNT(*) FROM linker WHERE linker.language_id = ?) AS links
 `
 
 type AdminLanguageUsageCountsParams struct {

--- a/internal/db/queries-linker.sql
+++ b/internal/db/queries-linker.sql
@@ -1,18 +1,18 @@
 -- AdminDeleteLinkerCategory removes a linker category.
 -- name: AdminDeleteLinkerCategory :exec
 DELETE FROM linker_category
-WHERE idlinkerCategory = ?;
+WHERE id = ?;
 
 -- name: AdminRenameLinkerCategory :exec
 UPDATE linker_category SET title = ?, position = ?
-WHERE idlinkerCategory = ?;
+WHERE id = ?;
 
 -- name: AdminCreateLinkerCategory :exec
 INSERT INTO linker_category (title, position) VALUES (sqlc.arg(title), sqlc.arg(position));
 
 -- name: GetAllLinkerCategories :many
 SELECT
-    lc.idlinkerCategory,
+    lc.id,
     lc.position,
     lc.title,
     lc.sortorder
@@ -33,7 +33,7 @@ grants_for_viewer AS (
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
 SELECT
-    lc.idlinkerCategory,
+    lc.id,
     lc.position,
     lc.title,
     lc.sortorder
@@ -44,21 +44,21 @@ WHERE EXISTS (
     WHERE g.section = 'linker'
       AND (g.item = 'category' OR g.item IS NULL)
       AND g.action = 'see'
-      AND (g.item_id = lc.idlinkerCategory OR g.item_id IS NULL)
+      AND (g.item_id = lc.id OR g.item_id IS NULL)
 )
   AND EXISTS (
     SELECT 1 FROM linker l
-    WHERE l.linker_category_id = lc.idlinkerCategory
+    WHERE l.category_id = lc.id
       AND l.listed IS NOT NULL
       AND l.deleted_at IS NULL
   )
 ORDER BY lc.position;
 
 -- name: GetLinkerCategoryLinkCounts :many
-SELECT c.idlinkerCategory, c.title, c.position, COUNT(l.idlinker) as LinkCount
+SELECT c.id, c.title, c.position, COUNT(l.id) as LinkCount
 FROM linker_category c
-LEFT JOIN linker l ON c.idlinkerCategory = l.linker_category_id AND l.listed IS NOT NULL AND l.deleted_at IS NULL
-GROUP BY c.idlinkerCategory
+LEFT JOIN linker l ON c.id = l.category_id AND l.listed IS NOT NULL AND l.deleted_at IS NULL
+GROUP BY c.id
 ORDER BY c.position
 ;
 
@@ -66,15 +66,15 @@ ORDER BY c.position
 
 -- name: AdminDeleteLinkerQueuedItem :exec
 DELETE FROM linker_queue
-WHERE idlinkerQueue = ?;
+WHERE id = ?;
 
 -- name: AdminUpdateLinkerQueuedItem :exec
-UPDATE linker_queue SET linker_category_id = ?, title = ?, url = ?, description = ?
-WHERE idlinkerQueue = ?;
+UPDATE linker_queue SET category_id = ?, title = ?, url = ?, description = ?
+WHERE id = ?;
 
 -- name: CreateLinkerQueuedItemForWriter :exec
-INSERT INTO linker_queue (users_idusers, linker_category_id, title, url, description, timezone)
-SELECT sqlc.arg(writer_id), sqlc.arg(linker_category_id), sqlc.arg(title), sqlc.arg(url), sqlc.arg(description), sqlc.arg(timezone)
+INSERT INTO linker_queue (submitter_id, category_id, title, url, description, timezone)
+SELECT sqlc.arg(writer_id), sqlc.arg(category_id), sqlc.arg(title), sqlc.arg(url), sqlc.arg(description), sqlc.arg(timezone)
 WHERE EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='linker'
@@ -89,35 +89,35 @@ WHERE EXISTS (
 );
 
 -- name: GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails :many
-SELECT l.*, u.username, c.title as category_title, c.idlinkerCategory
+SELECT l.*, u.username, c.title as category_title, c.id AS category_id
 FROM linker_queue l
-JOIN users u ON l.users_idusers = u.idusers
-JOIN linker_category c ON l.linker_category_id = c.idlinkerCategory
+JOIN users u ON l.submitter_id = u.idusers
+JOIN linker_category c ON l.category_id = c.id
 ;
 -- name: AdminInsertQueuedLinkFromQueue :execlastid
-INSERT INTO linker (users_idusers, linker_category_id, language_idlanguage, title, `url`, description, timezone)
-SELECT l.users_idusers, l.linker_category_id, l.language_idlanguage, l.title, l.url, l.description, l.timezone
+INSERT INTO linker (author_id, category_id, language_id, title, `url`, description, timezone)
+SELECT l.submitter_id, l.category_id, l.language_id, l.title, l.url, l.description, l.timezone
 FROM linker_queue l
-WHERE l.idlinkerQueue = ?;
+WHERE l.id = ?;
 
 -- name: AdminCreateLinkerItem :exec
-INSERT INTO linker (users_idusers, linker_category_id, title, url, description, listed, timezone)
-VALUES (sqlc.arg(users_idusers), sqlc.arg(linker_category_id), sqlc.arg(title), sqlc.arg(url), sqlc.arg(description), NOW(), sqlc.arg(timezone));
+INSERT INTO linker (author_id, category_id, title, url, description, listed, timezone)
+VALUES (sqlc.arg(author_id), sqlc.arg(category_id), sqlc.arg(title), sqlc.arg(url), sqlc.arg(description), NOW(), sqlc.arg(timezone));
 
 -- name: AdminUpdateLinkerItem :exec
-UPDATE linker SET title = ?, url = ?, description = ?, linker_category_id = ?, language_idlanguage = ?
-WHERE idlinker = ?;
+UPDATE linker SET title = ?, url = ?, description = ?, category_id = ?, language_id = ?
+WHERE id = ?;
 
 -- name: SystemAssignLinkerThreadID :exec
-UPDATE linker SET forumthread_id = ? WHERE idlinker = ?;
+UPDATE linker SET thread_id = ? WHERE id = ?;
 
 -- name: GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercategory) = 0)
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE (lc.id = sqlc.arg(category_id) OR sqlc.arg(category_id) = 0)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
 ORDER BY l.listed DESC;
@@ -134,12 +134,12 @@ grants_for_viewer AS (
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercategory) = 0)
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE (lc.id = sqlc.arg(category_id) OR sqlc.arg(category_id) = 0)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
   AND EXISTS (
@@ -148,17 +148,17 @@ WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercate
     WHERE g.section = 'linker'
       AND (g.item = 'link' OR g.item IS NULL)
       AND g.action = 'see'
-      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+      AND (g.item_id = l.id OR g.item_id IS NULL)
   )
 ORDER BY l.listed DESC;
 
 -- name: GetLinkerItemsByUserDescending :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE l.users_idusers = ?
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE l.author_id = ?
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?;
 
@@ -174,12 +174,12 @@ grants_for_viewer AS (
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercategory) = 0)
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE (lc.id = sqlc.arg(category_id) OR sqlc.arg(category_id) = 0)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
   AND EXISTS (
@@ -188,7 +188,7 @@ WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercate
     WHERE g.section = 'linker'
       AND (g.item = 'link' OR g.item IS NULL)
       AND g.action = 'see'
-      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+      AND (g.item_id = l.id OR g.item_id IS NULL)
   )
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?;
@@ -205,12 +205,12 @@ grants_for_viewer AS (
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE l.users_idusers = sqlc.arg(user_id)
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE l.author_id = sqlc.arg(user_id)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
   AND EXISTS (
@@ -219,17 +219,17 @@ WHERE l.users_idusers = sqlc.arg(user_id)
     WHERE g.section = 'linker'
       AND (g.item = 'link' OR g.item IS NULL)
       AND g.action = 'see'
-      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+      AND (g.item_id = l.id OR g.item_id IS NULL)
   )
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?;
 
 -- name: GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending :one
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
-JOIN users u ON l.users_idusers = u.idusers
-JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-WHERE l.idlinker = ?;
+JOIN users u ON l.author_id = u.idusers
+JOIN linker_category lc ON l.category_id = lc.id
+WHERE l.id = ?;
 
 -- name: GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUser :one
 WITH role_ids AS (
@@ -243,11 +243,11 @@ grants_for_viewer AS (
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
-JOIN users u ON l.users_idusers = u.idusers
-JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-WHERE l.idlinker = sqlc.arg(idlinker)
+JOIN users u ON l.author_id = u.idusers
+JOIN linker_category lc ON l.category_id = lc.id
+WHERE l.id = sqlc.arg(id)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
   AND EXISTS (
@@ -256,16 +256,16 @@ WHERE l.idlinker = sqlc.arg(idlinker)
     WHERE g.section = 'linker'
       AND (g.item = 'link' OR g.item IS NULL)
       AND g.action IN ('view')
-      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+      AND (g.item_id = l.id OR g.item_id IS NULL)
   )
 LIMIT 1;
 
 -- name: GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescending :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
-JOIN users u ON l.users_idusers = u.idusers
-JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-WHERE l.idlinker IN (sqlc.slice(linkerIds));
+JOIN users u ON l.author_id = u.idusers
+JOIN linker_category lc ON l.category_id = lc.id
+WHERE l.id IN (sqlc.slice(linkerIds));
 
 -- name: GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUser :many
 WITH role_ids AS (
@@ -279,11 +279,11 @@ grants_for_viewer AS (
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
-JOIN users u ON l.users_idusers = u.idusers
-JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-WHERE l.idlinker IN (sqlc.slice(linkerIds))
+JOIN users u ON l.author_id = u.idusers
+JOIN linker_category lc ON l.category_id = lc.id
+WHERE l.id IN (sqlc.slice(linkerIds))
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
   AND EXISTS (
@@ -292,35 +292,35 @@ WHERE l.idlinker IN (sqlc.slice(linkerIds))
     WHERE g.section = 'linker'
       AND (g.item = 'link' OR g.item IS NULL)
       AND g.action = 'view'
-      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+      AND (g.item_id = l.id OR g.item_id IS NULL)
   );
 
 -- name: GetLinkerCategoriesWithCount :many
-SELECT c.idlinkerCategory, c.title, c.sortorder, COUNT(l.idlinker) AS linkcount
+SELECT c.id, c.title, c.sortorder, COUNT(l.id) AS linkcount
 FROM linker_category c
-LEFT JOIN linker l ON l.linker_category_id = c.idlinkerCategory AND l.listed IS NOT NULL AND l.deleted_at IS NULL
-GROUP BY c.idlinkerCategory
+LEFT JOIN linker l ON l.category_id = c.id AND l.listed IS NOT NULL AND l.deleted_at IS NULL
+GROUP BY c.id
 ORDER BY c.sortorder;
 
 -- name: AdminUpdateLinkerCategorySortOrder :exec
 UPDATE linker_category SET sortorder = ?
-WHERE idlinkerCategory = ?;
+WHERE id = ?;
 
 -- name: AdminCountLinksByCategory :one
-SELECT COUNT(*) FROM linker WHERE linker_category_id = ?;
+SELECT COUNT(*) FROM linker WHERE category_id = ?;
 
 
 -- name: SystemSetLinkerLastIndex :exec
-UPDATE linker SET last_index = NOW() WHERE idlinker = ?;
+UPDATE linker SET last_index = NOW() WHERE id = ?;
 
 
 -- name: GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercategory) = 0)
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE (lc.id = sqlc.arg(category_id) OR sqlc.arg(category_id) = 0)
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?;
 
@@ -336,34 +336,34 @@ grants_for_viewer AS (
       AND (g.user_id = sqlc.arg(viewer_user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercategory) = 0)
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE (lc.id = sqlc.arg(category_id) OR sqlc.arg(category_id) = 0)
   AND EXISTS (
     SELECT 1
     FROM grants_for_viewer g
     WHERE g.section = 'linker'
       AND (g.item = 'link' OR g.item IS NULL)
       AND g.action = 'see'
-      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+      AND (g.item_id = l.id OR g.item_id IS NULL)
   )
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?;
 
 -- name: GetAllLinkersForIndex :many
-SELECT idlinker, title, description FROM linker WHERE deleted_at IS NULL AND listed IS NOT NULL;
+SELECT id, title, description FROM linker WHERE deleted_at IS NULL AND listed IS NOT NULL;
 
 -- name: GetLinkerCategoryById :one
-SELECT * FROM linker_category WHERE idlinkerCategory = ?;
+SELECT * FROM linker_category WHERE id = ?;
 
 -- name: ListLinkerCategoryPath :many
 WITH RECURSIVE category_path AS (
-    SELECT lc.idlinkerCategory, NULL AS parent_id, lc.title, 0 AS depth
+    SELECT lc.id, NULL AS parent_id, lc.title, 0 AS depth
     FROM linker_category lc
-    WHERE lc.idlinkerCategory = sqlc.arg(category_id)
+    WHERE lc.id = sqlc.arg(category_id)
 )
-SELECT category_path.idlinkerCategory, category_path.title
+SELECT category_path.id, category_path.title
 FROM category_path;

--- a/internal/db/queries-linker.sql.go
+++ b/internal/db/queries-linker.sql.go
@@ -12,11 +12,11 @@ import (
 )
 
 const adminCountLinksByCategory = `-- name: AdminCountLinksByCategory :one
-SELECT COUNT(*) FROM linker WHERE linker_category_id = ?
+SELECT COUNT(*) FROM linker WHERE category_id = ?
 `
 
-func (q *Queries) AdminCountLinksByCategory(ctx context.Context, linkerCategoryID sql.NullInt32) (int64, error) {
-	row := q.db.QueryRowContext(ctx, adminCountLinksByCategory, linkerCategoryID)
+func (q *Queries) AdminCountLinksByCategory(ctx context.Context, categoryID sql.NullInt32) (int64, error) {
+	row := q.db.QueryRowContext(ctx, adminCountLinksByCategory, categoryID)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -37,23 +37,23 @@ func (q *Queries) AdminCreateLinkerCategory(ctx context.Context, arg AdminCreate
 }
 
 const adminCreateLinkerItem = `-- name: AdminCreateLinkerItem :exec
-INSERT INTO linker (users_idusers, linker_category_id, title, url, description, listed, timezone)
+INSERT INTO linker (author_id, category_id, title, url, description, listed, timezone)
 VALUES (?, ?, ?, ?, ?, NOW(), ?)
 `
 
 type AdminCreateLinkerItemParams struct {
-	UsersIdusers     int32
-	LinkerCategoryID sql.NullInt32
-	Title            sql.NullString
-	Url              sql.NullString
-	Description      sql.NullString
-	Timezone         sql.NullString
+	AuthorID    int32
+	CategoryID  sql.NullInt32
+	Title       sql.NullString
+	Url         sql.NullString
+	Description sql.NullString
+	Timezone    sql.NullString
 }
 
 func (q *Queries) AdminCreateLinkerItem(ctx context.Context, arg AdminCreateLinkerItemParams) error {
 	_, err := q.db.ExecContext(ctx, adminCreateLinkerItem,
-		arg.UsersIdusers,
-		arg.LinkerCategoryID,
+		arg.AuthorID,
+		arg.CategoryID,
 		arg.Title,
 		arg.Url,
 		arg.Description,
@@ -64,34 +64,34 @@ func (q *Queries) AdminCreateLinkerItem(ctx context.Context, arg AdminCreateLink
 
 const adminDeleteLinkerCategory = `-- name: AdminDeleteLinkerCategory :exec
 DELETE FROM linker_category
-WHERE idlinkerCategory = ?
+WHERE id = ?
 `
 
 // AdminDeleteLinkerCategory removes a linker category.
-func (q *Queries) AdminDeleteLinkerCategory(ctx context.Context, idlinkercategory int32) error {
-	_, err := q.db.ExecContext(ctx, adminDeleteLinkerCategory, idlinkercategory)
+func (q *Queries) AdminDeleteLinkerCategory(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, adminDeleteLinkerCategory, id)
 	return err
 }
 
 const adminDeleteLinkerQueuedItem = `-- name: AdminDeleteLinkerQueuedItem :exec
 DELETE FROM linker_queue
-WHERE idlinkerQueue = ?
+WHERE id = ?
 `
 
-func (q *Queries) AdminDeleteLinkerQueuedItem(ctx context.Context, idlinkerqueue int32) error {
-	_, err := q.db.ExecContext(ctx, adminDeleteLinkerQueuedItem, idlinkerqueue)
+func (q *Queries) AdminDeleteLinkerQueuedItem(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, adminDeleteLinkerQueuedItem, id)
 	return err
 }
 
 const adminInsertQueuedLinkFromQueue = `-- name: AdminInsertQueuedLinkFromQueue :execlastid
-INSERT INTO linker (users_idusers, linker_category_id, language_idlanguage, title, ` + "`" + `url` + "`" + `, description, timezone)
-SELECT l.users_idusers, l.linker_category_id, l.language_idlanguage, l.title, l.url, l.description, l.timezone
+INSERT INTO linker (author_id, category_id, language_id, title, ` + "`" + `url` + "`" + `, description, timezone)
+SELECT l.submitter_id, l.category_id, l.language_id, l.title, l.url, l.description, l.timezone
 FROM linker_queue l
-WHERE l.idlinkerQueue = ?
+WHERE l.id = ?
 `
 
-func (q *Queries) AdminInsertQueuedLinkFromQueue(ctx context.Context, idlinkerqueue int32) (int64, error) {
-	result, err := q.db.ExecContext(ctx, adminInsertQueuedLinkFromQueue, idlinkerqueue)
+func (q *Queries) AdminInsertQueuedLinkFromQueue(ctx context.Context, id int32) (int64, error) {
+	result, err := q.db.ExecContext(ctx, adminInsertQueuedLinkFromQueue, id)
 	if err != nil {
 		return 0, err
 	}
@@ -100,47 +100,47 @@ func (q *Queries) AdminInsertQueuedLinkFromQueue(ctx context.Context, idlinkerqu
 
 const adminRenameLinkerCategory = `-- name: AdminRenameLinkerCategory :exec
 UPDATE linker_category SET title = ?, position = ?
-WHERE idlinkerCategory = ?
+WHERE id = ?
 `
 
 type AdminRenameLinkerCategoryParams struct {
-	Title            sql.NullString
-	Position         int32
-	Idlinkercategory int32
+	Title    sql.NullString
+	Position int32
+	ID       int32
 }
 
 func (q *Queries) AdminRenameLinkerCategory(ctx context.Context, arg AdminRenameLinkerCategoryParams) error {
-	_, err := q.db.ExecContext(ctx, adminRenameLinkerCategory, arg.Title, arg.Position, arg.Idlinkercategory)
+	_, err := q.db.ExecContext(ctx, adminRenameLinkerCategory, arg.Title, arg.Position, arg.ID)
 	return err
 }
 
 const adminUpdateLinkerCategorySortOrder = `-- name: AdminUpdateLinkerCategorySortOrder :exec
 UPDATE linker_category SET sortorder = ?
-WHERE idlinkerCategory = ?
+WHERE id = ?
 `
 
 type AdminUpdateLinkerCategorySortOrderParams struct {
-	Sortorder        int32
-	Idlinkercategory int32
+	Sortorder int32
+	ID        int32
 }
 
 func (q *Queries) AdminUpdateLinkerCategorySortOrder(ctx context.Context, arg AdminUpdateLinkerCategorySortOrderParams) error {
-	_, err := q.db.ExecContext(ctx, adminUpdateLinkerCategorySortOrder, arg.Sortorder, arg.Idlinkercategory)
+	_, err := q.db.ExecContext(ctx, adminUpdateLinkerCategorySortOrder, arg.Sortorder, arg.ID)
 	return err
 }
 
 const adminUpdateLinkerItem = `-- name: AdminUpdateLinkerItem :exec
-UPDATE linker SET title = ?, url = ?, description = ?, linker_category_id = ?, language_idlanguage = ?
-WHERE idlinker = ?
+UPDATE linker SET title = ?, url = ?, description = ?, category_id = ?, language_id = ?
+WHERE id = ?
 `
 
 type AdminUpdateLinkerItemParams struct {
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	LinkerCategoryID   sql.NullInt32
-	LanguageIdlanguage sql.NullInt32
-	Idlinker           int32
+	Title       sql.NullString
+	Url         sql.NullString
+	Description sql.NullString
+	CategoryID  sql.NullInt32
+	LanguageID  sql.NullInt32
+	ID          int32
 }
 
 func (q *Queries) AdminUpdateLinkerItem(ctx context.Context, arg AdminUpdateLinkerItemParams) error {
@@ -148,39 +148,39 @@ func (q *Queries) AdminUpdateLinkerItem(ctx context.Context, arg AdminUpdateLink
 		arg.Title,
 		arg.Url,
 		arg.Description,
-		arg.LinkerCategoryID,
-		arg.LanguageIdlanguage,
-		arg.Idlinker,
+		arg.CategoryID,
+		arg.LanguageID,
+		arg.ID,
 	)
 	return err
 }
 
 const adminUpdateLinkerQueuedItem = `-- name: AdminUpdateLinkerQueuedItem :exec
-UPDATE linker_queue SET linker_category_id = ?, title = ?, url = ?, description = ?
-WHERE idlinkerQueue = ?
+UPDATE linker_queue SET category_id = ?, title = ?, url = ?, description = ?
+WHERE id = ?
 `
 
 type AdminUpdateLinkerQueuedItemParams struct {
-	LinkerCategoryID sql.NullInt32
-	Title            sql.NullString
-	Url              sql.NullString
-	Description      sql.NullString
-	Idlinkerqueue    int32
+	CategoryID  sql.NullInt32
+	Title       sql.NullString
+	Url         sql.NullString
+	Description sql.NullString
+	ID          int32
 }
 
 func (q *Queries) AdminUpdateLinkerQueuedItem(ctx context.Context, arg AdminUpdateLinkerQueuedItemParams) error {
 	_, err := q.db.ExecContext(ctx, adminUpdateLinkerQueuedItem,
-		arg.LinkerCategoryID,
+		arg.CategoryID,
 		arg.Title,
 		arg.Url,
 		arg.Description,
-		arg.Idlinkerqueue,
+		arg.ID,
 	)
 	return err
 }
 
 const createLinkerQueuedItemForWriter = `-- name: CreateLinkerQueuedItemForWriter :exec
-INSERT INTO linker_queue (users_idusers, linker_category_id, title, url, description, timezone)
+INSERT INTO linker_queue (submitter_id, category_id, title, url, description, timezone)
 SELECT ?, ?, ?, ?, ?, ?
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -197,20 +197,20 @@ WHERE EXISTS (
 `
 
 type CreateLinkerQueuedItemForWriterParams struct {
-	WriterID         int32
-	LinkerCategoryID sql.NullInt32
-	Title            sql.NullString
-	Url              sql.NullString
-	Description      sql.NullString
-	Timezone         sql.NullString
-	GrantCategoryID  sql.NullInt32
-	GranteeID        sql.NullInt32
+	WriterID        int32
+	CategoryID      sql.NullInt32
+	Title           sql.NullString
+	Url             sql.NullString
+	Description     sql.NullString
+	Timezone        sql.NullString
+	GrantCategoryID sql.NullInt32
+	GranteeID       sql.NullInt32
 }
 
 func (q *Queries) CreateLinkerQueuedItemForWriter(ctx context.Context, arg CreateLinkerQueuedItemForWriterParams) error {
 	_, err := q.db.ExecContext(ctx, createLinkerQueuedItemForWriter,
 		arg.WriterID,
-		arg.LinkerCategoryID,
+		arg.CategoryID,
 		arg.Title,
 		arg.Url,
 		arg.Description,
@@ -224,7 +224,7 @@ func (q *Queries) CreateLinkerQueuedItemForWriter(ctx context.Context, arg Creat
 
 const getAllLinkerCategories = `-- name: GetAllLinkerCategories :many
 SELECT
-    lc.idlinkerCategory,
+    lc.id,
     lc.position,
     lc.title,
     lc.sortorder
@@ -242,7 +242,7 @@ func (q *Queries) GetAllLinkerCategories(ctx context.Context) ([]*LinkerCategory
 	for rows.Next() {
 		var i LinkerCategory
 		if err := rows.Scan(
-			&i.Idlinkercategory,
+			&i.ID,
 			&i.Position,
 			&i.Title,
 			&i.Sortorder,
@@ -273,7 +273,7 @@ grants_for_viewer AS (
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
 SELECT
-    lc.idlinkerCategory,
+    lc.id,
     lc.position,
     lc.title,
     lc.sortorder
@@ -284,11 +284,11 @@ WHERE EXISTS (
     WHERE g.section = 'linker'
       AND (g.item = 'category' OR g.item IS NULL)
       AND g.action = 'see'
-      AND (g.item_id = lc.idlinkerCategory OR g.item_id IS NULL)
+      AND (g.item_id = lc.id OR g.item_id IS NULL)
 )
   AND EXISTS (
     SELECT 1 FROM linker l
-    WHERE l.linker_category_id = lc.idlinkerCategory
+    WHERE l.category_id = lc.id
       AND l.listed IS NOT NULL
       AND l.deleted_at IS NULL
   )
@@ -310,7 +310,7 @@ func (q *Queries) GetAllLinkerCategoriesForUser(ctx context.Context, arg GetAllL
 	for rows.Next() {
 		var i LinkerCategory
 		if err := rows.Scan(
-			&i.Idlinkercategory,
+			&i.ID,
 			&i.Position,
 			&i.Title,
 			&i.Sortorder,
@@ -329,39 +329,39 @@ func (q *Queries) GetAllLinkerCategoriesForUser(ctx context.Context, arg GetAllL
 }
 
 const getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending = `-- name: GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE (lc.idlinkerCategory = ? OR ? = 0)
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE (lc.id = ? OR ? = 0)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
 ORDER BY l.listed DESC
 `
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams struct {
-	Idlinkercategory int32
+	CategoryID int32
 }
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	ID             int32
+	LanguageID     sql.NullInt32
+	AuthorID       int32
+	CategoryID     sql.NullInt32
+	ThreadID       int32
+	Title          sql.NullString
+	Url            sql.NullString
+	Description    sql.NullString
+	Listed         sql.NullTime
+	Timezone       sql.NullString
+	Comments       sql.NullInt32
+	CategoryTitle  sql.NullString
+	Posterusername sql.NullString
 }
 
 func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow, error) {
-	rows, err := q.db.QueryContext(ctx, getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending, arg.Idlinkercategory, arg.Idlinkercategory)
+	rows, err := q.db.QueryContext(ctx, getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescending, arg.CategoryID, arg.CategoryID)
 	if err != nil {
 		return nil, err
 	}
@@ -370,11 +370,11 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 	for rows.Next() {
 		var i GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow
 		if err := rows.Scan(
-			&i.Idlinker,
-			&i.LanguageIdlanguage,
-			&i.UsersIdusers,
-			&i.LinkerCategoryID,
-			&i.ForumthreadID,
+			&i.ID,
+			&i.LanguageID,
+			&i.AuthorID,
+			&i.CategoryID,
+			&i.ThreadID,
 			&i.Title,
 			&i.Url,
 			&i.Description,
@@ -409,12 +409,12 @@ grants_for_viewer AS (
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE (lc.idlinkerCategory = ? OR ? = 0)
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE (lc.id = ? OR ? = 0)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
   AND EXISTS (
@@ -423,39 +423,39 @@ WHERE (lc.idlinkerCategory = ? OR ? = 0)
     WHERE g.section = 'linker'
       AND (g.item = 'link' OR g.item IS NULL)
       AND g.action = 'see'
-      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+      AND (g.item_id = l.id OR g.item_id IS NULL)
   )
 ORDER BY l.listed DESC
 `
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserParams struct {
-	ViewerID         int32
-	ViewerUserID     sql.NullInt32
-	Idlinkercategory int32
+	ViewerID     int32
+	ViewerUserID sql.NullInt32
+	CategoryID   int32
 }
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	ID             int32
+	LanguageID     sql.NullInt32
+	AuthorID       int32
+	CategoryID     sql.NullInt32
+	ThreadID       int32
+	Title          sql.NullString
+	Url            sql.NullString
+	Description    sql.NullString
+	Listed         sql.NullTime
+	Timezone       sql.NullString
+	Comments       sql.NullInt32
+	CategoryTitle  sql.NullString
+	Posterusername sql.NullString
 }
 
 func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUser(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserRow, error) {
 	rows, err := q.db.QueryContext(ctx, getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUser,
 		arg.ViewerID,
 		arg.ViewerUserID,
-		arg.Idlinkercategory,
-		arg.Idlinkercategory,
+		arg.CategoryID,
+		arg.CategoryID,
 	)
 	if err != nil {
 		return nil, err
@@ -465,11 +465,11 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 	for rows.Next() {
 		var i GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserRow
 		if err := rows.Scan(
-			&i.Idlinker,
-			&i.LanguageIdlanguage,
-			&i.UsersIdusers,
-			&i.LinkerCategoryID,
-			&i.ForumthreadID,
+			&i.ID,
+			&i.LanguageID,
+			&i.AuthorID,
+			&i.CategoryID,
+			&i.ThreadID,
 			&i.Title,
 			&i.Url,
 			&i.Description,
@@ -504,54 +504,54 @@ grants_for_viewer AS (
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE (lc.idlinkerCategory = ? OR ? = 0)
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE (lc.id = ? OR ? = 0)
   AND EXISTS (
     SELECT 1
     FROM grants_for_viewer g
     WHERE g.section = 'linker'
       AND (g.item = 'link' OR g.item IS NULL)
       AND g.action = 'see'
-      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+      AND (g.item_id = l.id OR g.item_id IS NULL)
   )
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?
 `
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedParams struct {
-	ViewerID         int32
-	ViewerUserID     sql.NullInt32
-	Idlinkercategory int32
-	Limit            int32
-	Offset           int32
+	ViewerID     int32
+	ViewerUserID sql.NullInt32
+	CategoryID   int32
+	Limit        int32
+	Offset       int32
 }
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	ID             int32
+	LanguageID     sql.NullInt32
+	AuthorID       int32
+	CategoryID     sql.NullInt32
+	ThreadID       int32
+	Title          sql.NullString
+	Url            sql.NullString
+	Description    sql.NullString
+	Listed         sql.NullTime
+	Timezone       sql.NullString
+	Comments       sql.NullInt32
+	CategoryTitle  sql.NullString
+	Posterusername sql.NullString
 }
 
 func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginated(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow, error) {
 	rows, err := q.db.QueryContext(ctx, getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginated,
 		arg.ViewerID,
 		arg.ViewerUserID,
-		arg.Idlinkercategory,
-		arg.Idlinkercategory,
+		arg.CategoryID,
+		arg.CategoryID,
 		arg.Limit,
 		arg.Offset,
 	)
@@ -563,11 +563,11 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 	for rows.Next() {
 		var i GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow
 		if err := rows.Scan(
-			&i.Idlinker,
-			&i.LanguageIdlanguage,
-			&i.UsersIdusers,
-			&i.LinkerCategoryID,
-			&i.ForumthreadID,
+			&i.ID,
+			&i.LanguageID,
+			&i.AuthorID,
+			&i.CategoryID,
+			&i.ThreadID,
 			&i.Title,
 			&i.Url,
 			&i.Description,
@@ -602,12 +602,12 @@ grants_for_viewer AS (
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE (lc.idlinkerCategory = ? OR ? = 0)
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE (lc.id = ? OR ? = 0)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
   AND EXISTS (
@@ -616,42 +616,42 @@ WHERE (lc.idlinkerCategory = ? OR ? = 0)
     WHERE g.section = 'linker'
       AND (g.item = 'link' OR g.item IS NULL)
       AND g.action = 'see'
-      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+      AND (g.item_id = l.id OR g.item_id IS NULL)
   )
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?
 `
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRowParams struct {
-	ViewerID         int32
-	ViewerUserID     sql.NullInt32
-	Idlinkercategory int32
-	Limit            int32
-	Offset           int32
+	ViewerID     int32
+	ViewerUserID sql.NullInt32
+	CategoryID   int32
+	Limit        int32
+	Offset       int32
 }
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRowRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	ID             int32
+	LanguageID     sql.NullInt32
+	AuthorID       int32
+	CategoryID     sql.NullInt32
+	ThreadID       int32
+	Title          sql.NullString
+	Url            sql.NullString
+	Description    sql.NullString
+	Listed         sql.NullTime
+	Timezone       sql.NullString
+	Comments       sql.NullInt32
+	CategoryTitle  sql.NullString
+	Posterusername sql.NullString
 }
 
 func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRowParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRowRow, error) {
 	rows, err := q.db.QueryContext(ctx, getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRow,
 		arg.ViewerID,
 		arg.ViewerUserID,
-		arg.Idlinkercategory,
-		arg.Idlinkercategory,
+		arg.CategoryID,
+		arg.CategoryID,
 		arg.Limit,
 		arg.Offset,
 	)
@@ -663,11 +663,11 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 	for rows.Next() {
 		var i GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingForUserPaginatedRowRow
 		if err := rows.Scan(
-			&i.Idlinker,
-			&i.LanguageIdlanguage,
-			&i.UsersIdusers,
-			&i.LinkerCategoryID,
-			&i.ForumthreadID,
+			&i.ID,
+			&i.LanguageID,
+			&i.AuthorID,
+			&i.CategoryID,
+			&i.ThreadID,
 			&i.Title,
 			&i.Url,
 			&i.Description,
@@ -691,42 +691,42 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 }
 
 const getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated = `-- name: GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.Comments, lc.title as Category_Title, u.Username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE (lc.idlinkerCategory = ? OR ? = 0)
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE (lc.id = ? OR ? = 0)
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?
 `
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedParams struct {
-	Idlinkercategory int32
-	Limit            int32
-	Offset           int32
+	CategoryID int32
+	Limit      int32
+	Offset     int32
 }
 
 type GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	ID             int32
+	LanguageID     sql.NullInt32
+	AuthorID       int32
+	CategoryID     sql.NullInt32
+	ThreadID       int32
+	Title          sql.NullString
+	Url            sql.NullString
+	Description    sql.NullString
+	Listed         sql.NullTime
+	Timezone       sql.NullString
+	Comments       sql.NullInt32
+	CategoryTitle  sql.NullString
+	Posterusername sql.NullString
 }
 
 func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated(ctx context.Context, arg GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedParams) ([]*GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow, error) {
 	rows, err := q.db.QueryContext(ctx, getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginated,
-		arg.Idlinkercategory,
-		arg.Idlinkercategory,
+		arg.CategoryID,
+		arg.CategoryID,
 		arg.Limit,
 		arg.Offset,
 	)
@@ -738,11 +738,11 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 	for rows.Next() {
 		var i GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingPaginatedRow
 		if err := rows.Scan(
-			&i.Idlinker,
-			&i.LanguageIdlanguage,
-			&i.UsersIdusers,
-			&i.LinkerCategoryID,
-			&i.ForumthreadID,
+			&i.ID,
+			&i.LanguageID,
+			&i.AuthorID,
+			&i.CategoryID,
+			&i.ThreadID,
 			&i.Title,
 			&i.Url,
 			&i.Description,
@@ -766,24 +766,24 @@ func (q *Queries) GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTi
 }
 
 const getAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails = `-- name: GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails :many
-SELECT l.idlinkerqueue, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.title, l.url, l.description, l.timezone, u.username, c.title as category_title, c.idlinkerCategory
+SELECT l.id, l.language_id, l.submitter_id, l.category_id, l.title, l.url, l.description, l.timezone, u.username, c.title as category_title, c.id AS category_id
 FROM linker_queue l
-JOIN users u ON l.users_idusers = u.idusers
-JOIN linker_category c ON l.linker_category_id = c.idlinkerCategory
+JOIN users u ON l.submitter_id = u.idusers
+JOIN linker_category c ON l.category_id = c.id
 `
 
 type GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetailsRow struct {
-	Idlinkerqueue      int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Timezone           sql.NullString
-	Username           sql.NullString
-	CategoryTitle      sql.NullString
-	Idlinkercategory   int32
+	ID            int32
+	LanguageID    sql.NullInt32
+	SubmitterID   int32
+	CategoryID    sql.NullInt32
+	Title         sql.NullString
+	Url           sql.NullString
+	Description   sql.NullString
+	Timezone      sql.NullString
+	Username      sql.NullString
+	CategoryTitle sql.NullString
+	CategoryID_2  int32
 }
 
 func (q *Queries) GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails(ctx context.Context) ([]*GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetailsRow, error) {
@@ -796,17 +796,17 @@ func (q *Queries) GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails(ctx co
 	for rows.Next() {
 		var i GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetailsRow
 		if err := rows.Scan(
-			&i.Idlinkerqueue,
-			&i.LanguageIdlanguage,
-			&i.UsersIdusers,
-			&i.LinkerCategoryID,
+			&i.ID,
+			&i.LanguageID,
+			&i.SubmitterID,
+			&i.CategoryID,
 			&i.Title,
 			&i.Url,
 			&i.Description,
 			&i.Timezone,
 			&i.Username,
 			&i.CategoryTitle,
-			&i.Idlinkercategory,
+			&i.CategoryID_2,
 		); err != nil {
 			return nil, err
 		}
@@ -822,11 +822,11 @@ func (q *Queries) GetAllLinkerQueuedItemsWithUserAndLinkerCategoryDetails(ctx co
 }
 
 const getAllLinkersForIndex = `-- name: GetAllLinkersForIndex :many
-SELECT idlinker, title, description FROM linker WHERE deleted_at IS NULL AND listed IS NOT NULL
+SELECT id, title, description FROM linker WHERE deleted_at IS NULL AND listed IS NOT NULL
 `
 
 type GetAllLinkersForIndexRow struct {
-	Idlinker    int32
+	ID          int32
 	Title       sql.NullString
 	Description sql.NullString
 }
@@ -840,7 +840,7 @@ func (q *Queries) GetAllLinkersForIndex(ctx context.Context) ([]*GetAllLinkersFo
 	var items []*GetAllLinkersForIndexRow
 	for rows.Next() {
 		var i GetAllLinkersForIndexRow
-		if err := rows.Scan(&i.Idlinker, &i.Title, &i.Description); err != nil {
+		if err := rows.Scan(&i.ID, &i.Title, &i.Description); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -855,18 +855,18 @@ func (q *Queries) GetAllLinkersForIndex(ctx context.Context) ([]*GetAllLinkersFo
 }
 
 const getLinkerCategoriesWithCount = `-- name: GetLinkerCategoriesWithCount :many
-SELECT c.idlinkerCategory, c.title, c.sortorder, COUNT(l.idlinker) AS linkcount
+SELECT c.id, c.title, c.sortorder, COUNT(l.id) AS linkcount
 FROM linker_category c
-LEFT JOIN linker l ON l.linker_category_id = c.idlinkerCategory AND l.listed IS NOT NULL AND l.deleted_at IS NULL
-GROUP BY c.idlinkerCategory
+LEFT JOIN linker l ON l.category_id = c.id AND l.listed IS NOT NULL AND l.deleted_at IS NULL
+GROUP BY c.id
 ORDER BY c.sortorder
 `
 
 type GetLinkerCategoriesWithCountRow struct {
-	Idlinkercategory int32
-	Title            sql.NullString
-	Sortorder        int32
-	Linkcount        int64
+	ID        int32
+	Title     sql.NullString
+	Sortorder int32
+	Linkcount int64
 }
 
 func (q *Queries) GetLinkerCategoriesWithCount(ctx context.Context) ([]*GetLinkerCategoriesWithCountRow, error) {
@@ -879,7 +879,7 @@ func (q *Queries) GetLinkerCategoriesWithCount(ctx context.Context) ([]*GetLinke
 	for rows.Next() {
 		var i GetLinkerCategoriesWithCountRow
 		if err := rows.Scan(
-			&i.Idlinkercategory,
+			&i.ID,
 			&i.Title,
 			&i.Sortorder,
 			&i.Linkcount,
@@ -898,14 +898,14 @@ func (q *Queries) GetLinkerCategoriesWithCount(ctx context.Context) ([]*GetLinke
 }
 
 const getLinkerCategoryById = `-- name: GetLinkerCategoryById :one
-SELECT idlinkercategory, position, title, sortorder FROM linker_category WHERE idlinkerCategory = ?
+SELECT id, position, title, sortorder FROM linker_category WHERE id = ?
 `
 
-func (q *Queries) GetLinkerCategoryById(ctx context.Context, idlinkercategory int32) (*LinkerCategory, error) {
-	row := q.db.QueryRowContext(ctx, getLinkerCategoryById, idlinkercategory)
+func (q *Queries) GetLinkerCategoryById(ctx context.Context, id int32) (*LinkerCategory, error) {
+	row := q.db.QueryRowContext(ctx, getLinkerCategoryById, id)
 	var i LinkerCategory
 	err := row.Scan(
-		&i.Idlinkercategory,
+		&i.ID,
 		&i.Position,
 		&i.Title,
 		&i.Sortorder,
@@ -914,18 +914,18 @@ func (q *Queries) GetLinkerCategoryById(ctx context.Context, idlinkercategory in
 }
 
 const getLinkerCategoryLinkCounts = `-- name: GetLinkerCategoryLinkCounts :many
-SELECT c.idlinkerCategory, c.title, c.position, COUNT(l.idlinker) as LinkCount
+SELECT c.id, c.title, c.position, COUNT(l.id) as LinkCount
 FROM linker_category c
-LEFT JOIN linker l ON c.idlinkerCategory = l.linker_category_id AND l.listed IS NOT NULL AND l.deleted_at IS NULL
-GROUP BY c.idlinkerCategory
+LEFT JOIN linker l ON c.id = l.category_id AND l.listed IS NOT NULL AND l.deleted_at IS NULL
+GROUP BY c.id
 ORDER BY c.position
 `
 
 type GetLinkerCategoryLinkCountsRow struct {
-	Idlinkercategory int32
-	Title            sql.NullString
-	Position         int32
-	Linkcount        int64
+	ID        int32
+	Title     sql.NullString
+	Position  int32
+	Linkcount int64
 }
 
 func (q *Queries) GetLinkerCategoryLinkCounts(ctx context.Context) ([]*GetLinkerCategoryLinkCountsRow, error) {
@@ -938,7 +938,7 @@ func (q *Queries) GetLinkerCategoryLinkCounts(ctx context.Context) ([]*GetLinker
 	for rows.Next() {
 		var i GetLinkerCategoryLinkCountsRow
 		if err := rows.Scan(
-			&i.Idlinkercategory,
+			&i.ID,
 			&i.Title,
 			&i.Position,
 			&i.Linkcount,
@@ -957,37 +957,37 @@ func (q *Queries) GetLinkerCategoryLinkCounts(ctx context.Context) ([]*GetLinker
 }
 
 const getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending = `-- name: GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending :one
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
-JOIN users u ON l.users_idusers = u.idusers
-JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-WHERE l.idlinker = ?
+JOIN users u ON l.author_id = u.idusers
+JOIN linker_category lc ON l.category_id = lc.id
+WHERE l.id = ?
 `
 
 type GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Username           sql.NullString
-	Title_2            sql.NullString
+	ID          int32
+	LanguageID  sql.NullInt32
+	AuthorID    int32
+	CategoryID  sql.NullInt32
+	ThreadID    int32
+	Title       sql.NullString
+	Url         sql.NullString
+	Description sql.NullString
+	Listed      sql.NullTime
+	Timezone    sql.NullString
+	Username    sql.NullString
+	Title_2     sql.NullString
 }
 
-func (q *Queries) GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(ctx context.Context, idlinker int32) (*GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow, error) {
-	row := q.db.QueryRowContext(ctx, getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending, idlinker)
+func (q *Queries) GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(ctx context.Context, id int32) (*GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow, error) {
+	row := q.db.QueryRowContext(ctx, getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending, id)
 	var i GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow
 	err := row.Scan(
-		&i.Idlinker,
-		&i.LanguageIdlanguage,
-		&i.UsersIdusers,
-		&i.LinkerCategoryID,
-		&i.ForumthreadID,
+		&i.ID,
+		&i.LanguageID,
+		&i.AuthorID,
+		&i.CategoryID,
+		&i.ThreadID,
 		&i.Title,
 		&i.Url,
 		&i.Description,
@@ -1011,11 +1011,11 @@ grants_for_viewer AS (
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
-JOIN users u ON l.users_idusers = u.idusers
-JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-WHERE l.idlinker = ?
+JOIN users u ON l.author_id = u.idusers
+JOIN linker_category lc ON l.category_id = lc.id
+WHERE l.id = ?
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
   AND EXISTS (
@@ -1024,7 +1024,7 @@ WHERE l.idlinker = ?
     WHERE g.section = 'linker'
       AND (g.item = 'link' OR g.item IS NULL)
       AND g.action IN ('view')
-      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+      AND (g.item_id = l.id OR g.item_id IS NULL)
   )
 LIMIT 1
 `
@@ -1032,33 +1032,33 @@ LIMIT 1
 type GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams struct {
 	ViewerID     int32
 	ViewerUserID sql.NullInt32
-	Idlinker     int32
+	ID           int32
 }
 
 type GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Username           sql.NullString
-	Title_2            sql.NullString
+	ID          int32
+	LanguageID  sql.NullInt32
+	AuthorID    int32
+	CategoryID  sql.NullInt32
+	ThreadID    int32
+	Title       sql.NullString
+	Url         sql.NullString
+	Description sql.NullString
+	Listed      sql.NullTime
+	Timezone    sql.NullString
+	Username    sql.NullString
+	Title_2     sql.NullString
 }
 
 func (q *Queries) GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUser(ctx context.Context, arg GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams) (*GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow, error) {
-	row := q.db.QueryRowContext(ctx, getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUser, arg.ViewerID, arg.ViewerUserID, arg.Idlinker)
+	row := q.db.QueryRowContext(ctx, getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUser, arg.ViewerID, arg.ViewerUserID, arg.ID)
 	var i GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow
 	err := row.Scan(
-		&i.Idlinker,
-		&i.LanguageIdlanguage,
-		&i.UsersIdusers,
-		&i.LinkerCategoryID,
-		&i.ForumthreadID,
+		&i.ID,
+		&i.LanguageID,
+		&i.AuthorID,
+		&i.CategoryID,
+		&i.ThreadID,
 		&i.Title,
 		&i.Url,
 		&i.Description,
@@ -1071,26 +1071,26 @@ func (q *Queries) GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingF
 }
 
 const getLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescending = `-- name: GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescending :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
-JOIN users u ON l.users_idusers = u.idusers
-JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-WHERE l.idlinker IN (/*SLICE:linkerids*/?)
+JOIN users u ON l.author_id = u.idusers
+JOIN linker_category lc ON l.category_id = lc.id
+WHERE l.id IN (/*SLICE:linkerids*/?)
 `
 
 type GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Username           sql.NullString
-	Title_2            sql.NullString
+	ID          int32
+	LanguageID  sql.NullInt32
+	AuthorID    int32
+	CategoryID  sql.NullInt32
+	ThreadID    int32
+	Title       sql.NullString
+	Url         sql.NullString
+	Description sql.NullString
+	Listed      sql.NullTime
+	Timezone    sql.NullString
+	Username    sql.NullString
+	Title_2     sql.NullString
 }
 
 func (q *Queries) GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescending(ctx context.Context, linkerids []int32) ([]*GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow, error) {
@@ -1113,11 +1113,11 @@ func (q *Queries) GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendin
 	for rows.Next() {
 		var i GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingRow
 		if err := rows.Scan(
-			&i.Idlinker,
-			&i.LanguageIdlanguage,
-			&i.UsersIdusers,
-			&i.LinkerCategoryID,
-			&i.ForumthreadID,
+			&i.ID,
+			&i.LanguageID,
+			&i.AuthorID,
+			&i.CategoryID,
+			&i.ThreadID,
 			&i.Title,
 			&i.Url,
 			&i.Description,
@@ -1151,11 +1151,11 @@ grants_for_viewer AS (
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, u.username, lc.title
 FROM linker l
-JOIN users u ON l.users_idusers = u.idusers
-JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-WHERE l.idlinker IN (/*SLICE:linkerids*/?)
+JOIN users u ON l.author_id = u.idusers
+JOIN linker_category lc ON l.category_id = lc.id
+WHERE l.id IN (/*SLICE:linkerids*/?)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
   AND EXISTS (
@@ -1164,7 +1164,7 @@ WHERE l.idlinker IN (/*SLICE:linkerids*/?)
     WHERE g.section = 'linker'
       AND (g.item = 'link' OR g.item IS NULL)
       AND g.action = 'view'
-      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+      AND (g.item_id = l.id OR g.item_id IS NULL)
   )
 `
 
@@ -1175,18 +1175,18 @@ type GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserParam
 }
 
 type GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Username           sql.NullString
-	Title_2            sql.NullString
+	ID          int32
+	LanguageID  sql.NullInt32
+	AuthorID    int32
+	CategoryID  sql.NullInt32
+	ThreadID    int32
+	Title       sql.NullString
+	Url         sql.NullString
+	Description sql.NullString
+	Listed      sql.NullTime
+	Timezone    sql.NullString
+	Username    sql.NullString
+	Title_2     sql.NullString
 }
 
 func (q *Queries) GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUser(ctx context.Context, arg GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserParams) ([]*GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserRow, error) {
@@ -1211,11 +1211,11 @@ func (q *Queries) GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendin
 	for rows.Next() {
 		var i GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendingForUserRow
 		if err := rows.Scan(
-			&i.Idlinker,
-			&i.LanguageIdlanguage,
-			&i.UsersIdusers,
-			&i.LinkerCategoryID,
-			&i.ForumthreadID,
+			&i.ID,
+			&i.LanguageID,
+			&i.AuthorID,
+			&i.CategoryID,
+			&i.ThreadID,
 			&i.Title,
 			&i.Url,
 			&i.Description,
@@ -1238,40 +1238,40 @@ func (q *Queries) GetLinkerItemsByIdsWithPosterUsernameAndCategoryTitleDescendin
 }
 
 const getLinkerItemsByUserDescending = `-- name: GetLinkerItemsByUserDescending :many
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE l.users_idusers = ?
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE l.author_id = ?
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?
 `
 
 type GetLinkerItemsByUserDescendingParams struct {
-	UsersIdusers int32
-	Limit        int32
-	Offset       int32
+	AuthorID int32
+	Limit    int32
+	Offset   int32
 }
 
 type GetLinkerItemsByUserDescendingRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	ID             int32
+	LanguageID     sql.NullInt32
+	AuthorID       int32
+	CategoryID     sql.NullInt32
+	ThreadID       int32
+	Title          sql.NullString
+	Url            sql.NullString
+	Description    sql.NullString
+	Listed         sql.NullTime
+	Timezone       sql.NullString
+	Comments       sql.NullInt32
+	CategoryTitle  sql.NullString
+	Posterusername sql.NullString
 }
 
 func (q *Queries) GetLinkerItemsByUserDescending(ctx context.Context, arg GetLinkerItemsByUserDescendingParams) ([]*GetLinkerItemsByUserDescendingRow, error) {
-	rows, err := q.db.QueryContext(ctx, getLinkerItemsByUserDescending, arg.UsersIdusers, arg.Limit, arg.Offset)
+	rows, err := q.db.QueryContext(ctx, getLinkerItemsByUserDescending, arg.AuthorID, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
@@ -1280,11 +1280,11 @@ func (q *Queries) GetLinkerItemsByUserDescending(ctx context.Context, arg GetLin
 	for rows.Next() {
 		var i GetLinkerItemsByUserDescendingRow
 		if err := rows.Scan(
-			&i.Idlinker,
-			&i.LanguageIdlanguage,
-			&i.UsersIdusers,
-			&i.LinkerCategoryID,
-			&i.ForumthreadID,
+			&i.ID,
+			&i.LanguageID,
+			&i.AuthorID,
+			&i.CategoryID,
+			&i.ThreadID,
 			&i.Title,
 			&i.Url,
 			&i.Description,
@@ -1319,12 +1319,12 @@ grants_for_viewer AS (
       AND (g.user_id = ? OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
-SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id, l.forumthread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
+SELECT l.id, l.language_id, l.author_id, l.category_id, l.thread_id, l.title, l.url, l.description, l.listed, l.timezone, th.comments, lc.title as Category_Title, u.username as PosterUsername
 FROM linker l
-LEFT JOIN users u ON l.users_idusers = u.idusers
-LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
-WHERE l.users_idusers = ?
+LEFT JOIN users u ON l.author_id = u.idusers
+LEFT JOIN linker_category lc ON l.category_id = lc.id
+LEFT JOIN forumthread th ON l.thread_id = th.idforumthread
+WHERE l.author_id = ?
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
   AND EXISTS (
@@ -1333,7 +1333,7 @@ WHERE l.users_idusers = ?
     WHERE g.section = 'linker'
       AND (g.item = 'link' OR g.item IS NULL)
       AND g.action = 'see'
-      AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+      AND (g.item_id = l.id OR g.item_id IS NULL)
   )
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?
@@ -1348,19 +1348,19 @@ type GetLinkerItemsByUserDescendingForUserParams struct {
 }
 
 type GetLinkerItemsByUserDescendingForUserRow struct {
-	Idlinker           int32
-	LanguageIdlanguage sql.NullInt32
-	UsersIdusers       int32
-	LinkerCategoryID   sql.NullInt32
-	ForumthreadID      int32
-	Title              sql.NullString
-	Url                sql.NullString
-	Description        sql.NullString
-	Listed             sql.NullTime
-	Timezone           sql.NullString
-	Comments           sql.NullInt32
-	CategoryTitle      sql.NullString
-	Posterusername     sql.NullString
+	ID             int32
+	LanguageID     sql.NullInt32
+	AuthorID       int32
+	CategoryID     sql.NullInt32
+	ThreadID       int32
+	Title          sql.NullString
+	Url            sql.NullString
+	Description    sql.NullString
+	Listed         sql.NullTime
+	Timezone       sql.NullString
+	Comments       sql.NullInt32
+	CategoryTitle  sql.NullString
+	Posterusername sql.NullString
 }
 
 func (q *Queries) GetLinkerItemsByUserDescendingForUser(ctx context.Context, arg GetLinkerItemsByUserDescendingForUserParams) ([]*GetLinkerItemsByUserDescendingForUserRow, error) {
@@ -1379,11 +1379,11 @@ func (q *Queries) GetLinkerItemsByUserDescendingForUser(ctx context.Context, arg
 	for rows.Next() {
 		var i GetLinkerItemsByUserDescendingForUserRow
 		if err := rows.Scan(
-			&i.Idlinker,
-			&i.LanguageIdlanguage,
-			&i.UsersIdusers,
-			&i.LinkerCategoryID,
-			&i.ForumthreadID,
+			&i.ID,
+			&i.LanguageID,
+			&i.AuthorID,
+			&i.CategoryID,
+			&i.ThreadID,
 			&i.Title,
 			&i.Url,
 			&i.Description,
@@ -1408,17 +1408,17 @@ func (q *Queries) GetLinkerItemsByUserDescendingForUser(ctx context.Context, arg
 
 const listLinkerCategoryPath = `-- name: ListLinkerCategoryPath :many
 WITH RECURSIVE category_path AS (
-    SELECT lc.idlinkerCategory, NULL AS parent_id, lc.title, 0 AS depth
+    SELECT lc.id, NULL AS parent_id, lc.title, 0 AS depth
     FROM linker_category lc
-    WHERE lc.idlinkerCategory = ?
+    WHERE lc.id = ?
 )
-SELECT category_path.idlinkerCategory, category_path.title
+SELECT category_path.id, category_path.title
 FROM category_path
 `
 
 type ListLinkerCategoryPathRow struct {
-	Idlinkercategory int32
-	Title            sql.NullString
+	ID    int32
+	Title sql.NullString
 }
 
 func (q *Queries) ListLinkerCategoryPath(ctx context.Context, categoryID int32) ([]*ListLinkerCategoryPathRow, error) {
@@ -1430,7 +1430,7 @@ func (q *Queries) ListLinkerCategoryPath(ctx context.Context, categoryID int32) 
 	var items []*ListLinkerCategoryPathRow
 	for rows.Next() {
 		var i ListLinkerCategoryPathRow
-		if err := rows.Scan(&i.Idlinkercategory, &i.Title); err != nil {
+		if err := rows.Scan(&i.ID, &i.Title); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -1445,24 +1445,24 @@ func (q *Queries) ListLinkerCategoryPath(ctx context.Context, categoryID int32) 
 }
 
 const systemAssignLinkerThreadID = `-- name: SystemAssignLinkerThreadID :exec
-UPDATE linker SET forumthread_id = ? WHERE idlinker = ?
+UPDATE linker SET thread_id = ? WHERE id = ?
 `
 
 type SystemAssignLinkerThreadIDParams struct {
-	ForumthreadID int32
-	Idlinker      int32
+	ThreadID int32
+	ID       int32
 }
 
 func (q *Queries) SystemAssignLinkerThreadID(ctx context.Context, arg SystemAssignLinkerThreadIDParams) error {
-	_, err := q.db.ExecContext(ctx, systemAssignLinkerThreadID, arg.ForumthreadID, arg.Idlinker)
+	_, err := q.db.ExecContext(ctx, systemAssignLinkerThreadID, arg.ThreadID, arg.ID)
 	return err
 }
 
 const systemSetLinkerLastIndex = `-- name: SystemSetLinkerLastIndex :exec
-UPDATE linker SET last_index = NOW() WHERE idlinker = ?
+UPDATE linker SET last_index = NOW() WHERE id = ?
 `
 
-func (q *Queries) SystemSetLinkerLastIndex(ctx context.Context, idlinker int32) error {
-	_, err := q.db.ExecContext(ctx, systemSetLinkerLastIndex, idlinker)
+func (q *Queries) SystemSetLinkerLastIndex(ctx context.Context, id int32) error {
+	_, err := q.db.ExecContext(ctx, systemSetLinkerLastIndex, id)
 	return err
 }

--- a/internal/db/queries-search.sql
+++ b/internal/db/queries-search.sql
@@ -103,7 +103,7 @@ WHERE swl.word=sqlc.arg(word)
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -139,7 +139,7 @@ WHERE swl.word=sqlc.arg(word)
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -174,7 +174,7 @@ WHERE swl.word=sqlc.arg(word)
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -210,7 +210,7 @@ WHERE swl.word=sqlc.arg(word)
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -269,7 +269,7 @@ WHERE swl.word = sqlc.arg(word)
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = w.language_idlanguage
+            AND ul.language_id = w.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -302,7 +302,7 @@ WHERE swl.word = sqlc.arg(word)
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = w.language_idlanguage
+            AND ul.language_id = w.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -334,7 +334,7 @@ WHERE swl.word = sqlc.arg(word)
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = sn.language_idlanguage
+            AND ul.language_id = sn.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -367,7 +367,7 @@ WHERE swl.word = sqlc.arg(word)
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = sn.language_idlanguage
+            AND ul.language_id = sn.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -393,15 +393,15 @@ WITH role_ids AS (
 SELECT DISTINCT cs.linker_id
 FROM linker_search cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearchwordlist
-JOIN linker l ON l.idlinker = cs.linker_id
+JOIN linker l ON l.id = cs.linker_id
 WHERE swl.word = sqlc.arg(word)
   AND (
-      l.language_idlanguage = 0
-      OR l.language_idlanguage IS NULL
+      l.language_id = 0
+      OR l.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = l.language_idlanguage
+            AND ul.language_id = l.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -413,7 +413,7 @@ WHERE swl.word = sqlc.arg(word)
         AND (g.item='link' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+        AND (g.item_id = l.id OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -425,16 +425,16 @@ WITH role_ids AS (
 SELECT DISTINCT cs.linker_id
 FROM linker_search cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearchwordlist
-JOIN linker l ON l.idlinker = cs.linker_id
+JOIN linker l ON l.id = cs.linker_id
 WHERE swl.word = sqlc.arg(word)
   AND cs.linker_id IN (sqlc.slice('ids'))
   AND (
-      l.language_idlanguage = 0
-      OR l.language_idlanguage IS NULL
+      l.language_id = 0
+      OR l.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(lister_id)
-            AND ul.language_idlanguage = l.language_idlanguage
+            AND ul.language_id = l.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(lister_id)
@@ -446,7 +446,7 @@ WHERE swl.word = sqlc.arg(word)
         AND (g.item='link' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+        AND (g.item_id = l.id OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );

--- a/internal/db/queries-search.sql.go
+++ b/internal/db/queries-search.sql.go
@@ -167,15 +167,15 @@ WITH role_ids AS (
 SELECT DISTINCT cs.linker_id
 FROM linker_search cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearchwordlist
-JOIN linker l ON l.idlinker = cs.linker_id
+JOIN linker l ON l.id = cs.linker_id
 WHERE swl.word = ?
   AND (
-      l.language_idlanguage = 0
-      OR l.language_idlanguage IS NULL
+      l.language_id = 0
+      OR l.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = l.language_idlanguage
+            AND ul.language_id = l.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -187,7 +187,7 @@ WHERE swl.word = ?
         AND (g.item='link' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+        AND (g.item_id = l.id OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -235,16 +235,16 @@ WITH role_ids AS (
 SELECT DISTINCT cs.linker_id
 FROM linker_search cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist = cs.searchwordlist_idsearchwordlist
-JOIN linker l ON l.idlinker = cs.linker_id
+JOIN linker l ON l.id = cs.linker_id
 WHERE swl.word = ?
   AND cs.linker_id IN (/*SLICE:ids*/?)
   AND (
-      l.language_idlanguage = 0
-      OR l.language_idlanguage IS NULL
+      l.language_id = 0
+      OR l.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = l.language_idlanguage
+            AND ul.language_id = l.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -256,7 +256,7 @@ WHERE swl.word = ?
         AND (g.item='link' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = l.idlinker OR g.item_id IS NULL)
+        AND (g.item_id = l.id OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -325,7 +325,7 @@ WHERE swl.word=?
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -406,7 +406,7 @@ WHERE swl.word=?
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -478,7 +478,7 @@ WHERE swl.word=?
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -569,7 +569,7 @@ WHERE swl.word=?
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = c.language_idlanguage
+            AND ul.language_id = c.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -647,7 +647,7 @@ WHERE swl.word = ?
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = sn.language_idlanguage
+            AND ul.language_id = sn.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -716,7 +716,7 @@ WHERE swl.word = ?
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = sn.language_idlanguage
+            AND ul.language_id = sn.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -794,7 +794,7 @@ WHERE swl.word = ?
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = w.language_idlanguage
+            AND ul.language_id = w.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?
@@ -863,7 +863,7 @@ WHERE swl.word = ?
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = ?
-            AND ul.language_idlanguage = w.language_idlanguage
+            AND ul.language_id = w.language_idlanguage
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?

--- a/internal/db/queries-stats.sql
+++ b/internal/db/queries-stats.sql
@@ -61,7 +61,7 @@ LEFT JOIN (SELECT users_idusers AS uid, COUNT(*) AS blogs FROM blogs GROUP BY us
 LEFT JOIN (SELECT users_idusers AS uid, COUNT(*) AS news FROM site_news GROUP BY users_idusers) n ON n.uid = u.idusers
 LEFT JOIN (SELECT users_idusers AS uid, COUNT(*) AS comments FROM comments GROUP BY users_idusers) c ON c.uid = u.idusers
 LEFT JOIN (SELECT users_idusers AS uid, COUNT(*) AS images FROM imagepost GROUP BY users_idusers) i ON i.uid = u.idusers
-LEFT JOIN (SELECT users_idusers AS uid, COUNT(*) AS links FROM linker GROUP BY users_idusers) l ON l.uid = u.idusers
+LEFT JOIN (SELECT author_id AS uid, COUNT(*) AS links FROM linker GROUP BY author_id) l ON l.uid = u.idusers
 LEFT JOIN (SELECT users_idusers AS uid, COUNT(*) AS writings FROM writing GROUP BY users_idusers) w ON w.uid = u.idusers
 ORDER BY u.username;
 
@@ -71,7 +71,7 @@ SELECT
   (SELECT COUNT(*) FROM site_news n WHERE n.users_idusers = u.idusers)  AS news,
   (SELECT COUNT(*) FROM comments c WHERE c.users_idusers = u.idusers)   AS comments,
   (SELECT COUNT(*) FROM imagepost i WHERE i.users_idusers = u.idusers)  AS images,
-  (SELECT COUNT(*) FROM linker l WHERE l.users_idusers = u.idusers)     AS links,
+   (SELECT COUNT(*) FROM linker l WHERE l.author_id = u.idusers)     AS links,
   (SELECT COUNT(*) FROM writing w WHERE w.users_idusers = u.idusers)    AS writings
 FROM users u
 WHERE u.idusers = ?;

--- a/internal/db/queries-stats.sql.go
+++ b/internal/db/queries-stats.sql.go
@@ -397,7 +397,7 @@ LEFT JOIN (SELECT users_idusers AS uid, COUNT(*) AS blogs FROM blogs GROUP BY us
 LEFT JOIN (SELECT users_idusers AS uid, COUNT(*) AS news FROM site_news GROUP BY users_idusers) n ON n.uid = u.idusers
 LEFT JOIN (SELECT users_idusers AS uid, COUNT(*) AS comments FROM comments GROUP BY users_idusers) c ON c.uid = u.idusers
 LEFT JOIN (SELECT users_idusers AS uid, COUNT(*) AS images FROM imagepost GROUP BY users_idusers) i ON i.uid = u.idusers
-LEFT JOIN (SELECT users_idusers AS uid, COUNT(*) AS links FROM linker GROUP BY users_idusers) l ON l.uid = u.idusers
+LEFT JOIN (SELECT author_id AS uid, COUNT(*) AS links FROM linker GROUP BY author_id) l ON l.uid = u.idusers
 LEFT JOIN (SELECT users_idusers AS uid, COUNT(*) AS writings FROM writing GROUP BY users_idusers) w ON w.uid = u.idusers
 ORDER BY u.username
 `
@@ -451,7 +451,7 @@ SELECT
   (SELECT COUNT(*) FROM site_news n WHERE n.users_idusers = u.idusers)  AS news,
   (SELECT COUNT(*) FROM comments c WHERE c.users_idusers = u.idusers)   AS comments,
   (SELECT COUNT(*) FROM imagepost i WHERE i.users_idusers = u.idusers)  AS images,
-  (SELECT COUNT(*) FROM linker l WHERE l.users_idusers = u.idusers)     AS links,
+   (SELECT COUNT(*) FROM linker l WHERE l.author_id = u.idusers)     AS links,
   (SELECT COUNT(*) FROM writing w WHERE w.users_idusers = u.idusers)    AS writings
 FROM users u
 WHERE u.idusers = ?

--- a/migrations/0066.mysql.sql
+++ b/migrations/0066.mysql.sql
@@ -1,0 +1,18 @@
+ALTER TABLE linker
+    CHANGE COLUMN idlinker id INT NOT NULL AUTO_INCREMENT,
+    CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL,
+    CHANGE COLUMN users_idusers author_id INT NOT NULL,
+    CHANGE COLUMN linker_category_id category_id INT DEFAULT NULL,
+    CHANGE COLUMN forumthread_id thread_id INT DEFAULT NULL;
+
+ALTER TABLE linker_category
+    CHANGE COLUMN idlinkerCategory id INT NOT NULL AUTO_INCREMENT;
+
+ALTER TABLE linker_queue
+    CHANGE COLUMN idlinkerQueue id INT NOT NULL AUTO_INCREMENT,
+    CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL,
+    CHANGE COLUMN users_idusers submitter_id INT NOT NULL,
+    CHANGE COLUMN linker_category_id category_id INT DEFAULT NULL;
+
+-- Update schema version
+UPDATE schema_version SET version = 66 WHERE version = 65;

--- a/migrations/0066.postgres.sql
+++ b/migrations/0066.postgres.sql
@@ -1,0 +1,15 @@
+ALTER TABLE linker RENAME COLUMN idlinker TO id;
+ALTER TABLE linker RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE linker RENAME COLUMN users_idusers TO author_id;
+ALTER TABLE linker RENAME COLUMN linker_category_id TO category_id;
+ALTER TABLE linker RENAME COLUMN forumthread_id TO thread_id;
+
+ALTER TABLE linker_category RENAME COLUMN idlinkerCategory TO id;
+
+ALTER TABLE linker_queue RENAME COLUMN idlinkerQueue TO id;
+ALTER TABLE linker_queue RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE linker_queue RENAME COLUMN users_idusers TO submitter_id;
+ALTER TABLE linker_queue RENAME COLUMN linker_category_id TO category_id;
+
+-- Update schema version
+UPDATE schema_version SET version = 66 WHERE version = 65;

--- a/migrations/0066.sqlite.sql
+++ b/migrations/0066.sqlite.sql
@@ -1,0 +1,15 @@
+ALTER TABLE linker RENAME COLUMN idlinker TO id;
+ALTER TABLE linker RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE linker RENAME COLUMN users_idusers TO author_id;
+ALTER TABLE linker RENAME COLUMN linker_category_id TO category_id;
+ALTER TABLE linker RENAME COLUMN forumthread_id TO thread_id;
+
+ALTER TABLE linker_category RENAME COLUMN idlinkerCategory TO id;
+
+ALTER TABLE linker_queue RENAME COLUMN idlinkerQueue TO id;
+ALTER TABLE linker_queue RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE linker_queue RENAME COLUMN users_idusers TO submitter_id;
+ALTER TABLE linker_queue RENAME COLUMN linker_category_id TO category_id;
+
+-- Update schema version
+UPDATE schema_version SET version = 66 WHERE version = 65;

--- a/schema/schema.mysql.sql
+++ b/schema/schema.mysql.sql
@@ -176,11 +176,11 @@ CREATE TABLE `language` (
 );
 
 CREATE TABLE `linker` (
-  `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
-  `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `linker_category_id` int(10) DEFAULT NULL,
-  `forumthread_id` int(10) NOT NULL DEFAULT 0,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `language_id` int(10) DEFAULT NULL,
+  `author_id` int(10) NOT NULL DEFAULT 0,
+  `category_id` int(10) DEFAULT NULL,
+  `thread_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `url` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
@@ -188,34 +188,34 @@ CREATE TABLE `linker` (
   `timezone` tinytext DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
   `last_index` datetime DEFAULT NULL,
-  PRIMARY KEY (`idlinker`),
-  KEY `linker_FKIndex1` (`forumthread_id`),
-  KEY `linker_FKIndex2` (`linker_category_id`),
-  KEY `linker_FKIndex3` (`users_idusers`),
-  KEY `linker_FKIndex4` (`language_idlanguage`)
+  PRIMARY KEY (`id`),
+  KEY `linker_FKIndex1` (`thread_id`),
+  KEY `linker_FKIndex2` (`category_id`),
+  KEY `linker_FKIndex3` (`author_id`),
+  KEY `linker_FKIndex4` (`language_id`)
 );
 
 CREATE TABLE `linker_category` (
-  `idlinkerCategory` int(10) NOT NULL AUTO_INCREMENT,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
   `position` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `sortorder` int(10) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`idlinkerCategory`)
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `linker_queue` (
-  `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
-  `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `linker_category_id` int(10) DEFAULT NULL,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `language_id` int(10) DEFAULT NULL,
+  `submitter_id` int(10) NOT NULL DEFAULT 0,
+  `category_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `url` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `timezone` tinytext DEFAULT NULL,
-  PRIMARY KEY (`idlinkerQueue`),
-  KEY `linkerQueue_FKIndex1` (`linker_category_id`),
-  KEY `linkerQueue_FKIndex2` (`users_idusers`),
-  KEY `linkerQueue_FKIndex3` (`language_idlanguage`)
+  PRIMARY KEY (`id`),
+  KEY `linkerQueue_FKIndex1` (`category_id`),
+  KEY `linkerQueue_FKIndex2` (`submitter_id`),
+  KEY `linkerQueue_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `linker_search` (

--- a/schema/schema.postgres.sql
+++ b/schema/schema.postgres.sql
@@ -175,11 +175,11 @@ CREATE TABLE `language` (
 );
 
 CREATE TABLE `linker` (
-  `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
-  `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `linker_category_id` int(10) DEFAULT NULL,
-  `forumthread_id` int(10) NOT NULL DEFAULT 0,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `language_id` int(10) DEFAULT NULL,
+  `author_id` int(10) NOT NULL DEFAULT 0,
+  `category_id` int(10) DEFAULT NULL,
+  `thread_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `url` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
@@ -187,34 +187,34 @@ CREATE TABLE `linker` (
   `timezone` text DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
   `last_index` datetime DEFAULT NULL,
-  PRIMARY KEY (`idlinker`),
-  KEY `linker_FKIndex1` (`forumthread_id`),
-  KEY `linker_FKIndex2` (`linker_category_id`),
-  KEY `linker_FKIndex3` (`users_idusers`),
-  KEY `linker_FKIndex4` (`language_idlanguage`)
+  PRIMARY KEY (`id`),
+  KEY `linker_FKIndex1` (`thread_id`),
+  KEY `linker_FKIndex2` (`category_id`),
+  KEY `linker_FKIndex3` (`author_id`),
+  KEY `linker_FKIndex4` (`language_id`)
 );
 
 CREATE TABLE `linker_category` (
-  `idlinkerCategory` int(10) NOT NULL AUTO_INCREMENT,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
   `position` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `sortorder` int(10) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`idlinkerCategory`)
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `linker_queue` (
-  `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
-  `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `linker_category_id` int(10) DEFAULT NULL,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `language_id` int(10) DEFAULT NULL,
+  `submitter_id` int(10) NOT NULL DEFAULT 0,
+  `category_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `url` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `timezone` text DEFAULT NULL,
-  PRIMARY KEY (`idlinkerQueue`),
-  KEY `linkerQueue_FKIndex1` (`linker_category_id`),
-  KEY `linkerQueue_FKIndex2` (`users_idusers`),
-  KEY `linkerQueue_FKIndex3` (`language_idlanguage`)
+  PRIMARY KEY (`id`),
+  KEY `linkerQueue_FKIndex1` (`category_id`),
+  KEY `linkerQueue_FKIndex2` (`submitter_id`),
+  KEY `linkerQueue_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `linker_search` (

--- a/schema/schema.sqlite.sql
+++ b/schema/schema.sqlite.sql
@@ -175,11 +175,11 @@ CREATE TABLE `language` (
 );
 
 CREATE TABLE `linker` (
-  `idlinker` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
-  `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `linker_category_id` int(10) DEFAULT NULL,
-  `forumthread_id` int(10) NOT NULL DEFAULT 0,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `language_id` int(10) DEFAULT NULL,
+  `author_id` int(10) NOT NULL DEFAULT 0,
+  `category_id` int(10) DEFAULT NULL,
+  `thread_id` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `url` tinytext DEFAULT NULL,
   `description` tinytext DEFAULT NULL,
@@ -187,34 +187,34 @@ CREATE TABLE `linker` (
   `timezone` text,
   `deleted_at` datetime DEFAULT NULL,
   `last_index` datetime DEFAULT NULL,
-  PRIMARY KEY (`idlinker`),
-  KEY `linker_FKIndex1` (`forumthread_id`),
-  KEY `linker_FKIndex2` (`linker_category_id`),
-  KEY `linker_FKIndex3` (`users_idusers`),
-  KEY `linker_FKIndex4` (`language_idlanguage`)
+  PRIMARY KEY (`id`),
+  KEY `linker_FKIndex1` (`thread_id`),
+  KEY `linker_FKIndex2` (`category_id`),
+  KEY `linker_FKIndex3` (`author_id`),
+  KEY `linker_FKIndex4` (`language_id`)
 );
 
 CREATE TABLE `linker_category` (
-  `idlinkerCategory` int(10) NOT NULL AUTO_INCREMENT,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
   `position` int(10) NOT NULL DEFAULT 0,
   `title` tinytext DEFAULT NULL,
   `sortorder` int(10) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`idlinkerCategory`)
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `linker_queue` (
-  `idlinkerQueue` int(10) NOT NULL AUTO_INCREMENT,
-  `language_idlanguage` int(10) DEFAULT NULL,
-  `users_idusers` int(10) NOT NULL DEFAULT 0,
-  `linker_category_id` int(10) DEFAULT NULL,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `language_id` int(10) DEFAULT NULL,
+  `submitter_id` int(10) NOT NULL DEFAULT 0,
+  `category_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `url` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `timezone` text,
-  PRIMARY KEY (`idlinkerQueue`),
-  KEY `linkerQueue_FKIndex1` (`linker_category_id`),
-  KEY `linkerQueue_FKIndex2` (`users_idusers`),
-  KEY `linkerQueue_FKIndex3` (`language_idlanguage`)
+  PRIMARY KEY (`id`),
+  KEY `linkerQueue_FKIndex1` (`category_id`),
+  KEY `linkerQueue_FKIndex2` (`submitter_id`),
+  KEY `linkerQueue_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `linker_search` (


### PR DESCRIPTION
## Summary
- rename linker-related columns to normalized ids
- update queries, handlers, and templates for new linker schema
- bump expected schema version and regenerate sqlc models

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689989b95404832fb3680c50f316684e