### PR TITLE
Implement admin forum category creation

### DIFF
--- a/handlers/forum/forumAdminCategoryCreatePage_test.go
+++ b/handlers/forum/forumAdminCategoryCreatePage_test.go
@@ -1,0 +1,97 @@
+package forum
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestAdminCategoryCreateSubmitSuccess(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	mock.MatchExpectationsInOrder(false)
+	categoriesRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_id, f.title, f.description\nFROM forumcategory f\nWHERE (\n    f.language_id = 0\n    OR f.language_id IS NULL\n    OR EXISTS (\n        SELECT 1 FROM user_language ul\n        WHERE ul.users_idusers = ?\n          AND ul.language_id = f.language_id\n    )\n    OR NOT EXISTS (\n        SELECT 1 FROM user_language ul WHERE ul.users_idusers = ?\n    )\n)\n")).WithArgs(int32(0), int32(0)).WillReturnRows(categoriesRows)
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO forumcategory (forumcategory_idforumcategory, language_id, title, description)\nVALUES (?, ?, ?, ?)")).WithArgs(
+		int32(1),
+		sql.NullInt32{Int32: 2, Valid: true},
+		sql.NullString{String: "name", Valid: true},
+		sql.NullString{String: "desc", Valid: true},
+	).WillReturnResult(sqlmock.NewResult(5, 1))
+
+	queries := db.New(sqlDB)
+	form := url.Values{
+		"name":     {"name"},
+		"desc":     {"desc"},
+		"pcid":     {"1"},
+		"language": {"2"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/admin/forum/categories/create", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := req.Context()
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	AdminCategoryCreateSubmit(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	location := rr.Header().Get("Location")
+	if !strings.Contains(location, "/admin/forum/categories") || !strings.Contains(location, "error=category created") {
+		t.Fatalf("unexpected redirect location %q", location)
+	}
+}
+
+func TestAdminCategoryCreateSubmitValidationError(t *testing.T) {
+	sqlDB, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	queries := db.New(sqlDB)
+	form := url.Values{
+		"desc":     {"desc"},
+		"pcid":     {"1"},
+		"language": {"2"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/admin/forum/categories/create", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := req.Context()
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	AdminCategoryCreateSubmit(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	location := rr.Header().Get("Location")
+	if !strings.Contains(location, "/admin/forum/categories/create") || !strings.Contains(location, "error=missing name") {
+		t.Fatalf("expected validation error in redirect, got %q", location)
+	}
+}

--- a/handlers/privateforum/page_test.go
+++ b/handlers/privateforum/page_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"reflect"
 	"strings"
 	"testing"

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -34,6 +34,7 @@ type Querier interface {
 	AdminCountWordList(ctx context.Context) (int64, error)
 	AdminCountWordListByPrefix(ctx context.Context, prefix interface{}) (int64, error)
 	AdminCreateFAQCategory(ctx context.Context, name sql.NullString) error
+	AdminCreateForumCategory(ctx context.Context, arg AdminCreateForumCategoryParams) (int64, error)
 	AdminCreateGrant(ctx context.Context, arg AdminCreateGrantParams) (int64, error)
 	AdminCreateImageBoard(ctx context.Context, arg AdminCreateImageBoardParams) error
 	// AdminCreateLanguage adds a new language.

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -238,7 +238,9 @@ WHERE (
     )
 );
 
-INSERT INTO forumcategory (forumcategory_idforumcategory, language_id, title, description) VALUES (?, sqlc.narg(category_language_id), ?, ?);
+-- name: AdminCreateForumCategory :execlastid
+INSERT INTO forumcategory (forumcategory_idforumcategory, language_id, title, description)
+VALUES (sqlc.arg(parent_id), sqlc.narg(category_language_id), sqlc.arg(title), sqlc.arg(description));
 
 INSERT INTO forumtopic (forumcategory_idforumcategory, language_id, title, description, handler) VALUES (?, sqlc.narg(topic_language_id), ?, ?, ?);
 
@@ -423,4 +425,3 @@ WITH RECURSIVE category_path AS (
 SELECT category_path.idforumcategory, category_path.title
 FROM category_path
 ORDER BY category_path.depth DESC;
-

--- a/internal/db/queries-forum.sql.go
+++ b/internal/db/queries-forum.sql.go
@@ -38,6 +38,31 @@ func (q *Queries) AdminCountForumCategories(ctx context.Context, arg AdminCountF
 	return count, err
 }
 
+const adminCreateForumCategory = `-- name: AdminCreateForumCategory :execlastid
+INSERT INTO forumcategory (forumcategory_idforumcategory, language_id, title, description)
+VALUES (?, ?, ?, ?)
+`
+
+type AdminCreateForumCategoryParams struct {
+	ParentID           int32
+	CategoryLanguageID sql.NullInt32
+	Title              sql.NullString
+	Description        sql.NullString
+}
+
+func (q *Queries) AdminCreateForumCategory(ctx context.Context, arg AdminCreateForumCategoryParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, adminCreateForumCategory,
+		arg.ParentID,
+		arg.CategoryLanguageID,
+		arg.Title,
+		arg.Description,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.LastInsertId()
+}
+
 const adminDeleteForumCategory = `-- name: AdminDeleteForumCategory :exec
 UPDATE forumcategory SET deleted_at = NOW() WHERE idforumcategory = ?
 `


### PR DESCRIPTION
## Summary
- add validation, loop checks, and flash messaging when creating forum categories and persist submissions with the selected language
- introduce an AdminCreateForumCategory query via sqlc and expose it through the querier
- cover category creation success and validation failures with sqlmock-based tests and clean up an unused import in private forum tests

## Testing
- go vet ./...
- golangci-lint run
- go test ./... *(fails: existing core/templates tests missing helpers like formatLocalTime and forum thread mark-read tests expecting CSRF/task wiring)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69429e2091dc832f876feb71b2bfa60f)