### PR TITLE
Add fallbacks for unnamed forum topics and descriptions

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -18,6 +18,13 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 )
 
+const (
+	// defaultTopicTitle is used when a topic is missing a title.
+	defaultTopicTitle = "🧵 Untitled topic"
+	// defaultTopicDescription is used when a topic is missing a description.
+	defaultTopicDescription = "ℹ️ No description provided"
+)
+
 // Funcs returns template helpers configured with cd's ImageURLMapper.
 func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 	mapper := cd.ImageURLMapper
@@ -60,6 +67,18 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 				log.Printf("process markup: %v", cerr)
 			}
 			return string(out)
+		},
+		"topicTitleOrDefault": func(title string) string {
+			if trimmed := strings.TrimSpace(title); trimmed != "" {
+				return trimmed
+			}
+			return defaultTopicTitle
+		},
+		"topicDescriptionOrDefault": func(description string) string {
+			if trimmed := strings.TrimSpace(description); trimmed != "" {
+				return trimmed
+			}
+			return defaultTopicDescription
 		},
 		"trim": strings.TrimSpace,
 		"firstline": func(s string) string {

--- a/core/templates/site/admin/adminCommentPage.gohtml
+++ b/core/templates/site/admin/adminCommentPage.gohtml
@@ -1,7 +1,7 @@
 {{ define "admin/commentPage.gohtml" }}
 {{ template "head" $ }}
 <h2>Comment {{ .Comment.Idcomments }}</h2>
-<p>Topic <a href="/forum/topic/{{ .Comment.Idforumtopic }}">{{ .Comment.ForumtopicTitle.String }}</a> thread <a href="/forum/topic/{{ .Comment.Idforumtopic }}/thread/{{ .Comment.Idforumthread }}">{{ if .Comment.ThreadTitle.Valid }}{{ left 40 .Comment.ThreadTitle.String }}{{ else }}{{ .Comment.Idforumthread }}{{ end }}</a></p>
+<p>Topic <a href="/forum/topic/{{ .Comment.Idforumtopic }}">{{ topicTitleOrDefault .Comment.ForumtopicTitle.String }}</a> thread <a href="/forum/topic/{{ .Comment.Idforumtopic }}/thread/{{ .Comment.Idforumthread }}">{{ if .Comment.ThreadTitle.Valid }}{{ left 40 .Comment.ThreadTitle.String }}{{ else }}{{ .Comment.Idforumthread }}{{ end }}</a></p>
 <p>{{ if .Comment.Text.Valid }}{{ .Comment.Text.String | a4code2html }}{{ end }}</p>
 <p><a href="/forum/topic/{{ .Comment.Idforumtopic }}/thread/{{ .Comment.Idforumthread }}#c{{ .Comment.Idcomments }}">Original</a></p>
 <h3>Thread Context</h3>

--- a/core/templates/site/admin/usageStatsPage.gohtml
+++ b/core/templates/site/admin/usageStatsPage.gohtml
@@ -15,7 +15,7 @@
     {{- range .ForumTopics }}
     <tr>
         <td><a href="/admin/forum/topics/topic/{{ .Idforumtopic }}/edit">{{ .Idforumtopic }}</a></td>
-        <td><a href="/forum/topic/{{ .Idforumtopic }}">{{ .Title.String }}</a></td>
+        <td><a href="/forum/topic/{{ .Idforumtopic }}">{{ topicTitleOrDefault .Title.String }}</a></td>
         <td>{{ .Handler }}</td>
         <td>{{ .Threads }}</td>
         <td>{{ .Comments }}</td>

--- a/core/templates/site/admin/userCommentsPage.gohtml
+++ b/core/templates/site/admin/userCommentsPage.gohtml
@@ -7,7 +7,7 @@
     <tr>
         <td><a href="/admin/comment/{{ .Idcomments }}">{{ .Idcomments }}</a></td>
         <td>{{ if .Written.Valid }}{{ cd.LocalTimeIn .Written.Time .Timezone.String }}{{ end }}</td>
-        <td>{{ if .ForumtopicIdforumtopic.Valid }}<a href="/forum/topic/{{ .ForumtopicIdforumtopic.Int32 }}">{{ .ForumtopicTitle.String }}</a>{{ end }}</td>
+        <td>{{ if .ForumtopicIdforumtopic.Valid }}<a href="/forum/topic/{{ .ForumtopicIdforumtopic.Int32 }}">{{ topicTitleOrDefault .ForumtopicTitle.String }}</a>{{ end }}</td>
         <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic.Int32 }}/thread/{{ .ForumthreadID }}">{{ if .ThreadTitle.Valid }}{{ left 40 .ThreadTitle.String }}{{ else }}{{ .ForumthreadID }}{{ end }}</a></td>
         <td>{{ if .Text.Valid }}{{ left 40 .Text.String }}{{ end }}</td>
         <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic.Int32 }}/thread/{{ .ForumthreadID }}#c{{ .Idcomments }}">View</a></td>

