### PR TITLE
refactor topic restriction form layout

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -35,6 +35,21 @@ textarea {
         vertical-align: top;
 }
 
+.topic-restrictions {
+        width: 100%;
+}
+
+.topic-restrictions-row {
+        display: grid;
+        grid-template-columns: 2fr repeat(8, 1fr) 2fr;
+        gap: 0.5em;
+        align-items: center;
+}
+
+.topic-restrictions-header {
+        font-weight: bold;
+}
+
 .navbar {
         display: flex;
         justify-content: space-between;

--- a/core/templates/site/topicRestrictions.gohtml
+++ b/core/templates/site/topicRestrictions.gohtml
@@ -1,42 +1,41 @@
 {{ define "topicRestrictions" }}
     <span class="section-title">Topic Restrictions:</span><br>
-    <table width="100%">
-        <tr>
-            <th>Topic
-            <th>view level
-            <th>reply level
-            <th>new thread level
-            <th>see level
-            <th>Starting roles
-            <th>read level
-            <th>Moderator Level
-            <th>Administrator level
-            <th>Options
-        </tr>
+    <div class="topic-restrictions">
+        <div class="topic-restrictions-row topic-restrictions-header">
+            <div>Topic</div>
+            <div>view level</div>
+            <div>reply level</div>
+            <div>new thread level</div>
+            <div>see level</div>
+            <div>Starting roles</div>
+            <div>read level</div>
+            <div>Moderator Level</div>
+            <div>Administrator level</div>
+            <div>Options</div>
+        </div>
         {{- range .Restrictions }}
-            <form method="post">
-        {{ csrfField }}
-                <tr>
-                    <td><input type="hidden" name="ftid" value="{{ .ForumTopicID }}">{{ .Title }}
-                    <td><input name="view" value="{{ .ViewLevel }}" size="8">
-                    <td><input name="reply" value="{{ .ReplyLevel }}" size="8">
-                    <td><input name="newthread" value="{{ .NewThreadLevel }}" size="8">
-                    <td><input name="see" value="{{ .SeeLevel }}" size="8">
-                    <td><input name="invite" value="{{ .InviteLevel }}" size="8">
-                    <td><input name="read" value="{{ .ReadLevel }}" size="8">
-                    <td><input name="mod" value="{{ .ModeratorLevel }}" size="8">
-                    <td><input name="admin" value="{{ .AdminLevel }}" size="8">
-                    <td>
-                        {{- if .HasRestriction }}
-                        <input type="submit" name="task" value="Update topic restriction">
-                        <input type="submit" name="task" value="Delete topic restriction">
-                        {{- else }}
-                        <input type="submit" name="task" value="Set topic restriction">
-                        {{- end }}
-                </tr>
-            </form>
+        <form method="post" class="topic-restrictions-row">
+            {{ csrfField }}
+            <div><input type="hidden" name="ftid" value="{{ .ForumTopicID }}">{{ .Title }}</div>
+            <div><input name="view" value="{{ .ViewLevel }}" size="8"></div>
+            <div><input name="reply" value="{{ .ReplyLevel }}" size="8"></div>
+            <div><input name="newthread" value="{{ .NewThreadLevel }}" size="8"></div>
+            <div><input name="see" value="{{ .SeeLevel }}" size="8"></div>
+            <div><input name="invite" value="{{ .InviteLevel }}" size="8"></div>
+            <div><input name="read" value="{{ .ReadLevel }}" size="8"></div>
+            <div><input name="mod" value="{{ .ModeratorLevel }}" size="8"></div>
+            <div><input name="admin" value="{{ .AdminLevel }}" size="8"></div>
+            <div>
+                {{- if .HasRestriction }}
+                <input type="submit" name="task" value="Update topic restriction">
+                <input type="submit" name="task" value="Delete topic restriction">
+                {{- else }}
+                <input type="submit" name="task" value="Set topic restriction">
+                {{- end }}
+            </div>
+        </form>
         {{- end }}
-    </table><br>
+    </div><br>
     Remember:
     <ul>
         <li>View threads


### PR DESCRIPTION
## Summary
- Replace table markup in topicRestrictions template with div-based forms
- Add CSS grid styling for aligned topic restriction inputs

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestNewsPostPageNoDuplicateLabels expected 2 label bars, got 0)*

------
https://chatgpt.com/codex/tasks/task_e_689a77754f80832f9510aaf51a1fb9e7