### PR TITLE
Link forum reply notifications to posted comment

### DIFF
--- a/handlers/forum/forumReplyTask_event_test.go
+++ b/handlers/forum/forumReplyTask_event_test.go
@@ -77,6 +77,9 @@ func TestForumReplyTaskEventData(t *testing.T) {
 	if _, ok := evt.Data["Username"].(string); !ok {
 		t.Fatalf("username not set: %+v", evt.Data)
 	}
+	if v, ok := evt.Data["CommentURL"].(string); !ok || v != "/forum/topic/1/thread/2#c1" {
+		t.Fatalf("comment URL: %+v", evt.Data)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -131,7 +131,11 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if base == "" {
 		base = "/forum"
 	}
-	endUrl := fmt.Sprintf("%s/topic/%d/thread/%d#bottom", base, topicRow.Idforumtopic, threadRow.Idforumthread)
+	commentNum := int32(1)
+	if threadRow.Comments.Valid {
+		commentNum = threadRow.Comments.Int32 + 1
+	}
+	endUrl := fmt.Sprintf("%s/topic/%d/thread/%d#c%d", base, topicRow.Idforumtopic, threadRow.Idforumthread, commentNum)
 
 	cid, err := cd.CreateForumCommentForCommenter(uid, threadRow.Idforumthread, topicRow.Idforumtopic, int32(languageId), text)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Link forum reply redirects and notifications to the new comment anchor instead of the thread bottom
- Test that reply events include the comment URL

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899be0f9568832f976766b438d804e4