### PR TITLE
Refactor contextual actions to sidebar for blogs, news, and writings

### DIFF
--- a/core/templates/site/blogs/blogPage.gohtml
+++ b/core/templates/site/blogs/blogPage.gohtml
@@ -4,7 +4,7 @@
         <article class="blog-post">
                 <header class="bg-muted">{{ cd.LocalTimeIn $blog.Written $blog.Timezone.String }}</header>
                 <div class="post-content">
-        {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog $blog.Idblogs $blog.UsersIdusers }} - [<a href="/blogs/blog/{{$blog.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{$blog.Idblogs}}">ADMIN</a>]{{ end }}{{ if .Labels }} <section class="label-list">{{ template "topicLabels" .Labels }}</section>{{ end }}
+        {{$blog.Blog.String | a4code2html}}<br><br>{{$blog.Username.String}} - [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]{{ if .Labels }} <section class="label-list">{{ template "topicLabels" .Labels }}</section>{{ end }}
                 </div>
         </article><br>
         {{ template "threadComments" }}

--- a/core/templates/site/blogs/bloggerPostsPage.gohtml
+++ b/core/templates/site/blogs/bloggerPostsPage.gohtml
@@ -12,7 +12,7 @@
                         <header class="bg-muted">{{ cd.LocalTimeIn .Written .Timezone.String }}</header>
                         <div class="post-content">
                         {{ $labels := cd.BlogLabels .Idblogs }}
-                        {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{.Idblogs}}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{.Idblogs}}">ADMIN</a>]{{ end }}{{ if $labels }} <section class="label-list">{{ template "topicLabels" $labels }}</section>{{ end }}
+                        {{.Blog.String | a4code2html}}<br><br>{{.Username.String}} - [<a href="/blogs/blog/{{.Idblogs}}/comments">{{.Comments}} COMMENTS</a>]{{ if $labels }} <section class="label-list">{{ template "topicLabels" $labels }}</section>{{ end }}
                         </div>
                     </article>
                 {{end}}

--- a/core/templates/site/blogs/page.gohtml
+++ b/core/templates/site/blogs/page.gohtml
@@ -19,7 +19,7 @@
                 <header class="bg-muted">{{ cd.LocalTimeIn .Written .Timezone.String }}</header>
                 <div class="post-content">
                     {{ $labels := cd.BlogLabels .Idblogs }}
-                    {{ .Blog.String | a4code2html}}<br><br>{{ .Username.String }} - [<a href="/blogs/blog/{{ .Idblogs }}/comments">{{ .Comments }} COMMENTS</a>]{{ if cd.CanEditBlog .Idblogs .UsersIdusers }} - [<a href="/blogs/blog/{{ .Idblogs }}/edit">EDIT</a>]{{ end }}{{ if and cd.IsAdmin cd.IsAdminMode }} - [<a href="/admin/blogs/blog/{{ .Idblogs }}">ADMIN</a>]{{ end }}{{ if $labels }} <section class="label-list">{{ template "topicLabels" $labels }}</section>{{ end }}
+                    {{ .Blog.String | a4code2html}}<br><br>{{ .Username.String }} - [<a href="/blogs/blog/{{ .Idblogs }}/comments">{{ .Comments }} COMMENTS</a>]{{ if $labels }} <section class="label-list">{{ template "topicLabels" $labels }}</section>{{ end }}
                 </div>
             </article>
         {{ else }}

--- a/core/templates/site/news/postPage.gohtml
+++ b/core/templates/site/news/postPage.gohtml
@@ -1,19 +1,6 @@
 {{ template "head" $ }}
     {{ template "newsPost" $.Post }}
-    <div class="mark-read-bar">
-        <form method="post" action="/news/news/{{ .Post.Idsitenews }}/labels" class="mark-read">
-            {{ csrfField }}
-            <input type="hidden" name="task" value="Mark Thread Read"/>
-            <input type="hidden" name="redirect" value="{{ .BackURL }}"/>
-            <button type="submit">Mark as read</button>
-        </form>
-        <form method="post" action="/news/news/{{ .Post.Idsitenews }}/labels" class="mark-read">
-            {{ csrfField }}
-            <input type="hidden" name="task" value="Mark Thread Read"/>
-            <input type="hidden" name="redirect" value="/news"/>
-            <button type="submit">Mark as read and go back</button>
-        </form>
-    </div>
+
     <hr><h2 class="section-heading">Replies:</h2>
     {{ template "threadComments" }}
     <div class="label-editor">
