### PR TITLE
Move thread side effects into CoreData and centralize handling

### DIFF
--- a/cmd/goa4web/role_template.go
+++ b/cmd/goa4web/role_template.go
@@ -161,7 +161,9 @@ func (c *roleTemplateExplainCmd) Run() error {
 			fmt.Println("    Grants:")
 			for _, g := range r.Grants {
 				item := g.Item
-				if item == "" { item = "*" }
+				if item == "" {
+					item = "*"
+				}
 				fmt.Printf("      - %s / %s / %s (ID: %d)\n", g.Section, item, g.Action, g.ItemID)
 			}
 		} else {
@@ -277,7 +279,9 @@ func printRolesState(ctx context.Context, q *db.Queries, roles []RoleDef) error 
 
 		for _, g := range grants {
 			item := g.Item.String
-			if !g.Item.Valid { item = "*" }
+			if !g.Item.Valid {
+				item = "*"
+			}
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n", roleInfo, g.Section, item, g.Action, g.ItemID.Int32)
 		}
 	}
@@ -402,8 +406,12 @@ func (c *roleTemplateDiffCmd) Run() error {
 
 		// Role Properties Diff
 		changes := []string{}
-		if role.CanLogin != rDef.CanLogin { changes = append(changes, fmt.Sprintf("CanLogin: %v -> %v", role.CanLogin, rDef.CanLogin)) }
-		if role.IsAdmin != rDef.IsAdmin { changes = append(changes, fmt.Sprintf("IsAdmin: %v -> %v", role.IsAdmin, rDef.IsAdmin)) }
+		if role.CanLogin != rDef.CanLogin {
+			changes = append(changes, fmt.Sprintf("CanLogin: %v -> %v", role.CanLogin, rDef.CanLogin))
+		}
+		if role.IsAdmin != rDef.IsAdmin {
+			changes = append(changes, fmt.Sprintf("IsAdmin: %v -> %v", role.IsAdmin, rDef.IsAdmin))
+		}
 
 		if len(changes) > 0 {
 			fmt.Println("  Properties Update:")
@@ -462,7 +470,9 @@ func (c *roleTemplateDiffCmd) Run() error {
 }
 
 func grantKey(section, item, action string, itemID int32) string {
-	if item == "" { item = "*" }
+	if item == "" {
+		item = "*"
+	}
 	return fmt.Sprintf("%s / %s / %s [%d]", section, item, action, itemID)
 }
 

--- a/core/common/thread_sideeffects.go
+++ b/core/common/thread_sideeffects.go
@@ -1,0 +1,108 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/workers/postcountworker"
+	"github.com/arran4/goa4web/workers/searchworker"
+)
+
+// ThreadUpdatedEvent captures side effects tied to thread updates.
+type ThreadUpdatedEvent struct {
+	Event *eventbus.TaskEvent
+
+	ThreadID   int32
+	TopicID    int32
+	CommentID  int32
+	Thread     any
+	TopicTitle string
+	Username   string
+	Author     string
+
+	CommentText string
+	CommentURL  string
+	PostURL     string
+	ThreadURL   string
+
+	ClearUnreadForOthers bool
+	MarkThreadRead       bool
+	IncludePostCount     bool
+	IncludeSearch        bool
+
+	AdditionalData map[string]any
+}
+
+// HandleThreadUpdated applies notification, email, and thread-update side effects.
+func (cd *CoreData) HandleThreadUpdated(ctx context.Context, event ThreadUpdatedEvent) error {
+	_ = ctx
+
+	var errs []error
+	if cd != nil {
+		if event.ClearUnreadForOthers {
+			if err := cd.ClearThreadUnreadForOthers(event.ThreadID); err != nil {
+				errs = append(errs, fmt.Errorf("clear unread labels: %w", err))
+			}
+		}
+		if event.MarkThreadRead {
+			if err := cd.SetThreadReadMarker(event.ThreadID, event.CommentID); err != nil {
+				errs = append(errs, fmt.Errorf("set read marker: %w", err))
+			}
+		}
+	}
+
+	evt := event.Event
+	if evt == nil && cd != nil {
+		evt = cd.Event()
+	}
+	if evt != nil {
+		if evt.Data == nil {
+			evt.Data = map[string]any{}
+		}
+		if event.TopicTitle != "" {
+			evt.Data["TopicTitle"] = event.TopicTitle
+		}
+		if event.Username != "" {
+			evt.Data["Username"] = event.Username
+		}
+		if event.Author != "" {
+			evt.Data["Author"] = event.Author
+		}
+		if event.Thread != nil {
+			evt.Data["Thread"] = event.Thread
+		}
+		if event.ThreadID != 0 {
+			evt.Data["ThreadID"] = event.ThreadID
+		}
+		if event.CommentURL != "" {
+			evt.Data["CommentURL"] = event.CommentURL
+		}
+		if event.PostURL != "" {
+			evt.Data["PostURL"] = event.PostURL
+		}
+		if event.ThreadURL != "" {
+			evt.Data["ThreadURL"] = event.ThreadURL
+		}
+		for key, value := range event.AdditionalData {
+			evt.Data[key] = value
+		}
+		if event.IncludePostCount {
+			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{
+				CommentID: event.CommentID,
+				ThreadID:  event.ThreadID,
+				TopicID:   event.TopicID,
+			}
+		}
+		if event.IncludeSearch {
+			evt.Data[searchworker.EventKey] = searchworker.IndexEventData{
+				Type: searchworker.TypeComment,
+				ID:   event.CommentID,
+				Text: event.CommentText,
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -190,23 +191,19 @@ func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(cid), ThreadID: pthid, TopicID: ptid}
-			evt.Data["CommentURL"] = cd.AbsoluteURL(endUrl)
-			evt.Data["target"] = notif.Target{Type: "blog", ID: int32(bid)}
-		}
-	}
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[searchworker.EventKey] = searchworker.IndexEventData{Type: searchworker.TypeComment, ID: int32(cid), Text: text}
-		}
+	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
+		ThreadID:         pthid,
+		TopicID:          ptid,
+		CommentID:        int32(cid),
+		CommentText:      text,
+		CommentURL:       cd.AbsoluteURL(endUrl),
+		IncludePostCount: true,
+		IncludeSearch:    true,
+		AdditionalData: map[string]any{
+			"target": notif.Target{Type: "blog", ID: int32(bid)},
+		},
+	}); err != nil {
+		log.Printf("blog reply side effects: %v", err)
 	}
 
 	return handlers.RedirectHandler(endUrl)

