### PR TITLE
Preserve original request data through login redirect

### DIFF
--- a/core/session.go
+++ b/core/session.go
@@ -55,7 +55,7 @@ func GetSessionOrFail(w http.ResponseWriter, r *http.Request) (*sessions.Session
 // an error occurs retrieving the session.
 func SessionErrorRedirect(w http.ResponseWriter, r *http.Request, err error) {
 	SessionError(w, r, err)
-	http.Redirect(w, r, "/login", http.StatusFound)
+	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }
 
 // SessionError logs the error and clears the session cookie.

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -33,7 +33,7 @@ func TestSessionMiddlewareBadSession(t *testing.T) {
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
-	if rr.Code != http.StatusFound {
+	if rr.Code != http.StatusSeeOther {
 		t.Fatalf("expected redirect got %d", rr.Code)
 	}
 	sc := rr.Header().Get("Set-Cookie")
@@ -53,7 +53,7 @@ func TestGetSessionOrFailBadSession(t *testing.T) {
 	if ok {
 		t.Fatalf("expected failure, got session %v", sess)
 	}
-	if rr.Code != http.StatusFound {
+	if rr.Code != http.StatusSeeOther {
 		t.Fatalf("expected redirect got %d", rr.Code)
 	}
 	sc := rr.Header().Get("Set-Cookie")

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -73,7 +73,7 @@ func userEmailVerifyCodePage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 	if uid == 0 {
-		middleware.RedirectToLogin(w, r, session)
+		_ = middleware.RedirectToLogin(w, r, session)
 		return
 	}
 

--- a/handlers/user/userPage.go
+++ b/handlers/user/userPage.go
@@ -25,7 +25,7 @@ func userPage(w http.ResponseWriter, r *http.Request) {
 			handlers.RenderErrorPage(w, r, fmt.Errorf("Internal Server Error"))
 			return
 		}
-		middleware.RedirectToLogin(w, r, session)
+		_ = middleware.RedirectToLogin(w, r, session)
 		return
 	}
 

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -199,7 +199,7 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 					delete(session.Values, "UID")
 					delete(session.Values, "LoginTime")
 					delete(session.Values, "ExpiryTime")
-					middleware.RedirectToLogin(w, r, session)
+					_ = middleware.RedirectToLogin(w, r, session)
 					return
 				}
 			}

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -1,0 +1,79 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/sessions"
+)
+
+func TestRedirectToLogin(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test"))
+	req := httptest.NewRequest(http.MethodGet, "/path", nil)
+	sess, _ := store.New(req, "sess")
+	rr := httptest.NewRecorder()
+	code := RedirectToLogin(rr, req, sess)
+	if code != http.StatusSeeOther {
+		t.Fatalf("code=%d", code)
+	}
+	if rr.Result().StatusCode != http.StatusSeeOther {
+		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+}
+
+func TestRedirectToLoginIncludesBackAndQuery(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/page?x=1", nil)
+	rr := httptest.NewRecorder()
+	RedirectToLogin(rr, req, nil)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	loc := rr.Header().Get("Location")
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse location: %v", err)
+	}
+	q := u.Query()
+	if got := q.Get("back"); got != "/page?x=1" {
+		t.Fatalf("back=%q", got)
+	}
+	if q.Has("method") {
+		t.Fatalf("unexpected method param: %s", q.Get("method"))
+	}
+	if q.Has("data") {
+		t.Fatalf("unexpected data param: %s", q.Get("data"))
+	}
+}
+
+func TestRedirectToLoginPreservesPostData(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test"))
+	form := url.Values{"a": {"1"}, "b": {"2"}}
+	req := httptest.NewRequest(http.MethodPost, "/submit?foo=1", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	sess, _ := store.New(req, "sess")
+	rr := httptest.NewRecorder()
+	RedirectToLogin(rr, req, sess)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	loc := rr.Header().Get("Location")
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse location: %v", err)
+	}
+	q := u.Query()
+	if got := q.Get("back"); got != "/submit?foo=1" {
+		t.Fatalf("back=%q", got)
+	}
+	if got := q.Get("method"); got != http.MethodPost {
+		t.Fatalf("method=%q", got)
+	}
+	if got := q.Get("data"); got != form.Encode() {
+		t.Fatalf("data=%q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- keep RedirectToLogin recording the original method and POST body separately while logging parse failures
- add middleware tests covering GET and POST redirect metadata preservation
- ensure failed login attempts retain hidden back fields so users can retry with their prior input

## Testing
- go mod tidy
- go vet ./... && echo vetdone
- golangci-lint run
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c225a14cfc832f9562593c9581e2ce