### PR TITLE
Add mark read controls to writing articles

### DIFF
--- a/core/templates/article_page_test.go
+++ b/core/templates/article_page_test.go
@@ -1,0 +1,27 @@
+package templates
+
+import (
+	_ "embed"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+//go:embed site/writings/articlePage.gohtml
+var articlePageTemplate string
+
+func TestArticlePageMarkReadIncludesCSRF(t *testing.T) {
+	re := regexp.MustCompile(`(?s)<form[^>]*class="mark-read"[^>]*>.*{{ csrfField }}`)
+	if !re.MatchString(articlePageTemplate) {
+		t.Fatalf("mark-read form missing csrfField")
+	}
+}
+
+func TestArticlePageUsesThreadMarkReadTask(t *testing.T) {
+	if strings.Contains(articlePageTemplate, "Mark Topic Read") {
+		t.Fatalf("template uses deprecated Mark Topic Read task")
+	}
+	if c := strings.Count(articlePageTemplate, "Mark Thread Read"); c != 4 {
+		t.Fatalf("expected 4 Mark Thread Read tasks, got %d", c)
+	}
+}

--- a/core/templates/site/writings/articlePage.gohtml
+++ b/core/templates/site/writings/articlePage.gohtml
@@ -10,11 +10,21 @@
         {{ $writing.Abstract.String | a4code2html }}
         <hr>
         {{ $writing.Writing.String | a4code2html }}
-        {{ if .Labels }}
         <div class="label-bar">
             {{ template "topicLabels" .Labels }}
+            <form method="post" action="/writings/article/{{ $writing.Idwriting }}/labels" class="mark-read">
+            {{ csrfField }}
+                <input type="hidden" name="task" value="Mark Thread Read"/>
+                <input type="hidden" name="redirect" value="{{ .BackURL }}"/>
+                <button type="submit">Mark as read</button>
+            </form>
+            <form method="post" action="/writings/article/{{ $writing.Idwriting }}/labels" class="mark-read">
+            {{ csrfField }}
+                <input type="hidden" name="task" value="Mark Thread Read"/>
+                <input type="hidden" name="redirect" value="/writings/category/{{ $writing.WritingCategoryID }}"/>
+                <button type="submit">Mark as read and go back</button>
+            </form>
         </div>
-        {{ end }}
         <hr>Comments:<br>
         {{ template "threadComments" }}
         <div class="label-editor">
@@ -31,6 +41,18 @@
                 {{ end }}
                 <input type="text" class="label-input" data-type="private" placeholder="Add private label"/>
                 <input type="submit" value="Save Labels"/>
+            </form>
+            <form method="post" action="/writings/article/{{ $writing.Idwriting }}/labels" class="mark-read">
+            {{ csrfField }}
+                <input type="hidden" name="task" value="Mark Thread Read"/>
+                <input type="hidden" name="redirect" value="{{ .BackURL }}"/>
+                <button type="submit">Mark as read</button>
+            </form>
+            <form method="post" action="/writings/article/{{ $writing.Idwriting }}/labels" class="mark-read">
+            {{ csrfField }}
+                <input type="hidden" name="task" value="Mark Thread Read"/>
+                <input type="hidden" name="redirect" value="/writings/category/{{ $writing.WritingCategoryID }}"/>
+                <button type="submit">Mark as read and go back</button>
             </form>
         </div>
         <script src="/forum/topic_labels.js"></script>

--- a/handlers/writings/label_tasks.go
+++ b/handlers/writings/label_tasks.go
@@ -2,6 +2,7 @@ package writings
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -20,6 +21,13 @@ type SetLabelsTask struct{ tasks.TaskString }
 var setLabelsTask = &SetLabelsTask{TaskString: forumhandlers.TaskSetLabels}
 
 var _ tasks.Task = (*SetLabelsTask)(nil)
+
+// MarkWritingReadTask clears the special new/unread flags for a writing and its thread.
+type MarkWritingReadTask struct{ tasks.TaskString }
+
+var markWritingReadTask = &MarkWritingReadTask{TaskString: forumhandlers.TaskMarkThreadRead}
+
+var _ tasks.Task = (*MarkWritingReadTask)(nil)
 
 // labelsRedirect determines the page to return to after processing a label task.
 // It first checks the "back" form value, then falls back to the Referer header
@@ -59,4 +67,44 @@ func (SetLabelsTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("set private label status %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	return labelsRedirect(r)
+}
+
+func (MarkWritingReadTask) Action(w http.ResponseWriter, r *http.Request) any {
+	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+	vars := mux.Vars(r)
+	writingID, _ := strconv.Atoi(vars["writing"])
+	if err := r.ParseForm(); err != nil {
+		return fmt.Errorf("parse form fail %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+
+	threadID, err := cd.Queries().SystemGetWritingByID(r.Context(), int32(writingID))
+	if err != nil {
+		log.Printf("get writing thread: %v", err)
+	} else {
+		if err := cd.SetThreadPrivateLabelStatus(threadID, false, false); err != nil {
+			log.Printf("mark thread read: %v", err)
+			return fmt.Errorf("mark thread read %w", handlers.ErrRedirectOnSamePageHandler(err))
+		}
+		if last := r.PostFormValue("last_comment"); last != "" {
+			if cid, err := strconv.Atoi(last); err == nil {
+				if err := cd.SetThreadReadMarker(threadID, int32(cid)); err != nil {
+					log.Printf("set read marker: %v", err)
+					return fmt.Errorf("set read marker %w", handlers.ErrRedirectOnSamePageHandler(err))
+				}
+			}
+		}
+	}
+
+	if err := cd.SetPrivateLabelStatus("writing", int32(writingID), false, false); err != nil {
+		return fmt.Errorf("mark read %w", handlers.ErrRedirectOnSamePageHandler(err))
+	}
+
+	target := r.PostFormValue("redirect")
+	if target == "" {
+		target = r.Header.Get("Referer")
+	}
+	if target == "" {
+		target = strings.TrimSuffix(r.URL.Path, "/labels")
+	}
+	return handlers.RefreshDirectHandler{TargetURL: target}
 }

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -35,6 +35,7 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Regis
 	wr.Handle("/article/{writing}/edit", RequireWritingAuthor(http.HandlerFunc(updateWritingTask.Page))).Methods("GET").MatcherFunc(handlers.RequiredAccess("content writer", "administrator"))
 	wr.Handle("/article/{writing}/edit", RequireWritingAuthor(http.HandlerFunc(handlers.TaskHandler(updateWritingTask)))).Methods("POST").MatcherFunc(handlers.RequiredAccess("content writer", "administrator")).MatcherFunc(updateWritingTask.Matcher())
 	wr.HandleFunc("/article/{writing}/labels", handlers.TaskHandler(setLabelsTask)).Methods("POST").MatcherFunc(setLabelsTask.Matcher())
+	wr.HandleFunc("/article/{writing}/labels", handlers.TaskHandler(markWritingReadTask)).Methods("POST").MatcherFunc(markWritingReadTask.Matcher())
 	wr.HandleFunc("/categories", CategoriesPage).Methods("GET")
 	wr.HandleFunc("/categories/", CategoriesPage).Methods("GET")
 	wr.HandleFunc("/category/{category}", CategoryPage).Methods("GET")


### PR DESCRIPTION
## Summary
- add MarkWritingReadTask and route to handle marking writing articles as read
- show Mark as read and Mark as read and go back controls at top and bottom of articles
- test that writing article template includes mark-read forms

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899df3d1448832fbf9b5c8f27ff3109