@@ -33,18 +20,6 @@
             </span>
             <input type="text" class="label-input" data-type="private" placeholder="Add private label"/>
             <input type="submit" value="Save Labels"/>
-        </form>
-        <form method="post" action="/news/news/{{ .Post.Idsitenews }}/labels" class="mark-read">
-            {{ csrfField }}
-            <input type="hidden" name="task" value="Mark Thread Read"/>
-            <input type="hidden" name="redirect" value="{{ .BackURL }}"/>
-            <button type="submit">Mark as read</button>
-        </form>
-        <form method="post" action="/news/news/{{ .Post.Idsitenews }}/labels" class="mark-read">
-            {{ csrfField }}
-            <input type="hidden" name="task" value="Mark Thread Read"/>
-            <input type="hidden" name="redirect" value="/news"/>
-            <button type="submit">Mark as read and go back</button>
         </form>
     </div>
     <script src="/forum/topic_labels.js"></script>

--- a/core/templates/site/writings/articlePage.gohtml
+++ b/core/templates/site/writings/articlePage.gohtml
@@ -3,8 +3,6 @@
     {{ if $writing }}
         <span class="text-large">At {{ cd.LocalTime $writing.Published.Time }}, By {{ $writing.Writerusername.String }}; {{ $writing.Title.String | trim | a4code2html }}:</span>
         {{ if $writing.Private.Bool }} (Restricted access) {{ end }}
-        {{ if .CanEdit }}[<a href="/writings/article/{{ $writing.Idwriting }}/edit">EDIT</a>]{{ end }}
-        {{ if and cd.IsAdmin cd.IsAdminMode }}[<a href="/admin/writings/article/{{ $writing.Idwriting }}">ADMIN</a>]{{ end }}
         <br>
         <strong>Abstract:</strong><br>
         {{ $writing.Abstract.String | a4code2html }}
@@ -12,18 +10,6 @@
         {{ $writing.Writing.String | a4code2html }}
         <div class="label-bar">
             {{ template "topicLabels" .Labels }}
-            <form method="post" action="/writings/article/{{ $writing.Idwriting }}/labels" class="mark-read">
-            {{ csrfField }}
-                <input type="hidden" name="task" value="Mark Thread Read"/>
-                <input type="hidden" name="redirect" value="{{ .BackURL }}"/>
-                <button type="submit">Mark as read</button>
-            </form>
-            <form method="post" action="/writings/article/{{ $writing.Idwriting }}/labels" class="mark-read">
-            {{ csrfField }}
-                <input type="hidden" name="task" value="Mark Thread Read"/>
-                <input type="hidden" name="redirect" value="/writings/category/{{ $writing.WritingCategoryID }}"/>
-                <button type="submit">Mark as read and go back</button>
-            </form>
         </div>
         <hr>Comments:<br>
         {{ template "threadComments" }}
@@ -41,18 +27,6 @@
                 {{ end }}
                 <input type="text" class="label-input" data-type="private" placeholder="Add private label"/>
                 <input type="submit" value="Save Labels"/>
-            </form>
-            <form method="post" action="/writings/article/{{ $writing.Idwriting }}/labels" class="mark-read">
-            {{ csrfField }}
-                <input type="hidden" name="task" value="Mark Thread Read"/>
-                <input type="hidden" name="redirect" value="{{ .BackURL }}"/>
-                <button type="submit">Mark as read</button>
-            </form>
-            <form method="post" action="/writings/article/{{ $writing.Idwriting }}/labels" class="mark-read">
-            {{ csrfField }}
-                <input type="hidden" name="task" value="Mark Thread Read"/>
-                <input type="hidden" name="redirect" value="/writings/category/{{ $writing.WritingCategoryID }}"/>
-                <button type="submit">Mark as read and go back</button>
             </form>
         </div>
         <script src="/forum/topic_labels.js"></script>

