### PR TITLE
Refactor linker page title and style

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -91,13 +91,21 @@ a:hover {
 	color: #FF0000;
 }
 h1 {
-	font-family: tahoma, arial, helvetica, sans-serif;
-	text-align: center;
-	color: #800000;
-	background-color: transparent;
+        font-family: tahoma, arial, helvetica, sans-serif;
+        text-align: center;
+        color: #800000;
+        background-color: transparent;
+}
+.section-title {
+        font-family: tahoma, arial, helvetica, sans-serif;
+        font-size: 1.5em;
+        font-weight: normal;
+        color: #800000;
+        background-color: transparent;
+        margin: 0 0 1em 0;
 }
 div.index {
-	text-align: center;
+        text-align: center;
 }
 div.index table {
 	margin-left: auto;

--- a/core/templates/site/linker/linkerPage.gohtml
+++ b/core/templates/site/linker/linkerPage.gohtml
@@ -1,4 +1,4 @@
 {{ template "head" $ }}
-    <font size="5">{{ .Username }}'s links.</font><br>
+    <h2 class="section-title">{{ .Username }}'s links.</h2>
     {{ template "getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingLinks" $ }}
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- Replace deprecated font element with semantic `<h2>` on linker page using generic `.section-title`
- Add `.section-title` styling to main stylesheet to match previous appearance

## Testing
- `go mod tidy`
- `go fmt ./...`
- `timeout 5 go vet ./...`
- `golangci-lint run`
- `go test ./...` *(failed: TestNewsPostPageNoDuplicateLabels)*

------
https://chatgpt.com/codex/tasks/task_e_6899eb6349a0832f8c9c9d886bfc79c9