### PR TITLE
Replace table border attributes with CSS classes

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -96,6 +96,17 @@ h1 {
 	color: #800000;
 	background-color: transparent;
 }
+
+
+.table {
+        border-collapse: collapse;
+}
+
+.table-bordered,
+.table-bordered th,
+.table-bordered td {
+        border: 1px solid #000;
+}
 div.index {
 	text-align: center;
 }

--- a/core/templates/site/admin/adminFilesPage.gohtml
+++ b/core/templates/site/admin/adminFilesPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 <h2>Uploaded Files - {{ .Path }}</h2>
 {{ if .Parent }}<a href="/admin/files?path={{ .Parent }}">Parent</a><br>{{ end }}
-<table border="1">
+<table class="table table-bordered">
 <tr><th>Name<th>Size<th>Type<th>User<th>Board<th>Posted<th>Preview</tr>
 {{ range .Entries }}
 <tr>

--- a/core/templates/site/admin/adminRolePage.gohtml
+++ b/core/templates/site/admin/adminRolePage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 <h2>Role: {{ .Role.Name }} (ID {{ .Role.ID }})</h2>
 <p><a href="/admin/role/{{ .Role.ID }}/edit">Edit Role</a></p>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Can Login</th><th>Is Admin</th><th>Public Profiles</th></tr>
     <tr>
         <td>{{ if .Role.CanLogin }}yes{{ else }}no{{ end }}</td>

--- a/core/templates/site/admin/adminUserPage.gohtml
+++ b/core/templates/site/admin/adminUserPage.gohtml
@@ -30,7 +30,7 @@
 {{ $emails := cd.CurrentProfileEmails }}
 <h4>Emails</h4>
 {{ if $emails }}
-<table border="1">
+<table class="table table-bordered">
 <tr><th>Email</th><th>Verified</th><th>Priority</th></tr>
 {{ range $emails }}
 <tr>
@@ -75,7 +75,7 @@
 {{ $grants := cd.CurrentProfileGrants }}
 <h4>Direct Grants</h4>
 {{ if $grants }}
-<table border="1">
+<table class="table table-bordered">
 <tr><th>Section</th><th>Item</th><th>Action</th><th>Extra</th></tr>
 {{ range $grants }}
 <tr>
@@ -100,7 +100,7 @@
 {{ $comments := cd.CurrentProfileComments }}
 <h4>Comments</h4>
 {{ if $comments }}
-<table border="1">
+<table class="table table-bordered">
 <tr><th>Date</th><th>Comment</th></tr>
 {{ range $comments }}
 <tr>

--- a/core/templates/site/admin/announcementsPage.gohtml
+++ b/core/templates/site/admin/announcementsPage.gohtml
@@ -7,7 +7,7 @@
 </form>
 <form method="post">
     {{ csrfField }}
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Select</th><th>ID</th><th>News ID</th><th>Created</th><th>Active</th><th>News</th></tr>
     {{- range .Announcements }}
     <tr>

--- a/core/templates/site/admin/auditLogPage.gohtml
+++ b/core/templates/site/admin/auditLogPage.gohtml
@@ -5,7 +5,7 @@
     Action: <input name="action" value="{{$.Action}}">
     <input type="submit" name="task" value="Filter">
 </form>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>User</th><th>Action</th><th>Time</th></tr>
     {{- range .Rows}}
     <tr>

--- a/core/templates/site/admin/commentsPage.gohtml
+++ b/core/templates/site/admin/commentsPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h2>Comments</h2>
-<table border="1">
+<table class="table table-bordered">
 <tr><th>ID</th><th>Date</th><th>Topic</th><th>Thread</th><th>Excerpt</th><th>Link</th></tr>
 {{- range .Comments }}
 <tr>

--- a/core/templates/site/admin/deactivatedCommentsPage.gohtml
+++ b/core/templates/site/admin/deactivatedCommentsPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h2>Deactivated Comments</h2>
-<table border="1">
+<table class="table table-bordered">
 <tr><th>ID</th><th>Excerpt</th><th>Link</th></tr>
 {{- range .Comments }}
 <tr>

--- a/core/templates/site/admin/dlqPage.gohtml
+++ b/core/templates/site/admin/dlqPage.gohtml
@@ -7,7 +7,7 @@ Configured providers: {{ .Providers }}<br />
 
 {{- if .FileErrors }}
 <h2>File DLQ</h2>
-<table border="1">
+<table class="table table-bordered">
 <tr><th>Time</th><th>Message</th></tr>
 {{- range .FileErrors }}
 <tr><td>{{ localTime .Time }}</td><td>{{ .Message }}</td></tr>
@@ -28,7 +28,7 @@ Configured providers: {{ .Providers }}<br />
 
 {{- if .DirErrors }}
 <h2>Directory DLQ</h2>
