### PR TITLE
refactor: use semantic markup for link and blog templates

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -35,6 +35,22 @@ textarea {
         vertical-align: top;
 }
 
+.entry-list {
+        width: 100%;
+}
+
+.entry {
+        margin-bottom: 1em;
+}
+
+.entry-header {
+        font-weight: bold;
+}
+
+.entry-body {
+        /* container for entry details */
+}
+
 .navbar {
         display: flex;
         justify-content: space-between;

--- a/core/templates/site/blogs/blogPage.gohtml
+++ b/core/templates/site/blogs/blogPage.gohtml
@@ -1,16 +1,14 @@
 {{ template "head" $ }}
         {{ $blog := cd.BlogPost }}
         <h2 class="blog-title"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</h2>
-        <table width="100%">
-                <tr>
-                    <th class="bg-muted">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>
-                </tr>
-                <tr>
-                    <td>
+        <section class="entry-list">
+                <article class="entry">
+                    <header class="entry-header bg-muted">{{ localTimeIn $blog.Written $blog.Timezone.String }}</header>
+                    <div class="entry-body">
         {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <span class="label-list">{{ template "topicLabels" .Labels }}</span>{{ end }}
-                    </td>
-                </tr>
-        </table><br>
+                    </div>
+                </article>
+        </section><br>
         {{ template "threadComments" }}
         <div class="label-editor">
             <form method="post" action="/blogs/blog/{{$blog.Idblogs}}/labels" id="label-form">

--- a/core/templates/site/blogs/bloggerPostsPage.gohtml
+++ b/core/templates/site/blogs/bloggerPostsPage.gohtml
@@ -6,19 +6,17 @@
             {{else}}
                 <h2 class="blog-title"><a href="/blogs/bloggers">All bloggers</a>' blogs.</h2>
             {{end}}
-            <table width="100%">
+            <section class="entry-list">
                 {{range $rows}}
-                    <tr>
-                        <th class="bg-muted">{{ localTimeIn .Written .Timezone.String }}</th>
-                    </tr>
-                <tr>
-                    <td>
-                        {{ $labels := BlogLabels .Idblogs }}
-                        {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{.Idblogs}}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-list">{{ template "topicLabels" $labels }}</span>{{ end }}
-                    </td>
-                </tr>
-            {{end}}
-        </table><br>
+                    <article class="entry">
+                        <header class="entry-header bg-muted">{{ localTimeIn .Written .Timezone.String }}</header>
+                        <div class="entry-body">
+                            {{ $labels := BlogLabels .Idblogs }}
+                            {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{.Idblogs}}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-list">{{ template "topicLabels" $labels }}</span>{{ end }}
+                        </div>
+                    </article>
+                {{end}}
+            </section><br>
         {{else}}
             {{if gt (cd.Offset) 0}}
                 {{if cd.CurrentProfileUserID}}

--- a/core/templates/site/blogs/commentPage.gohtml
+++ b/core/templates/site/blogs/commentPage.gohtml
@@ -2,16 +2,14 @@
 {{ template "head" $ }}
             {{ $blog := cd.BlogPost }}
             <h2 class="blog-title"><a href="/blogs/blogger/{{$blog.Username.String}}">{{$blog.Username.String}}'s Blog</a>:</h2>
-            <table width="100%">
-                <tr>
-                    <th class="bg-muted">{{ localTimeIn $blog.Written $blog.Timezone.String }}</th>
-                </tr>
-                <tr>
-                    <td>
+            <section class="entry-list">
+                <article class="entry">
+                    <header class="entry-header bg-muted">{{ localTimeIn $blog.Written $blog.Timezone.String }}</header>
+                    <div class="entry-body">
                         {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <span class="label-bar">{{ template "topicLabels" .Labels }}</span>{{ end }}
-                    </td>
-                </tr>
-        </table><br>
+                    </div>
+                </article>
+            </section><br>
         {{ template "threadComments" }}
         <div class="label-editor">
             <form method="post" action="/blogs/blog/{{$blog.Idblogs}}/labels" id="label-form">

--- a/core/templates/site/blogs/page.gohtml
+++ b/core/templates/site/blogs/page.gohtml
@@ -13,17 +13,15 @@
             <h2 class="blog-title"><a href="/blogs/bloggers">All bloggers</a>' blogs.</h2>
         {{ end }}
     {{ end }}
-    <table width="100%">
+    <section class="entry-list">
         {{ range $rows }}
-            <tr>
-                <th class="bg-muted">{{ localTimeIn .Written .Timezone.String }}</th>
-            </tr>
-            <tr>
-                <td>
+            <article class="entry">
+                <header class="entry-header bg-muted">{{ localTimeIn .Written .Timezone.String }}</header>
+                <div class="entry-body">
                     {{ $labels := BlogLabels .Idblogs }}
                     {{ .Blog.String | a4code2html}}<br><br>{{ .Username.String }} - [<a href="/blogs/blog/{{ .Idblogs }}/comments">{{ .Comments }} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{ .Idblogs }}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{ .Idblogs }}">ADMIN</a>]{{ end }}{{ if $labels }} <span class="label-list">{{ template "topicLabels" $labels }}</span>{{ end }}
-                </td>
-            </tr>
+                </div>
+            </article>
         {{ else }}
             {{ if gt (cd.Offset) 0 }}
                 {{ if cd.CurrentProfileUserID }}
@@ -39,6 +37,6 @@
                 {{ end }}
             {{ end }}
         {{ end }}
-    </table><br>
+    </section><br>
     {{ template "tail" $ }}
 {{ end }}

--- a/core/templates/site/listAbstracts.gohtml
+++ b/core/templates/site/listAbstracts.gohtml
@@ -5,25 +5,25 @@
     {{ $abstracts := cd.SelectedCategoryPublicWritings $.CategoryId $.Request }}
     {{ if gt (len $abstracts) 0 }}
         <span class="section-title">Writing abstracts:</span><br>
-    {{ end }}
-    {{ range $abstracts }}
-        {{ $title := .Title.String | a4code2html }}
-        {{ $username := .Username.String }}
-        {{ $published := localTime .Published.Time }}
-        {{ $abstract := .Abstract.String | a4code2html }}
-        {{ $idwriting := .Idwriting }}
-        {{ $private := .Private.Bool }}
-        {{ $comments := .Comments }}
-        {{ $labels := WritingLabels $idwriting }}
-        <table width="100%">
-            <tr><th class="bg-muted">{{ $title }} By {{ $username }} on {{ $published }}
-                {{ if $private }} - <i>Warning: Privileged information.</i>{{ end }}
-            </th></tr>
-            <tr><td>Abstract:<br>{{ $abstract }}
-                <br>-<br><a href="/writings/article/{{ $idwriting }}">Read now</a> - {{ $comments }} comments exist.
-                {{ if $labels }}<span class="label-list">{{ template "topicLabels" $labels }}</span>{{ end }}
-            </td></tr>
-        </table>
+        <section class="entry-list">
+        {{ range $abstracts }}
+            {{ $title := .Title.String | a4code2html }}
+            {{ $username := .Username.String }}
+            {{ $published := localTime .Published.Time }}
+            {{ $abstract := .Abstract.String | a4code2html }}
+            {{ $idwriting := .Idwriting }}
+            {{ $private := .Private.Bool }}
+            {{ $comments := .Comments }}
+            {{ $labels := WritingLabels $idwriting }}
+            <article class="entry">
+                <header class="entry-header bg-muted">{{ $title }} By {{ $username }} on {{ $published }}{{ if $private }} - <i>Warning: Privileged information.</i>{{ end }}</header>
+                <div class="entry-body">Abstract:<br>{{ $abstract }}
+                    <br>-<br><a href="/writings/article/{{ $idwriting }}">Read now</a> - {{ $comments }} comments exist.
+                    {{ if $labels }}<span class="label-list">{{ template "topicLabels" $labels }}</span>{{ end }}
+                </div>
+            </article>
+        {{ end }}
+        </section>
     {{ else }}
         There are no writings.
     {{ end }}

--- a/core/templates/site/showLatestLinks.gohtml
+++ b/core/templates/site/showLatestLinks.gohtml
@@ -1,49 +1,37 @@
 {{ define "getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingLinks" }}
-    <table width="100%">
+    <section class="entry-list">
         {{ if .HasOffset }}
             {{- range cd.SelectedLinkerItemsForCurrentUser (int32 .CatId) (int32 .Offset) }}
-                <tr>
-                    <th class="bg-muted">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
-                </tr>
-                <tr>
-                    <td>
+                <article class="entry">
+                    <header class="entry-header bg-muted">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></header>
+                    <div class="entry-body">
                         {{ .Description.String | a4code2html }}<hr>
                         {{ .Posterusername.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }} - [<a href="/linker/comments/{{ .ID }}">{{.Comments.Int32}} COMMENTS</a>]<br>
-                    </td>
-                </tr>
+                    </div>
+                </article>
             {{- else }}
                 {{- if .CatId }}
-                    <tr>
-                        <td>There are no more links under this category.</td>
-                    </tr>
+                    <div class="entry">There are no more links under this category.</div>
                 {{- else }}
-                    <tr>
-                        <td>There are no more links.</td>
-                    </tr>
+                    <div class="entry">There are no more links.</div>
                 {{- end }}
             {{- end }}
         {{ else }}
             {{- range cd.SelectedLinkerItemsForCurrentUser (int32 .CatId) 0 }}
-                <tr>
-                    <th class="bg-muted">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
-                </tr>
-                <tr>
-                    <td>
+                <article class="entry">
+                    <header class="entry-header bg-muted">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></header>
+                    <div class="entry-body">
                         {{ .Description.String | a4code2html }}<hr>
                         {{ .Posterusername.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }} - [<a href="/linker/comments/{{ .ID }}">{{.Comments.Int32}} COMMENTS</a>]<br>
-                    </td>
-                </tr>
+                    </div>
+                </article>
             {{- else }}
                 {{- if .CatId }}
-                    <tr>
-                        <td>Nothing under this category.</td>
-                    </tr>
+                    <div class="entry">Nothing under this category.</div>
                 {{- else }}
-                    <tr>
-                        <td>There are no links here.</td>
-                    </tr>
+                    <div class="entry">There are no links here.</div>
                 {{- end }}
             {{- end }}
         {{ end }}
-    </table><br>
+    </section><br>
 {{ end }}

--- a/core/templates/site/showLinkComments.gohtml
+++ b/core/templates/site/showLinkComments.gohtml
@@ -1,17 +1,15 @@
 {{ define "getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingComments" }}
     {{ with .Link }}
-        <table width="100%">
-            <tr>
-                <th class="bg-muted">{{ .Title.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
-            </tr>
-            <tr>
-                <td>
+        <section class="entry-list">
+            <article class="entry">
+                <header class="entry-header bg-muted">{{ .Title.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></header>
+                <div class="entry-body">
                     {{ .Description.String | a4code2html }}
                     <hr>
                     {{ .Username.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }}
-                </td>
-            </tr>
-        </table><br>
+                </div>
+            </article>
+        </section><br>
 
         {{ with .ThreadID }}
             {{ template "threadComments" }}


### PR DESCRIPTION
## Summary
- replace table-based link and blog templates with semantic `<section>`/`<article>` markup
- add reusable CSS classes for entry lists and entries
- update writing abstracts to use new structure

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a83f7fa30832f96a6b8d0b5e47227