### PR TITLE
refactor: replace table layouts with semantic blocks

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -259,10 +259,20 @@ div.title {
         margin: 0 0.25em;
 }
 
+/* generic blocks replacing table layouts */
+.item-block {
+        width: 100%;
+        margin-bottom: 1em;
+}
+.item-header {
+        background-color: lightgrey;
+        font-weight: bold;
+}
+
 /* spoiler text hidden until hovered */
 .spoiler {
-	color: #000000;
-	background-color: #000000;
+        color: #000000;
+        background-color: #000000;
 }
 .spoiler:hover {
 	color: #FFFFFF;

--- a/core/templates/site/blogs/blogPage.gohtml
+++ b/core/templates/site/blogs/blogPage.gohtml
@@ -1,16 +1,12 @@
 {{ template "head" $ }}
         {{ $blog := cd.BlogPost }}
         <h2 class="blog-title"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</h2>
-        <table width="100%">
-                <tr>
-                    <th bgcolor="lightgrey">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>
-                </tr>
-                <tr>
-                    <td>
+        <article class="item-block">
+                <header class="item-header">{{ localTimeIn $blog.Written $blog.Timezone.String }}</header>
+                <div class="item-body">
         {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <span class="label-bar">{{ template "topicLabels" .Labels }}</span>{{ end }}
-                    </td>
-                </tr>
-        </table><br>
+                </div>
+        </article><br>
         {{ template "threadComments" }}
         <div class="label-editor">
             <form method="post" action="/blogs/blog/{{$blog.Idblogs}}/labels" id="label-form">

--- a/core/templates/site/blogs/bloggerPostsPage.gohtml
+++ b/core/templates/site/blogs/bloggerPostsPage.gohtml
@@ -6,19 +6,17 @@
             {{else}}
                 <h2 class="blog-title"><a href="/blogs/bloggers">All bloggers</a>' blogs.</h2>
             {{end}}
-            <table width="100%">
+            <section class="blog-list">
                 {{range $rows}}
-                    <tr>
-                        <th bgcolor="lightgrey">{{ localTimeIn .Written .Timezone.String }}</th>
-                    </tr>
-                <tr>
-                    <td>
-                        {{ $labels := BlogLabels .Idblogs }}
-                        {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{.Idblogs}}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-bar">{{ template "topicLabels" $labels }}</span>{{ end }}
-                    </td>
-                </tr>
-            {{end}}
-        </table><br>
+                    <article class="item-block">
+                        <header class="item-header">{{ localTimeIn .Written .Timezone.String }}</header>
+                        <div class="item-body">
+                            {{ $labels := BlogLabels .Idblogs }}
+                            {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{.Idblogs}}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-bar">{{ template "topicLabels" $labels }}</span>{{ end }}
+                        </div>
+                    </article>
+                {{end}}
+            </section><br>
         {{else}}
             {{if gt (cd.Offset) 0}}
                 {{if cd.CurrentProfileUserID}}

--- a/core/templates/site/blogs/commentPage.gohtml
+++ b/core/templates/site/blogs/commentPage.gohtml
@@ -2,16 +2,12 @@
 {{ template "head" $ }}
             {{ $blog := cd.BlogPost }}
             <h2 class="blog-title"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</h2>
-            <table width="100%">
-                <tr>
-                    <th bgcolor="lightgrey">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>
-                </tr>
-                <tr>
-                    <td>
+            <article class="item-block">
+                <header class="item-header">{{ localTimeIn $blog.Written $blog.Timezone.String }}</header>
+                <div class="item-body">
                         {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <span class="label-bar">{{ template "topicLabels" .Labels }}</span>{{ end }}
-                    </td>
-                </tr>
-        </table><br>
+                </div>
+        </article><br>
         {{ template "threadComments" }}
         <div class="label-editor">
             <form method="post" action="/blogs/blog/{{$blog.Idblogs}}/labels" id="label-form">

--- a/core/templates/site/blogs/page.gohtml
+++ b/core/templates/site/blogs/page.gohtml
@@ -13,32 +13,30 @@
             <h2 class="blog-title"><a href="/blogs/bloggers">All bloggers</a>' blogs.</h2>
         {{ end }}
     {{ end }}
-    <table width="100%">
+    <section class="blog-list">
         {{ range $rows }}
-            <tr>
-                <th bgcolor="lightgrey">{{ localTimeIn .Written .Timezone.String }}</th>
-            </tr>
-            <tr>
-                <td>
+            <article class="item-block">
+                <header class="item-header">{{ localTimeIn .Written .Timezone.String }}</header>
+                <div class="item-body">
                     {{ $labels := BlogLabels .Idblogs }}
                     {{ .Blog.String | a4code2html}}<br><br>{{ .Username.String }} - [<a href="/blogs/blog/{{ .Idblogs }}/comments">{{ .Comments }} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{ .Idblogs }}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{ .Idblogs }}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-bar">{{ template "topicLabels" $labels }}</span>{{ end }}
-                </td>
-            </tr>
+                </div>
+            </article>
         {{ else }}
             {{ if gt (cd.Offset) 0 }}
                 {{ if cd.CurrentProfileUserID }}
-                    There are no more blogs under this user.<br>
+                    <div class="item-body">There are no more blogs under this user.</div>
                 {{ else }}
-                    There are no more blogs.<br>
+                    <div class="item-body">There are no more blogs.</div>
                 {{ end }}
             {{ else }}
                 {{ if cd.CurrentProfileUserID }}
-                    Nothing under this blog.<br>
+                    <div class="item-body">Nothing under this blog.</div>
                 {{ else }}
-                    There are no blogs here.<br>
+                    <div class="item-body">There are no blogs here.</div>
                 {{ end }}
             {{ end }}
         {{ end }}
-    </table><br>
+    </section><br>
     {{ template "tail" $ }}
 {{ end }}

--- a/core/templates/site/faq/page.gohtml
+++ b/core/templates/site/faq/page.gohtml
@@ -2,16 +2,14 @@
     {{ template "head" $ }}
     {{ range $index, $categoryFAQs := (cd).AllAnsweredFAQ }}
         <font size="5">Section: {{ $categoryFAQs.Category.Name.String }}</font><br>
-        <table width="100%">
+        <div class="faq-category">
         {{ range $index, $faq := $categoryFAQs.FAQs }}
-            <tr>
-                <th bgcolor="lightgrey">Q: {{ $faq.Question | a4code2html }}</th>
-            </tr>
-            <tr>
-                <td>A: {{ $faq.Answer | a4code2html }}</td>
-            </tr>
+            <article class="item-block">
+                <header class="item-header">Q: {{ $faq.Question | a4code2html }}</header>
+                <div class="item-body">A: {{ $faq.Answer | a4code2html }}</div>
+            </article>
         {{ end }}
-        </table>
+        </div>
     {{ end }}
     {{ template "tail" $ }}
 {{ end }}

--- a/core/templates/site/listAbstracts.gohtml
+++ b/core/templates/site/listAbstracts.gohtml
@@ -15,15 +15,15 @@
         {{ $private := .Private.Bool }}
         {{ $comments := .Comments }}
         {{ $labels := WritingLabels $idwriting }}
-        <table width="100%">
-            <tr><th bgcolor="lightgrey">{{ $title }} By {{ $username }} on {{ $published }}
+        <article class="item-block">
+            <header class="item-header">{{ $title }} By {{ $username }} on {{ $published }}
                 {{ if $private }} - <em>Warning: Privileged information.</em>{{ end }}
-            </th></tr>
-            <tr><td>Abstract:<br>{{ $abstract }}
+            </header>
+            <div class="item-body">Abstract:<br>{{ $abstract }}
                 <br>-<br><a href="/writings/article/{{ $idwriting }}">Read now</a> - {{ $comments }} comments exist.
                 {{ if $labels }}<span class="label-bar">{{ template "topicLabels" $labels }}</span>{{ end }}
-            </td></tr>
-        </table>
+            </div>
+        </article>
     {{ else }}
         There are no writings.
     {{ end }}

--- a/core/templates/site/showLatestLinks.gohtml
+++ b/core/templates/site/showLatestLinks.gohtml
@@ -1,49 +1,37 @@
 {{ define "getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingLinks" }}
-    <table width="100%">
+    <section class="link-list">
         {{ if .HasOffset }}
             {{- range cd.SelectedLinkerItemsForCurrentUser (int32 .CatId) (int32 .Offset) }}
-                <tr>
-                    <th bgcolor="lightgrey">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
-                </tr>
-                <tr>
-                    <td>
+                <article class="item-block">
+                    <header class="item-header">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></header>
+                    <div class="item-body">
                         {{ .Description.String | a4code2html }}<hr>
                         {{ .Posterusername.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }} - [<a href="/linker/comments/{{ .ID }}">{{.Comments.Int32}} COMMENTS</a>]<br>
-                    </td>
-                </tr>
+                    </div>
+                </article>
             {{- else }}
                 {{- if .CatId }}
-                    <tr>
-                        <td>There are no more links under this category.</td>
-                    </tr>
+                    <div class="item-body">There are no more links under this category.</div>
                 {{- else }}
-                    <tr>
-                        <td>There are no more links.</td>
-                    </tr>
+                    <div class="item-body">There are no more links.</div>
                 {{- end }}
             {{- end }}
         {{ else }}
             {{- range cd.SelectedLinkerItemsForCurrentUser (int32 .CatId) 0 }}
-                <tr>
-                    <th bgcolor="lightgrey">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
-                </tr>
-                <tr>
-                    <td>
+                <article class="item-block">
+                    <header class="item-header">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></header>
+                    <div class="item-body">
                         {{ .Description.String | a4code2html }}<hr>
                         {{ .Posterusername.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }} - [<a href="/linker/comments/{{ .ID }}">{{.Comments.Int32}} COMMENTS</a>]<br>
-                    </td>
-                </tr>
+                    </div>
+                </article>
             {{- else }}
                 {{- if .CatId }}
-                    <tr>
-                        <td>Nothing under this category.</td>
-                    </tr>
+                    <div class="item-body">Nothing under this category.</div>
                 {{- else }}
-                    <tr>
-                        <td>There are no links here.</td>
-                    </tr>
+                    <div class="item-body">There are no links here.</div>
                 {{- end }}
             {{- end }}
         {{ end }}
-    </table><br>
+    </section><br>
 {{ end }}

--- a/core/templates/site/showLinkComments.gohtml
+++ b/core/templates/site/showLinkComments.gohtml
@@ -1,17 +1,13 @@
 {{ define "getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingComments" }}
     {{ with .Link }}
-        <table width="100%">
-            <tr>
-                <th bgcolor="lightgrey">{{ .Title.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
-            </tr>
-            <tr>
-                <td>
-                    {{ .Description.String | a4code2html }}
-                    <hr>
-                    {{ .Username.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }}
-                </td>
-            </tr>
-        </table><br>
+        <article class="item-block">
+            <header class="item-header">{{ .Title.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></header>
+            <div class="item-body">
+                {{ .Description.String | a4code2html }}
+                <hr>
+                {{ .Username.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }}
+            </div>
+        </article><br>
 
         {{ with .ThreadID }}
             {{ template "threadComments" }}


### PR DESCRIPTION
## Summary
- replace table-based layouts in several templates with semantic sections and articles
- move inline width and bgcolor styling into reusable `.item-block` and `.item-header` classes
- adjust FAQ, blog, link, and writing templates to use new structure

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `go test ./...` *(fails: TestNewsPostPageNoDuplicateLabels expects 2 label bars)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6899f4c5bd44832fb179c50c3d31014a