### PR TITLE
Fix forum topic delete task submit value

### DIFF
--- a/core/templates/site/forum/adminTopicEditPage.gohtml
+++ b/core/templates/site/forum/adminTopicEditPage.gohtml
@@ -16,6 +16,6 @@ Category: <select name="cid"><option value="0">None</option>{{ range .Categories
 <form method="post" action="/admin/forum/topics/topic/{{ .Topic.Idforumtopic }}/delete">
 {{ csrfField }}
 <label><input type="checkbox" name="cascade" value="true"> Cascade Delete</label>
-<input type="submit" name="task" value="Delete Topic">
+<input type="submit" name="task" value="Forum topic delete">
 </form>
 {{ template "tail" $ }}

--- a/handlers/forum/admin_topic_edit_template_test.go
+++ b/handlers/forum/admin_topic_edit_template_test.go
@@ -1,0 +1,49 @@
+package forum
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestAdminTopicEditTemplateDeleteTaskValue(t *testing.T) {
+	cd := common.NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
+	req := httptest.NewRequest("GET", "/admin/forum/topics/topic/12/edit", nil)
+
+	data := struct {
+		Topic       *db.GetForumTopicByIdForUserRow
+		Categories  []*db.Forumcategory
+		Roles       []*db.Role
+		Restriction any
+	}{
+		Topic: &db.GetForumTopicByIdForUserRow{
+			Idforumtopic:                 12,
+			Title:                        sql.NullString{String: "topic", Valid: true},
+			Description:                  sql.NullString{String: "desc", Valid: true},
+			ForumcategoryIdforumcategory: 1,
+		},
+		Categories: []*db.Forumcategory{{
+			Idforumcategory: 1,
+			Title:           sql.NullString{String: "category", Valid: true},
+		}},
+	}
+
+	var out bytes.Buffer
+	if err := cd.ExecuteSiteTemplate(&out, req, "forum/adminTopicEditPage.gohtml", data); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	body := out.String()
+	if !strings.Contains(body, "value=\"Forum topic delete\"") {
+		t.Fatalf("expected delete task value to match topic delete task, got: %s", body)
+	}
+	if strings.Contains(body, "value=\"Delete Topic\"") {
+		t.Fatalf("unexpected legacy delete task value in template")
+	}
+}


### PR DESCRIPTION
### Motivation

- Admin topic delete UI was submitting a legacy button value which did not match the task matcher and could cause the delete route to not be invoked (resulting in a 404). 
- The task matcher expects the task string `Forum topic delete` (see `TaskForumTopicDelete`) while the template used `Delete Topic`. 
- Aligning the template with the configured task string ensures form submissions are routed to the correct handler. 

### Description

- Update the admin topic edit template `core/templates/site/forum/adminTopicEditPage.gohtml` to set the delete submit input value to `Forum topic delete`.
- Add a template regression test `handlers/forum/admin_topic_edit_template_test.go` that renders the edit template using `cd.ExecuteSiteTemplate` and asserts the delete button value is the expected string and that the old legacy string is not present.
- Run formatting and module tidy steps as part of the change preparation (`go fmt` and `go mod tidy`).

### Testing

- Ran `go test ./...` which executed the test suite including the new `TestAdminTopicEditTemplateDeleteTaskValue` and succeeded.
- Attempted `go vet ./...` but it hung / was interrupted during the run.
- `golangci-lint run` failed due to an unsupported configuration version in the repository configuration file and did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947349fa6a0832f98bde56bd2938b93)