### PR TITLE
Add public-forum maintenance CLI (clean-empty / clean-empty-threads) and supporting admin DB queries

### DIFF
--- a/cmd/goa4web/forum.go
+++ b/cmd/goa4web/forum.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/arran4/goa4web/internal/db"
+)
+
+const (
+	// forumListPageSize is the default page size for forum maintenance listings.
+	forumListPageSize = 200
+)
+
+func isPublicForumHandler(handler string) bool {
+	return handler == ""
+}
+
+// forumCmd handles forum utilities.
+type forumCmd struct {
+	*rootCmd
+	fs *flag.FlagSet
+}
+
+func parseForumCmd(parent *rootCmd, args []string) (*forumCmd, error) {
+	c := &forumCmd{rootCmd: parent}
+	c.fs = newFlagSet("forum")
+	c.fs.Usage = c.Usage
+	if err := c.fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *forumCmd) Run() error {
+	args := c.fs.Args()
+	if len(args) == 0 {
+		c.fs.Usage()
+		return fmt.Errorf("missing forum command")
+	}
+	if err := usageIfHelp(c.fs, args); err != nil {
+		return err
+	}
+	switch args[0] {
+	case "clean-empty":
+		cmd, err := parseForumCleanEmptyCmd(c, args[1:])
+		if err != nil {
+			return fmt.Errorf("clean-empty: %w", err)
+		}
+		return cmd.Run()
+	case "clean-empty-threads":
+		cmd, err := parseForumCleanEmptyThreadsCmd(c, args[1:])
+		if err != nil {
+			return fmt.Errorf("clean-empty-threads: %w", err)
+		}
+		return cmd.Run()
+	default:
+		c.fs.Usage()
+		return fmt.Errorf("unknown forum command %q", args[0])
+	}
+}
+
+// Usage prints command usage information.
+func (c *forumCmd) Usage() {
+	executeUsage(c.fs.Output(), "forum_usage.txt", c)
+}
+
+func (c *forumCmd) FlagGroups() []flagGroup {
+	return append(c.rootCmd.FlagGroups(), flagGroup{Title: c.fs.Name() + " flags", Flags: flagInfos(c.fs)})
+}
+
+// forumCleanEmptyCmd implements "forum clean-empty".
+type forumCleanEmptyCmd struct {
+	*forumCmd
+	fs       *flag.FlagSet
+	dryRun   bool
+	verbose  bool
+	pageSize int
+}
+
+func parseForumCleanEmptyCmd(parent *forumCmd, args []string) (*forumCleanEmptyCmd, error) {
+	c := &forumCleanEmptyCmd{forumCmd: parent}
+	c.fs = newFlagSet("clean-empty")
+	c.fs.BoolVar(&c.dryRun, "dry-run", false, "Dry run")
+	c.fs.BoolVar(&c.verbose, "verbose", false, "Verbose output")
+	c.fs.IntVar(&c.pageSize, "page-size", forumListPageSize, "Number of topics to inspect per page")
+	if err := c.fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *forumCleanEmptyCmd) Run() error {
+	conn, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	queries := db.New(conn)
+	ctx := context.Background()
+
+	if c.dryRun {
+		log.Println("Dry run mode enabled. No changes will be made.")
+	}
+
+	topicCounts, err := queries.AdminForumTopicThreadCounts(ctx)
+	if err != nil {
+		return fmt.Errorf("getting topic thread counts: %w", err)
+	}
+	threadsByTopic := make(map[int32]int64, len(topicCounts))
+	for _, tc := range topicCounts {
+		if isPublicForumHandler(tc.Handler) {
+			threadsByTopic[tc.Idforumtopic] = tc.Threads
+		}
+	}
+
+	offset := 0
+	for {
+		topics, err := queries.AdminListForumTopics(ctx, db.AdminListForumTopicsParams{
+			Limit:  int32(c.pageSize),
+			Offset: int32(offset),
+		})
+		if err != nil {
+			return fmt.Errorf("getting forum topics: %w", err)
+		}
+		if len(topics) == 0 {
+			break
+		}
+
+		for _, topic := range topics {
+			if !isPublicForumHandler(topic.Handler) {
+				continue
+			}
+			threads := threadsByTopic[topic.Idforumtopic]
+			if threads == 0 {
+				if c.verbose {
+					log.Printf("Found empty forum topic: %s (ID: %d)", topic.Title.String, topic.Idforumtopic)
+				}
+
+				grants, err := queries.AdminListForumTopicGrantsByTopicID(ctx, sql.NullInt32{Int32: topic.Idforumtopic, Valid: true})
+				if err != nil {
+					log.Printf("error getting grants for topic %d: %v", topic.Idforumtopic, err)
+					continue
+				}
+
+				for _, grant := range grants {
+					if c.verbose {
+						log.Printf("  - Deleting grant ID: %d", grant.ID)
+					}
+					if !c.dryRun {
+						if err := queries.AdminDeleteGrant(ctx, grant.ID); err != nil {
+							log.Printf("  - error deleting grant %d: %v", grant.ID, err)
+						}
+					}
+				}
+
+				if c.verbose {
+					log.Printf("  - Deleting topic ID: %d", topic.Idforumtopic)
+				}
+				if !c.dryRun {
+					if err := queries.AdminDeleteForumTopic(ctx, topic.Idforumtopic); err != nil {
+						log.Printf("  - error deleting topic %d: %v", topic.Idforumtopic, err)
+					}
+				}
+			}
+		}
+
+		offset += c.pageSize
+	}
+
+	log.Println("Cleanup of empty forum topics complete.")
+	return nil
+}
+
+// forumCleanEmptyThreadsCmd implements "forum clean-empty-threads".
+type forumCleanEmptyThreadsCmd struct {
+	*forumCmd
+	fs       *flag.FlagSet
+	dryRun   bool
+	verbose  bool
+	pageSize int
+}
+
+func parseForumCleanEmptyThreadsCmd(parent *forumCmd, args []string) (*forumCleanEmptyThreadsCmd, error) {
+	c := &forumCleanEmptyThreadsCmd{forumCmd: parent}
+	c.fs = newFlagSet("clean-empty-threads")
+	c.fs.BoolVar(&c.dryRun, "dry-run", false, "Dry run")
+	c.fs.BoolVar(&c.verbose, "verbose", false, "Verbose output")
+	c.fs.IntVar(&c.pageSize, "page-size", forumListPageSize, "Number of threads to inspect per page")
+	if err := c.fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *forumCleanEmptyThreadsCmd) Run() error {
+	conn, err := c.rootCmd.DB()
+	if err != nil {
+		return fmt.Errorf("database: %w", err)
+	}
+	queries := db.New(conn)
+	ctx := context.Background()
+
+	if c.dryRun {
+		log.Println("Dry run mode enabled. No changes will be made.")
+	}
+
+	offset := 0
+	for {
+		threads, err := queries.AdminListForumThreads(ctx, db.AdminListForumThreadsParams{
+			Limit:  int32(c.pageSize),
+			Offset: int32(offset),
+		})
+		if err != nil {
+			return fmt.Errorf("getting forum threads: %w", err)
+		}
+		if len(threads) == 0 {
+			break
+		}
+
+		for _, thread := range threads {
+			if !isPublicForumHandler(thread.TopicHandler) {
+				continue
+			}
+			if !thread.PostCount.Valid || thread.PostCount.Int32 == 0 {
+				if c.verbose {
+					log.Printf("Found empty forum thread: (ID: %d)", thread.Idforumthread)
+				}
+
+				grants, err := queries.AdminListForumThreadGrantsByThreadID(ctx, sql.NullInt32{Int32: thread.Idforumthread, Valid: true})
+				if err != nil {
+					log.Printf("error getting grants for thread %d: %v", thread.Idforumthread, err)
+					continue
+				}
+
+				for _, grant := range grants {
+					if c.verbose {
+						log.Printf("  - Deleting grant ID: %d", grant.ID)
+					}
+					if !c.dryRun {
+						if err := queries.AdminDeleteGrant(ctx, grant.ID); err != nil {
+							log.Printf("  - error deleting grant %d: %v", grant.ID, err)
+						}
+					}
+				}
+
+				if c.verbose {
+					log.Printf("  - Deleting thread ID: %d", thread.Idforumthread)
+				}
+				if !c.dryRun {
+					if err := queries.AdminDeleteForumThread(ctx, thread.Idforumthread); err != nil {
+						log.Printf("  - error deleting thread %d: %v", thread.Idforumthread, err)
+					}
+				}
+			}
+		}
+
+		offset += c.pageSize
+	}
+
+	log.Println("Cleanup of empty forum threads complete.")
+	return nil
+}
+
+var _ usageData = (*forumCmd)(nil)