-<table border="1">
+<table class="table table-bordered">
 <tr><th>Name</th><th>Message</th></tr>
 {{- range .DirErrors }}
 <tr><td>{{ .Name }}</td><td>{{ .Message }}</td></tr>
@@ -43,7 +43,7 @@ Configured providers: {{ .Providers }}<br />
 <h2>Database DLQ</h2>
 <form method="post">
     {{ csrfField }}
-<table border="1">
+<table class="table table-bordered">
 <tr><th>Select</th><th>ID</th><th>Message</th><th>Created</th></tr>
 {{- range .Errors }}
 <tr>

--- a/core/templates/site/admin/emailFailedPage.gohtml
+++ b/core/templates/site/admin/emailFailedPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 [<a href="/admin">Admin:</a> <a href="/admin/email/failed">(This page/Refresh)</a> | <a href="/admin/email/queue">Queue</a> | <a href="/admin/email/sent">Sent</a>]<br />
-<table border="1">
+<table class="table table-bordered">
 <tr><th>ID</th><th>To</th><th>Subject</th><th>Errors</th><th>Created</th></tr>
 {{- range .Emails }}
 <tr>

--- a/core/templates/site/admin/emailQueuePage.gohtml
+++ b/core/templates/site/admin/emailQueuePage.gohtml
@@ -2,7 +2,7 @@
     [<a href="/admin">Admin:</a> <a href="/admin/email/queue">(This page/Refresh)</a> | <a href="/admin/email/failed">Failed</a> | <a href="/admin/email/sent">Sent</a>]<br />
 <form method="post">
         {{ csrfField }}
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Select</th><th>ID</th><th>To</th><th>Subject</th><th>Created</th></tr>
     {{- range .Emails }}
     <tr>

--- a/core/templates/site/admin/emailSentPage.gohtml
+++ b/core/templates/site/admin/emailSentPage.gohtml
@@ -2,7 +2,7 @@
 [<a href="/admin">Admin:</a> <a href="/admin/email/sent">(This page/Refresh)</a> | <a href="/admin/email/queue">Queue</a> | <a href="/admin/email/failed">Failed</a>]<br />
 <form method="post">
     {{ csrfField }}
-<table border="1">
+<table class="table table-bordered">
 <tr><th>Select</th><th>ID</th><th>To</th><th>Subject</th><th>Retries</th><th>Outcome</th></tr>
 {{- range .Emails }}
 <tr>

--- a/core/templates/site/admin/emailTemplateListPage.gohtml
+++ b/core/templates/site/admin/emailTemplateListPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 [<a href="/admin">Admin</a>]<br />
 {{ with .Infos }}
-<table border="1">
+<table class="table table-bordered">
 <tr><th>Section</th><th>Task</th><th>Self Email</th><th>Self Internal</th><th>Direct Email</th><th>Target Email</th><th>Target Internal</th><th>Subscribed Email</th><th>Subscribed Internal</th><th>Admin Email</th><th>Admin Internal</th></tr>
 {{- range . }}
 <tr>

--- a/core/templates/site/admin/externalLinksPage.gohtml
+++ b/core/templates/site/admin/externalLinksPage.gohtml
@@ -2,7 +2,7 @@
 <h2>External Links</h2>
 <form method="post">
     {{ csrfField }}
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Select</th><th>ID</th><th>URL</th><th>Clicks</th><th>Created</th><th>Updated</th><th>Card Title</th><th>Card Description</th><th>Card Image Cache</th><th>Favicon Cache</th></tr>
     {{- range .Links }}
     <tr>

--- a/core/templates/site/admin/grantPage.gohtml
+++ b/core/templates/site/admin/grantPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <p><a href="/admin/grants">Back to grants</a></p>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Field</th><th>Value</th></tr>
 <tr><td>User</td><td>{{ if .Grant.UserID.Valid }}<a href="/admin/user/{{ .Grant.UserID.Int32 }}">{{ .Grant.UserName }} ({{ .Grant.UserID.Int32 }})</a>{{ else if not .Grant.RoleID.Valid }}<a href="/admin/grants/anyone">{{ .Grant.UserName }}</a>{{ else }}-{{ end }}</td></tr>
     <tr><td>Role</td><td>{{ if .Grant.RoleID.Valid }}<a href="/admin/role/{{ .Grant.RoleID.Int32 }}">{{ .Grant.RoleName }} ({{ .Grant.RoleID.Int32 }})</a>{{ else }}-{{ end }}</td></tr>

--- a/core/templates/site/admin/grantsPage.gohtml
+++ b/core/templates/site/admin/grantsPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <p><a href="/admin/grant/add">Add grant</a></p>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>User</th><th>Role</th><th>Section</th><th>Item</th><th>Item ID</th><th>Actions</th></tr>
     {{- range .Grants }}
     <tr>

