### PR TITLE
Refactor user email handling for multi-address support

### DIFF
--- a/cmd/goa4web/user_approve_test.go
+++ b/cmd/goa4web/user_approve_test.go
@@ -27,8 +27,8 @@ func TestUserApproveCmd(t *testing.T) {
 			setupMocks: func(mock sqlmock.Sqlmock) {
 				mock.ExpectQuery("(?s).*SystemGetUserByUsername.*").
 					WithArgs(sql.NullString{String: "alice", Valid: true}).
-					WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(
-						int32(7), "alice@example.com", sql.NullString{String: "alice", Valid: true}, sql.NullTime{},
+					WillReturnRows(sqlmock.NewRows([]string{"idusers", "username", "public_profile_enabled_at"}).AddRow(
+						int32(7), sql.NullString{String: "alice", Valid: true}, sql.NullTime{},
 					))
 				mock.ExpectExec("(?s).*SystemCreateUserRole.*").
 					WithArgs(int32(7), "user").

--- a/handlers/auth/forgotPassword_event_test.go
+++ b/handlers/auth/forgotPassword_event_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
@@ -26,7 +27,8 @@ func TestForgotPasswordEventData(t *testing.T) {
 	}
 	defer conn.Close()
 	q := db.New(conn)
-	mock.ExpectQuery("SystemGetLogin").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "passwd", "passwd_algorithm", "username"}).AddRow(1, "a@test.com", "", "", "u"))
+	mock.ExpectQuery("SystemGetLogin").WillReturnRows(sqlmock.NewRows([]string{"idusers", "passwd", "passwd_algorithm", "username"}).AddRow(1, "", "", "u"))
+	mock.ExpectQuery("SystemListVerifiedEmailsByUserID").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "a@test.com", time.Now(), nil, nil, 0))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 	mock.ExpectQuery("SystemGetUserByEmail").WithArgs("a@test.com").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test.com", "u"))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, passwd")).WithArgs(int32(1), sqlmock.AnyArg()).WillReturnError(sql.ErrNoRows)

--- a/handlers/auth/forgotPassword_limit_test.go
+++ b/handlers/auth/forgotPassword_limit_test.go
@@ -26,7 +26,8 @@ func TestForgotPasswordRateLimit(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 
-	mock.ExpectQuery("SystemGetLogin").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "passwd", "passwd_algorithm", "username"}).AddRow(1, "a@test.com", "", "", "u"))
+	mock.ExpectQuery("SystemGetLogin").WillReturnRows(sqlmock.NewRows([]string{"idusers", "passwd", "passwd_algorithm", "username"}).AddRow(1, "", "", "u"))
+	mock.ExpectQuery("SystemListVerifiedEmailsByUserID").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "a@test.com", time.Now(), nil, nil, 0))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 	mock.ExpectQuery("SystemGetUserByEmail").WithArgs("a@test.com").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test.com", "u"))
 	resetRows := sqlmock.NewRows([]string{"id", "user_id", "passwd", "passwd_algorithm", "verification_code", "created_at", "verified_at"}).
@@ -59,7 +60,8 @@ func TestForgotPasswordReplaceOld(t *testing.T) {
 	defer conn.Close()
 	q := db.New(conn)
 
-	mock.ExpectQuery("SystemGetLogin").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "passwd", "passwd_algorithm", "username"}).AddRow(1, "a@test.com", "", "", "u"))
+	mock.ExpectQuery("SystemGetLogin").WillReturnRows(sqlmock.NewRows([]string{"idusers", "passwd", "passwd_algorithm", "username"}).AddRow(1, "", "", "u"))
+	mock.ExpectQuery("SystemListVerifiedEmailsByUserID").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "a@test.com", time.Now(), nil, nil, 0))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 	mock.ExpectQuery("SystemGetUserByEmail").WithArgs("a@test.com").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test.com", "u"))
 	oldRows := sqlmock.NewRows([]string{"id", "user_id", "passwd", "passwd_algorithm", "verification_code", "created_at", "verified_at"}).

--- a/handlers/auth/forgotPassword_no_email_test.go
+++ b/handlers/auth/forgotPassword_no_email_test.go
@@ -24,7 +24,8 @@ func TestForgotPasswordNoEmail(t *testing.T) {
 	}
 	defer conn.Close()
 	q := db.New(conn)
-	mock.ExpectQuery("SystemGetLogin").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "passwd", "passwd_algorithm", "username"}).AddRow(1, "", "", "", "u"))
+	mock.ExpectQuery("SystemGetLogin").WillReturnRows(sqlmock.NewRows([]string{"idusers", "passwd", "passwd_algorithm", "username"}).AddRow(1, "", "", "u"))
+	mock.ExpectQuery("SystemListVerifiedEmailsByUserID").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.users_idusers = ? AND r.can_login = 1 LIMIT 1")).WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"column_1"}).AddRow(1))
 
 	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
