### PR TITLE
Add CLI `user rename` command

### DIFF
--- a/cmd/goa4web/templates/user_usage.txt
+++ b/cmd/goa4web/templates/user_usage.txt
@@ -23,6 +23,7 @@ Commands:
   reject      Reject a pending user account, with an optional reason.
   comments    Manage administrative comments for a user.
   roles       List the roles assigned to a specific user.
+  rename      Rename a user account, updating the username.
   profile     Display detailed profile information for a user.
 
 Examples:
@@ -46,5 +47,8 @@ Examples:
 
   # List all roles assigned to the current user
   {{.Prog}} user roles
+
+  # Rename a user from "alice" to "alice2"
+  {{.Prog}} user rename -from alice -to alice2
 
 {{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/user.go
+++ b/cmd/goa4web/user.go
@@ -121,6 +121,12 @@ func (c *userCmd) Run() error {
 			return fmt.Errorf("profile: %w", err)
 		}
 		return cmd.Run()
+	case "rename":
+		cmd, err := parseUserRenameCmd(c, args[1:])
+		if err != nil {
+			return fmt.Errorf("rename: %w", err)
+		}
+		return cmd.Run()
 	default:
 		c.fs.Usage()
 		return fmt.Errorf("unknown user command %q", args[0])

--- a/cmd/goa4web/user_rename.go
+++ b/cmd/goa4web/user_rename.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// userRenameCmd implements "user rename".
+type userRenameCmd struct {
+	*userCmd
+	fs          *flag.FlagSet
+	OldUsername string
+	NewUsername string
+}
+
+func parseUserRenameCmd(parent *userCmd, args []string) (*userRenameCmd, error) {
+	c := &userRenameCmd{userCmd: parent}
+	fs, remaining, err := parseFlags("rename", args, func(fs *flag.FlagSet) {
+		fs.StringVar(&c.OldUsername, "from", "", "The existing username to rename.")
+		fs.StringVar(&c.NewUsername, "to", "", "The new username to assign.")
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.fs = fs
+	if c.OldUsername == "" && len(remaining) > 0 {
+		c.OldUsername = remaining[0]
+		remaining = remaining[1:]
+	}
+	if c.NewUsername == "" && len(remaining) > 0 {
+		c.NewUsername = remaining[0]
+		remaining = remaining[1:]
+	}
+	if len(remaining) > 0 {
+		fs.Usage()
+		return nil, fmt.Errorf("too many arguments")
+	}
+	return c, nil
+}
+
+func (c *userRenameCmd) Run() error {
+	if c.OldUsername == "" || c.NewUsername == "" {
+		c.fs.Usage()
+		return fmt.Errorf("from and to usernames required")
+	}
+	conn, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	ctx := context.Background()
+	queries := db.New(conn)
+	user, err := queries.SystemGetUserByUsername(ctx, sql.NullString{String: c.OldUsername, Valid: true})
+	if err != nil {
+		return fmt.Errorf("get user: %w", err)
+	}
+	if err := queries.AdminUpdateUsernameByID(ctx, db.AdminUpdateUsernameByIDParams{
+		Username: sql.NullString{String: c.NewUsername, Valid: true},
+		Idusers:  user.Idusers,
+	}); err != nil {
+		if strings.Contains(err.Error(), "Duplicate entry") || strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return fmt.Errorf("username already exists")
+		}
+		return fmt.Errorf("rename user: %w", err)
+	}
+	c.rootCmd.Infof("renamed %s to %s", c.OldUsername, c.NewUsername)
+	return nil
+}

--- a/cmd/goa4web/user_rename_test.go
+++ b/cmd/goa4web/user_rename_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestUserRenameCmd(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		args          []string
+		setupMocks    func(sqlmock.Sqlmock)
+		expectedError string
+	}{
+		{
+			name: "positional args",
+			args: []string{"alice", "alice2"},
+			setupMocks: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("(?s).*SystemGetUserByUsername.*").
+					WithArgs(sql.NullString{String: "alice", Valid: true}).
+					WillReturnRows(sqlmock.NewRows([]string{"idusers", "username", "public_profile_enabled_at"}).AddRow(
+						int32(7), sql.NullString{String: "alice", Valid: true}, sql.NullTime{},
+					))
+				mock.ExpectExec("(?s).*AdminUpdateUsernameByID.*").
+					WithArgs(sql.NullString{String: "alice2", Valid: true}, int32(7)).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			},
+		},
+		{
+			name: "flag args",
+			args: []string{"-from", "bob", "-to", "bob2"},
+			setupMocks: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("(?s).*SystemGetUserByUsername.*").
+					WithArgs(sql.NullString{String: "bob", Valid: true}).
+					WillReturnRows(sqlmock.NewRows([]string{"idusers", "username", "public_profile_enabled_at"}).AddRow(
+						int32(9), sql.NullString{String: "bob", Valid: true}, sql.NullTime{},
+					))
+				mock.ExpectExec("(?s).*AdminUpdateUsernameByID.*").
+					WithArgs(sql.NullString{String: "bob2", Valid: true}, int32(9)).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			},
+		},
+		{
+			name:          "missing args",
+			args:          nil,
+			expectedError: "from and to usernames required",
+		},
+		{
+			name:          "too many args",
+			args:          []string{"one", "two", "three"},
+			expectedError: "too many arguments",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := &rootCmd{fs: flag.NewFlagSet("prog", flag.ContinueOnError)}
+
+			var mock sqlmock.Sqlmock
+			if tc.setupMocks != nil {
+				conn, m, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+				if err != nil {
+					t.Fatalf("sqlmock.New: %v", err)
+				}
+				mock = m
+				root.db = conn
+				tc.setupMocks(mock)
+			}
+
+			parent := &userCmd{rootCmd: root}
+			cmd, err := parseUserRenameCmd(parent, tc.args)
+			if tc.expectedError != "" && err != nil {
+				if err.Error() != tc.expectedError {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseUserRenameCmd: %v", err)
+			}
+
+			err = cmd.Run()
+			if tc.expectedError != "" {
+				if err == nil {
+					t.Fatalf("expected error %q, got nil", tc.expectedError)
+				}
+				if err.Error() != tc.expectedError {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if tc.setupMocks != nil {
+				if err := mock.ExpectationsWereMet(); err != nil {
+					t.Fatalf("unmet expectations: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation

- Provide an administrative CLI to rename a user account (change username) from the `goa4web` command-line tools.
- Support both flag-style (`-from`, `-to`) and positional arguments for convenience.
- Ensure the rename is performed via existing admin DB queries so application state remains consistent.

### Description

- Added a new CLI command implementation in `cmd/goa4web/user_rename.go` that implements `user rename` with flags `-from` and `-to` (positional args are also supported).
- The command looks up the existing user with `SystemGetUserByUsername` and updates the username with `AdminUpdateUsernameByID`; duplicate-name error conditions are handled and surfaced as `username already exists`.
- Integrated the subcommand dispatch into `cmd/goa4web/user.go` so `rename` is available via the `user` command.
- Updated the usage template `cmd/goa4web/templates/user_usage.txt` and added sqlmock-backed unit tests in `cmd/goa4web/user_rename_test.go` to cover parsing and DB interactions.

### Testing

- Ran `go mod tidy` (succeeded) and `go fmt ./...` (succeeded).
- Ran `golangci-lint run` (0 issues).
- Ran `go test ./...`: many packages passed (including `cmd/goa4web`), but the overall test run failed due to an unrelated failing test in `internal/feedsign` (`TestSigner_SignedURL_and_Verify` expects a different RSS URL format). This unrelated failure caused the test suite to be non-green.
- Note: `go vet ./...` was started but interrupted during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944c7117524832fa19f367d86675813)