### PR TITLE
Implement admin forum category updates

### DIFF
--- a/handlers/forum/forumAdminCategoryEditPage.go
+++ b/handlers/forum/forumAdminCategoryEditPage.go
@@ -50,37 +50,85 @@ func AdminCategoryEditPage(w http.ResponseWriter, r *http.Request) {
 
 // AdminCategoryEditSubmit processes updates to an existing forum category.
 func AdminCategoryEditSubmit(w http.ResponseWriter, r *http.Request) {
-	name := r.PostFormValue("name")
-	desc := r.PostFormValue("desc")
-	_ = name
-	_ = desc
+	name := strings.TrimSpace(r.PostFormValue("name"))
+	desc := strings.TrimSpace(r.PostFormValue("desc"))
 	pcid, err := strconv.Atoi(r.PostFormValue("pcid"))
 	if err != nil {
 		handlers.RedirectSeeOtherWithError(w, r, "", err)
 		return
 	}
+	vars := mux.Vars(r)
+	categoryId, err := strconv.Atoi(vars["category"])
+	if err != nil {
+		handlers.RedirectSeeOtherWithError(w, r, "", err)
+		return
+	}
+	langValue := strings.TrimSpace(r.PostFormValue("language"))
+	languageID := 0
+	if langValue != "" {
+		languageID, err = strconv.Atoi(langValue)
+		if err != nil {
+			handlers.RedirectSeeOtherWithError(w, r, "", err)
+			return
+		}
+	}
+	if name == "" {
+		handlers.RedirectSeeOtherWithMessage(w, r, "", "category name cannot be empty")
+		return
+	}
+
 	cd := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
 	queries := cd.Queries()
-	_ = queries
-	vars := mux.Vars(r)
-	categoryId, _ := strconv.Atoi(vars["category"])
+	cat, err := queries.GetForumCategoryById(r.Context(), db.GetForumCategoryByIdParams{
+		Idforumcategory: int32(categoryId),
+		ViewerID:        cd.UserID,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			w.WriteHeader(http.StatusNotFound)
+			handlers.RenderErrorPage(w, r, fmt.Errorf("Category not found"))
+			return
+		}
+		handlers.RedirectSeeOtherWithError(w, r, "", err)
+		return
+	}
+	if langValue == "" && cat.LanguageID.Valid {
+		languageID = int(cat.LanguageID.Int32)
+	}
 
 	cats, err := cd.ForumCategories()
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		handlers.RedirectSeeOtherWithError(w, r, "", err)
 		return
 	}
-	parents := make(map[int32]int32, len(cats))
+	parents := make(map[int32]int32, len(cats)+1)
+	parents[int32(categoryId)] = cat.ForumcategoryIdforumcategory
+	parentExists := pcid == 0 || pcid == int(cat.ForumcategoryIdforumcategory)
 	for _, c := range cats {
 		parents[c.Idforumcategory] = c.ForumcategoryIdforumcategory
+		if int(c.Idforumcategory) == pcid {
+			parentExists = true
+		}
+	}
+	if !parentExists {
+		handlers.RedirectSeeOtherWithMessage(w, r, "", fmt.Sprintf("parent category %d not found", pcid))
+		return
 	}
 	if path, loop := algorithms.WouldCreateLoop(parents, int32(categoryId), int32(pcid)); loop {
 		handlers.RedirectSeeOtherWithMessage(w, r, "", fmt.Sprintf("loop %v", path))
 		return
 	}
 
-	languageID, _ := strconv.Atoi(r.PostFormValue("language"))
-	_ = languageID // TODO: implement category update
+	if err := queries.AdminUpdateForumCategory(r.Context(), db.AdminUpdateForumCategoryParams{
+		Title:           sql.NullString{String: name, Valid: true},
+		Description:     sql.NullString{String: desc, Valid: true},
+		ParentID:        int32(pcid),
+		LanguageID:      sql.NullInt32{Int32: int32(languageID), Valid: languageID != 0},
+		Idforumcategory: int32(categoryId),
+	}); err != nil {
+		handlers.RedirectSeeOtherWithError(w, r, "", err)
+		return
+	}
 
 	redirectURL := "/admin/forum/categories"
 	if strings.HasSuffix(r.URL.Path, "/edit") {

--- a/handlers/forum/forumAdminCategoryEditPage_submit_test.go
+++ b/handlers/forum/forumAdminCategoryEditPage_submit_test.go
@@ -1,0 +1,140 @@
+package forum
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func setupCategoryEditRequest(t *testing.T, queries *db.Queries, path string, form url.Values, vars map[string]string) (*http.Request, *httptest.ResponseRecorder) {
+	t.Helper()
+	req := httptest.NewRequest("POST", path, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := req.Context()
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+	req = mux.SetURLVars(req, vars)
+	rr := httptest.NewRecorder()
+	return req, rr
+}
+
+func TestAdminCategoryEditSubmitSuccess(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	queries := db.New(sqlDB)
+	mock.MatchExpectationsInOrder(false)
+
+	categoryRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}).
+		AddRow(1, 0, 0, "cat", "desc")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idforumcategory, forumcategory_idforumcategory, language_id, title, description FROM forumcategory")).
+		WithArgs(int32(1), int32(0), int32(0)).
+		WillReturnRows(categoryRows)
+
+	allRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}).
+		AddRow(1, 0, 0, "cat", "desc").
+		AddRow(2, 0, 0, "parent", "pdesc")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_id, f.title, f.description\nFROM forumcategory f")).
+		WithArgs(int32(0), int32(0)).
+		WillReturnRows(allRows)
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE forumcategory\nSET title = ?,\n    description = ?,\n    forumcategory_idforumcategory = ?,\n    language_id = ?\nWHERE idforumcategory = ?")).
+		WithArgs(sql.NullString{String: "Updated", Valid: true}, sql.NullString{String: "Updated desc", Valid: true}, int32(2), sql.NullInt32{Int32: 3, Valid: true}, int32(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	form := url.Values{
+		"name":     {"Updated"},
+		"desc":     {"Updated desc"},
+		"pcid":     {"2"},
+		"language": {"3"},
+	}
+	req, rr := setupCategoryEditRequest(t, queries, "/admin/forum/categories/category/1/edit", form, map[string]string{"category": "1"})
+
+	AdminCategoryEditSubmit(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	if loc := rr.Header().Get("Location"); loc != "/admin/forum/categories/category/1" {
+		t.Fatalf("redirect=%s", loc)
+	}
+}
+
+func TestAdminCategoryEditSubmitMissingCategory(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	queries := db.New(sqlDB)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT idforumcategory, forumcategory_idforumcategory, language_id, title, description FROM forumcategory")).
+		WithArgs(int32(99), int32(0), int32(0)).
+		WillReturnError(sql.ErrNoRows)
+
+	form := url.Values{
+		"name": {"Updated"},
+		"desc": {"Updated desc"},
+		"pcid": {"0"},
+	}
+	req, rr := setupCategoryEditRequest(t, queries, "/admin/forum/categories/category/99/edit", form, map[string]string{"category": "99"})
+
+	AdminCategoryEditSubmit(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status=%d", rr.Code)
+	}
+}
+
+func TestAdminCategoryEditSubmitValidationError(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer sqlDB.Close()
+
+	queries := db.New(sqlDB)
+
+	form := url.Values{
+		"name": {""},
+		"desc": {"Updated desc"},
+		"pcid": {"1"},
+	}
+	req, rr := setupCategoryEditRequest(t, queries, "/admin/forum/categories/category/1/edit", form, map[string]string{"category": "1"})
+
+	AdminCategoryEditSubmit(rr, req)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	if loc := rr.Header().Get("Location"); !strings.HasSuffix(loc, "?error=category name cannot be empty") {
+		t.Fatalf("redirect=%s", loc)
+	}
+}

--- a/handlers/privateforum/page_test.go
+++ b/handlers/privateforum/page_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"reflect"
 	"strings"
 	"testing"

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -209,6 +209,7 @@ type Querier interface {
 	AdminSetTemplateOverride(ctx context.Context, arg AdminSetTemplateOverrideParams) error
 	AdminUpdateBannedIp(ctx context.Context, arg AdminUpdateBannedIpParams) error
 	AdminUpdateFAQQuestionAnswer(ctx context.Context, arg AdminUpdateFAQQuestionAnswerParams) error
+	AdminUpdateForumCategory(ctx context.Context, arg AdminUpdateForumCategoryParams) error
 	AdminUpdateGrantActive(ctx context.Context, arg AdminUpdateGrantActiveParams) error
 	AdminUpdateImageBoard(ctx context.Context, arg AdminUpdateImageBoardParams) error
 	AdminUpdateImagePost(ctx context.Context, arg AdminUpdateImagePostParams) error

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -1,4 +1,10 @@
-UPDATE forumcategory SET title = ?, description = ?, forumcategory_idforumcategory = ?, language_id = sqlc.narg(category_language_id) WHERE idforumcategory = ?;
+-- name: AdminUpdateForumCategory :exec
+UPDATE forumcategory
+SET title = sqlc.arg(title),
+    description = sqlc.arg(description),
+    forumcategory_idforumcategory = sqlc.arg(parent_id),
+    language_id = sqlc.narg(language_id)
+WHERE idforumcategory = sqlc.arg(idforumcategory);
 
 -- name: GetAllForumCategoriesWithSubcategoryCount :many
 SELECT c.*, COUNT(c2.idforumcategory) as SubcategoryCount,
@@ -423,4 +429,3 @@ WITH RECURSIVE category_path AS (
 SELECT category_path.idforumcategory, category_path.title
 FROM category_path
 ORDER BY category_path.depth DESC;
-

--- a/internal/db/queries-forum.sql.go
+++ b/internal/db/queries-forum.sql.go
@@ -256,6 +256,34 @@ func (q *Queries) AdminRebuildAllForumTopicMetaColumns(ctx context.Context) erro
 	return err
 }
 
+const adminUpdateForumCategory = `-- name: AdminUpdateForumCategory :exec
+UPDATE forumcategory
+SET title = ?,
+    description = ?,
+    forumcategory_idforumcategory = ?,
+    language_id = ?
+WHERE idforumcategory = ?
+`
+
+type AdminUpdateForumCategoryParams struct {
+	Title           sql.NullString
+	Description     sql.NullString
+	ParentID        int32
+	LanguageID      sql.NullInt32
+	Idforumcategory int32
+}
+
+func (q *Queries) AdminUpdateForumCategory(ctx context.Context, arg AdminUpdateForumCategoryParams) error {
+	_, err := q.db.ExecContext(ctx, adminUpdateForumCategory,
+		arg.Title,
+		arg.Description,
+		arg.ParentID,
+		arg.LanguageID,
+		arg.Idforumcategory,
+	)
+	return err
+}
+
 const createForumTopicForPoster = `-- name: CreateForumTopicForPoster :execlastid
 INSERT INTO forumtopic (forumcategory_idforumcategory, language_id, title, description, handler)
 SELECT ?, ?, ?, ?, ?


### PR DESCRIPTION
## Summary
- implement the admin forum category edit submission flow: load the category, validate inputs (including language and parent loops), and persist updates
- add an AdminUpdateForumCategory sqlc query plus tests covering successful edits, missing categories, and validation errors
- clean up an unused import flagged by `go vet`

## Testing
- gofmt -w handlers/forum/forumAdminCategoryEditPage.go handlers/forum/forumAdminCategoryEditPage_submit_test.go handlers/privateforum/page_test.go
- go vet ./...
- golangci-lint run
- go test ./... *(fails: TestThreadPageMarkReadIncludesCSRF, TestThreadPageUsesThreadMarkReadTask, and TestPaginationTemplateWithoutPageSize panic due to missing template helper)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69429e22e984832f9057f84ce7f5636d)