### PR TITLE
Show private topic titles in thread breadcrumbs

### DIFF
--- a/core/common/breadcrumb.go
+++ b/core/common/breadcrumb.go
@@ -1,9 +1,12 @@
 package common
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"strings"
+
+	"github.com/arran4/goa4web/internal/db"
 )
 
 // Breadcrumb represents a single navigation step.
@@ -89,6 +92,25 @@ func (cd *CoreData) forumBreadcrumbs() ([]Breadcrumb, error) {
 			title := fmt.Sprintf("Topic %d", topicID)
 			if topic.Title.Valid {
 				title = topic.Title.String
+			}
+			if topic.Handler == "private" && cd.queries != nil {
+				parts, err := cd.queries.ListPrivateTopicParticipantsByTopicIDForUser(cd.ctx, db.ListPrivateTopicParticipantsByTopicIDForUserParams{
+					TopicID:  sql.NullInt32{Int32: topic.Idforumtopic, Valid: true},
+					ViewerID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+				})
+				if err != nil {
+					log.Printf("list private participants: %v", err)
+				} else {
+					var names []string
+					for _, p := range parts {
+						if p.Idusers != cd.UserID {
+							names = append(names, p.Username.String)
+						}
+					}
+					if len(names) > 0 {
+						title = strings.Join(names, ", ")
+					}
+				}
 			}
 			link := fmt.Sprintf("%s/topic/%d", base, topicID)
 			if threadID == 0 {

--- a/core/common/breadcrumb_private_title_test.go
+++ b/core/common/breadcrumb_private_title_test.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"context"
+	"database/sql"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestPrivateForumBreadcrumbUsesDisplayTitle(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	topicRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername"}).
+		AddRow(1, 0, 0, nil, sql.NullString{String: "Hidden", Valid: true}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullTime{}, "private", sql.NullString{})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT t.idforumtopic")).
+		WithArgs(int32(1), int32(1), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
+		WillReturnRows(topicRows)
+
+	participantRows := sqlmock.NewRows([]string{"idusers", "username"}).
+		AddRow(2, sql.NullString{String: "Alice", Valid: true}).
+		AddRow(3, sql.NullString{String: "Bob", Valid: true})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, u.username")).
+		WithArgs(sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).
+		WillReturnRows(participantRows)
+
+	queries := db.New(conn)
+	cd := NewCoreData(context.Background(), queries, config.NewRuntimeConfig())
+	cd.SetCurrentSection("privateforum")
+	cd.ForumBasePath = "/private"
+	cd.UserID = 1
+	cd.currentTopicID = 1
+
+	crumbs, err := cd.forumBreadcrumbs()
+	if err != nil {
+		t.Fatalf("forumBreadcrumbs error: %v", err)
+	}
+	if len(crumbs) < 2 {
+		t.Fatalf("expected >=2 crumbs, got %v", crumbs)
+	}
+	if crumbs[1].Title != "Alice, Bob" {
+		t.Fatalf("unexpected crumb title: %v", crumbs[1].Title)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("mock expectations: %v", err)
+	}
+}

--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -1,12 +1,14 @@
 package forum
 
 import (
+	"database/sql"
 	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/arran4/goa4web/a4code"
 	"github.com/arran4/goa4web/core/common"
@@ -61,7 +63,27 @@ func ThreadPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
-	cd.PageTitle = fmt.Sprintf("Forum - %s", topicRow.Title.String)
+	displayTitle := topicRow.Title.String
+	if topicRow.Handler == "private" && cd.Queries() != nil {
+		parts, err := cd.Queries().ListPrivateTopicParticipantsByTopicIDForUser(r.Context(), db.ListPrivateTopicParticipantsByTopicIDForUserParams{
+			TopicID:  sql.NullInt32{Int32: topicRow.Idforumtopic, Valid: true},
+			ViewerID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		})
+		if err != nil {
+			log.Printf("list private participants: %v", err)
+		} else {
+			var names []string
+			for _, p := range parts {
+				if p.Idusers != cd.UserID {
+					names = append(names, p.Username.String)
+				}
+			}
+			if len(names) > 0 {
+				displayTitle = strings.Join(names, ", ")
+			}
+		}
+	}
+	cd.PageTitle = fmt.Sprintf("Forum - %s", displayTitle)
 
 	if _, ok := core.GetSessionOrFail(w, r); !ok {
 		return
@@ -113,6 +135,7 @@ func ThreadPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 		ForumcategoryIdforumcategory: topicRow.ForumcategoryIdforumcategory,
 		Title:                        topicRow.Title,
 		Description:                  topicRow.Description,
+		DisplayTitle:                 displayTitle,
 		Threads:                      topicRow.Threads,
 		Comments:                     topicRow.Comments,
 		Lastaddition:                 topicRow.Lastaddition,


### PR DESCRIPTION
## Summary
- use participant names for private topic breadcrumbs
- compute display title for private threads
- test private topic breadcrumb shows participant names

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./handlers/news -run TestNewsPostPageNoDuplicateLabels -count=1` *(fails: expected 1 label bar, got 2)*


------
https://chatgpt.com/codex/tasks/task_e_6899eb3f3a8c832fba0373608d048370