### PR TITLE
Refine role list command outputs

### DIFF
--- a/cmd/goa4web/role_list.go
+++ b/cmd/goa4web/role_list.go
@@ -8,15 +8,68 @@ import (
 // roleListCmd implements the "role list" subcommand.
 type roleListCmd struct {
 	*roleCmd
-	fs *flag.FlagSet
+	fs   *flag.FlagSet
+	args []string
 }
-
-// TODO make it clear that this is listing sql statements and that the actual role name is different (has spaces for one.) Should probably be 2 separate commands.
 
 func parseRoleListCmd(parent *roleCmd, args []string) (*roleListCmd, error) {
 	c := &roleListCmd{roleCmd: parent}
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
 	c.fs = fs
+	fs.SetOutput(parent.fs.Output())
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	c.args = fs.Args()
+	return c, nil
+}
+
+func (c *roleListCmd) Run() error {
+	if len(c.args) == 0 {
+		c.fs.Usage()
+		return fmt.Errorf("missing list command")
+	}
+	if err := usageIfHelp(c.fs, c.args); err != nil {
+		return err
+	}
+	switch c.args[0] {
+	case "sql":
+		cmd, err := parseRoleListSQLCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("sql: %w", err)
+		}
+		return cmd.Run()
+	case "names":
+		cmd, err := parseRoleListNamesCmd(c, c.args[1:])
+		if err != nil {
+			return fmt.Errorf("names: %w", err)
+		}
+		return cmd.Run()
+	default:
+		c.fs.Usage()
+		return fmt.Errorf("unknown list command %q", c.args[0])
+	}
+}
+
+func (c *roleListCmd) Usage() { executeUsage(c.fs.Output(), "role_list_usage.txt", c) }
+
+func (c *roleListCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*roleListCmd)(nil)
+
+type roleListSQLCmd struct {
+	*roleListCmd
+	fs *flag.FlagSet
+}
+
+func parseRoleListSQLCmd(parent *roleListCmd, args []string) (*roleListSQLCmd, error) {
+	c := &roleListSQLCmd{roleListCmd: parent}
+	fs := flag.NewFlagSet("sql", flag.ContinueOnError)
+	c.fs = fs
+	fs.SetOutput(parent.fs.Output())
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return nil, err
@@ -24,7 +77,7 @@ func parseRoleListCmd(parent *roleCmd, args []string) (*roleListCmd, error) {
 	return c, nil
 }
 
-func (c *roleListCmd) Run() error {
+func (c *roleListSQLCmd) Run() error {
 	roles, err := listEmbeddedRoles()
 	if err != nil {
 		return err
@@ -35,10 +88,45 @@ func (c *roleListCmd) Run() error {
 	return nil
 }
 
-func (c *roleListCmd) Usage() { executeUsage(c.fs.Output(), "role_list_usage.txt", c) }
+func (c *roleListSQLCmd) Usage() { executeUsage(c.fs.Output(), "role_list_sql_usage.txt", c) }
 
-func (c *roleListCmd) FlagGroups() []flagGroup {
-	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+func (c *roleListSQLCmd) FlagGroups() []flagGroup {
+	return append(c.roleCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
 }
 
-var _ usageData = (*roleListCmd)(nil)
+type roleListNamesCmd struct {
+	*roleListCmd
+	fs *flag.FlagSet
+}
+
+func parseRoleListNamesCmd(parent *roleListCmd, args []string) (*roleListNamesCmd, error) {
+	c := &roleListNamesCmd{roleListCmd: parent}
+	fs := flag.NewFlagSet("names", flag.ContinueOnError)
+	c.fs = fs
+	fs.SetOutput(parent.fs.Output())
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *roleListNamesCmd) Run() error {
+	names, err := listEmbeddedRoleNames()
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		fmt.Fprintln(c.fs.Output(), name)
+	}
+	return nil
+}
+
+func (c *roleListNamesCmd) Usage() { executeUsage(c.fs.Output(), "role_list_names_usage.txt", c) }
+
+func (c *roleListNamesCmd) FlagGroups() []flagGroup {
+	return append(c.roleCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+var _ usageData = (*roleListSQLCmd)(nil)
+var _ usageData = (*roleListNamesCmd)(nil)

--- a/cmd/goa4web/role_list_test.go
+++ b/cmd/goa4web/role_list_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRoleListSQL(t *testing.T) {
+	t.Parallel()
+
+	root := &rootCmd{fs: newFlagSet("prog")}
+	var buf bytes.Buffer
+	root.fs.SetOutput(&buf)
+
+	parent := &roleCmd{rootCmd: root, fs: newFlagSet("role")}
+	parent.fs.SetOutput(&buf)
+
+	cmd, err := parseRoleListCmd(parent, []string{"sql"})
+	if err != nil {
+		t.Fatalf("parseRoleListCmd: %v", err)
+	}
+
+	cmd.fs.SetOutput(&buf)
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	want := []string{"content-writer", "labeler", "moderator", "moderator-sectional", "private-forum-user"}
+	got := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(got) != len(want) {
+		t.Fatalf("unexpected line count: got %d want %d (%v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Fatalf("line %d mismatch: got %q want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestRoleListNames(t *testing.T) {
+	t.Parallel()
+
+	root := &rootCmd{fs: newFlagSet("prog")}
+	var buf bytes.Buffer
+	root.fs.SetOutput(&buf)
+
+	parent := &roleCmd{rootCmd: root, fs: newFlagSet("role")}
+	parent.fs.SetOutput(&buf)
+
+	cmd, err := parseRoleListCmd(parent, []string{"names"})
+	if err != nil {
+		t.Fatalf("parseRoleListCmd: %v", err)
+	}
+
+	cmd.fs.SetOutput(&buf)
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	want := []string{"content writer", "labeler", "moderator", "moderator-sectional", "private forum user"}
+	got := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(got) != len(want) {
+		t.Fatalf("unexpected line count: got %d want %d (%v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Fatalf("line %d mismatch: got %q want %q", i, got[i], w)
+		}
+	}
+}

--- a/cmd/goa4web/roles_fs.go
+++ b/cmd/goa4web/roles_fs.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	fs2 "io/fs"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -42,4 +45,54 @@ func listEmbeddedRoles() ([]string, error) {
 	}
 	sort.Strings(out)
 	return out, nil
+}
+
+func listEmbeddedRoleNames() ([]string, error) {
+	roles, err := listEmbeddedRoles()
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, role := range roles {
+		name, err := readEmbeddedRoleName(role)
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func readEmbeddedRoleName(identifier string) (string, error) {
+	data, err := readEmbeddedRole(identifier)
+	if err != nil {
+		return "", err
+	}
+	name, err := parseEmbeddedRoleName(data)
+	if err != nil {
+		return "", fmt.Errorf("embedded role %q: %w", identifier, err)
+	}
+	return name, nil
+}
+
+var roleInsertNameRegexp = regexp.MustCompile(`(?is)insert\s+into\s+roles\s*\([^)]*name[^)]*\)\s*values\s*\(\s*'([^']+)'`)
+
+func parseEmbeddedRoleName(data []byte) (string, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(strings.ToLower(line), "-- role:") {
+			name := strings.TrimSpace(line[len("-- role:"):])
+			if name != "" {
+				return name, nil
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scan role comments: %w", err)
+	}
+	if matches := roleInsertNameRegexp.FindSubmatch(data); len(matches) > 1 {
+		return string(matches[1]), nil
+	}
+	return "", fmt.Errorf("role name not found")
 }

--- a/cmd/goa4web/templates/role_list_names_usage.txt
+++ b/cmd/goa4web/templates/role_list_names_usage.txt
@@ -1,0 +1,5 @@
+Usage: {{.Prog}} role list names
+
+Lists the human-friendly role names defined inside the embedded seed scripts.
+
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/role_list_sql_usage.txt
+++ b/cmd/goa4web/templates/role_list_sql_usage.txt
@@ -1,0 +1,5 @@
+Usage: {{.Prog}} role list sql
+
+Lists the raw role identifiers provided by embedded SQL seed scripts.
+
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/role_list_usage.txt
+++ b/cmd/goa4web/templates/role_list_usage.txt
@@ -1,6 +1,12 @@
-Usage: goa4web role list
+Usage:
+  {{.Prog}} role list <command> [<args>]
 
-Lists available embedded role seed scripts.
+Commands:
+  sql    list embedded role identifiers (SQL filenames)
+  names  list human-friendly role names declared in the seed scripts
 
-Flags:
-  (none)
+Examples:
+  {{.Prog}} role list sql
+  {{.Prog}} role list names
+
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/role_usage.txt
+++ b/cmd/goa4web/templates/role_usage.txt
@@ -6,7 +6,7 @@ Subcommands:
   apply  Applies the grants from a source role to a destination role.
   remove Removes the grants from a destination role that match a source role.
   users  Lists the users in a role.
-  list   Lists available embedded role seed scripts.
+  list   Lists embedded role identifiers or human-friendly role names.
 
 Examples:
   # Load the "content-writer" role from its seed script
@@ -27,5 +27,8 @@ Examples:
   # Remove all grants from the "user" role
   {{.Prog}} role remove -dest user
 
-  # List embedded roles available in this build
-  {{.Prog}} role list
+  # List raw SQL role identifiers available in this build
+  {{.Prog}} role list sql
+
+  # List the human-friendly role names from embedded seed scripts
+  {{.Prog}} role list names

--- a/handlers/privateforum/page_test.go
+++ b/handlers/privateforum/page_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"reflect"
 	"strings"
 	"testing"


### PR DESCRIPTION
## Summary
- split `role list` into `sql` and `names` subcommands with updated usage guidance and examples
- extract human-friendly role names from embedded seed scripts for display alongside raw identifiers
- add coverage for both list outputs and clean up the unused test import flagged by `go vet`

## Testing
- go vet ./...
- golangci-lint run
- go test ./... *(fails in core/templates: missing formatLocalTime helper and thread mark-read expectations)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69429dd340ec832f9c44b3f28468f9fd)