### PR TITLE
Use semantic markup for news posts

### DIFF
--- a/core/templates/site/news/post.gohtml
+++ b/core/templates/site/news/post.gohtml
@@ -1,10 +1,7 @@
 {{ define "newsPost" }}
-    <table width="100%">
-        <tr bgcolor="lightgrey">
-            <th>{{ localTimeIn .Occurred.Time .Timezone.String }}</th>
-        </tr>
-        <tr>
-            <td>{{ .News.String | a4code2html }}<br>-<br>{{ .Writername.String }}
+    <article class="thread">
+        <header class="thread-header">{{ localTimeIn .Occurred.Time .Timezone.String }}</header>
+        <div class="thread-content">{{ .News.String | a4code2html }}<br>-<br>{{ .Writername.String }}
             -
             {{ if cd.SelectedThreadID }}
                 {{ .Comments.Int32 }} COMMENTS [<a href="#bottom">BOTTOM</a>]{{ if cd.SelectedThreadCanReply }} [<a href="#bottom">REPLY</a>]{{ end }}
@@ -28,7 +25,6 @@
             {{ end }}
             {{ $labels := NewsLabels .Idsitenews }}
             {{ if $labels }}<span class="label-bar">{{ template "topicLabels" $labels }}</span>{{ end }}
-            </td>
-        </tr>
-    </table><br>
+        </div>
+    </article>
 {{ end }}

--- a/core/templates/site/news/postPage.gohtml
+++ b/core/templates/site/news/postPage.gohtml
@@ -17,6 +17,7 @@
     <hr><h2 class="section-heading">Replies:</h2>
     {{ template "threadComments" }}
     <div class="label-editor">
+        {{ if .Labels }}<span class="label-bar">{{ template "topicLabels" .Labels }}</span>{{ end }}
         <form method="post" action="/news/news/{{ .Post.Idsitenews }}/labels" id="label-form">
         {{ csrfField }}
             <input type="hidden" name="task" value="Set Labels"/>


### PR DESCRIPTION
## Summary
- replace news post table with semantic `<article>` and `<header>` markup
- style news posts using existing CSS classes instead of table attributes
- surface selected labels alongside the editor

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899f4c8848c832f8773419a06a2fc88