### PR TITLE
Replace font tags in forum templates with semantic spans

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -91,13 +91,17 @@ a:hover {
 	color: #FF0000;
 }
 h1 {
-	font-family: tahoma, arial, helvetica, sans-serif;
-	text-align: center;
-	color: #800000;
-	background-color: transparent;
+        font-family: tahoma, arial, helvetica, sans-serif;
+        text-align: center;
+        color: #800000;
+        background-color: transparent;
+}
+
+.section-title {
+        font-size: 1.2em;
 }
 div.index {
-	text-align: center;
+        text-align: center;
 }
 div.index table {
 	margin-left: auto;

--- a/core/templates/site/forum/reply.gohtml
+++ b/core/templates/site/forum/reply.gohtml
@@ -23,7 +23,7 @@
             </aside>
             <section class="body">
                 <a id="bottom"></a>
-                <font size="4">Reply:</font><br>
+                <span class="section-title">Reply:</span><br>
                 {{ $base := "/forum" }}
                 {{ with $.BasePath }}{{ $base = . }}{{ end }}
                 <form method="post" action="{{$base}}/topic/{{$.Topic.Idforumtopic}}/thread/{{$.Thread.Idforumthread}}/reply">

--- a/core/templates/site/forum/threadNewPage.gohtml
+++ b/core/templates/site/forum/threadNewPage.gohtml
@@ -22,7 +22,7 @@
         </aside>
         <section class="body">
             <a id="bottom"></a>
-            <font size="4">New Thread:</font><br>
+            <span class="section-title">New Thread:</span><br>
             <form method="post" action="">
                 {{ csrfField }}
                 <textarea id="reply" name="replytext" cols="40" rows="20"></textarea><br>


### PR DESCRIPTION
## Summary
- replace deprecated `<font size="4">` markup in forum reply and new thread templates with a span using a CSS class
- add `.section-title` CSS class to maintain visual styling

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestNewsPostPageNoDuplicateLabels)*

------
https://chatgpt.com/codex/tasks/task_e_6899eb647ed0832faacbf83a8beec70a