### PR TITLE
Standardize dashboard and email timestamp formatting

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gorilla/sessions"
 
 	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/dbdrivers"
@@ -1664,6 +1665,14 @@ func (cd *CoreData) Location() *time.Location {
 // LocalTime converts t to cd's configured time zone.
 func (cd *CoreData) LocalTime(t time.Time) time.Time { return t.In(cd.Location()) }
 
+// FormatLocalTime renders t using the configured time zone and standard layout.
+func (cd *CoreData) FormatLocalTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return cd.LocalTime(t).Format(consts.DisplayDateTimeFormat)
+}
+
 // LocalTimeIn converts t to the named time zone when available, otherwise
 // falling back to cd's configured time zone.
 func (cd *CoreData) LocalTimeIn(t time.Time, zone string) time.Time {
@@ -1673,6 +1682,15 @@ func (cd *CoreData) LocalTimeIn(t time.Time, zone string) time.Time {
 		}
 	}
 	return t.In(cd.Location())
+}
+
+// FormatLocalTimeIn renders t using the provided zone when valid or the configured
+// time zone, applying the standard timestamp layout.
+func (cd *CoreData) FormatLocalTimeIn(t time.Time, zone string) string {
+	if t.IsZero() {
+		return ""
+	}
+	return cd.LocalTimeIn(t, zone).Format(consts.DisplayDateTimeFormat)
 }
 
 // PublicWritings returns public writings in a category, cached per category and offset.

--- a/core/consts/time_formats.go
+++ b/core/consts/time_formats.go
@@ -1,0 +1,4 @@
+package consts
+
+// DisplayDateTimeFormat defines the standard layout for user-facing timestamps.
+const DisplayDateTimeFormat = "2006-01-02 15:04 MST"

--- a/core/templates/email/replyEmail.gohtml
+++ b/core/templates/email/replyEmail.gohtml
@@ -2,7 +2,7 @@
 <html>
 <body>
 <p>Hi {{.Item.Thread.Lastposterusername.String}},</p>