@@ -52,7 +53,8 @@ func TestEmailAssociationRequestTask(t *testing.T) {
 	}
 	defer conn.Close()
 	q := db.New(conn)
-	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "", "u", nil))
+	mock.ExpectQuery("SystemGetUserByUsername").WillReturnRows(sqlmock.NewRows([]string{"idusers", "username", "public_profile_enabled_at"}).AddRow(1, "u", nil))
+	mock.ExpectQuery("SystemListVerifiedEmailsByUserID").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}))
 	mock.ExpectExec("INSERT INTO admin_request_queue").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO admin_request_comments").WillReturnResult(sqlmock.NewResult(1, 1))
 

--- a/handlers/auth/registerPage_test.go
+++ b/handlers/auth/registerPage_test.go
@@ -54,7 +54,7 @@ func TestRegisterActionRedirectsToLogin(t *testing.T) {
 	defer conn.Close()
 
 	queries := db.New(conn)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idusers,\n       (SELECT email FROM user_emails ue WHERE ue.user_id = users.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,\n       username,\n       public_profile_enabled_at\nFROM users\nWHERE username = ?\n")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idusers,\n       username,\n       public_profile_enabled_at\nFROM users\nWHERE username = ?\n")).
 		WithArgs(sql.NullString{String: "alice", Valid: true}).
 		WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username\nFROM users u JOIN user_emails ue ON ue.user_id = u.idusers\nWHERE ue.email = ?\nLIMIT 1\n")).

--- a/handlers/blogs/blogsPage_test.go
+++ b/handlers/blogs/blogsPage_test.go
@@ -58,9 +58,9 @@ func TestBlogsBloggerPostsPage(t *testing.T) {
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
-	userRows := sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).
-		AddRow(1, "e", "bob", nil)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idusers, (SELECT email FROM user_emails ue WHERE ue.user_id = users.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email, username, public_profile_enabled_at\nFROM users\nWHERE username = ?")).
+	userRows := sqlmock.NewRows([]string{"idusers", "username", "public_profile_enabled_at"}).
+		AddRow(1, "bob", nil)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idusers, username, public_profile_enabled_at\nFROM users\nWHERE username = ?")).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnRows(userRows)
 
@@ -90,10 +90,10 @@ func TestBlogsRssPageWritesRSS(t *testing.T) {
 	}
 	defer conn.Close()
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idusers, (SELECT email FROM user_emails ue WHERE ue.user_id = users.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email, username, public_profile_enabled_at\nFROM users\nWHERE username = ?")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idusers, username, public_profile_enabled_at\nFROM users\nWHERE username = ?")).
 		WithArgs("bob").
-		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).
-			AddRow(1, "e", "bob", nil))
+		WillReturnRows(sqlmock.NewRows([]string{"idusers", "username", "public_profile_enabled_at"}).
+			AddRow(1, "bob", nil))
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT b.idblogs")).
 		WithArgs(int32(1), int32(1), int32(1), int32(1), int32(1), int32(1), sqlmock.AnyArg(), int32(15), int32(0)).

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -53,7 +53,7 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(2, "bob@test", "bob", nil))
 	mock.ExpectQuery("FROM users").
 		WithArgs(sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(2, "bob@test", "bob", nil))
+		WillReturnRows(sqlmock.NewRows([]string{"idusers", "username", "public_profile_enabled_at"}).AddRow(2, "bob", nil))
 	mock.ExpectExec("INSERT INTO user_roles").
 		WithArgs(int32(2), "moderator").
 		WillReturnResult(sqlmock.NewResult(1, 1))

--- a/handlers/user/permissionUserAllowTask.go
+++ b/handlers/user/permissionUserAllowTask.go
@@ -43,6 +43,13 @@ func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) an
 	if cpu.Idusers != 0 {
 		back = fmt.Sprintf("/admin/user/%d/permissions", cpu.Idusers)
 	}
