### PR TITLE
Use private breadcrumb label for private forums

### DIFF
--- a/core/common/breadcrumb.go
+++ b/core/common/breadcrumb.go
@@ -54,7 +54,11 @@ func (cd *CoreData) forumBreadcrumbs() ([]Breadcrumb, error) {
 	if base == "" {
 		base = "/forum"
 	}
-	crumbs := []Breadcrumb{{Title: "Forum", Link: base}}
+	crumbTitle := "Forum"
+	if cd != nil && cd.currentSection == "privateforum" {
+		crumbTitle = "Private"
+	}
+	crumbs := []Breadcrumb{{Title: crumbTitle, Link: base}}
 	catID := cd.currentCategoryID
 	topicID := cd.currentTopicID
 	threadID := cd.currentThreadID

--- a/core/common/breadcrumb_private_title_test.go
+++ b/core/common/breadcrumb_private_title_test.go
@@ -45,6 +45,9 @@ func TestPrivateForumBreadcrumbUsesDisplayTitle(t *testing.T) {
 	if len(crumbs) < 2 {
 		t.Fatalf("expected >=2 crumbs, got %v", crumbs)
 	}
+	if crumbs[0].Title != "Private" {
+		t.Fatalf("unexpected root crumb title: %v", crumbs[0].Title)
+	}
 	if crumbs[1].Title != "Alice, Bob" {
 		t.Fatalf("unexpected crumb title: %v", crumbs[1].Title)
 	}

--- a/handlers/privateforum/topic_page_test.go
+++ b/handlers/privateforum/topic_page_test.go
@@ -62,7 +62,7 @@ func TestTopicPage_Prefix(t *testing.T) {
 	if !strings.Contains(body, "/private/topic/1/thread") {
 		t.Fatalf("expected private thread link, got %q", body)
 	}
-	if !strings.Contains(body, `<nav class="breadcrumbs"`) || !strings.Contains(body, `href="/private">Forum</a>`) {
+	if !strings.Contains(body, `<nav class="breadcrumbs"`) || !strings.Contains(body, `href="/private">Private</a>`) {
 		t.Fatalf("expected private breadcrumb, got %q", body)
 	}
 


### PR DESCRIPTION
## Summary
- show "Private" instead of "Forum" in breadcrumbs for private forums
- adjust private forum tests for new breadcrumb label

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...` *(fails: TestNewsPostPageNoDuplicateLabels)*

------
https://chatgpt.com/codex/tasks/task_e_689aea56a4ec832f89186eae870febe1