### PR TITLE
refactor: replace inline styling with css classes

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -17,6 +17,24 @@ textarea {
         flex: none;
 }
 
+/* Utility classes */
+.bg-muted {
+        background-color: lightgrey;
+}
+
+.text-centered {
+        text-align: center;
+}
+
+.centered-table {
+        margin-left: auto;
+        margin-right: auto;
+}
+
+.top-aligned td {
+        vertical-align: top;
+}
+
 .navbar {
         display: flex;
         justify-content: space-between;

--- a/core/templates/site/blogs/blogPage.gohtml
+++ b/core/templates/site/blogs/blogPage.gohtml
@@ -3,11 +3,11 @@
         <font size="5"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</font><br>
         <table width="100%">
                 <tr>
-                    <th bgcolor="lightgrey">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>
+                    <th class="bg-muted">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>
                 </tr>
                 <tr>
                     <td>
-        {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <span class="label-bar">{{ template "topicLabels" .Labels }}</span>{{ end }}
+        {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <span class="label-list">{{ template "topicLabels" .Labels }}</span>{{ end }}
                     </td>
                 </tr>
         </table><br>

--- a/core/templates/site/blogs/bloggerPostsPage.gohtml
+++ b/core/templates/site/blogs/bloggerPostsPage.gohtml
@@ -9,12 +9,12 @@
             <table width="100%">
                 {{range $rows}}
                     <tr>
-                        <th bgcolor="lightgrey">{{ localTimeIn .Written .Timezone.String }}</th>
+                        <th class="bg-muted">{{ localTimeIn .Written .Timezone.String }}</th>
                     </tr>
                 <tr>
                     <td>
                         {{ $labels := BlogLabels .Idblogs }}
-                        {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{.Idblogs}}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-bar">{{ template "topicLabels" $labels }}</span>{{ end }}
+                        {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{.Idblogs}}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-list">{{ template "topicLabels" $labels }}</span>{{ end }}
                     </td>
                 </tr>
             {{end}}

--- a/core/templates/site/blogs/commentPage.gohtml
+++ b/core/templates/site/blogs/commentPage.gohtml
@@ -4,7 +4,7 @@
             <font size="5"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</font><br>
             <table width="100%">
                 <tr>
-                    <th bgcolor="lightgrey">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>
+                    <th class="bg-muted">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>
                 </tr>
                 <tr>
                     <td>

--- a/core/templates/site/blogs/page.gohtml
+++ b/core/templates/site/blogs/page.gohtml
@@ -16,12 +16,12 @@
     <table width="100%">
         {{ range $rows }}
             <tr>
-                <th bgcolor="lightgrey">{{ localTimeIn .Written .Timezone.String }}</th>
+                <th class="bg-muted">{{ localTimeIn .Written .Timezone.String }}</th>
             </tr>
             <tr>
                 <td>
                     {{ $labels := BlogLabels .Idblogs }}
-                    {{ .Blog.String | a4code2html}}<br><br>{{ .Username.String }} - [<a href="/blogs/blog/{{ .Idblogs }}/comments">{{ .Comments }} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{ .Idblogs }}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{ .Idblogs }}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-bar">{{ template "topicLabels" $labels }}</span>{{ end }}
+                    {{ .Blog.String | a4code2html}}<br><br>{{ .Username.String }} - [<a href="/blogs/blog/{{ .Idblogs }}/comments">{{ .Comments }} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{ .Idblogs }}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{ .Idblogs }}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-list">{{ template "topicLabels" $labels }}</span>{{ end }}
                 </td>
             </tr>
         {{ else }}

--- a/core/templates/site/bookmarks/minePage.gohtml
+++ b/core/templates/site/bookmarks/minePage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
 <table>
-    <tr valign="top">
+    <tr class="top-aligned">
         {{- range .Columns }}
             <td>
                 {{- range .Categories }}

--- a/core/templates/site/expandCategories.gohtml
+++ b/core/templates/site/expandCategories.gohtml
@@ -1,7 +1,7 @@
 {{ define "expandCategories" }}
     <font size="4">Topics:</font><br>
     {{ range .Categories }}
-        <table width="90%" border="1" align="center">
+        <table class="centered-table" width="90%" border="1">
             <tr>
                 <td>
                     {{ if .Admin }}
@@ -36,8 +36,8 @@
                     <i>{{ .Description }}</i><br>
                 {{ end }}
                 {{ if .LastReply }}
-                    <td align="center">{{ .LastReply }}<br>{{ .LastUser }}</td>
-                    <td align="center">{{ .Threads }}<br>{{ .Replies }}</td>
+                    <td class="text-centered">{{ .LastReply }}<br>{{ .LastUser }}</td>
+                    <td class="text-centered">{{ .Threads }}<br>{{ .Replies }}</td>
                 {{ else }}
                     <td>N/A</td><td>N/A</td>
                 {{ end }}

--- a/core/templates/site/faq/page.gohtml
+++ b/core/templates/site/faq/page.gohtml
@@ -5,7 +5,7 @@
         <table width="100%">
         {{ range $index, $faq := $categoryFAQs.FAQs }}
             <tr>
-                <th bgcolor="lightgrey">Q: {{ $faq.Question | a4code2html }}</th>
+                <th class="bg-muted">Q: {{ $faq.Question | a4code2html }}</th>
             </tr>
             <tr>
                 <td>A: {{ $faq.Answer | a4code2html }}</td>

--- a/core/templates/site/forum/categories.gohtml
+++ b/core/templates/site/forum/categories.gohtml
@@ -1,6 +1,6 @@
 {{ define "getAllForumCategories" }}
     {{ if .Categories }}
-        <table align="center" width="90%" border="1">
+        <table class="centered-table" width="90%" border="1">
             {{ range .Categories }}
             <tr>
                 <td>

--- a/core/templates/site/listAbstracts.gohtml
+++ b/core/templates/site/listAbstracts.gohtml
@@ -16,12 +16,12 @@
         {{ $comments := .Comments }}
         {{ $labels := WritingLabels $idwriting }}
         <table width="100%">
-            <tr><th bgcolor="lightgrey">{{ $title }} By {{ $username }} on {{ $published }}
+            <tr><th class="bg-muted">{{ $title }} By {{ $username }} on {{ $published }}
                 {{ if $private }} - <i>Warning: Privileged information.</i>{{ end }}
             </th></tr>
             <tr><td>Abstract:<br>{{ $abstract }}
                 <br>-<br><a href="/writings/article/{{ $idwriting }}">Read now</a> - {{ $comments }} comments exist.
-                {{ if $labels }}<span class="label-bar">{{ template "topicLabels" $labels }}</span>{{ end }}
+                {{ if $labels }}<span class="label-list">{{ template "topicLabels" $labels }}</span>{{ end }}
             </td></tr>
         </table>
     {{ else }}

--- a/core/templates/site/news/post.gohtml
+++ b/core/templates/site/news/post.gohtml
@@ -1,6 +1,6 @@
 {{ define "newsPost" }}
     <table width="100%">
-        <tr bgcolor="lightgrey">
+        <tr class="bg-muted">
             <th>{{ localTimeIn .Occurred.Time .Timezone.String }}</th>
         </tr>
         <tr>
@@ -27,7 +27,7 @@
                 </a>]
             {{ end }}
             {{ $labels := NewsLabels .Idsitenews }}
