### PR TITLE
Introduce redirect helper that uses SeeOther for POST

### DIFF
--- a/core/session.go
+++ b/core/session.go
@@ -55,7 +55,11 @@ func GetSessionOrFail(w http.ResponseWriter, r *http.Request) (*sessions.Session
 // an error occurs retrieving the session.
 func SessionErrorRedirect(w http.ResponseWriter, r *http.Request, err error) {
 	SessionError(w, r, err)
-	http.Redirect(w, r, "/login", http.StatusFound)
+	status := http.StatusSeeOther
+	if r.Method == http.MethodGet || r.Method == http.MethodHead {
+		status = http.StatusFound
+	}
+	http.Redirect(w, r, "/login", status)
 }
 
 // SessionError logs the error and clears the session cookie.

--- a/handlers/auth/forgotPassword_limit_test.go
+++ b/handlers/auth/forgotPassword_limit_test.go
@@ -43,7 +43,7 @@ func TestForgotPasswordRateLimit(t *testing.T) {
 
 	handlers.TaskHandler(forgotPasswordTask)(rr, req)
 
-	if rr.Code != http.StatusTemporaryRedirect {
+	if rr.Code != http.StatusSeeOther {
 		t.Fatalf("status=%d", rr.Code)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/handlers/auth/registerPage_test.go
+++ b/handlers/auth/registerPage_test.go
@@ -33,7 +33,7 @@ func TestRegisterActionPageValidation(t *testing.T) {
 		handlers.TaskHandler(registerTask)(rr, req)
 		want := http.StatusOK
 		if c.name == "invalid email" {
-			want = http.StatusTemporaryRedirect
+			want = http.StatusSeeOther
 		}
 		if rr.Result().StatusCode != want {
 			t.Errorf("%s: status=%d", c.name, rr.Result().StatusCode)

--- a/handlers/auth/verify_password_task_test.go
+++ b/handlers/auth/verify_password_task_test.go
@@ -79,7 +79,7 @@ func TestVerifyPasswordAction_InvalidPassword(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handlers.TaskHandler(verifyPasswordTask)(rr, req)
 
-	if rr.Code != http.StatusTemporaryRedirect {
+	if rr.Code != http.StatusSeeOther {
 		t.Fatalf("status=%d", rr.Code)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/handlers/blogs/bloggerListPage.go
+++ b/handlers/blogs/bloggerListPage.go
@@ -53,7 +53,7 @@ func BloggerListPage(w http.ResponseWriter, r *http.Request) {
 
 	if data.Search != "" {
 		if len(rows) == 1 {
-			http.Redirect(w, r, "/blogs/blogger/"+rows[0].Username.String, http.StatusFound)
+			handlers.RedirectToGet(w, r, "/blogs/blogger/"+rows[0].Username.String)
 			return
 		}
 		if len(rows) == 0 {

--- a/handlers/errorhandlers.go
+++ b/handlers/errorhandlers.go
@@ -7,7 +7,7 @@ type errRedirectOnSamePageHandler struct {
 }
 
 func (e errRedirectOnSamePageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "?error="+e.Error(), http.StatusTemporaryRedirect)
+	RedirectToGet(w, r, "?error="+e.Error())
 }
 
 var _ http.Handler = (*errRedirectOnSamePageHandler)(nil)

--- a/handlers/externallink/redirect.go
+++ b/handlers/externallink/redirect.go
@@ -36,7 +36,7 @@ func RedirectHandler(w http.ResponseWriter, r *http.Request) {
 	raw := link.Url
 	if r.URL.Query().Get("go") != "" {
 		cd.RegisterExternalLinkClick(raw)
-		http.Redirect(w, r, raw, http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, raw)
 		return
 	}
 

--- a/handlers/forum/adminForumHandler.go
+++ b/handlers/forum/adminForumHandler.go
@@ -52,7 +52,7 @@ func AdminForumPage(w http.ResponseWriter, r *http.Request) {
 	categoryRows, err := cd.ForumCategories()
 	if err != nil {
 		log.Printf("getAllForumCategories Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 
@@ -66,7 +66,7 @@ func AdminForumPage(w http.ResponseWriter, r *http.Request) {
 	rows, err := cd.ForumTopics(0)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("ForumTopics Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	var topicRows []*ForumtopicPlus

--- a/handlers/forum/forumAdminCategoryCreatePage.go
+++ b/handlers/forum/forumAdminCategoryCreatePage.go
@@ -38,7 +38,7 @@ func AdminCategoryCreateSubmit(w http.ResponseWriter, r *http.Request) {
 	_ = desc
 	pcid, err := strconv.Atoi(r.PostFormValue("pcid"))
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 
@@ -46,7 +46,7 @@ func AdminCategoryCreateSubmit(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	cats, err := queries.GetAllForumCategories(r.Context(), db.GetAllForumCategoriesParams{ViewerID: cd.UserID})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	parents := make(map[int32]int32, len(cats))
@@ -54,11 +54,11 @@ func AdminCategoryCreateSubmit(w http.ResponseWriter, r *http.Request) {
 		parents[c.Idforumcategory] = c.ForumcategoryIdforumcategory
 	}
 	if path, loop := algorithms.WouldCreateLoop(parents, 0, int32(pcid)); loop {
-		http.Redirect(w, r, "?error="+fmt.Sprintf("loop %v", path), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+fmt.Sprintf("loop %v", path))
 		return
 	}
 
 	languageID, _ := strconv.Atoi(r.PostFormValue("language"))
 	_ = languageID // TODO: implement category creation
-	http.Redirect(w, r, "/admin/forum/categories", http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, "/admin/forum/categories")
 }

--- a/handlers/forum/forumAdminCategoryEditPage.go
+++ b/handlers/forum/forumAdminCategoryEditPage.go
@@ -56,7 +56,7 @@ func AdminCategoryEditSubmit(w http.ResponseWriter, r *http.Request) {
 	_ = desc
 	pcid, err := strconv.Atoi(r.PostFormValue("pcid"))
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
@@ -67,7 +67,7 @@ func AdminCategoryEditSubmit(w http.ResponseWriter, r *http.Request) {
 
 	cats, err := cd.ForumCategories()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	parents := make(map[int32]int32, len(cats))
@@ -75,7 +75,7 @@ func AdminCategoryEditSubmit(w http.ResponseWriter, r *http.Request) {
 		parents[c.Idforumcategory] = c.ForumcategoryIdforumcategory
 	}
 	if path, loop := algorithms.WouldCreateLoop(parents, int32(categoryId), int32(pcid)); loop {
-		http.Redirect(w, r, "?error="+fmt.Sprintf("loop %v", path), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+fmt.Sprintf("loop %v", path))
 		return
 	}
 
@@ -86,7 +86,7 @@ func AdminCategoryEditSubmit(w http.ResponseWriter, r *http.Request) {
 	if strings.HasSuffix(r.URL.Path, "/edit") {
 		redirectURL = fmt.Sprintf("/admin/forum/categories/category/%d", categoryId)
 	}
-	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, redirectURL)
 }
 
 // AdminCategoryDeletePage removes a forum category.
@@ -94,12 +94,12 @@ func AdminCategoryDeletePage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	cid, err := strconv.Atoi(mux.Vars(r)["category"])
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	if err := cd.Queries().AdminDeleteForumCategory(r.Context(), int32(cid)); err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
-	http.Redirect(w, r, "/admin/forum/categories", http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, "/admin/forum/categories")
 }

--- a/handlers/forum/forumAdminThreadsPage.go
+++ b/handlers/forum/forumAdminThreadsPage.go
@@ -24,26 +24,26 @@ func AdminThreadsPage(w http.ResponseWriter, r *http.Request) {
 func AdminThreadDeletePage(w http.ResponseWriter, r *http.Request) {
 	threadID, err := strconv.Atoi(mux.Vars(r)["thread"])
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	topicID, err := cd.Queries().GetForumTopicIdByThreadId(r.Context(), int32(threadID))
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	if err := ThreadDelete(r.Context(), cd.Queries(), int32(threadID), topicID); err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
-	http.Redirect(w, r, "/admin/forum/threads", http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, "/admin/forum/threads")
 }
 
 func AdminThreadDeleteConfirmPage(w http.ResponseWriter, r *http.Request) {
 	threadID, err := strconv.Atoi(mux.Vars(r)["thread"])
 	if err != nil {
-		http.Redirect(w, r, "/admin/forum/threads?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "/admin/forum/threads?error="+err.Error())
 		return
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
@@ -63,7 +63,7 @@ func AdminThreadDeleteConfirmPage(w http.ResponseWriter, r *http.Request) {
 func AdminThreadPage(w http.ResponseWriter, r *http.Request) {
 	threadID, err := strconv.Atoi(mux.Vars(r)["thread"])
 	if err != nil {
-		http.Redirect(w, r, "/admin/forum/threads?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "/admin/forum/threads?error="+err.Error())
 		return
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
@@ -80,7 +80,7 @@ func AdminThreadPage(w http.ResponseWriter, r *http.Request) {
 		ViewerMatchID: sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})
 	if err != nil {
-		http.Redirect(w, r, "/admin/forum/threads?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "/admin/forum/threads?error="+err.Error())
 		return
 	}
 

--- a/handlers/forum/forumAdminTopicsPage.go
+++ b/handlers/forum/forumAdminTopicsPage.go
@@ -61,13 +61,13 @@ func AdminTopicEditPage(w http.ResponseWriter, r *http.Request) {
 	desc := r.PostFormValue("desc")
 	cid, err := strconv.Atoi(r.PostFormValue("cid"))
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	tid, err := strconv.Atoi(mux.Vars(r)["topic"])
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	_ = name
@@ -77,7 +77,7 @@ func AdminTopicEditPage(w http.ResponseWriter, r *http.Request) {
 	_ = tid
 	languageID, _ := strconv.Atoi(r.PostFormValue("language"))
 	_ = languageID // TODO: implement topic update
-	http.Redirect(w, r, "/admin/forum/topics", http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, "/admin/forum/topics")
 }
 
 func AdminTopicCreatePage(w http.ResponseWriter, r *http.Request) {
@@ -85,7 +85,7 @@ func AdminTopicCreatePage(w http.ResponseWriter, r *http.Request) {
 	desc := r.PostFormValue("desc")
 	pcid, err := strconv.Atoi(r.PostFormValue("pcid"))
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
@@ -120,7 +120,7 @@ func AdminTopicCreatePage(w http.ResponseWriter, r *http.Request) {
 		GranteeID:       sql.NullInt32{Int32: uid, Valid: uid != 0},
 	})
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	if topicID == 0 {
@@ -128,19 +128,19 @@ func AdminTopicCreatePage(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("forbidden"))
 		return
 	}
-	http.Redirect(w, r, "/admin/forum/topics", http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, "/admin/forum/topics")
 }
 
 func AdminTopicDeletePage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	tid, err := strconv.Atoi(mux.Vars(r)["topic"])
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	if err := cd.Queries().AdminDeleteForumTopic(r.Context(), int32(tid)); err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
-	http.Redirect(w, r, "/admin/forum/topics", http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, "/admin/forum/topics")
 }

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -51,14 +51,14 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	categoryRows, err := cd.ForumCategories()
 	if err != nil {
 		log.Printf("getAllForumCategories Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	var topicRows []*ForumtopicPlus
 	rows, err := cd.ForumTopics(int32(categoryId))
 	if err != nil {
 		log.Printf("ForumTopics Error: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	for _, row := range rows {

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -217,5 +217,5 @@ func ThreadNewCancelPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	endUrl := fmt.Sprintf("%s/topic/%d", base, topicId)
-	http.Redirect(w, r, endUrl, http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, endUrl)
 }

--- a/handlers/forum/forumTopicPage.go
+++ b/handlers/forum/forumTopicPage.go
@@ -131,7 +131,7 @@ func TopicsPageWithBasePath(w http.ResponseWriter, r *http.Request, basePath str
 	threadRows, err := cd.ForumThreads(int32(topicId))
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Printf("Error: ForumThreads: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	threads := make([]*threadWithLabels, len(threadRows))

--- a/handlers/forum/forumTopicThreadCommentEditPage.go
+++ b/handlers/forum/forumTopicThreadCommentEditPage.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/workers/postcountworker"
 	"github.com/gorilla/mux"
 )
@@ -14,7 +15,7 @@ import (
 func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	languageId, err := strconv.Atoi(r.PostFormValue("language"))
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	text := r.PostFormValue("replytext")
@@ -24,19 +25,19 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	cd.PageTitle = "Forum - Edit Comment"
 	threadRow, err := cd.SelectedThread()
 	if err != nil || threadRow == nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	topicRow, err := cd.CurrentTopic()
 	if err != nil || topicRow == nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	commentId, _ := strconv.Atoi(mux.Vars(r)["comment"])
 
 	err = cd.UpdateForumComment(int32(commentId), int32(languageId), text)
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 
@@ -50,7 +51,7 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	http.Redirect(w, r, fmt.Sprintf("/forum/topic/%d/thread/%d#comment-%d", topicRow.Idforumtopic, threadRow.Idforumthread, commentId), http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, fmt.Sprintf("/forum/topic/%d/thread/%d#comment-%d", topicRow.Idforumtopic, threadRow.Idforumthread, commentId))
 }
 
 func TopicThreadCommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
@@ -59,16 +60,16 @@ func TopicThreadCommentEditActionCancelPage(w http.ResponseWriter, r *http.Reque
 	cd.PageTitle = "Forum - Edit Comment"
 	threadRow, err := cd.SelectedThread()
 	if err != nil || threadRow == nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	topicRow, err := cd.CurrentTopic()
 	if err != nil || topicRow == nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 
 	endUrl := fmt.Sprintf("/forum/topic/%d/thread/%d#bottom", topicRow.Idforumtopic, threadRow.Idforumthread)
 
-	http.Redirect(w, r, endUrl, http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, endUrl)
 }

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -180,12 +180,12 @@ func TopicThreadReplyCancelPage(w http.ResponseWriter, r *http.Request) {
 	cd.PageTitle = "Forum - Reply"
 	threadRow, err := cd.SelectedThread()
 	if err != nil || threadRow == nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	topicRow, err := cd.CurrentTopic()
 	if err != nil || topicRow == nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	base := cd.ForumBasePath
@@ -193,5 +193,5 @@ func TopicThreadReplyCancelPage(w http.ResponseWriter, r *http.Request) {
 		base = "/forum"
 	}
 	endUrl := fmt.Sprintf("%s/topic/%d/thread/%d#bottom", base, topicRow.Idforumtopic, threadRow.Idforumthread)
-	http.Redirect(w, r, endUrl, http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, endUrl)
 }

--- a/handlers/imagebbs/imagebbsAdminNewBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminNewBoardPage.go
@@ -37,7 +37,7 @@ func (NewBoardTask) AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *s
 }
 
 func AdminNewBoardPage(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/admin/imagebbs/boards", http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, "/admin/imagebbs/boards")
 }
 
 func (NewBoardTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -42,7 +42,7 @@ func AdminAddPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getAllForumCategories Error: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			handlers.RedirectToGet(w, r, "?error="+err.Error())
 			return
 		}
 	}

--- a/handlers/linker/linkerCommentsEditPage.go
+++ b/handlers/linker/linkerCommentsEditPage.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/handlers"
 	"github.com/gorilla/mux"
 )
 
@@ -12,5 +13,5 @@ import (
 func CommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	linkId, _ := strconv.Atoi(vars["link"])
-	http.Redirect(w, r, fmt.Sprintf("/linker/comments/%d", linkId), http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, fmt.Sprintf("/linker/comments/%d", linkId))
 }

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -118,7 +118,7 @@ func CommentsPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("Error: getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			handlers.RedirectToGet(w, r, "?error="+err.Error())
 			return
 		}
 	}

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -79,12 +79,12 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 	linkId, err := strconv.Atoi(vars["link"])
 
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	if linkId == 0 {
 		log.Printf("Error: no bid")
-		http.Redirect(w, r, "?error="+"No bid", http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+"No bid")
 		return
 	}
 
@@ -133,13 +133,13 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		})
 		if err != nil {
 			log.Printf("Error: createForumTopic: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			handlers.RedirectToGet(w, r, "?error="+err.Error())
 			return
 		}
 		ptid = int32(ptidi)
 	} else if err != nil {
 		log.Printf("Error: findForumTopicByTitle: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	} else {
 		ptid = pt.Idforumtopic
@@ -148,7 +148,7 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		pthidi, err := queries.SystemCreateThread(r.Context(), ptid)
 		if err != nil {
 			log.Printf("Error: makeThread: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			handlers.RedirectToGet(w, r, "?error="+err.Error())
 			return
 		}
 		pthid = int32(pthidi)
@@ -157,7 +157,7 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 			ID:       int32(linkId),
 		}); err != nil {
 			log.Printf("Error: assignThreadIdToBlogEntry: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			handlers.RedirectToGet(w, r, "?error="+err.Error())
 			return
 		}
 	}
@@ -171,13 +171,13 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 	cid, err := cd.CreateLinkerCommentForCommenter(uid, pthid, int32(linkId), int32(languageId), text)
 	if err != nil {
 		log.Printf("Error: createComment: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	if cid == 0 {
 		err := handlers.ErrForbidden
 		log.Printf("Error: createComment: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 
@@ -199,5 +199,5 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	http.Redirect(w, r, endUrl, http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, endUrl)
 }

--- a/handlers/linker/linkerSuggestPage.go
+++ b/handlers/linker/linkerSuggestPage.go
@@ -42,7 +42,7 @@ func SuggestPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("getAllForumCategories Error: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			handlers.RedirectToGet(w, r, "?error="+err.Error())
 			return
 		}
 	}

--- a/handlers/news/admin_pages.go
+++ b/handlers/news/admin_pages.go
@@ -89,7 +89,7 @@ func AdminNewsPostPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	pid, err := strconv.Atoi(mux.Vars(r)["news"])
 	if err != nil {
-		http.Redirect(w, r, "/admin/news", http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "/admin/news")
 		return
 	}
 	post, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(r.Context(), db.GetNewsPostByIdWithWriterIdAndThreadCommentCountParams{
@@ -98,7 +98,7 @@ func AdminNewsPostPage(w http.ResponseWriter, r *http.Request) {
 		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	})
 	if err != nil {
-		http.Redirect(w, r, "/admin/news?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "/admin/news?error="+err.Error())
 		return
 	}
 	topicID, err := queries.GetForumTopicIdByThreadId(r.Context(), post.ForumthreadID)
@@ -152,7 +152,7 @@ func adminNewsEditFormPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	pid, err := strconv.Atoi(mux.Vars(r)["news"])
 	if err != nil {
-		http.Redirect(w, r, "/admin/news", http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "/admin/news")
 		return
 	}
 	post, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(r.Context(), db.GetNewsPostByIdWithWriterIdAndThreadCommentCountParams{
@@ -161,7 +161,7 @@ func adminNewsEditFormPage(w http.ResponseWriter, r *http.Request) {
 		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	})
 	if err != nil {
-		http.Redirect(w, r, "/admin/news?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "/admin/news?error="+err.Error())
 		return
 	}
 	langs, err := cd.Languages()
@@ -191,7 +191,7 @@ func AdminNewsDeleteConfirmPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	pid, err := strconv.Atoi(mux.Vars(r)["news"])
 	if err != nil {
-		http.Redirect(w, r, "/admin/news", http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "/admin/news")
 		return
 	}
 	cd.PageTitle = "Confirm news delete"

--- a/handlers/news/newsEditPostTask.go
+++ b/handlers/news/newsEditPostTask.go
@@ -82,7 +82,7 @@ func newsEditFormPage(w http.ResponseWriter, r *http.Request) {
 	queries := cd.Queries()
 	pid, err := strconv.Atoi(mux.Vars(r)["news"])
 	if err != nil {
-		http.Redirect(w, r, "/news", http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "/news")
 		return
 	}
 	post, err := queries.GetNewsPostByIdWithWriterIdAndThreadCommentCount(r.Context(), db.GetNewsPostByIdWithWriterIdAndThreadCommentCountParams{
@@ -91,7 +91,7 @@ func newsEditFormPage(w http.ResponseWriter, r *http.Request) {
 		UserID:   sql.NullInt32{Int32: cd.UserID, Valid: cd.UserID != 0},
 	})
 	if err != nil {
-		http.Redirect(w, r, "/news?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "/news?error="+err.Error())
 		return
 	}
 	if !cd.HasGrant("news", "post", "edit", post.Idsitenews) {

--- a/handlers/news/newsPostPage.go
+++ b/handlers/news/newsPostPage.go
@@ -97,7 +97,7 @@ func NewsPostPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("Error: getThreadByIdForUserByIdWithLastPosterUserNameAndPermissions: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			handlers.RedirectToGet(w, r, "?error="+err.Error())
 			return
 		}
 	}

--- a/handlers/news/newsPostPage_labels_test.go
+++ b/handlers/news/newsPostPage_labels_test.go
@@ -133,9 +133,9 @@ func TestNewsPostPagePrivateLabelsOnce(t *testing.T) {
 
 	out := buf.String()
 
-  if strings.Count(out, "class=\"label-bar\"") != 2 {
+	if strings.Count(out, "class=\"label-bar\"") != 2 {
 		t.Fatalf("expected 2 label bars, got %d: %q", strings.Count(out, "class=\"label-bar\""), out)
-  }
+	}
 	if strings.Contains(out, "label-list") {
 		t.Fatalf("expected no label list for private labels: %q", out)
 	}

--- a/handlers/redirect.go
+++ b/handlers/redirect.go
@@ -1,0 +1,23 @@
+package handlers
+
+import "net/http"
+
+// RedirectToGet redirects the client to targetURL. Non-idempotent methods such
+// as POST are converted into a GET request using HTTP 303 to avoid resubmission.
+// GET and HEAD requests continue to use HTTP 302 so their semantics remain
+// unchanged.
+func RedirectToGet(w http.ResponseWriter, r *http.Request, targetURL string) {
+	http.Redirect(w, r, targetURL, redirectStatus(r))
+}
+
+func redirectStatus(r *http.Request) int {
+	if r == nil {
+		return http.StatusSeeOther
+	}
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+		return http.StatusFound
+	default:
+		return http.StatusSeeOther
+	}
+}

--- a/handlers/taskhandler.go
+++ b/handlers/taskhandler.go
@@ -21,7 +21,7 @@ func TaskHandler(t tasks.Task) func(http.ResponseWriter, *http.Request) {
 		result := t.Action(w, r)
 		switch result := result.(type) {
 		case RedirectHandler:
-			http.Redirect(w, r, string(result), http.StatusTemporaryRedirect)
+			RedirectToGet(w, r, string(result))
 		case RefreshDirectHandler:
 			cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 			cd.AutoRefresh = result.Content()
@@ -73,5 +73,5 @@ func loginRedirect(w http.ResponseWriter, r *http.Request) {
 			vals.Set("data", r.Form.Encode())
 		}
 	}
-	http.Redirect(w, r, "/login?"+vals.Encode(), http.StatusTemporaryRedirect)
+	RedirectToGet(w, r, "/login?"+vals.Encode())
 }

--- a/handlers/user/addEmailTask.go
+++ b/handlers/user/addEmailTask.go
@@ -126,7 +126,7 @@ func (AddEmailTask) Notify(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 	if err := r.ParseForm(); err != nil {
-		http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
+		handlers.RedirectToGet(w, r, "/usr/email")
 		return
 	}
 	id, _ := strconv.Atoi(r.FormValue("id"))
@@ -134,7 +134,7 @@ func (AddEmailTask) Notify(w http.ResponseWriter, r *http.Request) {
 	if err := cd.AddEmail(uid, int32(id)); err != nil {
 		log.Printf("set notification priority: %v", err)
 	}
-	http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
+	handlers.RedirectToGet(w, r, "/usr/email")
 }
 
 func (AddEmailTask) DirectEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/user/userEmailPage.go
+++ b/handlers/user/userEmailPage.go
@@ -105,7 +105,7 @@ func userEmailVerifyCodePage(w http.ResponseWriter, r *http.Request) {
 		if err := queries.SystemDeleteUserEmailsByEmailExceptID(r.Context(), db.SystemDeleteUserEmailsByEmailExceptIDParams{Email: ue.Email, ID: ue.ID}); err != nil {
 			log.Printf("delete user emails: %v", err)
 		}
-		http.Redirect(w, r, "/usr/email", http.StatusSeeOther)
+		handlers.RedirectToGet(w, r, "/usr/email")
 		return
 	}
 

--- a/handlers/user/userNotificationsPage.go
+++ b/handlers/user/userNotificationsPage.go
@@ -94,7 +94,7 @@ func userNotificationEmailActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 	uid, _ := session.Values["UID"].(int32)
 	if err := r.ParseForm(); err != nil {
-		http.Redirect(w, r, "/usr/notifications", http.StatusSeeOther)
+		handlers.RedirectToGet(w, r, "/usr/notifications")
 		return
 	}
 	idStr := r.FormValue("email_id")
@@ -113,5 +113,5 @@ func userNotificationEmailActionPage(w http.ResponseWriter, r *http.Request) {
 			log.Printf("set notification priority: %v", err)
 		}
 	}
-	http.Redirect(w, r, "/usr/notifications", http.StatusSeeOther)
+	handlers.RedirectToGet(w, r, "/usr/notifications")
 }

--- a/handlers/writings/writingsAdminCategoriesPage.go
+++ b/handlers/writings/writingsAdminCategoriesPage.go
@@ -32,7 +32,7 @@ func AdminCategoriesPage(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			log.Printf("writingCategories Error: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			handlers.RedirectToGet(w, r, "?error="+err.Error())
 			return
 		}
 	}

--- a/handlers/writings/writingsArticleCommentEditPage.go
+++ b/handlers/writings/writingsArticleCommentEditPage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/workers/postcountworker"
 )
 
@@ -15,7 +16,7 @@ import (
 func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	languageId, err := strconv.Atoi(r.PostFormValue("language"))
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	text := r.PostFormValue("replytext")
@@ -23,12 +24,12 @@ func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	writing, err := cd.Article()
 	if err != nil || writing == nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	comment, err := cd.ArticleComment(r)
 	if err != nil || comment == nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 
@@ -38,7 +39,7 @@ func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 
 	thread, err := cd.UpdateWritingReply(comment.Idcomments, int32(languageId), text)
 	if err != nil {
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
@@ -50,7 +51,7 @@ func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	http.Redirect(w, r, fmt.Sprintf("/writings/article/%d", writing.Idwriting), http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, fmt.Sprintf("/writings/article/%d", writing.Idwriting))
 }
 
 // ArticleCommentEditActionCancelPage aborts editing a comment.
@@ -58,8 +59,8 @@ func ArticleCommentEditActionCancelPage(w http.ResponseWriter, r *http.Request) 
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	writing, err := cd.Article()
 	if err != nil || writing == nil {
-		http.Redirect(w, r, "/writings", http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "/writings")
 		return
 	}
-	http.Redirect(w, r, fmt.Sprintf("/writings/article/%d", writing.Idwriting), http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, fmt.Sprintf("/writings/article/%d", writing.Idwriting))
 }

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -176,11 +176,11 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 	cid, threadID, topicID, err := cd.CreateWritingReply(writing, int32(languageId), text)
 	if err != nil {
 		log.Printf("Error: createComment: %s", err)
-		http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+err.Error())
 		return
 	}
 	if cid == 0 {
-		http.Redirect(w, r, "?error="+"failed to create comment", http.StatusTemporaryRedirect)
+		handlers.RedirectToGet(w, r, "?error="+"failed to create comment")
 		return
 	}
 

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -60,5 +60,5 @@ func RedirectToLogin(w http.ResponseWriter, r *http.Request, session *sessions.S
 			vals.Set("data", r.Form.Encode())
 		}
 	}
-	http.Redirect(w, r, "/login?"+vals.Encode(), http.StatusTemporaryRedirect)
+	handlers.RedirectToGet(w, r, "/login?"+vals.Encode())
 }

--- a/workers/searchworker/http.go
+++ b/workers/searchworker/http.go
@@ -1,0 +1,11 @@
+package searchworker
+
+import "net/http"
+
+func redirectToGet(w http.ResponseWriter, r *http.Request, target string) {
+	status := http.StatusSeeOther
+	if r.Method == http.MethodGet || r.Method == http.MethodHead {
+		status = http.StatusFound
+	}
+	http.Redirect(w, r, target, status)
+}

--- a/workers/searchworker/insert.go
+++ b/workers/searchworker/insert.go
@@ -15,7 +15,7 @@ func InsertWords(w http.ResponseWriter, r *http.Request, words []WordCount, inse
 	for _, wc := range words {
 		if err := insertFn(r.Context(), wc.ID, wc.Count); err != nil {
 			log.Printf("Error inserting search word: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			redirectToGet(w, r, "?error="+err.Error())
 			return true
 		}
 	}

--- a/workers/searchworker/tokenize.go
+++ b/workers/searchworker/tokenize.go
@@ -57,7 +57,7 @@ func SearchWordIdsFromText(w http.ResponseWriter, r *http.Request, text string, 
 		id, err := queries.SystemCreateSearchWord(r.Context(), strings.ToLower(word))
 		if err != nil {
 			log.Printf("Error: createSearchWord: %s", err)
-			http.Redirect(w, r, "?error="+err.Error(), http.StatusTemporaryRedirect)
+			redirectToGet(w, r, "?error="+err.Error())
 			return nil, true
 		}
 		results = append(results, WordCount{ID: id, Count: c})

--- a/workers/searchworker/tokenize_test.go
+++ b/workers/searchworker/tokenize_test.go
@@ -147,7 +147,7 @@ func TestSearchWordIdsFromTextError(t *testing.T) {
 	if !redirect {
 		t.Fatal("expected redirect")
 	}
-	if rr.Result().StatusCode != http.StatusTemporaryRedirect {
+	if rr.Result().StatusCode != http.StatusFound {
 		t.Fatalf("status %d", rr.Result().StatusCode)
 	}
 }


### PR DESCRIPTION
## Summary
- add a handlers.RedirectToGet helper that keeps GET/HEAD redirects at 302 but upgrades POST-style actions to 303
- update handlers, middleware, and supporting workers to use the helper instead of hard-coded status codes
- adjust session/login redirects and tests to expect 302 for GET flows while keeping 303 for POST-driven resubmissions

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c225a9fd74832fa9edaba86f1c867b