### PR TITLE
Fix login form action after registration

### DIFF
--- a/core/templates/site/loginPage.gohtml
+++ b/core/templates/site/loginPage.gohtml
@@ -3,7 +3,7 @@
     <p style="color:red">{{ cd.CurrentError }}</p>
     {{- end }}
     Login:<br>
-    <form method="post">
+    <form method="post" action="/login">
         {{ csrfField }}
         {{- if $.Back }}
         <input type="hidden" name="back" value="{{ $.Back }}">

--- a/handlers/auth/loginPage_test.go
+++ b/handlers/auth/loginPage_test.go
@@ -186,6 +186,21 @@ func TestLoginPageHiddenFields(t *testing.T) {
 	}
 }
 
+func TestLoginFormHandler_ActionTarget(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/register", nil)
+	cd := common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	loginFormHandler{msg: "approval is pending"}.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "<form method=\"post\" action=\"/login\">") {
+		t.Fatalf("expected login form to post to /login: %q", body)
+	}
+}
+
 func TestLoginAction_PendingResetPrompt(t *testing.T) {
 	conn, mock, err := sqlmock.New()
 	if err != nil {


### PR DESCRIPTION
## Summary
- ensure the login template always posts to /login so registration follow-up logins succeed
- add a regression test covering the login form when rendered from the registration route

## Testing
- go mod tidy
- go fmt ./...
- go vet ./...
- golangci-lint run ./...
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ac241bcb0832f9343e07fbe65f40c)