### PR TITLE
Filter index navigation by view permission

### DIFF
--- a/handlers/blogs/routes.go
+++ b/handlers/blogs/routes.go
@@ -14,7 +14,7 @@ import (
 
 // RegisterRoutes attaches the public blog endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
-	navReg.RegisterIndexLink("Blogs", "/blogs", SectionWeight)
+	navReg.RegisterIndexLinkWithViewPermission("Blogs", "/blogs", SectionWeight, "blogs", "entry")
 	navReg.RegisterAdminControlCenter("Blogs", "Blogs", "/admin/blogs", SectionWeight)
 	br := r.PathPrefix("/blogs").Subrouter()
 	br.Use(handlers.IndexMiddleware(CustomBlogIndex), handlers.SectionMiddleware("blogs"))

--- a/handlers/faq/routes.go
+++ b/handlers/faq/routes.go
@@ -18,7 +18,7 @@ func noTask() mux.MatcherFunc {
 
 // RegisterRoutes attaches the public FAQ endpoints to the router.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
-	navReg.RegisterIndexLink("Help", "/faq", SectionWeight)
+	navReg.RegisterIndexLinkWithViewPermission("Help", "/faq", SectionWeight, "faq", "question/answer")
 	navReg.RegisterAdminControlCenter("Help", "Help Questions", "/admin/faq/questions", SectionWeight)
 	navReg.RegisterAdminControlCenter("Help", "Help Categories", "/admin/faq/categories", SectionWeight+2)
 	faqr := r.PathPrefix("/faq").Subrouter()

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -14,7 +14,7 @@ import (
 
 // RegisterRoutes attaches the public forum endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
-	navReg.RegisterIndexLink("Forum", "/forum", SectionWeight)
+	navReg.RegisterIndexLinkWithViewPermission("Forum", "/forum", SectionWeight, "forum", "category")
 	navReg.RegisterAdminControlCenter("Forum", "Forum", "/admin/forum", SectionWeight)
 	fr := r.PathPrefix("/forum").Subrouter()
 	fr.Use(handlers.IndexMiddleware(CustomForumIndex), handlers.SectionMiddleware("forum"))

--- a/handlers/imagebbs/routes.go
+++ b/handlers/imagebbs/routes.go
@@ -14,7 +14,7 @@ import (
 
 // RegisterRoutes attaches the public image board endpoints to r.
 func RegisterRoutes(r *mux.Router, cfg *config.RuntimeConfig, navReg *navpkg.Registry) {
-	navReg.RegisterIndexLink("ImageBBS", "/imagebbs", SectionWeight)
+	navReg.RegisterIndexLinkWithViewPermission("ImageBBS", "/imagebbs", SectionWeight, "imagebbs", "board")
 	navReg.RegisterAdminControlCenter("ImageBBS", "ImageBBS", "/admin/imagebbs", SectionWeight)
 	r.HandleFunc("/imagebbs.rss", RssPage).Methods("GET")
 	ibr := r.PathPrefix("/imagebbs").Subrouter()

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -16,7 +16,7 @@ var legacyRedirectsEnabled = true
 
 // RegisterRoutes attaches the public linker endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
-	navReg.RegisterIndexLink("Linker", "/linker", SectionWeight)
+	navReg.RegisterIndexLinkWithViewPermission("Linker", "/linker", SectionWeight, "linker", "category")
 	navReg.RegisterAdminControlCenter("Linker", "Linker", "/admin/linker", SectionWeight)
 	lr := r.PathPrefix("/linker").Subrouter()
 	lr.Use(handlers.IndexMiddleware(CustomLinkerIndex), handlers.SectionMiddleware("linker"))

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -18,7 +18,7 @@ import (
 // RegisterRoutes attaches the public news endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
 	log.Printf("News: Registering Routes")
-	navReg.RegisterIndexLink("News", "/", SectionWeight)
+	navReg.RegisterIndexLinkWithViewPermission("News", "/", SectionWeight, "news", "post")
 	navReg.RegisterAdminControlCenter("News", "News", "/admin/news", SectionWeight)
 	r.Use(handlers.IndexMiddleware(CustomNewsIndex), handlers.SectionMiddleware("news"))
 	r.HandleFunc("/", NewsPage).Methods("GET")

--- a/handlers/privateforum/routes.go
+++ b/handlers/privateforum/routes.go
@@ -15,7 +15,7 @@ import (
 
 // RegisterRoutes attaches the private forum endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
-	navReg.RegisterIndexLink("Private", "/private", SectionWeight)
+	navReg.RegisterIndexLinkWithViewPermission("Private", "/private", SectionWeight, "privateforum", "topic")
 	pr := r.PathPrefix("/private").Subrouter()
 	pr.Use(handlers.IndexMiddleware(CustomIndex), handlers.SectionMiddleware("privateforum"), forumhandlers.BasePathMiddleware("/private"))
 	pr.HandleFunc("", Page).Methods(http.MethodGet)

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -16,7 +16,7 @@ var legacyRedirectsEnabled = true
 
 // RegisterRoutes attaches the public writings endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Registry) {
-	navReg.RegisterIndexLink("Writings", "/writings", SectionWeight)
+	navReg.RegisterIndexLinkWithViewPermission("Writings", "/writings", SectionWeight, "writing", "category")
 	navReg.RegisterAdminControlCenter("Writings", "Writings", "/admin/writings", SectionWeight)
 	wr := r.PathPrefix("/writings").Subrouter()
 	wr.Use(handlers.IndexMiddleware(CustomWritingsIndex), handlers.SectionMiddleware("writing"))

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -261,7 +261,9 @@ func (s *Server) CoreDataMiddleware() func(http.Handler) http.Handler {
 			_ = cd.UserRoles()
 
 			if s.Nav != nil {
-				cd.IndexItems = s.Nav.IndexItems()
+				cd.IndexItems = s.Nav.IndexItemsWithPermission(func(section, item string) bool {
+					return cd.HasGrant(section, item, "view", 0)
+				})
 			}
 			cd.FeedsEnabled = s.Config.FeedsEnabled
 			cd.AdminMode = r.URL.Query().Get("mode") == "admin"

--- a/internal/navigation/registry_test.go
+++ b/internal/navigation/registry_test.go
@@ -44,3 +44,25 @@ func TestIndexItemsSkipEmpty(t *testing.T) {
 		t.Fatalf("unexpected admin sections %#v", secs)
 	}
 }
+
+func TestIndexItemsPermissionFilter(t *testing.T) {
+	defaultRegistry = NewRegistry()
+	t.Cleanup(func() { defaultRegistry = NewRegistry() })
+
+	RegisterIndexLinkWithViewPermission("protected", "/protected", 5, "news", "post")
+	RegisterIndexLink("public", "/public", 10)
+
+	items := IndexItemsWithPermission(func(section, item string) bool {
+		return section == "news" && item == "post"
+	})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items when permission is granted, got %d", len(items))
+	}
+
+	items = IndexItemsWithPermission(func(section, item string) bool {
+		return false
+	})
+	if len(items) != 1 || items[0].Name != "public" {
+		t.Fatalf("expected only public item when permission denied, got %#v", items)
+	}
+}


### PR DESCRIPTION
## Summary
- add permission-aware index navigation helpers and filter menu items when the user lacks view access
- require view grants for public section links such as news, forums, blogs, writings, images, and FAQs
- cover navigation filtering with a dedicated unit test

## Testing
- go mod tidy
- go fmt ./...
- go vet ./...
- golangci-lint run
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cc4f4a870832fb7bbad6749b94652)