### PR TITLE
Fix 404 page showing internal error and guard notFound template

### DIFF
--- a/core/templates/site/notFoundPage.gohtml
+++ b/core/templates/site/notFoundPage.gohtml
@@ -3,7 +3,7 @@
 {{- if $.Error }}
 <p>{{ $.Error }}</p>
 {{- end }}
-{{- if $.NotFoundLink.URL }}
+{{- if $.NotFoundLink }}
 <p><a href="{{ $.NotFoundLink.URL }}">{{ $.NotFoundLink.Text }}</a></p>
 {{- end }}
 {{- if $.BackURL }}

--- a/handlers/errorpage.go
+++ b/handlers/errorpage.go
@@ -42,13 +42,17 @@ func RenderErrorPage(w http.ResponseWriter, r *http.Request, err error) {
 		cd.PageTitle = "Error"
 	}
 
+	errorMessage := err.Error()
+	if status == http.StatusNotFound {
+		errorMessage = ""
+	}
 	data := struct {
 		*common.CoreData
 		Error   string
 		BackURL string
 	}{
 		CoreData: cd,
-		Error:    err.Error(),
+		Error:    errorMessage,
 		BackURL:  r.Referer(),
 	}
 	w.WriteHeader(status)

--- a/handlers/errorpage_test.go
+++ b/handlers/errorpage_test.go
@@ -1,0 +1,53 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestRenderErrorPageNotFoundOmitsInternalError(t *testing.T) {
+	conn, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer conn.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/missing", nil)
+	cd := common.NewCoreData(req.Context(), db.New(conn), config.NewRuntimeConfig())
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	data := struct {
+		*common.CoreData
+		Error   string
+		BackURL string
+	}{
+		CoreData: cd,
+		Error:    "",
+		BackURL:  "",
+	}
+	rr := httptest.NewRecorder()
+	if err := cd.ExecuteSiteTemplate(rr, req, "notFoundPage.gohtml", data); err != nil {
+		t.Fatalf("ExecuteSiteTemplate: %v", err)
+	}
+	rr = httptest.NewRecorder()
+	RenderErrorPage(rr, req, WrapNotFound(errors.New("Internal Server Error")))
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d got %d", http.StatusNotFound, rr.Code)
+	}
+	if strings.Contains(rr.Body.String(), "Internal Server Error") {
+		t.Fatalf("expected 404 page to omit internal error message")
+	}
+}


### PR DESCRIPTION
### Motivation
- Prevent 404 pages from displaying sensitive or misleading internal error text when an underlying error wraps `Not Found`.
- Avoid a nil-pointer evaluation in the not-found template when no contextual `NotFoundLink` is set.
- Provide a regression test to ensure 404 rendering omits internal error messages going forward.

### Description
- Change `RenderErrorPage` to suppress the error message for `http.StatusNotFound` responses by passing an empty `Error` to templates for 404s.
- Update `core/templates/site/notFoundPage.gohtml` to check `$.NotFoundLink` is non-nil before accessing its fields.
- Add `handlers/errorpage_test.go` which exercises rendering a 404 response and asserts the internal error text is not exposed.

### Testing
- Ran `go mod tidy` successfully.
- Ran formatting and linters: `go fmt ./...` and `go vet ./...` completed without errors.
- Ran unit tests with `go test ./...` and all package tests passed after the fix.
- `golangci-lint run` was attempted but failed in this environment due to an unsupported configuration version (environment-specific issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694734a97374832fa1c7ac4d8240c946)