### PR TITLE
refactor: replace layout tables with semantic elements

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -58,6 +58,23 @@ textarea {
         width: 90%;
 }
 
+.link-list {
+        width: 100%;
+        margin-bottom: 1em;
+}
+
+.link-item {
+        margin-bottom: 1em;
+}
+
+.link-header {
+        padding: 0.5em;
+}
+
+.link-body {
+        padding: 0.5em;
+}
+
 .navbar {
         display: flex;
         justify-content: space-between;

--- a/core/templates/site/listAbstracts.gohtml
+++ b/core/templates/site/listAbstracts.gohtml
@@ -5,25 +5,27 @@
     {{ $abstracts := cd.SelectedCategoryPublicWritings $.CategoryId $.Request }}
     {{ if gt (len $abstracts) 0 }}
         <span class="section-title">Writing abstracts:</span><br>
-    {{ end }}
-    {{ range $abstracts }}
-        {{ $title := .Title.String | a4code2html }}
-        {{ $username := .Username.String }}
-        {{ $published := localTime .Published.Time }}
-        {{ $abstract := .Abstract.String | a4code2html }}
-        {{ $idwriting := .Idwriting }}
-        {{ $private := .Private.Bool }}
-        {{ $comments := .Comments }}
-        {{ $labels := WritingLabels $idwriting }}
-        <table class="full-width">
-            <tr><th class="bg-muted">{{ $title }} By {{ $username }} on {{ $published }}
-                {{ if $private }} - <i>Warning: Privileged information.</i>{{ end }}
-            </th></tr>
-            <tr><td>Abstract:<br>{{ $abstract }}
-                <br>-<br><a href="/writings/article/{{ $idwriting }}">Read now</a> - {{ $comments }} comments exist.
-                {{ if $labels }}<span class="label-list">{{ template "topicLabels" $labels }}</span>{{ end }}
-            </td></tr>
-        </table>
+        <section class="link-list">
+        {{ range $abstracts }}
+            {{ $title := .Title.String | a4code2html }}
+            {{ $username := .Username.String }}
+            {{ $published := localTime .Published.Time }}
+            {{ $abstract := .Abstract.String | a4code2html }}
+            {{ $idwriting := .Idwriting }}
+            {{ $private := .Private.Bool }}
+            {{ $comments := .Comments }}
+            {{ $labels := WritingLabels $idwriting }}
+            <article class="full-width link-item">
+                <header class="bg-muted link-header">{{ $title }} By {{ $username }} on {{ $published }}
+                    {{ if $private }} - <i>Warning: Privileged information.</i>{{ end }}
+                </header>
+                <div class="link-body">Abstract:<br>{{ $abstract }}
+                    <br>-<br><a href="/writings/article/{{ $idwriting }}">Read now</a> - {{ $comments }} comments exist.
+                    {{ if $labels }}<span class="label-list">{{ template "topicLabels" $labels }}</span>{{ end }}
+                </div>
+            </article>
+        {{ end }}
+        </section>
     {{ else }}
         There are no writings.
     {{ end }}

--- a/core/templates/site/showLatestLinks.gohtml
+++ b/core/templates/site/showLatestLinks.gohtml
@@ -1,49 +1,37 @@
 {{ define "getAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingLinks" }}
-    <table class="full-width">
+    <section class="full-width link-list">
         {{ if .HasOffset }}
             {{- range cd.SelectedLinkerItemsForCurrentUser (int32 .CatId) (int32 .Offset) }}
-                <tr>
-                    <th class="bg-muted">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
-                </tr>
-                <tr>
-                    <td>
+                <article class="link-item">
+                    <header class="bg-muted link-header">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></header>
+                    <div class="link-body">
                         {{ .Description.String | a4code2html }}<hr>
                         {{ .Posterusername.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }} - [<a href="/linker/comments/{{ .ID }}">{{.Comments.Int32}} COMMENTS</a>]<br>
-                    </td>
-                </tr>
+                    </div>
+                </article>
             {{- else }}
                 {{- if .CatId }}
-                    <tr>
-                        <td>There are no more links under this category.</td>
-                    </tr>
+                    <div class="link-item"><div class="link-body">There are no more links under this category.</div></div>
                 {{- else }}
-                    <tr>
-                        <td>There are no more links.</td>
-                    </tr>
+                    <div class="link-item"><div class="link-body">There are no more links.</div></div>
                 {{- end }}
             {{- end }}
         {{ else }}
             {{- range cd.SelectedLinkerItemsForCurrentUser (int32 .CatId) 0 }}
-                <tr>
-                    <th class="bg-muted">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
-                </tr>
-                <tr>
-                    <td>
+                <article class="link-item">
+                    <header class="bg-muted link-header">{{ .CategoryTitle.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></header>
+                    <div class="link-body">
                         {{ .Description.String | a4code2html }}<hr>
                         {{ .Posterusername.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }} - [<a href="/linker/comments/{{ .ID }}">{{.Comments.Int32}} COMMENTS</a>]<br>
-                    </td>
-                </tr>
+                    </div>
+                </article>
             {{- else }}
                 {{- if .CatId }}
-                    <tr>
-                        <td>Nothing under this category.</td>
-                    </tr>
+                    <div class="link-item"><div class="link-body">Nothing under this category.</div></div>
                 {{- else }}
-                    <tr>
-                        <td>There are no links here.</td>
-                    </tr>
+                    <div class="link-item"><div class="link-body">There are no links here.</div></div>
                 {{- end }}
             {{- end }}
         {{ end }}
-    </table><br>
+    </section>
 {{ end }}

--- a/core/templates/site/showLinkComments.gohtml
+++ b/core/templates/site/showLinkComments.gohtml
@@ -1,17 +1,15 @@
 {{ define "getLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingComments" }}
     {{ with .Link }}
-        <table class="full-width">
-            <tr>
-                <th class="bg-muted">{{ .Title.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></th>
-            </tr>
-            <tr>
-                <td>
+        <section class="full-width link-list">
+            <article class="link-item">
+                <header class="bg-muted link-header">{{ .Title.String }}: <a href="{{ .Url.String }}" target="_BLANK">{{ .Title.String }}</a></header>
+                <div class="link-body">
                     {{ .Description.String | a4code2html }}
                     <hr>
                     {{ .Username.String }} - Listed: {{ localTimeIn .Listed.Time .Timezone.String }}
-                </td>
-            </tr>
-        </table><br>
+                </div>
+            </article>
+        </section>
 
         {{ with .ThreadID }}
             {{ template "threadComments" }}


### PR DESCRIPTION
## Summary
- replace layout `<table>` structures with semantic `<section>`/`article>` wrappers
- introduce reusable CSS classes for link lists and items

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestNewsPostPageNoDuplicateLabels)*

------
https://chatgpt.com/codex/tasks/task_e_689ab7e4ca28832f9bc37252c72cf0b4