--- a/core/templates/site/admin/userForumPage.gohtml
+++ b/core/templates/site/admin/userForumPage.gohtml
@@ -5,7 +5,7 @@
     {{- range .Threads }}
     <tr>
         <td><a href="/admin/forum/topics/topic/{{ .ForumtopicIdforumtopic }}">{{ .ForumtopicIdforumtopic }}</a></td>
-        <td><a href="/admin/forum/topics/topic/{{ .ForumtopicIdforumtopic }}/edit">{{ .TopicTitle.String }}</a></td>
+        <td><a href="/admin/forum/topics/topic/{{ .ForumtopicIdforumtopic }}/edit">{{ topicTitleOrDefault .TopicTitle.String }}</a></td>
         <td>{{ if .CategoryID.Valid }}<a href="/admin/forum/categories/category/{{ .CategoryID.Int32 }}/grants">{{ .CategoryTitle.String }}</a>{{ end }}</td>
         <td>{{ .Comments.Int32 }}</td>
         <td>{{ cd.LocalTime .Lastaddition.Time }}</td>

--- a/core/templates/site/commentSearchReslts.gohtml
+++ b/core/templates/site/commentSearchReslts.gohtml
@@ -8,7 +8,7 @@
     {{- else }}
         <ul>
         {{- range $i, $result := $cd.SearchComments }}
-            <li>{{ $i }}: <a href="/forum/category/{{$result.Idforumcategory}}">{{ $result.ForumcategoryTitle.String}}</a>: <a href="/forum/topic/{{$result.Idforumtopic}}">{{ $result.ForumtopicTitle.String }}</a>: {{$result.Posterusername.String}} on {{ cd.LocalTimeIn $result.Written.Time $result.Timezone.String }}: <a href="/forum/topic/{{$result.Idforumtopic}}/thread/{{$result.Idforumthread}}">{{ $result.Text.String | a4code2html}}</a></li>
+            <li>{{ $i }}: <a href="/forum/category/{{$result.Idforumcategory}}">{{ $result.ForumcategoryTitle.String}}</a>: <a href="/forum/topic/{{$result.Idforumtopic}}">{{ topicTitleOrDefault $result.ForumtopicTitle.String }}</a>: {{$result.Posterusername.String}} on {{ cd.LocalTimeIn $result.Written.Time $result.Timezone.String }}: <a href="/forum/topic/{{$result.Idforumtopic}}/thread/{{$result.Idforumthread}}">{{ $result.Text.String | a4code2html}}</a></li>
         {{- end }}
         </ul>
     {{ end }}

--- a/core/templates/site/forum/adminThreadsPage.gohtml
+++ b/core/templates/site/forum/adminThreadsPage.gohtml
@@ -1,7 +1,7 @@
 {{ template "head" $ }}
 {{ $cd := cd }}
 {{ range $topic := $cd.AdminForumTopics }}
-    <h2>{{ $topic.Title.String }}</h2>
+    <h2>{{ topicTitleOrDefault $topic.Title.String }}</h2>
     <table class="table table-bordered">
         <tr><th>ID<th>Posts<th>Last Addition<th>View public</tr>
         {{ range $cd.ForumThreads $topic.Idforumtopic }}

--- a/core/templates/site/forum/adminTopicPage.gohtml
+++ b/core/templates/site/forum/adminTopicPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
-<h2>Forum topic {{ .Topic.Idforumtopic }} - {{ .Topic.Title.String }}</h2>
-<p>{{ .Topic.Description.String }}</p>
+<h2>Forum topic {{ .Topic.Idforumtopic }} - {{ topicTitleOrDefault .Topic.Title.String }}</h2>
+<p>{{ topicDescriptionOrDefault .Topic.Description.String }}</p>
 <table class="table table-bordered">
     <tr><th>ID</th><th>Threads</th><th>Posts</th><th>Last Addition</th><th>View</th></tr>
     <tr>

