### PR TITLE
feat(news): add edit page for news posts

### DIFF
--- a/core/templates/site/news/newsEditPage.gohtml
+++ b/core/templates/site/news/newsEditPage.gohtml
@@ -1,0 +1,10 @@
+{{ template "head" $ }}
+<form method="post">
+    {{ csrfField }}
+    <input type="hidden" name="task" value="Edit">
+    <textarea name="text" cols=40 rows=20>{{ .Post.News.String }}</textarea><br>
+    {{ template "languageCombobox" }}
+    <input type="submit" value="Save">
+</form>
+<p><a href="/news/news/{{ .Post.Idsitenews }}">Cancel</a></p>
+{{ template "tail" $ }}

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -29,6 +29,8 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Regis
 	nr.HandleFunc("", NewsPage).Methods("GET")
 	nr.HandleFunc("", handlers.TaskDoneAutoRefreshPage).Methods("POST")
 	nr.HandleFunc("/news/{news}", NewsPostPage).Methods("GET")
+	nr.Handle("/news/{news}/edit", RequireNewsPostAuthor(http.HandlerFunc(editTask.Page))).Methods("GET").MatcherFunc(handlers.RequiredAccess("content writer", "administrator"))
+	nr.Handle("/news/{news}/edit", RequireNewsPostAuthor(http.HandlerFunc(handlers.TaskHandler(editTask)))).Methods("POST").MatcherFunc(handlers.RequiredAccess("content writer", "administrator")).MatcherFunc(editTask.Matcher())
 	nr.HandleFunc("/news/{news}", handlers.TaskHandler(replyTask)).Methods("POST").MatcherFunc(handlers.RequiresAnAccount()).MatcherFunc(replyTask.Matcher())
 	nr.Handle("/news/{news}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(handlers.TaskHandler(editReplyTask)))).Methods("POST").MatcherFunc(editReplyTask.Matcher())
 	nr.Handle("/news/{news}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(handlers.TaskHandler(cancelTask)))).Methods("POST").MatcherFunc(cancelTask.Matcher())

--- a/handlers/news/routes_test.go
+++ b/handlers/news/routes_test.go
@@ -1,0 +1,37 @@
+package news
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/config"
+	navpkg "github.com/arran4/goa4web/internal/navigation"
+)
+
+func TestEditRouteRegistered(t *testing.T) {
+	r := mux.NewRouter()
+	navReg := navpkg.NewRegistry()
+	RegisterRoutes(r, config.NewRuntimeConfig(), navReg)
+
+	found := false
+	_ = r.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+		path, err := route.GetPathTemplate()
+		if err != nil {
+			return nil
+		}
+		if path == "/news/news/{news}/edit" {
+			methods, _ := route.GetMethods()
+			for _, m := range methods {
+				if m == http.MethodGet {
+					found = true
+				}
+			}
+		}
+		return nil
+	})
+	if !found {
+		t.Fatalf("expected edit route to be registered")
+	}
+}


### PR DESCRIPTION
## Summary
- allow authors to load and submit edits at `/news/news/{id}/edit`
- render new `newsEditPage` template for editing posts
- test that the edit route is registered

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899bb653808832f97d0273b6abbed11