### PR TITLE
Ensure thread pages have titles

### DIFF
--- a/handlers/forum/forumThreadPage.go
+++ b/handlers/forum/forumThreadPage.go
@@ -1,12 +1,14 @@
 package forum
 
 import (
+	"database/sql"
 	"fmt"
 	"github.com/arran4/goa4web/core/consts"
 	"log"
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/arran4/goa4web/a4code"
 	"github.com/arran4/goa4web/core/common"
@@ -61,7 +63,26 @@ func ThreadPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 		handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 		return
 	}
-	cd.PageTitle = fmt.Sprintf("Forum - %s", topicRow.Title.String)
+	displayTitle := topicRow.Title.String
+	if topicRow.Handler == "private" && cd.Queries() != nil {
+		parts, err := cd.Queries().ListPrivateTopicParticipantsByTopicIDForUser(r.Context(), db.ListPrivateTopicParticipantsByTopicIDForUserParams{
+			TopicID:  sql.NullInt32{Int32: topicRow.Idforumtopic, Valid: true},
+			ViewerID: sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
+		})
+		if err != nil {
+			log.Printf("list private participants: %v", err)
+		}
+		var names []string
+		for _, p := range parts {
+			if p.Idusers != cd.UserID {
+				names = append(names, p.Username.String)
+			}
+		}
+		if len(names) > 0 {
+			displayTitle = strings.Join(names, ", ")
+		}
+	}
+	cd.PageTitle = fmt.Sprintf("Forum - %s", displayTitle)
 
 	if _, ok := core.GetSessionOrFail(w, r); !ok {
 		return

--- a/handlers/forum/forumThreadPage_private_title_test.go
+++ b/handlers/forum/forumThreadPage_private_title_test.go
@@ -1,0 +1,70 @@
+package forum
+
+import (
+	"context"
+	"database/sql"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestThreadPagePrivateSetsTitle(t *testing.T) {
+	dbconn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer dbconn.Close()
+
+	mock.ExpectQuery("SELECT th.idforumthread").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername",
+		}).AddRow(int32(1), int32(1), int32(1), int32(1), sql.NullInt32{}, sql.NullTime{}, sql.NullBool{}, sql.NullString{}))
+
+	mock.ExpectQuery("SELECT").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername",
+		}).AddRow(int32(1), int32(1), int32(1), int32(1), sql.NullString{}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullTime{}, "private", sql.NullString{}))
+
+	mock.ExpectQuery("SELECT").
+		WillReturnRows(sqlmock.NewRows([]string{"idusers", "username"}).AddRow(int32(2), sql.NullString{String: "Bob", Valid: true}))
+
+	origStore := core.Store
+	origName := core.SessionName
+	core.Store = sessions.NewCookieStore([]byte("test"))
+	core.SessionName = "test-session"
+	defer func() {
+		core.Store = origStore
+		core.SessionName = origName
+	}()
+
+	req := httptest.NewRequest("GET", "/private/topic/1/thread/1", nil)
+	req = mux.SetURLVars(req, map[string]string{"topic": "1", "thread": "1"})
+	// Inject an invalid session to force GetSessionOrFail to fail before rendering.
+	ctx := context.WithValue(req.Context(), core.ContextValues("session"), "bad")
+
+	q := db.New(dbconn)
+	cfg := config.NewRuntimeConfig()
+	cd := common.NewCoreData(ctx, q, cfg)
+	cd.SetCurrentSection("privateforum")
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	ThreadPageWithBasePath(rr, req, "/private")
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if cd.PageTitle == "" {
+		t.Fatalf("page title not set")
+	}
+}


### PR DESCRIPTION
## Summary
- derive display titles for private threads from participant usernames
- add regression test for private thread page title

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestNewsPostPageNoDuplicateLabels)*


------
https://chatgpt.com/codex/tasks/task_e_6899eb4d99f4832f9fee71ca9db13b8f