### PR TITLE
Inline labels with comments

### DIFF
--- a/core/templates/site/news/post.gohtml
+++ b/core/templates/site/news/post.gohtml
@@ -26,12 +26,9 @@
                     {{ end }}
                 </a>]
             {{ end }}
+            {{ $labels := NewsLabels .Idsitenews }}
+            {{ if $labels }}<span class="label-bar">{{ template "topicLabels" $labels }}</span>{{ end }}
+            </td>
         </tr>
-    </table>
-    {{ $labels := NewsLabels .Idsitenews }}
-    {{ if $labels }}
-    <div class="label-bar">
-        {{ template "topicLabels" $labels }}
-    </div>
-    {{ end }}<br>
+    </table><br>
 {{ end }}

--- a/core/templates/site/news/postPage.gohtml
+++ b/core/templates/site/news/postPage.gohtml
@@ -1,10 +1,5 @@
 {{ template "head" $ }}
     {{ template "newsPost" $.Post }}
-    {{ if .Labels }}
-    <div class="label-bar">
-        {{ template "topicLabels" .Labels }}
-    </div>
-    {{ end }}
     <hr><font size=4>Replies:</font>
     {{ template "threadComments" }}
     <div class="label-editor">


### PR DESCRIPTION
## Summary
- Render news item labels on the same line as comments/edit links
- Remove duplicate label block from the news post page

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899deb7d0f8832f91ec129d7bfb129a