### PR TITLE
Replace font tags with semantic markup and CSS

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -97,8 +97,13 @@ h1 {
         background-color: transparent;
 }
 
-.section-title {
+.section-title,
+.font-size-4 {
         font-size: 1.2em;
+}
+
+.font-size-5 {
+        font-size: 1.5em;
 }
 div.index {
         text-align: center;

--- a/core/templates/site/blogs/blogPage.gohtml
+++ b/core/templates/site/blogs/blogPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
         {{ $blog := cd.BlogPost }}
-        <font size="5"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</font><br>
+        <h2 class="font-size-5"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</h2><br>
         <table width="100%">
                 <tr>
                     <th bgcolor="lightgrey">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>

--- a/core/templates/site/blogs/blogReply.gohtml
+++ b/core/templates/site/blogs/blogReply.gohtml
@@ -24,7 +24,7 @@
                 </aside>
                 <section class="body">
                     <a id="bottom"></a>
-                    <font size="4">Reply:</font><br>
+                    <span class="font-size-4">Reply:</span><br>
                     <form method="post" action="/blogs/blog/{{$blog.Idblogs}}/reply">
                 {{ csrfField }}
                         <textarea id="reply" name="replytext" cols="40" rows="20">{{$.Text}}</textarea><br>

--- a/core/templates/site/blogs/bloggerListPage.gohtml
+++ b/core/templates/site/blogs/bloggerListPage.gohtml
@@ -5,7 +5,7 @@
     </form>
     {{if .Search}}
         {{if .Rows}}
-            <font size="5">Search results for "{{.Search}}".</font><br>
+            <h2 class="font-size-5">Search results for "{{.Search}}".</h2><br>
             {{range .Rows}}
                 Blogger: <a href="/blogs/blogger/{{.Username.String}}">{{.Username.String}}</a> has {{.Count}} blogs.<br>
             {{end}}
@@ -14,7 +14,7 @@
         {{end}}
     {{else}}
         {{if .Rows}}
-            <font size="5">All bloggers.</font><br>
+            <h2 class="font-size-5">All bloggers.</h2><br>
             {{range .Rows}}
                 Blogger: <a href="/blogs/blogger/{{.Username.String}}">{{.Username.String}}</a> has {{.Count}} blogs.<br>
             {{end}}

--- a/core/templates/site/blogs/bloggerPostsPage.gohtml
+++ b/core/templates/site/blogs/bloggerPostsPage.gohtml
@@ -2,9 +2,9 @@
         {{ $rows := cd.BloggerPosts }}
         {{if $rows}}
             {{if cd.CurrentProfileUserID}}
-                <font size="5"><a href="/blogs/blogger/{{(index $rows 0).Username.String}}">{{(index $rows 0).Username.String}}</a>'s blogs.</font><br>
+                <h2 class="font-size-5"><a href="/blogs/blogger/{{(index $rows 0).Username.String}}">{{(index $rows 0).Username.String}}</a>'s blogs.</h2><br>
             {{else}}
-                <font size="5"><a href="/blogs/bloggers">All bloggers</a>' blogs.</font><br>
+                <h2 class="font-size-5"><a href="/blogs/bloggers">All bloggers</a>' blogs.</h2><br>
             {{end}}
             <table width="100%">
                 {{range $rows}}

--- a/core/templates/site/blogs/commentPage.gohtml
+++ b/core/templates/site/blogs/commentPage.gohtml
@@ -1,7 +1,7 @@
 {{ define "blogs/commentPage.gohtml" }}
 {{ template "head" $ }}
             {{ $blog := cd.BlogPost }}
-            <font size="5"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</font><br>
+            <h2 class="font-size-5"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</h2><br>
             <table width="100%">
                 <tr>
                     <th bgcolor="lightgrey">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>

--- a/core/templates/site/blogs/page.gohtml
+++ b/core/templates/site/blogs/page.gohtml
@@ -8,9 +8,9 @@
     {{ end }}
     {{ if $rows }}
         {{ if cd.CurrentProfileUserID }}
-            <font size="5"><a href="/blogs/blogger/{{ (index $rows 0).Username.String }}">{{ (index $rows 0).Username.String }}</a>'s blogs.</font><br>
+            <h2 class="font-size-5"><a href="/blogs/blogger/{{ (index $rows 0).Username.String }}">{{ (index $rows 0).Username.String }}</a>'s blogs.</h2><br>
         {{ else }}
-            <font size="5"><a href="/blogs/bloggers">All bloggers</a>' blogs.</font><br>
+            <h2 class="font-size-5"><a href="/blogs/bloggers">All bloggers</a>' blogs.</h2><br>
         {{ end }}
     {{ end }}
     <table width="100%">

--- a/core/templates/site/boardPosts.gohtml
+++ b/core/templates/site/boardPosts.gohtml
@@ -2,7 +2,7 @@
     {{ $cd := cd }}
     {{ $posts := $cd.SelectedBoardPosts }}
     {{- if $posts }}
-        <font size="4">Pictures:</font><br>
+        <span class="font-size-4">Pictures:</span><br>
         {{- range $posts }}
             <table>
                 <tr>

--- a/core/templates/site/comment.gohtml
+++ b/core/templates/site/comment.gohtml
@@ -18,7 +18,7 @@
         <section class="body">
             {{ if cd.CommentEditing $cmt }}
                 <a id="edit"></a>
-                <font size="4">Edit:</font><br>
+                <span class="font-size-4">Edit:</span><br>
                 <form method="post" action="{{ cd.CommentEditSaveURL $cmt }}">
                     {{ csrfField }}
                     <textarea id="reply" name="replytext" cols="40" rows="20">{{ $cmt.Text.String }}</textarea><br>

--- a/core/templates/site/expandCategories.gohtml
+++ b/core/templates/site/expandCategories.gohtml
@@ -1,5 +1,5 @@
 {{ define "expandCategories" }}
-    <font size="4">Topics:</font><br>
+    <span class="font-size-4">Topics:</span><br>
     {{ range .Categories }}
         <table width="90%" border="1" align="center">
             <tr>

--- a/core/templates/site/faq/askPage.gohtml
+++ b/core/templates/site/faq/askPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-        <font size="5">Add a Question of your own:</font><br>
+        <h2 class="font-size-5">Add a Question of your own:</h2><br>
         <form method="post" action="">
         {{ csrfField }}
             <textarea name="text" cols="60" rows="20"></textarea><br>

--- a/core/templates/site/faq/page.gohtml
+++ b/core/templates/site/faq/page.gohtml
@@ -1,7 +1,7 @@
 {{ define "faqPage" }}
     {{ template "head" $ }}
     {{ range $index, $categoryFAQs := (cd).AllAnsweredFAQ }}
-        <font size="5">Section: {{ $categoryFAQs.Category.Name.String }}</font><br>
+        <h2 class="font-size-5">Section: {{ $categoryFAQs.Category.Name.String }}</h2><br>
         <table width="100%">
         {{ range $index, $faq := $categoryFAQs.FAQs }}
             <tr>

--- a/core/templates/site/imagebbs/boardThreadPage.gohtml
+++ b/core/templates/site/imagebbs/boardThreadPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
     {{ if .ImagePost }}
-        <font size="4">Picture:</font><br>
+        <span class="font-size-4">Picture:</span><br>
         <table>
             <tr>
                 <th><a href="{{ .ImagePost.Fullimage.String }}" target="_BLANK"><img src="{{ .ImagePost.Thumbnail.String }}"></a>
@@ -32,7 +32,7 @@
             </aside>
             <section class="body">
                 <a id="bottom"></a>
-                <font size="4">Reply:</font><br>
+                <span class="font-size-4">Reply:</span><br>
                 <form method="post" action="?board={{ .BoardID }}">
                 {{ csrfField }}
                     <input type="hidden" name="replyTo" value="{{ .ForumThreadID }}">

--- a/core/templates/site/imagebbs/posterPage.gohtml
+++ b/core/templates/site/imagebbs/posterPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
-    <font size="5">{{ .Username }}'s images.</font><br>
+    <h2 class="font-size-5">{{ .Username }}'s images.</h2><br>
     {{- if .Posts }}
-        <font size="4">Pictures:</font><br>
+        <span class="font-size-4">Pictures:</span><br>
         {{- range .Posts }}
             <table>
                 <tr>

--- a/core/templates/site/linker/linkerPage.gohtml
+++ b/core/templates/site/linker/linkerPage.gohtml
@@ -1,4 +1,4 @@
 {{ template "head" $ }}
-    <font size="5">{{ .Username }}'s links.</font><br>
+    <h2 class="font-size-5">{{ .Username }}'s links.</h2><br>
     {{ template "getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingLinks" $ }}
 {{ template "tail" $ }}

--- a/core/templates/site/listAbstracts.gohtml
+++ b/core/templates/site/listAbstracts.gohtml
@@ -4,7 +4,7 @@
     {{ end }}
     {{ $abstracts := cd.SelectedCategoryPublicWritings $.CategoryId $.Request }}
     {{ if gt (len $abstracts) 0 }}
-        <font size="4">Writing abstracts:</font><br>
+        <span class="font-size-4">Writing abstracts:</span><br>
     {{ end }}
     {{ range $abstracts }}
         {{ $title := .Title.String | a4code2html }}

--- a/core/templates/site/listWritingCategories.gohtml
+++ b/core/templates/site/listWritingCategories.gohtml
@@ -1,5 +1,5 @@
 {{ define "listWritingCategories" }}
-    <font size="4">{{ if $.WritingCategoryID }}Sub-{{ end }}Categories:</font><br>
+    <span class="font-size-4">{{ if $.WritingCategoryID }}Sub-{{ end }}Categories:</span><br>
     <table>
         {{ $cats := cd.VisibleWritingCategories }}
         {{ $found := false }}

--- a/core/templates/site/news/adminNewsPostPage.gohtml
+++ b/core/templates/site/news/adminNewsPostPage.gohtml
@@ -9,7 +9,7 @@
 <p><a href="/admin/news/article/{{ .Post.Idsitenews }}/edit">Edit</a></p>
 <p><a href="/admin/news/article/{{ .Post.Idsitenews }}/delete">Delete</a></p>
 <a id="comments"></a>
-{{ if .Comments }}<hr><font size=4>Comments:</font>{{ end }}
+{{ if .Comments }}<hr><span class="font-size-4">Comments:</span>{{ end }}
 {{ template "threadComments" }}
 <p><a href="/admin/news">Back</a></p>
 {{ template "tail" $ }}

--- a/core/templates/site/news/postPage.gohtml
+++ b/core/templates/site/news/postPage.gohtml
@@ -14,7 +14,7 @@
             <button type="submit">Mark as read and go back</button>
         </form>
     </div>
-    <hr><font size=4>Replies:</font>
+    <hr><span class="font-size-4">Replies:</span>
     {{ template "threadComments" }}
     <div class="label-editor">
         <form method="post" action="/news/news/{{ .Post.Idsitenews }}/labels" id="label-form">
@@ -69,7 +69,7 @@
             </aside>
             <section class="body">
                 <a id="bottom"></a>
-                <font size=4>Reply:</font><br>
+                <span class="font-size-4">Reply:</span><br>
                 <form method="post" action="?#bottom">
                 {{ csrfField }}
                     <input type="hidden" name="replyto" value="{{ .Thread.Idforumthread }}">

--- a/core/templates/site/postImage.gohtml
+++ b/core/templates/site/postImage.gohtml
@@ -1,5 +1,5 @@
 {{ define "postImage" }}
-        <font size="4">Post image</font>:<br>
+        <span class="font-size-4">Post image</span>:<br>
                 <form method="post" enctype="multipart/form-data">
         {{ csrfField }}
                         Image file: <input type="file" name="image"><br>

--- a/core/templates/site/showLinkComments.gohtml
+++ b/core/templates/site/showLinkComments.gohtml
@@ -41,7 +41,7 @@
                 </aside>
                 <section class="body">
                     <a id="bottom"></a>
-                    <font size="4">Reply:</font><br>
+                    <span class="font-size-4">Reply:</span><br>
                     <form method="post">
                 {{ csrfField }}
                         <input type="hidden" name="replyTo" value="{{ .ThreadID }}">

--- a/core/templates/site/subBoards.gohtml
+++ b/core/templates/site/subBoards.gohtml
@@ -2,7 +2,7 @@
     {{ $cd := cd }}
     {{ $boards := $cd.SubImageBoards $cd.SelectedBoardID }}
     {{- if $boards }}
-        <font size="4">{{ if gt ($cd.SelectedBoardID) 0 }}Sub-{{ end }}Boards:</font><br>
+        <span class="font-size-4">{{ if gt ($cd.SelectedBoardID) 0 }}Sub-{{ end }}Boards:</span><br>
         <table>
             {{- range $boards }}
                 <tr>

--- a/core/templates/site/topicRestrictions.gohtml
+++ b/core/templates/site/topicRestrictions.gohtml
@@ -1,5 +1,5 @@
 {{ define "topicRestrictions" }}
-    <font size="4">Topic Restrictions:</font><br>
+    <span class="font-size-4">Topic Restrictions:</span><br>
     <table width="100%">
         <tr>
             <th>Topic

--- a/core/templates/site/user/topicRestrictions.gohtml
+++ b/core/templates/site/user/topicRestrictions.gohtml
@@ -1,5 +1,5 @@
 {{ define "userTopicRestrictions" }}
-    <font size="4">Topic Restrictions:</font><br>
+    <span class="font-size-4">Topic Restrictions:</span><br>
     <table width="100%">
         <tr>
             <th>Topic

--- a/core/templates/site/writings/articleAddPage.gohtml
+++ b/core/templates/site/writings/articleAddPage.gohtml
@@ -1,5 +1,5 @@
 {{ template "head" $ }}
-    <font size="4">New writing:</font><br>
+    <span class="font-size-4">New writing:</span><br>
     (Please select an appropriate section before writing this.)<br>
     <form method="post">
         {{ csrfField }}

--- a/core/templates/site/writings/articleEditPage.gohtml
+++ b/core/templates/site/writings/articleEditPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
     {{ if .Writing }}
-        <font size="4">New writing:</font><br>
+        <span class="font-size-4">New writing:</span><br>
         (Please select an appropriate section before writing this.)<br>
         <form method="post">
         {{ csrfField }}

--- a/core/templates/site/writings/articlePage.gohtml
+++ b/core/templates/site/writings/articlePage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
     {{ $writing := cd.CurrentWritingLoaded }}
     {{ if $writing }}
-        <font size="4">At {{ localTime $writing.Published.Time }}, By {{ $writing.Writerusername.String }}; {{ $writing.Title.String | trim | a4code2html }}:</font>
+        <span class="font-size-4">At {{ localTime $writing.Published.Time }}, By {{ $writing.Writerusername.String }}; {{ $writing.Title.String | trim | a4code2html }}:</span>
         {{ if $writing.Private.Bool }} (Restricted access) {{ end }}
         {{ if .CanEdit }}[<a href="/writings/article/{{ $writing.Idwriting }}/edit">EDIT</a>]{{ end }}
         {{ if and cd.IsAdmin cd.IsAdminMode }}[<a href="/admin/writings/article/{{ $writing.Idwriting }}">ADMIN</a>]{{ end }}
@@ -80,7 +80,7 @@
                 </aside>
                 <section class="body">
                     <a id="bottom"></a>
-                    <hr><font size="4">Reply:</font><br>
+                    <hr><span class="font-size-4">Reply:</span><br>
                     <form method="post">
                     {{ csrfField }}
                         <textarea name="replytext" cols="40" rows="20">{{ .ReplyText }}</textarea><br>

--- a/core/templates/site/writings/writerListPage.gohtml
+++ b/core/templates/site/writings/writerListPage.gohtml
@@ -4,7 +4,7 @@
         <input type="submit" name="task" value="Search">
     </form>
     {{if .Rows}}
-        <font size="5">All writers.</font><br>
+        <h2 class="font-size-5">All writers.</h2><br>
         {{range .Rows}}
             Writer: <a href="/writings/writer/{{.Username.String}}">{{.Username.String}}</a> has {{.Count}} articles.<br>
         {{end}}

--- a/core/templates/site/writings/writerPage.gohtml
+++ b/core/templates/site/writings/writerPage.gohtml
@@ -1,4 +1,4 @@
 {{ template "head" $ }}
-    <font size="5">{{ .Username }}'s writings.</font><br>
+    <h2 class="font-size-5">{{ .Username }}'s writings.</h2><br>
     {{ template "listAbstracts" $ }}
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- replace deprecated `<font>` tags in site templates with semantic `<span>`/`<h2>` elements
- add `.font-size-4` and `.font-size-5` classes to centralize size styling

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: expected 1 label bar, got 2 in handlers/news TestNewsPostPageNoDuplicateLabels)*

------
https://chatgpt.com/codex/tasks/task_e_6899ef449eec832fa526664565981ea9