### PR TITLE
Fix quote actions to respect CSP

### DIFF
--- a/a4code/quote_test.go
+++ b/a4code/quote_test.go
@@ -122,11 +122,11 @@ func TestQuoteTrim(t *testing.T) {
 
 func TestSubstring(t *testing.T) {
 	tests := []struct {
-		name   string
-		s      string
-		start  int
-		end    int
-		want   string
+		name  string
+		s     string
+		start int
+		end   int
+		want  string
 	}{
 		{
 			name:  "Simple",

--- a/core/static/quote.js
+++ b/core/static/quote.js
@@ -33,3 +33,22 @@ function quote(type, commentId) {
             });
     }
 }
+
+function handleQuoteClick(event) {
+    const trigger = event.target.closest('.quote-action');
+    if (!trigger) {
+        return;
+    }
+    event.preventDefault();
+    const type = trigger.dataset.quoteType;
+    const commentId = trigger.dataset.commentId;
+    if (!type || !commentId) {
+        console.error('Quote action missing data attributes');
+        return;
+    }
+    quote(type, commentId);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('click', handleQuoteClick);
+});

--- a/core/templates/site/comment.gohtml
+++ b/core/templates/site/comment.gohtml
@@ -30,9 +30,9 @@
                 {{ $cmt.Text.String | a4code2html}}
                 <footer>
                     {{ if cd.SelectedThreadCanReply }}
-                        [<a href="javascript:quote('full', {{ $cmt.Idcomments }})">FULL REPLY</a>]
-                        [<a href="javascript:quote('paragraph', {{ $cmt.Idcomments }})">PARAGRAPH REPLY</a>]
-                        [<a href="javascript:quote('selected')">QUOTE SELECTED</a>]
+                        [<a class="quote-action" href="#" data-quote-type="full" data-comment-id="{{ $cmt.Idcomments }}">FULL REPLY</a>]
+                        [<a class="quote-action" href="#" data-quote-type="paragraph" data-comment-id="{{ $cmt.Idcomments }}">PARAGRAPH REPLY</a>]
+                        [<a class="quote-action" href="#" data-quote-type="selected" data-comment-id="{{ $cmt.Idcomments }}">QUOTE SELECTED</a>]
                     {{ end }}
                     {{ if cd.CanEditComment $cmt }}[<a href="{{ cd.CommentEditURL $cmt }}">EDIT</a>]{{ end }}
                     {{ $admin := cd.CommentAdminURL $cmt }}{{ if $admin }}[<a href="{{ $admin }}">ADMIN</a>]{{ end }}

--- a/handlers/forum/api.go
+++ b/handlers/forum/api.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 
 	"github.com/arran4/goa4web/a4code"
-	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/gorilla/mux"
 )
 


### PR DESCRIPTION
## Summary
- replace inline javascript quote links with data attributes to avoid CSP violations while keeping the quote controls
- add delegated click handling in quote.js so quote actions invoke the API without javascript URLs
- ensure selected quote requests include the relevant comment identifier

## Testing
- go mod tidy
- go fmt ./...
- go vet ./...
- golangci-lint run ./...
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694360e95b34832f8f999316b11fc77f)