### PR TITLE
Move forum actions to custom index

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -31,6 +31,10 @@ func (cd *CoreData) Funcs(r *http.Request) template.FuncMap {
 	return map[string]any{
 		"cd":        func() *CoreData { return cd },
 		"now":       func() time.Time { return time.Now().In(cd.Location()) },
+		"localTime": cd.LocalTime,
+		"formatLocalTime": func(t time.Time) string {
+			return cd.FormatLocalTime(t)
+		},
 		"csrfField": func() template.HTML { return csrfmiddleware.TemplateField(r) },
 		"csrfToken": func() string { return csrfmiddleware.Token(r) },
 		"version":   func() string { return goa4web.Version },

--- a/core/templates/site/forum/topicsPage.gohtml
+++ b/core/templates/site/forum/topicsPage.gohtml
@@ -6,22 +6,7 @@
     {{ end }}
 {{ $topicTitle := topicTitleOrDefault .Topic.Title.String }}
 {{ if .Topic.DisplayTitle }}{{ $topicTitle = topicTitleOrDefault .Topic.DisplayTitle }}{{ end }}
-<h2>Topic: {{ $topicTitle }}</h2>
-    {{ $base := "/forum" }}
-    {{ with .BasePath }}{{ $base = . }}{{ end }}
-    <div class="topic-actions">
-        <a href="{{$base}}/topic/{{.Topic.Idforumtopic}}/thread">New Thread</a>
-        {{- if and cd.IsAdmin cd.IsAdminMode }} | [<a href="/admin/forum/topics/topic/{{.Topic.Idforumtopic}}/edit">ADMIN</a>]{{ end }}
-        {{- if .Subscribed }} | <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/unsubscribe">
-                <input type="hidden" name="task" value="Unsubscribe From Topic"/>
-                <input type="submit" value="Unsubscribe"/>
-            </form>
-        {{- else }} | <form method="post" action="{{$base}}/topic/{{.Topic.Idforumtopic}}/subscribe">
-                <input type="hidden" name="task" value="Subscribe To Topic"/>
-                <input type="submit" value="Subscribe"/>
-            </form>
-        {{- end }}
-    </div>
+<h2>Topic: {{ $topicTitle }}{{- if and cd.IsAdmin cd.IsAdminMode }} [<a href="/admin/forum/topics/topic/{{.Topic.Idforumtopic}}/edit">ADMIN</a>]{{- end }}</h2>
     {{ if gt (len .Labels) 0 }}
         {{ template "topicLabels" .Labels }}
     {{ end }}

--- a/core/templates/site/topicThreads.gohtml
+++ b/core/templates/site/topicThreads.gohtml
@@ -26,20 +26,6 @@
                 [<a href="{{$base}}/topic/{{.ForumtopicIdforumtopic}}/thread/{{ .Idforumthread }}">
                     {{- .Comments.Int32 }} comments.</a>]{{" "}}
                 {{- template "topicLabels" .Labels }}
-                {{ if .IsUnread }}
-                <form method="post" action="{{$base}}/thread/{{.Idforumthread}}/labels" class="mark-read">
-                    {{ csrfField }}
-                    <input type="hidden" name="task" value="Mark Thread Read"/>
-                    <input type="hidden" name="redirect" value="{{ $.BackURL }}"/>
-                    <button type="submit">Mark as read</button>
-                </form>
-                <form method="post" action="{{$base}}/thread/{{.Idforumthread}}/labels" class="mark-read">
-                    {{ csrfField }}
-                    <input type="hidden" name="task" value="Mark Thread Read"/>
-                    <input type="hidden" name="redirect" value="{{$base}}/topic/{{.ForumtopicIdforumtopic}}"/>
-                    <button type="submit">Mark as read and go back</button>
-                </form>
-                {{ end }}
             </div>
         </div>
     {{- end }}

--- a/core/templates/thread_page_test.go
+++ b/core/templates/thread_page_test.go
@@ -3,28 +3,22 @@ package templates
 import (
 	_ "embed"
 	"regexp"
-	"strings"
 	"testing"
 )
 
 //go:embed site/forum/threadPage.gohtml
 var threadPageTemplate string
 
-func TestThreadPageMarkReadIncludesCSRF(t *testing.T) {
-	re := regexp.MustCompile(`(?s)<form[^>]*class="mark-read"[^>]*>.*{{ csrfField }}`)
+func TestThreadPageLabelFormIncludesCSRF(t *testing.T) {
+	re := regexp.MustCompile(`(?s)<form[^>]*id="label-form"[^>]*>.*{{ csrfField }}`)
 	if !re.MatchString(threadPageTemplate) {
-		t.Fatalf("mark-read form missing csrfField")
+		t.Fatalf("label form missing csrfField")
 	}
 }
 
-func TestThreadPageUsesThreadMarkReadTask(t *testing.T) {
-	if strings.Contains(threadPageTemplate, "Mark Topic Read") {
-		t.Fatalf("template uses deprecated Mark Topic Read task")
-	}
-	if c := strings.Count(threadPageTemplate, "Mark Thread Read"); c != 4 {
-		t.Fatalf("expected 4 Mark Thread Read tasks, got %d", c)
-	}
-	if strings.Contains(threadPageTemplate, "/topic/{{.Topic.Idforumtopic}}/labels") {
-		t.Fatalf("mark-read form posts to topic labels endpoint")
+func TestThreadPageDoesNotContainInlineMarkRead(t *testing.T) {
+	re := regexp.MustCompile(`class="mark-read"`)
+	if re.MatchString(threadPageTemplate) {
+		t.Fatalf("mark-read actions should be provided by the custom index, not inline forms")
 	}
 }

--- a/handlers/forum/customindex.go
+++ b/handlers/forum/customindex.go
@@ -1,0 +1,140 @@
+package forum
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/gorilla/mux"
+)
+
+// CustomForumIndex builds context-aware index items for the public forum.
+func CustomForumIndex(cd *common.CoreData, r *http.Request) {
+	cd.CustomIndexItems = ForumCustomIndexItems(cd, r)
+}
+
+// ForumCustomIndexItems returns the context-aware index items for forum pages.
+func ForumCustomIndexItems(cd *common.CoreData, r *http.Request) []common.IndexItem {
+	base := forumBasePath(cd, r)
+	vars := mux.Vars(r)
+	threadID := vars["thread"]
+	topicID := vars["topic"]
+
+	items := []common.IndexItem{}
+	if cd.FeedsEnabled && topicID != "" && threadID == "" {
+		cd.RSSFeedURL = fmt.Sprintf("%s/topic/%s.rss", base, topicID)
+		cd.AtomFeedURL = fmt.Sprintf("%s/topic/%s.atom", base, topicID)
+		items = append(items,
+			common.IndexItem{Name: "Atom Feed", Link: cd.AtomFeedURL},
+			common.IndexItem{Name: "RSS Feed", Link: cd.RSSFeedURL},
+		)
+	}
+
+	if threadID != "" && topicID != "" {
+		if hasThreadUnread(cd, threadID) {
+			items = append(items,
+				common.IndexItem{
+					Name: "Mark as read",
+					Link: markThreadReadLink(base, threadID, r.URL.RequestURI()),
+				},
+				common.IndexItem{
+					Name: "Mark as read and go back",
+					Link: markThreadReadLink(base, threadID, fmt.Sprintf("%s/topic/%s", base, topicID)),
+				},
+			)
+		}
+		items = append(items, common.IndexItem{
+			Name: "Go to topic",
+			Link: fmt.Sprintf("%s/topic/%s", base, topicID),
+		})
+		if tid, err := strconv.Atoi(topicID); err == nil && cd.HasGrant("forum", "topic", "reply", int32(tid)) {
+			items = append(items,
+				common.IndexItem{
+					Name: "Write Reply",
+					Link: fmt.Sprintf("%s/topic/%s/thread/%s/reply", base, topicID, threadID),
+				},
+			)
+		}
+	}
+
+	if threadID == "" && topicID != "" {
+		if cd.IsAdmin() && cd.IsAdminMode() {
+			items = append(items, common.IndexItem{
+				Name: "Admin Edit Topic",
+				Link: fmt.Sprintf("/admin/forum/topics/topic/%s/edit", topicID),
+			})
+		}
+		if tid, err := strconv.Atoi(topicID); err == nil && cd.HasGrant("forum", "topic", "post", int32(tid)) {
+			items = append(items,
+				common.IndexItem{
+					Name: "New Thread",
+					Link: fmt.Sprintf("%s/topic/%s/thread", base, topicID),
+				},
+			)
+		}
+		if cd.UserID != 0 {
+			if tid, err := strconv.Atoi(topicID); err == nil {
+				if subscribedToTopic(cd, int32(tid)) {
+					items = append(items,
+						common.IndexItem{
+							Name: "Unsubscribe From Topic",
+							Link: fmt.Sprintf("%s/topic/%s/unsubscribe", base, topicID),
+						},
+					)
+				} else {
+					items = append(items,
+						common.IndexItem{
+							Name: "Subscribe To Topic",
+							Link: fmt.Sprintf("%s/topic/%s/subscribe", base, topicID),
+						},
+					)
+				}
+			}
+		}
+	}
+
+	return items
+}
+
+func hasThreadUnread(cd *common.CoreData, threadID string) bool {
+	if cd == nil || cd.UserID == 0 {
+		return false
+	}
+	tid, err := strconv.Atoi(threadID)
+	if err != nil {
+		return false
+	}
+	labels, err := cd.ThreadPrivateLabels(int32(tid))
+	if err != nil {
+		log.Printf("thread private labels: %v", err)
+		return false
+	}
+	for _, l := range labels {
+		if l == "unread" || l == "new" {
+			return true
+		}
+	}
+	return false
+}
+
+func markThreadReadLink(base, threadID, redirect string) string {
+	link := fmt.Sprintf("%s/thread/%s/labels?task=%s", base, threadID, url.QueryEscape(string(TaskMarkThreadRead)))
+	if redirect != "" {
+		link = fmt.Sprintf("%s&redirect=%s", link, url.QueryEscape(redirect))
+	}
+	return link
+}
+
+func forumBasePath(cd *common.CoreData, r *http.Request) string {
+	if cd != nil && cd.ForumBasePath != "" {
+		return cd.ForumBasePath
+	}
+	if r != nil && strings.HasPrefix(r.URL.Path, "/private") {
+		return "/private"
+	}
+	return "/forum"
+}

--- a/handlers/forum/forumPage.go
+++ b/handlers/forum/forumPage.go
@@ -1,14 +1,13 @@
 package forum
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/consts"
 
-	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers"
@@ -95,61 +94,4 @@ func Page(w http.ResponseWriter, r *http.Request) {
 	}
 
 	handlers.TemplateHandler(w, r, "forumPage", data)
-}
-
-func CustomForumIndex(data *common.CoreData, r *http.Request) {
-	vars := mux.Vars(r)
-	threadId := vars["thread"]
-	topicId := vars["topic"]
-	categoryId := vars["category"]
-	data.CustomIndexItems = []common.IndexItem{}
-	if data.FeedsEnabled && topicId != "" && threadId == "" {
-		data.RSSFeedURL = fmt.Sprintf("/forum/topic/%s.rss", topicId)
-		data.AtomFeedURL = fmt.Sprintf("/forum/topic/%s.atom", topicId)
-		data.CustomIndexItems = append(data.CustomIndexItems,
-			common.IndexItem{Name: "Atom Feed", Link: data.AtomFeedURL},
-			common.IndexItem{Name: "RSS Feed", Link: data.RSSFeedURL},
-		)
-	}
-	// Administrative actions moved to the admin portal.
-	if threadId != "" && topicId != "" {
-		if tid, err := strconv.Atoi(topicId); err == nil && data.HasGrant("forum", "topic", "reply", int32(tid)) {
-			data.CustomIndexItems = append(data.CustomIndexItems,
-				common.IndexItem{
-					Name: "Write Reply",
-					Link: fmt.Sprintf("/forum/topic/%s/thread/%s/reply", topicId, threadId),
-				},
-			)
-		}
-	}
-	if categoryId != "" && topicId != "" {
-		if tid, err := strconv.Atoi(topicId); err == nil && data.HasGrant("forum", "topic", "post", int32(tid)) {
-			data.CustomIndexItems = append(data.CustomIndexItems,
-				common.IndexItem{
-					Name: "Create Thread",
-					Link: fmt.Sprintf("/forum/topic/%s/thread", topicId),
-				},
-			)
-		}
-	}
-	if threadId == "" && topicId != "" && data.UserID != 0 {
-		tid, err := strconv.Atoi(topicId)
-		if err == nil {
-			if subscribedToTopic(data, int32(tid)) {
-				data.CustomIndexItems = append(data.CustomIndexItems,
-					common.IndexItem{
-						Name: "Unsubscribe From Topic",
-						Link: fmt.Sprintf("/forum/topic/%s/unsubscribe", topicId),
-					},
-				)
-			} else {
-				data.CustomIndexItems = append(data.CustomIndexItems,
-					common.IndexItem{
-						Name: "Subscribe To Topic",
-						Link: fmt.Sprintf("/forum/topic/%s/subscribe", topicId),
-					},
-				)
-			}
-		}
-	}
 }

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -33,6 +33,7 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Regis
 	fr.HandleFunc("/topic/{topic}/subscribe", handlers.TaskHandler(subscribeTopicTaskAction)).Methods("POST").MatcherFunc(subscribeTopicTaskAction.Matcher())
 	fr.HandleFunc("/topic/{topic}/unsubscribe", handlers.TaskHandler(unsubscribeTopicTaskAction)).Methods("POST").MatcherFunc(unsubscribeTopicTaskAction.Matcher())
 	fr.HandleFunc("/topic_labels.js", handlers.TopicLabelsJS).Methods(http.MethodGet)
+	fr.HandleFunc("/thread/{thread}/labels", handlers.TaskHandler(markThreadReadTask)).Methods(http.MethodGet)
 	fr.HandleFunc("/thread/{thread}/labels", handlers.TaskHandler(setLabelsTask)).Methods("POST").MatcherFunc(setLabelsTask.Matcher())
 	fr.HandleFunc("/thread/{thread}/labels", handlers.TaskHandler(addPublicLabelTask)).Methods("POST").MatcherFunc(addPublicLabelTask.Matcher())
 	fr.HandleFunc("/thread/{thread}/labels", handlers.TaskHandler(removePublicLabelTask)).Methods("POST").MatcherFunc(removePublicLabelTask.Matcher())

--- a/handlers/forum/thread_label_tasks.go
+++ b/handlers/forum/thread_label_tasks.go
@@ -196,7 +196,7 @@ func (MarkThreadReadTask) Action(w http.ResponseWriter, r *http.Request) any {
 		log.Printf("mark read: %v", err)
 		return fmt.Errorf("mark read %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if last := r.PostFormValue("last_comment"); last != "" {
+	if last := r.FormValue("last_comment"); last != "" {
 		if cid, err := strconv.Atoi(last); err == nil {
 			if err := cd.SetThreadReadMarker(int32(threadID), int32(cid)); err != nil {
 				log.Printf("set read marker: %v", err)
@@ -205,7 +205,7 @@ func (MarkThreadReadTask) Action(w http.ResponseWriter, r *http.Request) any {
 		}
 	}
 
-	target := r.PostFormValue("redirect")
+	target := r.FormValue("redirect")
 	if target == "" {
 		target = r.Header.Get("Referer")
 	}

--- a/handlers/privateforum/customindex.go
+++ b/handlers/privateforum/customindex.go
@@ -4,14 +4,14 @@ import (
 	"net/http"
 
 	"github.com/arran4/goa4web/core/common"
+	forumhandlers "github.com/arran4/goa4web/handlers/forum"
 )
 
 // CustomIndex injects private forum specific index items.
 var CustomIndex = func(cd *common.CoreData, r *http.Request) {
-	cd.CustomIndexItems = []common.IndexItem{}
-	// Action to start a new private group discussion
-	cd.CustomIndexItems = append(cd.CustomIndexItems, common.IndexItem{
+	items := []common.IndexItem{{
 		Name: "Start Group Discussion",
 		Link: "/private/topic/new",
-	})
+	}}
+	cd.CustomIndexItems = append(items, forumhandlers.ForumCustomIndexItems(cd, r)...)
 }

--- a/handlers/privateforum/page_test.go
+++ b/handlers/privateforum/page_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"reflect"
 	"strings"
 	"testing"

--- a/handlers/privateforum/routes.go
+++ b/handlers/privateforum/routes.go
@@ -32,6 +32,7 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Regis
 	pr.HandleFunc("/topic/{topic}/subscribe", handlers.TaskHandler(forumhandlers.SubscribeTopicTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.SubscribeTopicTaskHandler.Matcher())
 	pr.HandleFunc("/topic/{topic}/unsubscribe", handlers.TaskHandler(forumhandlers.UnsubscribeTopicTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.UnsubscribeTopicTaskHandler.Matcher())
 
+	pr.HandleFunc("/thread/{thread}/labels", handlers.TaskHandler(forumhandlers.MarkThreadReadTaskHandler)).Methods(http.MethodGet)
 	pr.HandleFunc("/thread/{thread}/labels", handlers.TaskHandler(forumhandlers.SetLabelsTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.SetLabelsTaskHandler.Matcher())
 	pr.HandleFunc("/thread/{thread}/labels", handlers.TaskHandler(forumhandlers.AddPublicLabelTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.AddPublicLabelTaskHandler.Matcher())
 	pr.HandleFunc("/thread/{thread}/labels", handlers.TaskHandler(forumhandlers.RemovePublicLabelTaskHandler)).Methods(http.MethodPost).MatcherFunc(forumhandlers.RemovePublicLabelTaskHandler.Matcher())


### PR DESCRIPTION
## Summary
- move forum and private forum thread/topic actions into the left custom index menus, including mark-read and navigation links
- add shared custom index builder, GET support for mark-read actions, updated routes, and admin topic edit link in the custom index
- clean up templates and tests to reflect menu-based actions and align email template parsing with production helpers

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69429d6e9394832f9758af2ef753d2ac)