### PR TITLE
Add mark read actions to bottom of thread page

### DIFF
--- a/core/templates/site/forum/threadPage.gohtml
+++ b/core/templates/site/forum/threadPage.gohtml
@@ -38,6 +38,13 @@
             <input type="submit" value="Save Labels"/>
         </form>
         <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" class="mark-read">
+            {{ csrfField }}
+            <input type="hidden" name="task" value="Mark Thread Read"/>
+            <input type="hidden" name="redirect" value="{{ .BackURL }}"/>
+            <button type="submit">Mark as read</button>
+        </form>
+        <form method="post" action="{{$base}}/thread/{{.Thread.Idforumthread}}/labels" class="mark-read">
+            {{ csrfField }}
             <input type="hidden" name="task" value="Mark Thread Read"/>
             <input type="hidden" name="redirect" value="{{$base}}/topic/{{.Topic.Idforumtopic}}"/>
             <button type="submit">Mark as read and go back</button>

--- a/core/templates/thread_page_test.go
+++ b/core/templates/thread_page_test.go
@@ -21,8 +21,8 @@ func TestThreadPageUsesThreadMarkReadTask(t *testing.T) {
 	if strings.Contains(threadPageTemplate, "Mark Topic Read") {
 		t.Fatalf("template uses deprecated Mark Topic Read task")
 	}
-	if c := strings.Count(threadPageTemplate, "Mark Thread Read"); c != 3 {
-		t.Fatalf("expected 3 Mark Thread Read tasks, got %d", c)
+	if c := strings.Count(threadPageTemplate, "Mark Thread Read"); c != 4 {
+		t.Fatalf("expected 4 Mark Thread Read tasks, got %d", c)
 	}
 	if strings.Contains(threadPageTemplate, "/topic/{{.Topic.Idforumtopic}}/labels") {
 		t.Fatalf("mark-read form posts to topic labels endpoint")


### PR DESCRIPTION
## Summary
- show both "Mark as read" and "Mark as read and go back" buttons at top and bottom of threads
- adjust tests for new mark-read actions

## Testing
- `go mod tidy`
- `go fmt ./...`
- `timeout 30 go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899df5ab73c832fb734b4e313309821