### PR TITLE
Enable thread label tests

### DIFF
--- a/handlers/forum/thread_label_tasks_test.go
+++ b/handlers/forum/thread_label_tasks_test.go
@@ -57,9 +57,6 @@ func TestMarkThreadReadTaskRefererFallback(t *testing.T) {
 }
 
 func TestSetLabelsTaskAddsInverseLabels(t *testing.T) {
-	if true {
-		t.Skip("TODO: update expectations for content labels")
-	}
 	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
@@ -101,9 +98,6 @@ func TestSetLabelsTaskAddsInverseLabels(t *testing.T) {
 }
 
 func TestSetLabelsTaskUpdatesSpecialLabels(t *testing.T) {
-	if true {
-		t.Skip("TODO: update expectations for content labels")
-	}
 	conn, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)


### PR DESCRIPTION
## Summary
- enable thread label task tests by removing skips

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899cbb1d8b0832f8fa10003fb782dd9