### PR TITLE
style: center footer via css

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -75,6 +75,7 @@ textarea {
 }
 
 .site-footer {
+        text-align: center;
         font-size: 0.7em;
         color: #666;
 }

--- a/core/templates/site/tail.gohtml
+++ b/core/templates/site/tail.gohtml
@@ -6,9 +6,7 @@
         <div id="bottom"></div>
         <hr>
         <footer class="site-footer">
-            <div class="text-center">
-                {{template "footer"}}
-            </div>
+            {{template "footer"}}
         </footer>
     {{ end }}
     {{ if cd.Marked "bodyEnd" }}


### PR DESCRIPTION
## Summary
- remove the extra centering wrapper from the site footer template
- center the footer text using a `.site-footer { text-align: center; }` rule in main.css

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(hangs, terminated)*
- `golangci-lint run`
- `go test ./...` *(fails: TestNewsPostPageNoDuplicateLabels)*

------
https://chatgpt.com/codex/tasks/task_e_6899ef603790832fb4d3b4ac5fed3827