### PR TITLE
test: use per-file receiver stubs for handler tests and fix test failures

### DIFF
--- a/cmd/goa4web/role_template.go
+++ b/cmd/goa4web/role_template.go
@@ -161,7 +161,9 @@ func (c *roleTemplateExplainCmd) Run() error {
 			fmt.Println("    Grants:")
 			for _, g := range r.Grants {
 				item := g.Item
-				if item == "" { item = "*" }
+				if item == "" {
+					item = "*"
+				}
 				fmt.Printf("      - %s / %s / %s (ID: %d)\n", g.Section, item, g.Action, g.ItemID)
 			}
 		} else {
@@ -277,7 +279,9 @@ func printRolesState(ctx context.Context, q *db.Queries, roles []RoleDef) error 
 
 		for _, g := range grants {
 			item := g.Item.String
-			if !g.Item.Valid { item = "*" }
+			if !g.Item.Valid {
+				item = "*"
+			}
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n", roleInfo, g.Section, item, g.Action, g.ItemID.Int32)
 		}
 	}
@@ -402,8 +406,12 @@ func (c *roleTemplateDiffCmd) Run() error {
 
 		// Role Properties Diff
 		changes := []string{}
-		if role.CanLogin != rDef.CanLogin { changes = append(changes, fmt.Sprintf("CanLogin: %v -> %v", role.CanLogin, rDef.CanLogin)) }
-		if role.IsAdmin != rDef.IsAdmin { changes = append(changes, fmt.Sprintf("IsAdmin: %v -> %v", role.IsAdmin, rDef.IsAdmin)) }
+		if role.CanLogin != rDef.CanLogin {
+			changes = append(changes, fmt.Sprintf("CanLogin: %v -> %v", role.CanLogin, rDef.CanLogin))
+		}
+		if role.IsAdmin != rDef.IsAdmin {
+			changes = append(changes, fmt.Sprintf("IsAdmin: %v -> %v", role.IsAdmin, rDef.IsAdmin))
+		}
 
 		if len(changes) > 0 {
 			fmt.Println("  Properties Update:")
@@ -462,7 +470,9 @@ func (c *roleTemplateDiffCmd) Run() error {
 }
 
 func grantKey(section, item, action string, itemID int32) string {
-	if item == "" { item = "*" }
+	if item == "" {
+		item = "*"
+	}
 	return fmt.Sprintf("%s / %s / %s [%d]", section, item, action, itemID)
 }
 

--- a/handlers/admin/adminAnyoneGrantsPage_test.go
+++ b/handlers/admin/adminAnyoneGrantsPage_test.go
@@ -2,35 +2,42 @@ package admin
 
 import (
 	"context"
+	"database/sql"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"strings"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/db"
 )
 
+type anyoneGrantsQueries struct {
+	db.Querier
+	grants []*db.Grant
+}
+
+func (q *anyoneGrantsQueries) ListGrants(context.Context) ([]*db.Grant, error) {
+	return q.grants, nil
+}
+
 func TestAdminAnyoneGrantsPage(t *testing.T) {
-	sqlDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	queries := &anyoneGrantsQueries{
+		grants: []*db.Grant{{
+			ID:       1,
+			Section:  "forum",
+			Item:     sql.NullString{},
+			RuleType: "allow",
+			Action:   "search",
+			Active:   true,
+		}},
 	}
-	defer sqlDB.Close()
-
-	queries := db.New(sqlDB)
-
-	grantsRows := sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}).
-		AddRow(1, nil, nil, nil, nil, "forum", "", "allow", nil, nil, "search", nil, true)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants ORDER BY id")).WillReturnRows(grantsRows)
 
 	req := httptest.NewRequest("GET", "/admin/grants/anyone", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -39,9 +46,6 @@ func TestAdminAnyoneGrantsPage(t *testing.T) {
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d", rr.Code)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
 	}
 	body := rr.Body.String()
 	if !strings.Contains(body, `<a href="/admin/grants/anyone">Anyone</a>`) {

--- a/handlers/admin/adminCommentPage_test.go
+++ b/handlers/admin/adminCommentPage_test.go
@@ -2,13 +2,14 @@ package admin
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
@@ -17,35 +18,86 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 )
 
-func TestAdminCommentPage_UsesURLParam(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	mock.MatchExpectationsInOrder(false)
+type commentPageQueries struct {
+	db.Querier
+	commentID  int32
+	comment    *db.GetCommentByIdForUserRow
+	threadInfo []*db.GetCommentsByIdsForUserWithThreadInfoRow
+	threadRows []*db.GetCommentsByThreadIdForUserRow
+}
 
+func (q *commentPageQueries) GetCommentByIdForUser(_ context.Context, arg db.GetCommentByIdForUserParams) (*db.GetCommentByIdForUserRow, error) {
+	if arg.ID != q.commentID {
+		return nil, fmt.Errorf("unexpected comment id: %d", arg.ID)
+	}
+	return q.comment, nil
+}
+
+func (q *commentPageQueries) GetCommentsByIdsForUserWithThreadInfo(context.Context, db.GetCommentsByIdsForUserWithThreadInfoParams) ([]*db.GetCommentsByIdsForUserWithThreadInfoRow, error) {
+	return q.threadInfo, nil
+}
+
+func (q *commentPageQueries) GetCommentsByThreadIdForUser(context.Context, db.GetCommentsByThreadIdForUserParams) ([]*db.GetCommentsByThreadIdForUserRow, error) {
+	return q.threadRows, nil
+}
+
+func TestAdminCommentPage_UsesURLParam(t *testing.T) {
 	commentID := 44
 	threadID := 55
 	topicID := 66
-
-	rows1 := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "username", "is_owner"}).
-		AddRow(commentID, threadID, 2, 1, time.Now(), "body", nil, nil, nil, "user", true)
-	mock.ExpectQuery("SELECT").WillReturnRows(rows1)
-
-	rows2 := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner", "idforumthread", "idforumtopic", "forumtopic_title", "thread_title", "idforumcategory", "forumcategory_title"}).
-		AddRow(commentID, threadID, 2, 1, time.Now(), "body", nil, nil, nil, "user", true, threadID, topicID, "topic", "thread", 1, "cat")
-	mock.ExpectQuery("SELECT").WillReturnRows(rows2)
-
-	rows3 := sqlmock.NewRows([]string{"idcomments", "forumthread_id", "users_idusers", "language_id", "written", "text", "timezone", "deleted_at", "last_index", "posterusername", "is_owner"}).
-		AddRow(commentID, threadID, 2, 1, time.Now(), "body", nil, nil, nil, "user", true)
-	mock.ExpectQuery("SELECT").WillReturnRows(rows3)
+	queries := &commentPageQueries{
+		commentID: int32(commentID),
+		comment: &db.GetCommentByIdForUserRow{
+			Idcomments:    int32(commentID),
+			ForumthreadID: int32(threadID),
+			UsersIdusers:  2,
+			LanguageID:    sql.NullInt32{Int32: 1, Valid: true},
+			Written:       sql.NullTime{Time: time.Now(), Valid: true},
+			Text:          sql.NullString{String: "body", Valid: true},
+			Timezone:      sql.NullString{},
+			DeletedAt:     sql.NullTime{},
+			LastIndex:     sql.NullTime{},
+			Username:      sql.NullString{String: "user", Valid: true},
+			IsOwner:       true,
+		},
+		threadInfo: []*db.GetCommentsByIdsForUserWithThreadInfoRow{{
+			Idcomments:         int32(commentID),
+			ForumthreadID:      int32(threadID),
+			UsersIdusers:       2,
+			LanguageID:         sql.NullInt32{Int32: 1, Valid: true},
+			Written:            sql.NullTime{Time: time.Now(), Valid: true},
+			Text:               sql.NullString{String: "body", Valid: true},
+			Timezone:           sql.NullString{},
+			DeletedAt:          sql.NullTime{},
+			LastIndex:          sql.NullTime{},
+			Posterusername:     sql.NullString{String: "user", Valid: true},
+			IsOwner:            true,
+			Idforumthread:      sql.NullInt32{Int32: int32(threadID), Valid: true},
+			Idforumtopic:       sql.NullInt32{Int32: int32(topicID), Valid: true},
+			ForumtopicTitle:    sql.NullString{String: "topic", Valid: true},
+			ThreadTitle:        sql.NullString{String: "thread", Valid: true},
+			Idforumcategory:    sql.NullInt32{Int32: 1, Valid: true},
+			ForumcategoryTitle: sql.NullString{String: "cat", Valid: true},
+		}},
+		threadRows: []*db.GetCommentsByThreadIdForUserRow{{
+			Idcomments:     int32(commentID),
+			ForumthreadID:  int32(threadID),
+			UsersIdusers:   2,
+			LanguageID:     sql.NullInt32{Int32: 1, Valid: true},
+			Written:        sql.NullTime{Time: time.Now(), Valid: true},
+			Text:           sql.NullString{String: "body", Valid: true},
+			Timezone:       sql.NullString{},
+			DeletedAt:      sql.NullTime{},
+			LastIndex:      sql.NullTime{},
+			Posterusername: sql.NullString{String: "user", Valid: true},
+			IsOwner:        true,
+		}},
+	}
 
 	req := httptest.NewRequest("GET", "/admin/comment/"+strconv.Itoa(commentID), nil)
 	req = mux.SetURLVars(req, map[string]string{"comment": strconv.Itoa(commentID)})
 	cfg := config.NewRuntimeConfig()
-	q := db.New(conn)
-	cd := common.NewCoreData(req.Context(), q, cfg)
+	cd := common.NewCoreData(req.Context(), queries, cfg)
 	cd.LoadSelectionsFromRequest(req)
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -54,8 +106,5 @@ func TestAdminCommentPage_UsesURLParam(t *testing.T) {
 	adminCommentPage(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d", rr.Code)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expect: %v", err)
 	}
 }

--- a/handlers/admin/adminGrantsPage_test.go
+++ b/handlers/admin/adminGrantsPage_test.go
@@ -2,42 +2,85 @@ package admin
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"strings"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/db"
 )
 