--- a/handlers/forum/comment_edit_action_task.go
+++ b/handlers/forum/comment_edit_action_task.go
@@ -2,6 +2,7 @@ package forum
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/tasks"
-	"github.com/arran4/goa4web/workers/postcountworker"
 	"github.com/gorilla/mux"
 )
 
@@ -46,13 +46,13 @@ func (topicThreadCommentEditActionTask) Action(w http.ResponseWriter, r *http.Re
 		return fmt.Errorf("update comment %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(commentID), ThreadID: threadRow.Idforumthread, TopicID: topicRow.Idforumtopic}
-		}
+	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
+		ThreadID:         threadRow.Idforumthread,
+		TopicID:          topicRow.Idforumtopic,
+		CommentID:        int32(commentID),
+		IncludePostCount: true,
+	}); err != nil {
+		log.Printf("thread comment update side effects: %v", err)
 	}
 
 	base := cd.ForumBasePath

--- a/handlers/forum/forumTopicThreadCommentEditPage.go
+++ b/handlers/forum/forumTopicThreadCommentEditPage.go
@@ -2,13 +2,14 @@ package forum
 
 import (
 	"fmt"
-	"github.com/arran4/goa4web/core/consts"
+	"log"
 	"net/http"
 	"strconv"
 
+	"github.com/arran4/goa4web/core/consts"
+
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/workers/postcountworker"
 	"github.com/gorilla/mux"
 )
 
