### PR TITLE
Refactor blog templates with semantic HTML

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -592,9 +592,33 @@ tr.unsupported td {
         padding: 0.25em;
 }
 
+.blog-list {
+        width: 100%;
+}
+
+.blog-post {
+        border: 1px solid #000;
+        margin-bottom: 1em;
+}
+
+.blog-post header {
+        padding: 0.25em;
+}
+
+.post-content {
+        padding: 0.25em;
+}
+
+.label-list,
+.label-bar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+}
+
 .poster-name.first,
 .post-time.first {
-	color: green;
+        color: green;
 }
 
 .poster-name.last,

--- a/core/templates/site/blogs/blogPage.gohtml
+++ b/core/templates/site/blogs/blogPage.gohtml
@@ -1,16 +1,12 @@
 {{ template "head" $ }}
         {{ $blog := cd.BlogPost }}
         <h2 class="blog-title"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</h2>
-        <table width="100%">
-                <tr>
-                    <th class="bg-muted">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>
-                </tr>
-                <tr>
-                    <td>
-        {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <span class="label-list">{{ template "topicLabels" .Labels }}</span>{{ end }}
-                    </td>
-                </tr>
-        </table><br>
+        <article class="blog-post">
+                <header class="bg-muted">{{ localTimeIn $blog.Written $blog.Timezone.String }}</header>
+                <div class="post-content">
+        {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <section class="label-list">{{ template "topicLabels" .Labels }}</section>{{ end }}
+                </div>
+        </article><br>
         {{ template "threadComments" }}
         <div class="label-editor">
             <form method="post" action="/blogs/blog/{{$blog.Idblogs}}/labels" id="label-form">

--- a/core/templates/site/blogs/bloggerPostsPage.gohtml
+++ b/core/templates/site/blogs/bloggerPostsPage.gohtml
@@ -6,19 +6,17 @@
             {{else}}
                 <h2 class="blog-title"><a href="/blogs/bloggers">All bloggers</a>' blogs.</h2>
             {{end}}
-            <table width="100%">
+            <section class="blog-list">
                 {{range $rows}}
-                    <tr>
-                        <th class="bg-muted">{{ localTimeIn .Written .Timezone.String }}</th>
-                    </tr>
-                <tr>
-                    <td>
+                    <article class="blog-post">
+                        <header class="bg-muted">{{ localTimeIn .Written .Timezone.String }}</header>
+                        <div class="post-content">
                         {{ $labels := BlogLabels .Idblogs }}
-                        {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{.Idblogs}}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-list">{{ template "topicLabels" $labels }}</span>{{ end }}
-                    </td>
-                </tr>
-            {{end}}
-        </table><br>
+                        {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{.Idblogs}}">ADMIN</a>]{{ end }}{{ if $labels }} <section class="label-list">{{ template "topicLabels" $labels }}</section>{{ end }}
+                        </div>
+                    </article>
+                {{end}}
+            </section><br>
         {{else}}
             {{if gt (cd.Offset) 0}}
                 {{if cd.CurrentProfileUserID}}

--- a/core/templates/site/blogs/commentPage.gohtml
+++ b/core/templates/site/blogs/commentPage.gohtml
@@ -2,16 +2,12 @@
 {{ template "head" $ }}
             {{ $blog := cd.BlogPost }}
             <h2 class="blog-title"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</h2>
-            <table width="100%">
-                <tr>
-                    <th class="bg-muted">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>
-                </tr>
-                <tr>
-                    <td>
-                        {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <span class="label-bar">{{ template "topicLabels" .Labels }}</span>{{ end }}
-                    </td>
-                </tr>
-        </table><br>
+            <article class="blog-post">
+                <header class="bg-muted">{{ localTimeIn $blog.Written $blog.Timezone.String }}</header>
+                <div class="post-content">
+                        {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <section class="label-bar">{{ template "topicLabels" .Labels }}</section>{{ end }}
+                </div>
+            </article><br>
         {{ template "threadComments" }}
         <div class="label-editor">
             <form method="post" action="/blogs/blog/{{$blog.Idblogs}}/labels" id="label-form">

--- a/core/templates/site/blogs/page.gohtml
+++ b/core/templates/site/blogs/page.gohtml
@@ -13,17 +13,15 @@
             <h2 class="blog-title"><a href="/blogs/bloggers">All bloggers</a>' blogs.</h2>
         {{ end }}
     {{ end }}
-    <table width="100%">
+    <section class="blog-list">
         {{ range $rows }}
-            <tr>
-                <th class="bg-muted">{{ localTimeIn .Written .Timezone.String }}</th>
-            </tr>
-            <tr>
-                <td>
+            <article class="blog-post">
+                <header class="bg-muted">{{ localTimeIn .Written .Timezone.String }}</header>
+                <div class="post-content">
                     {{ $labels := BlogLabels .Idblogs }}
-                    {{ .Blog.String | a4code2html}}<br><br>{{ .Username.String }} - [<a href="/blogs/blog/{{ .Idblogs }}/comments">{{ .Comments }} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{ .Idblogs }}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{ .Idblogs }}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-list">{{ template "topicLabels" $labels }}</span>{{ end }}
-                </td>
-            </tr>
+                    {{ .Blog.String | a4code2html}}<br><br>{{ .Username.String }} - [<a href="/blogs/blog/{{ .Idblogs }}/comments">{{ .Comments }} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{ .Idblogs }}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{ .Idblogs }}">ADMIN</a>]{{ end }}{{ if $labels }} <section class="label-list">{{ template "topicLabels" $labels }}</section>{{ end }}
+                </div>
+            </article>
         {{ else }}
             {{ if gt (cd.Offset) 0 }}
                 {{ if cd.CurrentProfileUserID }}
@@ -39,6 +37,6 @@
                 {{ end }}
             {{ end }}
         {{ end }}
-    </table><br>
+    </section><br>
     {{ template "tail" $ }}
 {{ end }}

--- a/core/templates/site/news/post.gohtml
+++ b/core/templates/site/news/post.gohtml
@@ -24,7 +24,7 @@
                 </a>]
             {{ end }}
             {{ $labels := NewsLabels .Idsitenews }}
-            {{ if $labels }}<span class="label-bar">{{ template "topicLabels" $labels }}</span>{{ end }}
+            {{ if $labels }}<section class="label-bar">{{ template "topicLabels" $labels }}</section>{{ end }}
         </div>
     </article>
 {{ end }}

--- a/core/templates/site/news/postPage.gohtml
+++ b/core/templates/site/news/postPage.gohtml
@@ -17,7 +17,7 @@
     <hr><h2 class="section-heading">Replies:</h2>
     {{ template "threadComments" }}
     <div class="label-editor">
-        {{ if .Labels }}<span class="label-bar">{{ template "topicLabels" .Labels }}</span>{{ end }}
+        {{ if .Labels }}<section class="label-list">{{ template "topicLabels" .Labels }}</section>{{ end }}
         <form method="post" action="/news/news/{{ .Post.Idsitenews }}/labels" id="label-form">
         {{ csrfField }}
             <input type="hidden" name="task" value="Set Labels"/>

--- a/core/templates/site/threadComments.gohtml
+++ b/core/templates/site/threadComments.gohtml
@@ -2,7 +2,7 @@
     {{ if gt (cd.Offset) 0 }}
         <br>Skipping {{ cd.Offset }} comments.<br><br><br>
     {{ end }}
-    <div class="comments">
+    <section class="comments">
         {{ $prev := 0 }}
         {{ range $i, $c := cd.SelectedSectionThreadComments }}
             {{ $num := add (add $i 1) (cd.Offset) }}
@@ -12,5 +12,5 @@
         {{ else }}
             No comments.
         {{ end }}
-    </div>
+    </section>
 {{ end }}


### PR DESCRIPTION
## Summary
- Replace blog post tables with `<article>`/`<section>` wrappers and use `<header>` for metadata
- Move comments and label listings into semantic containers and style them via CSS
- Align news templates with updated label container semantics

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a83f47ec4832fafd3b6c70e6b380a