### PR TITLE
Refactor board post templates to use flexbox layout

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -602,6 +602,20 @@ tr.unsupported td {
        flex: 1;
 }
 
+/* Board posts */
+.board-post-list {
+       list-style: none;
+       margin: 0;
+       padding: 0;
+}
+
+.board-post-item {
+       display: flex;
+       align-items: flex-start;
+       gap: 0.5em;
+       margin-bottom: 1em;
+}
+
 @media (max-width: 600px) {
        .navbar {
                flex-direction: column;

--- a/core/templates/site/boardPosts.gohtml
+++ b/core/templates/site/boardPosts.gohtml
@@ -3,13 +3,16 @@
     {{ $posts := $cd.SelectedBoardPosts }}
     {{- if $posts }}
         <font size="4">Pictures:</font><br>
-        {{- range $posts }}
-            <table>
-                <tr>
-                    <th><a href="{{ .Fullimage.String }}" target="_BLANK"><img src="{{ .Thumbnail.String }}"></a>
-                    <td>{{ .Description.String }}<hr>{{ .Username.String }} - Posted: {{ localTimeIn .Posted.Time .Timezone.String }} - [<a href="/imagebbs/board/{{ $cd.SelectedBoardID }}/thread/{{ .ForumthreadID }}">{{ .Comments.Int32 }} COMMENTS</a>]
-            </table><br>
-        {{- end }}
+        <section class="board-posts">
+            <ul class="board-post-list">
+            {{- range $posts }}
+                <li class="board-post-item">
+                    <a href="{{ .Fullimage.String }}" target="_BLANK"><img src="{{ .Thumbnail.String }}" alt=""></a>
+                    <div>{{ .Description.String }}<hr>{{ .Username.String }} - Posted: {{ localTimeIn .Posted.Time .Timezone.String }} - [<a href="/imagebbs/board/{{ $cd.SelectedBoardID }}/thread/{{ .ForumthreadID }}">{{ .Comments.Int32 }} COMMENTS</a>]</div>
+                </li>
+            {{- end }}
+            </ul>
+        </section>
     {{- else }}
         There isn't anything to see.
     {{- end }}

--- a/core/templates/site/imagebbs/posterPage.gohtml
+++ b/core/templates/site/imagebbs/posterPage.gohtml
@@ -2,13 +2,16 @@
     <h1>{{ .Username }}'s images.</h1>
     {{- if .Posts }}
         <h2>Pictures:</h2>
-        {{- range .Posts }}
-            <table>
-                <tr>
-                    <th><a href="{{ .Fullimage.String }}" target="_BLANK"><img src="{{ .Thumbnail.String }}"></a>
-                    <td>{{ .Description.String }}<hr>{{ .Username.String }} - Posted: {{ localTimeIn .Posted.Time .Timezone.String }} - [<a href="/imagebbs/board/{{ .ImageboardID }}/thread/{{ .ForumthreadID }}">{{ .Comments.Int32 }} COMMENTS</a>]
-            </table><br>
-        {{- end }}
+        <section class="board-posts">
+            <ul class="board-post-list">
+            {{- range .Posts }}
+                <li class="board-post-item">
+                    <a href="{{ .Fullimage.String }}" target="_BLANK"><img src="{{ .Thumbnail.String }}" alt=""></a>
+                    <div>{{ .Description.String }}<hr>{{ .Username.String }} - Posted: {{ localTimeIn .Posted.Time .Timezone.String }} - [<a href="/imagebbs/board/{{ .ImageboardID }}/thread/{{ .ForumthreadID }}">{{ .Comments.Int32 }} COMMENTS</a>]</div>
+                </li>
+            {{- end }}
+            </ul>
+        </section>
     {{- else }}
         There isn't anything to see.
     {{- end }}


### PR DESCRIPTION
## Summary
- replace table-based board post templates with semantic sections and flexbox list items
- add CSS classes to handle spacing and alignment via flexbox

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(hung; terminated after waiting)*
- `golangci-lint run`
- `go test ./...` *(failed: TestNewsPostPageNoDuplicateLabels)*

------
https://chatgpt.com/codex/tasks/task_e_6899f4cb9590832f8f3fc3c626489aa9