### PR TITLE
Softened label pill colours outside forums

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -2133,6 +2133,9 @@ func (cd *CoreData) SetCurrentRoleID(id int32) { cd.currentRoleID = id }
 // SetCurrentSection stores the current section name.
 func (cd *CoreData) SetCurrentSection(section string) { cd.currentSection = section }
 
+// Section returns the current section name.
+func (cd *CoreData) Section() string { return cd.currentSection }
+
 // SetCurrentNotificationTemplate records the notification template being edited along with an error message.
 func (cd *CoreData) SetCurrentNotificationTemplate(name, errMsg string) {
 	cd.currentNotificationTemplateName = name

--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -254,26 +254,56 @@ div.title {
 }
 
 .label.pill.public {
-        background: #2e7d32;
-}
-
-.label.pill.public.unsaved {
         background: #81c784;
 }
 
-.label.pill.author {
-        background: #1565c0;
+.label.pill.public.unsaved {
+        background: #c8e6c9;
 }
 
-.label.pill.author.unsaved {
+.label.pill.author {
         background: #90caf9;
 }
 
+.label.pill.author.unsaved {
+        background: #bbdefb;
+}
+
 .label.pill.private {
-        background: #e65100;
+        background: #ffb74d;
 }
 
 .label.pill.private.unsaved {
+        background: #ffe0b2;
+}
+
+body.forum .label.pill.public,
+body.privateforum .label.pill.public {
+        background: #2e7d32;
+}
+
+body.forum .label.pill.public.unsaved,
+body.privateforum .label.pill.public.unsaved {
+        background: #81c784;
+}
+
+body.forum .label.pill.author,
+body.privateforum .label.pill.author {
+        background: #1565c0;
+}
+
+body.forum .label.pill.author.unsaved,
+body.privateforum .label.pill.author.unsaved {
+        background: #90caf9;
+}
+
+body.forum .label.pill.private,
+body.privateforum .label.pill.private {
+        background: #e65100;
+}
+
+body.forum .label.pill.private.unsaved,
+body.privateforum .label.pill.private.unsaved {
         background: #ffb74d;
 }
 

--- a/core/templates/site/head.gohtml
+++ b/core/templates/site/head.gohtml
@@ -20,7 +20,7 @@
     </head>
     {{ end }}
     {{ if cd.Marked "bodyBegin" }}
-    <body>
+    <body{{if cd.Section}} class="{{ cd.Section }}"{{end}}>
     {{ end }}
         {{ if cd.Marked "header" }}
             {{template "header"}}


### PR DESCRIPTION
## Summary
- expose current section name and use it to add a body class
- lighten default label pill colours and keep vivid colours for forum pages

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899e806bef8832f9714e39b76d29d50