### PR TITLE
Align flag help rendering

### DIFF
--- a/cmd/goa4web/flagutil.go
+++ b/cmd/goa4web/flagutil.go
@@ -38,6 +38,14 @@ type flagInfo struct {
 	DefValue string
 }
 
+func flagGroupFromFlagSet(fs *flag.FlagSet) flagGroup {
+	title := ""
+	if fs.Name() != "" {
+		title = fs.Name() + " flags"
+	}
+	return flagGroup{Title: title, Flags: flagInfos(fs)}
+}
+
 // flagGroup describes a set of related flags that belong to a command level.
 type flagGroup struct {
 	Title string
@@ -61,7 +69,8 @@ func flagInfos(fs *flag.FlagSet) []flagInfo {
 }
 
 func printFlags(fs *flag.FlagSet) {
-	if err := getTemplates().ExecuteTemplate(fs.Output(), "flag_group", flagInfos(fs)); err != nil {
+	data := []flagGroup{flagGroupFromFlagSet(fs)}
+	if err := getTemplates().ExecuteTemplate(fs.Output(), "flag_groups_section", data); err != nil {
 		fmt.Fprintf(fs.Output(), "template execute: %v\n", err)
 	}
 }

--- a/cmd/goa4web/flagutil_test.go
+++ b/cmd/goa4web/flagutil_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"errors"
+	"flag"
 	"strings"
 	"testing"
 )
@@ -18,5 +20,29 @@ func TestExecuteUsageWithGroups(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, "Global Flags") {
 		t.Errorf("missing global flags: %s", out)
+	}
+}
+
+func TestPrintFlagsHelp(t *testing.T) {
+	fs := newFlagSet("print-test")
+	fs.String("config", "", "config file path")
+	fs.Bool("verbose", false, "enable verbose output")
+
+	buf := &bytes.Buffer{}
+	fs.SetOutput(buf)
+
+	err := fs.Parse([]string{"-help"})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp parsing -help, got %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "print-test flags:") {
+		t.Fatalf("flag group title missing from help output: %q", output)
+	}
+	for _, want := range []string{"config file path", "enable verbose output"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("missing flag description %q in output: %q", want, output)
+		}
 	}
 }

--- a/cmd/goa4web/templates/flags.txt
+++ b/cmd/goa4web/templates/flags.txt
@@ -1,5 +1,5 @@
 {{define "flags"}}
-{{- range .}}
+{{- range .Flags}}
 -{{printf "%-30s" .Name}} {{printf "%-20s" .DefValue}}{{printf "%-20s" .Usage}}
 {{- end}}
 {{- end}}
@@ -7,7 +7,7 @@
 {{- define "flag_group"}}
 {{- if .Title}}{{.Title}}:
 {{end}}
-{{- template "flags" .Flags}}
+{{- template "flags" .}}
 {{end}}
 
 {{- define "flag_groups_section"}}


### PR DESCRIPTION
## Summary
- ensure flagset help rendering passes grouped flag metadata, including titles, to shared templates
- update the flags template to expect grouped flag data consistently
- add a printFlags help test covering help output for a test flag set

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ac2f70a1c832f9af573eb8f136066)