--- a/core/templates/site/forum/adminTopicsPage.gohtml
+++ b/core/templates/site/forum/adminTopicsPage.gohtml
@@ -4,7 +4,7 @@
     {{ range .Topics }}
         <tr>
             <td>{{ .Idforumtopic }}</td>
-            <td><a href="/admin/forum/topics/topic/{{ .Idforumtopic }}">{{ .Title.String }}</a></td>
+            <td><a href="/admin/forum/topics/topic/{{ .Idforumtopic }}">{{ topicTitleOrDefault .Title.String }}</a></td>
             <td>{{ .Threads.Int32 }}</td>
             <td>{{ .Comments.Int32 }}</td>
             <td><a href="/forum/topic/{{ .Idforumtopic }}">View</a></td>

--- a/core/templates/site/forum/topicsPage.gohtml
+++ b/core/templates/site/forum/topicsPage.gohtml
@@ -3,7 +3,9 @@
     {{ if .Category }}
         <h1>Category: {{ .Category.Title.String }}</h1>
     {{ end }}
-    <h2>Topic: {{ if .Topic.DisplayTitle }}{{ .Topic.DisplayTitle }}{{ else }}{{ .Topic.Title.String }}{{ end }}</h2>
+{{ $topicTitle := topicTitleOrDefault .Topic.Title.String }}
+{{ if .Topic.DisplayTitle }}{{ $topicTitle = topicTitleOrDefault .Topic.DisplayTitle }}{{ end }}
+<h2>Topic: {{ $topicTitle }}</h2>
     {{ $base := "/forum" }}
     {{ with .BasePath }}{{ $base = . }}{{ end }}
     <div class="topic-actions">

--- a/core/templates/site/tableTopics.gohtml
+++ b/core/templates/site/tableTopics.gohtml
@@ -9,15 +9,15 @@
             <div class="replies">Replies</div>
         </div>
         <ul class="topic-list">
-        {{ range .Topics }}
-            <li class="topic-item">
-                <div class="topic-name">
-                    {{ $title := .Title.String }}
-                    {{ if .DisplayTitle }}{{ $title = .DisplayTitle }}{{ end }}
-                    <a href="{{$base}}/topic/{{ .Idforumtopic }}">{{ $title | a4code2html }}</a>{{ if and cd.IsAdmin cd.IsAdminMode }} [<a href="/admin/forum/topics/topic/{{ .Idforumtopic }}/edit">ADMIN</a>]{{ end }}<br>
-                    {{ with .Description.String }}<em>{{ . | a4code2html }}</em>{{ end }}
-                    {{- if .Labels }}<br>{{ template "topicLabels" .Labels }}{{ end }}
-                </div>
+    {{ range .Topics }}
+        <li class="topic-item">
+            <div class="topic-name">
+                {{ $title := topicTitleOrDefault .Title.String }}
+                {{ if .DisplayTitle }}{{ $title = topicTitleOrDefault .DisplayTitle }}{{ end }}
+                <a href="{{$base}}/topic/{{ .Idforumtopic }}">{{ $title | a4code2html }}</a>{{ if and cd.IsAdmin cd.IsAdminMode }} [<a href="/admin/forum/topics/topic/{{ .Idforumtopic }}/edit">ADMIN</a>]{{ end }}<br>
+                {{ $description := topicDescriptionOrDefault .Description.String }}<em>{{ $description | a4code2html }}</em>
+                {{- if .Labels }}<br>{{ template "topicLabels" .Labels }}{{ end }}
+            </div>
                 <div class="last-reply">{{ cd.LocalTime .Lastaddition.Time }}<br>{{ .Lastposterusername.String }}</div>
                 <div class="threads">{{ .Threads.Int32 }}</div>
                 <div class="replies">{{ .Comments.Int32 }}</div>


### PR DESCRIPTION
## Summary
- add reusable template helpers to supply default topic titles and descriptions with unicode icons
- update forum and admin templates to show placeholder text when topic fields are empty so links remain visible

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cda30d2ec832f9a43f8317fec34c0)