### PR TITLE
Add labels to blog comments page

### DIFF
--- a/core/templates/site/blogs/commentPage.gohtml
+++ b/core/templates/site/blogs/commentPage.gohtml
@@ -8,11 +8,28 @@
                 </tr>
                 <tr>
                     <td>
-                        {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}
+                        {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <span class="label-bar">{{ template "topicLabels" .Labels }}</span>{{ end }}
                     </td>
                 </tr>
         </table><br>
         {{ template "threadComments" }}
+        <div class="label-editor">
+            <form method="post" action="/blogs/blog/{{$blog.Idblogs}}/labels" id="label-form">
+            {{ csrfField }}
+                <input type="hidden" name="task" value="Set Labels"/>
+                <input type="hidden" name="back" value="{{ .BackURL }}"/>
+                {{ range .Labels }}
+                    {{ if eq .Type "private" }}
+                    <span class="label pill private">{{ .Name }}<button type="button" class="remove" data-type="private">x</button><input type="hidden" name="private" value="{{ .Name }}"/></span>
+                    {{ else if eq .Type "author" }}
+                    <span class="label pill author">{{ .Name }}</span>
+                    {{ end }}
+                {{ end }}
+                <input type="text" class="label-input" data-type="private" placeholder="Add private label"/>
+                <input type="submit" value="Save Labels"/>
+            </form>
+        </div>
+        <script src="/forum/topic_labels.js"></script>
         {{ template "blogReply" $ }}
 {{ template "tail" $ }}
 {{ end }}

--- a/handlers/blogs/blogsCommentPage.go
+++ b/handlers/blogs/blogsCommentPage.go
@@ -17,7 +17,9 @@ import (
 
 func CommentPage(w http.ResponseWriter, r *http.Request) {
 	type Data struct {
-		Text string
+		Text    string
+		Labels  []templates.TopicLabel
+		BackURL string
 	}
 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
@@ -49,7 +51,7 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := Data{}
+	data := Data{BackURL: r.URL.RequestURI()}
 	replyType := r.URL.Query().Get("type")
 	commentId, _ := strconv.Atoi(r.URL.Query().Get("comment"))
 	if commentId != 0 {
@@ -60,6 +62,16 @@ func CommentPage(w http.ResponseWriter, r *http.Request) {
 			default:
 				data.Text = a4code.QuoteText(comment.Username.String, comment.Text.String)
 			}
+		}
+	}
+	if als, err := cd.BlogAuthorLabels(blog.Idblogs); err == nil {
+		for _, l := range als {
+			data.Labels = append(data.Labels, templates.TopicLabel{Name: l, Type: "author"})
+		}
+	}
+	if pls, err := cd.BlogPrivateLabels(blog.Idblogs); err == nil {
+		for _, l := range pls {
+			data.Labels = append(data.Labels, templates.TopicLabel{Name: l, Type: "private"})
 		}
 	}
 


### PR DESCRIPTION
## Summary
- show author and private labels on blog comment pages
- allow label editing on blog comment pages

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(hung: terminated after ~100s)*
- `golangci-lint run handlers/blogs/...`
- `go test ./...` *(fails: TestNewsPostPageNoDuplicateLabels)*

------
https://chatgpt.com/codex/tasks/task_e_6899ea10b370832fbd7c6dc606bc461e