### PR TITLE
Fix writing replies not marking unread

### DIFF
--- a/core/common/coredata_labels.go
+++ b/core/common/coredata_labels.go
@@ -179,6 +179,15 @@ func (cd *CoreData) ClearPrivateLabelStatus(item string, itemID int32) error {
 	return cd.queries.SystemClearContentPrivateLabel(cd.ctx, db.SystemClearContentPrivateLabelParams{Item: item, ItemID: itemID, Label: "unread"})
 }
 
+// ClearUnreadForOthers removes the inverted unread label for an item from all
+// users except the current one.
+func (cd *CoreData) ClearUnreadForOthers(item string, itemID int32) error {
+	if cd.queries == nil {
+		return nil
+	}
+	return cd.queries.ClearUnreadContentPrivateLabelExceptUser(cd.ctx, db.ClearUnreadContentPrivateLabelExceptUserParams{Item: item, ItemID: itemID, UserID: cd.UserID})
+}
+
 // SetPrivateLabelStatus updates the special new/unread flags for an item.
 func (cd *CoreData) SetPrivateLabelStatus(item string, itemID int32, newLabel, unreadLabel bool) error {
 	if cd.queries == nil {
@@ -296,6 +305,10 @@ func (cd *CoreData) ClearThreadPrivateLabelStatus(threadID int32) error {
 	return cd.ClearPrivateLabelStatus("thread", threadID)
 }
 
+func (cd *CoreData) ClearThreadUnreadForOthers(threadID int32) error {
+	return cd.ClearUnreadForOthers("thread", threadID)
+}
+
 func (cd *CoreData) SetThreadPrivateLabelStatus(threadID int32, newLabel, unreadLabel bool) error {
 	return cd.SetPrivateLabelStatus("thread", threadID, newLabel, unreadLabel)
 }
@@ -341,6 +354,10 @@ func (cd *CoreData) WritingPrivateLabels(writingID int32) ([]string, error) {
 
 func (cd *CoreData) SetWritingPrivateLabels(writingID int32, labels []string) error {
 	return cd.SetPrivateLabels("writing", writingID, labels)
+}
+
+func (cd *CoreData) ClearWritingUnreadForOthers(writingID int32) error {
+	return cd.ClearUnreadForOthers("writing", writingID)
 }
 
 // News

--- a/core/templates/site/news/postPage.gohtml
+++ b/core/templates/site/news/postPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
     {{ template "newsPost" $.Post }}
-    <div class="label-bar">
+    <div class="mark-read-bar">
         <form method="post" action="/news/news/{{ .Post.Idsitenews }}/labels" class="mark-read">
             {{ csrfField }}
             <input type="hidden" name="task" value="Mark Thread Read"/>

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -147,11 +147,8 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		log.Printf("Error: CreateComment: %s", err)
 		return fmt.Errorf("create comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if err := cd.ClearThreadPrivateLabelStatus(threadRow.Idforumthread); err != nil {
-		log.Printf("clear label status: %v", err)
-	}
-	if err := cd.SetThreadPrivateLabelStatus(threadRow.Idforumthread, false, false); err != nil {
-		log.Printf("set label status: %v", err)
+	if err := cd.ClearThreadUnreadForOthers(threadRow.Idforumthread); err != nil {
+		log.Printf("clear unread labels: %v", err)
 	}
 	if err := cd.SetThreadReadMarker(threadRow.Idforumthread, int32(cid)); err != nil {
 		log.Printf("set read marker: %v", err)

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -115,6 +115,10 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
+	if err := cd.ClearUnreadForOthers("writing", writing.Idwriting); err != nil {
+		log.Printf("clear unread labels: %v", err)
+	}
+
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 		if evt := cd.Event(); evt != nil {
 			if evt.Data == nil {

--- a/handlers/writings/reply_task_test.go
+++ b/handlers/writings/reply_task_test.go
@@ -1,14 +1,84 @@
 package writings
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/lazy"
 	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
 )
 
 func TestReplyTaskAutoSubscribe(t *testing.T) {
 	var task ReplyTask
 	if _, ok := interface{}(task).(notif.AutoSubscribeProvider); !ok {
 		t.Fatalf("AutoSubscribeProvider must auto subscribe as users will want updates")
+	}
+}
+
+func TestReplyMarksWritingUnread(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	q := db.New(conn)
+	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+	cd.UserID = 2
+
+	now := time.Now()
+	writingID := int32(1)
+	threadID := int32(3)
+
+	_, _ = cd.WritingByID(writingID, lazy.Set(&db.GetWritingForListerByIDRow{Idwriting: writingID, ForumthreadID: threadID}))
+	cd.SetCurrentWriting(writingID)
+
+	mock.ExpectQuery("(?s).*SELECT 1 FROM grants.*").
+		WithArgs(cd.UserID, "writing", sqlmock.AnyArg(), "reply", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	mock.ExpectQuery("SELECT idforumtopic").
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler"}).
+			AddRow(1, 0, 0, 1, common.WritingTopicName, "desc", 0, 0, now, "writing"))
+
+	mock.ExpectExec("INSERT INTO comments").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), threadID, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "writing", sqlmock.AnyArg(), writingID, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(5, 1))
+
+	mock.ExpectExec("DELETE FROM content_private_labels").
+		WithArgs("writing", writingID, cd.UserID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	form := url.Values{}
+	form.Set("replytext", "hi")
+	form.Set("language", "1")
+	req := httptest.NewRequest(http.MethodPost, "/writings/article/1/reply", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = mux.SetURLVars(req, map[string]string{"writing": "1"})
+
+	sess := &sessions.Session{}
+	ctx := context.WithValue(req.Context(), core.ContextValues("session"), sess)
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	replyTask.Action(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
 	}
 }

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -184,6 +184,10 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := cd.ClearUnreadForOthers("writing", writing.Idwriting); err != nil {
+		log.Printf("clear unread labels: %v", err)
+	}
+
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
 		if evt := cd.Event(); evt != nil {
 			if evt.Data == nil {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -227,6 +227,7 @@ type Querier interface {
 	AdminWordListWithCounts(ctx context.Context, arg AdminWordListWithCountsParams) ([]*AdminWordListWithCountsRow, error)
 	AdminWordListWithCountsByPrefix(ctx context.Context, arg AdminWordListWithCountsByPrefixParams) ([]*AdminWordListWithCountsByPrefixRow, error)
 	AdminWritingCategoryCounts(ctx context.Context) ([]*AdminWritingCategoryCountsRow, error)
+	ClearUnreadContentPrivateLabelExceptUser(ctx context.Context, arg ClearUnreadContentPrivateLabelExceptUserParams) error
 	CreateBlogEntryForWriter(ctx context.Context, arg CreateBlogEntryForWriterParams) (int64, error)
 	// This query adds a new entry to the "bookmarks" table for a lister.
 	CreateBookmarksForLister(ctx context.Context, arg CreateBookmarksForListerParams) error

--- a/internal/db/queries-labels.sql
+++ b/internal/db/queries-labels.sql
@@ -30,6 +30,10 @@ WHERE item = ? AND item_id = ? AND user_id = ?;
 DELETE FROM content_private_labels
 WHERE item = ? AND item_id = ? AND label = ?;
 
+-- name: ClearUnreadContentPrivateLabelExceptUser :exec
+DELETE FROM content_private_labels
+WHERE item = ? AND item_id = ? AND label = 'unread' AND invert = true AND user_id <> ?;
+
 -- name: AddContentLabelStatus :exec
 INSERT IGNORE INTO content_label_status (
     item, item_id, label

--- a/internal/db/queries-labels.sql.go
+++ b/internal/db/queries-labels.sql.go
@@ -68,6 +68,22 @@ func (q *Queries) AddContentPublicLabel(ctx context.Context, arg AddContentPubli
 	return err
 }
 
+const clearUnreadContentPrivateLabelExceptUser = `-- name: ClearUnreadContentPrivateLabelExceptUser :exec
+DELETE FROM content_private_labels
+WHERE item = ? AND item_id = ? AND label = 'unread' AND invert = true AND user_id <> ?
+`
+
+type ClearUnreadContentPrivateLabelExceptUserParams struct {
+	Item   string
+	ItemID int32
+	UserID int32
+}
+
+func (q *Queries) ClearUnreadContentPrivateLabelExceptUser(ctx context.Context, arg ClearUnreadContentPrivateLabelExceptUserParams) error {
+	_, err := q.db.ExecContext(ctx, clearUnreadContentPrivateLabelExceptUser, arg.Item, arg.ItemID, arg.UserID)
+	return err
+}
+
 const listContentLabelStatus = `-- name: ListContentLabelStatus :many
 SELECT item, item_id, label
 FROM content_label_status


### PR DESCRIPTION
## Summary
- remove inverted unread labels for other users when replying to writings or threads
- avoid duplicate label bar in news post template

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `go test ./handlers/writings -run ReplyMarksWritingUnread -count=1`
- `go test ./handlers/news -run TestNewsPostPageNoDuplicateLabels -count=1`
- `go test ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6899ea81c4f4832fa8c84fc18c19790e