### PR TITLE
Fix duplicated private labels on news posts

### DIFF
--- a/core/templates/site/news/postPage.gohtml
+++ b/core/templates/site/news/postPage.gohtml
@@ -17,7 +17,7 @@
     <hr><h2 class="section-heading">Replies:</h2>
     {{ template "threadComments" }}
     <div class="label-editor">
-        {{ if .Labels }}<section class="label-list">{{ template "topicLabels" .Labels }}</section>{{ end }}
+        {{ if .PublicLabels }}<section class="label-list">{{ template "topicLabels" .PublicLabels }}</section>{{ end }}
         <form method="post" action="/news/news/{{ .Post.Idsitenews }}/labels" id="label-form">
         {{ csrfField }}
             <input type="hidden" name="task" value="Set Labels"/>

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -32,6 +32,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		Editing        func(*db.GetCommentsByThreadIdForUserRow) bool
 		AdminURL       func(*db.GetCommentsByThreadIdForUserRow) string
 		Labels         []templates.TopicLabel
+		PublicLabels   []templates.TopicLabel
 		BackURL        string
 	}
 
@@ -150,7 +151,9 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 
 	if als, err := cd.NewsAuthorLabels(post.Idsitenews); err == nil {
 		for _, l := range als {
-			data.Labels = append(data.Labels, templates.TopicLabel{Name: l, Type: "author"})
+			tl := templates.TopicLabel{Name: l, Type: "author"}
+			data.Labels = append(data.Labels, tl)
+			data.PublicLabels = append(data.PublicLabels, tl)
 		}
 	}
 	if pls, err := cd.NewsPrivateLabels(post.Idsitenews); err == nil {


### PR DESCRIPTION
## Summary
- avoid rendering private labels in news posts twice by separating public and private labels
- ensure each private label has a dismiss button
- add tests covering private label display logic

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689aea1d1454832fb38cbc520b6c0d5a