### PR TITLE
Use 303 redirect for single blogger search result

### DIFF
--- a/handlers/blogs/bloggerListPage.go
+++ b/handlers/blogs/bloggerListPage.go
@@ -53,7 +53,7 @@ func BloggerListPage(w http.ResponseWriter, r *http.Request) {
 
 	if data.Search != "" {
 		if len(rows) == 1 {
-			http.Redirect(w, r, "/blogs/blogger/"+rows[0].Username.String, http.StatusFound)
+			http.Redirect(w, r, "/blogs/blogger/"+rows[0].Username.String, http.StatusSeeOther)
 			return
 		}
 		if len(rows) == 0 {

--- a/handlers/blogs/bloggerListPage_search_test.go
+++ b/handlers/blogs/bloggerListPage_search_test.go
@@ -39,7 +39,7 @@ func TestBloggerListPageSearchRedirect(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
 	}
-	if rr.Result().StatusCode != http.StatusFound {
+	if rr.Result().StatusCode != http.StatusSeeOther {
 		t.Fatalf("status=%d", rr.Result().StatusCode)
 	}
 	if loc := rr.Result().Header.Get("Location"); loc != "/blogs/blogger/arran4" {


### PR DESCRIPTION
## Summary
- use http.StatusSeeOther when a single blogger search result redirects to the profile page
- adjust the search redirect unit test to match the new redirect status

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dc88b68604832f8aeafb74c151c8b8