### PR TITLE
docs: remove outdated future tasks list

### DIFF
--- a/docs/future_tasks.md
+++ b/docs/future_tasks.md
@@ -1,7 +1,0 @@
-# Future Improvements
-
-- Rewrite older PostgreSQL and SQLite migration scripts to use engine-appropriate syntax instead of MySQL-specific `CHANGE COLUMN` directives.
-- Regenerate `schema/*.sql` files for PostgreSQL and SQLite to reflect dialect-specific features.
-- Add automated tests exercising migration application on PostgreSQL and SQLite backends.
-- Create lint checks to prevent introduction of MySQL-only syntax into non-MySQL migration files.
-- Improve template coverage with tests for additional rendering contexts and data structures.


### PR DESCRIPTION
## Summary
- remove obsolete future tasks document

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899cbc82e98832f8e18e98d8fe224de