### PR TITLE
Add `AutoMigrate` runtime option and wire `--auto-migrate`/`AUTO_MIGRATE`

### DIFF
--- a/cmd/goa4web/role_template.go
+++ b/cmd/goa4web/role_template.go
@@ -161,7 +161,9 @@ func (c *roleTemplateExplainCmd) Run() error {
 			fmt.Println("    Grants:")
 			for _, g := range r.Grants {
 				item := g.Item
-				if item == "" { item = "*" }
+				if item == "" {
+					item = "*"
+				}
 				fmt.Printf("      - %s / %s / %s (ID: %d)\n", g.Section, item, g.Action, g.ItemID)
 			}
 		} else {
@@ -277,7 +279,9 @@ func printRolesState(ctx context.Context, q *db.Queries, roles []RoleDef) error 
 
 		for _, g := range grants {
 			item := g.Item.String
-			if !g.Item.Valid { item = "*" }
+			if !g.Item.Valid {
+				item = "*"
+			}
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n", roleInfo, g.Section, item, g.Action, g.ItemID.Int32)
 		}
 	}
@@ -402,8 +406,12 @@ func (c *roleTemplateDiffCmd) Run() error {
 
 		// Role Properties Diff
 		changes := []string{}
-		if role.CanLogin != rDef.CanLogin { changes = append(changes, fmt.Sprintf("CanLogin: %v -> %v", role.CanLogin, rDef.CanLogin)) }
-		if role.IsAdmin != rDef.IsAdmin { changes = append(changes, fmt.Sprintf("IsAdmin: %v -> %v", role.IsAdmin, rDef.IsAdmin)) }
+		if role.CanLogin != rDef.CanLogin {
+			changes = append(changes, fmt.Sprintf("CanLogin: %v -> %v", role.CanLogin, rDef.CanLogin))
+		}
+		if role.IsAdmin != rDef.IsAdmin {
+			changes = append(changes, fmt.Sprintf("IsAdmin: %v -> %v", role.IsAdmin, rDef.IsAdmin))
+		}
 
 		if len(changes) > 0 {
 			fmt.Println("  Properties Update:")
@@ -462,7 +470,9 @@ func (c *roleTemplateDiffCmd) Run() error {
 }
 
 func grantKey(section, item, action string, itemID int32) string {
-	if item == "" { item = "*" }
+	if item == "" {
+		item = "*"
+	}
 	return fmt.Sprintf("%s / %s / %s [%d]", section, item, action, itemID)
 }
 

--- a/config/options_runtime.go
+++ b/config/options_runtime.go
@@ -106,5 +106,6 @@ var BoolOptions = []BoolOption{
 	{"notifications-enabled", EnvNotificationsEnabled, "Enable or disable the internal notification system.", true, "", func(c *RuntimeConfig) *bool { return &c.NotificationsEnabled }},
 	{"csrf-enabled", EnvCSRFEnabled, "Enable or disable CSRF protection.", true, "", func(c *RuntimeConfig) *bool { return &c.CSRFEnabled }},
 	{"admin-notify", EnvAdminNotify, "Enable or disable email notifications for administrators.", true, "", func(c *RuntimeConfig) *bool { return &c.AdminNotify }},
+	{"auto-migrate", EnvAutoMigrate, "Run database migrations on startup.", false, "", func(c *RuntimeConfig) *bool { return &c.AutoMigrate }},
 	{"create-dirs", EnvCreateDirs, "Enable or disable the automatic creation of missing directories.", false, "", func(c *RuntimeConfig) *bool { return &c.CreateDirs }},
 }

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -119,6 +119,8 @@ type RuntimeConfig struct {
 
 	// TemplatesDir specifies a directory to load templates and assets from.
 	TemplatesDir string
+	// AutoMigrate toggles automatic database migrations on startup.
+	AutoMigrate bool
 	// MigrationsDir specifies a directory to load migrations from at runtime.
 	MigrationsDir string
 

--- a/config/runtime_config_automigrate_test.go
+++ b/config/runtime_config_automigrate_test.go
@@ -1,0 +1,34 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+)
+
+func TestAutoMigratePrecedence(t *testing.T) {
+	env := map[string]string{config.EnvAutoMigrate: "0"}
+	vals := map[string]string{config.EnvAutoMigrate: "1"}
+
+	fs := config.NewRuntimeFlagSet("test")
+	_ = fs.Parse(nil)
+	cfg := config.NewRuntimeConfig(
+		config.WithFlagSet(fs),
+		config.WithFileValues(vals),
+		config.WithGetenv(func(k string) string { return env[k] }),
+	)
+	if !cfg.AutoMigrate {
+		t.Fatalf("expected file value to override env")
+	}
+
+	fs = config.NewRuntimeFlagSet("test")
+	_ = fs.Parse([]string{"--auto-migrate=0"})
+	cfg = config.NewRuntimeConfig(
+		config.WithFlagSet(fs),
+		config.WithFileValues(vals),
+		config.WithGetenv(func(k string) string { return env[k] }),
+	)
+	if cfg.AutoMigrate {
+		t.Fatalf("expected CLI value to override file and env")
+	}
+}

--- a/examples/config.env
+++ b/examples/config.env
@@ -8,6 +8,8 @@ ADMIN_EMAILS=
 ADMIN_NOTIFY=true
 # The AWS region to use for SES. (default: ) (examples: us-east-1)
 AWS_REGION=
+# Run database migrations on startup. (default: false)
+AUTO_MIGRATE=false
 # default: 
 CONFIG_FILE=
 # Enable or disable the automatic creation of missing directories. (default: false)

--- a/examples/config.json
+++ b/examples/config.json
@@ -4,6 +4,7 @@
   "ADMIN_EMAILS": "",
   "ADMIN_NOTIFY": "true",
   "AWS_REGION": "",
+  "AUTO_MIGRATE": "false",
   "CONFIG_FILE": "",
   "CREATE_DIRS": "false",
   "CSRF_ENABLED": "true",

--- a/internal/app/dbstart/automigrate.go
+++ b/internal/app/dbstart/automigrate.go
@@ -9,23 +9,11 @@ import (
 	"io/fs"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/dbdrivers"
 )
-
-// autoMigrateEnabled reports whether automatic migrations should run.
-func autoMigrateEnabled() bool {
-	v := strings.ToLower(os.Getenv(config.EnvAutoMigrate))
-	switch v {
-	case "1", "true", "on", "yes":
-		return true
-	default:
-		return false
-	}
-}
 
 // applyMigrations connects to the database and executes SQL migrations.
 func applyMigrations(ctx context.Context, cfg *config.RuntimeConfig, reg *dbdrivers.Registry) error {
@@ -59,9 +47,9 @@ func applyMigrations(ctx context.Context, cfg *config.RuntimeConfig, reg *dbdriv
 	return Apply(ctx, sdb, fsys, false, cfg.DBDriver)
 }
 
-// MaybeAutoMigrate runs migrations when enabled via AUTO_MIGRATE.
+// MaybeAutoMigrate runs migrations when enabled via runtime configuration.
 func MaybeAutoMigrate(cfg *config.RuntimeConfig, reg *dbdrivers.Registry) error {
-	if !autoMigrateEnabled() {
+	if !cfg.AutoMigrate {
 		return nil
 	}
 	ctx := context.Background()

--- a/readme.md
+++ b/readme.md
@@ -267,7 +267,7 @@ You can supply settings on the command line, in a config file or via environment
 | `DEFAULT_LANGUAGE` | `--default-language` | No | - | Site's default language name. |
 | `DLQ_PROVIDER` | `--dlq-provider` | No | `log` | Dead letter queue provider. |
 | `DLQ_FILE` | `--dlq-file` | No | `dlq.log` | File path for the file or directory DLQ providers. |
-| `AUTO_MIGRATE` | n/a | No | `false` | Run database migrations on startup. |
+| `AUTO_MIGRATE` | `--auto-migrate` | No | `false` | Run database migrations on startup. |
 | `CREATE_DIRS` | `--create-dirs` | No | `false` | Create missing directories on startup. |
 
 Paths using the `s3://` scheme must include a bucket name and may specify an optional prefix, e.g. `s3://mybucket/uploads`.
@@ -315,8 +315,8 @@ example provider built with the `sendgrid` tag.
 
 Database schema changes are stored in the `migrations/` directory. Run
 `goa4web db migrate` to apply all pending scripts using your configured
-database connection. Set `AUTO_MIGRATE=true` to perform this step
-automatically when the server starts.
+database connection. Set `AUTO_MIGRATE=true` or pass `--auto-migrate=1`
+to perform this step automatically when the server starts.
 Every new migration must conclude with an `UPDATE schema_version` statement, and the `ExpectedSchemaVersion` constant in `handlers/constants.go` should be incremented.
 
 When upgrading from v0.0.1 the script `migrations/0002.mysql.sql` must be applied.


### PR DESCRIPTION
### Motivation

- Allow automatic DB migrations to be controlled via the resolved runtime configuration (flags, config file, env) instead of reading the env var directly.
- Expose the behavior as a CLI flag so operators can enable/disable migrations at process start time.
- Ensure configuration precedence (CLI > file > env) applies to the auto-migrate setting and add a test to cover it.

### Description

- Added `AutoMigrate bool` (with comment) to `RuntimeConfig` in `config/runtime.go`.
- Added a `BoolOption` entry for `"auto-migrate"` in `config/options_runtime.go` bound to `EnvAutoMigrate` and `RuntimeConfig.AutoMigrate`.
- Updated `internal/app/dbstart/automigrate.go` to read `cfg.AutoMigrate` (removed the environment helper) so auto-migration honours the resolved config.
- Updated documentation and examples: `readme.md`, `examples/config.env`, and `examples/config.json` to show the new `--auto-migrate` flag and `AUTO_MIGRATE` key.
- Added `config/runtime_config_automigrate_test.go` to assert precedence (file overrides env, CLI overrides file+env).
- Minor formatting/cleanup applied to `cmd/goa4web/role_template.go` (result of `go fmt`).

### Testing

- Ran `go mod tidy` — succeeded.
- Ran `go fmt ./...` — succeeded (formatting changes applied).
- Ran `go vet ./...` — failed (unrelated build issue: `cmd/goa4web/role.go:69:40: c.args undefined`).
- Ran `golangci-lint run` — could not run in this environment (config/version issue reported).
- Ran `go test ./...` — overall run failed due to the same unrelated build error in `cmd/goa4web` (`c.args undefined`), but package-level tests including `config` executed (the new `AutoMigrate` precedence test lives in `config` and is included in the repo changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69453ff54db0832f9ef9ffec7ff95168)