--- a/core/templates/site/admin/ipBanPage.gohtml
+++ b/core/templates/site/admin/ipBanPage.gohtml
@@ -9,7 +9,7 @@
 </form>
 <form method="post">
     {{ csrfField }}
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Select</th><th>IP</th><th>Reason</th><th>Created</th><th>Expires</th><th>Cancelled</th></tr>
     {{- range .Bans }}
     <tr>

--- a/core/templates/site/admin/loginAttemptsPage.gohtml
+++ b/core/templates/site/admin/loginAttemptsPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Time</th><th>Username</th><th>IP</th></tr>
     {{- range cd.AdminLoginAttempts }}
     <tr>

--- a/core/templates/site/admin/notificationsPage.gohtml
+++ b/core/templates/site/admin/notificationsPage.gohtml
@@ -3,7 +3,7 @@
     <div>Total: {{ .Total }} Unread: {{ .Unread }}</div>
 <form method="post">
     {{ csrfField }}
-<table border="1">
+<table class="table table-bordered">
     <tr><th><label><input type="checkbox" id="select-all"> All</label>
         <button type="button" id="select-none">None</button>
         <button type="button" id="select-invert">Invert</button></th><th>ID</th><th>User</th><th>Message</th><th>Link</th><th>Read</th></tr>

--- a/core/templates/site/admin/page.gohtml
+++ b/core/templates/site/admin/page.gohtml
@@ -20,7 +20,7 @@
 <h3>Site statistics</h3>
 {{ $stats := cd.AdminDashboardStats }}
 {{ if $stats }}
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Item</th><th>Count</th></tr>
     <tr><td>Users</td><td>{{ $stats.Users }}</td></tr>
     <tr><td>Languages</td><td>{{ $stats.Languages }}</td></tr>

--- a/core/templates/site/admin/pendingUsersPage.gohtml
+++ b/core/templates/site/admin/pendingUsersPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
     [<a href="/admin">Admin:</a> <a href="/admin/users/pending">(This page/Refresh)</a>]<br />
-    <table border="1">
+    <table class="table table-bordered">
         <tr><th>ID</th><th>User</th><th>Email</th><th>Actions</th></tr>
         {{range .Rows}}
         <tr>

--- a/core/templates/site/admin/permissionsSectionPage.gohtml
+++ b/core/templates/site/admin/permissionsSectionPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
     [<a href="/admin">Admin:</a> <a href="/admin/permissions/sections">(This page/Refresh)</a>]<br />
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Section</th><th>Count</th></tr>
     {{ range $.Sections }}
     <tr>

--- a/core/templates/site/admin/permissionsSectionViewPage.gohtml
+++ b/core/templates/site/admin/permissionsSectionViewPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 [<a href="/admin/permissions/sections">Back to sections</a>]<br/>
 <h3>Permissions for {{ .Section }}</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>User</th><th>Email</th><th>Role</th></tr>
     {{ range .Rows }}
     <tr>

--- a/core/templates/site/admin/requestArchivePage.gohtml
+++ b/core/templates/site/admin/requestArchivePage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 [<a href="/admin">Admin:</a> <a href="/admin/requests/archive">(This page/Refresh)</a> | <a href="/admin/requests">Pending</a>]<br />
 {{ if cd.ArchivedRequests }}
-<table border="1">
+<table class="table table-bordered">
 <tr><th>ID</th><th>User</th><th>Status</th><th>Value</th><th>Acted At</th></tr>
 {{ range cd.ArchivedRequests }}
 <tr>

--- a/core/templates/site/admin/requestPage.gohtml
+++ b/core/templates/site/admin/requestPage.gohtml
@@ -9,7 +9,7 @@
 {{ $comments := cd.CurrentRequestComments }}
 {{ if $comments }}
 <h3>Comments</h3>
-<table border="1">
+<table class="table table-bordered">
 <tr><th>Date</th><th>Comment</th></tr>
 {{ range $comments }}
 <tr><td>{{ localTime .CreatedAt }}</td><td>{{ .Comment }}</td></tr>

--- a/core/templates/site/admin/requestQueuePage.gohtml
+++ b/core/templates/site/admin/requestQueuePage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 [<a href="/admin">Admin:</a> <a href="/admin/requests">(This page/Refresh)</a> | <a href="/admin/requests/archive">Archive</a>]<br />
 {{ if cd.PendingRequests }}
-<table border="1">
+<table class="table table-bordered">
 <tr><th>ID</th><th>User</th><th>Field</th><th>Value</th><th>Contact</th><th>Actions</th></tr>
 {{ range cd.PendingRequests }}
 <tr>

--- a/core/templates/site/admin/roleGrantsEditor.gohtml
+++ b/core/templates/site/admin/roleGrantsEditor.gohtml
@@ -1,6 +1,6 @@
 <h3>Grants</h3>
 <button id="commit-all" class="hidden">Commit All</button>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Section</th><th>Item</th><th>Item ID</th><th>Info</th><th>Has</th><th>Disabled</th><th>Can Have</th><th>Commit</th></tr>
     {{- range .GrantGroups }}
         <tr data-section="{{ .Section }}" data-item="{{ .Item }}" data-itemid="{{ if .ItemID.Valid }}{{ .ItemID.Int32 }}{{ end }}"{{ if .Unsupported }} class="unsupported"{{ end }}>

