### PR TITLE
Replace deprecated font tags in blog templates

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -1,6 +1,6 @@
 body {
-        background-color: #FFFBF0;
-        color: #800000;
+	background-color: #FFFBF0;
+	color: #800000;
         min-height: 100vh;
         display: flex;
         flex-direction: column;
@@ -22,7 +22,7 @@ textarea {
         justify-content: space-between;
         align-items: center;
         padding: 0.5em 1em;
-        background-color: #FFF6E0;
+	background-color: #FFF6E0;
 }
 
 .navbar-left,
@@ -43,8 +43,8 @@ textarea {
         flex: 1;
         text-align: center;
         font-weight: bold;
-        font-family: tahoma, arial, helvetica, sans-serif;
-        color: #800000;
+	font-family: tahoma, arial, helvetica, sans-serif;
+	color: #800000;
         position: relative;
 }
 
@@ -54,7 +54,7 @@ textarea {
 
 .hamburger {
         display: none;
-        font-size: 1.5em;
+	font-size: 1.5em;
         cursor: pointer;
 }
 
@@ -75,8 +75,8 @@ textarea {
 }
 
 .site-footer {
-        font-size: 0.7em;
-        color: #666;
+	font-size: 0.7em;
+	color: #666;
 }
 a {
 	background-color: transparent;
@@ -92,7 +92,21 @@ a:hover {
 }
 h1 {
 	font-family: tahoma, arial, helvetica, sans-serif;
-	text-align: center;
+        text-align: center;
+	color: #800000;
+	background-color: transparent;
+}
+
+.blog-title {
+	font-family: tahoma, arial, helvetica, sans-serif;
+	font-size: 1.5em;
+	color: #800000;
+	background-color: transparent;
+}
+
+.blog-subtitle {
+	font-family: tahoma, arial, helvetica, sans-serif;
+	font-size: 1.2em;
 	color: #800000;
 	background-color: transparent;
 }
@@ -168,14 +182,14 @@ div.title {
         border: 1px solid #808000;
         padding: 0.5em;
         margin-bottom: 0.5em;
-        background-color: #FFF6E0;
+	background-color: #FFF6E0;
 }
 
 .pagination-bar {
         position: sticky;
         bottom: 0;
         margin-top: auto;
-        background-color: #FFF6E0;
+	background-color: #FFF6E0;
         padding: 0.5em;
         display: flex;
         justify-content: space-between;
@@ -198,11 +212,11 @@ div.title {
 
 /* spoiler text hidden until hovered */
 .spoiler {
-        color: #000000;
-        background-color: #000000;
+	color: #000000;
+	background-color: #000000;
 }
 .spoiler:hover {
-        color: #FFFFFF;
+	color: #FFFFFF;
 }
 
 /* role grant editor */
@@ -246,11 +260,11 @@ div.title {
         align-items: center;
         padding-right: 8px;
         cursor: default;
-        color: #fff;
+	color: #fff;
 }
 
 .label.pill.unsaved {
-        color: #000;
+	color: #000;
 }
 
 .label.pill.public {
@@ -340,12 +354,12 @@ tr.unsupported td {
 }
 
 .a4code-code {
-        background-color: lightblue;
+	background-color: lightblue;
 }
 
 .a4code-quote,
 .a4code-quoteof {
-        background-color: lightgreen;
+	background-color: lightgreen;
 }
 
 .a4code-image {
@@ -354,8 +368,8 @@ tr.unsupported td {
 
 /* Breadcrumb navigation */
 .breadcrumbs {
-        font-family: tahoma, arial, helvetica, sans-serif;
-        font-size: 0.8em;
+	font-family: tahoma, arial, helvetica, sans-serif;
+	font-size: 0.8em;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
@@ -380,7 +394,7 @@ tr.unsupported td {
 .breadcrumbs li + li:before {
         content: ">";
         padding: 0 0.25em;
-        color: #800000;
+	color: #800000;
 }
 
 .breadcrumbs a {
@@ -389,7 +403,7 @@ tr.unsupported td {
 
 .navbar-center .page-title-link {
         text-decoration: none;
-        color: inherit;
+	color: inherit;
 }
 
 /* Forum topic actions */
@@ -456,7 +470,7 @@ tr.unsupported td {
 }
 
 .thread-header {
-        background-color: lightgrey;
+	background-color: lightgrey;
 }
 
 .thread-content {
@@ -465,12 +479,12 @@ tr.unsupported td {
 
 .poster-name.first,
 .post-time.first {
-        color: green;
+	color: green;
 }
 
 .poster-name.last,
 .post-time.last {
-        color: blue;
+	color: blue;
 }
 
 

--- a/core/templates/site/blogs/blogPage.gohtml
+++ b/core/templates/site/blogs/blogPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
         {{ $blog := cd.BlogPost }}
-        <font size="5"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</font><br>
+        <h2 class="blog-title"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</h2>
         <table width="100%">
                 <tr>
                     <th bgcolor="lightgrey">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>

--- a/core/templates/site/blogs/blogReply.gohtml
+++ b/core/templates/site/blogs/blogReply.gohtml
@@ -24,7 +24,7 @@
                 </aside>
                 <section class="body">
                     <a id="bottom"></a>
-                    <font size="4">Reply:</font><br>
+                    <h3 class="blog-subtitle">Reply:</h3>
                     <form method="post" action="/blogs/blog/{{$blog.Idblogs}}/reply">
                 {{ csrfField }}
                         <textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>

--- a/core/templates/site/blogs/bloggerListPage.gohtml
+++ b/core/templates/site/blogs/bloggerListPage.gohtml
@@ -5,7 +5,7 @@
     </form>
     {{if .Search}}
         {{if .Rows}}
-            <font size="5">Search results for "{{.Search}}".</font><br>
+            <h2 class="blog-title">Search results for "{{.Search}}".</h2>
             {{range .Rows}}
                 Blogger: <a href="/blogs/blogger/{{.Username.String}}">{{.Username.String}}</a> has {{.Count}} blogs.<br>
             {{end}}
@@ -14,7 +14,7 @@
         {{end}}
     {{else}}
         {{if .Rows}}
-            <font size="5">All bloggers.</font><br>
+            <h2 class="blog-title">All bloggers.</h2>
             {{range .Rows}}
                 Blogger: <a href="/blogs/blogger/{{.Username.String}}">{{.Username.String}}</a> has {{.Count}} blogs.<br>
             {{end}}

--- a/core/templates/site/blogs/bloggerPostsPage.gohtml
+++ b/core/templates/site/blogs/bloggerPostsPage.gohtml
@@ -2,9 +2,9 @@
         {{ $rows := cd.BloggerPosts }}
         {{if $rows}}
             {{if cd.CurrentProfileUserID}}
-                <font size="5"><a href="/blogs/blogger/{{(index $rows 0).Username.String}}">{{(index $rows 0).Username.String}}</a>'s blogs.</font><br>
+                <h2 class="blog-title"><a href="/blogs/blogger/{{(index $rows 0).Username.String}}">{{(index $rows 0).Username.String}}</a>'s blogs.</h2>
             {{else}}
-                <font size="5"><a href="/blogs/bloggers">All bloggers</a>' blogs.</font><br>
+                <h2 class="blog-title"><a href="/blogs/bloggers">All bloggers</a>' blogs.</h2>
             {{end}}
             <table width="100%">
                 {{range $rows}}

--- a/core/templates/site/blogs/commentPage.gohtml
+++ b/core/templates/site/blogs/commentPage.gohtml
@@ -1,7 +1,7 @@
 {{ define "blogs/commentPage.gohtml" }}
 {{ template "head" $ }}
             {{ $blog := cd.BlogPost }}
-            <font size="5"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</font><br>
+            <h2 class="blog-title"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</h2>
             <table width="100%">
                 <tr>
                     <th bgcolor="lightgrey">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>

--- a/core/templates/site/blogs/page.gohtml
+++ b/core/templates/site/blogs/page.gohtml
@@ -8,9 +8,9 @@
     {{ end }}
     {{ if $rows }}
         {{ if cd.CurrentProfileUserID }}
-            <font size="5"><a href="/blogs/blogger/{{ (index $rows 0).Username.String }}">{{ (index $rows 0).Username.String }}</a>'s blogs.</font><br>
+            <h2 class="blog-title"><a href="/blogs/blogger/{{ (index $rows 0).Username.String }}">{{ (index $rows 0).Username.String }}</a>'s blogs.</h2>
         {{ else }}
-            <font size="5"><a href="/blogs/bloggers">All bloggers</a>' blogs.</font><br>
+            <h2 class="blog-title"><a href="/blogs/bloggers">All bloggers</a>' blogs.</h2>
         {{ end }}
     {{ end }}
     <table width="100%">


### PR DESCRIPTION
## Summary
- Replace `<font>` tags in blog templates with semantic headings
- Add `.blog-title` and `.blog-subtitle` classes for consistent blog typography

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestNewsPostPageNoDuplicateLabels)*

------
https://chatgpt.com/codex/tasks/task_e_6899eb6167e4832f93b062086c40388b