### PR TITLE
Rename forum table columns and update schema

### DIFF
--- a/cmd/goa4web/writing_tree.go
+++ b/cmd/goa4web/writing_tree.go
@@ -36,14 +36,14 @@ func (c *writingTreeCmd) Run() error {
 	if err != nil {
 		return fmt.Errorf("tree: %w", err)
 	}
-        children := map[int32][]*db.WritingCategory{}
-        for _, cat := range rows {
-                var parent int32
-                if cat.WritingCategoryID.Valid {
-                        parent = cat.WritingCategoryID.Int32
-                }
-                children[parent] = append(children[parent], cat)
-        }
+	children := map[int32][]*db.WritingCategory{}
+	for _, cat := range rows {
+		var parent int32
+		if cat.WritingCategoryID.Valid {
+			parent = cat.WritingCategoryID.Int32
+		}
+		children[parent] = append(children[parent], cat)
+	}
 	var printTree func(parent int32, prefix string)
 	printTree = func(parent int32, prefix string) {
 		for _, cat := range children[parent] {

--- a/core/common/breadcrumb.go
+++ b/core/common/breadcrumb.go
@@ -58,12 +58,12 @@ func (cd *CoreData) forumBreadcrumbs() ([]Breadcrumb, error) {
 
 	if threadID != 0 && topicID == 0 {
 		if th, err := cd.SelectedThread(); err == nil && th != nil {
-			topicID = th.ForumtopicIdforumtopic
+			topicID = th.TopicID
 		}
 	}
 	if topicID != 0 && catID == 0 {
 		if tp, err := cd.ForumTopicByID(topicID); err == nil && tp != nil {
-			catID = tp.ForumcategoryIdforumcategory
+			catID = tp.CategoryID
 		}
 	}
 	if catID != 0 {
@@ -72,12 +72,12 @@ func (cd *CoreData) forumBreadcrumbs() ([]Breadcrumb, error) {
 			return nil, err
 		}
 		for _, row := range rows {
-			title := fmt.Sprintf("Category %d", row.Idforumcategory)
+			title := fmt.Sprintf("Category %d", row.ID)
 			if row.Title.Valid {
 				title = row.Title.String
 			}
-			link := fmt.Sprintf("%s/category/%d", base, row.Idforumcategory)
-			if row.Idforumcategory == catID && topicID == 0 && threadID == 0 {
+			link := fmt.Sprintf("%s/category/%d", base, row.ID)
+			if row.ID == catID && topicID == 0 && threadID == 0 {
 				crumbs = append(crumbs, Breadcrumb{Title: title})
 			} else {
 				crumbs = append(crumbs, Breadcrumb{Title: title, Link: link})

--- a/core/common/coredata_forum.go
+++ b/core/common/coredata_forum.go
@@ -24,7 +24,7 @@ func (cd *CoreData) ForumCategory(id int32) (*db.Forumcategory, error) {
 	if cd.queries == nil {
 		return nil, nil
 	}
-	return cd.queries.GetForumCategoryById(cd.ctx, db.GetForumCategoryByIdParams{Idforumcategory: id, ViewerID: cd.UserID})
+	return cd.queries.GetForumCategoryById(cd.ctx, db.GetForumCategoryByIdParams{ID: id, ViewerID: cd.UserID})
 }
 
 // ForumThreadByID returns a single forum thread lazily loading it once per ID.
@@ -77,7 +77,7 @@ func (cd *CoreData) ForumTopicByID(id int32, ops ...lazy.Option[*db.GetForumTopi
 		}
 		return cd.queries.GetForumTopicByIdForUser(cd.ctx, db.GetForumTopicByIdForUserParams{
 			ViewerID:      cd.UserID,
-			Idforumtopic:  i,
+			ID:            i,
 			ViewerMatchID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 		})
 	}
@@ -112,17 +112,17 @@ func (cd *CoreData) ForumTopics(categoryID int32) ([]*db.GetForumTopicsForUserRo
 		result := make([]*db.GetForumTopicsForUserRow, len(rows))
 		for i, r := range rows {
 			result[i] = &db.GetForumTopicsForUserRow{
-				Idforumtopic:                 r.Idforumtopic,
-				Lastposter:                   r.Lastposter,
-				ForumcategoryIdforumcategory: r.ForumcategoryIdforumcategory,
-				LanguageIdlanguage:           r.LanguageIdlanguage,
-				Title:                        r.Title,
-				Description:                  r.Description,
-				Threads:                      r.Threads,
-				Comments:                     r.Comments,
-				Lastaddition:                 r.Lastaddition,
-				Handler:                      r.Handler,
-				Lastposterusername:           r.Lastposterusername,
+				ID:                 r.ID,
+				LastAuthorID:       r.LastAuthorID,
+				CategoryID:         r.CategoryID,
+				LanguageID: r.LanguageID,
+				Title:              r.Title,
+				Description:        r.Description,
+				Threads:            r.Threads,
+				Comments:           r.Comments,
+				Lastaddition:       r.Lastaddition,
+				Handler:            r.Handler,
+				LastAuthorUsername: r.LastAuthorUsername,
 			}
 		}
 		return result, nil

--- a/core/common/coredata_news.go
+++ b/core/common/coredata_news.go
@@ -50,7 +50,7 @@ func (cd *CoreData) ThreadInfo(post *db.GetNewsPostByIdWithWriterIdAndThreadComm
 	} else if err != nil {
 		return ti, fmt.Errorf("find forum topic: %w", err)
 	} else {
-		ti.TopicID = pt.Idforumtopic
+		ti.TopicID = pt.ID
 	}
 	threadID := post.ForumthreadID
 	if threadID == 0 {
@@ -117,7 +117,7 @@ func (cd *CoreData) UpdateNewsReply(commentID, editorID, languageID int32, text 
 	}); err != nil {
 		return ThreadInfo{}, fmt.Errorf("update comment: %w", err)
 	}
-	return ThreadInfo{ThreadID: thread.Idforumthread, TopicID: thread.ForumtopicIdforumtopic}, nil
+	return ThreadInfo{ThreadID: thread.ID, TopicID: thread.TopicID}, nil
 }
 
 // UpdateNewsPost modifies an existing news post.

--- a/core/common/coredata_search.go
+++ b/core/common/coredata_search.go
@@ -31,7 +31,7 @@ func (cd *CoreData) SearchLinker(r *http.Request) error {
 		return fmt.Errorf("Internal Server Error")
 	}
 
-	comments, emptyWords, noResults, err := cd.forumCommentSearchInRestrictedTopic(r, []int32{ftbn.Idforumtopic}, uid)
+	comments, emptyWords, noResults, err := cd.forumCommentSearchInRestrictedTopic(r, []int32{ftbn.ID}, uid)
 	if err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func (cd *CoreData) SearchWritings(r *http.Request) error {
 		return fmt.Errorf("Internal Server Error")
 	}
 
-	comments, emptyWords, noResults, err := cd.forumCommentSearchInRestrictedTopic(r, []int32{ftbn.Idforumtopic}, uid)
+	comments, emptyWords, noResults, err := cd.forumCommentSearchInRestrictedTopic(r, []int32{ftbn.ID}, uid)
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (cd *CoreData) SearchBlogs(r *http.Request) error {
 		return fmt.Errorf("Internal Server Error")
 	}
 
-	comments, emptyWords, noResults, err := cd.forumCommentSearchInRestrictedTopic(r, []int32{ftbn.Idforumtopic}, uid)
+	comments, emptyWords, noResults, err := cd.forumCommentSearchInRestrictedTopic(r, []int32{ftbn.ID}, uid)
 	if err != nil {
 		return err
 	}

--- a/core/common/coredata_user.go
+++ b/core/common/coredata_user.go
@@ -173,21 +173,21 @@ func (cd *CoreData) SetUserLanguage(userID, languageID int32) error {
 	pref, err := cd.queries.GetPreferenceForLister(cd.ctx, userID)
 	if err != nil {
 		if err == sql.ErrNoRows {
-                        return cd.queries.InsertPreferenceForLister(cd.ctx, db.InsertPreferenceForListerParams{
-                                LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
-                                ListerID:   userID,
-                                PageSize:   int32(cd.Config.PageSizeDefault),
-                                Timezone:   sql.NullString{},
-                        })
+			return cd.queries.InsertPreferenceForLister(cd.ctx, db.InsertPreferenceForListerParams{
+				LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
+				ListerID:   userID,
+				PageSize:   int32(cd.Config.PageSizeDefault),
+				Timezone:   sql.NullString{},
+			})
 		}
 		return err
 	}
-        return cd.queries.UpdatePreferenceForLister(cd.ctx, db.UpdatePreferenceForListerParams{
-                LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
-                ListerID:   userID,
-                PageSize:   pref.PageSize,
-                Timezone:   pref.Timezone,
-        })
+	return cd.queries.UpdatePreferenceForLister(cd.ctx, db.UpdatePreferenceForListerParams{
+		LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
+		ListerID:   userID,
+		PageSize:   pref.PageSize,
+		Timezone:   pref.Timezone,
+	})
 }
 
 // SetUserLanguages replaces a user's language selections.
@@ -214,12 +214,12 @@ func (cd *CoreData) SetTimezone(userID int32, tz string) error {
 	pref, err := cd.queries.GetPreferenceForLister(cd.ctx, userID)
 	if err != nil {
 		if err == sql.ErrNoRows {
-                        return cd.queries.InsertPreferenceForLister(cd.ctx, db.InsertPreferenceForListerParams{
-                                LanguageID: sql.NullInt32{},
-                                ListerID:   userID,
-                                PageSize:   int32(cd.Config.PageSizeDefault),
-                                Timezone:   sql.NullString{String: tz, Valid: tz != ""},
-                        })
+			return cd.queries.InsertPreferenceForLister(cd.ctx, db.InsertPreferenceForListerParams{
+				LanguageID: sql.NullInt32{},
+				ListerID:   userID,
+				PageSize:   int32(cd.Config.PageSizeDefault),
+				Timezone:   sql.NullString{String: tz, Valid: tz != ""},
+			})
 		}
 		return err
 	}

--- a/core/common/coredata_writings.go
+++ b/core/common/coredata_writings.go
@@ -151,17 +151,17 @@ func (cd *CoreData) CreateWritingReply(w *db.GetWritingForListerByIDRow, languag
 	pt, err := cd.queries.SystemGetForumTopicByTitle(cd.ctx, sql.NullString{String: WritingTopicName, Valid: true})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
-                ptidi, err := cd.queries.CreateForumTopicForPoster(cd.ctx, db.CreateForumTopicForPosterParams{
-                        ForumcategoryID: 0,
-                        ForumLang:       w.LanguageIdlanguage,
-                        Title:           sql.NullString{String: WritingTopicName, Valid: true},
-                        Description:     sql.NullString{String: WritingTopicDescription, Valid: true},
-                        Handler:         "writing",
-                        Section:         "forum",
-                        GrantCategoryID: sql.NullInt32{},
-                        GranteeID:       sql.NullInt32{},
-                        PosterID:        0,
-                })
+		ptidi, err := cd.queries.CreateForumTopicForPoster(cd.ctx, db.CreateForumTopicForPosterParams{
+			ForumcategoryID: 0,
+			ForumLang:       w.LanguageIdlanguage,
+			Title:           sql.NullString{String: WritingTopicName, Valid: true},
+			Description:     sql.NullString{String: WritingTopicDescription, Valid: true},
+			Handler:         "writing",
+			Section:         "forum",
+			GrantCategoryID: sql.NullInt32{},
+			GranteeID:       sql.NullInt32{},
+			PosterID:        0,
+		})
 		if err != nil {
 			return 0, 0, 0, err
 		}
@@ -169,7 +169,7 @@ func (cd *CoreData) CreateWritingReply(w *db.GetWritingForListerByIDRow, languag
 	} else if err != nil {
 		return 0, 0, 0, err
 	} else {
-		ptid = pt.Idforumtopic
+		ptid = pt.ID
 	}
 	if pthid == 0 {
 		pthidi, err := cd.queries.SystemCreateThread(cd.ctx, ptid)
@@ -198,7 +198,7 @@ func (cd *CoreData) UpdateWriting(w *db.GetWritingForListerByIDRow, title, abstr
 		Abstract:   sql.NullString{Valid: true, String: abstract},
 		Content:    sql.NullString{Valid: true, String: body},
 		Private:    sql.NullBool{Valid: true, Bool: private},
-                LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
+		LanguageID: sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		WritingID:  w.Idwriting,
 		WriterID:   cd.UserID,
 		GranteeID:  sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
@@ -220,7 +220,7 @@ func (cd *CoreData) CreateWriting(categoryID, languageID int32, title, abstract,
 		Abstract:          sql.NullString{Valid: true, String: abstract},
 		Writing:           sql.NullString{Valid: true, String: body},
 		Private:           sql.NullBool{Valid: true, Bool: private},
-                LanguageID:        sql.NullInt32{Int32: languageID, Valid: languageID != 0},
+		LanguageID:        sql.NullInt32{Int32: languageID, Valid: languageID != 0},
 		GrantCategoryID:   sql.NullInt32{Int32: categoryID, Valid: true},
 		GranteeID:         sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	})
@@ -278,19 +278,19 @@ func (cd *CoreData) CreateWritingCategory(parentID int32, name, desc string) err
 	if err != nil {
 		return err
 	}
-        parents := make(map[int32]int32, len(cats))
-        for _, c := range cats {
-                var pid int32
-                if c.WritingCategoryID.Valid {
-                        pid = c.WritingCategoryID.Int32
-                }
-                parents[c.Idwritingcategory] = pid
-        }
+	parents := make(map[int32]int32, len(cats))
+	for _, c := range cats {
+		var pid int32
+		if c.WritingCategoryID.Valid {
+			pid = c.WritingCategoryID.Int32
+		}
+		parents[c.Idwritingcategory] = pid
+	}
 	if path, loop := algorithms.WouldCreateLoop(parents, 0, parentID); loop && len(path) > 0 {
 		return UserError{ErrorMessage: "invalid parent category: loop detected"}
 	}
-        return cd.queries.AdminInsertWritingCategory(cd.ctx, db.AdminInsertWritingCategoryParams{
-                WritingCategoryID: sql.NullInt32{Int32: parentID, Valid: parentID != 0},
+	return cd.queries.AdminInsertWritingCategory(cd.ctx, db.AdminInsertWritingCategoryParams{
+		WritingCategoryID: sql.NullInt32{Int32: parentID, Valid: parentID != 0},
 		Title: sql.NullString{
 			Valid:  true,
 			String: name,
@@ -311,21 +311,21 @@ func (cd *CoreData) ChangeWritingCategory(id, parentID int32, name, desc string)
 	if err != nil {
 		return err
 	}
-        parents := make(map[int32]int32, len(cats))
-        for _, c := range cats {
-                var pid int32
-                if c.WritingCategoryID.Valid {
-                        pid = c.WritingCategoryID.Int32
-                }
-                parents[c.Idwritingcategory] = pid
-        }
+	parents := make(map[int32]int32, len(cats))
+	for _, c := range cats {
+		var pid int32
+		if c.WritingCategoryID.Valid {
+			pid = c.WritingCategoryID.Int32
+		}
+		parents[c.Idwritingcategory] = pid
+	}
 	if path, loop := algorithms.WouldCreateLoop(parents, id, parentID); loop {
 		return UserError{ErrorMessage: fmt.Sprintf("invalid parent category: loop %v", path)}
 	}
-        return cd.queries.AdminUpdateWritingCategory(cd.ctx, db.AdminUpdateWritingCategoryParams{
-                Title:             sql.NullString{Valid: true, String: name},
-                Description:       sql.NullString{Valid: true, String: desc},
-                Idwritingcategory: id,
-                WritingCategoryID: sql.NullInt32{Int32: parentID, Valid: parentID != 0},
-        })
+	return cd.queries.AdminUpdateWritingCategory(cd.ctx, db.AdminUpdateWritingCategoryParams{
+		Title:             sql.NullString{Valid: true, String: name},
+		Description:       sql.NullString{Valid: true, String: desc},
+		Idwritingcategory: id,
+		WritingCategoryID: sql.NullInt32{Int32: parentID, Valid: parentID != 0},
+	})
 }

--- a/core/common/privateforum.go
+++ b/core/common/privateforum.go
@@ -35,7 +35,7 @@ func (cd *CoreData) PrivateForumTopics() ([]*PrivateTopic, error) {
 		var pts []*PrivateTopic
 		for _, t := range tops {
 			parts, _ := cd.queries.ListPrivateTopicParticipantsByTopicIDForUser(cd.ctx, db.ListPrivateTopicParticipantsByTopicIDForUserParams{
-				TopicID:  sql.NullInt32{Int32: t.Idforumtopic, Valid: true},
+				TopicID:  sql.NullInt32{Int32: t.ID, Valid: true},
 				ViewerID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 			})
 			var names []string

--- a/core/templates/email/replyEmail.gohtml
+++ b/core/templates/email/replyEmail.gohtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <body>
-<p>Hi {{.Item.Thread.Lastposterusername.String}},</p>
+<p>Hi {{.Item.Thread.LastAuthorUsername.String}},</p>
 <p>A new reply was posted in "{{.Item.TopicTitle}}" (thread #{{.Item.ThreadID}}) on {{ localTime .Item.Time }}.</p>
 <p>There are now {{.Item.Thread.Comments.Int32}} comments in the discussion.</p>
 <p>Read it <a href="{{.URL}}">here</a>.</p>

--- a/core/templates/email_execute_test.go
+++ b/core/templates/email_execute_test.go
@@ -1,13 +1,13 @@
 package templates_test
 
 import (
-        htemplate "html/template"
-        "io"
-        "strings"
-        "testing"
-        "time"
+	htemplate "html/template"
+	"io"
+	"strings"
+	"testing"
+	"time"
 
-        "github.com/arran4/goa4web/core/templates"
+	"github.com/arran4/goa4web/core/templates"
 )
 
 type emailData struct {
@@ -42,12 +42,12 @@ func sampleEmailData() emailData {
 		"ResetURL":     "https://example.com/reset",
 		"Role":         "role",
 		"Thread": map[string]interface{}{
-			"Lastposterusername": map[string]interface{}{"String": "poster"},
+			"LastAuthorUsername": map[string]interface{}{"String": "poster"},
 			"Comments":           map[string]interface{}{"Int32": 1},
 		},
 		"ThreadID":           1,
 		"ThreadURL":          "https://example.com/thread",
-                "Time":               time.Now(),
+		"Time":               time.Now(),
 		"Title":              map[string]interface{}{"String": "title"},
 		"TopicTitle":         "topic title",
 		"UnsubURL":           "https://example.com/unsub",

--- a/core/templates/site/admin/adminCommentPage.gohtml
+++ b/core/templates/site/admin/adminCommentPage.gohtml
@@ -1,9 +1,9 @@
 {{ define "admin/commentPage.gohtml" }}
 {{ template "head" $ }}
 <h2>Comment {{ .Comment.Idcomments }}</h2>
-<p>Topic <a href="/forum/topic/{{ .Comment.Idforumtopic }}">{{ .Comment.ForumtopicTitle.String }}</a> thread <a href="/forum/topic/{{ .Comment.Idforumtopic }}/thread/{{ .Comment.Idforumthread }}">{{ if .Comment.ThreadTitle.Valid }}{{ left 40 .Comment.ThreadTitle.String }}{{ else }}{{ .Comment.Idforumthread }}{{ end }}</a></p>
+<p>Topic <a href="/forum/topic/{{ .Comment.ID }}">{{ .Comment.ForumtopicTitle.String }}</a> thread <a href="/forum/topic/{{ .Comment.ID }}/thread/{{ .Comment.ID }}">{{ if .Comment.ThreadTitle.Valid }}{{ left 40 .Comment.ThreadTitle.String }}{{ else }}{{ .Comment.ID }}{{ end }}</a></p>
 <p>{{ if .Comment.Text.Valid }}{{ .Comment.Text.String | a4code2html }}{{ end }}</p>
-<p><a href="/forum/topic/{{ .Comment.Idforumtopic }}/thread/{{ .Comment.Idforumthread }}#c{{ .Comment.Idcomments }}">Original</a></p>
+<p><a href="/forum/topic/{{ .Comment.ID }}/thread/{{ .Comment.ID }}#c{{ .Comment.Idcomments }}">Original</a></p>
 <h3>Thread Context</h3>
 {{ range .Context }}
 <p>{{ .Posterusername.String }}: {{ if .Text.Valid }}{{ .Text.String | left 80 }}{{ end }}</p>

--- a/core/templates/site/admin/commentsPage.gohtml
+++ b/core/templates/site/admin/commentsPage.gohtml
@@ -6,8 +6,8 @@
 <tr>
 <td>{{ .Idcomments }}</td>
 <td>{{ if .Written.Valid }}{{ localTimeIn .Written.Time .Timezone.String }}{{ end }}</td>
-<td>{{ .ForumtopicIdforumtopic }}</td>
-<td>{{ .Idforumthread }}</td>
+<td>{{ .ForumtopicID }}</td>
+<td>{{ .ID }}</td>
 <td>{{ if .Text.Valid }}{{ left 40 .Text.String }}{{ end }}</td>
 <td><a href="/admin/comment/{{ .Idcomments }}">View</a></td>
 </tr>

--- a/core/templates/site/admin/usageStatsPage.gohtml
+++ b/core/templates/site/admin/usageStatsPage.gohtml
@@ -14,8 +14,8 @@
     <tr><th>ID</th><th>Topic</th><th>Handler</th><th>Threads</th><th>Comments</th></tr>
     {{- range .ForumTopics }}
     <tr>
-        <td><a href="/admin/forum/topics/topic/{{ .Idforumtopic }}/edit">{{ .Idforumtopic }}</a></td>
-        <td><a href="/forum/topic/{{ .Idforumtopic }}">{{ .Title.String }}</a></td>
+        <td><a href="/admin/forum/topics/topic/{{ .ID }}/edit">{{ .ID }}</a></td>
+        <td><a href="/forum/topic/{{ .ID }}">{{ .Title.String }}</a></td>
         <td>{{ .Handler }}</td>
         <td>{{ .Threads }}</td>
         <td>{{ .Comments }}</td>
@@ -36,8 +36,8 @@
     <tr><th>ID</th><th>Category</th><th>Threads</th><th>Comments</th></tr>
     {{- range .ForumCategories }}
     <tr>
-        <td><a href="/admin/forum/categories/category/{{ .Idforumcategory }}">{{ .Idforumcategory }}</a></td>
-        <td><a href="/forum/category/{{ .Idforumcategory }}">{{ .Title.String }}</a></td>
+        <td><a href="/admin/forum/categories/category/{{ .ID }}">{{ .ID }}</a></td>
+        <td><a href="/forum/category/{{ .ID }}">{{ .Title.String }}</a></td>
         <td>{{ .Threads }}</td>
         <td>{{ .Comments }}</td>
     </tr>

--- a/core/templates/site/admin/userBlogsPage.gohtml
+++ b/core/templates/site/admin/userBlogsPage.gohtml
@@ -8,7 +8,7 @@
         <td>{{ localTimeIn .Written .Timezone.String }}</td>
         <td>{{ .Comments }}</td>
         <td>{{ .LanguageIdlanguage }}</td>
-        <td>{{if .Idforumcategory.Valid}}<a href="/forum/category/{{ .Idforumcategory.Int32 }}">{{ .ForumcategoryTitle.String }}</a>{{end}}</td>
+        <td>{{if .ID.Valid}}<a href="/forum/category/{{ .ID.Int32 }}">{{ .ForumcategoryTitle.String }}</a>{{end}}</td>
         <td>{{ left 40 (firstline (a4code2string .Blog.String)) }}</td>
         <td><a href="/blogs/blog/{{ .Idblogs }}">View</a></td>
     </tr>

--- a/core/templates/site/admin/userCommentsPage.gohtml
+++ b/core/templates/site/admin/userCommentsPage.gohtml
@@ -7,10 +7,10 @@
     <tr>
         <td><a href="/admin/comment/{{ .Idcomments }}">{{ .Idcomments }}</a></td>
         <td>{{ if .Written.Valid }}{{ localTimeIn .Written.Time .Timezone.String }}{{ end }}</td>
-        <td>{{ if .ForumtopicIdforumtopic.Valid }}<a href="/forum/topic/{{ .ForumtopicIdforumtopic.Int32 }}">{{ .ForumtopicTitle.String }}</a>{{ end }}</td>
-        <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic.Int32 }}/thread/{{ .ForumthreadID }}">{{ if .ThreadTitle.Valid }}{{ left 40 .ThreadTitle.String }}{{ else }}{{ .ForumthreadID }}{{ end }}</a></td>
+        <td>{{ if .ForumtopicID.Valid }}<a href="/forum/topic/{{ .ForumtopicID.Int32 }}">{{ .ForumtopicTitle.String }}</a>{{ end }}</td>
+        <td><a href="/forum/topic/{{ .ForumtopicID.Int32 }}/thread/{{ .ForumthreadID }}">{{ if .ThreadTitle.Valid }}{{ left 40 .ThreadTitle.String }}{{ else }}{{ .ForumthreadID }}{{ end }}</a></td>
         <td>{{ if .Text.Valid }}{{ left 40 .Text.String }}{{ end }}</td>
-        <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic.Int32 }}/thread/{{ .ForumthreadID }}#c{{ .Idcomments }}">View</a></td>
+        <td><a href="/forum/topic/{{ .ForumtopicID.Int32 }}/thread/{{ .ForumthreadID }}#c{{ .Idcomments }}">View</a></td>
     </tr>
     {{- end }}
 </table>

--- a/core/templates/site/admin/userForumPage.gohtml
+++ b/core/templates/site/admin/userForumPage.gohtml
@@ -4,12 +4,12 @@
     <tr><th>ID</th><th>Topic</th><th>Category</th><th>Comments</th><th>Last Addition</th><th>View</th></tr>
     {{- range .Threads }}
     <tr>
-        <td><a href="/admin/forum/topics/topic/{{ .ForumtopicIdforumtopic }}">{{ .ForumtopicIdforumtopic }}</a></td>
-        <td><a href="/admin/forum/topics/topic/{{ .ForumtopicIdforumtopic }}/edit">{{ .TopicTitle.String }}</a></td>
+        <td><a href="/admin/forum/topics/topic/{{ .ForumtopicID }}">{{ .ForumtopicID }}</a></td>
+        <td><a href="/admin/forum/topics/topic/{{ .ForumtopicID }}/edit">{{ .TopicTitle.String }}</a></td>
         <td>{{ if .CategoryID.Valid }}<a href="/admin/forum/categories/category/{{ .CategoryID.Int32 }}/grants">{{ .CategoryTitle.String }}</a>{{ end }}</td>
         <td>{{ .Comments.Int32 }}</td>
         <td>{{ localTime .Lastaddition.Time }}</td>
-        <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic }}/thread/{{ .Idforumthread }}">View</a></td>
+        <td><a href="/forum/topic/{{ .ForumtopicID }}/thread/{{ .ID }}">View</a></td>
     </tr>
     {{- end }}
 </table>

--- a/core/templates/site/commentSearchReslts.gohtml
+++ b/core/templates/site/commentSearchReslts.gohtml
@@ -8,7 +8,7 @@
     {{- else }}
         <ul>
         {{- range $i, $result := $cd.SearchComments }}
-            <li>{{ $i }}: <a href="/forum/category/{{$result.Idforumcategory}}">{{ $result.ForumcategoryTitle.String}}</a>: <a href="/forum/topic/{{$result.Idforumtopic}}">{{ $result.ForumtopicTitle.String }}</a>: {{$result.Posterusername.String}} on {{ localTimeIn $result.Written.Time $result.Timezone.String }}: <a href="/forum/topic/{{$result.Idforumtopic}}/thread/{{$result.Idforumthread}}">{{ $result.Text.String | a4code2html}}</a></li>
+            <li>{{ $i }}: <a href="/forum/category/{{$result.ID}}">{{ $result.ForumcategoryTitle.String}}</a>: <a href="/forum/topic/{{$result.ID}}">{{ $result.ForumtopicTitle.String }}</a>: {{$result.Posterusername.String}} on {{ localTimeIn $result.Written.Time $result.Timezone.String }}: <a href="/forum/topic/{{$result.ID}}/thread/{{$result.ID}}">{{ $result.Text.String | a4code2html}}</a></li>
         {{- end }}
         </ul>
     {{ end }}

--- a/core/templates/site/forum/adminThreadPage.gohtml
+++ b/core/templates/site/forum/adminThreadPage.gohtml
@@ -1,14 +1,14 @@
 {{ template "head" $ }}
-<h2>Forum thread {{ .Thread.Idforumthread }}</h2>
+<h2>Forum thread {{ .Thread.ID }}</h2>
 <table border="1">
     <tr><th>ID<th>Posts<th>Last Addition<th>View public</tr>
     <tr>
-        <td>{{ .Thread.Idforumthread }}</td>
+        <td>{{ .Thread.ID }}</td>
         <td>{{ .Thread.Comments.Int32 }}</td>
         <td>{{ localTime .Thread.Lastaddition.Time }}</td>
-        <td><a href="/forum/topic/{{ .Thread.ForumtopicIdforumtopic }}/thread/{{ .Thread.Idforumthread }}">View</a></td>
+        <td><a href="/forum/topic/{{ .Thread.ForumtopicID }}/thread/{{ .Thread.ID }}">View</a></td>
     </tr>
 </table>
-<p><a href="/admin/forum/thread/{{ .Thread.Idforumthread }}/delete">Delete thread</a></p>
+<p><a href="/admin/forum/thread/{{ .Thread.ID }}/delete">Delete thread</a></p>
 <p><a href="/admin/forum/threads">Back</a></p>
 {{ template "tail" $ }}

--- a/core/templates/site/forum/adminThreadsPage.gohtml
+++ b/core/templates/site/forum/adminThreadsPage.gohtml
@@ -4,12 +4,12 @@
     <h2>{{ $topic.Title.String }}</h2>
     <table border="1">
         <tr><th>ID<th>Posts<th>Last Addition<th>View public</tr>
-        {{ range $cd.ForumThreads $topic.Idforumtopic }}
+        {{ range $cd.ForumThreads $topic.ID }}
             <tr>
-                <td><a href="/admin/forum/thread/{{ .Idforumthread }}">{{ .Idforumthread }}</a></td>
+                <td><a href="/admin/forum/thread/{{ .ID }}">{{ .ID }}</a></td>
                 <td>{{ .Comments.Int32 }}</td>
                 <td>{{ localTime .Lastaddition.Time }}</td>
-                <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic }}/thread/{{ .Idforumthread }}">View</a></td>
+                <td><a href="/forum/topic/{{ .ForumtopicID }}/thread/{{ .ID }}">View</a></td>
             </tr>
         {{ else }}
             <tr><td colspan="4">No threads</td></tr>

--- a/core/templates/site/forum/adminTopicCreatePage.gohtml
+++ b/core/templates/site/forum/adminTopicCreatePage.gohtml
@@ -5,7 +5,7 @@
 Title: <input name="name"><br>
 Description:<br>
 <textarea name="desc"></textarea><br>
-Category: <select name="pcid"><option value="0">None</option>{{ range .Categories }}<option value="{{.Idforumcategory}}">{{.Title.String}}</option>{{ end }}</select><br>
+Category: <select name="pcid"><option value="0">None</option>{{ range .Categories }}<option value="{{.ID}}">{{.Title.String}}</option>{{ end }}</select><br>
 <h5>Grants</h5>
 View: <select name="view">{{- range $.Roles }}<option value="{{.ID}}">{{.Name}}</option>{{- end }}</select><br>
 Reply: <select name="reply">{{- range $.Roles }}<option value="{{.ID}}">{{.Name}}</option>{{- end }}</select><br>

--- a/core/templates/site/forum/adminTopicEditPage.gohtml
+++ b/core/templates/site/forum/adminTopicEditPage.gohtml
@@ -1,11 +1,11 @@
 {{ template "head" $ }}
 <h4>Edit Topic</h4>
-<form method="post" action="/admin/forum/topics/topic/{{ .Topic.Idforumtopic }}/edit">
+<form method="post" action="/admin/forum/topics/topic/{{ .Topic.ID }}/edit">
 {{ csrfField }}
 Title: <input name="name" value="{{ .Topic.Title.String }}"><br>
 Description:<br>
 <textarea name="desc">{{ .Topic.Description.String }}</textarea><br>
-Category: <select name="cid"><option value="0">None</option>{{ range .Categories }}<option value="{{.Idforumcategory}}" {{if eq $.Topic.ForumcategoryIdforumcategory .Idforumcategory}}selected{{end}}>{{.Title.String}}</option>{{ end }}</select><br>
+Category: <select name="cid"><option value="0">None</option>{{ range .Categories }}<option value="{{.ID}}" {{if eq $.Topic.ForumcategoryID .ID}}selected{{end}}>{{.Title.String}}</option>{{ end }}</select><br>
 <h5>Grants</h5>
 View: <select name="view">{{- range $.Roles }}<option value="{{.ID}}" {{if $.Restriction}}{{if eq $.Restriction.ViewRoleID.Int32 .ID}}selected{{end}}{{end}}>{{.Name}}</option>{{- end }}</select><br>
 Reply: <select name="reply">{{- range $.Roles }}<option value="{{.ID}}" {{if $.Restriction}}{{if eq $.Restriction.ReplyRoleID.Int32 .ID}}selected{{end}}{{end}}>{{.Name}}</option>{{- end }}</select><br>

--- a/core/templates/site/forum/adminTopicPage.gohtml
+++ b/core/templates/site/forum/adminTopicPage.gohtml
@@ -1,20 +1,20 @@
 {{ template "head" $ }}
-<h2>Forum topic {{ .Topic.Idforumtopic }} - {{ .Topic.Title.String }}</h2>
+<h2>Forum topic {{ .Topic.ID }} - {{ .Topic.Title.String }}</h2>
 <p>{{ .Topic.Description.String }}</p>
 <table border="1">
     <tr><th>ID</th><th>Threads</th><th>Posts</th><th>Last Addition</th><th>View</th></tr>
     <tr>
-        <td>{{ .Topic.Idforumtopic }}</td>
+        <td>{{ .Topic.ID }}</td>
         <td>{{ .Topic.Threads.Int32 }}</td>
         <td>{{ .Topic.Comments.Int32 }}</td>
         <td>{{ localTime .Topic.Lastaddition.Time }}</td>
-        <td><a href="/forum/topic/{{ .Topic.Idforumtopic }}">View</a></td>
+        <td><a href="/forum/topic/{{ .Topic.ID }}">View</a></td>
     </tr>
 </table>
 <ul>
-    <li><a href="/admin/forum/topics/topic/{{ .Topic.Idforumtopic }}/edit">Edit</a></li>
-    <li><a href="/admin/forum/topics/topic/{{ .Topic.Idforumtopic }}/grants">Grants</a></li>
-    <li><a href="/forum/topic/{{ .Topic.Idforumtopic }}">Contents</a></li>
+    <li><a href="/admin/forum/topics/topic/{{ .Topic.ID }}/edit">Edit</a></li>
+    <li><a href="/admin/forum/topics/topic/{{ .Topic.ID }}/grants">Grants</a></li>
+    <li><a href="/forum/topic/{{ .Topic.ID }}">Contents</a></li>
 </ul>
 <p><a href="/admin/forum/topics">Back</a></p>
 {{ template "tail" $ }}

--- a/core/templates/site/forum/adminTopicsPage.gohtml
+++ b/core/templates/site/forum/adminTopicsPage.gohtml
@@ -3,11 +3,11 @@
     <tr><th>ID<th>Title<th>Threads<th>Posts<th>View</tr>
     {{ range .Topics }}
         <tr>
-            <td>{{ .Idforumtopic }}</td>
-            <td><a href="/admin/forum/topics/topic/{{ .Idforumtopic }}">{{ .Title.String }}</a></td>
+            <td>{{ .ID }}</td>
+            <td><a href="/admin/forum/topics/topic/{{ .ID }}">{{ .Title.String }}</a></td>
             <td>{{ .Threads.Int32 }}</td>
             <td>{{ .Comments.Int32 }}</td>
-            <td><a href="/forum/topic/{{ .Idforumtopic }}">View</a></td>
+            <td><a href="/forum/topic/{{ .ID }}">View</a></td>
         </tr>
     {{ else }}
         <tr><td colspan="5">No topics</td></tr>

--- a/core/templates/site/forum/categories.gohtml
+++ b/core/templates/site/forum/categories.gohtml
@@ -5,20 +5,20 @@
             <tr>
                 <td>
                     {{ if and $.Admin .Edit }}
-                        <form method="post" action="/admin/forum/categories/category/{{ .Idforumcategory }}">
+                        <form method="post" action="/admin/forum/categories/category/{{ .ID }}">
         {{ csrfField }}
                             Title <input name="name" value="{{ .Title.String }}">: -
                             Description: <textarea name="desc" cols="30" rows="2">{{ .Description.String }}</textarea>
-                            {{ $pid := .ForumcategoryIdforumcategory }}
-                            Parent <select name="pcid" value="{{ $pid }}"><option value="0">None</option>{{ range $.Categories }}<option value="{{ .Idforumcategory }}" {{ if eq $pid .Idforumcategory }}selected{{ end }}>{{ .Title.String }}</option>{{ end }}</select>
+                            {{ $pid := .ForumcategoryID }}
+                            Parent <select name="pcid" value="{{ $pid }}"><option value="0">None</option>{{ range $.Categories }}<option value="{{ .ID }}" {{ if eq $pid .ID }}selected{{ end }}>{{ .Title.String }}</option>{{ end }}</select>
                             ({{ len .Topics }} topics)
                             <input type="submit" name="task" value="Forum category change">
                             {{ if eq (len .Topics) 0 }}
-                            <input type="submit" name="task" formaction="/admin/forum/categories/category/{{ .Idforumcategory }}/delete" value="Delete Category">
+                            <input type="submit" name="task" formaction="/admin/forum/categories/category/{{ .ID }}/delete" value="Delete Category">
                             {{ end }}
                         </form>
                     {{ else }}
-                        <strong><a href="/forum/category/{{ .Idforumcategory }}">{{ .Title.String }}</a></strong> - {{ .Description.String }} ({{ len .Topics }})<br>
+                        <strong><a href="/forum/category/{{ .ID }}">{{ .Title.String }}</a></strong> - {{ .Description.String }} ({{ len .Topics }})<br>
                     {{ end }}
                 </td>
             </tr>
@@ -27,9 +27,9 @@
                     {{ template "getAllForumCategories" (call $.CopyDataToSubCategories .) }}
                     {{ template "tableTopics" (dict "Topics" .Topics) }}
                     {{ if $.Admin }}
-                        <a href="/admin/forum/categories/create?category={{ .Idforumcategory }}">Create Category</a><br>
-                        {{ if ne .Idforumcategory 0 }}
-                            <a href="/admin/forum/topics/create?category={{ .Idforumcategory }}">Create Topic</a><br>
+                        <a href="/admin/forum/categories/create?category={{ .ID }}">Create Category</a><br>
+                        {{ if ne .ID 0 }}
+                            <a href="/admin/forum/topics/create?category={{ .ID }}">Create Topic</a><br>
                         {{ end }}
                     {{ end }}
                 </td>

--- a/core/templates/site/forum/forumAdminCategoriesPage.gohtml
+++ b/core/templates/site/forum/forumAdminCategoriesPage.gohtml
@@ -11,13 +11,13 @@
     </tr>
     {{ range .Categories }}
     <tr>
-        <td><a id="fc{{ .Idforumcategory }}" href="/admin/forum/categories/category/{{ .Idforumcategory }}">{{ .Idforumcategory }}</a></td>
-        <td>{{ $fcid := .ForumcategoryIdforumcategory }}<a href="#fc{{ $fcid }}">{{ $fcid }}</a></td>
+        <td><a id="fc{{ .ID }}" href="/admin/forum/categories/category/{{ .ID }}">{{ .ID }}</a></td>
+        <td>{{ $fcid := .ForumcategoryID }}<a href="#fc{{ $fcid }}">{{ $fcid }}</a></td>
         <td>{{ .Title.String }}</td>
         <td>{{ .Description.String }}</td>
         <td>{{ .Subcategorycount }}</td>
         <td>{{ .Topiccount }}</td>
-        <td><a href="/admin/forum/categories/category/{{ .Idforumcategory }}">Dashboard</a></td>
+        <td><a href="/admin/forum/categories/category/{{ .ID }}">Dashboard</a></td>
     </tr>
     {{ end }}
 </table>

--- a/core/templates/site/forum/forumAdminCategoryCreatePage.gohtml
+++ b/core/templates/site/forum/forumAdminCategoryCreatePage.gohtml
@@ -2,7 +2,7 @@
 <h2>Create Forum Category</h2>
 <form method="post" action="/admin/forum/categories/create">
     {{ csrfField }}
-    <p>Parent <select name="pcid" value=""><option value="0">None</option>{{ range .Categories }}<option value="{{ .Idforumcategory }}">{{ .Title.String }}</option>{{ end }}</select></p>
+    <p>Parent <select name="pcid" value=""><option value="0">None</option>{{ range .Categories }}<option value="{{ .ID }}">{{ .Title.String }}</option>{{ end }}</select></p>
     <p>Title <input name="name" value=""></p>
     <p>Description <textarea name="desc"></textarea></p>
     <input type="submit" name="task" value="Forum category create">

--- a/core/templates/site/forum/forumAdminCategoryEditPage.gohtml
+++ b/core/templates/site/forum/forumAdminCategoryEditPage.gohtml
@@ -1,13 +1,13 @@
 {{ template "head" $ }}
-<h2>Edit Forum Category {{ .Category.Idforumcategory }}</h2>
-<form method="post" action="/admin/forum/categories/category/{{ .Category.Idforumcategory }}/edit">
+<h2>Edit Forum Category {{ .Category.ID }}</h2>
+<form method="post" action="/admin/forum/categories/category/{{ .Category.ID }}/edit">
     {{ csrfField }}
-    <p>Parent <select name="pcid" value="{{ .Category.ForumcategoryIdforumcategory }}"><option value="0">None</option>{{ range .Categories }}<option value="{{ .Idforumcategory }}" {{ if eq .Idforumcategory $.Category.ForumcategoryIdforumcategory }}selected{{ end }}>{{ .Title.String }}</option>{{ end }}</select></p>
+    <p>Parent <select name="pcid" value="{{ .Category.ForumcategoryID }}"><option value="0">None</option>{{ range .Categories }}<option value="{{ .ID }}" {{ if eq .ID $.Category.ForumcategoryID }}selected{{ end }}>{{ .Title.String }}</option>{{ end }}</select></p>
     <p>Title <input name="name" value="{{ .Category.Title.String }}"></p>
     <p>Description <textarea name="desc">{{ .Category.Description.String }}</textarea></p>
     <input type="submit" name="task" value="Forum category change">
 </form>
-<form method="post" action="/admin/forum/categories/category/{{ .Category.Idforumcategory }}/delete" style="margin-top:1em">
+<form method="post" action="/admin/forum/categories/category/{{ .Category.ID }}/delete" style="margin-top:1em">
     {{ csrfField }}
     <input type="submit" name="task" value="Delete Category">
 </form>

--- a/core/templates/site/forum/forumAdminCategoryPage.gohtml
+++ b/core/templates/site/forum/forumAdminCategoryPage.gohtml
@@ -1,8 +1,8 @@
 {{ template "head" $ }}
-<h2>Forum Category {{ .Category.Idforumcategory }} - {{ .Category.Title.String }}</h2>
+<h2>Forum Category {{ .Category.ID }} - {{ .Category.Title.String }}</h2>
 <p>
-    <a href="/admin/forum/categories/category/{{ .Category.Idforumcategory }}/edit">Edit</a> |
-    <a href="/admin/forum/categories/category/{{ .Category.Idforumcategory }}/grants">Grants</a>
+    <a href="/admin/forum/categories/category/{{ .Category.ID }}/edit">Edit</a> |
+    <a href="/admin/forum/categories/category/{{ .Category.ID }}/grants">Grants</a>
 </p>
 <p>{{ .Category.Description.String }}</p>
 <h3 id="topics">Topics</h3>
@@ -18,12 +18,12 @@
     </tr>
     {{ range .Topics }}
     <tr>
-        <td><a href="/admin/forum/topic/{{ .Idforumtopic }}">{{ .Idforumtopic }}</a></td>
+        <td><a href="/admin/forum/topic/{{ .ID }}">{{ .ID }}</a></td>
         <td>{{ .Title.String }}</td>
         <td>{{ .Description.String }}</td>
         <td>{{ .Threads.Int32 }}</td>
         <td>{{ .Comments.Int32 }}</td>
-        <td><a href="/admin/forum/topics/topic/{{ .Idforumtopic }}">Manage</a></td>
+        <td><a href="/admin/forum/topics/topic/{{ .ID }}">Manage</a></td>
     </tr>
     {{ end }}
 </table>

--- a/core/templates/site/forum/reply.gohtml
+++ b/core/templates/site/forum/reply.gohtml
@@ -26,7 +26,7 @@
                 <font size="4">Reply:</font><br>
                 {{ $base := "/forum" }}
                 {{ with $.BasePath }}{{ $base = . }}{{ end }}
-                <form method="post" action="{{$base}}/topic/{{$.Topic.Idforumtopic}}/thread/{{$.Thread.Idforumthread}}/reply">
+                <form method="post" action="{{$base}}/topic/{{$.Topic.ID}}/thread/{{$.Thread.ID}}/reply">
                     {{ csrfField }}
                     <textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>
                     {{ template "languageCombobox" }}

--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -3,16 +3,16 @@
     {{ with .BasePath }}{{ $base = . }}{{ end }}
     <div class="label-bar">
         {{ template "topicLabels" (dict "Public" .PublicLabels "Author" .AuthorLabels "Private" .PrivateLabels) }}
-        <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" class="mark-read">
+        <form method="post" action="{{$base}}/thread/{{.Thread.ID}}/labels" class="mark-read">
             {{ csrfField }}
             <input type="hidden" name="task" value="Mark Topic Read"/>
             <input type="hidden" name="redirect" value="{{ .BackURL }}"/>
             <button type="submit">Mark as read</button>
         </form>
-        <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/labels" class="mark-read">
+        <form method="post" action="{{$base}}/topic/{{.Topic.ID}}/labels" class="mark-read">
             {{ csrfField }}
             <input type="hidden" name="task" value="Mark Topic Read"/>
-            <input type="hidden" name="redirect" value="{{$base}}/topic/{{.Topic.Idforumtopic}}"/>
+            <input type="hidden" name="redirect" value="{{$base}}/topic/{{.Topic.ID}}"/>
             <button type="submit">Mark as read and go back</button>
         </form>
     </div>
@@ -20,7 +20,7 @@
     {{ template "forumReply" $ }}
 
     <div class="label-editor">
-        <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" id="label-form">
+        <form method="post" action="{{$base}}/thread/{{.Thread.ID}}/labels" id="label-form">
             {{ csrfField }}
             <input type="hidden" name="task" value="Set Labels"/>
             <input type="hidden" name="back" value="{{ .BackURL }}"/>
@@ -43,12 +43,12 @@
             </div>
             <input type="submit" value="Save Labels"/>
         </form>
-        <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" class="mark-read">
+        <form method="post" action="{{$base}}/thread/{{.Thread.ID}}/labels" class="mark-read">
             <input type="hidden" name="task" value="Mark Topic Read"/>
-            <input type="hidden" name="redirect" value="{{$base}}/topic/{{.Topic.Idforumtopic}}"/>
+            <input type="hidden" name="redirect" value="{{$base}}/topic/{{.Topic.ID}}"/>
             <button type="submit">Mark as read and go back</button>
         </form>
-        <form method="get" action="{{$base}}/topic/{{.Topic.Idforumtopic}}">
+        <form method="get" action="{{$base}}/topic/{{.Topic.ID}}">
             <button type="submit">Go to topic</button>
         </form>
     </div>

--- a/core/templates/site/forum/topicsPage.gohtml
+++ b/core/templates/site/forum/topicsPage.gohtml
@@ -7,13 +7,13 @@
     {{ $base := "/forum" }}
     {{ with .BasePath }}{{ $base = . }}{{ end }}
     <div class="topic-actions">
-        <a href="{{$base}}/topic/{{.Topic.Idforumtopic}}/thread">New Thread</a>
-        {{- if and cd.IsAdmin cd.IsAdminMode }} | [<a href="/admin/forum/topics/topic/{{.Topic.Idforumtopic}}/edit">ADMIN</a>]{{ end }}
-        {{- if .Subscribed }} | <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/unsubscribe">
+        <a href="{{$base}}/topic/{{.Topic.ID}}/thread">New Thread</a>
+        {{- if and cd.IsAdmin cd.IsAdminMode }} | [<a href="/admin/forum/topics/topic/{{.Topic.ID}}/edit">ADMIN</a>]{{ end }}
+        {{- if .Subscribed }} | <form method="post" action="{{$base}}/topic/{{.Topic.ID}}/unsubscribe">
                 <input type="hidden" name="task" value="Unsubscribe From Topic"/>
                 <input type="submit" value="Unsubscribe"/>
             </form>
-        {{- else }} | <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/subscribe">
+        {{- else }} | <form method="post" action="{{$base}}/topic/{{.Topic.ID}}/subscribe">
                 <input type="hidden" name="task" value="Subscribe To Topic"/>
                 <input type="submit" value="Subscribe"/>
             </form>

--- a/core/templates/site/news/postPage.gohtml
+++ b/core/templates/site/news/postPage.gohtml
@@ -29,7 +29,7 @@
                 <font size=4>Reply:</font><br>
                 <form method="post" action="?#bottom">
                 {{ csrfField }}
-                    <input type="hidden" name="replyto" value="{{ .Thread.Idforumthread }}">
+                    <input type="hidden" name="replyto" value="{{ .Thread.ID }}">
                     <textarea name="replytext" cols=40 rows=20>{{.ReplyText}}</textarea><br>
                     {{ template "languageCombobox" }}
                     <input type="submit" name="task" value="Reply">

--- a/core/templates/site/tableTopics.gohtml
+++ b/core/templates/site/tableTopics.gohtml
@@ -13,10 +13,10 @@
             <td>
                 {{ $title := .Title.String }}
                 {{ if .DisplayTitle }}{{ $title = .DisplayTitle }}{{ end }}
-                <a href="{{$base}}/topic/{{ .Idforumtopic }}">{{ $title | a4code2html }}</a>{{ if and cd.IsAdmin cd.IsAdminMode }} [<a href="/admin/forum/topics/topic/{{ .Idforumtopic }}/edit">ADMIN</a>]{{ end }}<br>
+                <a href="{{$base}}/topic/{{ .ID }}">{{ $title | a4code2html }}</a>{{ if and cd.IsAdmin cd.IsAdminMode }} [<a href="/admin/forum/topics/topic/{{ .ID }}/edit">ADMIN</a>]{{ end }}<br>
                 {{ with .Description.String }}<i>{{ . | a4code2html }}</i>{{ end }}
             </td>
-            <td align="center">{{ localTime .Lastaddition.Time }}<br>{{ .Lastposterusername.String }}</td>
+            <td align="center">{{ localTime .Lastaddition.Time }}<br>{{ .LastAuthorUsername.String }}</td>
             <td align="center">{{ .Threads.Int32 }}</td>
             <td align="center">{{ .Comments.Int32 }}</td>
         </tr>

--- a/core/templates/site/topicThreads.gohtml
+++ b/core/templates/site/topicThreads.gohtml
@@ -6,16 +6,16 @@
     {{- range .Threads }}
         <div class="thread">
             <div class="thread-meta thread-header">
-                First poster: <span class="poster-name first">{{ .Firstpostusername.String }}</span>
-                At <span class="post-time first">{{ localTime .Firstpostwritten.Time }}</span>
+                First poster: <span class="poster-name first">{{ .FirstCommentUsername.String }}</span>
+                At <span class="post-time first">{{ localTime .FirstCommentWritten.Time }}</span>
             </div>
             <div class="thread-content">
-                {{ .Firstposttext.String | a4code2html }}<br>
+                {{ .FirstCommentText.String | a4code2html }}<br>
             </div>
             <div class="thread-meta">
-                Lastposter: <span class="poster-name last">{{ .Lastposterusername.String }}</span>
+                LastAuthorID: <span class="poster-name last">{{ .LastAuthorUsername.String }}</span>
                 At <span class="post-time last">{{ localTime .Lastaddition.Time }}</span>
-                [<a href="{{$base}}/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">
+                [<a href="{{$base}}/topic/{{.ForumtopicID}}/thread/{{ .ID }}">
                     {{- .Comments.Int32 }} comments.</a>]{{" "}}
                 {{- template "topicLabels" (dict
                     "Public" .PublicLabels

--- a/core/templates/threadPage_labels_test.go
+++ b/core/templates/threadPage_labels_test.go
@@ -37,16 +37,16 @@ func TestThreadPageShowsDefaultPrivateLabels(t *testing.T) {
 	}
 
 	data := struct {
-		Topic         struct{ Idforumtopic int32 }
-		Thread        struct{ Idforumthread int32 }
+		Topic         struct{ ID int32 }
+		Thread        struct{ ID int32 }
 		PublicLabels  []string
 		AuthorLabels  []string
 		PrivateLabels []string
 		BasePath      string
 		BackURL       string
 	}{}
-	data.Topic.Idforumtopic = 1
-	data.Thread.Idforumthread = 3
+	data.Topic.ID = 1
+	data.Thread.ID = 3
 	data.PrivateLabels = []string{"new", "unread"}
 	data.BasePath = "/forum"
 	data.BackURL = "/forum/topic/1/thread/1"

--- a/handlers/admin/adminEmailQueuePage.go
+++ b/handlers/admin/adminEmailQueuePage.go
@@ -1,19 +1,19 @@
 package admin
 
 import (
-        "database/sql"
-        "fmt"
-        "log"
-        "net/http"
-        "net/mail"
-        "strconv"
-        "strings"
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"net/mail"
+	"strconv"
+	"strings"
 
-        "github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/core/consts"
 
-        "github.com/arran4/goa4web/core/common"
-        "github.com/arran4/goa4web/handlers"
-        "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 )
 
 func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
@@ -31,10 +31,10 @@ func AdminEmailQueuePage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	langID, _ := strconv.Atoi(r.URL.Query().Get("lang"))
 	role := r.URL.Query().Get("role")
-        rows, err := queries.AdminListUnsentPendingEmails(r.Context(), db.AdminListUnsentPendingEmailsParams{
-                LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
-                RoleName:   role,
-        })
+	rows, err := queries.AdminListUnsentPendingEmails(r.Context(), db.AdminListUnsentPendingEmailsParams{
+		LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
+		RoleName:   role,
+	})
 	if err != nil {
 		log.Printf("list pending emails: %v", err)
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))

--- a/handlers/admin/adminFailedEmailsPage.go
+++ b/handlers/admin/adminFailedEmailsPage.go
@@ -1,19 +1,19 @@
 package admin
 
 import (
-        "database/sql"
-        "fmt"
-        "log"
-        "net/http"
-        "net/mail"
-        "net/url"
-        "strconv"
-        "strings"
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"net/mail"
+	"net/url"
+	"strconv"
+	"strings"
 
-        "github.com/arran4/goa4web/core/common"
-        "github.com/arran4/goa4web/core/consts"
-        "github.com/arran4/goa4web/handlers"
-        "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 )
 
 // AdminFailedEmailsPage shows queued emails with errors.
@@ -40,12 +40,12 @@ func AdminFailedEmailsPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	langID, _ := strconv.Atoi(r.URL.Query().Get("lang"))
 	role := r.URL.Query().Get("role")
-        rows, err := queries.AdminListFailedEmails(r.Context(), db.AdminListFailedEmailsParams{
-                LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
-                RoleName:   role,
-                Limit:      int32(pageSize + 1),
-                Offset:     int32(offset),
-        })
+	rows, err := queries.AdminListFailedEmails(r.Context(), db.AdminListFailedEmailsParams{
+		LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
+		RoleName:   role,
+		Limit:      int32(pageSize + 1),
+		Offset:     int32(offset),
+	})
 	if err != nil {
 		log.Printf("list failed emails: %v", err)
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))

--- a/handlers/admin/adminGrantAddPage.go
+++ b/handlers/admin/adminGrantAddPage.go
@@ -76,7 +76,7 @@ func adminGrantAddPage(w http.ResponseWriter, r *http.Request) {
 			cats, _ := queries.GetAllForumCategories(r.Context(), db.GetAllForumCategoriesParams{ViewerID: 0})
 			catMap := map[int32]*db.Forumcategory{}
 			for _, c := range cats {
-				catMap[c.Idforumcategory] = c
+				catMap[c.ID] = c
 			}
 			var buildPath func(int32) string
 			buildPath = func(id int32) string {
@@ -87,15 +87,15 @@ func adminGrantAddPage(w http.ResponseWriter, r *http.Request) {
 				if !ok || !c.Title.Valid {
 					return ""
 				}
-				parent := buildPath(c.ForumcategoryIdforumcategory)
+				parent := buildPath(c.ParentCategoryID)
 				if parent != "" {
 					return parent + "/" + c.Title.String
 				}
 				return c.Title.String
 			}
 			for _, c := range cats {
-				label := buildPath(c.Idforumcategory)
-				data.ItemOptions = append(data.ItemOptions, ItemOption{ID: c.Idforumcategory, Label: label})
+				label := buildPath(c.ID)
+				data.ItemOptions = append(data.ItemOptions, ItemOption{ID: c.ID, Label: label})
 			}
 		}
 	}

--- a/handlers/admin/adminRoleGrantAddPage.go
+++ b/handlers/admin/adminRoleGrantAddPage.go
@@ -76,7 +76,7 @@ func adminRoleGrantAddPage(w http.ResponseWriter, r *http.Request) {
 			cats, _ := queries.GetAllForumCategories(r.Context(), db.GetAllForumCategoriesParams{ViewerID: 0})
 			catMap := map[int32]*db.Forumcategory{}
 			for _, c := range cats {
-				catMap[c.Idforumcategory] = c
+				catMap[c.ID] = c
 			}
 			var buildPath func(int32) string
 			buildPath = func(id int32) string {
@@ -87,15 +87,15 @@ func adminRoleGrantAddPage(w http.ResponseWriter, r *http.Request) {
 				if !ok || !c.Title.Valid {
 					return ""
 				}
-				parent := buildPath(c.ForumcategoryIdforumcategory)
+				parent := buildPath(c.ParentCategoryID)
 				if parent != "" {
 					return parent + "/" + c.Title.String
 				}
 				return c.Title.String
 			}
 			for _, c := range cats {
-				label := buildPath(c.Idforumcategory)
-				data.ItemOptions = append(data.ItemOptions, ItemOption{ID: c.Idforumcategory, Label: label})
+				label := buildPath(c.ID)
+				data.ItemOptions = append(data.ItemOptions, ItemOption{ID: c.ID, Label: label})
 			}
 		}
 	}

--- a/handlers/admin/adminSentEmailsPage.go
+++ b/handlers/admin/adminSentEmailsPage.go
@@ -1,19 +1,19 @@
 package admin
 
 import (
-        "database/sql"
-        "fmt"
-        "log"
-        "net/http"
-        "net/mail"
-        "net/url"
-        "strconv"
-        "strings"
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"net/mail"
+	"net/url"
+	"strconv"
+	"strings"
 
-        "github.com/arran4/goa4web/core/common"
-        "github.com/arran4/goa4web/core/consts"
-        "github.com/arran4/goa4web/handlers"
-        "github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
 )
 
 // AdminSentEmailsPage shows previously sent emails with pagination.
@@ -40,12 +40,12 @@ func AdminSentEmailsPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	langID, _ := strconv.Atoi(r.URL.Query().Get("lang"))
 	role := r.URL.Query().Get("role")
-        rows, err := queries.AdminListSentEmails(r.Context(), db.AdminListSentEmailsParams{
-                LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
-                RoleName:   role,
-                Limit:      int32(pageSize + 1),
-                Offset:     int32(offset),
-        })
+	rows, err := queries.AdminListSentEmails(r.Context(), db.AdminListSentEmailsParams{
+		LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
+		RoleName:   role,
+		Limit:      int32(pageSize + 1),
+		Offset:     int32(offset),
+	})
 	if err != nil {
 		log.Printf("list sent emails: %v", err)
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))

--- a/handlers/admin/adminUserGrantAddPage.go
+++ b/handlers/admin/adminUserGrantAddPage.go
@@ -70,7 +70,7 @@ func adminUserGrantAddPage(w http.ResponseWriter, r *http.Request) {
 			cats, _ := queries.GetAllForumCategories(r.Context(), db.GetAllForumCategoriesParams{ViewerID: cd.UserID})
 			catMap := map[int32]*db.Forumcategory{}
 			for _, c := range cats {
-				catMap[c.Idforumcategory] = c
+				catMap[c.ID] = c
 			}
 			var buildPath func(int32) string
 			buildPath = func(id int32) string {
@@ -81,15 +81,15 @@ func adminUserGrantAddPage(w http.ResponseWriter, r *http.Request) {
 				if !ok || !c.Title.Valid {
 					return ""
 				}
-				parent := buildPath(c.ForumcategoryIdforumcategory)
+				parent := buildPath(c.ParentCategoryID)
 				if parent != "" {
 					return parent + "/" + c.Title.String
 				}
 				return c.Title.String
 			}
 			for _, c := range cats {
-				label := buildPath(c.Idforumcategory)
-				data.ItemOptions = append(data.ItemOptions, ItemOption{ID: c.Idforumcategory, Label: label})
+				label := buildPath(c.ID)
+				data.ItemOptions = append(data.ItemOptions, ItemOption{ID: c.ID, Label: label})
 			}
 		}
 	}

--- a/handlers/admin/maintenancePage.go
+++ b/handlers/admin/maintenancePage.go
@@ -37,7 +37,7 @@ func AdminMaintenancePage(w http.ResponseWriter, r *http.Request) {
 		if row.Title.Valid {
 			title = row.Title.String
 		}
-		topics = append(topics, &maintenanceTopic{ID: row.Idforumtopic, Title: title})
+		topics = append(topics, &maintenanceTopic{ID: row.ID, Title: title})
 	}
 	data := Data{Topics: topics, TaskName: string(TaskForumTopicConvertPrivate)}
 	handlers.TemplateHandler(w, r, "maintenancePage.gohtml", data)

--- a/handlers/admin/role_grants.go
+++ b/handlers/admin/role_grants.go
@@ -96,7 +96,7 @@ func buildGrantGroupsFromGrants(ctx context.Context, cd *common.CoreData, grants
 	forumCats, _ := queries.GetAllForumCategories(ctx, db.GetAllForumCategoriesParams{ViewerID: 0})
 	catMap := map[int32]*db.Forumcategory{}
 	for _, c := range forumCats {
-		catMap[c.Idforumcategory] = c
+		catMap[c.ID] = c
 	}
 
 	langs, _ := cd.Languages()
@@ -118,7 +118,7 @@ func buildGrantGroupsFromGrants(ctx context.Context, cd *common.CoreData, grants
 				break
 			}
 			parts = append([]string{c.Title.String}, parts...)
-			cid = c.ForumcategoryIdforumcategory
+			cid = c.ParentCategoryID
 		}
 		return strings.Join(parts, "/")
 	}
@@ -143,7 +143,7 @@ func buildGrantGroupsFromGrants(ctx context.Context, cd *common.CoreData, grants
 					if t, err := queries.GetForumTopicById(ctx, g.ItemID.Int32); err == nil {
 						if t.Title.Valid {
 							info := t.Title.String
-							cat := buildCatPath(t.ForumcategoryIdforumcategory)
+							cat := buildCatPath(t.CategoryID)
 							if cat != "" {
 								info = fmt.Sprintf("%s (%s)", info, cat)
 							}
@@ -152,15 +152,15 @@ func buildGrantGroupsFromGrants(ctx context.Context, cd *common.CoreData, grants
 					}
 				case "category":
 					gi.Link = fmt.Sprintf("/admin/forum/categories/category/%d/grants#g%d", g.ItemID.Int32, g.ID)
-					if c, err := queries.GetForumCategoryById(ctx, db.GetForumCategoryByIdParams{Idforumcategory: g.ItemID.Int32, ViewerID: 0}); err == nil && c.Title.Valid {
-						path := buildCatPath(c.Idforumcategory)
+					if c, err := queries.GetForumCategoryById(ctx, db.GetForumCategoryByIdParams{ID: g.ItemID.Int32, ViewerID: 0}); err == nil && c.Title.Valid {
+						path := buildCatPath(c.ID)
 						gi.Info = path
 					}
 				case "thread":
 					if tid, err := queries.GetForumTopicIdByThreadId(ctx, g.ItemID.Int32); err == nil {
 						if t, err := queries.GetForumTopicById(ctx, tid); err == nil {
 							if t.Title.Valid {
-								cat := buildCatPath(t.ForumcategoryIdforumcategory)
+								cat := buildCatPath(t.CategoryID)
 								info := fmt.Sprintf("%s thread", t.Title.String)
 								if cat != "" {
 									info = fmt.Sprintf("%s (%s)", info, cat)

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -160,7 +160,7 @@ func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 	} else if err != nil {
 		return fmt.Errorf("findForumTopicByTitle fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	} else {
-		ptid = pt.Idforumtopic
+		ptid = pt.ID
 	}
 	if pthid == 0 {
 		pthidi, err := queries.SystemCreateThread(r.Context(), ptid)

--- a/handlers/blogs/blogsCommentEditReplyTask.go
+++ b/handlers/blogs/blogsCommentEditReplyTask.go
@@ -87,7 +87,7 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(commentId), ThreadID: thread.Idforumthread, TopicID: thread.ForumtopicIdforumtopic}
+			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(commentId), ThreadID: thread.ID, TopicID: thread.TopicID}
 			evt.Data["CommentURL"] = cd.AbsoluteURL(fmt.Sprintf("/blogs/blog/%d/comments", blogId))
 		}
 	}

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 65
+	ExpectedSchemaVersion = 66
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/handlers/forum/adminForumHandler.go
+++ b/handlers/forum/adminForumHandler.go
@@ -72,15 +72,15 @@ func AdminForumPage(w http.ResponseWriter, r *http.Request) {
 	var topicRows []*ForumtopicPlus
 	for _, row := range rows {
 		topicRows = append(topicRows, &ForumtopicPlus{
-			Idforumtopic:                 row.Idforumtopic,
-			Lastposter:                   row.Lastposter,
-			ForumcategoryIdforumcategory: row.ForumcategoryIdforumcategory,
-			Title:                        row.Title,
-			Description:                  row.Description,
-			Threads:                      row.Threads,
-			Comments:                     row.Comments,
-			Lastaddition:                 row.Lastaddition,
-			Lastposterusername:           row.Lastposterusername,
+			ID:                 row.ID,
+			LastAuthorID:       row.LastAuthorID,
+			CategoryID:         row.CategoryID,
+			Title:              row.Title,
+			Description:        row.Description,
+			Threads:            row.Threads,
+			Comments:           row.Comments,
+			Lastaddition:       row.Lastaddition,
+			LastAuthorUsername: row.LastAuthorUsername,
 		})
 	}
 

--- a/handlers/forum/category_prune_test.go
+++ b/handlers/forum/category_prune_test.go
@@ -8,13 +8,13 @@ import (
 
 func TestCategoryTreePruneEmpty(t *testing.T) {
 	cats := []*db.Forumcategory{
-		{Idforumcategory: 1, ForumcategoryIdforumcategory: 0},
-		{Idforumcategory: 2, ForumcategoryIdforumcategory: 1},
-		{Idforumcategory: 3, ForumcategoryIdforumcategory: 1},
-		{Idforumcategory: 4, ForumcategoryIdforumcategory: 0},
+		{ID: 1, ParentCategoryID: 0},
+		{ID: 2, ParentCategoryID: 1},
+		{ID: 3, ParentCategoryID: 1},
+		{ID: 4, ParentCategoryID: 0},
 	}
 	topics := []*ForumtopicPlus{
-		{Idforumtopic: 10, ForumcategoryIdforumcategory: 3},
+		{ID: 10, CategoryID: 3},
 	}
 	ct := NewCategoryTree(cats, topics)
 	if _, ok := ct.CategoryLookup[4]; ok {
@@ -27,7 +27,7 @@ func TestCategoryTreePruneEmpty(t *testing.T) {
 	if !ok {
 		t.Fatalf("root category 1 missing")
 	}
-	if len(root1.Categories) != 1 || root1.Categories[0].Idforumcategory != 3 {
+	if len(root1.Categories) != 1 || root1.Categories[0].ID != 3 {
 		t.Fatalf("unexpected children for root 1: %#v", root1.Categories)
 	}
 }

--- a/handlers/forum/comment_edit_action_cancel_task.go
+++ b/handlers/forum/comment_edit_action_cancel_task.go
@@ -35,6 +35,6 @@ func (topicThreadCommentEditActionCancelTask) Action(w http.ResponseWriter, r *h
 	if base == "" {
 		base = "/forum"
 	}
-	endURL := fmt.Sprintf("%s/topic/%d/thread/%d#bottom", base, topicRow.Idforumtopic, threadRow.Idforumthread)
+	endURL := fmt.Sprintf("%s/topic/%d/thread/%d#bottom", base, topicRow.ID, threadRow.ID)
 	return handlers.RedirectHandler(endURL)
 }

--- a/handlers/forum/comment_edit_action_task.go
+++ b/handlers/forum/comment_edit_action_task.go
@@ -51,7 +51,7 @@ func (topicThreadCommentEditActionTask) Action(w http.ResponseWriter, r *http.Re
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(commentID), ThreadID: threadRow.Idforumthread, TopicID: topicRow.Idforumtopic}
+			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(commentID), ThreadID: threadRow.ID, TopicID: topicRow.ID}
 		}
 	}
 
@@ -59,5 +59,5 @@ func (topicThreadCommentEditActionTask) Action(w http.ResponseWriter, r *http.Re
 	if base == "" {
 		base = "/forum"
 	}
-	return handlers.RedirectHandler(fmt.Sprintf("%s/topic/%d/thread/%d#comment-%d", base, topicRow.Idforumtopic, threadRow.Idforumthread, commentID))
+	return handlers.RedirectHandler(fmt.Sprintf("%s/topic/%d/thread/%d#comment-%d", base, topicRow.ID, threadRow.ID, commentID))
 }

--- a/handlers/forum/forum.go
+++ b/handlers/forum/forum.go
@@ -7,17 +7,17 @@ import (
 )
 
 type ForumtopicPlus struct {
-	Idforumtopic                 int32
-	Lastposter                   int32
-	ForumcategoryIdforumcategory int32
-	Title                        sql.NullString
-	Description                  sql.NullString
+	ID           int32
+	LastAuthorID int32
+	CategoryID   int32
+	Title        sql.NullString
+	Description  sql.NullString
 	// DisplayTitle optionally overrides Title for display purposes.
 	DisplayTitle       string
 	Threads            sql.NullInt32
 	Comments           sql.NullInt32
 	Lastaddition       sql.NullTime
-	Lastposterusername sql.NullString
+	LastAuthorUsername sql.NullString
 	Edit               bool
 }
 
@@ -43,11 +43,11 @@ func NewCategoryTree(categoryRows []*db.Forumcategory, topicRows []*ForumtopicPl
 			Categories:    nil,
 			Edit:          false,
 		}
-		categoryTree.CategoryChildrenLookup[row.ForumcategoryIdforumcategory] = append(categoryTree.CategoryChildrenLookup[row.ForumcategoryIdforumcategory], fcp)
-		categoryTree.CategoryLookup[row.Idforumcategory] = fcp
+		categoryTree.CategoryChildrenLookup[row.ParentCategoryID] = append(categoryTree.CategoryChildrenLookup[row.ParentCategoryID], fcp)
+		categoryTree.CategoryLookup[row.ID] = fcp
 	}
 	for _, row := range topicRows {
-		c, ok := categoryTree.CategoryLookup[row.ForumcategoryIdforumcategory]
+		c, ok := categoryTree.CategoryLookup[row.CategoryID]
 		if !ok || c == nil {
 			continue
 		}
@@ -72,14 +72,14 @@ func (ct *CategoryTree) pruneCategory(cat *ForumcategoryPlus) bool {
 			filtered = append(filtered, c)
 			keep = true
 		} else {
-			delete(ct.CategoryLookup, c.Idforumcategory)
-			delete(ct.CategoryChildrenLookup, c.Idforumcategory)
+			delete(ct.CategoryLookup, c.ID)
+			delete(ct.CategoryChildrenLookup, c.ID)
 		}
 	}
 	cat.Categories = filtered
 	if !keep {
-		delete(ct.CategoryLookup, cat.Idforumcategory)
-		delete(ct.CategoryChildrenLookup, cat.Idforumcategory)
+		delete(ct.CategoryLookup, cat.ID)
+		delete(ct.CategoryChildrenLookup, cat.ID)
 	}
 	return keep
 }
@@ -93,8 +93,8 @@ func (ct *CategoryTree) PruneEmpty() {
 		if ct.pruneCategory(root) {
 			filtered = append(filtered, root)
 		} else {
-			delete(ct.CategoryLookup, root.Idforumcategory)
-			delete(ct.CategoryChildrenLookup, root.Idforumcategory)
+			delete(ct.CategoryLookup, root.ID)
+			delete(ct.CategoryChildrenLookup, root.ID)
 		}
 	}
 	ct.CategoryChildrenLookup[0] = filtered
@@ -108,7 +108,7 @@ func (ct *CategoryTree) CategoryRoots(categoryId int32) (result []*Forumcategory
 			break
 		}
 		result = append(result, cat)
-		catId = cat.ForumcategoryIdforumcategory
+		catId = cat.ParentCategoryID
 		if catId == 0 {
 			break
 		}

--- a/handlers/forum/forumAdminCategoriesPage.go
+++ b/handlers/forum/forumAdminCategoriesPage.go
@@ -65,7 +65,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	if err == nil {
 		children := map[int32][]*db.Forumcategory{}
 		for _, c := range catsAll {
-			children[c.ForumcategoryIdforumcategory] = append(children[c.ForumcategoryIdforumcategory], c)
+			children[c.ParentCategoryID] = append(children[c.ParentCategoryID], c)
 		}
 		var build func(parent int32) string
 		build = func(parent int32) string {
@@ -75,7 +75,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 				for _, c := range cs {
 					sb.WriteString("<li>")
 					sb.WriteString(template.HTMLEscapeString(c.Title.String))
-					sb.WriteString(build(c.Idforumcategory))
+					sb.WriteString(build(c.ID))
 					sb.WriteString("</li>")
 				}
 				sb.WriteString("</ul>")

--- a/handlers/forum/forumAdminCategoryCreatePage.go
+++ b/handlers/forum/forumAdminCategoryCreatePage.go
@@ -51,7 +51,7 @@ func AdminCategoryCreateSubmit(w http.ResponseWriter, r *http.Request) {
 	}
 	parents := make(map[int32]int32, len(cats))
 	for _, c := range cats {
-		parents[c.Idforumcategory] = c.ForumcategoryIdforumcategory
+		parents[c.ID] = c.ParentCategoryID
 	}
 	if path, loop := algorithms.WouldCreateLoop(parents, 0, int32(pcid)); loop {
 		http.Redirect(w, r, "?error="+fmt.Sprintf("loop %v", path), http.StatusTemporaryRedirect)

--- a/handlers/forum/forumAdminCategoryEditPage.go
+++ b/handlers/forum/forumAdminCategoryEditPage.go
@@ -72,7 +72,7 @@ func AdminCategoryEditSubmit(w http.ResponseWriter, r *http.Request) {
 	}
 	parents := make(map[int32]int32, len(cats))
 	for _, c := range cats {
-		parents[c.Idforumcategory] = c.ForumcategoryIdforumcategory
+		parents[c.ID] = c.ParentCategoryID
 	}
 	if path, loop := algorithms.WouldCreateLoop(parents, int32(categoryId), int32(pcid)); loop {
 		http.Redirect(w, r, "?error="+fmt.Sprintf("loop %v", path), http.StatusTemporaryRedirect)

--- a/handlers/forum/forumFeed.go
+++ b/handlers/forum/forumFeed.go
@@ -29,10 +29,10 @@ func TopicFeed(r *http.Request, title string, topicID int, rows []*db.GetForumTh
 		Created:     time.Now(),
 	}
 	for _, row := range rows {
-		if !row.Firstposttext.Valid {
+		if !row.FirstCommentText.Valid {
 			continue
 		}
-		text := row.Firstposttext.String
+		text := row.FirstCommentText.String
 		conv := a4code2html.New(cd.ImageURLMapper)
 		conv.CodeType = a4code2html.CTTagStrip
 		conv.SetInput(text)
@@ -43,17 +43,17 @@ func TopicFeed(r *http.Request, title string, topicID int, rows []*db.GetForumTh
 		}
 		item := &feeds.Item{
 			Title:   text[:i],
-			Link:    &feeds.Link{Href: fmt.Sprintf("/forum/topic/%d/thread/%d", topicID, row.Idforumthread)},
+			Link:    &feeds.Link{Href: fmt.Sprintf("/forum/topic/%d/thread/%d", topicID, row.ID)},
 			Created: time.Now(),
 			Description: fmt.Sprintf("%s\n-\n%s", string(out), func() string {
-				if row.Firstpostusername.Valid {
-					return row.Firstpostusername.String
+				if row.FirstCommentUsername.Valid {
+					return row.FirstCommentUsername.String
 				}
 				return ""
 			}()),
 		}
-		if row.Firstpostwritten.Valid {
-			item.Created = row.Firstpostwritten.Time
+		if row.FirstCommentWritten.Valid {
+			item.Created = row.FirstCommentWritten.Time
 		}
 		feed.Items = append(feed.Items, item)
 	}

--- a/handlers/forum/forumFeed_test.go
+++ b/handlers/forum/forumFeed_test.go
@@ -17,10 +17,10 @@ import (
 func TestForumTopicFeed(t *testing.T) {
 	rows := []*db.GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow{
 		{
-			Idforumthread:     1,
-			Firstposttext:     sql.NullString{String: "hello world", Valid: true},
-			Firstpostusername: sql.NullString{String: "bob", Valid: true},
-			Firstpostwritten:  sql.NullTime{Time: time.Unix(0, 0), Valid: true},
+			ID:                   1,
+			FirstCommentText:     sql.NullString{String: "hello world", Valid: true},
+			FirstCommentUsername: sql.NullString{String: "bob", Valid: true},
+			FirstCommentWritten:  sql.NullTime{Time: time.Unix(0, 0), Valid: true},
 		},
 	}
 	r := httptest.NewRequest("GET", "http://example.com/forum/topic/1.rss", nil)

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -63,15 +63,15 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, row := range rows {
 		topicRows = append(topicRows, &ForumtopicPlus{
-			Idforumtopic:                 row.Idforumtopic,
-			Lastposter:                   row.Lastposter,
-			ForumcategoryIdforumcategory: row.ForumcategoryIdforumcategory,
-			Title:                        row.Title,
-			Description:                  row.Description,
-			Threads:                      row.Threads,
-			Comments:                     row.Comments,
-			Lastaddition:                 row.Lastaddition,
-			Lastposterusername:           row.Lastposterusername,
+			ID:                 row.ID,
+			LastAuthorID:       row.LastAuthorID,
+			CategoryID:         row.CategoryID,
+			Title:              row.Title,
+			Description:        row.Description,
+			Threads:            row.Threads,
+			Comments:           row.Comments,
+			Lastaddition:       row.Lastaddition,
+			LastAuthorUsername: row.LastAuthorUsername,
 		})
 	}
 

--- a/handlers/forum/forumReplyTask_event_test.go
+++ b/handlers/forum/forumReplyTask_event_test.go
@@ -52,11 +52,11 @@ func TestForumReplyTaskEventData(t *testing.T) {
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess), common.WithEvent(evt), common.WithUserRoles([]string{"member"}))
 	cd.UserID = uid
 
-	thread := &db.GetThreadLastPosterAndPermsRow{Idforumthread: threadID, ForumtopicIdforumtopic: topicID}
+	thread := &db.GetThreadLastPosterAndPermsRow{ID: threadID, TopicID: topicID}
 	if _, err := cd.ForumThreadByID(threadID, lazy.Set(thread)); err != nil {
 		t.Fatalf("set thread: %v", err)
 	}
-	topic := &db.GetForumTopicByIdForUserRow{Idforumtopic: topicID, Title: sql.NullString{String: "t", Valid: true}}
+	topic := &db.GetForumTopicByIdForUserRow{ID: topicID, Title: sql.NullString{String: "t", Valid: true}}
 	if _, err := cd.ForumTopicByID(topicID, lazy.Set(topic)); err != nil {
 		t.Fatalf("set topic: %v", err)
 	}

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -147,7 +147,7 @@ func (CreateThreadTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	var topicTitle, author string
-	if trow, err := queries.GetForumTopicByIdForUser(r.Context(), db.GetForumTopicByIdForUserParams{ViewerID: uid, Idforumtopic: int32(topicId), ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0}}); err == nil {
+	if trow, err := queries.GetForumTopicByIdForUser(r.Context(), db.GetForumTopicByIdForUserParams{ViewerID: uid, ID: int32(topicId), ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0}}); err == nil {
 		topicTitle = trow.Title.String
 	}
 	if u, err := queries.SystemGetUserByID(r.Context(), uid); err == nil {

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -85,13 +85,13 @@ func ThreadPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 		if !data.CanEditComment(cmt) {
 			return ""
 		}
-		return fmt.Sprintf("%s/topic/%d/thread/%d?comment=%d#edit", data.BasePath, topicRow.Idforumtopic, threadRow.Idforumthread, cmt.Idcomments)
+		return fmt.Sprintf("%s/topic/%d/thread/%d?comment=%d#edit", data.BasePath, topicRow.ID, threadRow.ID, cmt.Idcomments)
 	}
 	data.EditSaveURL = func(cmt *db.GetCommentsByThreadIdForUserRow) string {
 		if !data.CanEditComment(cmt) {
 			return ""
 		}
-		return fmt.Sprintf("%s/topic/%d/thread/%d/comment/%d", data.BasePath, topicRow.Idforumtopic, threadRow.Idforumthread, cmt.Idcomments)
+		return fmt.Sprintf("%s/topic/%d/thread/%d/comment/%d", data.BasePath, topicRow.ID, threadRow.ID, cmt.Idcomments)
 	}
 	data.Editing = func(cmt *db.GetCommentsByThreadIdForUserRow) bool {
 		return data.CanEditComment(cmt) && commentId != 0 && int32(commentId) == cmt.Idcomments
@@ -108,25 +108,25 @@ func ThreadPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 
 	data.Thread = threadRow
 	data.Topic = &ForumtopicPlus{
-		Idforumtopic:                 topicRow.Idforumtopic,
-		Lastposter:                   topicRow.Lastposter,
-		ForumcategoryIdforumcategory: topicRow.ForumcategoryIdforumcategory,
-		Title:                        topicRow.Title,
-		Description:                  topicRow.Description,
-		Threads:                      topicRow.Threads,
-		Comments:                     topicRow.Comments,
-		Lastaddition:                 topicRow.Lastaddition,
-		Lastposterusername:           topicRow.Lastposterusername,
-		Edit:                         false,
+		ID:                 topicRow.ID,
+		LastAuthorID:       topicRow.LastAuthorID,
+		CategoryID:         topicRow.CategoryID,
+		Title:              topicRow.Title,
+		Description:        topicRow.Description,
+		Threads:            topicRow.Threads,
+		Comments:           topicRow.Comments,
+		Lastaddition:       topicRow.Lastaddition,
+		LastAuthorUsername: topicRow.LastAuthorUsername,
+		Edit:               false,
 	}
 
-	if pub, author, err := cd.ThreadPublicLabels(threadRow.Idforumthread); err == nil {
+	if pub, author, err := cd.ThreadPublicLabels(threadRow.ID); err == nil {
 		data.PublicLabels = pub
 		data.AuthorLabels = author
 	} else {
 		log.Printf("list public labels: %v", err)
 	}
-	if priv, err := cd.ThreadPrivateLabels(threadRow.Idforumthread); err == nil {
+	if priv, err := cd.ThreadPrivateLabels(threadRow.ID); err == nil {
 		data.PrivateLabels = priv
 	} else {
 		log.Printf("list private labels: %v", err)

--- a/handlers/forum/forumTopicPage.go
+++ b/handlers/forum/forumTopicPage.go
@@ -85,7 +85,7 @@ func TopicsPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 	displayTitle := topicRow.Title.String
 	if topicRow.Handler == "private" && cd.Queries() != nil {
 		parts, err := cd.Queries().ListPrivateTopicParticipantsByTopicIDForUser(r.Context(), db.ListPrivateTopicParticipantsByTopicIDForUserParams{
-			TopicID:  sql.NullInt32{Int32: topicRow.Idforumtopic, Valid: true},
+			TopicID:  sql.NullInt32{Int32: topicRow.ID, Valid: true},
 			ViewerID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 		})
 		if err != nil {
@@ -103,22 +103,22 @@ func TopicsPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 	}
 	cd.PageTitle = fmt.Sprintf("Forum - %s", displayTitle)
 	data.Topic = &ForumtopicPlus{
-		Idforumtopic:                 topicRow.Idforumtopic,
-		Lastposter:                   topicRow.Lastposter,
-		ForumcategoryIdforumcategory: topicRow.ForumcategoryIdforumcategory,
-		Title:                        topicRow.Title,
-		Description:                  topicRow.Description,
-		Threads:                      topicRow.Threads,
-		Comments:                     topicRow.Comments,
-		Lastaddition:                 topicRow.Lastaddition,
-		Lastposterusername:           topicRow.Lastposterusername,
-		DisplayTitle:                 displayTitle,
-		Edit:                         false,
+		ID:                 topicRow.ID,
+		LastAuthorID:       topicRow.LastAuthorID,
+		CategoryID:         topicRow.CategoryID,
+		Title:              topicRow.Title,
+		Description:        topicRow.Description,
+		Threads:            topicRow.Threads,
+		Comments:           topicRow.Comments,
+		Lastaddition:       topicRow.Lastaddition,
+		LastAuthorUsername: topicRow.LastAuthorUsername,
+		DisplayTitle:       displayTitle,
+		Edit:               false,
 	}
 
 	if topicRow.Handler != "private" {
 		categoryTree := NewCategoryTree(categoryRows, []*ForumtopicPlus{data.Topic})
-		if category, ok := categoryTree.CategoryLookup[topicRow.ForumcategoryIdforumcategory]; ok {
+		if category, ok := categoryTree.CategoryLookup[topicRow.CategoryID]; ok {
 			category.Topics = []*ForumtopicPlus{
 				data.Topic,
 			}
@@ -138,13 +138,13 @@ func TopicsPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 	threads := make([]*threadWithLabels, len(threadRows))
 	for i, r := range threadRows {
 		t := &threadWithLabels{GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow: r}
-		if pub, author, err := cd.ThreadPublicLabels(r.Idforumthread); err == nil {
+		if pub, author, err := cd.ThreadPublicLabels(r.ID); err == nil {
 			t.PublicLabels = pub
 			t.AuthorLabels = author
 		} else {
 			log.Printf("list public labels: %v", err)
 		}
-		if priv, err := cd.ThreadPrivateLabels(r.Idforumthread); err == nil {
+		if priv, err := cd.ThreadPrivateLabels(r.ID); err == nil {
 			t.PrivateLabels = priv
 		} else {
 			log.Printf("list private labels: %v", err)
@@ -153,19 +153,19 @@ func TopicsPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 	}
 	data.Threads = threads
 
-	if pub, author, err := cd.ThreadPublicLabels(topicRow.Idforumtopic); err == nil {
+	if pub, author, err := cd.ThreadPublicLabels(topicRow.ID); err == nil {
 		data.PublicLabels = pub
 		data.AuthorLabels = author
 	} else {
 		log.Printf("list public labels: %v", err)
 	}
-	if priv, err := cd.ThreadPrivateLabels(topicRow.Idforumtopic); err == nil {
+	if priv, err := cd.ThreadPrivateLabels(topicRow.ID); err == nil {
 		data.PrivateLabels = priv
 	} else {
 		log.Printf("list private labels: %v", err)
 	}
 
-	if subscribedToTopic(cd, topicRow.Idforumtopic) {
+	if subscribedToTopic(cd, topicRow.ID) {
 		data.Subscribed = true
 	}
 

--- a/handlers/forum/forumTopicThreadCommentEditPage.go
+++ b/handlers/forum/forumTopicThreadCommentEditPage.go
@@ -45,12 +45,12 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(commentId), ThreadID: threadRow.Idforumthread, TopicID: topicRow.Idforumtopic}
-			evt.Data["CommentURL"] = cd.AbsoluteURL(fmt.Sprintf("/forum/topic/%d/thread/%d#comment-%d", topicRow.Idforumtopic, threadRow.Idforumthread, commentId))
+			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(commentId), ThreadID: threadRow.ID, TopicID: topicRow.ID}
+			evt.Data["CommentURL"] = cd.AbsoluteURL(fmt.Sprintf("/forum/topic/%d/thread/%d#comment-%d", topicRow.ID, threadRow.ID, commentId))
 		}
 	}
 
-	http.Redirect(w, r, fmt.Sprintf("/forum/topic/%d/thread/%d#comment-%d", topicRow.Idforumtopic, threadRow.Idforumthread, commentId), http.StatusTemporaryRedirect)
+	http.Redirect(w, r, fmt.Sprintf("/forum/topic/%d/thread/%d#comment-%d", topicRow.ID, threadRow.ID, commentId), http.StatusTemporaryRedirect)
 }
 
 func TopicThreadCommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
@@ -68,7 +68,7 @@ func TopicThreadCommentEditActionCancelPage(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
+	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.ID, threadRow.ID)
 
 	http.Redirect(w, r, endUrl, http.StatusTemporaryRedirect)
 }

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -118,7 +118,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 				evt.Data = map[string]any{}
 			}
 			evt.Data["TopicTitle"] = topicRow.Title.String
-			evt.Data["ThreadID"] = threadRow.Idforumthread
+			evt.Data["ThreadID"] = threadRow.ID
 			evt.Data["Thread"] = threadRow
 			evt.Data["Username"] = username
 		}
@@ -131,9 +131,9 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if base == "" {
 		base = "/forum"
 	}
-	endUrl := fmt.Sprintf("%s/topic/%d/thread/%d#bottom", base, topicRow.Idforumtopic, threadRow.Idforumthread)
+	endUrl := fmt.Sprintf("%s/topic/%d/thread/%d#bottom", base, topicRow.ID, threadRow.ID)
 
-	cid, err := cd.CreateForumCommentForCommenter(uid, threadRow.Idforumthread, topicRow.Idforumtopic, int32(languageId), text)
+	cid, err := cd.CreateForumCommentForCommenter(uid, threadRow.ID, topicRow.ID, int32(languageId), text)
 	if err != nil {
 		log.Printf("Error: CreateComment: %s", err)
 		return fmt.Errorf("create comment %w", handlers.ErrRedirectOnSamePageHandler(err))
@@ -143,10 +143,10 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		log.Printf("Error: CreateComment: %s", err)
 		return fmt.Errorf("create comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := cd.ClearThreadPrivateLabelStatus(threadRow.Idforumthread); err != nil {
+	if err := cd.ClearThreadPrivateLabelStatus(threadRow.ID); err != nil {
 		log.Printf("clear label status: %v", err)
 	}
-	if err := cd.SetThreadPrivateLabelStatus(threadRow.Idforumthread, false, false); err != nil {
+	if err := cd.SetThreadPrivateLabelStatus(threadRow.ID, false, false); err != nil {
 		log.Printf("set label status: %v", err)
 	}
 
@@ -155,7 +155,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(cid), ThreadID: threadRow.Idforumthread, TopicID: topicRow.Idforumtopic}
+			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(cid), ThreadID: threadRow.ID, TopicID: topicRow.ID}
 			evt.Data["CommentURL"] = cd.AbsoluteURL(endUrl)
 		}
 	}
@@ -188,6 +188,6 @@ func TopicThreadReplyCancelPage(w http.ResponseWriter, r *http.Request) {
 	if base == "" {
 		base = "/forum"
 	}
-	endUrl := fmt.Sprintf("%s/topic/%d/thread/%d#bottom", base, topicRow.Idforumtopic, threadRow.Idforumthread)
+	endUrl := fmt.Sprintf("%s/topic/%d/thread/%d#bottom", base, topicRow.ID, threadRow.ID)
 	http.Redirect(w, r, endUrl, http.StatusTemporaryRedirect)
 }

--- a/handlers/forum/matchers.go
+++ b/handlers/forum/matchers.go
@@ -54,7 +54,7 @@ func RequireThreadAndTopic(next http.Handler) http.Handler {
 			return
 		}
 
-		topicRow, err := cd.ForumTopicByID(threadRow.ForumtopicIdforumtopic)
+		topicRow, err := cd.ForumTopicByID(threadRow.TopicID)
 		if err != nil {
 			if cd.Config.LogFlags&config.LogFlagAccess != 0 {
 				log.Printf("RequireThreadAndTopic topic uid=%d topic=%d thread=%d: %v", uid, topicID, threadID, err)
@@ -63,14 +63,14 @@ func RequireThreadAndTopic(next http.Handler) http.Handler {
 			return
 		}
 
-		if int(topicRow.Idforumtopic) != topicID {
+		if int(topicRow.ID) != topicID {
 			if cd.Config.LogFlags&config.LogFlagAccess != 0 {
-				log.Printf("RequireThreadAndTopic mismatch uid=%d urlTopic=%d threadTopic=%d", uid, topicID, topicRow.Idforumtopic)
+				log.Printf("RequireThreadAndTopic mismatch uid=%d urlTopic=%d threadTopic=%d", uid, topicID, topicRow.ID)
 			}
 			http.NotFound(w, r)
 			return
 		}
-		cd.SetCurrentThreadAndTopic(int32(threadID), threadRow.ForumtopicIdforumtopic)
+		cd.SetCurrentThreadAndTopic(int32(threadID), threadRow.TopicID)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/handlers/forum/topic_thread_reply_cancel_task.go
+++ b/handlers/forum/topic_thread_reply_cancel_task.go
@@ -35,6 +35,6 @@ func (topicThreadReplyCancelTask) Action(w http.ResponseWriter, r *http.Request)
 	if base == "" {
 		base = "/forum"
 	}
-	endURL := fmt.Sprintf("%s/topic/%d/thread/%d#bottom", base, topicRow.Idforumtopic, threadRow.Idforumthread)
+	endURL := fmt.Sprintf("%s/topic/%d/thread/%d#bottom", base, topicRow.ID, threadRow.ID)
 	return handlers.RedirectHandler(endURL)
 }

--- a/handlers/forum/topic_thread_reply_cancel_task_test.go
+++ b/handlers/forum/topic_thread_reply_cancel_task_test.go
@@ -17,8 +17,8 @@ import (
 func TestTopicThreadReplyCancel_BasePath(t *testing.T) {
 	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
 	cd.ForumBasePath = "/private"
-	thread := &db.GetThreadLastPosterAndPermsRow{Idforumthread: 2, ForumtopicIdforumtopic: 1}
-	topic := &db.GetForumTopicByIdForUserRow{Idforumtopic: 1}
+	thread := &db.GetThreadLastPosterAndPermsRow{ID: 2, TopicID: 1}
+	topic := &db.GetForumTopicByIdForUserRow{ID: 1}
 	if _, err := cd.ForumThreadByID(2, lazy.Set(thread)); err != nil {
 		t.Fatalf("set thread: %v", err)
 	}

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -172,7 +172,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	} else if err != nil {
 		return fmt.Errorf("find forum topic fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	} else {
-		ptid = pt.Idforumtopic
+		ptid = pt.ID
 	}
 	if pthid == 0 {
 		pthidi, err := queries.SystemCreateThread(r.Context(), ptid)

--- a/handlers/linker/edit_reply_task.go
+++ b/handlers/linker/edit_reply_task.go
@@ -82,7 +82,7 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(commentId), ThreadID: thread.Idforumthread, TopicID: thread.ForumtopicIdforumtopic}
+			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(commentId), ThreadID: thread.ID, TopicID: thread.TopicID}
 		}
 	}
 

--- a/handlers/linker/linkerAdminLinkPage.go
+++ b/handlers/linker/linkerAdminLinkPage.go
@@ -35,8 +35,8 @@ func adminLinkPage(w http.ResponseWriter, r *http.Request) {
 		SelectedLanguageId int
 	}{
 		Link:               link,
-                Selected:           int(link.LinkerCategoryID.Int32),
-                SelectedLanguageId: int(link.LanguageIdlanguage.Int32),
+		Selected:           int(link.LinkerCategoryID.Int32),
+		SelectedLanguageId: int(link.LanguageIdlanguage.Int32),
 	}
 
 	handlers.TemplateHandler(w, r, "adminLinkPage.gohtml", data)
@@ -68,8 +68,8 @@ func (editLinkTask) Action(w http.ResponseWriter, r *http.Request) any {
 		Title:              sql.NullString{Valid: true, String: title},
 		Url:                sql.NullString{Valid: true, String: URL},
 		Description:        sql.NullString{Valid: true, String: desc},
-                LinkerCategoryID:   sql.NullInt32{Int32: int32(cat), Valid: cat != 0},
-                LanguageIdlanguage: sql.NullInt32{Int32: int32(lang), Valid: lang != 0},
+		LinkerCategoryID:   sql.NullInt32{Int32: int32(cat), Valid: cat != 0},
+		LanguageIdlanguage: sql.NullInt32{Int32: int32(lang), Valid: lang != 0},
 		Idlinker:           id,
 	}); err != nil {
 		return fmt.Errorf("update linker item fail %w", handlers.ErrRedirectOnSamePageHandler(err))

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -261,7 +261,7 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	} else if err != nil {
 		return fmt.Errorf("find forum topic fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	} else {
-		ptid = pt.Idforumtopic
+		ptid = pt.ID
 	}
 	if pthid == 0 {
 		pthidi, err := queries.SystemCreateThread(r.Context(), ptid)

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -114,9 +114,9 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 	})
 	var ptid int32
 	if errors.Is(err, sql.ErrNoRows) {
-                ptidi, err := queries.CreateForumTopicForPoster(r.Context(), db.CreateForumTopicForPosterParams{
-                        ForumcategoryID: 0,
-                        ForumLang:       link.LanguageIdlanguage,
+		ptidi, err := queries.CreateForumTopicForPoster(r.Context(), db.CreateForumTopicForPosterParams{
+			ForumcategoryID: 0,
+			ForumLang:       link.LanguageIdlanguage,
 			Title: sql.NullString{
 				String: LinkerTopicName,
 				Valid:  true,
@@ -142,7 +142,7 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
 		return
 	} else {
-		ptid = pt.Idforumtopic
+		ptid = pt.ID
 	}
 	if pthid == 0 {
 		pthidi, err := queries.SystemCreateThread(r.Context(), ptid)

--- a/handlers/news/admin_pages.go
+++ b/handlers/news/admin_pages.go
@@ -177,7 +177,7 @@ func adminNewsEditFormPage(w http.ResponseWriter, r *http.Request) {
 	}{
 		Languages:          langs,
 		Post:               post,
-                SelectedLanguageId: int(post.LanguageIdlanguage.Int32),
+		SelectedLanguageId: int(post.LanguageIdlanguage.Int32),
 	}
 	if err := cd.ExecuteSiteTemplate(w, r, "adminNewsEditPage.gohtml", data); err != nil {
 		handlers.RenderErrorPage(w, r, err)

--- a/handlers/news/searchResultNewsActionPage.go
+++ b/handlers/news/searchResultNewsActionPage.go
@@ -46,7 +46,7 @@ func SearchResultNewsActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if comments, emptyWords, noResults, err := forumCommentSearchInRestrictedTopic(w, r, queries, []int32{ftbn.Idforumtopic}, uid); err != nil {
+	if comments, emptyWords, noResults, err := forumCommentSearchInRestrictedTopic(w, r, queries, []int32{ftbn.ID}, uid); err != nil {
 		return
 	} else {
 		data.Comments = comments

--- a/handlers/user/userLangPage.go
+++ b/handlers/user/userLangPage.go
@@ -69,13 +69,13 @@ func userLangPage(w http.ResponseWriter, r *http.Request) {
 		if selected[l.Idlanguage] {
 			opt.IsSelected = true
 		}
-                if pref != nil && pref.LanguageIdlanguage.Valid && pref.LanguageIdlanguage.Int32 == l.Idlanguage {
-                        opt.IsDefault = true
-                }
+		if pref != nil && pref.LanguageIdlanguage.Valid && pref.LanguageIdlanguage.Int32 == l.Idlanguage {
+			opt.IsDefault = true
+		}
 		opts = append(opts, opt)
 	}
 
-        defaultIsMulti := pref == nil || !pref.LanguageIdlanguage.Valid
+	defaultIsMulti := pref == nil || !pref.LanguageIdlanguage.Valid
 	data := Data{
 		LanguageOptions:       opts,
 		DefaultIsMultilingual: defaultIsMulti,
@@ -120,15 +120,15 @@ func updateDefaultLanguage(r *http.Request, queries db.Querier, uid int32) error
 	}
 
 	if errors.Is(err, sql.ErrNoRows) {
-                return queries.InsertPreferenceForLister(r.Context(), db.InsertPreferenceForListerParams{
-                        LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
-                        ListerID:   uid,
-                        PageSize:   int32(cd.Config.PageSizeDefault),
-                        Timezone:   sql.NullString{},
-                })
+		return queries.InsertPreferenceForLister(r.Context(), db.InsertPreferenceForListerParams{
+			LanguageID: sql.NullInt32{Int32: int32(langID), Valid: langID != 0},
+			ListerID:   uid,
+			PageSize:   int32(cd.Config.PageSizeDefault),
+			Timezone:   sql.NullString{},
+		})
 	}
 
-        pref.LanguageIdlanguage = sql.NullInt32{Int32: int32(langID), Valid: langID != 0}
+	pref.LanguageIdlanguage = sql.NullInt32{Int32: int32(langID), Valid: langID != 0}
 	return queries.UpdatePreferenceForLister(r.Context(), db.UpdatePreferenceForListerParams{
 		LanguageID: pref.LanguageIdlanguage,
 		ListerID:   uid,

--- a/handlers/user/userPagingPage.go
+++ b/handlers/user/userPagingPage.go
@@ -56,12 +56,12 @@ func (PagingSaveTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if errors.Is(err, sql.ErrNoRows) {
-                err = queries.InsertPreferenceForLister(r.Context(), db.InsertPreferenceForListerParams{
-                        LanguageID: sql.NullInt32{},
-                        ListerID:   uid,
-                        PageSize:   int32(size),
-                        Timezone:   sql.NullString{},
-                })
+		err = queries.InsertPreferenceForLister(r.Context(), db.InsertPreferenceForListerParams{
+			LanguageID: sql.NullInt32{},
+			ListerID:   uid,
+			PageSize:   int32(size),
+			Timezone:   sql.NullString{},
+		})
 	} else {
 		pref.PageSize = int32(size)
 		err = queries.UpdatePreferenceForLister(r.Context(), db.UpdatePreferenceForListerParams{

--- a/handlers/writings/edit_reply_task.go
+++ b/handlers/writings/edit_reply_task.go
@@ -58,7 +58,7 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: comment.Idcomments, ThreadID: thread.Idforumthread, TopicID: thread.ForumtopicIdforumtopic}
+			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: comment.Idcomments, ThreadID: thread.ID, TopicID: thread.TopicID}
 		}
 	}
 

--- a/handlers/writings/writing_category_change_task.go
+++ b/handlers/writings/writing_category_change_task.go
@@ -50,14 +50,14 @@ func writingCategoryWouldLoop(ctx context.Context, queries db.Querier, cid, pare
 		if err != nil {
 			return nil, false, err
 		}
-                parents = make(map[int32]int32, len(cats))
-                for _, c := range cats {
-                        var pid int32
-                        if c.WritingCategoryID.Valid {
-                                pid = c.WritingCategoryID.Int32
-                        }
-                        parents[c.Idwritingcategory] = pid
-                }
+		parents = make(map[int32]int32, len(cats))
+		for _, c := range cats {
+			var pid int32
+			if c.WritingCategoryID.Valid {
+				pid = c.WritingCategoryID.Int32
+			}
+			parents[c.Idwritingcategory] = pid
+		}
 	} else {
 		parents = map[int32]int32{}
 	}

--- a/handlers/writings/writing_category_change_task_test.go
+++ b/handlers/writings/writing_category_change_task_test.go
@@ -23,13 +23,13 @@ func TestWritingCategoryChangeTask(t *testing.T) {
 
 	queries := db.New(conn)
 
-        rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
-                AddRow(1, nil, "a", "")
+	rows := sqlmock.NewRows([]string{"idwritingcategory", "writing_category_id", "title", "description"}).
+		AddRow(1, nil, "a", "")
 	mock.ExpectQuery("SELECT wc.idwritingcategory").WillReturnRows(rows)
 
-        mock.ExpectExec("UPDATE writing_category").
-                WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), int32(1)).
-                WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE writing_category").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), int32(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	form := url.Values{"name": {"A"}, "desc": {"B"}, "pcid": {"0"}, "cid": {"1"}}
 	req := httptest.NewRequest("POST", "/admin/writings/categories/category/1/edit", strings.NewReader(form.Encode()))

--- a/handlers/writings/writingsAdminCategoriesPage.go
+++ b/handlers/writings/writingsAdminCategoriesPage.go
@@ -56,14 +56,14 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 	}
 	data.AllCategories = categoryRows
 	data.Categories = categoryRows[offset:end]
-        children := map[int32][]*db.WritingCategory{}
-        for _, c := range categoryRows {
-                var pid int32
-                if c.WritingCategoryID.Valid {
-                        pid = c.WritingCategoryID.Int32
-                }
-                children[pid] = append(children[pid], c)
-        }
+	children := map[int32][]*db.WritingCategory{}
+	for _, c := range categoryRows {
+		var pid int32
+		if c.WritingCategoryID.Valid {
+			pid = c.WritingCategoryID.Int32
+		}
+		children[pid] = append(children[pid], c)
+	}
 	var build func(parent int32) string
 	build = func(parent int32) string {
 		var sb strings.Builder

--- a/handlers/writings/writingsArticleCommentEditPage.go
+++ b/handlers/writings/writingsArticleCommentEditPage.go
@@ -46,7 +46,7 @@ func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 			if evt.Data == nil {
 				evt.Data = map[string]any{}
 			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: comment.Idcomments, ThreadID: thread.Idforumthread, TopicID: thread.ForumtopicIdforumtopic}
+			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: comment.Idcomments, ThreadID: thread.ID, TopicID: thread.TopicID}
 		}
 	}
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -245,34 +245,34 @@ type FaqRevision struct {
 }
 
 type Forumcategory struct {
-	Idforumcategory              int32
-	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           sql.NullInt32
-	Title                        sql.NullString
-	Description                  sql.NullString
+	ID               int32
+	ParentCategoryID int32
+	LanguageID       sql.NullInt32
+	Title            sql.NullString
+	Description      sql.NullString
 }
 
 type Forumthread struct {
-	Idforumthread          int32
-	Firstpost              int32
-	Lastposter             int32
-	ForumtopicIdforumtopic int32
-	Comments               sql.NullInt32
-	Lastaddition           sql.NullTime
-	Locked                 sql.NullBool
+	ID             int32
+	FirstCommentID int32
+	LastAuthorID   int32
+	TopicID        int32
+	Comments       sql.NullInt32
+	Lastaddition   sql.NullTime
+	Locked         sql.NullBool
 }
 
 type Forumtopic struct {
-	Idforumtopic                 int32
-	Lastposter                   int32
-	ForumcategoryIdforumcategory int32
-	LanguageIdlanguage           sql.NullInt32
-	Title                        sql.NullString
-	Description                  sql.NullString
-	Threads                      sql.NullInt32
-	Comments                     sql.NullInt32
-	Lastaddition                 sql.NullTime
-	Handler                      string
+	ID           int32
+	LastAuthorID int32
+	CategoryID   int32
+	LanguageID   sql.NullInt32
+	Title        sql.NullString
+	Description  sql.NullString
+	Threads      sql.NullInt32
+	Comments     sql.NullInt32
+	Lastaddition sql.NullTime
+	Handler      string
 }
 
 type Grant struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -46,10 +46,10 @@ type Querier interface {
 	AdminDeleteExternalLinkByURL(ctx context.Context, url string) error
 	AdminDeleteFAQ(ctx context.Context, id int32) error
 	AdminDeleteFAQCategory(ctx context.Context, id int32) error
-	AdminDeleteForumCategory(ctx context.Context, idforumcategory int32) error
-	AdminDeleteForumThread(ctx context.Context, idforumthread int32) error
+	AdminDeleteForumCategory(ctx context.Context, id int32) error
+	AdminDeleteForumThread(ctx context.Context, id int32) error
 	// Removes a forum topic by ID.
-	AdminDeleteForumTopic(ctx context.Context, idforumtopic int32) error
+	AdminDeleteForumTopic(ctx context.Context, id int32) error
 	AdminDeleteGrant(ctx context.Context, id int32) error
 	AdminDeleteImageBoard(ctx context.Context, idimageboard int32) error
 	AdminDeleteImagePost(ctx context.Context, idimagepost int32) error
@@ -181,7 +181,7 @@ type Querier interface {
 	AdminPurgeReadNotifications(ctx context.Context) error
 	AdminRebuildAllForumTopicMetaColumns(ctx context.Context) error
 	AdminRecalculateAllForumThreadMetaData(ctx context.Context) error
-	AdminRecalculateForumThreadByIdMetaData(ctx context.Context, idforumthread int32) error
+	AdminRecalculateForumThreadByIdMetaData(ctx context.Context, id int32) error
 	AdminRenameFAQCategory(ctx context.Context, arg AdminRenameFAQCategoryParams) error
 	// AdminRenameLanguage updates the language name.
 	// Parameters:
@@ -286,9 +286,9 @@ type Querier interface {
 	GetForumCategoryById(ctx context.Context, arg GetForumCategoryByIdParams) (*Forumcategory, error)
 	GetForumThreadIdByNewsPostId(ctx context.Context, idsitenews int32) (*GetForumThreadIdByNewsPostIdRow, error)
 	GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostText(ctx context.Context, arg GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextParams) ([]*GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostTextRow, error)
-	GetForumTopicById(ctx context.Context, idforumtopic int32) (*Forumtopic, error)
+	GetForumTopicById(ctx context.Context, id int32) (*Forumtopic, error)
 	GetForumTopicByIdForUser(ctx context.Context, arg GetForumTopicByIdForUserParams) (*GetForumTopicByIdForUserRow, error)
-	GetForumTopicIdByThreadId(ctx context.Context, idforumthread int32) (int32, error)
+	GetForumTopicIdByThreadId(ctx context.Context, id int32) (int32, error)
 	GetForumTopicsByCategoryId(ctx context.Context, arg GetForumTopicsByCategoryIdParams) ([]*Forumtopic, error)
 	GetForumTopicsForUser(ctx context.Context, arg GetForumTopicsForUserParams) ([]*GetForumTopicsForUserRow, error)
 	GetImageBoardById(ctx context.Context, idimageboard int32) (*Imageboard, error)
@@ -437,7 +437,7 @@ type Querier interface {
 	SystemCreateGrant(ctx context.Context, arg SystemCreateGrantParams) (int64, error)
 	SystemCreateNotification(ctx context.Context, arg SystemCreateNotificationParams) error
 	SystemCreateSearchWord(ctx context.Context, word string) (int64, error)
-	SystemCreateThread(ctx context.Context, forumtopicIdforumtopic int32) (int64, error)
+	SystemCreateThread(ctx context.Context, topicID int32) (int64, error)
 	// This query inserts a new permission into the "permissions" table.
 	// Parameters:
 	//   ? - User ID to be associated with the permission (int)
@@ -501,7 +501,7 @@ type Querier interface {
 	SystemPurgeDeadLettersBefore(ctx context.Context, createdAt time.Time) error
 	// Remove password reset entries that have expired or were already verified
 	SystemPurgePasswordResetsBefore(ctx context.Context, createdAt time.Time) (sql.Result, error)
-	SystemRebuildForumTopicMetaByID(ctx context.Context, idforumtopic int32) error
+	SystemRebuildForumTopicMetaByID(ctx context.Context, id int32) error
 	SystemRegisterExternalLinkClick(ctx context.Context, url string) error
 	SystemSetBlogLastIndex(ctx context.Context, id int32) error
 	SystemSetCommentLastIndex(ctx context.Context, idcomments int32) error

--- a/internal/db/queries-blog.sql
+++ b/internal/db/queries-blog.sql
@@ -317,13 +317,13 @@ SELECT b.idblogs,
        b.timezone,
        u.username,
        coalesce(th.comments, 0),
-       fc.idforumcategory,
+       fc.id,
        fc.title AS forumcategory_title
 FROM blogs b
 LEFT JOIN users u ON b.users_idusers = u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN forumcategory fc ON t.forumcategory_idforumcategory = fc.idforumcategory
+LEFT JOIN forumcategory fc ON t.category_id = fc.id
 WHERE b.users_idusers = sqlc.arg(author_id)
 ORDER BY b.written DESC;
 

--- a/internal/db/queries-blog.sql.go
+++ b/internal/db/queries-blog.sql.go
@@ -22,13 +22,13 @@ SELECT b.idblogs,
        b.timezone,
        u.username,
        coalesce(th.comments, 0),
-       fc.idforumcategory,
+       fc.id,
        fc.title AS forumcategory_title
 FROM blogs b
 LEFT JOIN users u ON b.users_idusers = u.idusers
 LEFT JOIN forumthread th ON b.forumthread_id = th.idforumthread
 LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN forumcategory fc ON t.forumcategory_idforumcategory = fc.idforumcategory
+LEFT JOIN forumcategory fc ON t.category_id = fc.id
 WHERE b.users_idusers = ?
 ORDER BY b.written DESC
 `
@@ -43,7 +43,7 @@ type AdminGetAllBlogEntriesByUserRow struct {
 	Timezone           sql.NullString
 	Username           sql.NullString
 	Comments           int32
-	Idforumcategory    sql.NullInt32
+	ID                 sql.NullInt32
 	ForumcategoryTitle sql.NullString
 }
 
@@ -66,7 +66,7 @@ func (q *Queries) AdminGetAllBlogEntriesByUser(ctx context.Context, authorID int
 			&i.Timezone,
 			&i.Username,
 			&i.Comments,
-			&i.Idforumcategory,
+			&i.ID,
 			&i.ForumcategoryTitle,
 		); err != nil {
 			return nil, err

--- a/internal/db/queries-comments.sql
+++ b/internal/db/queries-comments.sql
@@ -5,8 +5,8 @@ WITH role_ids AS (
 SELECT c.*, pu.Username,
        c.users_idusers = sqlc.arg(viewer_id) AS is_owner
 FROM comments c
-LEFT JOIN forumthread th ON c.forumthread_id=th.idforumthread
-LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
+LEFT JOIN forumthread th ON c.forumthread_id=th.id
+LEFT JOIN forumtopic t ON th.topic_id=t.id
 LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.idcomments = sqlc.arg(id)
   AND (
@@ -27,7 +27,7 @@ WHERE c.idcomments = sqlc.arg(id)
       AND (g.item='topic' OR g.item IS NULL)
       AND g.action='see'
       AND g.active=1
-      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
+      AND (g.item_id = t.id OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -63,14 +63,14 @@ WITH role_ids AS (
 )
 SELECT c.*, pu.username AS posterusername,
        c.users_idusers = sqlc.arg(viewer_id) AS is_owner,
-       th.idforumthread, t.idforumtopic, t.title AS forumtopic_title,
-       fp.text AS thread_title, fc.idforumcategory, fc.title AS forumcategory_title
+       th.id, t.id, t.title AS forumtopic_title,
+       fp.text AS thread_title, fc.id, fc.title AS forumcategory_title
 FROM comments c
-LEFT JOIN forumthread th ON c.forumthread_id=th.idforumthread
-LEFT JOIN comments fp ON th.firstpost = fp.idcomments
-LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
+LEFT JOIN forumthread th ON c.forumthread_id=th.id
+LEFT JOIN comments fp ON th.first_comment_id = fp.idcomments
+LEFT JOIN forumtopic t ON th.topic_id=t.id
 LEFT JOIN users pu ON pu.idusers = c.users_idusers
-LEFT JOIN forumcategory fc ON t.forumcategory_idforumcategory = fc.idforumcategory
+LEFT JOIN forumcategory fc ON t.category_id = fc.id
 WHERE c.Idcomments IN (sqlc.slice('ids'))
   AND (
       c.language_idlanguage = 0
@@ -90,7 +90,7 @@ WHERE c.Idcomments IN (sqlc.slice('ids'))
       AND (g.item='topic' OR g.item IS NULL)
       AND g.action='see'
       AND g.active=1
-      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
+      AND (g.item_id = t.id OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -120,8 +120,8 @@ WITH role_ids AS (
 SELECT c.*, pu.username AS posterusername,
        c.users_idusers = sqlc.arg(viewer_id) AS is_owner
 FROM comments c
-LEFT JOIN forumthread th ON c.forumthread_id=th.idforumthread
-LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
+LEFT JOIN forumthread th ON c.forumthread_id=th.id
+LEFT JOIN forumtopic t ON th.topic_id=t.id
 LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.forumthread_id=sqlc.arg(thread_id)
   AND c.forumthread_id IS NOT NULL
@@ -143,7 +143,7 @@ WHERE c.forumthread_id=sqlc.arg(thread_id)
       AND (g.item='topic' OR g.item IS NULL)
       AND g.action='see'
       AND g.active=1
-      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
+      AND (g.item_id = t.id OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -158,8 +158,8 @@ WITH role_ids(id) AS (
 SELECT c.*, pu.username AS posterusername,
        c.users_idusers = sqlc.arg(viewer_id) AS is_owner
 FROM comments c
-LEFT JOIN forumthread th ON c.forumthread_id=th.idforumthread
-LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
+LEFT JOIN forumthread th ON c.forumthread_id=th.id
+LEFT JOIN forumtopic t ON th.topic_id=t.id
 LEFT JOIN users pu ON pu.idusers = c.users_idusers
 WHERE c.forumthread_id=sqlc.arg(thread_id)
   AND c.forumthread_id IS NOT NULL
@@ -181,7 +181,7 @@ WHERE c.forumthread_id=sqlc.arg(thread_id)
       AND (g.item=sqlc.arg(item_type) OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
+      AND (g.item_id = t.id OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
 )
@@ -191,12 +191,12 @@ ORDER BY c.written;
 -- name: AdminGetAllCommentsByUser :many
 SELECT c.idcomments, c.forumthread_id, c.users_idusers, c.language_idlanguage,
        c.written, c.text, c.deleted_at, c.last_index, c.timezone,
-       th.forumtopic_idforumtopic, t.title AS forumtopic_title,
+       th.topic_id, t.title AS forumtopic_title,
        fp.text AS thread_title
 FROM comments c
-LEFT JOIN forumthread th ON c.forumthread_id = th.idforumthread
-LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN comments fp ON th.firstpost = fp.idcomments
+LEFT JOIN forumthread th ON c.forumthread_id = th.id
+LEFT JOIN forumtopic t ON th.topic_id = t.id
+LEFT JOIN comments fp ON th.first_comment_id = fp.idcomments
 WHERE c.users_idusers = sqlc.arg('user_id')
 ORDER BY c.written;
 
@@ -215,11 +215,11 @@ SELECT idcomments, text FROM comments WHERE deleted_at IS NULL;
 
 -- name: AdminListAllCommentsWithThreadInfo :many
 SELECT c.idcomments, c.written, c.text, c.deleted_at,
-       th.idforumthread, t.idforumtopic, t.title AS forumtopic_title,
+       th.id, t.id, t.title AS forumtopic_title,
        u.idusers, u.username AS posterusername
 FROM comments c
-LEFT JOIN forumthread th ON c.forumthread_id = th.idforumthread
-LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic = t.idforumtopic
+LEFT JOIN forumthread th ON c.forumthread_id = th.id
+LEFT JOIN forumtopic t ON th.topic_id = t.id
 LEFT JOIN users u ON u.idusers = c.users_idusers
 ORDER BY c.written DESC
 LIMIT ? OFFSET ?;

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -1,35 +1,35 @@
-UPDATE forumcategory SET title = ?, description = ?, forumcategory_idforumcategory = ?, language_idlanguage = sqlc.narg(category_language_id) WHERE idforumcategory = ?;
+UPDATE forumcategory SET title = ?, description = ?, parent_category_id = ?, language_id = sqlc.narg(category_language_id) WHERE forumtopic.id = ?;
 
 -- name: GetAllForumCategoriesWithSubcategoryCount :many
-SELECT c.*, COUNT(c2.idforumcategory) as SubcategoryCount,
-       COUNT(t.idforumtopic)   as TopicCount
+SELECT c.*, COUNT(c2.id) as SubcategoryCount,
+       COUNT(t.id)   as TopicCount
 FROM forumcategory c
-LEFT JOIN forumcategory c2 ON c.idforumcategory = c2.forumcategory_idforumcategory
-LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
+LEFT JOIN forumcategory c2 ON c.id = c2.parent_category_id
+LEFT JOIN forumtopic t ON c.id = t.category_id
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_id = 0
+    OR c.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
-          AND ul.language_idlanguage = c.language_idlanguage
+          AND ul.language_id = c.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
     )
 )
-GROUP BY c.idforumcategory;
+GROUP BY c.id;
 
 -- name: AdminCountForumCategories :one
 SELECT COUNT(*)
 FROM forumcategory c
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_id = 0
+    OR c.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
-          AND ul.language_idlanguage = c.language_idlanguage
+          AND ul.language_id = c.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -37,67 +37,67 @@ WHERE (
 );
 
 -- name: AdminListForumCategoriesWithCounts :many
-SELECT c.*, COUNT(c2.idforumcategory) AS SubcategoryCount,
-       COUNT(t.idforumtopic) AS TopicCount
+SELECT c.*, COUNT(c2.id) AS SubcategoryCount,
+       COUNT(t.id) AS TopicCount
 FROM forumcategory c
-LEFT JOIN forumcategory c2 ON c.idforumcategory = c2.forumcategory_idforumcategory
-LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
+LEFT JOIN forumcategory c2 ON c.id = c2.parent_category_id
+LEFT JOIN forumtopic t ON c.id = t.category_id
 WHERE (
-    c.language_idlanguage = 0
-    OR c.language_idlanguage IS NULL
+    c.language_id = 0
+    OR c.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
-          AND ul.language_idlanguage = c.language_idlanguage
+          AND ul.language_id = c.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
     )
 )
-GROUP BY c.idforumcategory
-ORDER BY c.idforumcategory
+GROUP BY c.id
+ORDER BY c.id
 LIMIT ? OFFSET ?;
 
 -- name: GetAllForumTopics :many
 SELECT t.*
 FROM forumtopic t
 WHERE (
-    t.language_idlanguage = 0
-    OR t.language_idlanguage IS NULL
+    t.language_id = 0
+    OR t.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
-          AND ul.language_idlanguage = t.language_idlanguage
+          AND ul.language_id = t.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
     )
 )
-GROUP BY t.idforumtopic;
+GROUP BY t.id;
 
 -- name: AdminListForumTopics :many
 SELECT t.*
 FROM forumtopic t
-ORDER BY t.idforumtopic
+ORDER BY t.id
 LIMIT ? OFFSET ?;
 
-UPDATE forumtopic SET title = ?, description = ?, forumcategory_idforumcategory = ?, language_idlanguage = sqlc.narg(topic_language_id) WHERE idforumtopic = ?;
+UPDATE forumtopic SET title = ?, description = ?, category_id = ?, language_id = sqlc.narg(topic_language_id) WHERE id = ?;
 
 -- name: GetAllForumTopicsByCategoryIdForUserWithLastPosterName :many
 WITH role_ids AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
-SELECT t.*, lu.username AS LastPosterUsername
+SELECT t.*, lu.username AS last_author_username
 FROM forumtopic t
-LEFT JOIN users lu ON lu.idusers = t.lastposter
-WHERE t.forumcategory_idforumcategory = sqlc.arg(category_id)
+LEFT JOIN users lu ON lu.idusers = t.last_author_id
+WHERE t.category_id = sqlc.arg(category_id)
   AND (
-      t.language_idlanguage = 0
-      OR t.language_idlanguage IS NULL
+      t.language_id = 0
+      OR t.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = t.language_idlanguage
+            AND ul.language_id = t.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -109,7 +109,7 @@ WHERE t.forumcategory_idforumcategory = sqlc.arg(category_id)
       AND (g.item='topic' OR g.item IS NULL)
       AND g.action='see'
       AND g.active=1
-      AND ((t.handler = 'private' AND g.item_id = t.idforumtopic) OR (t.handler <> 'private' AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)))
+      AND ((t.handler = 'private' AND g.item_id = t.id) OR (t.handler <> 'private' AND (g.item_id = t.id OR g.item_id IS NULL)))
       AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -136,42 +136,42 @@ WHERE g.section = 'forum'
   );
 
 -- name: SystemSetForumTopicHandlerByID :exec
-UPDATE forumtopic SET handler = sqlc.arg(handler) WHERE idforumtopic = sqlc.arg(id);
+UPDATE forumtopic SET handler = sqlc.arg(handler) WHERE id = sqlc.arg(id);
 
 -- name: AdminListTopicsWithUserGrantsNoRoles :many
-SELECT t.idforumtopic, t.title
+SELECT t.id, t.title
 FROM forumtopic t
 WHERE t.handler <> 'private'
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum' AND g.item='topic' AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND g.item_id = t.id
       AND g.user_id IS NOT NULL
       AND (sqlc.arg(include_admin) OR g.user_id <> 1)
   )
   AND NOT EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum' AND g.item='topic' AND g.active=1
-      AND g.item_id = t.idforumtopic
+      AND g.item_id = t.id
       AND g.role_id IS NOT NULL
   )
-ORDER BY t.idforumtopic;
+ORDER BY t.id;
 
 -- name: GetForumTopicsForUser :many
 WITH role_ids AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
-SELECT t.*, lu.username AS LastPosterUsername
+SELECT t.*, lu.username AS last_author_username
 FROM forumtopic t
-LEFT JOIN users lu ON lu.idusers = t.lastposter
+LEFT JOIN users lu ON lu.idusers = t.last_author_id
 WHERE t.handler <> 'private'
   AND (
-    t.language_idlanguage = 0
-    OR t.language_idlanguage IS NULL
+    t.language_id = 0
+    OR t.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
-          AND ul.language_idlanguage = t.language_idlanguage
+          AND ul.language_id = t.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -183,7 +183,7 @@ WHERE t.handler <> 'private'
       AND (g.item='topic' OR g.item IS NULL)
       AND g.action='see'
       AND g.active=1
-      AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)
+      AND (g.item_id = t.id OR g.item_id IS NULL)
       AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -193,17 +193,17 @@ ORDER BY t.lastaddition DESC;
 WITH role_ids AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
-SELECT t.*, lu.username AS LastPosterUsername
+SELECT t.*, lu.username AS last_author_username
 FROM forumtopic t
-LEFT JOIN users lu ON lu.idusers = t.lastposter
-WHERE t.idforumtopic = sqlc.arg(idforumtopic)
+LEFT JOIN users lu ON lu.idusers = t.last_author_id
+WHERE t.id = sqlc.arg(id)
   AND (
-      t.language_idlanguage = 0
-      OR t.language_idlanguage IS NULL
+      t.language_id = 0
+      OR t.language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = t.language_idlanguage
+            AND ul.language_id = t.language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -215,7 +215,7 @@ WHERE t.idforumtopic = sqlc.arg(idforumtopic)
       AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND ((t.handler = 'private' AND g.item_id = t.idforumtopic) OR (t.handler <> 'private' AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)))
+      AND ((t.handler = 'private' AND g.item_id = t.id) OR (t.handler <> 'private' AND (g.item_id = t.id OR g.item_id IS NULL)))
       AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -226,24 +226,24 @@ ORDER BY t.lastaddition DESC;
 SELECT f.*
 FROM forumcategory f
 WHERE (
-    f.language_idlanguage = 0
-    OR f.language_idlanguage IS NULL
+    f.language_id = 0
+    OR f.language_id IS NULL
     OR EXISTS (
         SELECT 1 FROM user_language ul
         WHERE ul.users_idusers = sqlc.arg(viewer_id)
-          AND ul.language_idlanguage = f.language_idlanguage
+          AND ul.language_id = f.language_id
     )
     OR NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
     )
 );
 
-INSERT INTO forumcategory (forumcategory_idforumcategory, language_idlanguage, title, description) VALUES (?, sqlc.narg(category_language_id), ?, ?);
+INSERT INTO forumcategory (parent_category_id, language_id, title, description) VALUES (?, sqlc.narg(category_language_id), ?, ?);
 
-INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description, handler) VALUES (?, sqlc.narg(topic_language_id), ?, ?, ?);
+INSERT INTO forumtopic (category_id, language_id, title, description, handler) VALUES (?, sqlc.narg(topic_language_id), ?, ?, ?);
 
 -- name: CreateForumTopicForPoster :execlastid
-INSERT INTO forumtopic (forumcategory_idforumcategory, language_idlanguage, title, description, handler)
+INSERT INTO forumtopic (category_id, language_id, title, description, handler)
 SELECT sqlc.arg(forumcategory_id), sqlc.arg(forum_lang), sqlc.arg(title), sqlc.arg(description), sqlc.arg(handler)
 WHERE EXISTS (
     SELECT 1 FROM grants g
@@ -266,46 +266,46 @@ WHERE title=?;
 -- name: GetForumTopicById :one
 SELECT *
 FROM forumtopic
-WHERE idforumtopic = ?;
+WHERE id = ?;
 
 -- name: GetForumThreadsByForumTopicIdForUserWithFirstAndLastPosterAndFirstPostText :many
 WITH role_ids AS (
     SELECT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = sqlc.arg(viewer_id)
 )
-SELECT th.*, lu.username AS lastposterusername, lu.idusers AS lastposterid, fcu.username as firstpostusername, fc.written as firstpostwritten, fc.text as firstposttext
+SELECT th.*, lu.username AS last_author_username, lu.idusers AS last_author_user_id, fcu.username as first_comment_username, fc.written as first_comment_written, fc.text as first_comment_text
 FROM forumthread th
-LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic=t.idforumtopic
-LEFT JOIN users lu ON lu.idusers = t.lastposter
-LEFT JOIN comments fc ON th.firstpost=fc.idcomments
+LEFT JOIN forumtopic t ON th.topic_id=t.id
+LEFT JOIN users lu ON lu.idusers = t.last_author_id
+LEFT JOIN comments fc ON th.first_comment_id=fc.idcomments
 LEFT JOIN users fcu ON fcu.idusers = fc.users_idusers
-WHERE th.forumtopic_idforumtopic=sqlc.arg(topic_id)
+WHERE th.topic_id=sqlc.arg(topic_id)
   AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='forum'
       AND (g.item='topic' OR g.item IS NULL)
       AND g.action='view'
       AND g.active=1
-      AND ((t.handler = 'private' AND g.item_id = t.idforumtopic) OR (t.handler <> 'private' AND (g.item_id = t.idforumtopic OR g.item_id IS NULL)))
+      AND ((t.handler = 'private' AND g.item_id = t.id) OR (t.handler <> 'private' AND (g.item_id = t.id OR g.item_id IS NULL)))
       AND (g.user_id = sqlc.arg(viewer_match_id) OR g.user_id IS NULL)
       AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
 ORDER BY th.lastaddition DESC;
 
 -- name: ListPrivateTopicsByUserID :many
-SELECT t.idforumtopic,
-       t.lastposter,
-       t.forumcategory_idforumcategory,
-       t.language_idlanguage,
+SELECT t.id,
+       t.last_author_id,
+       t.category_id,
+       t.language_id,
        t.title,
        t.description,
        t.threads,
        t.comments,
        t.lastaddition,
        t.handler,
-       lu.username AS LastPosterUsername
+       lu.username AS last_author_username
 FROM forumtopic t
-LEFT JOIN users lu ON lu.idusers = t.lastposter
-JOIN grants g ON g.item_id = t.idforumtopic
+LEFT JOIN users lu ON lu.idusers = t.last_author_id
+JOIN grants g ON g.item_id = t.id
 WHERE t.handler = 'private'
   AND g.section = 'forum'
   AND g.item = 'topic'
@@ -317,23 +317,23 @@ ORDER BY t.lastaddition DESC;
 -- name: AdminRebuildAllForumTopicMetaColumns :exec
 UPDATE forumtopic
 SET threads = (
-    SELECT COUNT(idforumthread)
+    SELECT COUNT(id)
     FROM forumthread
-    WHERE forumtopic_idforumtopic = idforumtopic
+    WHERE topic_id = forumtopic.id
 ), comments = (
     SELECT SUM(comments)
     FROM forumthread
-    WHERE forumtopic_idforumtopic = idforumtopic
+    WHERE topic_id = forumtopic.id
 ), lastaddition = (
     SELECT lastaddition
     FROM forumthread
-    WHERE forumtopic_idforumtopic = idforumtopic
+    WHERE topic_id = forumtopic.id
     ORDER BY lastaddition DESC
     LIMIT 1
-), lastposter = (
-    SELECT lastposter
+), last_author_id = (
+    SELECT last_author_id
     FROM forumthread
-    WHERE forumtopic_idforumtopic = idforumtopic
+    WHERE topic_id = forumtopic.id
     ORDER BY lastaddition DESC
     LIMIT 1
 );
@@ -341,52 +341,52 @@ SET threads = (
 -- name: SystemRebuildForumTopicMetaByID :exec
 UPDATE forumtopic
 SET threads = (
-    SELECT COUNT(idforumthread)
+    SELECT COUNT(id)
     FROM forumthread
-    WHERE forumtopic_idforumtopic = idforumtopic
+    WHERE topic_id = forumtopic.id
 ), comments = (
     SELECT SUM(comments)
     FROM forumthread
-    WHERE forumtopic_idforumtopic = idforumtopic
+    WHERE topic_id = forumtopic.id
 ), lastaddition = (
     SELECT lastaddition
     FROM forumthread
-    WHERE forumtopic_idforumtopic = idforumtopic
+    WHERE topic_id = forumtopic.id
     ORDER BY lastaddition DESC
     LIMIT 1
-), lastposter = (
-    SELECT lastposter
+), last_author_id = (
+    SELECT last_author_id
     FROM forumthread
-    WHERE forumtopic_idforumtopic = idforumtopic
+    WHERE topic_id = forumtopic.id
     ORDER BY lastaddition DESC
     LIMIT 1
 )
-WHERE idforumtopic = ?;
+WHERE forumtopic.id = ?;
 
 -- name: AdminDeleteForumCategory :exec
-UPDATE forumcategory SET deleted_at = NOW() WHERE idforumcategory = ?;
+UPDATE forumcategory SET deleted_at = NOW() WHERE id = ?;
 
 -- name: AdminDeleteForumTopic :exec
 -- Removes a forum topic by ID.
-UPDATE forumtopic SET deleted_at = NOW() WHERE idforumtopic = ?;
+UPDATE forumtopic SET deleted_at = NOW() WHERE id = ?;
 
 
 -- name: GetAllForumThreadsWithTopic :many
 SELECT th.*, t.title AS topic_title
 FROM forumthread th
-LEFT JOIN forumtopic t ON th.forumtopic_idforumtopic = t.idforumtopic
-ORDER BY t.idforumtopic, th.lastaddition DESC;
+LEFT JOIN forumtopic t ON th.topic_id = t.id
+ORDER BY t.id, th.lastaddition DESC;
 
 -- name: GetForumCategoryById :one
 SELECT * FROM forumcategory
-WHERE idforumcategory = sqlc.arg(idforumcategory)
+WHERE id = sqlc.arg(id)
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+      language_id = 0
+      OR language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = language_idlanguage
+            AND ul.language_id = language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -395,14 +395,14 @@ WHERE idforumcategory = sqlc.arg(idforumcategory)
 
 -- name: GetForumTopicsByCategoryId :many
 SELECT * FROM forumtopic
-WHERE forumcategory_idforumcategory = sqlc.arg(category_id)
+WHERE category_id = sqlc.arg(category_id)
   AND (
-      language_idlanguage = 0
-      OR language_idlanguage IS NULL
+      language_id = 0
+      OR language_id IS NULL
       OR EXISTS (
           SELECT 1 FROM user_language ul
           WHERE ul.users_idusers = sqlc.arg(viewer_id)
-            AND ul.language_idlanguage = language_idlanguage
+            AND ul.language_id = language_id
       )
       OR NOT EXISTS (
           SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -412,15 +412,15 @@ ORDER BY lastaddition DESC;
 
 -- name: ListForumcategoryPath :many
 WITH RECURSIVE category_path AS (
-    SELECT f.idforumcategory, f.forumcategory_idforumcategory AS parent_id, f.title, 0 AS depth
+    SELECT f.id, f.parent_category_id AS parent_id, f.title, 0 AS depth
     FROM forumcategory f
-    WHERE f.idforumcategory = sqlc.arg(category_id)
+    WHERE f.id = sqlc.arg(category_id)
     UNION ALL
-    SELECT c.idforumcategory, c.forumcategory_idforumcategory, c.title, p.depth + 1
+    SELECT c.id, c.parent_category_id, c.title, p.depth + 1
     FROM forumcategory c
-    JOIN category_path p ON p.parent_id = c.idforumcategory
+    JOIN category_path p ON p.parent_id = c.id
 )
-SELECT category_path.idforumcategory, category_path.title
+SELECT category_path.id, category_path.title
 FROM category_path
 ORDER BY category_path.depth DESC;
 

--- a/internal/db/queries-linker.sql
+++ b/internal/db/queries-linker.sql
@@ -116,7 +116,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercategory) = 0)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
@@ -138,7 +138,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercategory) = 0)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
@@ -157,7 +157,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE l.users_idusers = ?
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?;
@@ -178,7 +178,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercategory) = 0)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
@@ -209,7 +209,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE l.users_idusers = sqlc.arg(user_id)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
@@ -319,7 +319,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercategory) = 0)
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?;
@@ -340,7 +340,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE (lc.idlinkerCategory = sqlc.arg(idlinkercategory) OR sqlc.arg(idlinkercategory) = 0)
   AND EXISTS (
     SELECT 1

--- a/internal/db/queries-linker.sql.go
+++ b/internal/db/queries-linker.sql.go
@@ -333,7 +333,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE (lc.idlinkerCategory = ? OR ? = 0)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
@@ -413,7 +413,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE (lc.idlinkerCategory = ? OR ? = 0)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
@@ -508,7 +508,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE (lc.idlinkerCategory = ? OR ? = 0)
   AND EXISTS (
     SELECT 1
@@ -606,7 +606,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE (lc.idlinkerCategory = ? OR ? = 0)
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL
@@ -695,7 +695,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE (lc.idlinkerCategory = ? OR ? = 0)
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?
@@ -1242,7 +1242,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE l.users_idusers = ?
 ORDER BY l.listed DESC
 LIMIT ? OFFSET ?
@@ -1323,7 +1323,7 @@ SELECT l.idlinker, l.language_idlanguage, l.users_idusers, l.linker_category_id,
 FROM linker l
 LEFT JOIN users u ON l.users_idusers = u.idusers
 LEFT JOIN linker_category lc ON l.linker_category_id = lc.idlinkerCategory
-LEFT JOIN forumthread th ON l.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON l.forumthread_id = th.id
 WHERE l.users_idusers = ?
   AND l.listed IS NOT NULL
   AND l.deleted_at IS NULL

--- a/internal/db/queries-news.sql
+++ b/internal/db/queries-news.sql
@@ -56,7 +56,7 @@ WITH role_ids AS (
 SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
-LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON s.forumthread_id = th.id
 WHERE s.idsiteNews = sqlc.arg(id) AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='news'
@@ -77,7 +77,7 @@ WITH role_ids AS (
 SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
-LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON s.forumthread_id = th.id
 WHERE s.Idsitenews IN (sqlc.slice(newsIds))
   AND (
       NOT EXISTS (
@@ -110,7 +110,7 @@ WITH role_ids AS (
 SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
-LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON s.forumthread_id = th.id
 WHERE (
     NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = sqlc.arg(viewer_id)
@@ -140,7 +140,7 @@ SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthr
 s.news, s.occurred, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
-LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON s.forumthread_id = th.id
 ORDER BY s.occurred DESC
 LIMIT ? OFFSET ?;
 

--- a/internal/db/queries-news.sql.go
+++ b/internal/db/queries-news.sql.go
@@ -16,7 +16,7 @@ SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthr
 s.news, s.occurred, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
-LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON s.forumthread_id = th.id
 ORDER BY s.occurred DESC
 LIMIT ? OFFSET ?
 `
@@ -193,7 +193,7 @@ WITH role_ids AS (
 SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
-LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON s.forumthread_id = th.id
 WHERE s.idsiteNews = ? AND EXISTS (
     SELECT 1 FROM grants g
     WHERE g.section='news'
@@ -251,7 +251,7 @@ WITH role_ids AS (
 SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
-LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON s.forumthread_id = th.id
 WHERE s.Idsitenews IN (/*SLICE:newsids*/?)
   AND (
       NOT EXISTS (
@@ -352,7 +352,7 @@ WITH role_ids AS (
 SELECT u.username AS writerName, u.idusers as writerId, s.idsiteNews, s.forumthread_id, s.language_idlanguage, s.users_idusers, s.news, s.occurred, s.timezone, th.comments as Comments
 FROM site_news s
 LEFT JOIN users u ON s.users_idusers = u.idusers
-LEFT JOIN forumthread th ON s.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON s.forumthread_id = th.id
 WHERE (
     NOT EXISTS (
         SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?

--- a/internal/db/queries-search.sql
+++ b/internal/db/queries-search.sql
@@ -93,10 +93,10 @@ SELECT DISTINCT cs.comment_id
 FROM comments_search cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 LEFT JOIN comments c ON c.idcomments=cs.comment_id
-LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_id
-LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
+LEFT JOIN forumthread fth ON fth.id=c.forumthread_id
+LEFT JOIN forumtopic ft ON ft.id=fth.topic_id
 WHERE swl.word=sqlc.arg(word)
-  AND ft.forumcategory_idforumcategory!=0
+  AND ft.category_id!=0
   AND (
       c.language_idlanguage = 0
       OR c.language_idlanguage IS NULL
@@ -115,7 +115,7 @@ WHERE swl.word=sqlc.arg(word)
         AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
+        AND (g.item_id = ft.id OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -128,11 +128,11 @@ SELECT DISTINCT cs.comment_id
 FROM comments_search cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 LEFT JOIN comments c ON c.idcomments=cs.comment_id
-LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_id
-LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
+LEFT JOIN forumthread fth ON fth.id=c.forumthread_id
+LEFT JOIN forumtopic ft ON ft.id=fth.topic_id
 WHERE swl.word=sqlc.arg(word)
   AND cs.comment_id IN (sqlc.slice('ids'))
-  AND ft.forumcategory_idforumcategory!=0
+  AND ft.category_id!=0
   AND (
       c.language_idlanguage = 0
       OR c.language_idlanguage IS NULL
@@ -151,7 +151,7 @@ WHERE swl.word=sqlc.arg(word)
         AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
+        AND (g.item_id = ft.id OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -164,10 +164,10 @@ SELECT DISTINCT cs.comment_id
 FROM comments_search cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 LEFT JOIN comments c ON c.idcomments=cs.comment_id
-LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_id
-LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
+LEFT JOIN forumthread fth ON fth.id=c.forumthread_id
+LEFT JOIN forumtopic ft ON ft.id=fth.topic_id
 WHERE swl.word=sqlc.arg(word)
-  AND fth.forumtopic_idforumtopic IN (sqlc.slice('ftids'))
+  AND fth.topic_id IN (sqlc.slice('ftids'))
   AND (
       c.language_idlanguage = 0
       OR c.language_idlanguage IS NULL
@@ -186,7 +186,7 @@ WHERE swl.word=sqlc.arg(word)
         AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
+        AND (g.item_id = ft.id OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );
@@ -199,11 +199,11 @@ SELECT DISTINCT cs.comment_id
 FROM comments_search cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 LEFT JOIN comments c ON c.idcomments=cs.comment_id
-LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_id
-LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
+LEFT JOIN forumthread fth ON fth.id=c.forumthread_id
+LEFT JOIN forumtopic ft ON ft.id=fth.topic_id
 WHERE swl.word=sqlc.arg(word)
   AND cs.comment_id IN (sqlc.slice('ids'))
-  AND fth.forumtopic_idforumtopic IN (sqlc.slice('ftids'))
+  AND fth.topic_id IN (sqlc.slice('ftids'))
   AND (
       c.language_idlanguage = 0
       OR c.language_idlanguage IS NULL
@@ -222,7 +222,7 @@ WHERE swl.word=sqlc.arg(word)
         AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
+        AND (g.item_id = ft.id OR g.item_id IS NULL)
         AND (g.user_id = sqlc.arg(user_id) OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   );

--- a/internal/db/queries-search.sql.go
+++ b/internal/db/queries-search.sql.go
@@ -315,10 +315,10 @@ SELECT DISTINCT cs.comment_id
 FROM comments_search cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 LEFT JOIN comments c ON c.idcomments=cs.comment_id
-LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_id
-LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
+LEFT JOIN forumthread fth ON fth.id=c.forumthread_id
+LEFT JOIN forumtopic ft ON ft.id=fth.topic_id
 WHERE swl.word=?
-  AND fth.forumtopic_idforumtopic IN (/*SLICE:ftids*/?)
+  AND fth.topic_id IN (/*SLICE:ftids*/?)
   AND (
       c.language_idlanguage = 0
       OR c.language_idlanguage IS NULL
@@ -337,7 +337,7 @@ WHERE swl.word=?
         AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
+        AND (g.item_id = ft.id OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -396,10 +396,10 @@ SELECT DISTINCT cs.comment_id
 FROM comments_search cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 LEFT JOIN comments c ON c.idcomments=cs.comment_id
-LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_id
-LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
+LEFT JOIN forumthread fth ON fth.id=c.forumthread_id
+LEFT JOIN forumtopic ft ON ft.id=fth.topic_id
 WHERE swl.word=?
-  AND ft.forumcategory_idforumcategory!=0
+  AND ft.category_id!=0
   AND (
       c.language_idlanguage = 0
       OR c.language_idlanguage IS NULL
@@ -418,7 +418,7 @@ WHERE swl.word=?
         AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
+        AND (g.item_id = ft.id OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -467,11 +467,11 @@ SELECT DISTINCT cs.comment_id
 FROM comments_search cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 LEFT JOIN comments c ON c.idcomments=cs.comment_id
-LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_id
-LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
+LEFT JOIN forumthread fth ON fth.id=c.forumthread_id
+LEFT JOIN forumtopic ft ON ft.id=fth.topic_id
 WHERE swl.word=?
   AND cs.comment_id IN (/*SLICE:ids*/?)
-  AND fth.forumtopic_idforumtopic IN (/*SLICE:ftids*/?)
+  AND fth.topic_id IN (/*SLICE:ftids*/?)
   AND (
       c.language_idlanguage = 0
       OR c.language_idlanguage IS NULL
@@ -490,7 +490,7 @@ WHERE swl.word=?
         AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
+        AND (g.item_id = ft.id OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )
@@ -558,11 +558,11 @@ SELECT DISTINCT cs.comment_id
 FROM comments_search cs
 LEFT JOIN searchwordlist swl ON swl.idsearchwordlist=cs.searchwordlist_idsearchwordlist
 LEFT JOIN comments c ON c.idcomments=cs.comment_id
-LEFT JOIN forumthread fth ON fth.idforumthread=c.forumthread_id
-LEFT JOIN forumtopic ft ON ft.idforumtopic=fth.forumtopic_idforumtopic
+LEFT JOIN forumthread fth ON fth.id=c.forumthread_id
+LEFT JOIN forumtopic ft ON ft.id=fth.topic_id
 WHERE swl.word=?
   AND cs.comment_id IN (/*SLICE:ids*/?)
-  AND ft.forumcategory_idforumcategory!=0
+  AND ft.category_id!=0
   AND (
       c.language_idlanguage = 0
       OR c.language_idlanguage IS NULL
@@ -581,7 +581,7 @@ WHERE swl.word=?
         AND (g.item='topic' OR g.item IS NULL)
         AND g.action='see'
         AND g.active=1
-        AND (g.item_id = ft.idforumtopic OR g.item_id IS NULL)
+        AND (g.item_id = ft.id OR g.item_id IS NULL)
         AND (g.user_id = ? OR g.user_id IS NULL)
         AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))
   )

--- a/internal/db/queries-stats.sql
+++ b/internal/db/queries-stats.sql
@@ -4,33 +4,33 @@ FROM imagepost
 WHERE imageboard_idimageboard = ?;
 
 -- name: AdminForumTopicThreadCounts :many
-SELECT t.idforumtopic, t.title, t.handler,
-       COUNT(DISTINCT th.idforumthread) AS threads,
+SELECT t.id, t.title, t.handler,
+       COUNT(DISTINCT th.id) AS threads,
        COUNT(c.idcomments) AS comments
 FROM forumtopic t
-LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN comments c ON c.forumthread_id = th.idforumthread
-GROUP BY t.idforumtopic, t.title, t.handler
+LEFT JOIN forumthread th ON th.topic_id = t.id
+LEFT JOIN comments c ON c.forumthread_id = th.id
+GROUP BY t.id, t.title, t.handler
 ORDER BY t.title;
 
 -- name: AdminForumCategoryThreadCounts :many
-SELECT c.idforumcategory, c.title,
-       COUNT(DISTINCT th.idforumthread) AS threads,
+SELECT c.id, c.title,
+       COUNT(DISTINCT th.id) AS threads,
        COUNT(cm.idcomments) AS comments
 FROM forumcategory c
-LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
-LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN comments cm ON cm.forumthread_id = th.idforumthread
-GROUP BY c.idforumcategory
+LEFT JOIN forumtopic t ON c.id = t.category_id
+LEFT JOIN forumthread th ON th.topic_id = t.id
+LEFT JOIN comments cm ON cm.forumthread_id = th.id
+GROUP BY c.id
 ORDER BY c.title;
 
 -- name: AdminForumHandlerThreadCounts :many
 SELECT t.handler,
-       COUNT(DISTINCT th.idforumthread) AS threads,
+       COUNT(DISTINCT th.id) AS threads,
        COUNT(c.idcomments) AS comments
 FROM forumtopic t
-LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN comments c ON c.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON th.topic_id = t.id
+LEFT JOIN comments c ON c.forumthread_id = th.id
 GROUP BY t.handler
 ORDER BY t.handler;
 

--- a/internal/db/queries-stats.sql.go
+++ b/internal/db/queries-stats.sql.go
@@ -56,22 +56,22 @@ func (q *Queries) AdminDeleteTemplateOverride(ctx context.Context, name string) 
 }
 
 const adminForumCategoryThreadCounts = `-- name: AdminForumCategoryThreadCounts :many
-SELECT c.idforumcategory, c.title,
-       COUNT(DISTINCT th.idforumthread) AS threads,
+SELECT c.id, c.title,
+       COUNT(DISTINCT th.id) AS threads,
        COUNT(cm.idcomments) AS comments
 FROM forumcategory c
-LEFT JOIN forumtopic t ON c.idforumcategory = t.forumcategory_idforumcategory
-LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN comments cm ON cm.forumthread_id = th.idforumthread
-GROUP BY c.idforumcategory
+LEFT JOIN forumtopic t ON c.id = t.category_id
+LEFT JOIN forumthread th ON th.topic_id = t.id
+LEFT JOIN comments cm ON cm.forumthread_id = th.id
+GROUP BY c.id
 ORDER BY c.title
 `
 
 type AdminForumCategoryThreadCountsRow struct {
-	Idforumcategory int32
-	Title           sql.NullString
-	Threads         int64
-	Comments        int64
+	ID       int32
+	Title    sql.NullString
+	Threads  int64
+	Comments int64
 }
 
 func (q *Queries) AdminForumCategoryThreadCounts(ctx context.Context) ([]*AdminForumCategoryThreadCountsRow, error) {
@@ -84,7 +84,7 @@ func (q *Queries) AdminForumCategoryThreadCounts(ctx context.Context) ([]*AdminF
 	for rows.Next() {
 		var i AdminForumCategoryThreadCountsRow
 		if err := rows.Scan(
-			&i.Idforumcategory,
+			&i.ID,
 			&i.Title,
 			&i.Threads,
 			&i.Comments,
@@ -104,11 +104,11 @@ func (q *Queries) AdminForumCategoryThreadCounts(ctx context.Context) ([]*AdminF
 
 const adminForumHandlerThreadCounts = `-- name: AdminForumHandlerThreadCounts :many
 SELECT t.handler,
-       COUNT(DISTINCT th.idforumthread) AS threads,
+       COUNT(DISTINCT th.id) AS threads,
        COUNT(c.idcomments) AS comments
 FROM forumtopic t
-LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN comments c ON c.forumthread_id = th.idforumthread
+LEFT JOIN forumthread th ON th.topic_id = t.id
+LEFT JOIN comments c ON c.forumthread_id = th.id
 GROUP BY t.handler
 ORDER BY t.handler
 `
@@ -143,22 +143,22 @@ func (q *Queries) AdminForumHandlerThreadCounts(ctx context.Context) ([]*AdminFo
 }
 
 const adminForumTopicThreadCounts = `-- name: AdminForumTopicThreadCounts :many
-SELECT t.idforumtopic, t.title, t.handler,
-       COUNT(DISTINCT th.idforumthread) AS threads,
+SELECT t.id, t.title, t.handler,
+       COUNT(DISTINCT th.id) AS threads,
        COUNT(c.idcomments) AS comments
 FROM forumtopic t
-LEFT JOIN forumthread th ON th.forumtopic_idforumtopic = t.idforumtopic
-LEFT JOIN comments c ON c.forumthread_id = th.idforumthread
-GROUP BY t.idforumtopic, t.title, t.handler
+LEFT JOIN forumthread th ON th.topic_id = t.id
+LEFT JOIN comments c ON c.forumthread_id = th.id
+GROUP BY t.id, t.title, t.handler
 ORDER BY t.title
 `
 
 type AdminForumTopicThreadCountsRow struct {
-	Idforumtopic int32
-	Title        sql.NullString
-	Handler      string
-	Threads      int64
-	Comments     int64
+	ID       int32
+	Title    sql.NullString
+	Handler  string
+	Threads  int64
+	Comments int64
 }
 
 func (q *Queries) AdminForumTopicThreadCounts(ctx context.Context) ([]*AdminForumTopicThreadCountsRow, error) {
@@ -171,7 +171,7 @@ func (q *Queries) AdminForumTopicThreadCounts(ctx context.Context) ([]*AdminForu
 	for rows.Next() {
 		var i AdminForumTopicThreadCountsRow
 		if err := rows.Scan(
-			&i.Idforumtopic,
+			&i.ID,
 			&i.Title,
 			&i.Handler,
 			&i.Threads,

--- a/migrations/0066.mysql.sql
+++ b/migrations/0066.mysql.sql
@@ -1,0 +1,19 @@
+ALTER TABLE forumcategory
+    CHANGE COLUMN idforumcategory id int(10) NOT NULL AUTO_INCREMENT,
+    CHANGE COLUMN forumcategory_idforumcategory parent_category_id int(10) NOT NULL DEFAULT 0,
+    CHANGE COLUMN language_idlanguage language_id int(10) DEFAULT NULL;
+
+ALTER TABLE forumthread
+    CHANGE COLUMN idforumthread id int(10) NOT NULL AUTO_INCREMENT,
+    CHANGE COLUMN forumtopic_idforumtopic topic_id int(10) NOT NULL DEFAULT 0,
+    CHANGE COLUMN firstpost first_comment_id int(10) NOT NULL DEFAULT 0,
+    CHANGE COLUMN lastposter last_author_id int(10) NOT NULL DEFAULT 0;
+
+ALTER TABLE forumtopic
+    CHANGE COLUMN idforumtopic id int(10) NOT NULL AUTO_INCREMENT,
+    CHANGE COLUMN forumcategory_idforumcategory category_id int(10) NOT NULL DEFAULT 0,
+    CHANGE COLUMN language_idlanguage language_id int(10) DEFAULT NULL,
+    CHANGE COLUMN lastposter last_author_id int(10) NOT NULL DEFAULT 0;
+
+-- Update schema version
+UPDATE schema_version SET version = 66 WHERE version = 65;

--- a/migrations/0066.postgres.sql
+++ b/migrations/0066.postgres.sql
@@ -1,0 +1,16 @@
+ALTER TABLE forumcategory RENAME COLUMN idforumcategory TO id;
+ALTER TABLE forumcategory RENAME COLUMN forumcategory_idforumcategory TO parent_category_id;
+ALTER TABLE forumcategory RENAME COLUMN language_idlanguage TO language_id;
+
+ALTER TABLE forumthread RENAME COLUMN idforumthread TO id;
+ALTER TABLE forumthread RENAME COLUMN forumtopic_idforumtopic TO topic_id;
+ALTER TABLE forumthread RENAME COLUMN firstpost TO first_comment_id;
+ALTER TABLE forumthread RENAME COLUMN lastposter TO last_author_id;
+
+ALTER TABLE forumtopic RENAME COLUMN idforumtopic TO id;
+ALTER TABLE forumtopic RENAME COLUMN forumcategory_idforumcategory TO category_id;
+ALTER TABLE forumtopic RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE forumtopic RENAME COLUMN lastposter TO last_author_id;
+
+-- Update schema version
+UPDATE schema_version SET version = 66 WHERE version = 65;

--- a/migrations/0066.sqlite.sql
+++ b/migrations/0066.sqlite.sql
@@ -1,0 +1,16 @@
+ALTER TABLE forumcategory RENAME COLUMN idforumcategory TO id;
+ALTER TABLE forumcategory RENAME COLUMN forumcategory_idforumcategory TO parent_category_id;
+ALTER TABLE forumcategory RENAME COLUMN language_idlanguage TO language_id;
+
+ALTER TABLE forumthread RENAME COLUMN idforumthread TO id;
+ALTER TABLE forumthread RENAME COLUMN forumtopic_idforumtopic TO topic_id;
+ALTER TABLE forumthread RENAME COLUMN firstpost TO first_comment_id;
+ALTER TABLE forumthread RENAME COLUMN lastposter TO last_author_id;
+
+ALTER TABLE forumtopic RENAME COLUMN idforumtopic TO id;
+ALTER TABLE forumtopic RENAME COLUMN forumcategory_idforumcategory TO category_id;
+ALTER TABLE forumtopic RENAME COLUMN language_idlanguage TO language_id;
+ALTER TABLE forumtopic RENAME COLUMN lastposter TO last_author_id;
+
+-- Update schema version
+UPDATE schema_version SET version = 66 WHERE version = 65;

--- a/schema/schema.mysql.sql
+++ b/schema/schema.mysql.sql
@@ -88,45 +88,45 @@ CREATE TABLE IF NOT EXISTS `faq_revisions` (
 );
 
 CREATE TABLE `forumcategory` (
-  `idforumcategory` int(10) NOT NULL AUTO_INCREMENT,
-  `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `parent_category_id` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
-  PRIMARY KEY (`idforumcategory`),
-  KEY `forumcategory_FKIndex1` (`forumcategory_idforumcategory`),
-  KEY `forumcategory_FKIndex2` (`language_idlanguage`)
+  PRIMARY KEY (`id`),
+  KEY `forumcategory_FKIndex1` (`parent_category_id`),
+  KEY `forumcategory_FKIndex2` (`language_id`)
 );
 
 CREATE TABLE `forumthread` (
-  `idforumthread` int(10) NOT NULL AUTO_INCREMENT,
-  `firstpost` int(10) NOT NULL DEFAULT 0,
-  `lastposter` int(10) NOT NULL DEFAULT 0,
-  `forumtopic_idforumtopic` int(10) NOT NULL DEFAULT 0,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `first_comment_id` int(10) NOT NULL DEFAULT 0,
+  `last_author_id` int(10) NOT NULL DEFAULT 0,
+  `topic_id` int(10) NOT NULL DEFAULT 0,
   `comments` int(10) DEFAULT NULL,
   `lastaddition` datetime DEFAULT NULL,
   `locked` tinyint(1) DEFAULT NULL,
-  PRIMARY KEY (`idforumthread`),
-  KEY `forumdiscussions_FKIndex1` (`forumtopic_idforumtopic`),
-  KEY `forumthread_FKIndex2` (`lastposter`),
-  KEY `forumthread_FKIndex3` (`firstpost`)
+  PRIMARY KEY (`id`),
+  KEY `forumdiscussions_FKIndex1` (`topic_id`),
+  KEY `forumthread_FKIndex2` (`last_author_id`),
+  KEY `forumthread_FKIndex3` (`first_comment_id`)
 );
 
 CREATE TABLE `forumtopic` (
-  `idforumtopic` int(10) NOT NULL AUTO_INCREMENT,
-  `lastposter` int(10) NOT NULL DEFAULT 0,
-  `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `last_author_id` int(10) NOT NULL DEFAULT 0,
+  `category_id` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `threads` int(10) DEFAULT NULL,
   `comments` int(10) DEFAULT NULL,
   `lastaddition` datetime DEFAULT NULL,
   `handler` varchar(32) NOT NULL DEFAULT '',
-  PRIMARY KEY (`idforumtopic`),
-  KEY `forumtopic_FKIndex1` (`forumcategory_idforumcategory`),
-  KEY `forumtopic_FKIndex2` (`lastposter`),
-  KEY `forumtopic_FKIndex3` (`language_idlanguage`)
+  PRIMARY KEY (`id`),
+  KEY `forumtopic_FKIndex1` (`category_id`),
+  KEY `forumtopic_FKIndex2` (`last_author_id`),
+  KEY `forumtopic_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `imageboard` (

--- a/schema/schema.postgres.sql
+++ b/schema/schema.postgres.sql
@@ -88,45 +88,45 @@ CREATE TABLE IF NOT EXISTS `faq_revisions` (
 );
 
 CREATE TABLE `forumcategory` (
-  `idforumcategory` int(10) NOT NULL AUTO_INCREMENT,
-  `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `parent_category_id` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
-  PRIMARY KEY (`idforumcategory`),
-  KEY `forumcategory_FKIndex1` (`forumcategory_idforumcategory`),
-  KEY `forumcategory_FKIndex2` (`language_idlanguage`)
+  PRIMARY KEY (`id`),
+  KEY `forumcategory_FKIndex1` (`parent_category_id`),
+  KEY `forumcategory_FKIndex2` (`language_id`)
 );
 
 CREATE TABLE `forumthread` (
-  `idforumthread` int(10) NOT NULL AUTO_INCREMENT,
-  `firstpost` int(10) NOT NULL DEFAULT 0,
-  `lastposter` int(10) NOT NULL DEFAULT 0,
-  `forumtopic_idforumtopic` int(10) NOT NULL DEFAULT 0,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `first_comment_id` int(10) NOT NULL DEFAULT 0,
+  `last_author_id` int(10) NOT NULL DEFAULT 0,
+  `topic_id` int(10) NOT NULL DEFAULT 0,
   `comments` int(10) DEFAULT NULL,
   `lastaddition` datetime DEFAULT NULL,
   `locked` tinyint(1) DEFAULT NULL,
-  PRIMARY KEY (`idforumthread`),
-  KEY `forumdiscussions_FKIndex1` (`forumtopic_idforumtopic`),
-  KEY `forumthread_FKIndex2` (`lastposter`),
-  KEY `forumthread_FKIndex3` (`firstpost`)
+  PRIMARY KEY (`id`),
+  KEY `forumdiscussions_FKIndex1` (`topic_id`),
+  KEY `forumthread_FKIndex2` (`last_author_id`),
+  KEY `forumthread_FKIndex3` (`first_comment_id`)
 );
 
 CREATE TABLE `forumtopic` (
-  `idforumtopic` int(10) NOT NULL AUTO_INCREMENT,
-  `lastposter` int(10) NOT NULL DEFAULT 0,
-  `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `last_author_id` int(10) NOT NULL DEFAULT 0,
+  `category_id` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `threads` int(10) DEFAULT NULL,
   `comments` int(10) DEFAULT NULL,
   `lastaddition` datetime DEFAULT NULL,
   `handler` varchar(32) NOT NULL DEFAULT '',
-  PRIMARY KEY (`idforumtopic`),
-  KEY `forumtopic_FKIndex1` (`forumcategory_idforumcategory`),
-  KEY `forumtopic_FKIndex2` (`lastposter`),
-  KEY `forumtopic_FKIndex3` (`language_idlanguage`)
+  PRIMARY KEY (`id`),
+  KEY `forumtopic_FKIndex1` (`category_id`),
+  KEY `forumtopic_FKIndex2` (`last_author_id`),
+  KEY `forumtopic_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `imageboard` (

--- a/schema/schema.sqlite.sql
+++ b/schema/schema.sqlite.sql
@@ -88,45 +88,45 @@ CREATE TABLE IF NOT EXISTS `faq_revisions` (
 );
 
 CREATE TABLE `forumcategory` (
-  `idforumcategory` int(10) NOT NULL AUTO_INCREMENT,
-  `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `parent_category_id` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
-  PRIMARY KEY (`idforumcategory`),
-  KEY `forumcategory_FKIndex1` (`forumcategory_idforumcategory`),
-  KEY `forumcategory_FKIndex2` (`language_idlanguage`)
+  PRIMARY KEY (`id`),
+  KEY `forumcategory_FKIndex1` (`parent_category_id`),
+  KEY `forumcategory_FKIndex2` (`language_id`)
 );
 
 CREATE TABLE `forumthread` (
-  `idforumthread` int(10) NOT NULL AUTO_INCREMENT,
-  `firstpost` int(10) NOT NULL DEFAULT 0,
-  `lastposter` int(10) NOT NULL DEFAULT 0,
-  `forumtopic_idforumtopic` int(10) NOT NULL DEFAULT 0,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `first_comment_id` int(10) NOT NULL DEFAULT 0,
+  `last_author_id` int(10) NOT NULL DEFAULT 0,
+  `topic_id` int(10) NOT NULL DEFAULT 0,
   `comments` int(10) DEFAULT NULL,
   `lastaddition` datetime DEFAULT NULL,
   `locked` tinyint(1) DEFAULT NULL,
-  PRIMARY KEY (`idforumthread`),
-  KEY `forumdiscussions_FKIndex1` (`forumtopic_idforumtopic`),
-  KEY `forumthread_FKIndex2` (`lastposter`),
-  KEY `forumthread_FKIndex3` (`firstpost`)
+  PRIMARY KEY (`id`),
+  KEY `forumdiscussions_FKIndex1` (`topic_id`),
+  KEY `forumthread_FKIndex2` (`last_author_id`),
+  KEY `forumthread_FKIndex3` (`first_comment_id`)
 );
 
 CREATE TABLE `forumtopic` (
-  `idforumtopic` int(10) NOT NULL AUTO_INCREMENT,
-  `lastposter` int(10) NOT NULL DEFAULT 0,
-  `forumcategory_idforumcategory` int(10) NOT NULL DEFAULT 0,
-  `language_idlanguage` int(10) DEFAULT NULL,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
+  `last_author_id` int(10) NOT NULL DEFAULT 0,
+  `category_id` int(10) NOT NULL DEFAULT 0,
+  `language_id` int(10) DEFAULT NULL,
   `title` tinytext DEFAULT NULL,
   `description` mediumtext DEFAULT NULL,
   `threads` int(10) DEFAULT NULL,
   `comments` int(10) DEFAULT NULL,
   `lastaddition` datetime DEFAULT NULL,
   `handler` varchar(32) NOT NULL DEFAULT '',
-  PRIMARY KEY (`idforumtopic`),
-  KEY `forumtopic_FKIndex1` (`forumcategory_idforumcategory`),
-  KEY `forumtopic_FKIndex2` (`lastposter`),
-  KEY `forumtopic_FKIndex3` (`language_idlanguage`)
+  PRIMARY KEY (`id`),
+  KEY `forumtopic_FKIndex1` (`category_id`),
+  KEY `forumtopic_FKIndex2` (`last_author_id`),
+  KEY `forumtopic_FKIndex3` (`language_id`)
 );
 
 CREATE TABLE `imageboard` (


### PR DESCRIPTION
## Summary
- rename forum category, topic, and thread columns to modern names
- regenerate sqlc queries and update Go code and templates for new fields
- bump expected schema version to 66

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: SelectedThreadCanReply, ThreadPageShowsDefaultPrivateLabels, and others)*

------
https://chatgpt.com/codex/tasks/task_e_689989b80d14832f8e492ccd102be4a8