--- a/core/templates/site/admin/rolesPage.gohtml
+++ b/core/templates/site/admin/rolesPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Name</th><th>Can Login</th><th>Is Admin</th><th>Public Profiles</th><th>Edit</th></tr>
     {{- range .Roles }}
     <tr>

--- a/core/templates/site/admin/searchPage.gohtml
+++ b/core/templates/site/admin/searchPage.gohtml
@@ -2,7 +2,7 @@
     {{ template "head" $ }}
     [<a href="/admin">Admin:</a> <a href="/admin/search">(This page/Refresh)</a>]<br />
                 <p>Search index counts:</p>
-                <table border="1">
+                <table class="table table-bordered">
                         <tr><th>Section</th><th>Entries</th></tr>
                         <tr><td>Total words</td><td>{{ .Stats.Words }}</td></tr>
                         <tr><td>Comments</td><td>{{ .Stats.Comments }}</td></tr>

--- a/core/templates/site/admin/serverStatsPage.gohtml
+++ b/core/templates/site/admin/serverStatsPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h2>Server Runtime Statistics</h2>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Metric</th><th>Value</th></tr>
     <tr><td>Goroutines</td><td>{{ .Stats.Goroutines }}</td></tr>
     <tr><td>Alloc</td><td>{{ .Stats.Alloc }}</td></tr>

--- a/core/templates/site/admin/sessionsPage.gohtml
+++ b/core/templates/site/admin/sessionsPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Session ID</th><th>User ID</th><th>Username</th><th>Delete</th></tr>
     {{- range cd.AdminSessions }}
     <tr>

--- a/core/templates/site/admin/siteSettingsPage.gohtml
+++ b/core/templates/site/admin/siteSettingsPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 <p>Configuration values resolved at startup.</p>
 <p>Config file: {{ .ConfigFile }}</p>
-<table border="1">
+<table class="table table-bordered">
     <tr>
         <th>Env</th>
         <th>Flag</th>

--- a/core/templates/site/admin/usageStatsPage.gohtml
+++ b/core/templates/site/admin/usageStatsPage.gohtml
@@ -10,7 +10,7 @@
 <h2>Usage Statistics</h2>
 
 <h3>Threads per Forum Topic</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Topic</th><th>Handler</th><th>Threads</th><th>Comments</th></tr>
     {{- range .ForumTopics }}
     <tr>
@@ -24,7 +24,7 @@
 </table>
 
 <h3>Threads per Forum Handler</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Handler</th><th>Threads</th><th>Comments</th></tr>
     {{- range .ForumHandlers }}
     <tr><td>{{ .Handler }}</td><td>{{ .Threads }}</td><td>{{ .Comments }}</td></tr>
@@ -32,7 +32,7 @@
 </table>
 
 <h3>Threads per Forum Category</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Category</th><th>Threads</th><th>Comments</th></tr>
     {{- range .ForumCategories }}
     <tr>
@@ -45,7 +45,7 @@
 </table>
 
 <h3>Writings per Category</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Category</th><th>Writings</th></tr>
     {{- range .WritingCategories }}
     <tr>
@@ -57,7 +57,7 @@
 </table>
 
 <h3>Links per Category</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Category</th><th>Links</th></tr>
     {{- range .LinkerCategories }}
     <tr>
@@ -69,7 +69,7 @@
 </table>
 
 <h3>Posts per Imageboard</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Board</th><th>Posts</th></tr>
     {{- range .Imageboards }}
     <tr>
@@ -81,7 +81,7 @@
 </table>
 
 <h3>Posts by User</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>User</th><th>Blogs</th><th>News</th><th>Comments</th><th>Images</th><th>Links</th><th>Writings</th></tr>
     {{- range .Users }}
     <tr>
@@ -93,7 +93,7 @@
 </table>
 
 <h3>Monthly Usage (from {{ .StartYear }})</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Year</th><th>Month</th><th>Blogs</th><th>News</th><th>Comments</th><th>Images</th><th>Links</th><th>Writings</th></tr>
     {{- range .Monthly }}
     <tr><td>{{ .Year }}</td><td>{{ .Month }}</td><td>{{ .Blogs }}</td><td>{{ .News }}</td><td>{{ .Comments }}</td><td>{{ .Images }}</td><td>{{ .Links }}</td><td>{{ .Writings }}</td></tr>
@@ -101,7 +101,7 @@
 </table>
 
 <h3>Monthly Usage Per User (from {{ .StartYear }})</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>User</th><th>Year</th><th>Month</th><th>Blogs</th><th>News</th><th>Comments</th><th>Images</th><th>Links</th><th>Writings</th></tr>
     {{- range .UserMonthly }}
     <tr>