--- a/cmd/goa4web/main.go
+++ b/cmd/goa4web/main.go
@@ -306,6 +306,18 @@ func (r *rootCmd) Run() error {
 			return fmt.Errorf("rootCmd.Run: faq: %w", err)
 		}
 		return c.Run()
+	case "forum":
+		c, err := parseForumCmd(r, args[1:])
+		if err != nil {
+			return fmt.Errorf("rootCmd.Run: forum: %w", err)
+		}
+		return c.Run()
+	case "private-forum":
+		c, err := parsePrivateForumCmd(r, args[1:])
+		if err != nil {
+			return fmt.Errorf("rootCmd.Run: private-forum: %w", err)
+		}
+		return c.Run()
 	case "ipban":
 		c, err := parseIpBanCmd(r, args[1:])
 		if err != nil {

--- a/cmd/goa4web/templates/forum_usage.txt
+++ b/cmd/goa4web/templates/forum_usage.txt
@@ -1,0 +1,22 @@
+Usage:
+  {{.Prog}} forum <command> [<args>]
+
+The forum command provides maintenance utilities for public forum topics and
+threads. Use these commands to identify and remove empty records that no longer
+contain posts.
+
+Commands:
+  clean-empty          Clean up empty forum topics.
+  clean-empty-threads  Clean up empty forum threads.
+
+Examples:
+  # Preview empty forum topics
+  {{.Prog}} forum clean-empty -dry-run -verbose
+
+  # Remove empty forum topics
+  {{.Prog}} forum clean-empty
+
+  # Preview empty forum threads
+  {{.Prog}} forum clean-empty-threads -dry-run -verbose
+
+{{template "flag_groups_section" .FlagGroups}}

--- a/cmd/goa4web/templates/root_usage.txt
+++ b/cmd/goa4web/templates/root_usage.txt
@@ -23,6 +23,10 @@ Commands:
           articles.
   faq     Manage frequently asked questions. This allows you to create and
           update a list of FAQs.
+  forum   Manage forum topics and threads. This includes maintenance tasks for
+          the public forums.
+  private-forum Manage private forum topics and threads. This includes
+          maintenance tasks for the private forums.
   writing Manage writing articles. This is used for managing articles and other
           written content.
   ipban   Manage IP bans. This allows you to block specific IP addresses from

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -141,6 +141,9 @@ type Querier interface {
 	// admin task
 	AdminListFailedEmails(ctx context.Context, arg AdminListFailedEmailsParams) ([]*AdminListFailedEmailsRow, error)
 	AdminListForumCategoriesWithCounts(ctx context.Context, arg AdminListForumCategoriesWithCountsParams) ([]*AdminListForumCategoriesWithCountsRow, error)
+	AdminListForumThreadGrantsByThreadID(ctx context.Context, itemID sql.NullInt32) ([]*AdminListForumThreadGrantsByThreadIDRow, error)
+	AdminListForumThreads(ctx context.Context, arg AdminListForumThreadsParams) ([]*AdminListForumThreadsRow, error)
+	AdminListForumTopicGrantsByTopicID(ctx context.Context, itemID sql.NullInt32) ([]*AdminListForumTopicGrantsByTopicIDRow, error)
 	AdminListForumTopics(ctx context.Context, arg AdminListForumTopicsParams) ([]*Forumtopic, error)
 	// admin task
 	AdminListGrantsByRoleID(ctx context.Context, roleID sql.NullInt32) ([]*Grant, error)

--- a/internal/db/queries-forum.sql
+++ b/internal/db/queries-forum.sql
@@ -87,6 +87,24 @@ FROM forumtopic t
 ORDER BY t.idforumtopic
 LIMIT ? OFFSET ?;
 
+-- name: AdminListForumTopicGrantsByTopicID :many
+SELECT
+    g.id,
+    g.section,
+    g.action,
+    r.name AS role_name,
+    u.username
+FROM
+    grants g
+LEFT JOIN
+    roles r ON g.role_id = r.id
+LEFT JOIN
+    users u ON g.user_id = u.idusers
+WHERE
+    g.section = 'forum'
+    AND (g.item = 'topic' OR g.item IS NULL)
+    AND g.item_id = ?;
+
 -- name: AdminUpdateForumTopic :exec
 UPDATE forumtopic SET title = ?, description = ?, forumcategory_idforumcategory = ?, language_id = sqlc.narg(topic_language_id) WHERE idforumtopic = ?;
 


### PR DESCRIPTION
### Motivation

- Provide CLI maintenance parity with existing private-forum utilities so admins can clean up empty public forum topics and threads.
- Make cleanup safe by removing associated grants and soft-deleting empty items, and by restricting the operations to public forum handlers only.
- Expose admin SQL queries required to enumerate topics/threads and their grants so the CLI can operate efficiently in pages.

### Description

- Add a new CLI module `cmd/goa4web/forum.go` implementing the `forum` subcommand with `clean-empty` and `clean-empty-threads` actions. Each command supports `--dry-run`, `--verbose`, `--page-size` and uses pagination to avoid loading everything at once.
- Restrict cleanup to public forum items only via `isPublicForumHandler` (checks `handler == ""`). Private forum maintenance remains implemented in `cmd/goa4web/private_forum.go`.
- Add templated usage `cmd/goa4web/templates/forum_usage.txt` and wire the new commands into the root help and dispatcher by updating `cmd/goa4web/main.go` and `cmd/goa4web/templates/root_usage.txt`.
- Add admin SQL queries and regenerated wrappers to support the cleanup logic:
  - `AdminListForumTopicGrantsByTopicID` (in `internal/db/queries-forum.sql` / generated `*.go`)
  - `AdminListForumThreads` and `AdminListForumThreadGrantsByThreadID` (in `internal/db/queries-threads.sql` / generated `*.go`)
  - Expose these in the DB API by updating `internal/db/querier.go`.
- Cleanup actions use the existing admin operations where applicable (`AdminDeleteGrant`, `AdminDeleteForumTopic`, `AdminDeleteForumThread`) to perform removal/soft-delete.

### Testing

- Ran `sqlc generate` to regenerate query wrappers (succeeded).
- Ran `go mod tidy` (succeeded) and `go fmt ./...` (succeeded).
- Ran `golangci-lint run` during verification (initial run reported `0 issues`).
- Attempted `go vet ./...` during local verification but it was interrupted/cancelled; recommend CI to run full vet checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944c549ee84832f89a0892973b42c50)