### PR TITLE
Rotate CSRF tokens after authentication

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/arran4/goa4web"
 
-	"filippo.io/csrf/gorilla"
 	"github.com/arran4/goa4web/a4code/a4code2html"
 	"github.com/arran4/goa4web/core/consts"
+	csrfmiddleware "github.com/arran4/goa4web/internal/middleware/csrf"
 )
 
 const (
@@ -31,8 +31,8 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 	return map[string]any{
 		"cd":        func() *CoreData { return cd },
 		"now":       func() time.Time { return time.Now().In(cd.Location()) },
-		"csrfField": func() template.HTML { return csrf.TemplateField(r) },
-		"csrfToken": func() string { return csrf.Token(r) },
+		"csrfField": func() template.HTML { return csrfmiddleware.TemplateField(r) },
+		"csrfToken": func() string { return csrfmiddleware.Token(r) },
 		"version":   func() string { return goa4web.Version },
 		"dict": func(values ...any) map[string]any {
 			m := make(map[string]any)

--- a/internal/middleware/csrf/csrf.go
+++ b/internal/middleware/csrf/csrf.go
@@ -1,20 +1,163 @@
 package csrf
 
 import (
+	"context"
+	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"html/template"
+	"log"
 	"net/http"
 	"net/url"
 
 	"filippo.io/csrf/gorilla"
+
+	"github.com/arran4/goa4web/core"
+)
+
+type contextKey string
+
+const (
+	// contextTokenKey stores the CSRF token in the request context.
+	contextTokenKey contextKey = "csrfToken"
+	// sessionTokenKey stores the CSRF token alongside the user's session data.
+	sessionTokenKey = "CSRFToken"
+	// sessionUserKey tracks the user ID associated with the CSRF token.
+	sessionUserKey = "CSRFAuthUID"
+	// formFieldName is the expected CSRF form field name.
+	formFieldName = "gorilla.csrf.Token"
 )
 
 // NewCSRFMiddleware returns middleware enforcing CSRF protection using the
-// provided session secret and HTTP configuration.
+// provided session secret and HTTP configuration. It also issues per-session
+// CSRF tokens that rotate when the authenticated user changes.
 func NewCSRFMiddleware(secret string, hostname string, version string) func(http.Handler) http.Handler {
 	key := sha256.Sum256([]byte(secret))
 	origins := []string{}
 	if u, err := url.Parse(hostname); err == nil && u.Host != "" {
 		origins = append(origins, u.Host)
 	}
-	return csrf.Protect(key[:], csrf.Secure(version != "dev"), csrf.TrustedOrigins(origins))
+	protect := csrf.Protect(key[:], csrf.Secure(version != "dev"), csrf.TrustedOrigins(origins))
+	return func(next http.Handler) http.Handler {
+		validatedNext := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if requiresToken(r.Method) && !validateRequestToken(r) {
+				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+		protected := protect(validatedNext)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			withToken, ok := attachToken(w, r)
+			if !ok {
+				return
+			}
+			protected.ServeHTTP(w, withToken)
+		})
+	}
+}
+
+func attachToken(w http.ResponseWriter, r *http.Request) (*http.Request, bool) {
+	session, err := core.GetSession(r)
+	if err != nil {
+		core.SessionErrorRedirect(w, r, err)
+		return nil, false
+	}
+	currentUID := readUID(session.Values["UID"])
+	tokenUID := readUID(session.Values[sessionUserKey])
+	token, _ := session.Values[sessionTokenKey].(string)
+
+	if token == "" || currentUID != tokenUID {
+		token, err = newToken()
+		if err != nil {
+			log.Printf("generate csrf token: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return nil, false
+		}
+		session.Values[sessionTokenKey] = token
+		session.Values[sessionUserKey] = currentUID
+		if err := session.Save(r, w); err != nil {
+			log.Printf("save csrf token: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return nil, false
+		}
+	}
+
+	ctx := context.WithValue(r.Context(), contextTokenKey, token)
+	return r.WithContext(ctx), true
+}
+
+// Token returns the request-specific CSRF token.
+func Token(r *http.Request) string {
+	if token, ok := r.Context().Value(contextTokenKey).(string); ok {
+		return token
+	}
+	return ""
+}
+
+// TemplateField returns the HTML hidden input tag containing the CSRF token.
+func TemplateField(r *http.Request) template.HTML {
+	token := Token(r)
+	if token == "" {
+		return template.HTML("")
+	}
+	return template.HTML(fmt.Sprintf(`<input type="hidden" name="%s" value="%s">`, formFieldName, template.HTMLEscapeString(token)))
+}
+
+func validateRequestToken(r *http.Request) bool {
+	token := Token(r)
+	if token == "" {
+		return false
+	}
+	if header := r.Header.Get("X-CSRF-Token"); header != "" {
+		return subtleCompare(header, token)
+	}
+	if err := r.ParseForm(); err != nil {
+		return false
+	}
+	return subtleCompare(r.PostFormValue(formFieldName), token)
+}
+
+func subtleCompare(provided string, expected string) bool {
+	if provided == "" || expected == "" {
+		return false
+	}
+	if len(provided) != len(expected) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) == 1
+}
+
+func requiresToken(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
+		return false
+	default:
+		return true
+	}
+}
+
+func newToken() (string, error) {
+	token := make([]byte, 32)
+	if _, err := rand.Read(token); err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(token), nil
+}
+
+func readUID(uid any) int32 {
+	switch v := uid.(type) {
+	case int:
+		return int32(v)
+	case int32:
+		return v
+	case int64:
+		return int32(v)
+	case float64:
+		return int32(v)
+	default:
+		return 0
+	}
 }

--- a/internal/middleware/csrf/csrf_test.go
+++ b/internal/middleware/csrf/csrf_test.go
@@ -1,22 +1,17 @@
 package csrf
 
 import (
-	"crypto/sha256"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 
-	"filippo.io/csrf/gorilla"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 
 	"github.com/arran4/goa4web/config"
-
 	"github.com/arran4/goa4web/core"
-	"github.com/arran4/goa4web/handlers"
 )
 
 var (
@@ -28,23 +23,18 @@ func TestCSRFLoginFlow(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("testsecret"))
 	core.Store = store
 	core.SessionName = sessionName
-	key := sha256.Sum256([]byte("testsecret"))
 
 	r := mux.NewRouter()
 	r.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Token", csrf.Token(r))
+		w.Header().Set("X-Token", Token(r))
 	}).Methods("GET")
 	r.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}).Methods("POST")
 
