### PR TITLE
Replace deprecated center tag with semantic markup

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -151,17 +151,21 @@ div.title {
 	background-color: transparent;
 }
 .textright {
-	text-align: right;
-	font-family: tahoma, arial, helvetica, sans-serif;
-	font-size: 0.8em;
-	color: #800000;
-	background-color: transparent;
+        text-align: right;
+        font-family: tahoma, arial, helvetica, sans-serif;
+        font-size: 0.8em;
+        color: #800000;
+        background-color: transparent;
+}
+
+.text-center {
+        text-align: center;
 }
 .textcenter {
-	text-align: center;
-	font-family: tahoma, arial, helvetica, sans-serif;
-	font-size: 0.8em;
-	color: #800000;
+        text-align: center;
+        font-family: tahoma, arial, helvetica, sans-serif;
+        font-size: 0.8em;
+        color: #800000;
 	background-color: transparent;
 }
 .notification {

--- a/core/templates/site/tail.gohtml
+++ b/core/templates/site/tail.gohtml
@@ -6,9 +6,9 @@
         <div id="bottom"></div>
         <hr>
         <footer class="site-footer">
-            <center>
+            <div class="text-center">
                 {{template "footer"}}
-            </center>
+            </div>
         </footer>
     {{ end }}
     {{ if cd.Marked "bodyEnd" }}


### PR DESCRIPTION
## Summary
- replace `<center>` with `<div class="text-center">` in site footer template
- add `.text-center` utility class to global stylesheet for centering

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestNewsPostPageNoDuplicateLabels)*

------
https://chatgpt.com/codex/tasks/task_e_6899eb7958e8832f9968b45954a3f7ae