### PR TITLE
Replace deprecated font tags with CSS-styled spans

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -170,6 +170,7 @@ h2, h3 {
 
 .section-title {
         font-size: 1.2em;
+        color: #800000;
 }
 div.index {
         text-align: center;

--- a/core/templates/site/expandCategories.gohtml
+++ b/core/templates/site/expandCategories.gohtml
@@ -1,5 +1,5 @@
 {{ define "expandCategories" }}
-    <font size="4">Topics:</font><br>
+    <span class="section-title">Topics:</span><br>
     {{ range .Categories }}
         <table width="90%" align="center" class="table table-bordered centered-table">
             <tr>

--- a/core/templates/site/subBoards.gohtml
+++ b/core/templates/site/subBoards.gohtml
@@ -2,7 +2,7 @@
     {{ $cd := cd }}
     {{ $boards := $cd.SubImageBoards $cd.SelectedBoardID }}
     {{- if $boards }}
-        <font size="4">{{ if gt ($cd.SelectedBoardID) 0 }}Sub-{{ end }}Boards:</font><br>
+        <span class="section-title">{{ if gt ($cd.SelectedBoardID) 0 }}Sub-{{ end }}Boards:</span><br>
         <table>
             {{- range $boards }}
                 <tr>

--- a/core/templates/site/user/topicRestrictions.gohtml
+++ b/core/templates/site/user/topicRestrictions.gohtml
@@ -1,5 +1,5 @@
 {{ define "userTopicRestrictions" }}
-    <font size="4">Topic Restrictions:</font><br>
+    <span class="section-title">Topic Restrictions:</span><br>
     <table width="100%">
         <tr>
             <th>Topic


### PR DESCRIPTION
## Summary
- replace remaining `<font>` tags in site templates with `<span class="section-title">`
- style headings via `.section-title` class in main.css

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...` *(fails: TestNewsPostPageNoDuplicateLabels)*

------
https://chatgpt.com/codex/tasks/task_e_6899f60b355c832f8cd35c4dc9027a11