--- a/core/templates/site/admin/userBlogsPage.gohtml
+++ b/core/templates/site/admin/userBlogsPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h2>Blogs by <a href="/admin/user/{{ .User.Idusers }}">{{ .User.Username.String }}</a></h2>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Date</th><th>Comments</th><th>Language</th><th>Category</th><th>Snippet</th><th>Link</th></tr>
     {{- range .Blogs }}
     <tr>

--- a/core/templates/site/admin/userCommentsPage.gohtml
+++ b/core/templates/site/admin/userCommentsPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 {{ $u := cd.CurrentProfileUser }}
 <h2>Comments by {{ $u.Username.String }}</h2>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Date</th><th>Topic</th><th>Thread</th><th>Excerpt</th><th>Link</th></tr>
     {{- range cd.AdminCommentsByUser $u.Idusers }}
     <tr>

--- a/core/templates/site/admin/userForumPage.gohtml
+++ b/core/templates/site/admin/userForumPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h2>Forum threads by {{ .User.Username.String }}</h2>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Topic</th><th>Category</th><th>Comments</th><th>Last Addition</th><th>View</th></tr>
     {{- range .Threads }}
     <tr>

--- a/core/templates/site/admin/userGrantsEditor.gohtml
+++ b/core/templates/site/admin/userGrantsEditor.gohtml
@@ -1,6 +1,6 @@
 <h3>Grants</h3>
 <button id="commit-all" class="hidden">Commit All</button>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Section</th><th>Item</th><th>Item ID</th><th>Info</th><th>Has</th><th>Disabled</th><th>Can Have</th><th>Commit</th></tr>
     {{- range .GrantGroups }}
         <tr data-section="{{ .Section }}" data-item="{{ .Item }}" data-itemid="{{ if .ItemID.Valid }}{{ .ItemID.Int32 }}{{ end }}"{{ if .Unsupported }} class="unsupported"{{ end }}>

--- a/core/templates/site/admin/userImagebbsPage.gohtml
+++ b/core/templates/site/admin/userImagebbsPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h2>Images by {{ .User.Username.String }}</h2>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Date</th><th>Board</th><th>Approved</th><th>Link</th></tr>
     {{- range .Posts }}
     <tr>

--- a/core/templates/site/admin/userLinkerPage.gohtml
+++ b/core/templates/site/admin/userLinkerPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h2>Links by {{ .User.Username.String }}</h2>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Date</th><th>Title</th><th>URL</th><th>View</th></tr>
     {{- range .Links }}
     <tr>

--- a/core/templates/site/admin/userPermissionsPage.gohtml
+++ b/core/templates/site/admin/userPermissionsPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 [<a href="/admin">Admin:</a> <a href="/admin/user/{{.User.Idusers}}">Admin profile</a>: <a href="/admin/user/{{.User.Idusers}}/permissions">(This page/Refresh)</a>]<br />
-<table border="1" class="perm-table">
+<table class="table table-bordered perm-table">
     <thead>
         <tr>
             <th class="sortable">ID</th>

--- a/core/templates/site/admin/userSubscriptionsPage.gohtml
+++ b/core/templates/site/admin/userSubscriptionsPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h2>Subscriptions of {{ .User.Username.String }}</h2>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Pattern</th><th>Method</th><th>Actions</th></tr>
     {{- range .Subs }}
     <tr>

--- a/core/templates/site/admin/userWritingsPage.gohtml
+++ b/core/templates/site/admin/userWritingsPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h2>Writings by {{ .User.Username.String }}</h2>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Title</th><th>Category</th><th>Date</th><th>Comments</th><th>Actions</th></tr>
     {{- range .Writings }}
     <tr>

--- a/core/templates/site/admin/usersPage.gohtml
+++ b/core/templates/site/admin/usersPage.gohtml
@@ -15,7 +15,7 @@
         </select>
         <input type="submit" name="task" value="Search">
     </form>
-    <table border="1">
+    <table class="table table-bordered">
         <tr>
             <th>ID</th>
             <th>User</th>

--- a/core/templates/site/blogs/adminPage.gohtml
+++ b/core/templates/site/blogs/adminPage.gohtml
@@ -1,7 +1,7 @@
 {{ define "blogsAdminPage" }}
     {{ template "head" $ }}
     <p><a href="/blogs/add">New blog post</a></p>
-    <table border="1">
+    <table class="table table-bordered">
         <tr><th>ID<th>Date<th>Writer<th>Comments<th>View</tr>
         {{ range cd.BlogList }}
             <tr>
@@ -16,7 +16,7 @@
         {{ end }}
     </table>
     <p>Blog roles:</p>
-    <table border="1">
+    <table class="table table-bordered">
         <tr><th>ID<th>User<th>Email<th>Role</tr>
         {{ range .Rows }}
             <tr>