@@ -41,14 +42,14 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(commentId), ThreadID: threadRow.Idforumthread, TopicID: topicRow.Idforumtopic}
-			evt.Data["CommentURL"] = cd.AbsoluteURL(fmt.Sprintf("/forum/topic/%d/thread/%d#comment-%d", topicRow.Idforumtopic, threadRow.Idforumthread, commentId))
-		}
+	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
+		ThreadID:         threadRow.Idforumthread,
+		TopicID:          topicRow.Idforumtopic,
+		CommentID:        int32(commentId),
+		CommentURL:       cd.AbsoluteURL(fmt.Sprintf("/forum/topic/%d/thread/%d#comment-%d", topicRow.Idforumtopic, threadRow.Idforumthread, commentId)),
+		IncludePostCount: true,
+	}); err != nil {
+		log.Printf("thread comment edit side effects: %v", err)
 	}
 
 	http.Redirect(w, r, fmt.Sprintf("/forum/topic/%d/thread/%d#comment-%d", topicRow.Idforumtopic, threadRow.Idforumthread, commentId), http.StatusSeeOther)

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -19,7 +19,6 @@ import (
 	"github.com/arran4/goa4web/internal/eventbus"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
-	"github.com/arran4/goa4web/workers/postcountworker"
 	"github.com/arran4/goa4web/workers/searchworker"
 )
 
@@ -203,22 +202,16 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(cid), ThreadID: pthid, TopicID: ptid}
-			evt.Data["CommentURL"] = cd.AbsoluteURL(endUrl)
-		}
-	}
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[searchworker.EventKey] = searchworker.IndexEventData{Type: searchworker.TypeComment, ID: int32(cid), Text: text}
-		}
+	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
+		ThreadID:         pthid,
+		TopicID:          ptid,
+		CommentID:        int32(cid),
+		CommentText:      text,
+		CommentURL:       cd.AbsoluteURL(endUrl),
+		IncludePostCount: true,
+		IncludeSearch:    true,
+	}); err != nil {
+		log.Printf("imagebbs reply side effects: %v", err)
 	}
 
 	return handlers.RedirectHandler(endUrl)

--- a/handlers/linker/edit_reply_task.go
+++ b/handlers/linker/edit_reply_task.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
-	"github.com/arran4/goa4web/workers/postcountworker"
 	"github.com/gorilla/mux"
 )
 
@@ -77,13 +77,13 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("update comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(commentId), ThreadID: thread.Idforumthread, TopicID: thread.ForumtopicIdforumtopic}
-		}
+	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
+		ThreadID:         thread.Idforumthread,
+		TopicID:          thread.ForumtopicIdforumtopic,
+		CommentID:        int32(commentId),
+		IncludePostCount: true,
+	}); err != nil {
+		log.Printf("linker comment edit side effects: %v", err)
 	}
 
 	return handlers.RefreshDirectHandler{TargetURL: fmt.Sprintf("/linker/comments/%d", linkId)}

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -17,7 +17,6 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/tasks"
-	"github.com/arran4/goa4web/workers/postcountworker"
 	"github.com/arran4/goa4web/workers/searchworker"
 )
 
@@ -297,22 +296,16 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(cid), ThreadID: pthid, TopicID: ptid}
-			evt.Data["CommentURL"] = cd.AbsoluteURL(endUrl)
-		}
-	}
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[searchworker.EventKey] = searchworker.IndexEventData{Type: searchworker.TypeComment, ID: int32(cid), Text: text}
-		}
+	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
+		ThreadID:         pthid,
+		TopicID:          ptid,
+		CommentID:        int32(cid),
+		CommentText:      text,
+		CommentURL:       cd.AbsoluteURL(endUrl),
+		IncludePostCount: true,
+		IncludeSearch:    true,
+	}); err != nil {
+		log.Printf("linker comment side effects: %v", err)
 	}
 
 	return handlers.RefreshDirectHandler{TargetURL: endUrl}

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -14,8 +14,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
-	"github.com/arran4/goa4web/workers/postcountworker"
-	"github.com/arran4/goa4web/workers/searchworker"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/gorilla/mux"
@@ -195,22 +193,16 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(cid), ThreadID: pthid, TopicID: ptid}
-			evt.Data["CommentURL"] = cd.AbsoluteURL(endUrl)
-		}
-	}
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[searchworker.EventKey] = searchworker.IndexEventData{Type: searchworker.TypeComment, ID: int32(cid), Text: text}
-		}
+	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
+		ThreadID:         pthid,
+		TopicID:          ptid,
+		CommentID:        int32(cid),
+		CommentText:      text,
+		CommentURL:       cd.AbsoluteURL(endUrl),
+		IncludePostCount: true,
+		IncludeSearch:    true,
+	}); err != nil {
+		log.Printf("linker reply side effects: %v", err)
 	}
 
 	http.Redirect(w, r, endUrl, http.StatusSeeOther)

