### PR TITLE
Log template mode at startup

### DIFF
--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -205,6 +205,11 @@ func parseRoot(args []string) (*rootCmd, error) {
 		config.WithGetenv(os.Getenv),
 	)
 	coretemplates.SetDir(r.cfg.TemplatesDir)
+	if r.cfg.TemplatesDir == "" {
+		r.Infof("Embedded Template Mode")
+	} else {
+		r.Infof("Live Template Mode: %s", r.cfg.TemplatesDir)
+	}
 	return r, nil
 }
 

--- a/core/templates/templates.go
+++ b/core/templates/templates.go
@@ -4,7 +4,6 @@ import (
 	"embed"
 	htemplate "html/template"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	ttemplate "text/template"
@@ -20,14 +19,7 @@ var templatesDir string
 var embeddedFS embed.FS
 
 // SetDir configures templates to be loaded from dir. When dir is empty the embedded templates are used.
-func SetDir(dir string) {
-	templatesDir = dir
-	if dir == "" {
-		log.Printf("Embedded Template Mode")
-	} else {
-		log.Printf("Live Template Mode: %s", dir)
-	}
-}
+func SetDir(dir string) { templatesDir = dir }
 
 func getFS(sub string) fs.FS {
 	if templatesDir == "" {


### PR DESCRIPTION
## Summary
- log whether live or embedded templates are active during startup
- simplify template directory setup

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689af58fbe38832f9ba3efd2f8e0cec7