### PR TITLE
Introduce QuerierStub and assert notification behavior in tests

### DIFF
--- a/cmd/goa4web/role_template.go
+++ b/cmd/goa4web/role_template.go
@@ -161,7 +161,9 @@ func (c *roleTemplateExplainCmd) Run() error {
 			fmt.Println("    Grants:")
 			for _, g := range r.Grants {
 				item := g.Item
-				if item == "" { item = "*" }
+				if item == "" {
+					item = "*"
+				}
 				fmt.Printf("      - %s / %s / %s (ID: %d)\n", g.Section, item, g.Action, g.ItemID)
 			}
 		} else {
@@ -277,7 +279,9 @@ func printRolesState(ctx context.Context, q *db.Queries, roles []RoleDef) error 
 
 		for _, g := range grants {
 			item := g.Item.String
-			if !g.Item.Valid { item = "*" }
+			if !g.Item.Valid {
+				item = "*"
+			}
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n", roleInfo, g.Section, item, g.Action, g.ItemID.Int32)
 		}
 	}
@@ -402,8 +406,12 @@ func (c *roleTemplateDiffCmd) Run() error {
 
 		// Role Properties Diff
 		changes := []string{}
-		if role.CanLogin != rDef.CanLogin { changes = append(changes, fmt.Sprintf("CanLogin: %v -> %v", role.CanLogin, rDef.CanLogin)) }
-		if role.IsAdmin != rDef.IsAdmin { changes = append(changes, fmt.Sprintf("IsAdmin: %v -> %v", role.IsAdmin, rDef.IsAdmin)) }
+		if role.CanLogin != rDef.CanLogin {
+			changes = append(changes, fmt.Sprintf("CanLogin: %v -> %v", role.CanLogin, rDef.CanLogin))
+		}
+		if role.IsAdmin != rDef.IsAdmin {
+			changes = append(changes, fmt.Sprintf("IsAdmin: %v -> %v", role.IsAdmin, rDef.IsAdmin))
+		}
 
 		if len(changes) > 0 {
 			fmt.Println("  Properties Update:")
@@ -462,7 +470,9 @@ func (c *roleTemplateDiffCmd) Run() error {
 }
 
 func grantKey(section, item, action string, itemID int32) string {
-	if item == "" { item = "*" }
+	if item == "" {
+		item = "*"
+	}
 	return fmt.Sprintf("%s / %s / %s [%d]", section, item, action, itemID)
 }
 

--- a/internal/db/querier_stub.go
+++ b/internal/db/querier_stub.go
@@ -1,0 +1,89 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// QuerierStub records calls for selective db.Querier methods in tests.
+type QuerierStub struct {
+	Querier
+	mu sync.Mutex
+
+	SystemGetUserByIDRow   *SystemGetUserByIDRow
+	SystemGetUserByIDErr   error
+	SystemGetUserByIDCalls []int32
+
+	SystemGetUserByEmailRow   *SystemGetUserByEmailRow
+	SystemGetUserByEmailErr   error
+	SystemGetUserByEmailCalls []string
+
+	SystemGetLastNotificationForRecipientByMessageRow   *Notification
+	SystemGetLastNotificationForRecipientByMessageErr   error
+	SystemGetLastNotificationForRecipientByMessageCalls []SystemGetLastNotificationForRecipientByMessageParams
+
+	SystemCreateNotificationErr   error
+	SystemCreateNotificationCalls []SystemCreateNotificationParams
+
+	InsertPendingEmailErr   error
+	InsertPendingEmailCalls []InsertPendingEmailParams
+}
+
+// SystemGetUserByID records the call and returns the configured response.
+func (s *QuerierStub) SystemGetUserByID(ctx context.Context, idusers int32) (*SystemGetUserByIDRow, error) {
+	s.mu.Lock()
+	s.SystemGetUserByIDCalls = append(s.SystemGetUserByIDCalls, idusers)
+	s.mu.Unlock()
+	if s.SystemGetUserByIDErr != nil {
+		return nil, s.SystemGetUserByIDErr
+	}
+	if s.SystemGetUserByIDRow == nil {
+		return nil, errors.New("SystemGetUserByID not stubbed")
+	}
+	return s.SystemGetUserByIDRow, nil
+}
+
+// SystemGetUserByEmail records the call and returns the configured response.
+func (s *QuerierStub) SystemGetUserByEmail(ctx context.Context, email string) (*SystemGetUserByEmailRow, error) {
+	s.mu.Lock()
+	s.SystemGetUserByEmailCalls = append(s.SystemGetUserByEmailCalls, email)
+	s.mu.Unlock()
+	if s.SystemGetUserByEmailErr != nil {
+		return nil, s.SystemGetUserByEmailErr
+	}
+	if s.SystemGetUserByEmailRow == nil {
+		return nil, errors.New("SystemGetUserByEmail not stubbed")
+	}
+	return s.SystemGetUserByEmailRow, nil
+}
+
+// SystemGetLastNotificationForRecipientByMessage records the call and returns the configured response.
+func (s *QuerierStub) SystemGetLastNotificationForRecipientByMessage(ctx context.Context, arg SystemGetLastNotificationForRecipientByMessageParams) (*Notification, error) {
+	s.mu.Lock()
+	s.SystemGetLastNotificationForRecipientByMessageCalls = append(s.SystemGetLastNotificationForRecipientByMessageCalls, arg)
+	s.mu.Unlock()
+	if s.SystemGetLastNotificationForRecipientByMessageErr != nil {
+		return nil, s.SystemGetLastNotificationForRecipientByMessageErr
+	}
+	if s.SystemGetLastNotificationForRecipientByMessageRow == nil {
+		return nil, errors.New("SystemGetLastNotificationForRecipientByMessage not stubbed")
+	}
+	return s.SystemGetLastNotificationForRecipientByMessageRow, nil
+}
+
+// SystemCreateNotification records the call and returns the configured response.
+func (s *QuerierStub) SystemCreateNotification(ctx context.Context, arg SystemCreateNotificationParams) error {
+	s.mu.Lock()
+	s.SystemCreateNotificationCalls = append(s.SystemCreateNotificationCalls, arg)
+	s.mu.Unlock()
+	return s.SystemCreateNotificationErr
+}
+
+// InsertPendingEmail records the call and returns the configured response.
+func (s *QuerierStub) InsertPendingEmail(ctx context.Context, arg InsertPendingEmailParams) error {
+	s.mu.Lock()
+	s.InsertPendingEmailCalls = append(s.InsertPendingEmailCalls, arg)
+	s.mu.Unlock()
+	return s.InsertPendingEmailErr
+}

--- a/internal/notifications/permission_tasks_test.go
+++ b/internal/notifications/permission_tasks_test.go
@@ -3,12 +3,10 @@ package notifications_test
 import (
 	"context"
 	"database/sql"
-	"regexp"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/handlers/user"
 	"github.com/arran4/goa4web/internal/db"
@@ -45,12 +43,14 @@ func TestProcessEventPermissionTasks(t *testing.T) {
 	cfg.EmailFrom = "from@example.com"
 
 	bus := eventbus.NewBus()
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		SystemGetUserByIDRow: &db.SystemGetUserByIDRow{
+			Idusers:                2,
+			Email:                  sql.NullString{String: "u@test", Valid: true},
+			Username:               sql.NullString{String: "bob", Valid: true},
+			PublicProfileEnabledAt: sql.NullTime{},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
 	n := notif.New(notif.WithQueries(q), notif.WithConfig(cfg))
 
 	var wg sync.WaitGroup
@@ -72,16 +72,6 @@ func TestProcessEventPermissionTasks(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
-			WithArgs(int32(2)).
-			WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(2, "u@test", "bob", nil))
-		mock.ExpectQuery("SystemGetLastNotificationForRecipientByMessage").
-			WithArgs(int32(2), "missing email address").
-			WillReturnError(sql.ErrNoRows)
-		mock.ExpectExec(regexp.QuoteMeta("INSERT INTO notifications (users_idusers, link, message) VALUES (?, ?, ?)")).
-			WithArgs(int32(2), sqlmock.AnyArg(), sqlmock.AnyArg()).
-			WillReturnResult(sqlmock.NewResult(1, 1))
-
 		bus.Publish(eventbus.TaskEvent{Path: "/admin", Task: c.task, UserID: 1, Data: map[string]any{"targetUserID": int32(2), "Username": "bob"}, Outcome: eventbus.TaskOutcomeSuccess})
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -89,4 +79,21 @@ func TestProcessEventPermissionTasks(t *testing.T) {
 	cancel()
 	wg.Wait()
 
+	if len(q.SystemGetUserByIDCalls) != len(cases) {
+		t.Fatalf("expected %d user lookups got %d", len(cases), len(q.SystemGetUserByIDCalls))
+	}
+	if len(q.SystemCreateNotificationCalls) != len(cases) {
+		t.Fatalf("expected %d notifications got %d", len(cases), len(q.SystemCreateNotificationCalls))
+	}
+	for _, call := range q.SystemCreateNotificationCalls {
+		if call.RecipientID != int32(2) {
+			t.Fatalf("expected recipient 2 got %d", call.RecipientID)
+		}
+		if call.Link.String != "/admin" || !call.Link.Valid {
+			t.Fatalf("expected link /admin got %q (valid=%v)", call.Link.String, call.Link.Valid)
+		}
+		if !call.Message.Valid || call.Message.String == "" {
+			t.Fatalf("expected non-empty message")
+		}
+	}
 }


### PR DESCRIPTION
### Motivation

- Replace SQL-only assertions in notification tests with explicit expectations about function return values and recorded state.
- Make tests assert the behaviour callers care about (queued emails, created notifications, user lookups) instead of relying on `sqlmock` execution checks.
- Provide a small, thread-safe `db.Querier` test stub that can be configured by tests and records calls for later assertions.

### Description

- Add `internal/db/querier_stub.go` which implements `QuerierStub` that records calls and returns configured rows/errors for selected `db.Querier` methods (`SystemGetUserByID`, `SystemGetUserByEmail`, `SystemGetLastNotificationForRecipientByMessage`, `SystemCreateNotification`, `InsertPendingEmail`).
- Update `internal/notifications/permission_tasks_test.go` to use `QuerierStub` and assert recorded calls for `SystemGetUserByID` / `SystemCreateNotification` (counts and parameter validation) instead of `sqlmock` expectations.
- Update `internal/notifications/notifications_test.go` to use `QuerierStub` for admin email testing and assert `InsertPendingEmail` parameters (recipient, direct flag, non-empty body).
- Minor formatting/guarding cleanups in `cmd/goa4web/role_template.go` (braces/line breaks) to satisfy `gofmt`.

### Testing

- Ran `go mod tidy` — succeeded.
- Ran `go fmt ./...` — succeeded.
- Ran `go vet ./...` — failed due to an existing unrelated issue: `cmd/goa4web/role.go:69:40: c.args undefined` (this pre-existing problem blocks `go vet` and the full test run in this environment).
- Ran `golangci-lint run` — failed in this environment with: "unsupported configuration version" (local linter config issue).  `go test ./...` also fails here because of the same `cmd/goa4web/role.go` build/vet error.

If you want, I can:
- extend the stub to cover additional `db.Querier` methods used by other notification tests, or
- change stub semantics back to function-overrides if callers prefer that style.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694541943608832fab28b1b7831c53f1)