-func TestAdminGrantsPageGroupsActions(t *testing.T) {
-	sqlDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+type grantsPageQueries struct {
+	db.Querier
+	grants []*db.Grant
+	userID int32
+	user   *db.SystemGetUserByIDRow
+	roleID int32
+	role   *db.Role
+}
+
+func (q *grantsPageQueries) ListGrants(context.Context) ([]*db.Grant, error) {
+	return q.grants, nil
+}
+
+func (q *grantsPageQueries) SystemGetUserByID(_ context.Context, id int32) (*db.SystemGetUserByIDRow, error) {
+	if id != q.userID {
+		return nil, fmt.Errorf("unexpected user id: %d", id)
 	}
-	defer sqlDB.Close()
+	return q.user, nil
+}
 
-	queries := db.New(sqlDB)
+func (q *grantsPageQueries) AdminGetRoleByID(_ context.Context, id int32) (*db.Role, error) {
+	if id != q.roleID {
+		return nil, fmt.Errorf("unexpected role id: %d", id)
+	}
+	return q.role, nil
+}
 
-	grantsRows := sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}).
-		AddRow(1, nil, nil, 5, 7, "forum", "topic", "allow", 42, nil, "search", nil, true).
-		AddRow(2, nil, nil, 5, 7, "forum", "topic", "allow", 42, nil, "view", nil, true)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants ORDER BY id")).WillReturnRows(grantsRows)
-
-	userRows := sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(5, nil, "bob", nil)
-	mock.ExpectQuery("SELECT u\\.idusers").WithArgs(5).WillReturnRows(userRows)
-
-	roleRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "private_labels", "public_profile_allowed_at"}).AddRow(7, "admin", true, false, true, nil)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, can_login, is_admin, private_labels, public_profile_allowed_at FROM roles WHERE id = ?")).WithArgs(7).WillReturnRows(roleRows)
+func TestAdminGrantsPageGroupsActions(t *testing.T) {
+	queries := &grantsPageQueries{
+		userID: 5,
+		roleID: 7,
+		grants: []*db.Grant{
+			{
+				ID:       1,
+				UserID:   sql.NullInt32{Int32: 5, Valid: true},
+				RoleID:   sql.NullInt32{Int32: 7, Valid: true},
+				Section:  "forum",
+				Item:     sql.NullString{String: "topic", Valid: true},
+				RuleType: "allow",
+				ItemID:   sql.NullInt32{Int32: 42, Valid: true},
+				Action:   "search",
+				Active:   true,
+			},
+			{
+				ID:       2,
+				UserID:   sql.NullInt32{Int32: 5, Valid: true},
+				RoleID:   sql.NullInt32{Int32: 7, Valid: true},
+				Section:  "forum",
+				Item:     sql.NullString{String: "topic", Valid: true},
+				RuleType: "allow",
+				ItemID:   sql.NullInt32{Int32: 42, Valid: true},
+				Action:   "view",
+				Active:   true,
+			},
+		},
+		user: &db.SystemGetUserByIDRow{
+			Idusers:                5,
+			Username:               sql.NullString{String: "bob", Valid: true},
+			PublicProfileEnabledAt: sql.NullTime{},
+		},
+		role: &db.Role{Name: "admin", CanLogin: true, IsAdmin: false, PrivateLabels: true},
+	}
 
 	req := httptest.NewRequest("GET", "/admin/grants", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -46,9 +89,6 @@ func TestAdminGrantsPageGroupsActions(t *testing.T) {
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d", rr.Code)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
 	}
 	body := rr.Body.String()
 	if strings.Count(body, `<a href="/admin/user/5">bob (5)</a>`) != 1 {

--- a/handlers/admin/adminUserWritingsPage_test.go
+++ b/handlers/admin/adminUserWritingsPage_test.go
@@ -2,44 +2,72 @@ package admin
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/db"
 )
 
-func TestAdminUserWritingsPage(t *testing.T) {
-	sqlDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+type userWritingsQueries struct {
+	db.Querier
+	userID   int32
+	user     *db.SystemGetUserByIDRow
+	writings []*db.AdminGetAllWritingsByAuthorRow
+}
+
+func (q *userWritingsQueries) SystemGetUserByID(_ context.Context, id int32) (*db.SystemGetUserByIDRow, error) {
+	if id != q.userID {
+		return nil, fmt.Errorf("unexpected user id: %d", id)
 	}
-	defer sqlDB.Close()
+	return q.user, nil
+}
 
-	queries := db.New(sqlDB)
+func (q *userWritingsQueries) AdminGetAllWritingsByAuthor(_ context.Context, id int32) ([]*db.AdminGetAllWritingsByAuthorRow, error) {
+	if id != q.userID {
+		return nil, fmt.Errorf("unexpected author id: %d", id)
+	}
+	return q.writings, nil
+}
 
-	userRows := sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).
-		AddRow(1, "u@test", "user", nil)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
-		WithArgs(int32(1)).
-		WillReturnRows(userRows)
-
-	writingRows := sqlmock.NewRows([]string{"idwriting", "users_idusers", "forumthread_id", "language_id", "writing_category_id", "title", "published", "timezone", "writing", "abstract", "private", "deleted_at", "last_index", "username", "comments"}).
-		AddRow(1, 1, 0, 0, 2, "Title", time.Now(), time.Local.String(), "", "", false, nil, nil, "user", 0)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT w.idwriting, w.users_idusers, w.forumthread_id, w.language_id, w.writing_category_id, w.title, w.published, w.timezone, w.writing, w.abstract, w.private, w.deleted_at, w.last_index, u.username,\n    (SELECT COUNT(*) FROM comments c WHERE c.forumthread_id=w.forumthread_id AND w.forumthread_id IS NOT NULL) AS Comments\nFROM writing w\nLEFT JOIN users u ON w.users_idusers = u.idusers\nWHERE w.users_idusers = ?\nORDER BY w.published DESC")).
-		WithArgs(int32(1)).
-		WillReturnRows(writingRows)
+func TestAdminUserWritingsPage(t *testing.T) {
+	queries := &userWritingsQueries{
+		userID: 1,
+		user: &db.SystemGetUserByIDRow{
+			Idusers:                1,
+			Email:                  sql.NullString{String: "u@test", Valid: true},
+			Username:               sql.NullString{String: "user", Valid: true},
+			PublicProfileEnabledAt: sql.NullTime{},
+		},
+		writings: []*db.AdminGetAllWritingsByAuthorRow{{
+			Idwriting:         1,
+			UsersIdusers:      1,
+			ForumthreadID:     0,
+			LanguageID:        sql.NullInt32{},
+			WritingCategoryID: 2,
+			Title:             sql.NullString{String: "Title", Valid: true},
+			Published:         sql.NullTime{Time: time.Now(), Valid: true},
+			Timezone:          sql.NullString{String: time.Local.String(), Valid: true},
+			Writing:           sql.NullString{String: "", Valid: true},
+			Abstract:          sql.NullString{String: "", Valid: true},
+			Private:           sql.NullBool{Bool: false, Valid: true},
+			DeletedAt:         sql.NullTime{},
+			LastIndex:         sql.NullTime{},
+			Username:          sql.NullString{String: "user", Valid: true},
+			Comments:          0,
+		}},
+	}
 
 	req := httptest.NewRequest("GET", "/admin/user/1/writings", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
 	cd.SetCurrentProfileUserID(1)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -47,9 +75,6 @@ func TestAdminUserWritingsPage(t *testing.T) {
 
 	adminUserWritingsPage(rr, req)
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
 	if rr.Result().StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", rr.Result().StatusCode)
 	}

--- a/handlers/admin/admin_email_template_test.go
+++ b/handlers/admin/admin_email_template_test.go
@@ -3,24 +3,100 @@ package admin
 import (
 	"context"
 	"database/sql"
-	"github.com/arran4/goa4web/core/consts"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/mail"
 	"os"
-	"regexp"
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
 	logProv "github.com/arran4/goa4web/internal/email/log"
 	notif "github.com/arran4/goa4web/internal/notifications"
 )
+
+type emailTemplateQueries struct {
+	db.Querier
+	userID            int32
+	user              *db.SystemGetUserByIDRow
+	templateOverrides map[string]string
+	pendingEmails     []db.InsertPendingEmailParams
+}
+
+func (q *emailTemplateQueries) SystemGetUserByID(_ context.Context, id int32) (*db.SystemGetUserByIDRow, error) {
+	if id != q.userID {
+		return nil, fmt.Errorf("unexpected user id: %d", id)
+	}
+	return q.user, nil
+}
+
+func (q *emailTemplateQueries) SystemGetTemplateOverride(_ context.Context, name string) (string, error) {
+	body, ok := q.templateOverrides[name]
+	if !ok {
+		return "", sql.ErrNoRows
+	}
+	return body, nil
+}
+
+func (q *emailTemplateQueries) InsertPendingEmail(_ context.Context, arg db.InsertPendingEmailParams) error {
+	q.pendingEmails = append(q.pendingEmails, arg)
+	return nil
+}
+
+type pendingEmailQueries struct {
+	db.Querier
+	rows []*db.AdminListUnsentPendingEmailsRow
+}
+
+func (q *pendingEmailQueries) AdminListUnsentPendingEmails(context.Context, db.AdminListUnsentPendingEmailsParams) ([]*db.AdminListUnsentPendingEmailsRow, error) {
+	return q.rows, nil
+}
+
+type recentNotificationsQueries struct {
+	db.Querier
+	limit         int32
+	notifications []*db.Notification
+}
+
+func (q *recentNotificationsQueries) AdminListRecentNotifications(_ context.Context, limit int32) ([]*db.Notification, error) {
+	if q.limit != 0 && limit != q.limit {
+		return nil, fmt.Errorf("unexpected limit: %d", limit)
+	}
+	return q.notifications, nil
+}
+
+type notifyAdminsQueries struct {
+	db.Querier
+	usersByEmail      map[string]*db.SystemGetUserByEmailRow
+	templateOverrides map[string]string
+	pendingEmails     []db.InsertPendingEmailParams
+}
+
+func (q *notifyAdminsQueries) SystemGetUserByEmail(_ context.Context, email string) (*db.SystemGetUserByEmailRow, error) {
+	if user, ok := q.usersByEmail[email]; ok {
+		return user, nil
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (q *notifyAdminsQueries) SystemGetTemplateOverride(_ context.Context, name string) (string, error) {
+	body, ok := q.templateOverrides[name]
+	if !ok {
+		return "", sql.ErrNoRows
+	}
+	return body, nil
+}
+
+func (q *notifyAdminsQueries) InsertPendingEmail(_ context.Context, arg db.InsertPendingEmailParams) error {
+	q.pendingEmails = append(q.pendingEmails, arg)
+	return nil
+}
 
 func newEmailReg() *email.Registry {
 	r := email.NewRegistry()
@@ -52,24 +128,23 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
 	cfg.EmailProvider = "log"
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	queries := &emailTemplateQueries{
+		userID: 1,
+		user: &db.SystemGetUserByIDRow{
+			Idusers:                1,
+			Email:                  sql.NullString{String: "u@example.com", Valid: true},
+			Username:               sql.NullString{String: "u", Valid: true},
+			PublicProfileEnabledAt: sql.NullTime{},
+		},
+		templateOverrides: map[string]string{
+			"updateEmail.gotxt": "",
+		},
 	}
-	defer conn.Close()
-	rows := sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "u@example.com", "u", nil)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
-		WithArgs(int32(1)).WillReturnRows(rows)
-	mock.ExpectQuery("SELECT body FROM template_overrides WHERE name = ?").
-		WithArgs("updateEmail.gotxt").WillReturnError(sql.ErrNoRows)
-	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 1, Valid: true}, sqlmock.AnyArg(), false).
-		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	req := httptest.NewRequest("POST", "/admin/email/template", nil)
-	q := db.New(conn)
 	reg := newEmailReg()
 	p, _ := reg.ProviderFromConfig(cfg)
-	cd := common.NewCoreData(req.Context(), q, cfg, common.WithEmailProvider(p))
+	cd := common.NewCoreData(req.Context(), queries, cfg, common.WithEmailProvider(p))
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -80,42 +155,44 @@ func TestAdminEmailTemplateTestAction_WithProvider(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d", rr.Code)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expect: %v", err)
+	if len(queries.pendingEmails) != 1 {
+		t.Fatalf("expected pending email, got %d", len(queries.pendingEmails))
+	}
+	if pending := queries.pendingEmails[0]; !pending.ToUserID.Valid || pending.ToUserID.Int32 != 1 || pending.Body == "" || pending.DirectEmail {
+		t.Fatalf("unexpected pending email: %#v", pending)
 	}
 }
 
 func TestAdminListUnsentPendingEmails(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &pendingEmailQueries{
+		rows: []*db.AdminListUnsentPendingEmailsRow{{
+			ID:          1,
+			ToUserID:    sql.NullInt32{Int32: 2, Valid: true},
+			Body:        "b",
+			ErrorCount:  0,
+			CreatedAt:   time.Now(),
+			DirectEmail: false,
+		}},
 	}
-	defer conn.Close()
-	q := db.New(conn)
-	rows := sqlmock.NewRows([]string{"id", "to_user_id", "body", "error_count", "created_at", "direct_email"}).AddRow(1, 2, "b", 0, time.Now(), false)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT pe.id, pe.to_user_id, pe.body, pe.error_count, pe.created_at, pe.direct_email FROM pending_emails pe LEFT JOIN preferences p ON pe.to_user_id = p.users_idusers LEFT JOIN user_roles ur ON pe.to_user_id = ur.users_idusers LEFT JOIN roles r ON ur.role_id = r.id WHERE pe.sent_at IS NULL   AND (? IS NULL OR p.language_id = ?)   AND (? IS NULL OR r.name = ?) ORDER BY pe.id")).WillReturnRows(rows)
 	if _, err := q.AdminListUnsentPendingEmails(context.Background(), db.AdminListUnsentPendingEmailsParams{}); err != nil {
 		t.Fatalf("list: %v", err)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expect: %v", err)
 	}
 }
 
 func TestRecentNotifications(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &recentNotificationsQueries{
+		limit: 5,
+		notifications: []*db.Notification{{
+			ID:           1,
+			UsersIdusers: 1,
+			Link:         sql.NullString{String: "/l", Valid: true},
+			Message:      sql.NullString{String: "m", Valid: true},
+			CreatedAt:    time.Now(),
+			ReadAt:       sql.NullTime{},
+		}},
 	}
-	defer conn.Close()
-	q := db.New(conn)
-	rows := sqlmock.NewRows([]string{"id", "users_idusers", "link", "message", "created_at", "read_at"}).AddRow(1, 1, "/l", "m", time.Now(), nil)
-	mock.ExpectQuery("SELECT id, users_idusers, link, message, created_at, read_at FROM notifications ORDER BY id DESC LIMIT ?").WithArgs(int32(5)).WillReturnRows(rows)
 	if _, err := q.AdminListRecentNotifications(context.Background(), 5); err != nil {
 		t.Fatalf("recent: %v", err)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expect: %v", err)
 	}
 }
 
@@ -135,40 +212,21 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	cfg.EmailEnabled = true
 	cfg.EmailFrom = "from@example.com"
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	var q db.Querier
-	emails := []string{"a@test.com", "b@test.com"}
-	for _, e := range emails {
-		mock.ExpectQuery("SystemGetUserByEmail").
-			WithArgs(sql.NullString{String: e, Valid: true}).
-			WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, e, "u"))
-		mock.ExpectExec("INSERT INTO pending_emails").
-			WithArgs(sql.NullInt32{Int32: 1, Valid: true}, sqlmock.AnyArg(), false).
-			WillReturnResult(sqlmock.NewResult(1, 1))
-	}
-
 	os.Setenv(config.EnvAdminEmails, "a@test.com,b@test.com")
 	defer os.Unsetenv(config.EnvAdminEmails)
 	cfg = config.NewRuntimeConfig()
 	origEmails := cfg.AdminEmails
 	cfg.AdminEmails = "a@test.com,b@test.com"
 	defer func() { cfg.AdminEmails = origEmails }()
-	conn, mock, err = sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &notifyAdminsQueries{
+		usersByEmail: map[string]*db.SystemGetUserByEmailRow{
+			"a@test.com": {Idusers: 1, Email: "a@test.com", Username: sql.NullString{String: "a", Valid: true}},
+			"b@test.com": {Idusers: 2, Email: "b@test.com", Username: sql.NullString{String: "b", Valid: true}},
+		},
+		templateOverrides: map[string]string{
+			"adminNotificationEmailSubject.gotxt": "",
+		},
 	}
-	defer conn.Close()
-	q = db.New(conn)
-	rows := sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "a@test.com", "a")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username FROM users u JOIN user_emails ue ON ue.user_id = u.idusers WHERE ue.email = ? LIMIT 1")).WithArgs("a@test.com").WillReturnRows(rows)
-	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 1, Valid: true}, sqlmock.AnyArg(), false).WillReturnResult(sqlmock.NewResult(1, 1))
-	rows2 := sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(2, "b@test.com", "b")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username FROM users u JOIN user_emails ue ON ue.user_id = u.idusers WHERE ue.email = ? LIMIT 1")).WithArgs("b@test.com").WillReturnRows(rows2)
-	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 2, Valid: true}, sqlmock.AnyArg(), false).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	rec := &recordAdminMail{}
 	n := notif.New(notif.WithQueries(q), notif.WithEmailProvider(rec), notif.WithConfig(cfg))
