### PR TITLE
Add labeler role and private label permissions

### DIFF
--- a/core/common/coredata_allroles_test.go
+++ b/core/common/coredata_allroles_test.go
@@ -16,11 +16,11 @@ func TestAllRolesLazy(t *testing.T) {
 	}
 	defer conn.Close()
 
-	rows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).
-		AddRow(int32(1), "user", true, false, nil).
-		AddRow(int32(2), "administrator", true, true, nil)
+	rows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "private_labels", "public_profile_allowed_at"}).
+		AddRow(int32(1), "user", true, false, true, nil).
+		AddRow(int32(2), "administrator", true, true, true, nil)
 
-	mock.ExpectQuery("SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id").WillReturnRows(rows)
+	mock.ExpectQuery("SELECT id, name, can_login, is_admin, private_labels, public_profile_allowed_at FROM roles ORDER BY id").WillReturnRows(rows)
 
 	cd := NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
 

--- a/core/templates/site/admin/roleEditPage.gohtml
+++ b/core/templates/site/admin/roleEditPage.gohtml
@@ -6,6 +6,7 @@
     Name: <input name="name" value="{{.Role.Name}}"><br>
     Can Login: <input type="checkbox" name="can_login" {{if .Role.CanLogin}}checked{{end}}><br>
     Is Admin: <input type="checkbox" name="is_admin" {{if .Role.IsAdmin}}checked{{end}}><br>
+    Private Labels: <input type="checkbox" name="private_labels" {{if .Role.PrivateLabels}}checked{{end}}><br>
     <input type="submit" name="task" value="Save">
 </form>
 {{ template "roleGrantsEditor.gohtml" . }}

--- a/handlers/admin/adminGrantsPage_test.go
+++ b/handlers/admin/adminGrantsPage_test.go
@@ -32,8 +32,8 @@ func TestAdminGrantsPageGroupsActions(t *testing.T) {
 	userRows := sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(5, nil, "bob", nil)
 	mock.ExpectQuery("SELECT u\\.idusers").WithArgs(5).WillReturnRows(userRows)
 
-	roleRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).AddRow(7, "admin", true, false, nil)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles WHERE id = ?")).WithArgs(7).WillReturnRows(roleRows)
+	roleRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "private_labels", "public_profile_allowed_at"}).AddRow(7, "admin", true, false, true, nil)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, can_login, is_admin, private_labels, public_profile_allowed_at FROM roles WHERE id = ?")).WithArgs(7).WillReturnRows(roleRows)
 
 	req := httptest.NewRequest("GET", "/admin/grants", nil)
 	ctx := req.Context()

--- a/handlers/admin/adminRoleEditPage.go
+++ b/handlers/admin/adminRoleEditPage.go
@@ -48,6 +48,7 @@ func adminRoleEditSavePage(w http.ResponseWriter, r *http.Request) {
 	name := r.PostFormValue("name")
 	canLogin := r.PostFormValue("can_login") != ""
 	isAdmin := r.PostFormValue("is_admin") != ""
+	privateLabels := r.PostFormValue("private_labels") != ""
 
 	data := struct {
 		Errors []string
@@ -55,10 +56,11 @@ func adminRoleEditSavePage(w http.ResponseWriter, r *http.Request) {
 	}{Back: fmt.Sprintf("/admin/role/%d", id)}
 
 	if err := queries.AdminUpdateRole(r.Context(), db.AdminUpdateRoleParams{
-		Name:     name,
-		CanLogin: canLogin,
-		IsAdmin:  isAdmin,
-		ID:       id,
+		Name:          name,
+		CanLogin:      canLogin,
+		IsAdmin:       isAdmin,
+		PrivateLabels: privateLabels,
+		ID:            id,
 	}); err != nil {
 		data.Errors = append(data.Errors, fmt.Errorf("update role: %w", err).Error())
 	}

--- a/handlers/blogs/blogsAdminBlogPage_test.go
+++ b/handlers/blogs/blogsAdminBlogPage_test.go
@@ -29,7 +29,7 @@ func TestAdminBlogPage_UsesURLParam(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"idblogs", "forumthread_id", "users_idusers", "language_id", "blog", "written", "timezone", "username", "comments", "is_owner"}).
 		AddRow(blogID, nil, 1, 1, "body", time.Now(), time.Local.String(), "user", 0, true)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}))
