### PR TITLE
Replace font tags in writings templates with semantic spans

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -158,12 +158,20 @@ div.title {
 	background-color: transparent;
 }
 .textcenter {
-	text-align: center;
-	font-family: tahoma, arial, helvetica, sans-serif;
-	font-size: 0.8em;
-	color: #800000;
-	background-color: transparent;
+        text-align: center;
+        font-family: tahoma, arial, helvetica, sans-serif;
+        font-size: 0.8em;
+        color: #800000;
+        background-color: transparent;
 }
+
+.text-large {
+        font-size: 1.2em;
+}
+.text-xlarge {
+        font-size: 1.5em;
+}
+
 .notification {
         border: 1px solid #808000;
         padding: 0.5em;

--- a/core/templates/site/writings/articleAddPage.gohtml
+++ b/core/templates/site/writings/articleAddPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-    <font size="4">New writing:</font><br>
+    <span class="text-large">New writing:</span><br>
     (Please select an appropriate section before writing this.)<br>
     <form method="post">
         {{ csrfField }}

--- a/core/templates/site/writings/articleEditPage.gohtml
+++ b/core/templates/site/writings/articleEditPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
     {{ if .Writing }}
-        <font size="4">New writing:</font><br>
+        <span class="text-large">New writing:</span><br>
         (Please select an appropriate section before writing this.)<br>
         <form method="post">
         {{ csrfField }}

--- a/core/templates/site/writings/articlePage.gohtml
+++ b/core/templates/site/writings/articlePage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
     {{ $writing := cd.CurrentWritingLoaded }}
     {{ if $writing }}
-        <font size="4">At {{ localTime $writing.Published.Time }}, By {{ $writing.Writerusername.String }}; {{ $writing.Title.String | trim | a4code2html }}:</font>
+        <span class="text-large">At {{ localTime $writing.Published.Time }}, By {{ $writing.Writerusername.String }}; {{ $writing.Title.String | trim | a4code2html }}:</span>
         {{ if $writing.Private.Bool }} (Restricted access) {{ end }}
         {{ if .CanEdit }}[<a href="/writings/article/{{ $writing.Idwriting }}/edit">EDIT</a>]{{ end }}
         {{ if and cd.IsAdmin cd.IsAdminMode }}[<a href="/admin/writings/article/{{ $writing.Idwriting }}">ADMIN</a>]{{ end }}
@@ -80,7 +80,7 @@
                 </aside>
                 <section class="body">
                     <a id="bottom"></a>
-                    <hr><font size="4">Reply:</font><br>
+                    <hr><span class="text-large">Reply:</span><br>
                     <form method="post">
                     {{ csrfField }}
                         <textarea name="replytext" cols="40" rows="20">{{ .ReplyText }}</textarea><br>

--- a/core/templates/site/writings/writerListPage.gohtml
+++ b/core/templates/site/writings/writerListPage.gohtml
@@ -4,7 +4,7 @@
         <input type="submit" name="task" value="Search">
     </form>
     {{if .Rows}}
-        <font size="5">All writers.</font><br>
+        <span class="text-xlarge">All writers.</span><br>
         {{range .Rows}}
             Writer: <a href="/writings/writer/{{.Username.String}}">{{.Username.String}}</a> has {{.Count}} articles.<br>
         {{end}}

--- a/core/templates/site/writings/writerPage.gohtml
+++ b/core/templates/site/writings/writerPage.gohtml
@@ -1,4 +1,4 @@
 {{ template "head" $ }}
-    <font size="5">{{ .Username }}'s writings.</font><br>
+    <span class="text-xlarge">{{ .Username }}'s writings.</span><br>
     {{ template "listAbstracts" $ }}
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- replace deprecated `<font>` tags in writings templates with semantic `<span>` elements
- add `.text-large` and `.text-xlarge` CSS classes to preserve original font sizing

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./handlers/news` *(fails: expected 1 label bar, got 2)*

------
https://chatgpt.com/codex/tasks/task_e_6899eb6741f4832f8742e790d5b87b75