@@ -176,8 +234,13 @@ func TestNotifyAdminsEnv(t *testing.T) {
 	if len(rec.to) != 0 {
 		t.Fatalf("expected 0 direct mails, got %d", len(rec.to))
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expect: %v", err)
+	if len(q.pendingEmails) != 2 {
+		t.Fatalf("expected 2 pending emails, got %d", len(q.pendingEmails))
+	}
+	for _, pending := range q.pendingEmails {
+		if pending.Body == "" || pending.DirectEmail {
+			t.Fatalf("unexpected pending email: %#v", pending)
+		}
 	}
 }
 

--- a/handlers/admin/global_grant_create_task_test.go
+++ b/handlers/admin/global_grant_create_task_test.go
@@ -7,22 +7,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
-
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/db"
 )
 
+type globalGrantQueries struct{ db.Querier }
+
 // TestGlobalGrantCreateTask_ItemIDRequired verifies missing item_id errors.
 func TestGlobalGrantCreateTask_ItemIDRequired(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-
 	body := url.Values{
 		"section": {"forum"},
 		"item":    {"topic"},
@@ -31,7 +25,7 @@ func TestGlobalGrantCreateTask_ItemIDRequired(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/grant", strings.NewReader(body.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	cd := common.NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), &globalGrantQueries{}, config.NewRuntimeConfig())
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
@@ -40,8 +34,5 @@ func TestGlobalGrantCreateTask_ItemIDRequired(t *testing.T) {
 		t.Fatalf("expected error, got nil")
 	} else if err, ok := res.(error); !ok || err == nil {
 		t.Fatalf("expected error, got %v", res)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
 	}
 }

--- a/handlers/admin/user_grants_build_test.go
+++ b/handlers/admin/user_grants_build_test.go
@@ -2,33 +2,35 @@ package admin
 
 import (
 	"context"
-	"regexp"
+	"database/sql"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 )
 
+type userGrantGroupQueries struct {
+	db.Querier
+	grants []*db.Grant
+}
+
+func (q *userGrantGroupQueries) ListGrantsByUserID(context.Context, sql.NullInt32) ([]*db.Grant, error) {
+	return q.grants, nil
+}
+
+func (q *userGrantGroupQueries) GetAllForumCategories(context.Context, db.GetAllForumCategoriesParams) ([]*db.Forumcategory, error) {
+	return []*db.Forumcategory{}, nil
+}
+
+func (q *userGrantGroupQueries) SystemListLanguages(context.Context) ([]*db.Language, error) {
+	return []*db.Language{}, nil
+}
+
 // TestBuildUserGrantGroupsIncludesAvailableActionsWithoutGrants ensures groups exist when user has no grants.
 func TestBuildUserGrantGroupsIncludesAvailableActionsWithoutGrants(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := &userGrantGroupQueries{}
 	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
-
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, updated_at, user_id, role_id, section, item, rule_type, item_id, item_rule, action, extra, active FROM grants WHERE user_id = ? ORDER BY id\n")).
-		WithArgs(sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "user_id", "role_id", "section", "item", "rule_type", "item_id", "item_rule", "action", "extra", "active"}))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT f.idforumcategory, f.forumcategory_idforumcategory, f.language_id, f.title, f.description\nFROM forumcategory f\nWHERE (\nf.language_id = 0\nOR f.language_id IS NULL\nOR EXISTS (\nSELECT 1 FROM user_language ul\nWHERE ul.users_idusers = ?\nAND ul.language_id = f.language_id\n)\nOR NOT EXISTS (\nSELECT 1 FROM user_language ul WHERE ul.users_idusers = ?\n)\n)\n")).
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof\nFROM language\n")).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "nameof"}))
 
 	groups, err := buildGrantGroupsForUser(context.Background(), cd, 1)
 	if err != nil {
@@ -42,8 +44,5 @@ func TestBuildUserGrantGroupsIncludesAvailableActionsWithoutGrants(t *testing.T)
 	}
 	if len(groups) != expected {
 		t.Fatalf("expected %d groups, got %d", expected, len(groups))
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
 	}
 }

