### PR TITLE
Refactor postcountworker tests to use stubbed querier

### DIFF
--- a/workers/postcountworker/postupdate.go
+++ b/workers/postcountworker/postupdate.go
@@ -3,13 +3,17 @@ package postcountworker
 import (
 	"context"
 	"fmt"
-
-	"github.com/arran4/goa4web/internal/db"
 )
+
+// PostUpdateQuerier defines the database operations needed to refresh post metadata.
+type PostUpdateQuerier interface {
+	AdminRecalculateForumThreadByIdMetaData(ctx context.Context, idforumthread int32) error
+	SystemRebuildForumTopicMetaByID(ctx context.Context, idforumtopic int32) error
+}
 
 // PostUpdate refreshes metadata on the given forum thread and topic.
 // It recalculates thread counters and rebuilds the topic aggregates.
-func PostUpdate(ctx context.Context, q db.Querier, threadID, topicID int32) error {
+func PostUpdate(ctx context.Context, q PostUpdateQuerier, threadID, topicID int32) error {
 	if err := q.AdminRecalculateForumThreadByIdMetaData(ctx, threadID); err != nil {
 		return fmt.Errorf("recalc thread metadata: %w", err)
 	}

--- a/workers/postcountworker/worker.go
+++ b/workers/postcountworker/worker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 
-	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 )
 
@@ -19,7 +18,7 @@ type UpdateEventData struct {
 }
 
 // Worker listens for post count events and updates the related metadata.
-func Worker(ctx context.Context, bus *eventbus.Bus, q db.Querier) {
+func Worker(ctx context.Context, bus *eventbus.Bus, q PostUpdateQuerier) {
 	if bus == nil || q == nil {
 		return
 	}


### PR DESCRIPTION
## Summary
- introduce a minimal PostUpdateQuerier interface and update the worker to consume it
- replace sqlmock usage in post count worker tests with a stub that records calls
- keep post count updates focused on the necessary database operations without regex matchers

## Testing
- go mod tidy
- gofmt -w workers/postcountworker/postupdate.go workers/postcountworker/postupdate_test.go workers/postcountworker/worker.go
- go vet ./...
- golangci-lint run ./...
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd056d780832f8a97797f3e6413d7)