### PR TITLE
Improve grant check stubs

### DIFF
--- a/handlers/blogs/blogsIndexPermissions_test.go
+++ b/handlers/blogs/blogsIndexPermissions_test.go
@@ -23,7 +23,9 @@ func TestCustomBlogIndexRoles(t *testing.T) {
 		t.Errorf("admin should see write blog")
 	}
 
-	cd = common.NewCoreData(req.Context(), &db.QuerierStub{}, config.NewRuntimeConfig(), common.WithUserRoles([]string{"content writer"}))
+	cd = common.NewCoreData(req.Context(), &db.QuerierStub{
+		SystemCheckGrantReturns: 1,
+	}, config.NewRuntimeConfig(), common.WithUserRoles([]string{"content writer"}))
 	BlogsMiddlewareIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "Blogs Admin") {
 		t.Errorf("content writer should not see blogs admin link")

--- a/handlers/matchers_test.go
+++ b/handlers/matchers_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestRequiredGrantAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/blogs/add", nil)
-	q := &db.QuerierStub{}
+	q := &db.QuerierStub{SystemCheckGrantReturns: 1}
 	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)

--- a/internal/db/querier_stub.go
+++ b/internal/db/querier_stub.go
@@ -106,10 +106,10 @@ func (s *QuerierStub) SystemCheckGrant(ctx context.Context, arg SystemCheckGrant
 	if err != nil {
 		return 0, err
 	}
-	if ret == 0 {
-		ret = 1
+	if ret != 0 {
+		return ret, nil
 	}
-	return ret, nil
+	return 0, sql.ErrNoRows
 }
 
 // SystemCheckRoleGrant records the call and returns the configured response.
@@ -126,10 +126,10 @@ func (s *QuerierStub) SystemCheckRoleGrant(ctx context.Context, arg SystemCheckR
 	if err != nil {
 		return 0, err
 	}
-	if ret == 0 {
-		ret = 1
+	if ret != 0 {
+		return ret, nil
 	}
-	return ret, nil
+	return 0, sql.ErrNoRows
 }
 
 // SystemGetUserByID records the call and returns the configured response.


### PR DESCRIPTION
## Summary
- adjust QuerierStub grant checks to default to denial unless a stubbed return or function is provided
- update handler tests to explicitly stub grant checks for allowed scenarios

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd07085bc832f8f22c2fde0ce7f81)