-	handler := csrf.Protect(key[:], csrf.Secure(false), csrf.ErrorHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Logf("failure: %v", csrf.FailureReason(r))
-		w.WriteHeader(http.StatusForbidden)
-		handlers.RenderErrorPage(w, r, fmt.Errorf("fail"))
-	})))(r)
+	handler := NewCSRFMiddleware("testsecret", "http://example.com", "dev")(r)
 
-	req := csrf.PlaintextHTTPRequest(httptest.NewRequest("GET", "/login", nil))
+	req := httptest.NewRequest("GET", "http://example.com/login", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -58,14 +48,15 @@ func TestCSRFLoginFlow(t *testing.T) {
 	cookieHeader := rr.Header().Get("Set-Cookie")
 
 	data := url.Values{"gorilla.csrf.Token": {token}}
-	req2 := csrf.PlaintextHTTPRequest(httptest.NewRequest("POST", "/login", strings.NewReader(data.Encode())))
+	req2 := httptest.NewRequest("POST", "http://example.com/login", strings.NewReader(data.Encode()))
 	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req2.Header.Set("X-CSRF-Token", token)
 	req2.Header.Set("Cookie", cookieHeader)
 	rr2 := httptest.NewRecorder()
 	handler.ServeHTTP(rr2, req2)
 
 	if rr2.Code != http.StatusOK {
-		t.Fatalf("expected 200 got %d (%v)", rr2.Code, csrf.FailureReason(req2))
+		t.Fatalf("expected 200 got %d", rr2.Code)
 	}
 }
 
@@ -73,17 +64,16 @@ func TestCSRFCrossSite(t *testing.T) {
 	store = sessions.NewCookieStore([]byte("testsecret"))
 	core.Store = store
 	core.SessionName = sessionName
-	key := sha256.Sum256([]byte("testsecret"))
 
 	r := mux.NewRouter()
 	r.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Token", csrf.Token(r))
+		w.Header().Set("X-Token", Token(r))
 	}).Methods("GET")
 	r.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}).Methods("POST")
 
-	handler := csrf.Protect(key[:], csrf.Secure(true), csrf.TrustedOrigins([]string{"https://example.com"}))(r)
+	handler := NewCSRFMiddleware("testsecret", "https://example.com", "prod")(r)
 
 	req := httptest.NewRequest("GET", "https://example.com/login", nil)
 	rr := httptest.NewRecorder()