--- a/handlers/news/edit_reply_task.go
+++ b/handlers/news/edit_reply_task.go
@@ -2,6 +2,7 @@ package news
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
-	"github.com/arran4/goa4web/workers/postcountworker"
 )
 
 // EditReplyTask updates an existing comment.
@@ -56,12 +56,14 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("update comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if evt := cd.Event(); evt != nil {
-		if evt.Data == nil {
-			evt.Data = map[string]any{}
-		}
-		evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(commentId), ThreadID: ti.ThreadID, TopicID: ti.TopicID}
-		evt.Data["CommentURL"] = cd.AbsoluteURL(fmt.Sprintf("/news/news/%d", postId))
+	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
+		ThreadID:         ti.ThreadID,
+		TopicID:          ti.TopicID,
+		CommentID:        int32(commentId),
+		CommentURL:       cd.AbsoluteURL(fmt.Sprintf("/news/news/%d", postId)),
+		IncludePostCount: true,
+	}); err != nil {
+		log.Printf("news comment edit side effects: %v", err)
 	}
 
 	return handlers.RedirectHandler(fmt.Sprintf("/news/news/%d", postId))

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -2,6 +2,7 @@ package news
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -112,17 +113,23 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	endURL := cd.AbsoluteURL(fmt.Sprintf("/news/news/%d", pid))
-	evt := cd.Event()
-	if evt.Data == nil {
-		evt.Data = map[string]any{}
-	}
-	evt.Data["CommentURL"] = endURL
-	evt.Data["PostURL"] = endURL
+	username := ""
 	if user, err := cd.CurrentUser(); err == nil && user != nil {
-		evt.Data["Username"] = user.Username.String
+		username = user.Username.String
 	}
-	evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(cid), ThreadID: ti.ThreadID, TopicID: ti.TopicID}
-	evt.Data[searchworker.EventKey] = searchworker.IndexEventData{Type: searchworker.TypeComment, ID: int32(cid), Text: text}
+	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
+		ThreadID:         ti.ThreadID,
+		TopicID:          ti.TopicID,
+		CommentID:        int32(cid),
+		CommentText:      text,
+		CommentURL:       endURL,
+		PostURL:          endURL,
+		Username:         username,
+		IncludePostCount: true,
+		IncludeSearch:    true,
+	}); err != nil {
+		log.Printf("news reply side effects: %v", err)
+	}
 
 	return nil
 }

--- a/handlers/writings/edit_reply_task.go
+++ b/handlers/writings/edit_reply_task.go
@@ -3,6 +3,7 @@ package writings
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/arran4/goa4web/handlers"
 	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
-	"github.com/arran4/goa4web/workers/postcountworker"
 )
 
 // EditReplyTask updates an existing comment.
@@ -53,13 +53,13 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	if err != nil {
 		return fmt.Errorf("update comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: comment.Idcomments, ThreadID: thread.Idforumthread, TopicID: thread.ForumtopicIdforumtopic}
-		}
+	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
+		ThreadID:         thread.Idforumthread,
+		TopicID:          thread.ForumtopicIdforumtopic,
+		CommentID:        comment.Idcomments,
+		IncludePostCount: true,
+	}); err != nil {
+		log.Printf("writing comment edit side effects: %v", err)
 	}
 
 	return handlers.RedirectHandler(fmt.Sprintf("/writings/article/%d", writing.Idwriting))

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -89,15 +89,6 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return handlers.ErrRedirectOnSamePageHandler(handlers.ErrForbidden)
 	}
 
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data["target"] = notif.Target{Type: "writing", ID: writing.Idwriting}
-		}
-	}
-
 	text := r.PostFormValue("replytext")
 	languageID, err := strconv.Atoi(r.PostFormValue("language"))
 	if err != nil {
@@ -117,14 +108,18 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		log.Printf("clear unread labels: %v", err)
 	}
 
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: int32(cid), ThreadID: threadID, TopicID: topicID}
-			evt.Data[searchworker.EventKey] = searchworker.IndexEventData{Type: searchworker.TypeComment, ID: int32(cid), Text: text}
-		}
+	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
+		ThreadID:         threadID,
+		TopicID:          topicID,
+		CommentID:        int32(cid),
+		CommentText:      text,
+		IncludePostCount: true,
+		IncludeSearch:    true,
+		AdditionalData: map[string]any{
+			"target": notif.Target{Type: "writing", ID: writing.Idwriting},
+		},
+	}); err != nil {
+		log.Printf("writing reply side effects: %v", err)
 	}
 
 	return nil