+	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "private_labels", "public_profile_allowed_at"}))
 	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}))
 
 	req := httptest.NewRequest("GET", "/admin/blogs/blog/"+strconv.Itoa(blogID), nil)

--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 
 	// ExpectedSchemaVersion defines the required database schema version.
 	// Bump this when adding a new migration.
-	ExpectedSchemaVersion = 67
+	ExpectedSchemaVersion = 68
 
 	// CSRFField is the name of the hidden field used by gorilla/csrf.
 	CSRFField = "gorilla.csrf.Token"

--- a/handlers/forum/forumAdminCategoryPage_test.go
+++ b/handlers/forum/forumAdminCategoryPage_test.go
@@ -113,9 +113,9 @@ func TestAdminCategoryGrantsPage(t *testing.T) {
 	queries := db.New(sqlDB)
 	mock.MatchExpectationsInOrder(false)
 
-	rolesRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).
-		AddRow(1, "user", true, false, nil)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id")).
+	rolesRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "private_labels", "public_profile_allowed_at"}).
+		AddRow(1, "user", true, false, true, nil)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, can_login, is_admin, private_labels, public_profile_allowed_at FROM roles ORDER BY id")).
 		WillReturnRows(rolesRows)
 
 	grantsRows := sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}).

--- a/handlers/forum/forumAdminTopicPage_test.go
+++ b/handlers/forum/forumAdminTopicPage_test.go
@@ -62,8 +62,8 @@ func TestAdminTopicEditFormPage(t *testing.T) {
 		AddRow(1, 0, 0, "cat", "desc")
 	mock.ExpectQuery("SELECT").WillReturnRows(catRows)
 
-	roleRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).
-		AddRow(1, "role", true, false, nil)
+	roleRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "private_labels", "public_profile_allowed_at"}).
+		AddRow(1, "role", true, false, true, nil)
 	mock.ExpectQuery("SELECT").WillReturnRows(roleRows)
 
 	cd := common.NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())

--- a/handlers/forum/topic_grants_build_test.go
+++ b/handlers/forum/topic_grants_build_test.go
@@ -22,9 +22,9 @@ func TestBuildTopicGrantGroupsIncludesAllRoles(t *testing.T) {
 	q := db.New(conn)
 	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id\n")).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).
-			AddRow(1, "member", true, false, time.Now()))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, can_login, is_admin, private_labels, public_profile_allowed_at FROM roles ORDER BY id\n")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "private_labels", "public_profile_allowed_at"}).
+			AddRow(1, "member", true, false, true, time.Now()))
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants ORDER BY id\n")).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}))

--- a/handlers/user/admin_user_routes_test.go
+++ b/handlers/user/admin_user_routes_test.go
@@ -39,7 +39,7 @@ func setupRequest(t *testing.T, path string, userID int) (*http.Request, sqlmock
 func TestAdminUserPermissionsPage_UserIDInjected(t *testing.T) {
 	req, mock, _ := setupRequest(t, "/admin/user/%d/permissions", 2)
 	mock.ExpectQuery("SELECT").WithArgs(int32(2)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(2, "", "u", nil))
-	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}))
+	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "private_labels", "public_profile_allowed_at"}))
 	mock.ExpectQuery("SELECT").WithArgs(int32(2)).WillReturnRows(sqlmock.NewRows([]string{"iduser_roles", "users_idusers", "role_id", "name"}))
 	rr := httptest.NewRecorder()
 	adminUserPermissionsPage(rr, req)