--- a/handlers/blogs/blogsPage.go
+++ b/handlers/blogs/blogsPage.go
@@ -13,7 +13,6 @@ import (
 
 	"log"
 	"net/http"
-	"net/url"
 	"strconv"
 	"time"
 
@@ -45,39 +44,7 @@ func Page(w http.ResponseWriter, r *http.Request) {
 }
 
 func CustomBlogIndex(data *common.CoreData, r *http.Request) {
-	user := r.URL.Query().Get("user")
-	data.CustomIndexItems = []common.IndexItem{}
-	if data.FeedsEnabled {
-		suffix := ""
-		if user != "" {
-			suffix = "?user=" + url.QueryEscape(user)
-		}
-		data.RSSFeedURL = "/blogs/rss" + suffix
-		data.AtomFeedURL = "/blogs/atom" + suffix
-		data.CustomIndexItems = append(data.CustomIndexItems,
-			common.IndexItem{Name: "Atom Feed", Link: data.AtomFeedURL},
-			common.IndexItem{Name: "RSS Feed", Link: data.RSSFeedURL},
-		)
-	}
-
-	if data.IsAdmin() {
-		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
-			Name: "Blogs Admin",
-			Link: "/admin/blogs",
-		})
-	}
-	userHasWriter := data.HasRole("content writer")
-	if userHasWriter {
-		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
-			Name: "Write blog",
-			Link: "/blogs/add",
-		})
-
-	}
-	data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
-		Name: "List bloggers",
-		Link: "/blogs/bloggers",
-	})
+	CustomBlogsIndex(data, r)
 }
 
 func RssPage(w http.ResponseWriter, r *http.Request) {

--- a/handlers/blogs/customindex.go
+++ b/handlers/blogs/customindex.go
@@ -1,0 +1,90 @@
+package blogs
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/gorilla/mux"
+)
+
+// CustomBlogsIndex builds context-aware index items for blogs.
+func CustomBlogsIndex(cd *common.CoreData, r *http.Request) {
+	cd.CustomIndexItems = BlogsCustomIndexItems(cd, r)
+}
+
+// BlogsCustomIndexItems returns the context-aware index items for blog pages.
+func BlogsCustomIndexItems(cd *common.CoreData, r *http.Request) []common.IndexItem {
+	items := []common.IndexItem{}
+
+	user := r.URL.Query().Get("user")
+	vars := mux.Vars(r)
+	blogIDStr := vars["blog"]
+
+	// Feed links
+	if cd.FeedsEnabled {
+		path := "/blogs"
+		suffix := ""
+		if user != "" {
+			suffix = "?rss=" + url.QueryEscape(user)
+		}
+		cd.RSSFeedURL = cd.GenerateFeedURL(path + "/rss" + suffix)
+		cd.AtomFeedURL = cd.GenerateFeedURL(path + "/atom" + suffix)
+		cd.PublicRSSFeedURL = path + "/rss" + suffix
+		cd.PublicAtomFeedURL = path + "/atom" + suffix
+		items = append(items,
+			common.IndexItem{Name: "Atom Feed", Link: cd.AtomFeedURL},
+			common.IndexItem{Name: "RSS Feed", Link: cd.RSSFeedURL},
+		)
+	}
+
+	// List bloggers link (always present in old code)
+	items = append(items, common.IndexItem{
+		Name: "List bloggers",
+		Link: "/blogs/bloggers",
+	})
+
+	// Admin link
+	if cd.IsAdmin() {
+		items = append(items, common.IndexItem{
+			Name: "Blogs Admin",
+			Link: "/admin/blogs",
+		})
+	}
+
+	// Write blog link
+	if cd.HasRole("content writer") {
+		items = append(items, common.IndexItem{
+			Name: "Write blog",
+			Link: "/blogs/add",
+		})
+	}
+
+	// Blog specific actions
+	if blogIDStr != "" {
+		blogEntry := cd.CurrentBlogLoaded()
+		if blogEntry != nil {
+			// Edit link
+			if cd.CanEditBlog(blogEntry.Idblogs, blogEntry.UsersIdusers) {
+				items = append(items, common.IndexItem{
+					Name: "Edit Blog",
+					Link: fmt.Sprintf("/blogs/blog/%d/edit", blogEntry.Idblogs),
+				})
+			}
+			// Admin Edit link
+			if cd.IsAdmin() && cd.IsAdminMode() {
+				items = append(items, common.IndexItem{
+					Name: "Admin Edit Blog",
+					Link: fmt.Sprintf("/admin/blogs/blog/%d", blogEntry.Idblogs),
+				})
+			}
+			// Comments link (if not on comments page? context implies we are on blog page)
+			// The original template had [<a href="/blogs/blog/{{$blog.Idblogs}}/comments">{{$blog.Comments}} COMMENTS</a>]
+			// Maybe add "View Comments" if we are not on the comments anchor?
+			// The CustomIndex is for sidebar.
+		}
+	}
+
+	return items
+}

