### PR TITLE
Replace deprecated formatting tags

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -97,6 +97,10 @@ h1 {
         background-color: transparent;
 }
 
+.underline {
+        text-decoration: underline;
+}
+
 .section-title {
         font-size: 1.2em;
 }

--- a/core/templates/email/adminPasswordResetEmail.gohtml
+++ b/core/templates/email/adminPasswordResetEmail.gohtml
@@ -1,4 +1,4 @@
 <p>Hi {{.Item.Username}},</p>
 <p>An administrator has reset your password.</p>
-<p>Your new password is <b>{{.Item.Password}}</b>.</p>
+<p>Your new password is <strong>{{.Item.Password}}</strong>.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/passwordResetEmail.gohtml
+++ b/core/templates/email/passwordResetEmail.gohtml
@@ -1,5 +1,5 @@
 <p>Hi {{.Item.Username}},</p>
-<p>Use code <b>{{.Item.Code}}</b> when logging in with your new password.</p>
+<p>Use code <strong>{{.Item.Code}}</strong> when logging in with your new password.</p>
 <p>If you didn't request this change, you can ignore this email.</p>
 
 <p><a href="{{.Item.ResetURL}}">Reset password</a></p>

--- a/core/templates/site/bookmarks/page.gohtml
+++ b/core/templates/site/bookmarks/page.gohtml
@@ -2,7 +2,7 @@
     {{ template "head" $ }}
     <a href="/bookmarks/mine">View bookmarks</a><br>
     <a href="/bookmarks/edit">Edit page.</a><br>
-    <b><u>How to use this?</u></b><br>
+    <strong><span class="underline">How to use this?</span></strong><br>
     Simply. First edit your page using the keywords below then set it as your start page.<br>
     "<URL> <Name> <Newline>" - Will create a link to URL with name, if you need to use a space make it %20 and use that.<br>
     "Category: <name> <Newline>" - Creates a category named <name>.<br>

--- a/core/templates/site/expandCategories.gohtml
+++ b/core/templates/site/expandCategories.gohtml
@@ -33,7 +33,7 @@
                         <textarea name="desc" cols="30" rows="3">{{ .Description }}</textarea><br>
                 {{ else }}
                     <a href="?topic={{ .ID }}">{{ .Title }}</a><br>
-                    <i>{{ .Description }}</i><br>
+                    <em>{{ .Description }}</em><br>
                 {{ end }}
                 {{ if .LastReply }}
                     <td align="center">{{ .LastReply }}<br>{{ .LastUser }}</td>

--- a/core/templates/site/footer.gohtml
+++ b/core/templates/site/footer.gohtml
@@ -1,7 +1,7 @@
 {{define "footer"}}
 <div>
         Date and time is now: {{now}}<br>
-        <i>Arran 2004-2005, 2023-2025; All works on this page copyrighted to their respective authors.</i><br>
+        <em>Arran 2004-2005, 2023-2025; All works on this page copyrighted to their respective authors.</em><br>
         <a href="https://github.com/arran4/goa4web">GitHub</a> Version {{version}}
 </div>
 {{end}}

--- a/core/templates/site/listAbstracts.gohtml
+++ b/core/templates/site/listAbstracts.gohtml
@@ -17,7 +17,7 @@
         {{ $labels := WritingLabels $idwriting }}
         <table width="100%">
             <tr><th bgcolor="lightgrey">{{ $title }} By {{ $username }} on {{ $published }}
-                {{ if $private }} - <i>Warning: Privileged information.</i>{{ end }}
+                {{ if $private }} - <em>Warning: Privileged information.</em>{{ end }}
             </th></tr>
             <tr><td>Abstract:<br>{{ $abstract }}
                 <br>-<br><a href="/writings/article/{{ $idwriting }}">Read now</a> - {{ $comments }} comments exist.

--- a/core/templates/site/tableTopics.gohtml
+++ b/core/templates/site/tableTopics.gohtml
@@ -14,7 +14,7 @@
                 {{ $title := .Title.String }}
                 {{ if .DisplayTitle }}{{ $title = .DisplayTitle }}{{ end }}
                 <a href="{{$base}}/topic/{{ .Idforumtopic }}">{{ $title | a4code2html }}</a>{{ if and cd.IsAdmin cd.IsAdminMode }} [<a href="/admin/forum/topics/topic/{{ .Idforumtopic }}/edit">ADMIN</a>]{{ end }}<br>
-                {{ with .Description.String }}<i>{{ . | a4code2html }}</i>{{ end }}
+                {{ with .Description.String }}<em>{{ . | a4code2html }}</em>{{ end }}
                 {{- if .Labels }}<br>{{ template "topicLabels" .Labels }}{{ end }}
             </td>
             <td align="center">{{ localTime .Lastaddition.Time }}<br>{{ .Lastposterusername.String }}</td>


### PR DESCRIPTION
## Summary
- replace `<b>` and `<i>` tags in templates with `<strong>` and `<em>`
- swap `<u>` tags for `<span class="underline">` and add `.underline` CSS
- keep email and site templates stylistically consistent

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestNewsPostPageNoDuplicateLabels expected 1 label bar, got 2)*

------
https://chatgpt.com/codex/tasks/task_e_6899ef644ea8832fbff327a318ac3f2f