--- a/core/templates/site/blogs/blogsAdminBlogCommentsPage.gohtml
+++ b/core/templates/site/blogs/blogsAdminBlogCommentsPage.gohtml
@@ -2,7 +2,7 @@
 {{ $blog := cd.BlogPost }}
 <h2>Blog {{ $blog.Idblogs }} Comments Admin</h2>
 <p><a href="/admin/blogs/blog/{{ $blog.Idblogs }}">Back to blog</a></p>
-<table border="1">
+<table class="table table-bordered">
     <tr>
         <th>ID</th>
         <th>User</th>

--- a/core/templates/site/blogs/blogsAdminBlogPage.gohtml
+++ b/core/templates/site/blogs/blogsAdminBlogPage.gohtml
@@ -5,7 +5,7 @@
 <div>{{ $blog.Blog.String | a4code2html }}</div>
 <p><a href="/admin/blogs/blog/{{ $blog.Idblogs }}/edit">Edit</a> | <a href="/admin/blogs/blog/{{ $blog.Idblogs }}/comments">Comments</a></p>
 <h3>Grants</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr>
         <th>ID</th>
         <th>User / Role</th>

--- a/core/templates/site/expandCategories.gohtml
+++ b/core/templates/site/expandCategories.gohtml
@@ -1,7 +1,7 @@
 {{ define "expandCategories" }}
     <font size="4">Topics:</font><br>
     {{ range .Categories }}
-        <table width="90%" border="1" align="center">
+        <table width="90%" align="center" class="table table-bordered">
             <tr>
                 <td>
                     {{ if .Admin }}

--- a/core/templates/site/forum/adminCategoryGrantsPage.gohtml
+++ b/core/templates/site/forum/adminCategoryGrantsPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h3>Category {{ .CategoryID }} Grants</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr>
         <th>ID</th>
         <th>User / Role</th>

--- a/core/templates/site/forum/adminPage.gohtml
+++ b/core/templates/site/forum/adminPage.gohtml
@@ -9,7 +9,7 @@
 </ul>
 
 <p>Forum statistics:</p>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Item</th><th>Count</th></tr>
     <tr><td>Categories</td><td>{{ .Stats.Categories }}</td></tr>
     <tr><td>Topics</td><td>{{ .Stats.Topics }}</td></tr>

--- a/core/templates/site/forum/adminThreadPage.gohtml
+++ b/core/templates/site/forum/adminThreadPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h2>Forum thread {{ .Thread.Idforumthread }}</h2>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID<th>Posts<th>Last Addition<th>View public</tr>
     <tr>
         <td>{{ .Thread.Idforumthread }}</td>

--- a/core/templates/site/forum/adminThreadsPage.gohtml
+++ b/core/templates/site/forum/adminThreadsPage.gohtml
@@ -2,7 +2,7 @@
 {{ $cd := cd }}
 {{ range $topic := $cd.AdminForumTopics }}
     <h2>{{ $topic.Title.String }}</h2>
-    <table border="1">
+    <table class="table table-bordered">
         <tr><th>ID<th>Posts<th>Last Addition<th>View public</tr>
         {{ range $cd.ForumThreads $topic.Idforumtopic }}
             <tr>

--- a/core/templates/site/forum/adminTopicGrantsPage.gohtml
+++ b/core/templates/site/forum/adminTopicGrantsPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 <h3>Topic {{ .TopicID }} Grants</h3>
 <button id="commit-all" class="hidden">Commit All</button>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>Action</th><th>Has</th><th>Disabled</th><th>Can Have</th><th>Commit</th></tr>
     {{- range .GrantGroups }}
     <tr data-action="{{ .Action }}">

--- a/core/templates/site/forum/adminTopicPage.gohtml
+++ b/core/templates/site/forum/adminTopicPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 <h2>Forum topic {{ .Topic.Idforumtopic }} - {{ .Topic.Title.String }}</h2>
 <p>{{ .Topic.Description.String }}</p>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Threads</th><th>Posts</th><th>Last Addition</th><th>View</th></tr>
     <tr>
         <td>{{ .Topic.Idforumtopic }}</td>

--- a/core/templates/site/forum/adminTopicsPage.gohtml
+++ b/core/templates/site/forum/adminTopicsPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID<th>Title<th>Threads<th>Posts<th>View</tr>
     {{ range .Topics }}
         <tr>

--- a/core/templates/site/forum/categories.gohtml
+++ b/core/templates/site/forum/categories.gohtml
@@ -1,6 +1,6 @@
 {{ define "getAllForumCategories" }}
     {{ if .Categories }}
-        <table align="center" width="90%" border="1">
+        <table align="center" width="90%" class="table table-bordered">
             {{ range .Categories }}
             <tr>
                 <td>

--- a/core/templates/site/forum/forumAdminCategoriesPage.gohtml
+++ b/core/templates/site/forum/forumAdminCategoriesPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-<table border="1">
+<table class="table table-bordered">
     <tr>
         <th>ID</th>
         <th>Parent ID</th>