--- a/handlers/writings/writingsArticleCommentEditPage.go
+++ b/handlers/writings/writingsArticleCommentEditPage.go
@@ -2,14 +2,15 @@ package writings
 
 import (
 	"fmt"
-	"github.com/arran4/goa4web/core/consts"
+	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/arran4/goa4web/core/consts"
 
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/handlers"
-	"github.com/arran4/goa4web/workers/postcountworker"
 )
 
 // ArticleCommentEditActionPage updates a comment on a writing and refreshes thread metadata.
@@ -42,13 +43,13 @@ func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 		handlers.RedirectSeeOtherWithMessage(w, r, "", err.Error())
 		return
 	}
-	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
-		if evt := cd.Event(); evt != nil {
-			if evt.Data == nil {
-				evt.Data = map[string]any{}
-			}
-			evt.Data[postcountworker.EventKey] = postcountworker.UpdateEventData{CommentID: comment.Idcomments, ThreadID: thread.Idforumthread, TopicID: thread.ForumtopicIdforumtopic}
-		}
+	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
+		ThreadID:         thread.Idforumthread,
+		TopicID:          thread.ForumtopicIdforumtopic,
+		CommentID:        comment.Idcomments,
+		IncludePostCount: true,
+	}); err != nil {
+		log.Printf("writing comment edit side effects: %v", err)
 	}
 
 	http.Redirect(w, r, fmt.Sprintf("/writings/article/%d", writing.Idwriting), http.StatusSeeOther)


### PR DESCRIPTION
### Motivation

- Make thread-related side effects (notifications, email metadata, postcount/search events, unread/read markers) discoverable and auditable via a single, structured entry point.
- Replace ad-hoc mutations of `eventbus.TaskEvent` across many handlers with a centralized, reusable routine to reduce duplication and surface behavior.
- Keep behavior ownership with request-scoped `CoreData` so side effects operate against the same context used by handlers.

### Description

- Introduce `ThreadUpdatedEvent` and `HandleThreadUpdated` as a `CoreData` method in `core/common/thread_sideeffects.go`.
  - `ThreadUpdatedEvent` captures `ThreadID`, `TopicID`, `CommentID`, URLs, text, flags (e.g. `IncludePostCount`, `IncludeSearch`, `ClearUnreadForOthers`, etc.) and `AdditionalData`.
  - `CoreData.HandleThreadUpdated(ctx, event)` applies read/unread bookkeeping and populates `eventbus.TaskEvent` keys like `postcountworker.EventKey` and `searchworker.EventKey`.
- Replace direct event/data mutations in reply/edit flows so handlers now call `cd.HandleThreadUpdated(...)` (examples: forum, blogs, news, writings, linker, imagebbs).
- Removed the separate internal sideeffects module in favor of the `CoreData`-owned implementation so side effects use the same lifecycle/context as request handling.

### Testing

- Ran `go mod tidy` — succeeded.
- Ran `go fmt ./...` — succeeded (code formatted).
- Ran `go vet ./...` — failed due to an unrelated CLI issue: `cmd/goa4web/role.go:69:40: c.args undefined` (outside the changeset).
- Ran `golangci-lint run ./...` — failed due to repository linter configuration (unsupported configuration version); not caused by these changes.

If helpful I can add unit tests exercising `CoreData.HandleThreadUpdated` (mocking `CoreData.Event()` and verifying produced `TaskEvent.Data` and calls) and follow up to address the CLI `go vet` failure separately.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694540ce3180832fa8ab6c59175cb62a)