### PR TITLE
Refactor blog templates for semantic markup

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -124,10 +124,36 @@ h2, h3 {
 }
 
 .blog-subtitle {
-	font-family: tahoma, arial, helvetica, sans-serif;
-	font-size: 1.2em;
-	color: #800000;
-	background-color: transparent;
+        font-family: tahoma, arial, helvetica, sans-serif;
+        font-size: 1.2em;
+        color: #800000;
+        background-color: transparent;
+}
+
+.blog-post {
+        margin-bottom: 1em;
+}
+
+.post-body {
+        margin-top: 0.5em;
+}
+
+.post-meta {
+        font-size: 0.9em;
+        margin-top: 0.5em;
+}
+
+.post-meta span {
+        margin-right: 0.5em;
+}
+
+.label-bar {
+        display: block;
+        margin-top: 0.5em;
+}
+
+.comment-link {
+        margin-right: 0.5em;
 }
 
 .table {

--- a/core/templates/site/blogs/blogPage.gohtml
+++ b/core/templates/site/blogs/blogPage.gohtml
@@ -1,16 +1,17 @@
 {{ template "head" $ }}
         {{ $blog := cd.BlogPost }}
         <h2 class="blog-title"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</h2>
-        <table width="100%">
-                <tr>
-                    <th bgcolor="lightgrey">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>
-                </tr>
-                <tr>
-                    <td>
-        {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <span class="label-bar">{{ template "topicLabels" .Labels }}</span>{{ end }}
-                    </td>
-                </tr>
-        </table><br>
+        <article class="blog-post">
+                <header>{{ localTimeIn $blog.Written $blog.Timezone.String }}</header>
+                <div class="post-body">{{$blog.Blog.String | a4code2html}}</div>
+                <footer class="post-meta">
+                    <span class="author">{{$blog.Username.String}}</span>
+                    <span class="comment-link"><a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a></span>
+                    {{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }}<span class="edit"><a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a></span>{{ end }}
+                    {{ if and cd.IsAdmin cd.IsAdminMode }}<span class="admin"><a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a></span>{{ end }}
+                    {{ if .Labels }}<div class="label-bar">{{ template "topicLabels" .Labels }}</div>{{ end }}
+                </footer>
+        </article><br>
         {{ template "threadComments" }}
         <div class="label-editor">
             <form method="post" action="/blogs/blog/{{$blog.Idblogs}}/labels" id="label-form">

--- a/core/templates/site/blogs/bloggerPostsPage.gohtml
+++ b/core/templates/site/blogs/bloggerPostsPage.gohtml
@@ -6,19 +6,22 @@
             {{else}}
                 <h2 class="blog-title"><a href="/blogs/bloggers">All bloggers</a>' blogs.</h2>
             {{end}}
-            <table width="100%">
+            <section class="blog-posts">
                 {{range $rows}}
-                    <tr>
-                        <th bgcolor="lightgrey">{{ localTimeIn .Written .Timezone.String }}</th>
-                    </tr>
-                <tr>
-                    <td>
+                    <article class="blog-post">
+                        <header>{{ localTimeIn .Written .Timezone.String }}</header>
                         {{ $labels := BlogLabels .Idblogs }}
-                        {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{.Idblogs}}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-bar">{{ template "topicLabels" $labels }}</span>{{ end }}
-                    </td>
-                </tr>
-            {{end}}
-        </table><br>
+                        <div class="post-body">{{.Blog.String | a4code2html}}</div>
+                        <footer class="post-meta">
+                            <span class="author">{{.Username.String}}</span>
+                            <span class="comment-link"><a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a></span>
+                            {{ if cd.CanEditBlog .Idblogs .UsersIdusers }}<span class="edit"><a href="/blogs/blog/{{.Idblogs}}/edit">EDIT</a></span>{{ end }}
+                            {{ if and cd.IsAdmin cd.IsAdminMode }}<span class="admin"><a href="/admin/blogs/blog/{{.Idblogs}}">ADMIN</a></span>{{ end }}
+                            {{ if $labels }}<div class="label-bar">{{ template "topicLabels" $labels }}</div>{{ end }}
+                        </footer>
+                    </article>
+                {{end}}
+            </section><br>
         {{else}}
             {{if gt (cd.Offset) 0}}
                 {{if cd.CurrentProfileUserID}}

--- a/core/templates/site/blogs/commentPage.gohtml
+++ b/core/templates/site/blogs/commentPage.gohtml
@@ -2,16 +2,17 @@
 {{ template "head" $ }}
             {{ $blog := cd.BlogPost }}
             <h2 class="blog-title"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</h2>
-            <table width="100%">
-                <tr>
-                    <th bgcolor="lightgrey">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>
-                </tr>
-                <tr>
-                    <td>
-                        {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <span class="label-bar">{{ template "topicLabels" .Labels }}</span>{{ end }}
-                    </td>
-                </tr>
-        </table><br>
+            <article class="blog-post">
+                <header>{{ localTimeIn $blog.Written $blog.Timezone.String }}</header>
+                <div class="post-body">{{$blog.Blog.String | a4code2html}}</div>
+                <footer class="post-meta">
+                    <span class="author">{{$blog.Username.String}}</span>
+                    <span class="comment-link"><a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a></span>
+                    {{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }}<span class="edit"><a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a></span>{{ end }}
+                    {{ if and cd.IsAdmin cd.IsAdminMode }}<span class="admin"><a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a></span>{{ end }}
+                    {{ if .Labels }}<div class="label-bar">{{ template "topicLabels" .Labels }}</div>{{ end }}
+                </footer>
+            </article><br>
         {{ template "threadComments" }}
         <div class="label-editor">
             <form method="post" action="/blogs/blog/{{$blog.Idblogs}}/labels" id="label-form">

--- a/core/templates/site/blogs/page.gohtml
+++ b/core/templates/site/blogs/page.gohtml
@@ -13,17 +13,20 @@
             <h2 class="blog-title"><a href="/blogs/bloggers">All bloggers</a>' blogs.</h2>
         {{ end }}
     {{ end }}
-    <table width="100%">
+    <section class="blog-posts">
         {{ range $rows }}
-            <tr>
-                <th bgcolor="lightgrey">{{ localTimeIn .Written .Timezone.String }}</th>
-            </tr>
-            <tr>
-                <td>
-                    {{ $labels := BlogLabels .Idblogs }}
-                    {{ .Blog.String | a4code2html}}<br><br>{{ .Username.String }} - [<a href="/blogs/blog/{{ .Idblogs }}/comments">{{ .Comments }} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{ .Idblogs }}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{ .Idblogs }}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-bar">{{ template "topicLabels" $labels }}</span>{{ end }}
-                </td>
-            </tr>
+            <article class="blog-post">
+                <header>{{ localTimeIn .Written .Timezone.String }}</header>
+                {{ $labels := BlogLabels .Idblogs }}
+                <div class="post-body">{{ .Blog.String | a4code2html}}</div>
+                <footer class="post-meta">
+                    <span class="author">{{ .Username.String }}</span>
+                    <span class="comment-link"><a href="/blogs/blog/{{ .Idblogs }}/comments">{{ .Comments }} COMMENTS</a></span>
+                    {{ if cd.CanEditBlog .Idblogs .UsersIdusers }}<span class="edit"><a href="/blogs/blog/{{ .Idblogs }}/edit">EDIT</a></span>{{ end }}
+                    {{ if and cd.IsAdmin cd.IsAdminMode }}<span class="admin"><a href="/admin/blogs/blog/{{ .Idblogs }}">ADMIN</a></span>{{ end }}
+                    {{ if $labels }}<div class="label-bar">{{ template "topicLabels" $labels }}</div>{{ end }}
+                </footer>
+            </article>
         {{ else }}
             {{ if gt (cd.Offset) 0 }}
                 {{ if cd.CurrentProfileUserID }}
@@ -39,6 +42,6 @@
                 {{ end }}
             {{ end }}
         {{ end }}
-    </table><br>
+    </section><br>
     {{ template "tail" $ }}
 {{ end }}

--- a/core/templates/site/news/postPage.gohtml
+++ b/core/templates/site/news/postPage.gohtml
@@ -21,6 +21,7 @@
         {{ csrfField }}
             <input type="hidden" name="task" value="Set Labels"/>
             <input type="hidden" name="back" value="{{ .BackURL }}"/>
+            <div class="label-bar">
             {{ range .Labels }}
                 {{ if eq .Type "private" }}
                 <span class="label pill private">{{ .Name }}<button type="button" class="remove" data-type="private">x</button><input type="hidden" name="private" value="{{ .Name }}"/></span>
@@ -28,6 +29,7 @@
                 <span class="label pill author">{{ .Name }}</span>
                 {{ end }}
             {{ end }}
+            </div>
             <input type="text" class="label-input" data-type="private" placeholder="Add private label"/>
             <input type="submit" value="Save Labels"/>
         </form>


### PR DESCRIPTION
## Summary
- replace table-based blog post markup with `<section>` and `<article>` elements and use `<header>` for metadata
- wrap comment links and labels in semantic containers and style via CSS
- ensure news label editor uses `label-bar` container

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899f4c7c3e0832fa342033c2f1f721b