--- a/core/templates/site/forum/forumAdminCategoryPage.gohtml
+++ b/core/templates/site/forum/forumAdminCategoryPage.gohtml
@@ -7,7 +7,7 @@
 <p>{{ .Category.Description.String }}</p>
 <h3 id="topics">Topics</h3>
 <p><a href="/admin/forum/topics">Create Topic</a></p>
-<table border="1">
+<table class="table table-bordered">
     <tr>
         <th>ID</th>
         <th>Title</th>

--- a/core/templates/site/imagebbs/adminBoardListPage.gohtml
+++ b/core/templates/site/imagebbs/adminBoardListPage.gohtml
@@ -5,7 +5,7 @@
     <li><a href="/imagebbs/board/{{ .Board.Idimageboard }}">Public View</a></li>
 </ul>
 <h2>Images for Board {{ .Board.Idimageboard }}</h2>
-<table border="1">
+<table class="table table-bordered">
 <tr><th>ID<th>User<th>Description<th>Posted<th>Comments<th>Approved</tr>
 {{ range .Posts }}
 <tr>

--- a/core/templates/site/imagebbs/adminBoardViewPage.gohtml
+++ b/core/templates/site/imagebbs/adminBoardViewPage.gohtml
@@ -11,7 +11,7 @@
 </ul>
 
 <h3>Recent Posts</h3>
-<table border="1">
+<table class="table table-bordered">
 <tr><th>ID</th><th>User</th><th>Description</th><th>Posted</th><th>View</th></tr>
 {{ range .Posts }}
 <tr>

--- a/core/templates/site/imagebbs/adminBoardsPage.gohtml
+++ b/core/templates/site/imagebbs/adminBoardsPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID<th>Title<th>Threads<th>Dashboard<th>Edit</tr>
     {{ range .Boards }}
     <tr>

--- a/core/templates/site/imagebbs/adminPage.gohtml
+++ b/core/templates/site/imagebbs/adminPage.gohtml
@@ -8,7 +8,7 @@
 
     {{- if .Stats }}
     <p>Imageboard statistics:</p>
-    <table border="1">
+    <table class="table table-bordered">
         <tr><th>Board</th><th>Posts</th></tr>
         {{- range .Stats }}
         <tr><td>{{ .Title.String }}</td><td>{{ .Count }}</td></tr>

--- a/core/templates/site/imagebbs/adminPostCommentsPage.gohtml
+++ b/core/templates/site/imagebbs/adminPostCommentsPage.gohtml
@@ -4,7 +4,7 @@
     <a href="/admin/user/{{ .Post.UsersIdusers }}/imagebbs/post/{{ .Post.Idimagepost }}">Back to dashboard</a> |
     <a href="/admin/user/{{ .Post.UsersIdusers }}/imagebbs/post/{{ .Post.Idimagepost }}/edit">Edit Post</a>
 </p>
-<table border="1">
+<table class="table table-bordered">
 <tr><th>ID</th><th>User</th><th>Excerpt</th><th>Link</th></tr>
 {{ range .Comments }}
 <tr>

--- a/core/templates/site/linker/adminCategoryGrantsPage.gohtml
+++ b/core/templates/site/linker/adminCategoryGrantsPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h3>Category {{ .CategoryID }} Grants</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr>
         <th>ID</th>
         <th>User / Role</th>

--- a/core/templates/site/linker/adminLinkGrantsPage.gohtml
+++ b/core/templates/site/linker/adminLinkGrantsPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h3>Link {{ .LinkID }} Grants</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr>
         <th>ID</th>
         <th>User / Role</th>

--- a/core/templates/site/linker/linkerAdminCategoriesPage.gohtml
+++ b/core/templates/site/linker/linkerAdminCategoriesPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-    <table border="1">
+    <table class="table table-bordered">
         <tr>
             <th>ID</th>
             <th>Order</th>

--- a/core/templates/site/linker/linkerAdminCategoryPage.gohtml
+++ b/core/templates/site/linker/linkerAdminCategoryPage.gohtml
@@ -8,7 +8,7 @@
     <a href="/admin/linker/categories/category/{{ .CategoryID }}/grants">Permissions</a>
 </p>
 <h3 id="links">Links</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr>
         <th>ID</th>
         <th>Title</th>

--- a/core/templates/site/linker/linkerAdminDashboardPage.gohtml
+++ b/core/templates/site/linker/linkerAdminDashboardPage.gohtml
@@ -7,7 +7,7 @@
     <li><a href="/admin/linker/add">Add link</a></li>
 </ul>
 <h3>Roles</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr>
         <th>ID</th>
         <th>Name</th>