+	if evt := cd.Event(); evt != nil {
+		if evt.Data == nil {
+			evt.Data = map[string]any{}
+		}
+		evt.Data["Username"] = username
+		evt.Data["Permission"] = role
+	}
 	data := struct {
 		Errors   []string
 		Messages []string
@@ -61,8 +68,6 @@ func (PermissionUserAllowTask) Action(w http.ResponseWriter, r *http.Request) an
 		if evt.Data == nil {
 			evt.Data = map[string]any{}
 		}
-		evt.Data["Username"] = username
-		evt.Data["Permission"] = role
 		evt.Data["targetUserID"] = u.Idusers
 		evt.Data["Username"] = u.Username.String
 		evt.Data["Role"] = role

--- a/internal/db/email_utils.go
+++ b/internal/db/email_utils.go
@@ -1,0 +1,18 @@
+package db
+
+// EmailsByUserID groups verified email rows by the owning user.
+func EmailsByUserID(rows []*GetVerifiedUserEmailsRow) map[int32][]string {
+	emails := make(map[int32][]string, len(rows))
+	for _, row := range rows {
+		emails[row.UserID] = append(emails[row.UserID], row.Email)
+	}
+	return emails
+}
+
+// PrimaryEmail returns the highest priority email from the provided slice.
+func PrimaryEmail(emails []string) string {
+	if len(emails) == 0 {
+		return ""
+	}
+	return emails[0]
+}

--- a/internal/db/queries-stats.sql
+++ b/internal/db/queries-stats.sql
@@ -89,7 +89,6 @@ DELETE FROM template_overrides WHERE name = ?;
 
 -- name: SystemListUserInfo :many
 SELECT u.idusers, u.username,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
        IF(r.id IS NULL, 0, 1) AS admin,
        MIN(s.created_at) AS created_at
 FROM users u

--- a/internal/db/queries-stats.sql.go
+++ b/internal/db/queries-stats.sql.go
@@ -530,7 +530,6 @@ func (q *Queries) SystemGetTemplateOverride(ctx context.Context, name string) (s
 
 const systemListUserInfo = `-- name: SystemListUserInfo :many
 SELECT u.idusers, u.username,
-       (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email,
        IF(r.id IS NULL, 0, 1) AS admin,
        MIN(s.created_at) AS created_at
 FROM users u
@@ -544,7 +543,6 @@ ORDER BY u.idusers
 type SystemListUserInfoRow struct {
 	Idusers   int32
 	Username  sql.NullString
-	Email     string
 	Admin     interface{}
 	CreatedAt interface{}
 }
@@ -561,7 +559,6 @@ func (q *Queries) SystemListUserInfo(ctx context.Context) ([]*SystemListUserInfo
 		if err := rows.Scan(
 			&i.Idusers,
 			&i.Username,
-			&i.Email,
 			&i.Admin,
 			&i.CreatedAt,
 		); err != nil {

--- a/internal/db/queries_users_admin_test.go
+++ b/internal/db/queries_users_admin_test.go
@@ -43,18 +43,18 @@ func TestQueries_AdminListAllUsers(t *testing.T) {
 	defer conn.Close()
 	q := New(conn)
 
-        rows := sqlmock.NewRows([]string{"idusers", "username"}).
-                AddRow(1, "bob")
-        mock.ExpectQuery(regexp.QuoteMeta(adminListAllUsers)).
-                WillReturnRows(rows)
+	rows := sqlmock.NewRows([]string{"idusers", "username"}).
+		AddRow(1, "bob")
+	mock.ExpectQuery(regexp.QuoteMeta(adminListAllUsers)).
+		WillReturnRows(rows)
 
-        res, err := q.AdminListAllUsers(context.Background())
-        if err != nil {
-                t.Fatalf("AdminListAllUsers: %v", err)
-        }
-        if len(res) != 1 || res[0].Idusers != 1 || res[0].Username.String != "bob" {
-                t.Fatalf("unexpected result %+v", res)
-        }
+	res, err := q.AdminListAllUsers(context.Background())
+	if err != nil {
+		t.Fatalf("AdminListAllUsers: %v", err)
+	}
+	if len(res) != 1 || res[0].Idusers != 1 || res[0].Username.String != "bob" {
+		t.Fatalf("unexpected result %+v", res)
+	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations: %v", err)
@@ -69,8 +69,8 @@ func TestQueries_SystemListAllUsers(t *testing.T) {
 	defer conn.Close()
 	q := New(conn)
 
-	rows := sqlmock.NewRows([]string{"idusers", "username", "email", "admin", "created_at"}).
-		AddRow(1, "bob", "bob@example.com", false, time.Now())
+	rows := sqlmock.NewRows([]string{"idusers", "username", "admin", "created_at"}).
+		AddRow(1, "bob", false, time.Now())
 	mock.ExpectQuery(regexp.QuoteMeta(systemListAllUsers)).
 		WillReturnRows(rows)
 
@@ -78,7 +78,7 @@ func TestQueries_SystemListAllUsers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SystemListAllUsers: %v", err)
 	}
-	if len(res) != 1 || res[0].Idusers != 1 || res[0].Username.String != "bob" || res[0].Email != "bob@example.com" {
+	if len(res) != 1 || res[0].Idusers != 1 || res[0].Username.String != "bob" {
 		t.Fatalf("unexpected result %+v", res)
 	}
 


### PR DESCRIPTION
## Summary
- remove inline email subqueries from user queries and rely on verified email lookups
- add shared helpers and update user listing and admin views to surface multiple verified addresses
- adjust authentication flows and tests to work with the new multi-email handling

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bcf590380832f92257ef5fea20ed6)