-<p>A new reply was posted in "{{.Item.TopicTitle}}" (thread #{{.Item.ThreadID}}) on {{ localTime .Item.Time }}.</p>
+<p>A new reply was posted in "{{.Item.TopicTitle}}" (thread #{{.Item.ThreadID}}) on {{ formatLocalTime (localTime .Item.Time) }}.</p>
 <p>There are now {{.Item.Thread.Comments.Int32}} comments in the discussion.</p>
 <p>Read it <a href="{{.URL}}">here</a>.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/replyEmail.gotxt
+++ b/core/templates/email/replyEmail.gotxt
@@ -1,6 +1,6 @@
 Hi {{.Item.Thread.Lastposterusername.String}},
 
-A new reply was posted in "{{.Item.TopicTitle}}" (thread #{{.Item.ThreadID}}) on {{ localTime .Item.Time }}.
+A new reply was posted in "{{.Item.TopicTitle}}" (thread #{{.Item.ThreadID}}) on {{ formatLocalTime (localTime .Item.Time) }}.
 There are now {{.Item.Thread.Comments.Int32}} comments in the discussion.
 
 View it here:

--- a/core/templates/email/signupEmail.gohtml
+++ b/core/templates/email/signupEmail.gohtml
@@ -2,7 +2,7 @@
 <html>
 <body>
 <p>Hello,</p>
-<p>A new user {{.Item.Username}} has registered at {{ localTime .Item.Time }}.</p>
+<p>A new user {{.Item.Username}} has registered at {{ formatLocalTime (localTime .Item.Time) }}.</p>
 <p>Please add them to the user group to approve the account.</p>
 <p>Review the account <a href="{{.URL}}">here</a>.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>

--- a/core/templates/email/signupEmail.gotxt
+++ b/core/templates/email/signupEmail.gotxt
@@ -1,6 +1,6 @@
 Hello,
 
-A new user {{.Item.Username}} has registered at {{ localTime .Item.Time }}.
+A new user {{.Item.Username}} has registered at {{ formatLocalTime (localTime .Item.Time) }}.
 Please add them to the user group to approve the account.
 
 Review the account here:

--- a/core/templates/email/updateEmail.gohtml
+++ b/core/templates/email/updateEmail.gohtml
@@ -2,7 +2,7 @@
 <html>
 <body>
 <p>Hello,</p>
-<p>{{.Item.Action}} occurred at <a href="{{.URL}}">{{.URL}}</a> on {{ localTime .Item.Time }}.</p>
+<p>{{.Item.Action}} occurred at <a href="{{.URL}}">{{.URL}}</a> on {{ formatLocalTime (localTime .Item.Time) }}.</p>
 <p><a href="{{.UnsubscribeUrl}}">Manage notifications</a></p>
 {{- if .SignOff}}
 <p>{{.SignOffHTML}}</p>

--- a/core/templates/email/updateEmail.gotxt
+++ b/core/templates/email/updateEmail.gotxt
@@ -1,6 +1,6 @@
 Hello,
 
-{{.Item.Action}} occurred at {{.URL}} on {{ localTime .Item.Time }}.
+{{.Item.Action}} occurred at {{.URL}} on {{ formatLocalTime (localTime .Item.Time) }}.
 
 {{if .URL}}View details here:
 {{.URL}}

--- a/core/templates/site/admin/adminUserPage.gohtml
+++ b/core/templates/site/admin/adminUserPage.gohtml
@@ -35,7 +35,7 @@
 {{ range $emails }}
 <tr>
   <td>{{ .Email }}</td>
-  <td>{{ if .VerifiedAt.Valid }}{{ cd.LocalTime .VerifiedAt.Time }}{{ else }}no{{ end }}</td>
+  <td>{{ if .VerifiedAt.Valid }}{{ cd.FormatLocalTime .VerifiedAt.Time }}{{ else }}no{{ end }}</td>
   <td>{{ .NotificationPriority }}</td>
 </tr>
 {{ end }}
@@ -104,7 +104,7 @@
 <tr><th>Date</th><th>Comment</th></tr>
 {{ range $comments }}
 <tr>
-  <td>{{ (cd.LocalTime .CreatedAt).Format "2006-01-02 15:04" }}</td>
+  <td>{{ cd.FormatLocalTime .CreatedAt }}</td>
   <td>{{ .Comment }}</td>
 </tr>
 {{ end }}

--- a/core/templates/site/admin/announcementsPage.gohtml
+++ b/core/templates/site/admin/announcementsPage.gohtml
@@ -14,7 +14,7 @@
         <td><input type="checkbox" name="id" value="{{ .ID }}"></td>
         <td>{{ .ID }}</td>
         <td>{{ .SiteNewsID }}</td>
-        <td>{{ cd.LocalTime .CreatedAt }}</td>
+        <td>{{ cd.FormatLocalTime .CreatedAt }}</td>
         <td>{{ if .Active }}yes{{ else }}no{{ end }}</td>
         <td>{{ .News.String }}</td>
     </tr>

--- a/core/templates/site/admin/auditLogPage.gohtml
+++ b/core/templates/site/admin/auditLogPage.gohtml
@@ -12,7 +12,7 @@
         <td>{{.ID}}</td>
         <td>{{.Username.String}}</td>
         <td>{{.Action}}</td>
-        <td>{{ cd.LocalTime .CreatedAt }}</td>
+        <td>{{ cd.FormatLocalTime .CreatedAt }}</td>
     </tr>
     {{- end}}
 </table>

--- a/core/templates/site/admin/commentsPage.gohtml
+++ b/core/templates/site/admin/commentsPage.gohtml
@@ -5,7 +5,7 @@
 {{- range .Comments }}
 <tr>
 <td>{{ .Idcomments }}</td>
-<td>{{ if .Written.Valid }}{{ cd.LocalTimeIn .Written.Time .Timezone.String }}{{ end }}</td>
+<td>{{ if .Written.Valid }}{{ cd.FormatLocalTimeIn .Written.Time .Timezone.String }}{{ end }}</td>
 <td>{{ .ForumtopicIdforumtopic }}</td>
 <td>{{ .Idforumthread }}</td>
 <td>{{ if .Text.Valid }}{{ left 40 .Text.String }}{{ end }}</td>

--- a/core/templates/site/admin/dlqPage.gohtml
+++ b/core/templates/site/admin/dlqPage.gohtml
@@ -10,7 +10,7 @@ Configured providers: {{ .Providers }}<br />
 <table class="table table-bordered">
 <tr><th>Time</th><th>Message</th></tr>
 {{- range .FileErrors }}
-<tr><td>{{ cd.LocalTime .Time }}</td><td>{{ .Message }}</td></tr>
+<tr><td>{{ cd.FormatLocalTime .Time }}</td><td>{{ .Message }}</td></tr>
 {{- end }}
 </table>
 {{- end }}
@@ -50,7 +50,7 @@ Configured providers: {{ .Providers }}<br />
     <td><input type="checkbox" name="id" value="{{ .ID }}"></td>
     <td>{{ .ID }}</td>
     <td>{{ .Message }}</td>
-    <td>{{ cd.LocalTime .CreatedAt }}</td>
+    <td>{{ cd.FormatLocalTime .CreatedAt }}</td>
 </tr>
 {{- end }}
 </table>

--- a/core/templates/site/admin/emailFailedPage.gohtml
+++ b/core/templates/site/admin/emailFailedPage.gohtml
@@ -8,7 +8,7 @@
     <td>{{ .Email }}</td>
     <td>{{ .Subject }}</td>
     <td>{{ .ErrorCount }}</td>
-    <td>{{ if .CreatedAt.Valid }}{{ cd.LocalTime .CreatedAt.Time }}{{ end }}</td>
+    <td>{{ if .CreatedAt.Valid }}{{ cd.FormatLocalTime .CreatedAt.Time }}{{ end }}</td>
 </tr>
 {{- end }}
 </table>

--- a/core/templates/site/admin/emailQueuePage.gohtml
+++ b/core/templates/site/admin/emailQueuePage.gohtml
@@ -10,7 +10,7 @@
         <td>{{ .ID }}</td>
         <td>{{ .Email }}</td>
         <td>{{ .Subject }}</td>
-        <td>{{ if .CreatedAt.Valid }}{{ cd.LocalTime .CreatedAt.Time }}{{ end }}</td>
+        <td>{{ if .CreatedAt.Valid }}{{ cd.FormatLocalTime .CreatedAt.Time }}{{ end }}</td>
     </tr>
     {{- end }}
 </table>

--- a/core/templates/site/admin/emailSentPage.gohtml
+++ b/core/templates/site/admin/emailSentPage.gohtml
@@ -11,7 +11,7 @@
     <td>{{ .Email }}</td>
     <td>{{ .Subject }}</td>
     <td>{{ .ErrorCount }}</td>
-    <td>{{ if .SentAt.Valid }}Sent {{ cd.LocalTime .SentAt.Time }}{{ else }}Unknown{{ end }}</td>
+    <td>{{ if .SentAt.Valid }}Sent {{ cd.FormatLocalTime .SentAt.Time }}{{ else }}Unknown{{ end }}</td>
 </tr>
 {{- end }}
 </table>

--- a/core/templates/site/admin/externalLinksPage.gohtml
+++ b/core/templates/site/admin/externalLinksPage.gohtml
@@ -10,7 +10,7 @@
         <td>{{ .ID }}</td>
         <td>{{ .Url }}</td>
         <td>{{ .Clicks }}</td>
-        <td>{{ cd.LocalTime .CreatedAt }}</td>
+        <td>{{ cd.FormatLocalTime .CreatedAt }}</td>
         <td>{{ .UpdatedAt }}</td>
         <td>{{ .CardTitle.String }}</td>
         <td>{{ .CardDescription.String }}</td>

--- a/core/templates/site/admin/ipBanPage.gohtml
+++ b/core/templates/site/admin/ipBanPage.gohtml
@@ -16,9 +16,9 @@
         <td><input type="checkbox" name="ip" value="{{ .IpNet }}"></td>
         <td>{{ .IpNet }}</td>
         <td>{{ .Reason.String }}</td>
-        <td>{{ cd.LocalTime .CreatedAt }}</td>
-        <td>{{ if .ExpiresAt.Valid }}{{ cd.LocalTime .ExpiresAt.Time }}{{ end }}</td>
-        <td>{{ if .CanceledAt.Valid }}{{ cd.LocalTime .CanceledAt.Time }}{{ end }}</td>
+        <td>{{ cd.FormatLocalTime .CreatedAt }}</td>
+        <td>{{ if .ExpiresAt.Valid }}{{ cd.FormatLocalTime .ExpiresAt.Time }}{{ end }}</td>
+        <td>{{ if .CanceledAt.Valid }}{{ cd.FormatLocalTime .CanceledAt.Time }}{{ end }}</td>
     </tr>
     {{- end }}
 </table>

--- a/core/templates/site/admin/loginAttemptsPage.gohtml
+++ b/core/templates/site/admin/loginAttemptsPage.gohtml
@@ -3,7 +3,7 @@
     <tr><th>Time</th><th>Username</th><th>IP</th></tr>
     {{- range cd.AdminLoginAttempts }}
     <tr>
-        <td>{{ cd.LocalTime .CreatedAt }}</td>
+        <td>{{ cd.FormatLocalTime .CreatedAt }}</td>
         <td>{{ .Username }}</td>
         <td>{{ .IpAddress }}</td>
     </tr>

--- a/core/templates/site/admin/requestArchivePage.gohtml
+++ b/core/templates/site/admin/requestArchivePage.gohtml
@@ -9,7 +9,7 @@
     <td><a href="/admin/user/{{ .UsersIdusers }}">{{ with $u := cd.UserByID .UsersIdusers }}{{ if $u.Username.Valid }}{{ $u.Username.String }}{{ end }}{{ end }}</a></td>
     <td>{{ .Status }}</td>
     <td>{{ .ChangeValue.String }}</td>
-    <td>{{ if .ActedAt.Valid }}{{ cd.LocalTime .ActedAt.Time }}{{ end }}</td>
+    <td>{{ if .ActedAt.Valid }}{{ cd.FormatLocalTime .ActedAt.Time }}{{ end }}</td>
 </tr>
 {{ end }}
 </table>

--- a/core/templates/site/admin/requestPage.gohtml
+++ b/core/templates/site/admin/requestPage.gohtml
@@ -12,7 +12,7 @@
 <table class="table table-bordered">
 <tr><th>Date</th><th>Comment</th></tr>
 {{ range $comments }}
-<tr><td>{{ cd.LocalTime .CreatedAt }}</td><td>{{ .Comment }}</td></tr>
+<tr><td>{{ cd.FormatLocalTime .CreatedAt }}</td><td>{{ .Comment }}</td></tr>
 {{ end }}
 </table>
 {{ else }}

--- a/core/templates/site/admin/userBlogsPage.gohtml
+++ b/core/templates/site/admin/userBlogsPage.gohtml
@@ -5,7 +5,7 @@
     {{- range .Blogs }}
     <tr>
         <td><a href="/admin/blogs/blog/{{ .Idblogs }}">{{ .Idblogs }}</a></td>
-        <td>{{ cd.LocalTimeIn .Written .Timezone.String }}</td>
+        <td>{{ cd.FormatLocalTimeIn .Written .Timezone.String }}</td>
         <td>{{ .Comments }}</td>
         <td>{{ .LanguageID }}</td>
         <td>{{if .Idforumcategory.Valid}}<a href="/forum/category/{{ .Idforumcategory.Int32 }}">{{ .ForumcategoryTitle.String }}</a>{{end}}</td>

--- a/core/templates/site/admin/userCommentsPage.gohtml
+++ b/core/templates/site/admin/userCommentsPage.gohtml
@@ -6,7 +6,7 @@
     {{- range cd.AdminCommentsByUser $u.Idusers }}
     <tr>
         <td><a href="/admin/comment/{{ .Idcomments }}">{{ .Idcomments }}</a></td>
-        <td>{{ if .Written.Valid }}{{ cd.LocalTimeIn .Written.Time .Timezone.String }}{{ end }}</td>
+        <td>{{ if .Written.Valid }}{{ cd.FormatLocalTimeIn .Written.Time .Timezone.String }}{{ end }}</td>
         <td>{{ if .ForumtopicIdforumtopic.Valid }}<a href="/forum/topic/{{ .ForumtopicIdforumtopic.Int32 }}">{{ topicTitleOrDefault .ForumtopicTitle.String }}</a>{{ end }}</td>
         <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic.Int32 }}/thread/{{ .ForumthreadID }}">{{ if .ThreadTitle.Valid }}{{ left 40 .ThreadTitle.String }}{{ else }}{{ .ForumthreadID }}{{ end }}</a></td>
         <td>{{ if .Text.Valid }}{{ left 40 .Text.String }}{{ end }}</td>

--- a/core/templates/site/admin/userForumPage.gohtml
+++ b/core/templates/site/admin/userForumPage.gohtml
@@ -8,7 +8,7 @@
         <td><a href="/admin/forum/topics/topic/{{ .ForumtopicIdforumtopic }}/edit">{{ topicTitleOrDefault .TopicTitle.String }}</a></td>
         <td>{{ if .CategoryID.Valid }}<a href="/admin/forum/categories/category/{{ .CategoryID.Int32 }}/grants">{{ .CategoryTitle.String }}</a>{{ end }}</td>
         <td>{{ .Comments.Int32 }}</td>
-        <td>{{ cd.LocalTime .Lastaddition.Time }}</td>
+        <td>{{ cd.FormatLocalTime .Lastaddition.Time }}</td>
         <td><a href="/forum/topic/{{ .ForumtopicIdforumtopic }}/thread/{{ .Idforumthread }}">View</a></td>
     </tr>
     {{- end }}

--- a/core/templates/site/admin/userImagebbsPage.gohtml
+++ b/core/templates/site/admin/userImagebbsPage.gohtml
@@ -5,7 +5,7 @@
     {{- range .Posts }}
     <tr>
         <td><a href="/admin/user/{{ $.User.Idusers }}/imagebbs/post/{{ .Idimagepost }}">{{ .Idimagepost }}</a></td>
-        <td>{{ cd.LocalTimeIn .Posted .Timezone.String }}</td>
+        <td>{{ cd.FormatLocalTimeIn .Posted .Timezone.String }}</td>
         <td>{{ .ImageboardIdimageboard.Int32 }}</td>
         <td>{{ if .Approved }}Yes{{ else }}No{{ end }}</td>
         <td>

--- a/core/templates/site/admin/userLinkerPage.gohtml
+++ b/core/templates/site/admin/userLinkerPage.gohtml
@@ -5,7 +5,7 @@
     {{- range .Links }}
     <tr>
         <td><a href="/admin/linker/links/link/{{ .ID }}">{{ .ID }}</a></td>
-        <td>{{ if .Listed.Valid }}{{ cd.LocalTimeIn .Listed.Time .Timezone.String }}{{ end }}</td>
+        <td>{{ if .Listed.Valid }}{{ cd.FormatLocalTimeIn .Listed.Time .Timezone.String }}{{ end }}</td>
         <td>{{ if .Title.Valid }}{{ .Title.String }}{{ end }}</td>
         <td>{{ if .Url.Valid }}<a href="{{ .Url.String }}" target="_blank">{{ .Url.String }}</a>{{ end }}</td>
         <td><a href="/linker/show/{{ .ID }}">View</a></td>

--- a/core/templates/site/admin/userWritingsPage.gohtml
+++ b/core/templates/site/admin/userWritingsPage.gohtml
@@ -7,7 +7,7 @@
         <td><a href="/admin/writings/article/{{ .Idwriting }}">{{ .Idwriting }}</a></td>
         <td>{{ .Title.String }}</td>
         <td><a href="/admin/writings/categories/category/{{ .WritingCategoryID }}">{{ .WritingCategoryID }}</a></td>
-        <td>{{ if .Published.Valid }}{{ cd.LocalTime .Published.Time }}{{ end }}</td>
+        <td>{{ if .Published.Valid }}{{ cd.FormatLocalTime .Published.Time }}{{ end }}</td>
         <td>{{ .Comments }}</td>
         <td><a href="/writings/article/{{ .Idwriting }}">View</a> | <a href="/writings/article/{{ .Idwriting }}/edit">Edit</a></td>
     </tr>

--- a/core/templates/site/admin/usersPage.gohtml
+++ b/core/templates/site/admin/usersPage.gohtml
@@ -27,9 +27,8 @@
                 <td><a href="/admin/user/{{.Idusers}}">{{.Idusers}}</a></td>
                 <td>{{.Username.String}}</td>
                 <td>{{.Email.String}}</td>
-                <td>{{with $c := index $.Comments .Idusers}}{{ (cd.LocalTime $c.CreatedAt).Format "2006-01-02" }} - {{$c.Comment}}{{end}}</td>
+                <td>{{with $c := index $.Comments .Idusers}}{{ cd.FormatLocalTime $c.CreatedAt }} - {{$c.Comment}}{{end}}</td>
             </tr>
         {{end}}
     </table>
 {{ template "tail" $ }}
-

--- a/core/templates/templates.go
+++ b/core/templates/templates.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"embed"
+	"github.com/arran4/goa4web/core/consts"
 	htemplate "html/template"
 	"io/fs"
 	"os"
@@ -95,6 +96,14 @@ func GetCompiledEmailHtmlTemplates(funcs htemplate.FuncMap) *htemplate.Template 
 	if _, ok := funcs["localTime"]; !ok {
 		funcs["localTime"] = func(t time.Time) time.Time { return t }
 	}
+	if _, ok := funcs["formatLocalTime"]; !ok {
+		funcs["formatLocalTime"] = func(t time.Time) string {
+			if t.IsZero() {
+				return ""
+			}
+			return t.Format(consts.DisplayDateTimeFormat)
+		}
+	}
 	return htemplate.Must(htemplate.New("").Funcs(funcs).ParseFS(getFS("email"), "*.gohtml"))
 }
 
@@ -104,6 +113,14 @@ func GetCompiledEmailTextTemplates(funcs ttemplate.FuncMap) *ttemplate.Template 
 	}
 	if _, ok := funcs["localTime"]; !ok {
 		funcs["localTime"] = func(t time.Time) time.Time { return t }
+	}
+	if _, ok := funcs["formatLocalTime"]; !ok {
+		funcs["formatLocalTime"] = func(t time.Time) string {
+			if t.IsZero() {
+				return ""
+			}
+			return t.Format(consts.DisplayDateTimeFormat)
+		}
 	}
 	return ttemplate.Must(ttemplate.New("").Funcs(funcs).ParseFS(getFS("email"), "*.gotxt"))
 }


### PR DESCRIPTION
## Summary
- add a shared display timestamp layout and helpers for rendering local times
- apply the new formatting helpers across admin dashboard templates
- update email templates to use the shared timestamp formatting

## Testing
- go mod tidy
- go vet ./...
- golangci-lint run ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69423054b490832fa2646f1d7b4ca3ee)