--- a/handlers/news/customindex.go
+++ b/handlers/news/customindex.go
@@ -1,0 +1,67 @@
+package news
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/gorilla/mux"
+)
+
+// NewsCustomIndexItems returns the context-aware index items for news pages.
+func NewsCustomIndexItems(cd *common.CoreData, r *http.Request) []common.IndexItem {
+	items := []common.IndexItem{}
+
+	path := "/news"
+	cd.RSSFeedURL = cd.GenerateFeedURL(path + ".rss")
+	cd.PublicRSSFeedURL = path + ".rss"
+	items = append(items, common.IndexItem{
+		Name: "RSS Feed",
+		Link: cd.RSSFeedURL,
+	})
+
+	if cd.HasGrant("news", "post", "post", 0) {
+		items = append(items, common.IndexItem{
+			Name: "Add News",
+			Link: "/news/post",
+		})
+	}
+
+	vars := mux.Vars(r)
+	newsIDStr := vars["news"]
+
+	if newsIDStr != "" {
+		items = append(items, common.IndexItem{
+			Name: "Return to list",
+			Link: fmt.Sprintf("/?offset=%d", 0),
+		})
+
+		newsPost := cd.CurrentNewsPostLoaded()
+		if newsPost != nil {
+			newsID, _ := strconv.Atoi(newsIDStr)
+			// Mark as read
+			items = append(items,
+				common.IndexItem{
+					Name: "Mark as read",
+					Link: markNewsReadLink(int32(newsID), r.URL.RequestURI()),
+				},
+				common.IndexItem{
+					Name: "Mark as read and go back",
+					Link: markNewsReadLink(int32(newsID), "/news"),
+				},
+			)
+		}
+	}
+
+	return items
+}
+
+func markNewsReadLink(newsID int32, redirect string) string {
+	link := fmt.Sprintf("/news/news/%d/labels?task=%s", newsID, url.QueryEscape("Mark Thread Read"))
+	if redirect != "" {
+		link = fmt.Sprintf("%s&redirect=%s", link, url.QueryEscape(redirect))
+	}
+	return link
+}

--- a/handlers/news/newsPage.go
+++ b/handlers/news/newsPage.go
@@ -1,9 +1,7 @@
 package news
 
 import (
-	"fmt"
 	"github.com/arran4/goa4web/core/common"
-	"github.com/gorilla/mux"
 	"net/http"
 )
 