--- a/handlers/admin/user_subscription_tasks_test.go
+++ b/handlers/admin/user_subscription_tasks_test.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"context"
-	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -10,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
@@ -19,13 +17,30 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 )
 
-func setupSubscriptionTaskTest(t *testing.T, userID int, body url.Values) (*httptest.ResponseRecorder, *http.Request, *sql.DB, sqlmock.Sqlmock) {
+type subscriptionQueries struct {
+	db.Querier
+	inserted []db.InsertSubscriptionParams
+	updated  []db.UpdateSubscriptionByIDForSubscriberParams
+	deleted  []db.DeleteSubscriptionByIDForSubscriberParams
+}
+
+func (q *subscriptionQueries) InsertSubscription(_ context.Context, arg db.InsertSubscriptionParams) error {
+	q.inserted = append(q.inserted, arg)
+	return nil
+}
+
+func (q *subscriptionQueries) UpdateSubscriptionByIDForSubscriber(_ context.Context, arg db.UpdateSubscriptionByIDForSubscriberParams) error {
+	q.updated = append(q.updated, arg)
+	return nil
+}
+
+func (q *subscriptionQueries) DeleteSubscriptionByIDForSubscriber(_ context.Context, arg db.DeleteSubscriptionByIDForSubscriberParams) error {
+	q.deleted = append(q.deleted, arg)
+	return nil
+}
+
+func setupSubscriptionTaskTest(t *testing.T, userID int, body url.Values, queries db.Querier) (*httptest.ResponseRecorder, *http.Request) {
 	t.Helper()
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	mock.MatchExpectationsInOrder(false)
 	var reader *strings.Reader
 	if body != nil {
 		reader = strings.NewReader(body.Encode())
@@ -38,48 +53,53 @@ func setupSubscriptionTaskTest(t *testing.T, userID int, body url.Values) (*http
 	}
 	req = mux.SetURLVars(req, map[string]string{"user": strconv.Itoa(userID)})
 	cfg := config.NewRuntimeConfig()
-	q := db.New(conn)
-	cd := common.NewCoreData(req.Context(), q, cfg)
+	cd := common.NewCoreData(req.Context(), queries, cfg)
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
-	return httptest.NewRecorder(), req, conn, mock
+	return httptest.NewRecorder(), req
 }
 
 func TestAddUserSubscriptionTask_UsesURLParam(t *testing.T) {
 	body := url.Values{"pattern": {"/foo"}, "method": {"internal"}}
-	rr, req, conn, mock := setupSubscriptionTaskTest(t, 9, body)
-	defer conn.Close()
-	mock.ExpectExec("INSERT").WithArgs(int32(9), "/foo", "internal").WillReturnResult(sqlmock.NewResult(0, 1))
+	queries := &subscriptionQueries{}
+	rr, req := setupSubscriptionTaskTest(t, 9, body, queries)
 	if err, ok := addUserSubscriptionTask.Action(rr, req).(error); ok && err != nil {
 		t.Fatalf("Action: %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expect: %v", err)
+	if len(queries.inserted) != 1 {
+		t.Fatalf("expected insert, got %d", len(queries.inserted))
+	}
+	if arg := queries.inserted[0]; arg.UsersIdusers != 9 || arg.Pattern != "/foo" || arg.Method != "internal" {
+		t.Fatalf("unexpected insert args: %#v", arg)
 	}
 }
 
 func TestUpdateUserSubscriptionTask_UsesURLParam(t *testing.T) {
 	body := url.Values{"id": {"3"}, "pattern": {"/bar"}, "method": {"email"}}
-	rr, req, conn, mock := setupSubscriptionTaskTest(t, 4, body)
-	defer conn.Close()
-	mock.ExpectExec("UPDATE").WithArgs("/bar", "email", int32(4), int32(3)).WillReturnResult(sqlmock.NewResult(0, 1))
+	queries := &subscriptionQueries{}
+	rr, req := setupSubscriptionTaskTest(t, 4, body, queries)
 	if err, ok := updateUserSubscriptionTask.Action(rr, req).(error); ok && err != nil {
 		t.Fatalf("Action: %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expect: %v", err)
+	if len(queries.updated) != 1 {
+		t.Fatalf("expected update, got %d", len(queries.updated))
+	}
+	if arg := queries.updated[0]; arg.Pattern != "/bar" || arg.Method != "email" || arg.SubscriberID != 4 || arg.ID != 3 {
+		t.Fatalf("unexpected update args: %#v", arg)
 	}
 }
 
 func TestDeleteUserSubscriptionTask_UsesURLParam(t *testing.T) {
 	body := url.Values{"id": {"5"}}
-	rr, req, conn, mock := setupSubscriptionTaskTest(t, 11, body)
-	defer conn.Close()
-	mock.ExpectExec("DELETE").WithArgs(int32(11), int32(5)).WillReturnResult(sqlmock.NewResult(0, 1))
+	queries := &subscriptionQueries{}
+	rr, req := setupSubscriptionTaskTest(t, 11, body, queries)
 	if err, ok := deleteUserSubscriptionTask.Action(rr, req).(error); ok && err != nil {
 		t.Fatalf("Action: %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expect: %v", err)
+	if len(queries.deleted) != 1 {
+		t.Fatalf("expected delete, got %d", len(queries.deleted))
+	}
+	if arg := queries.deleted[0]; arg.SubscriberID != 11 || arg.ID != 5 {
+		t.Fatalf("unexpected delete args: %#v", arg)
 	}
 }

--- a/handlers/languages/delete_language_task_test.go
+++ b/handlers/languages/delete_language_task_test.go
@@ -2,13 +2,12 @@ package languages
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"net/http/httptest"
 	"net/url"
-	"regexp"
 	"strings"
 	"testing"
-
-	"github.com/DATA-DOG/go-sqlmock"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
@@ -16,13 +15,28 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 )
 
-func TestDeleteLanguageTask_PreventDeletion(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock: %v", err)
+type deleteLanguageQueries struct {
+	db.Querier
+	languages   []*db.Language
+	usageCounts *db.AdminLanguageUsageCountsRow
+}
+
+func (q *deleteLanguageQueries) SystemListLanguages(context.Context) ([]*db.Language, error) {
+	return q.languages, nil
+}
+
+func (q *deleteLanguageQueries) AdminLanguageUsageCounts(ctx context.Context, arg db.AdminLanguageUsageCountsParams) (*db.AdminLanguageUsageCountsRow, error) {
+	if arg.LangID.Int32 != 1 {
+		return nil, fmt.Errorf("unexpected language id: %v", arg.LangID.Int32)
 	}
-	defer dbMock.Close()
-	queries := db.New(dbMock)
+	return q.usageCounts, nil
+}
+
+func TestDeleteLanguageTask_PreventDeletion(t *testing.T) {
+	queries := &deleteLanguageQueries{
+		languages:   []*db.Language{{ID: 1, Nameof: sql.NullString{String: "en", Valid: true}}},
+		usageCounts: &db.AdminLanguageUsageCountsRow{Comments: 1},
+	}
 
 	form := url.Values{}
 	form.Set("cid", "1")
@@ -36,21 +50,11 @@ func TestDeleteLanguageTask_PreventDeletion(t *testing.T) {
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 
-	langRows := sqlmock.NewRows([]string{"id", "nameof"}).AddRow(1, "en")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof\nFROM language")).WillReturnRows(langRows)
-
-	countRows := sqlmock.NewRows([]string{"comments", "writings", "blogs", "news", "links"}).AddRow(1, 0, 0, 0, 0)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT\n    (SELECT COUNT(*) FROM comments WHERE comments.language_id = ?) AS comments,\n    (SELECT COUNT(*) FROM writing WHERE writing.language_id = ?) AS writings,\n    (SELECT COUNT(*) FROM blogs WHERE blogs.language_id = ?) AS blogs,\n    (SELECT COUNT(*) FROM site_news WHERE site_news.language_id = ?) AS news,\n    (SELECT COUNT(*) FROM linker WHERE linker.language_id = ?) AS links")).WithArgs(int32(1), int32(1), int32(1), int32(1), int32(1)).WillReturnRows(countRows)
-
 	result := deleteLanguageTask.Action(rr, req)
 	if result == nil {
 		t.Fatalf("expected error, got nil")
 	}
 	if _, ok := result.(error); !ok {
 		t.Fatalf("expected error result, got %T", result)
-	}
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
 	}
 }

--- a/handlers/languages/rename_language_task_test.go
+++ b/handlers/languages/rename_language_task_test.go
@@ -2,13 +2,12 @@ package languages
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"net/http/httptest"
 	"net/url"
-	"regexp"
 	"strings"
 	"testing"
-
-	"github.com/DATA-DOG/go-sqlmock"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
@@ -16,13 +15,32 @@ import (
 	"github.com/arran4/goa4web/internal/db"
 )
 
-func TestRenameLanguageTask_Action(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock: %v", err)
+type renameLanguageQueries struct {
+	db.Querier
+	languages  []*db.Language
+	renameArgs []db.AdminRenameLanguageParams
+}
+
+func (q *renameLanguageQueries) SystemListLanguages(context.Context) ([]*db.Language, error) {
+	return q.languages, nil
+}
+
+func (q *renameLanguageQueries) SystemGetLanguageIDByName(_ context.Context, name sql.NullString) (int32, error) {
+	if name.String != "en" {
+		return 0, fmt.Errorf("unexpected old name: %q", name.String)
 	}
-	defer dbMock.Close()
-	queries := db.New(dbMock)
+	return 1, nil
+}
+
+func (q *renameLanguageQueries) AdminRenameLanguage(_ context.Context, arg db.AdminRenameLanguageParams) error {
+	q.renameArgs = append(q.renameArgs, arg)
+	return nil
+}
+
+func TestRenameLanguageTask_Action(t *testing.T) {
+	queries := &renameLanguageQueries{
+		languages: []*db.Language{{ID: 1, Nameof: sql.NullString{String: "en", Valid: true}}},
+	}
 
 	form := url.Values{}
 	form.Set("cid", "1")
@@ -37,20 +55,14 @@ func TestRenameLanguageTask_Action(t *testing.T) {
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 
-	langRows := sqlmock.NewRows([]string{"id", "nameof"}).AddRow(1, "en")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof\nFROM language")).WillReturnRows(langRows)
-
-	idRow := sqlmock.NewRows([]string{"id"}).AddRow(1)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM language WHERE nameof = ?")).WithArgs("en").WillReturnRows(idRow)
-
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE language\nSET nameof = ?\nWHERE id = ?")).WithArgs("fr", int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
-
 	result := renameLanguageTask.Action(rr, req)
 	if result != nil {
 		t.Fatalf("expected nil, got %v", result)
 	}
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(queries.renameArgs) != 1 {
+		t.Fatalf("expected rename call, got %d", len(queries.renameArgs))
+	}
+	if arg := queries.renameArgs[0]; arg.ID != 1 || arg.Nameof.String != "fr" {
+		t.Fatalf("unexpected rename args: %#v", arg)
 	}
 }

--- a/handlers/user/addEmailTask_invalid_test.go
+++ b/handlers/user/addEmailTask_invalid_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/sessions"
 
 	"github.com/arran4/goa4web/config"
@@ -20,13 +19,10 @@ import (
 	"github.com/arran4/goa4web/internal/eventbus"
 )
 
+type addEmailInvalidQueries struct{ db.Querier }
+
 func TestAddEmailTaskInvalid(t *testing.T) {
-	conn, _, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := &addEmailInvalidQueries{}
 
 	store := sessions.NewCookieStore([]byte("test"))
 	core.Store = store

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -2,6 +2,8 @@ package user
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -9,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
@@ -20,6 +21,34 @@ import (
 	"github.com/arran4/goa4web/internal/notifications"
 	"github.com/gorilla/mux"
 )
+
+type permissionQueries struct {
+	db.Querier
+	userID     int32
+	user       *db.SystemGetUserByIDRow
+	username   string
+	userByName *db.SystemGetUserByUsernameRow
+	created    []db.SystemCreateUserRoleParams
+}
+
+func (q *permissionQueries) SystemGetUserByID(_ context.Context, id int32) (*db.SystemGetUserByIDRow, error) {
+	if id != q.userID {
+		return nil, fmt.Errorf("unexpected user id: %d", id)
+	}
+	return q.user, nil
+}
+
+func (q *permissionQueries) SystemGetUserByUsername(_ context.Context, username sql.NullString) (*db.SystemGetUserByUsernameRow, error) {
+	if username.String != q.username {
+		return nil, fmt.Errorf("unexpected username: %s", username.String)
+	}
+	return q.userByName, nil
+}
+
+func (q *permissionQueries) SystemCreateUserRole(_ context.Context, arg db.SystemCreateUserRoleParams) error {
+	q.created = append(q.created, arg)
+	return nil
+}
 
 func TestPermissionUserTasksTemplates(t *testing.T) {
 	admins := []notifications.AdminEmailTemplateProvider{
@@ -41,22 +70,17 @@ func TestPermissionUserTasksTemplates(t *testing.T) {
 func TestPermissionUserAllowEventData(t *testing.T) {
 	bus := eventbus.NewBus()
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	queries := &permissionQueries{
+		userID:   2,
+		username: "bob",
+		user: &db.SystemGetUserByIDRow{
+			Idusers:                2,
+			Email:                  sql.NullString{String: "bob@test", Valid: true},
+			Username:               sql.NullString{String: "bob", Valid: true},
+			PublicProfileEnabledAt: sql.NullTime{},
+		},
+		userByName: &db.SystemGetUserByUsernameRow{Idusers: 2, Username: sql.NullString{String: "bob", Valid: true}},
 	}
-	defer conn.Close()
-	queries := db.New(conn)
-
-	mock.ExpectQuery("FROM users").
-		WithArgs(int32(2)).
-		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(2, "bob@test", "bob", nil))
-	mock.ExpectQuery("FROM users").
-		WithArgs(sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"idusers", "username", "public_profile_enabled_at"}).AddRow(2, "bob", nil))
-	mock.ExpectExec("INSERT INTO user_roles").
-		WithArgs(int32(2), "moderator").
-		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	ch := bus.Subscribe(eventbus.TaskMessageType)
 
@@ -67,7 +91,7 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 	req := httptest.NewRequest("POST", "/admin/user/2/permissions", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req = mux.SetURLVars(req, map[string]string{"user": "2"})
-	cd := common.NewCoreData(req.Context(), queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
 	cd.LoadSelectionsFromRequest(req)
 	evt := &eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}
 	cd.SetEvent(evt)
@@ -90,8 +114,10 @@ func TestPermissionUserAllowEventData(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("no event")
 	}
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(queries.created) != 1 {
+		t.Fatalf("expected create user role, got %d", len(queries.created))
+	}
+	if arg := queries.created[0]; arg.UsersIdusers != 2 || arg.Name != "moderator" {
+		t.Fatalf("unexpected user role: %#v", arg)
 	}
 }

--- a/handlers/user/user_test.go
+++ b/handlers/user/user_test.go
@@ -3,26 +3,23 @@ package user
 import (
 	"context"
 	"database/sql"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"regexp"
 	"strings"
 	"testing"
+	"time"
 
-	"github.com/arran4/goa4web/handlers"
-
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/sessions"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/email"
 	logProv "github.com/arran4/goa4web/internal/email/log"
-	"time"
 )
 
 func newEmailReg() *email.Registry {
@@ -51,19 +48,95 @@ func newRequestWithSession(method, target string, values map[string]interface{})
 	return r, httptest.NewRecorder()
 }
 
+type testMailQueries struct {
+	db.Querier
+	user *db.SystemGetUserByIDRow
+}
+
+func (q *testMailQueries) SystemGetUserByID(context.Context, int32) (*db.SystemGetUserByIDRow, error) {
+	return q.user, nil
+}
+
+type userEmailPageQueries struct {
+	db.Querier
+	user    *db.SystemGetUserByIDRow
+	pref    *db.Preference
+	prefErr error
+	emails  []*db.UserEmail
+}
+
+func (q *userEmailPageQueries) SystemGetUserByID(context.Context, int32) (*db.SystemGetUserByIDRow, error) {
+	return q.user, nil
+}
+
+func (q *userEmailPageQueries) GetPreferenceForLister(context.Context, int32) (*db.Preference, error) {
+	if q.prefErr != nil {
+		return nil, q.prefErr
+	}
+	return q.pref, nil
+}
+
+func (q *userEmailPageQueries) ListUserEmailsForLister(context.Context, db.ListUserEmailsForListerParams) ([]*db.UserEmail, error) {
+	return q.emails, nil
+}
+
+type languageSaveQueries struct {
+	db.Querier
+	languages     []*db.Language
+	deleted       bool
+	insertedLangs []db.InsertUserLangParams
+	pref          *db.Preference
+	prefErr       error
+	insertedPrefs []db.InsertPreferenceForListerParams
+	updatedPrefs  []db.UpdatePreferenceForListerParams
+}
+
+func (q *languageSaveQueries) DeleteUserLanguagesForUser(context.Context, int32) error {
+	q.deleted = true
+	return nil
+}
+
+func (q *languageSaveQueries) SystemListLanguages(context.Context) ([]*db.Language, error) {
+	return q.languages, nil
+}
+
+func (q *languageSaveQueries) InsertUserLang(_ context.Context, arg db.InsertUserLangParams) error {
+	q.insertedLangs = append(q.insertedLangs, arg)
+	return nil
+}
+
+func (q *languageSaveQueries) GetPreferenceForLister(context.Context, int32) (*db.Preference, error) {
+	if q.prefErr != nil {
+		return nil, q.prefErr
+	}
+	return q.pref, nil
+}
+
+func (q *languageSaveQueries) InsertPreferenceForLister(_ context.Context, arg db.InsertPreferenceForListerParams) error {
+	q.insertedPrefs = append(q.insertedPrefs, arg)
+	return nil
+}
+
+func (q *languageSaveQueries) UpdatePreferenceForLister(_ context.Context, arg db.UpdatePreferenceForListerParams) error {
+	q.updatedPrefs = append(q.updatedPrefs, arg)
+	return nil
+}
+
 func TestUserEmailTestAction_NoProvider(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
 	cfg.EmailProvider = ""
-	conn, mock, _ := sqlmock.New()
-	defer conn.Close()
-	queries := db.New(conn)
-	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
-	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
+	queries := &testMailQueries{
+		user: &db.SystemGetUserByIDRow{
+			Idusers:  1,
+			Email:    sql.NullString{String: "e", Valid: true},
+			Username: sql.NullString{String: "u", Valid: true},
+		},
+	}
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := req.Context()
 	reg := newEmailReg()
 	p, _ := reg.ProviderFromConfig(cfg)
-	cd := common.NewCoreData(ctx, queries, cfg, common.WithEmailProvider(p))
+	cd := common.NewCoreData(ctx, queries, cfg, common.WithEmailProvider(p), common.WithUserRoles([]string{}))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -88,16 +161,18 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
 	cfg.EmailProvider = "log"
 
-	conn, mock, _ := sqlmock.New()
-	defer conn.Close()
-	queries := db.New(conn)
-	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
-	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
+	queries := &testMailQueries{
+		user: &db.SystemGetUserByIDRow{
+			Idusers:  1,
+			Email:    sql.NullString{String: "e", Valid: true},
+			Username: sql.NullString{String: "u", Valid: true},
+		},
+	}
 	req := httptest.NewRequest("POST", "/email", nil)
 	ctx := req.Context()
 	reg := newEmailReg()
 	p, _ := reg.ProviderFromConfig(cfg)
-	cd := common.NewCoreData(ctx, queries, cfg, common.WithEmailProvider(p))
+	cd := common.NewCoreData(ctx, queries, cfg, common.WithEmailProvider(p), common.WithUserRoles([]string{}))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -111,14 +186,18 @@ func TestUserEmailTestAction_WithProvider(t *testing.T) {
 }
 
 func TestUserEmailPage_ShowError(t *testing.T) {
-	conn, mock, _ := sqlmock.New()
-	defer conn.Close()
-	queries := db.New(conn)
-	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
-	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", nil, nil, nil, 100))
+	queries := &userEmailPageQueries{
+		user: &db.SystemGetUserByIDRow{
+			Idusers:  1,
+			Email:    sql.NullString{String: "e", Valid: true},
+			Username: sql.NullString{String: "u", Valid: true},
+		},
+		prefErr: sql.ErrNoRows,
+		emails:  []*db.UserEmail{{ID: 1, UserID: 1, Email: "e"}},
+	}
 	req := httptest.NewRequest("GET", "/usr/email?error=missing", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{}))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -135,15 +214,24 @@ func TestUserEmailPage_ShowError(t *testing.T) {
 }
 
 func TestUserEmailPage_NoUnverified(t *testing.T) {
-	conn, mock, _ := sqlmock.New()
-	defer conn.Close()
-	queries := db.New(conn)
-	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
-	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}).AddRow(1, 1, "e", time.Now(), nil, nil, 100))
+	queries := &userEmailPageQueries{
+		user: &db.SystemGetUserByIDRow{
+			Idusers:  1,
+			Email:    sql.NullString{String: "e", Valid: true},
+			Username: sql.NullString{String: "u", Valid: true},
+		},
+		prefErr: sql.ErrNoRows,
+		emails: []*db.UserEmail{{
+			ID:         1,
+			UserID:     1,
+			Email:      "e",
+			VerifiedAt: sql.NullTime{Time: time.Now(), Valid: true},
+		}},
+	}
 
 	req := httptest.NewRequest("GET", "/usr/email", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{}))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -161,15 +249,19 @@ func TestUserEmailPage_NoUnverified(t *testing.T) {
 }
 
 func TestUserEmailPage_NoVerified(t *testing.T) {
-	conn, mock, _ := sqlmock.New()
-	defer conn.Close()
-	queries := db.New(conn)
-	mock.ExpectQuery("SELECT u.idusers, ue.email, u.username").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(1, "e", "u", nil))
-	mock.ExpectQuery("SELECT id, user_id, email").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "email", "verified_at", "last_verification_code", "verification_expires_at", "notification_priority"}))
+	queries := &userEmailPageQueries{
+		user: &db.SystemGetUserByIDRow{
+			Idusers:  1,
+			Email:    sql.NullString{String: "e", Valid: true},
+			Username: sql.NullString{String: "u", Valid: true},
+		},
+		prefErr: sql.ErrNoRows,
+		emails:  []*db.UserEmail{},
+	}
 
 	req := httptest.NewRequest("GET", "/usr/email", nil)
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithUserRoles([]string{}))
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -187,13 +279,13 @@ func TestUserEmailPage_NoVerified(t *testing.T) {
 }
 
 func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	queries := &languageSaveQueries{
+		languages: []*db.Language{
+			{ID: 1, Nameof: sql.NullString{String: "en", Valid: true}},
+			{ID: 2, Nameof: sql.NullString{String: "fr", Valid: true}},
+		},
+		prefErr: sql.ErrNoRows,
 	}
-	defer conn.Close()
-
-	queries := db.New(conn)
 	store = sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = sessionName
@@ -224,31 +316,31 @@ func TestUserLangSaveAllActionPage_NewPref(t *testing.T) {
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
-	rows := sqlmock.NewRows([]string{"id", "nameof"}).AddRow(1, "en").AddRow(2, "fr")
-	mock.ExpectExec("DELETE FROM user_language").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof\nFROM language")).WillReturnRows(rows)
-	mock.ExpectExec("INSERT INTO user_language").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectQuery("SELECT idpreferences").WithArgs(int32(1)).WillReturnError(sql.ErrNoRows)
-	mock.ExpectExec("INSERT INTO preferences").WithArgs(int32(2), int32(1), int32(cfg.PageSizeDefault), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	saveAllTask.Action(rr, req)
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
 	if rr.Result().StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+	if !queries.deleted {
+		t.Fatal("expected user languages to be deleted")
+	}
+	if len(queries.insertedLangs) != 1 || queries.insertedLangs[0].LanguageID != 1 {
+		t.Fatalf("unexpected inserted languages: %#v", queries.insertedLangs)
+	}
+	if len(queries.insertedPrefs) != 1 {
+		t.Fatalf("unexpected preference inserts: %#v", queries.insertedPrefs)
+	}
+	insertedPref := queries.insertedPrefs[0]
+	if insertedPref.ListerID != 1 || insertedPref.LanguageID.Int32 != 2 || insertedPref.PageSize != int32(cfg.PageSizeDefault) {
+		t.Fatalf("unexpected preference insert: %#v", insertedPref)
 	}
 }
 
 func TestUserLangSaveLanguagesActionPage(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	queries := &languageSaveQueries{
+		languages: []*db.Language{{ID: 1, Nameof: sql.NullString{String: "en", Valid: true}}},
 	}
-	defer conn.Close()
-
-	queries := db.New(conn)
 	store = sessions.NewCookieStore([]byte("test"))
 
 	form := url.Values{}
@@ -273,29 +365,31 @@ func TestUserLangSaveLanguagesActionPage(t *testing.T) {
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
-	rows := sqlmock.NewRows([]string{"id", "nameof"}).AddRow(1, "en")
-	mock.ExpectExec("DELETE FROM user_language").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, nameof\nFROM language")).WillReturnRows(rows)
-	mock.ExpectExec("INSERT INTO user_language").WithArgs(int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
-
 	saveLanguagesTask.Action(rr, req)
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
 	if rr.Result().StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+	if !queries.deleted {
+		t.Fatal("expected user languages to be deleted")
+	}
+	if len(queries.insertedLangs) != 1 || queries.insertedLangs[0].LanguageID != 1 {
+		t.Fatalf("unexpected inserted languages: %#v", queries.insertedLangs)
 	}
 }
 
 func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	queries := &languageSaveQueries{
+		pref: &db.Preference{
+			Idpreferences:        1,
+			LanguageID:           sql.NullInt32{Int32: 1, Valid: true},
+			UsersIdusers:         1,
+			Emailforumupdates:    sql.NullBool{},
+			PageSize:             int32(15),
+			AutoSubscribeReplies: true,
+			Timezone:             sql.NullString{},
+		},
 	}
-	defer conn.Close()
-
-	queries := db.New(conn)
 	store = sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = sessionName
@@ -324,17 +418,16 @@ func TestUserLangSaveLanguageActionPage_UpdatePref(t *testing.T) {
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
-	prefRows := sqlmock.NewRows([]string{"idpreferences", "language_id", "users_idusers", "emailforumupdates", "page_size", "auto_subscribe_replies", "timezone"}).
-		AddRow(1, 1, 1, nil, cfg.PageSizeDefault, true, nil)
-	mock.ExpectQuery("SELECT idpreferences").WithArgs(int32(1)).WillReturnRows(prefRows)
-	mock.ExpectExec("UPDATE preferences").WithArgs(int32(2), int32(cfg.PageSizeDefault), sqlmock.AnyArg(), int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
-
 	saveLanguageTask.Action(rr, req)
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
 	if rr.Result().StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+	if len(queries.updatedPrefs) != 1 {
+		t.Fatalf("unexpected preference updates: %#v", queries.updatedPrefs)
+	}
+	updatedPref := queries.updatedPrefs[0]
+	if updatedPref.LanguageID.Int32 != 2 || updatedPref.ListerID != 1 {
+		t.Fatalf("unexpected preference update: %#v", updatedPref)
 	}
 }


### PR DESCRIPTION
### Motivation

- Reduce brittle SQL string/regex expectations in handler tests by verifying behavior via returned data and recorded calls.
- Replace a single large callback-based test querier with smaller, focused per-file stub structs that implement only the methods used by each test.
- Avoid global test helpers and keep test fixtures close to where they are used so tests are easier to read and maintain.

### Description

- Replaced `sqlmock`/callback-based shared `QuerierStub` usage with small receiver-based stub structs placed next to the tests in `handlers/admin`, `handlers/user` and `handlers/languages` that implement only the needed `db.Querier` methods and record arguments.
- Removed `internal/db/querier_stub.go` and added typedefs such as `commentTaskQueries`, `emailTemplateQueries`, `verifyEmailQueries`, `userWritingsQueries`, etc., which return controlled rows and capture insert/update/delete parameters.
- Seeded CoreData with user roles (via `common.WithUserRoles`) in admin/user tests to prevent template role lookups from panicking and fixed nullable field literal usage (`sql.Null*`) in fixtures.
- Kept test assertions focused on HTTP status/body and recorded model updates rather than SQL expectations, and made small formatting/type fixes discovered while updating tests.

### Testing

- Ran `go mod tidy` which completed successfully.
- Ran `go fmt ./...` which formatted updated files successfully.
- Ran the handler test suites `go test ./handlers/admin ./handlers/user` and they succeeded after the fixes.
- A full project `go test ./...` and `go vet ./...` remain blocked by an existing CLI build issue (`cmd/goa4web/role.go:69:40: c.args undefined`) and `golangci-lint run` could not run in this environment due to an unsupported local config version.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694541829bc4832fa0d6a2c1081f6214)