### PR TITLE
fix: clean up non-MySQL migrations

### DIFF
--- a/docs/future_tasks.md
+++ b/docs/future_tasks.md
@@ -1,0 +1,7 @@
+# Future Improvements
+
+- Rewrite older PostgreSQL and SQLite migration scripts to use engine-appropriate syntax instead of MySQL-specific `CHANGE COLUMN` directives.
+- Regenerate `schema/*.sql` files for PostgreSQL and SQLite to reflect dialect-specific features.
+- Add automated tests exercising migration application on PostgreSQL and SQLite backends.
+- Create lint checks to prevent introduction of MySQL-only syntax into non-MySQL migration files.
+- Improve template coverage with tests for additional rendering contexts and data structures.

--- a/migrations/0066.postgres.sql
+++ b/migrations/0066.postgres.sql
@@ -1,20 +1,4 @@
 ALTER TABLE faq RENAME COLUMN faq_category_id TO category_id;
-ALTER TABLE language CHANGE COLUMN idlanguage id INT NOT NULL AUTO_INCREMENT;
-ALTER TABLE blogs CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE comments CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE faq CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE forumcategory CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE forumtopic CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE linker CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE linker_queue CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE preferences CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE site_news CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE user_language CHANGE COLUMN language_idlanguage language_id INT NOT NULL DEFAULT 0;
-ALTER TABLE writing CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE deactivated_comments CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE deactivated_writings CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE deactivated_blogs CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE deactivated_linker CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
 
 ALTER TABLE language RENAME COLUMN idlanguage TO id;
 ALTER TABLE blogs RENAME COLUMN language_idlanguage TO language_id;

--- a/migrations/0066.sqlite.sql
+++ b/migrations/0066.sqlite.sql
@@ -1,20 +1,4 @@
 ALTER TABLE faq RENAME COLUMN faq_category_id TO category_id;
-ALTER TABLE language CHANGE COLUMN idlanguage id INT NOT NULL AUTO_INCREMENT;
-ALTER TABLE blogs CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE comments CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE faq CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE forumcategory CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE forumtopic CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE linker CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE linker_queue CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE preferences CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE site_news CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE user_language CHANGE COLUMN language_idlanguage language_id INT NOT NULL DEFAULT 0;
-ALTER TABLE writing CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE deactivated_comments CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE deactivated_writings CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE deactivated_blogs CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
-ALTER TABLE deactivated_linker CHANGE COLUMN language_idlanguage language_id INT DEFAULT NULL;
 
 ALTER TABLE language RENAME COLUMN idlanguage TO id;
 ALTER TABLE blogs RENAME COLUMN language_idlanguage TO language_id;

--- a/migrations/0067.postgres.sql
+++ b/migrations/0067.postgres.sql
@@ -1,17 +1,3 @@
-ALTER TABLE linker
-    CHANGE COLUMN idlinker id INT NOT NULL AUTO_INCREMENT,
-    CHANGE COLUMN users_idusers author_id INT NOT NULL DEFAULT 0,
-    CHANGE COLUMN linker_category_id category_id INT NULL DEFAULT NULL,
-    CHANGE COLUMN forumthread_id thread_id INT NOT NULL DEFAULT 0;
-
-ALTER TABLE linker_category
-    CHANGE COLUMN idlinkerCategory id INT NOT NULL AUTO_INCREMENT;
-
-ALTER TABLE linker_queue
-    CHANGE COLUMN idlinkerQueue id INT NOT NULL AUTO_INCREMENT,
-    CHANGE COLUMN users_idusers submitter_id INT NOT NULL DEFAULT 0,
-    CHANGE COLUMN linker_category_id category_id INT NULL DEFAULT NULL;
-
 ALTER TABLE linker RENAME COLUMN idlinker TO id;
 ALTER TABLE linker RENAME COLUMN users_idusers TO author_id;
 ALTER TABLE linker RENAME COLUMN linker_category_id TO category_id;

--- a/migrations/0067.sqlite.sql
+++ b/migrations/0067.sqlite.sql
@@ -1,17 +1,3 @@
-ALTER TABLE linker
-    CHANGE COLUMN idlinker id INT NOT NULL AUTO_INCREMENT,
-    CHANGE COLUMN users_idusers author_id INT NOT NULL DEFAULT 0,
-    CHANGE COLUMN linker_category_id category_id INT NULL DEFAULT NULL,
-    CHANGE COLUMN forumthread_id thread_id INT NOT NULL DEFAULT 0;
-
-ALTER TABLE linker_category
-    CHANGE COLUMN idlinkerCategory id INT NOT NULL AUTO_INCREMENT;
-
-ALTER TABLE linker_queue
-    CHANGE COLUMN idlinkerQueue id INT NOT NULL AUTO_INCREMENT,
-    CHANGE COLUMN users_idusers submitter_id INT NOT NULL DEFAULT 0,
-    CHANGE COLUMN linker_category_id category_id INT NULL DEFAULT NULL;
-
 ALTER TABLE linker RENAME COLUMN idlinker TO id;
 ALTER TABLE linker RENAME COLUMN users_idusers TO author_id;
 ALTER TABLE linker RENAME COLUMN linker_category_id TO category_id;


### PR DESCRIPTION
## Summary
- remove MySQL-only `CHANGE COLUMN` from PostgreSQL and SQLite migration scripts 0066 & 0067
- document follow-up tasks for cross-database support

## Testing
- `go vet ./...`
- `go test ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6899b86dcf28832f89457ffac86aca8c