--- a/handlers/writings/writingsAdminCategoryGrantsPage_test.go
+++ b/handlers/writings/writingsAdminCategoryGrantsPage_test.go
@@ -27,9 +27,9 @@ func TestAdminCategoryGrantsPage(t *testing.T) {
 
 	mock.MatchExpectationsInOrder(false)
 
-	rolesRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "public_profile_allowed_at"}).
-		AddRow(1, "user", true, false, nil)
-	mock.ExpectQuery("SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id").WillReturnRows(rolesRows)
+	rolesRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "private_labels", "public_profile_allowed_at"}).
+		AddRow(1, "user", true, false, true, nil)
+	mock.ExpectQuery("SELECT id, name, can_login, is_admin, private_labels, public_profile_allowed_at FROM roles ORDER BY id").WillReturnRows(rolesRows)
 
 	grantsRows := sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}).
 		AddRow(1, nil, nil, nil, nil, "writing", "category", "allow", 1, nil, "see", nil, true)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -426,6 +426,7 @@ type Role struct {
 	Name                   string
 	CanLogin               bool
 	IsAdmin                bool
+	PrivateLabels          bool
 	PublicProfileAllowedAt sql.NullTime
 }
 

--- a/internal/db/queries-roles.sql
+++ b/internal/db/queries-roles.sql
@@ -1,6 +1,6 @@
 -- name: AdminListRoles :many
 -- admin task
-SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id;
+SELECT id, name, can_login, is_admin, private_labels, public_profile_allowed_at FROM roles ORDER BY id;
 
 -- name: AdminListRolesWithUsers :many
 -- admin task
@@ -17,7 +17,7 @@ UPDATE roles SET public_profile_allowed_at = ? WHERE id = ?;
 
 -- name: AdminGetRoleByID :one
 -- admin task
-SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles WHERE id = ?;
+SELECT id, name, can_login, is_admin, private_labels, public_profile_allowed_at FROM roles WHERE id = ?;
 
 -- name: AdminListUsersByRoleID :many
 -- admin task
@@ -33,4 +33,4 @@ SELECT * FROM grants WHERE role_id = ? ORDER BY id;
 
 -- name: AdminUpdateRole :exec
 -- admin task
-UPDATE roles SET name = ?, can_login = ?, is_admin = ? WHERE id = ?;
+UPDATE roles SET name = ?, can_login = ?, is_admin = ?, private_labels = ? WHERE id = ?;

--- a/internal/db/queries-roles.sql.go
+++ b/internal/db/queries-roles.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const adminGetRoleByID = `-- name: AdminGetRoleByID :one
-SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles WHERE id = ?
+SELECT id, name, can_login, is_admin, private_labels, public_profile_allowed_at FROM roles WHERE id = ?
 `
 
 // admin task
@@ -23,6 +23,7 @@ func (q *Queries) AdminGetRoleByID(ctx context.Context, id int32) (*Role, error)
 		&i.Name,
 		&i.CanLogin,
 		&i.IsAdmin,
+		&i.PrivateLabels,
 		&i.PublicProfileAllowedAt,
 	)
 	return &i, err
@@ -71,7 +72,7 @@ func (q *Queries) AdminListGrantsByRoleID(ctx context.Context, roleID sql.NullIn
 }
 
 const adminListRoles = `-- name: AdminListRoles :many
-SELECT id, name, can_login, is_admin, public_profile_allowed_at FROM roles ORDER BY id
+SELECT id, name, can_login, is_admin, private_labels, public_profile_allowed_at FROM roles ORDER BY id
 `
 
 // admin task