@@ -94,6 +84,7 @@ func TestCSRFCrossSite(t *testing.T) {
 	data := url.Values{"gorilla.csrf.Token": {token}}
 	req2 := httptest.NewRequest("POST", "https://example.com/login", strings.NewReader(data.Encode()))
 	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req2.Header.Set("X-CSRF-Token", token)
 	req2.Header.Set("Cookie", cookie)
 	req2.Header.Set("Origin", "https://bad.com")
 	req2.Header.Set("Sec-Fetch-Site", "cross-site")
@@ -105,13 +96,14 @@ func TestCSRFCrossSite(t *testing.T) {
 
 	req3 := httptest.NewRequest("POST", "https://example.com/login", strings.NewReader(data.Encode()))
 	req3.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req3.Header.Set("X-CSRF-Token", token)
 	req3.Header.Set("Cookie", cookie)
 	req3.Header.Set("Origin", "https://example.com")
 	req3.Header.Set("Sec-Fetch-Site", "same-origin")
 	rr3 := httptest.NewRecorder()
 	handler.ServeHTTP(rr3, req3)
 	if rr3.Code != http.StatusOK {
-		t.Fatalf("expected 200 got %d (%v)", rr3.Code, csrf.FailureReason(req3))
+		t.Fatalf("expected 200 got %d", rr3.Code)
 	}
 }
 
@@ -129,8 +121,7 @@ func TestCSRFDisabled(t *testing.T) {
 
 	var handler http.Handler = r
 	if cfg.CSRFEnabled {
-		key := sha256.Sum256([]byte("testsecret"))
-		handler = csrf.Protect(key[:], csrf.Secure(false))(handler)
+		handler = NewCSRFMiddleware("testsecret", "http://example.com", "dev")(handler)
 	}
 
 	req := httptest.NewRequest("POST", "http://example.com/login", nil)
@@ -138,5 +129,69 @@ func TestCSRFDisabled(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+}
+
+func TestCSRFRotatesAfterAuthentication(t *testing.T) {
+	store = sessions.NewCookieStore([]byte("testsecret"))
+	core.Store = store
+	core.SessionName = sessionName
+
+	r := mux.NewRouter()
+	r.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Token", Token(r))
+	}).Methods(http.MethodGet)
+	r.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		session, _ := core.GetSession(r)
+		session.Values["UID"] = int32(42)
+		if err := session.Save(r, w); err != nil {
+			t.Fatalf("save session: %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}).Methods(http.MethodPost)
+
+	handler := NewCSRFMiddleware("testsecret", "http://example.com", "dev")(r)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/token", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	token := rr.Header().Get("X-Token")
+	if token == "" {
+		t.Fatalf("missing token on initial request")
+	}
+	cookie := rr.Header().Get("Set-Cookie")
+
+	req2 := httptest.NewRequest(http.MethodGet, "http://example.com/token", nil)
+	req2.Header.Set("Cookie", cookie)
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, req2)
+	if token != rr2.Header().Get("X-Token") {
+		t.Fatalf("token changed before authentication")
+	}
+
+	loginForm := url.Values{"gorilla.csrf.Token": {token}}
+	loginReq := httptest.NewRequest(http.MethodPost, "http://example.com/login", strings.NewReader(loginForm.Encode()))
+	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	loginReq.Header.Set("X-CSRF-Token", token)
+	loginReq.Header.Set("Cookie", cookie)
+	loginRR := httptest.NewRecorder()
+	handler.ServeHTTP(loginRR, loginReq)
+	if loginRR.Code != http.StatusNoContent {
+		t.Fatalf("login failed with status %d", loginRR.Code)
+	}
+	if updated := loginRR.Header().Get("Set-Cookie"); updated != "" {
+		cookie = updated
+	}
+
+	req3 := httptest.NewRequest(http.MethodGet, "http://example.com/token", nil)
+	req3.Header.Set("Cookie", cookie)
+	rr3 := httptest.NewRecorder()
+	handler.ServeHTTP(rr3, req3)
+	rotated := rr3.Header().Get("X-Token")
+	if rotated == "" {
+		t.Fatalf("missing token after login")
+	}
+	if rotated == token {
+		t.Fatalf("expected token rotation after authentication")
 	}
 }


### PR DESCRIPTION
## Summary
- generate and persist CSRF tokens in the middleware, validating unsafe requests and rotating the token when authentication state changes
- expose the middleware-backed CSRF token helpers to templates so forms and AJAX calls reuse the stored value
- expand CSRF middleware tests to cover login flow, cross-site rejection, and token rotation after login

## Testing
- go mod tidy
- go fmt ./...
- go vet ./...
- golangci-lint run ./...
- go test ./... *(fails: TestPageTemplatesRender/searchPage.gohtml, TestBoardPageRendersSubBoards, TestCommentsPageAllowsGlobalViewGrant, TestPage_Access, TestCanSearch)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69423081f568832f81c631cf2ada9249)