@@ -13,25 +11,6 @@ func NewsPageHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func CustomNewsIndex(data *common.CoreData, r *http.Request) {
-	data.RSSFeedURL = "/news.rss"
-	data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
-		Name: "RSS Feed",
-		Link: "/news.rss",
-	})
-	userHasWriter := data.HasGrant("news", "post", "post", 0)
-	if userHasWriter {
-		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
-			Name: "Add News",
-			Link: "/news/post",
-		})
-	}
-
-	vars := mux.Vars(r)
-	newsId := vars["news"]
-	if newsId != "" {
-		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
-			Name: "Return to list",
-			Link: fmt.Sprintf("/?offset=%d", 0),
-		})
-	}
+	cd := data
+	cd.CustomIndexItems = NewsCustomIndexItems(cd, r)
 }

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -37,7 +37,7 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Regis
 	nr.HandleFunc("/news/{news}", handlers.TaskHandler(editTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("content writer", "administrator")).MatcherFunc(editTask.Matcher())
 	nr.HandleFunc("/news/{news}", handlers.TaskHandler(newPostTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("content writer", "administrator")).MatcherFunc(newPostTask.Matcher())
 	nr.HandleFunc("/news/{news}/labels", handlers.TaskHandler(setLabelsTask)).Methods("POST").MatcherFunc(setLabelsTask.Matcher())
-	nr.HandleFunc("/news/{news}/labels", handlers.TaskHandler(markReadTask)).Methods("POST").MatcherFunc(markReadTask.Matcher())
+	nr.HandleFunc("/news/{news}/labels", handlers.TaskHandler(markReadTask)).Methods("GET", "POST").MatcherFunc(markReadTask.Matcher())
 	nr.HandleFunc("/news/{news}/announcement", handlers.TaskHandler(announcementAddTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(announcementAddTask.Matcher())
 	nr.HandleFunc("/news/{news}/announcement", handlers.TaskHandler(announcementDeleteTask)).Methods("POST").MatcherFunc(handlers.RequiredAccess("administrator")).MatcherFunc(announcementDeleteTask.Matcher())
 	nr.HandleFunc("/news/{news}", handlers.TaskDoneAutoRefreshPage).Methods("POST").MatcherFunc(cancelTask.Matcher())

--- a/handlers/writings/customindex.go
+++ b/handlers/writings/customindex.go
@@ -1,0 +1,94 @@
+package writings
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/arran4/goa4web/core/common"
+	"github.com/gorilla/mux"
+)
+
+// WritingsCustomIndexItems returns the context-aware index items for writing pages.
+func WritingsCustomIndexItems(cd *common.CoreData, r *http.Request) []common.IndexItem {
+	items := []common.IndexItem{}
+
+	path := "/writings"
+	cd.RSSFeedURL = cd.GenerateFeedURL(path + "/rss")
+	cd.AtomFeedURL = cd.GenerateFeedURL(path + "/atom")
+	cd.PublicRSSFeedURL = path + "/rss"
+	cd.PublicAtomFeedURL = path + "/atom"
+	items = append(items,
+		common.IndexItem{Name: "Atom Feed", Link: cd.AtomFeedURL},
+		common.IndexItem{Name: "RSS Feed", Link: cd.RSSFeedURL},
+	)
+
+	items = append(items, common.IndexItem{
+		Name: "Writings",
+		Link: "/writings",
+	})
+
+	items = append(items, common.IndexItem{
+		Name: "Writers",
+		Link: "/writings/writers",
+	})
+
+	if cd.HasRole("content writer") {
+		items = append(items, common.IndexItem{
+			Name: "Write writings",
+			Link: "/writings/add",
+		})
+	}
+
+	if cd.IsAdmin() {
+		items = append(items, common.IndexItem{
+			Name: "Writings Admin",
+			Link: "/admin/writings",
+		})
+	}
+
+	vars := mux.Vars(r)
+	writingIDStr := vars["writing"]
+
+	if writingIDStr != "" {
+		writing := cd.CurrentWritingLoaded()
+		if writing != nil {
+			// Mark as read
+			items = append(items,
+				common.IndexItem{
+					Name: "Mark as read",
+					Link: markWritingReadLink(writing.Idwriting, r.URL.RequestURI()),
+				},
+				common.IndexItem{
+					Name: "Mark as read and go back",
+					Link: markWritingReadLink(writing.Idwriting, fmt.Sprintf("/writings/category/%d", writing.WritingCategoryID)),
+				},
+			)
+
+			// Edit link
+			if cd.HasGrant("writing", "article", "edit", writing.Idwriting) {
+				items = append(items, common.IndexItem{
+					Name: "Edit Writing",
+					Link: fmt.Sprintf("/writings/article/%d/edit", writing.Idwriting),
+				})
+			}
+			// Admin Edit link
+			if cd.IsAdmin() && cd.IsAdminMode() {
+				items = append(items, common.IndexItem{
+					Name: "Admin Edit Writing",
+					Link: fmt.Sprintf("/admin/writings/article/%d", writing.Idwriting),
+				})
+			}
+		}
+	}
+
+	return items
+}
+
+func markWritingReadLink(writingID int32, redirect string) string {
+	link := fmt.Sprintf("/writings/article/%d/labels?task=%s", writingID, url.QueryEscape("Mark Thread Read"))
+	if redirect != "" {
+		link = fmt.Sprintf("%s&redirect=%s", link, url.QueryEscape(redirect))
+	}
+	return link
+}

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -35,7 +35,7 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig, navReg *navpkg.Regis
 	wr.Handle("/article/{writing}/edit", RequireWritingAuthor(http.HandlerFunc(updateWritingTask.Page))).Methods("GET").MatcherFunc(handlers.RequiredAccess("content writer", "administrator"))
 	wr.Handle("/article/{writing}/edit", RequireWritingAuthor(http.HandlerFunc(handlers.TaskHandler(updateWritingTask)))).Methods("POST").MatcherFunc(handlers.RequiredAccess("content writer", "administrator")).MatcherFunc(updateWritingTask.Matcher())
 	wr.HandleFunc("/article/{writing}/labels", handlers.TaskHandler(setLabelsTask)).Methods("POST").MatcherFunc(setLabelsTask.Matcher())
-	wr.HandleFunc("/article/{writing}/labels", handlers.TaskHandler(markWritingReadTask)).Methods("POST").MatcherFunc(markWritingReadTask.Matcher())
+	wr.HandleFunc("/article/{writing}/labels", handlers.TaskHandler(markWritingReadTask)).Methods("GET", "POST").MatcherFunc(markWritingReadTask.Matcher())
 	wr.HandleFunc("/categories", CategoriesPage).Methods("GET")
 	wr.HandleFunc("/categories/", CategoriesPage).Methods("GET")
 	wr.HandleFunc("/category/{category}", CategoryPage).Methods("GET")

--- a/handlers/writings/writingsPage.go
+++ b/handlers/writings/writingsPage.go
@@ -10,36 +10,6 @@ func WritingsPage(w http.ResponseWriter, r *http.Request) {
 	t.Get(w, r)
 }
 func CustomWritingsIndex(data *common.CoreData, r *http.Request) {
-	data.CustomIndexItems = []common.IndexItem{}
-
-	data.CustomIndexItems = append(data.CustomIndexItems,
-		common.IndexItem{Name: "Atom Feed", Link: "/writings/atom"},
-		common.IndexItem{Name: "RSS Feed", Link: "/writings/rss"},
-	)
-	data.RSSFeedURL = "/writings/rss"
-	data.AtomFeedURL = "/writings/atom"
-
-	if data.IsAdmin() {
-		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
-			Name: "Writings Admin",
-			Link: "/admin/writings",
-		})
-	}
-	userHasWriter := data.HasContentWriterRole()
-	if userHasWriter {
-		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
-			Name: "Write writings",
-			Link: "/writings/add",
-		})
-	}
-
-	data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
-		Name: "Writers",
-		Link: "/writings/writers",
-	})
-
-	data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
-		Name: "Return to list",
-		Link: "/writings?offset=0",
-	})
+	cd := data
+	cd.CustomIndexItems = WritingsCustomIndexItems(cd, r)
 }


### PR DESCRIPTION
Refactored the blogs, news, and writings modules to move page-specific actions (e.g., Edit, Admin, Mark as Read) from the main content templates to the sidebar using `CustomIndexItems`.

- Created `handlers/blogs/customindex.go` to handle sidebar items for blogs.
- Created `handlers/news/customindex.go` to handle sidebar items for news.
- Created `handlers/writings/customindex.go` to handle sidebar items for writings.
- Updated `news` and `writings` routes to accept GET requests for the "Mark Thread Read" task to facilitate sidebar links.
- Cleaned up `.gohtml` templates for blogs, news, and writings to remove redundant inline actions.