@@ -89,6 +90,7 @@ func (q *Queries) AdminListRoles(ctx context.Context) ([]*Role, error) {
 			&i.Name,
 			&i.CanLogin,
 			&i.IsAdmin,
+			&i.PrivateLabels,
 			&i.PublicProfileAllowedAt,
 		); err != nil {
 			return nil, err
@@ -182,14 +184,15 @@ func (q *Queries) AdminListUsersByRoleID(ctx context.Context, roleID int32) ([]*
 }
 
 const adminUpdateRole = `-- name: AdminUpdateRole :exec
-UPDATE roles SET name = ?, can_login = ?, is_admin = ? WHERE id = ?
+UPDATE roles SET name = ?, can_login = ?, is_admin = ?, private_labels = ? WHERE id = ?
 `
 
 type AdminUpdateRoleParams struct {
-	Name     string
-	CanLogin bool
-	IsAdmin  bool
-	ID       int32
+	Name          string
+	CanLogin      bool
+	IsAdmin       bool
+	PrivateLabels bool
+	ID            int32
 }
 
 // admin task
@@ -198,6 +201,7 @@ func (q *Queries) AdminUpdateRole(ctx context.Context, arg AdminUpdateRoleParams
 		arg.Name,
 		arg.CanLogin,
 		arg.IsAdmin,
+		arg.PrivateLabels,
 		arg.ID,
 	)
 	return err

--- a/internal/db/queries_roles_test.go
+++ b/internal/db/queries_roles_test.go
@@ -17,10 +17,10 @@ func TestQueries_AdminUpdateRole(t *testing.T) {
 	q := New(conn)
 
 	mock.ExpectExec(regexp.QuoteMeta(adminUpdateRole)).
-		WithArgs("name", true, false, int32(1)).
+		WithArgs("name", true, false, true, int32(1)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	if err := q.AdminUpdateRole(context.Background(), AdminUpdateRoleParams{Name: "name", CanLogin: true, IsAdmin: false, ID: 1}); err != nil {
+	if err := q.AdminUpdateRole(context.Background(), AdminUpdateRoleParams{Name: "name", CanLogin: true, IsAdmin: false, PrivateLabels: true, ID: 1}); err != nil {
 		t.Fatalf("AdminUpdateRole: %v", err)
 	}
 

--- a/migrations/0068.mysql.sql
+++ b/migrations/0068.mysql.sql
@@ -1,0 +1,27 @@
+ALTER TABLE roles
+    ADD COLUMN private_labels TINYINT(1) NOT NULL DEFAULT 1;
+UPDATE roles SET private_labels = can_login;
+
+-- Seed labeler role and grants
+INSERT INTO roles (name, can_login, is_admin)
+SELECT 'labeler', 1, 0
+WHERE NOT EXISTS (SELECT 1 FROM roles WHERE name = 'labeler');
+
+INSERT INTO grants (created_at, role_id, section, action, active)
+SELECT NOW(), r.id, g.section, 'label', 1
+FROM roles r
+JOIN (
+    SELECT DISTINCT section FROM grants WHERE action IN ('see', 'view')
+) g
+WHERE r.name = 'labeler';
+
+-- Grant label rights to all logged-in roles with view access
+INSERT INTO grants (created_at, role_id, section, action, active)
+SELECT NOW(), g.role_id, g.section, 'label', 1
+FROM grants g
+JOIN roles r ON r.id = g.role_id
+WHERE g.action IN ('see', 'view')
+  AND r.can_login = 1;
+
+-- Update schema version
+UPDATE schema_version SET version = 68 WHERE version = 67;

--- a/migrations/0068.postgres.sql
+++ b/migrations/0068.postgres.sql
@@ -1,0 +1,27 @@
+ALTER TABLE roles
+    ADD COLUMN private_labels BOOLEAN NOT NULL DEFAULT TRUE;
+UPDATE roles SET private_labels = can_login;
+
+-- Seed labeler role and grants
+INSERT INTO roles (name, can_login, is_admin)
+SELECT 'labeler', TRUE, FALSE
+WHERE NOT EXISTS (SELECT 1 FROM roles WHERE name = 'labeler');
+
+INSERT INTO grants (created_at, role_id, section, action, active)
+SELECT NOW(), r.id, g.section, 'label', TRUE
+FROM roles r
+JOIN (
+    SELECT DISTINCT section FROM grants WHERE action IN ('see', 'view')
+) g
+WHERE r.name = 'labeler';
+
+-- Grant label rights to all logged-in roles with view access
+INSERT INTO grants (created_at, role_id, section, action, active)
+SELECT NOW(), g.role_id, g.section, 'label', TRUE
+FROM grants g
+JOIN roles r ON r.id = g.role_id
+WHERE g.action IN ('see', 'view')
+  AND r.can_login = TRUE;
+
+-- Update schema version
+UPDATE schema_version SET version = 68 WHERE version = 67;

--- a/migrations/0068.sqlite.sql
+++ b/migrations/0068.sqlite.sql
@@ -1,0 +1,27 @@
+ALTER TABLE roles
+    ADD COLUMN private_labels BOOLEAN NOT NULL DEFAULT 1;
+UPDATE roles SET private_labels = can_login;
+
+-- Seed labeler role and grants
+INSERT INTO roles (name, can_login, is_admin)
+SELECT 'labeler', 1, 0
+WHERE NOT EXISTS (SELECT 1 FROM roles WHERE name = 'labeler');
+
+INSERT INTO grants (created_at, role_id, section, action, active)
+SELECT NOW(), r.id, g.section, 'label', 1
+FROM roles r
+JOIN (
+    SELECT DISTINCT section FROM grants WHERE action IN ('see', 'view')
+) g
+WHERE r.name = 'labeler';
+
+-- Grant label rights to all logged-in roles with view access
+INSERT INTO grants (created_at, role_id, section, action, active)
+SELECT NOW(), g.role_id, g.section, 'label', 1
+FROM grants g
+JOIN roles r ON r.id = g.role_id
+WHERE g.action IN ('see', 'view')
+  AND r.can_login = 1;
+
+-- Update schema version
+UPDATE schema_version SET version = 68 WHERE version = 67;

--- a/schema/schema.mysql.sql
+++ b/schema/schema.mysql.sql
@@ -234,6 +234,7 @@ CREATE TABLE `roles` (
   `name` tinytext NOT NULL,
   `can_login` tinyint(1) NOT NULL DEFAULT 0,
   `is_admin` tinyint(1) NOT NULL DEFAULT 0,
+  `private_labels` tinyint(1) NOT NULL DEFAULT 1,
   `public_profile_allowed_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `roles_name_idx` (`name`(255))

--- a/schema/schema.postgres.sql
+++ b/schema/schema.postgres.sql
@@ -233,6 +233,7 @@ CREATE TABLE `roles` (
   `name` tinytext NOT NULL,
   `can_login` tinyint(1) NOT NULL DEFAULT 0,
   `is_admin` tinyint(1) NOT NULL DEFAULT 0,
+  `private_labels` tinyint(1) NOT NULL DEFAULT 1,
   `public_profile_allowed_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `roles_name_idx` (`name`(255))

--- a/schema/schema.sqlite.sql
+++ b/schema/schema.sqlite.sql
@@ -233,6 +233,7 @@ CREATE TABLE `roles` (
   `name` tinytext NOT NULL,
   `can_login` tinyint(1) NOT NULL DEFAULT 0,
   `is_admin` tinyint(1) NOT NULL DEFAULT 0,
+  `private_labels` tinyint(1) NOT NULL DEFAULT 1,
   `public_profile_allowed_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `roles_name_idx` (`name`(255))

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -10,6 +10,7 @@ Roles define high level capabilities that can be assigned to users. The standard
 - **user** – regular authenticated user
 - **content writer** – may publish blogs and writing articles
 - **moderator** – moderation abilities
+- **labeler** – manage public/shared labels
 - **administrator** – full access
 
 Each role includes the following flags:
@@ -17,6 +18,7 @@ Each role includes the following flags:
 - **can_login** – whether accounts assigned the role are permitted to authenticate
 - **is_admin** – marks administrator roles that bypass permission checks
 - **public_profile_allowed_at** – when set, users with this role may expose a public profile
+- **private_labels** – whether the role can use private labels
 
 Users can hold multiple roles through the `user_roles` table. Roles are assigned
 explicitly without inheritance.
@@ -68,6 +70,8 @@ Permission actions describe groups of related operations. The main verbs are:
 - **search** – run a search query
 - **promote** – feature a news post as a site announcement
 - **demote** – remove a post from the announcements
+- **label** – create, edit or remove public/shared labels. Logged-in roles with
+  view access to a section receive this grant automatically.
 
 Sections may introduce extra actions but these form the base vocabulary used by
 the templates and permission checks.


### PR DESCRIPTION
## Summary
- consolidate labeler role seeding and grants into migration 0068
- automatically grant label rights to logged-in roles with view access
- bump expected schema version to 68

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899bfa1ea34832f9763ab173320c7e0