### PR TITLE
refactor: use divs for FAQ layout

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -648,3 +648,18 @@ tr.unsupported td {
        }
 }
 
+.faq-item {
+        border: 1px solid #000;
+        margin-bottom: 1em;
+}
+
+.faq-question {
+        background-color: lightgrey;
+        padding: 0.5em;
+        margin: 0;
+        border-bottom: 1px solid #000;
+}
+
+.faq-answer {
+        padding: 0.5em;
+}

--- a/core/templates/site/faq/page.gohtml
+++ b/core/templates/site/faq/page.gohtml
@@ -1,17 +1,15 @@
 {{ define "faqPage" }}
     {{ template "head" $ }}
     {{ range $index, $categoryFAQs := (cd).AllAnsweredFAQ }}
-        <font size="5">Section: {{ $categoryFAQs.Category.Name.String }}</font><br>
-        <table width="100%">
-        {{ range $index, $faq := $categoryFAQs.FAQs }}
-            <tr>
-                <th bgcolor="lightgrey">Q: {{ $faq.Question | a4code2html }}</th>
-            </tr>
-            <tr>
-                <td>A: {{ $faq.Answer | a4code2html }}</td>
-            </tr>
-        {{ end }}
-        </table>
+        <section class="faq-section">
+            <h2>Section: {{ $categoryFAQs.Category.Name.String }}</h2>
+            {{ range $index, $faq := $categoryFAQs.FAQs }}
+                <div class="faq-item">
+                    <h3 class="faq-question">Q: {{ $faq.Question | a4code2html }}</h3>
+                    <div class="faq-answer">A: {{ $faq.Answer | a4code2html }}</div>
+                </div>
+            {{ end }}
+        </section>
     {{ end }}
     {{ template "tail" $ }}
 {{ end }}


### PR DESCRIPTION
## Summary
- replace FAQ table layout with section/div structure
- style FAQ entries with CSS for borders and spacing

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `go test ./...` *(fails: TestNewsPostPageNoDuplicateLabels)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6899f4cb4c34832f8e8c68f2a56a168b