### PR TITLE
Add non-root user to Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,21 @@ WORKDIR /src
 COPY . .
 RUN go build -tags=ses -o /goa4web ./cmd/goa4web
 
+FROM alpine:3.20 AS runtime
+RUN addgroup -S goa4web && adduser -S -G goa4web -u 65532 goa4web \
+  && mkdir -p /data/imagebbs \
+  && chown -R goa4web:goa4web /data
+
 FROM scratch
 # Install the application into the final image.
 ENV PATH=/usr/local/bin
 ENV AUTO_MIGRATE=false
+COPY --from=runtime /etc/passwd /etc/passwd
+COPY --from=runtime /etc/group /etc/group
+COPY --from=runtime /data /data
 COPY --from=build /goa4web /usr/local/bin/goa4web
 # Image uploads are stored under /data/imagebbs inside the container.
 VOLUME ["/data/imagebbs"]
+USER goa4web
 ENTRYPOINT ["/usr/local/bin/goa4web"]
 CMD ["serve"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -2,12 +2,21 @@
 # GoReleaser builds the binary first and then copies it into the image,
 # so no build step is required here.
 # This image contains the goa4web binary.
+FROM alpine:3.20 AS runtime
+RUN addgroup -S goa4web && adduser -S -G goa4web -u 65532 goa4web \
+  && mkdir -p /data/imagebbs \
+  && chown -R goa4web:goa4web /data
+
 FROM scratch
 # Install the application into the final image.
 ENV PATH=/usr/local/bin
 ENV AUTO_MIGRATE=false
+COPY --from=runtime /etc/passwd /etc/passwd
+COPY --from=runtime /etc/group /etc/group
+COPY --from=runtime /data /data
 COPY goa4web /usr/local/bin/goa4web
 # Image uploads are stored under /data/imagebbs inside the container.
 VOLUME ["/data/imagebbs"]
+USER goa4web
 ENTRYPOINT ["/usr/local/bin/goa4web"]
 CMD ["serve"]

--- a/readme.md
+++ b/readme.md
@@ -445,7 +445,9 @@ docker run -p 8080:8080 \
 
 Setting `GOA4WEB_DOCKER=1` tells the application to store generated secret files
 such as `session_secret` under `/var/lib/goa4web`. Mount this directory as a
-volume to keep the secrets across container restarts.
+volume to keep the secrets across container restarts. The container runs as the
+unprivileged `goa4web` user (UID 65532), so ensure any mounted directories such
+as `/data` or `/var/lib/goa4web` are writable by that UID on the host.
 
 ### Docker Compose
 
@@ -490,4 +492,3 @@ Save the file as `docker-compose.yaml` and run:
 ```bash
 docker compose up
 ```
-


### PR DESCRIPTION
## Summary
- build a dedicated goa4web user during image builds and run containers as that user
- copy user metadata and pre-created data directory with correct ownership into both Dockerfile variants
- document the non-root runtime user and host directory permission requirements for Docker deployments

## Testing
- go mod tidy
- go fmt ./...
- go vet ./...
- golangci-lint run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942309f1c50832faf2f03fe04af7c3a)