-            {{ if $labels }}<span class="label-bar">{{ template "topicLabels" $labels }}</span>{{ end }}
+            {{ if $labels }}<span class="label-list">{{ template "topicLabels" $labels }}</span>{{ end }}
             </td>
         </tr>
     </table><br>

--- a/core/templates/site/showLatestLinks.gohtml
+++ b/core/templates/site/showLatestLinks.gohtml
@@ -3,7 +3,7 @@
         {{ if .HasOffset }}
             {{- range cd.SelectedLinkerItemsForCurrentUser (int32 .CatId) (int32 .Offset) }}
                 <tr>
-                    <th bgcolor="lightgrey">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
+                    <th class="bg-muted">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
                 </tr>
                 <tr>
                     <td>
@@ -25,7 +25,7 @@
         {{ else }}
             {{- range cd.SelectedLinkerItemsForCurrentUser (int32 .CatId) 0 }}
                 <tr>
-                    <th bgcolor="lightgrey">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
+                    <th class="bg-muted">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
                 </tr>
                 <tr>
                     <td>

--- a/core/templates/site/showLinkComments.gohtml
+++ b/core/templates/site/showLinkComments.gohtml
@@ -2,7 +2,7 @@
     {{ with .Link }}
         <table width="100%">
             <tr>
-                <th bgcolor="lightgrey">{{ .Title.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
+                <th class="bg-muted">{{ .Title.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
             </tr>
             <tr>
                 <td>

--- a/core/templates/site/tableTopics.gohtml
+++ b/core/templates/site/tableTopics.gohtml
@@ -17,9 +17,9 @@
                 {{ with .Description.String }}<i>{{ . | a4code2html }}</i>{{ end }}
                 {{- if .Labels }}<br>{{ template "topicLabels" .Labels }}{{ end }}
             </td>
-            <td align="center">{{ localTime .Lastaddition.Time }}<br>{{ .Lastposterusername.String }}</td>
-            <td align="center">{{ .Threads.Int32 }}</td>
-            <td align="center">{{ .Comments.Int32 }}</td>
+            <td class="text-centered">{{ localTime .Lastaddition.Time }}<br>{{ .Lastposterusername.String }}</td>
+            <td class="text-centered">{{ .Threads.Int32 }}</td>
+            <td class="text-centered">{{ .Comments.Int32 }}</td>
         </tr>
         {{ else }}
         <tr><td colspan="4">No topics</td></tr>


### PR DESCRIPTION
## Summary
- introduce semantic utility classes for common background, alignment, and table styles
- use `label-list` for post labels to avoid clashing with existing `label-bar`

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899eb7c4880832f8fb65ede4fcdaeb3