### PR TITLE
Fix private forum comment editing URLs

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -2066,7 +2066,7 @@ func (cd *CoreData) CommentEditURL(cmt *db.GetCommentsByThreadIdForUserRow) stri
 		return fmt.Sprintf("?editComment=%d#edit", cmt.Idcomments)
 	case "writing":
 		return fmt.Sprintf("?editComment=%d#edit", cmt.Idcomments)
-	case "forum":
+	case "forum", "privateforum":
 		return fmt.Sprintf("?comment=%d#edit", cmt.Idcomments)
 	case "imagebbs":
 		return fmt.Sprintf("?comment=%d#edit", cmt.Idcomments)
@@ -2084,6 +2084,7 @@ func (cd *CoreData) CommentEditSaveURL(cmt *db.GetCommentsByThreadIdForUserRow) 
 	if !cd.CanEditComment(cmt) {
 		return ""
 	}
+	base := cd.ForumBasePath
 	switch cd.currentSection {
 	case "blogs":
 		return fmt.Sprintf("/blogs/blog/%d/comment/%d", cd.currentBlogID, cmt.Idcomments)
@@ -2091,8 +2092,16 @@ func (cd *CoreData) CommentEditSaveURL(cmt *db.GetCommentsByThreadIdForUserRow) 
 		return fmt.Sprintf("/news/news/%d/comment/%d", cd.currentNewsPostID, cmt.Idcomments)
 	case "writing":
 		return fmt.Sprintf("/writings/article/%d/comment/%d", cd.currentWritingID, cmt.Idcomments)
+	case "privateforum":
+		if base != "" {
+			return fmt.Sprintf("%s/topic/%d/thread/%d/comment/%d", base, cd.currentTopicID, cd.currentThreadID, cmt.Idcomments)
+		}
+		fallthrough
 	case "forum":
-		return fmt.Sprintf("/forum/thread/%d/comment/%d", cd.currentThreadID, cmt.Idcomments)
+		if base == "" {
+			base = "/forum"
+		}
+		return fmt.Sprintf("%s/topic/%d/thread/%d/comment/%d", base, cd.currentTopicID, cd.currentThreadID, cmt.Idcomments)
 	case "imagebbs":
 		return fmt.Sprintf("/imagebbs/board/%d/thread/%d/comment/%d", cd.currentBoardID, cd.currentThreadID, cmt.Idcomments)
 	case "linker":

--- a/core/common/coredata_commentedit_test.go
+++ b/core/common/coredata_commentedit_test.go
@@ -1,0 +1,36 @@
+package common_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestCommentEditURLsPrivateForum(t *testing.T) {
+	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
+	cd.SetCurrentSection("privateforum")
+	cd.SetCurrentThreadAndTopic(106, 30)
+	cd.ForumBasePath = "/private"
+	cmt := &db.GetCommentsByThreadIdForUserRow{Idcomments: 42, IsOwner: true}
+
+	if got, want := cd.CommentEditURL(cmt), "?comment=42#edit"; got != want {
+		t.Fatalf("CommentEditURL got %q, want %q", got, want)
+	}
+	if got, want := cd.CommentEditSaveURL(cmt), "/private/topic/30/thread/106/comment/42"; got != want {
+		t.Fatalf("CommentEditSaveURL got %q, want %q", got, want)
+	}
+}
+
+func TestCommentEditSaveURLPrivateForumFallback(t *testing.T) {
+	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
+	cd.SetCurrentSection("privateforum")
+	cd.SetCurrentThreadAndTopic(106, 30)
+	cmt := &db.GetCommentsByThreadIdForUserRow{Idcomments: 42, IsOwner: true}
+
+	if got, want := cd.CommentEditSaveURL(cmt), "/forum/topic/30/thread/106/comment/42"; got != want {
+		t.Fatalf("CommentEditSaveURL got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- fix comment edit URL generation to include forum base path and topic
- ensure private forums fall back to public forum path when no base path is configured
- add tests covering private forum comment editing links and fallback behavior

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689afb05392c832fac91b2d563a46d44