--- a/core/templates/site/linker/linkerAdminLinksPage.gohtml
+++ b/core/templates/site/linker/linkerAdminLinksPage.gohtml
@@ -2,7 +2,7 @@
 <h2>All Links</h2>
 {{- range cd.LinkerCategories }}
 <h3>{{ .Title.String }} ({{ .ID }})</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID</th><th>Title</th><th>URL</th><th>Poster</th><th>View</th></tr>
     {{- range cd.LinkerLinksByCategoryID .ID }}
     <tr>

--- a/core/templates/site/news/adminNewsListPage.gohtml
+++ b/core/templates/site/news/adminNewsListPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 {{ if .Error }}<p>{{ .Error }}</p>{{ end }}
 {{ if .CanPost }}<p><a href="/news/post">New post</a></p>{{ end }}
-<table border="1">
+<table class="table table-bordered">
     <tr><th>ID<th>Date<th>Writer<th>Comments<th>View</tr>
     {{ range cd.AdminLatestNews }}
         <tr>
@@ -17,7 +17,7 @@
 </table>
 {{ if .UserRoles }}
 <h2>News Roles</h2>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>User</th><th>Email</th><th>Roles</th></tr>
     {{ range .UserRoles }}
     <tr>

--- a/core/templates/site/user/emailPage.gohtml
+++ b/core/templates/site/user/emailPage.gohtml
@@ -9,7 +9,7 @@
     </form>
 
     <h3>Verified Emails</h3>
-    <table border="1">
+    <table class="table table-bordered">
     {{ range .Verified }}
         <tr><td>{{ .Email }}</td><td>{{ if .VerifiedAt.Valid }}{{ localTime .VerifiedAt.Time }}{{ end }}</td><td>
             <form method="post" action="/usr/email/delete" style="display:inline">{{ csrfField }}<input type="hidden" name="id" value="{{ .ID }}"><input type="hidden" name="task" value="Delete"><input type="submit" value="Delete"></form>
@@ -22,7 +22,7 @@
 
     {{- if .Unverified }}
     <h3>Unverified Emails</h3>
-    <table border="1">
+    <table class="table table-bordered">
     {{ range .Unverified }}
         <tr><td>{{ .Email }}</td><td>
             <form method="post" action="/usr/email/delete" style="display:inline">{{ csrfField }}<input type="hidden" name="id" value="{{ .ID }}"><input type="hidden" name="task" value="Delete"><input type="submit" value="Delete"></form>

--- a/core/templates/site/writings/adminCategoryGrantsPage.gohtml
+++ b/core/templates/site/writings/adminCategoryGrantsPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <h3>Category <a href="/admin/writings/categories/category/{{ .CategoryID }}">{{ .CategoryID }}</a> Grants</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr>
         <th>ID</th>
         <th>User / Role</th>

--- a/core/templates/site/writings/adminWritingsPage.gohtml
+++ b/core/templates/site/writings/adminWritingsPage.gohtml
@@ -2,7 +2,7 @@
 {{ if .CanPost }}<p><a href="/writings/add">New writing</a></p>{{ end }}
 {{ if .UserRoles }}
 <h2>Writing Roles</h2>
-<table border="1">
+<table class="table table-bordered">
     <tr><th>User</th><th>Email</th><th>Roles</th></tr>
     {{ range .UserRoles }}
     <tr>

--- a/core/templates/site/writings/writingsAdminCategoriesPage.gohtml
+++ b/core/templates/site/writings/writingsAdminCategoriesPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-    <table border="1">
+    <table class="table table-bordered">
         <tr>
             <th>ID</th>
             <th>Parent ID</th>

--- a/core/templates/site/writings/writingsAdminCategoryPage.gohtml
+++ b/core/templates/site/writings/writingsAdminCategoryPage.gohtml
@@ -2,7 +2,7 @@
 <h2>Writing Category {{ .Category.Idwritingcategory }} - {{ .Category.Title.String }}</h2>
 <p>{{ .Category.Description.String }}</p>
 <h3 id="writings">Writings</h3>
-<table border="1">
+<table class="table table-bordered">
     <tr>
         <th>ID</th>
         <th>Title</th>

--- a/core/templates/site/writings/writingsAdminPage.gohtml
+++ b/core/templates/site/writings/writingsAdminPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 <h1>Writings Admin</h1>
 <p><a href="/writings/add">New writing</a></p>
-<table border="1">
+<table class="table table-bordered">
     <tr>
         <th>ID</th>
         <th>User</th>

--- a/core/templates/site/writings/writingsUserPermissionsPage.gohtml
+++ b/core/templates/site/writings/writingsUserPermissionsPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-        <table border="1">
+        <table class="table table-bordered">
             <tr>
                 <th>ID
                 <th>User


### PR DESCRIPTION
## Summary
- drop `border="1"` from site templates and apply `table table-bordered` classes for consistent styling
- add CSS rules for `.table` and `.table-bordered` to recreate 1px table borders

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899eb7da68c832f8f2f6c3ae0889523