### PR TITLE
Add linker query stub and refactor handler tests

### DIFF
--- a/handlers/linker/linkerAdminLinkViewPage_test.go
+++ b/handlers/linker/linkerAdminLinkViewPage_test.go
@@ -2,28 +2,48 @@ package linker
 
 import (
 	"context"
+	"database/sql"
 	"net/http/httptest"
-	"regexp"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/internal/db"
 )
 
 func TestAdminLinkViewPage(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	queries := &db.QuerierStub{
+		GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow: &db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow{
+			ID:          1,
+			LanguageID:  sql.NullInt32{Int32: 1, Valid: true},
+			AuthorID:    2,
+			CategoryID:  sql.NullInt32{Int32: 1, Valid: true},
+			ThreadID:    0,
+			Title:       sql.NullString{String: "t", Valid: true},
+			Url:         sql.NullString{String: "http://u", Valid: true},
+			Description: sql.NullString{String: "d", Valid: true},
+			Listed:      sql.NullTime{Time: time.Unix(0, 0), Valid: true},
+			Username:    sql.NullString{String: "bob", Valid: true},
+			Title_2:     sql.NullString{String: "cat", Valid: true},
+		},
 	}
-	defer conn.Close()
-
-	queries := db.New(conn)
+	dir := t.TempDir()
+	siteDir := filepath.Join(dir, "site")
+	if err := os.Mkdir(siteDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(siteDir, "adminLinkViewPage.gohtml"), []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+	templates.SetDir(dir)
+	t.Cleanup(func() { templates.SetDir("") })
 	req := httptest.NewRequest("GET", "/admin/linker/links/link/1", nil)
 	req = mux.SetURLVars(req, map[string]string{"link": "1"})
 	w := httptest.NewRecorder()
@@ -33,14 +53,12 @@ func TestAdminLinkViewPage(t *testing.T) {
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT l.id")).
-		WithArgs(int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "language_id", "author_id", "category_id", "thread_id", "title", "url", "description", "listed", "username", "title_2"}).
-			AddRow(1, 1, 2, 1, 0, "t", "http://u", "d", time.Unix(0, 0), "bob", "cat"))
-
 	adminLinkViewPage(w, req)
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingCalls) != 1 {
+		t.Fatalf("expected one call, got %d", len(queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingCalls))
+	}
+	if queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingCalls[0] != 1 {
+		t.Fatalf("unexpected link id %d", queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingCalls[0])
 	}
 }

--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -3,19 +3,34 @@ package linker
 import (
 	"context"
 	"database/sql"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 	imagesign "github.com/arran4/goa4web/internal/images"
 	"github.com/arran4/goa4web/workers/searchworker"
 )
+
+func linkerItemForSearch() *db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow {
+	return &db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow{
+		ID:          1,
+		LanguageID:  sql.NullInt32{Int32: 1, Valid: true},
+		AuthorID:    1,
+		CategoryID:  sql.NullInt32{Int32: 1, Valid: true},
+		ThreadID:    0,
+		Title:       sql.NullString{String: "Foo", Valid: true},
+		Url:         sql.NullString{String: "http://foo", Valid: true},
+		Description: sql.NullString{String: "Bar", Valid: true},
+		Listed:      sql.NullTime{Time: time.Unix(0, 0), Valid: true},
+		Username:    sql.NullString{String: "u", Valid: true},
+		Title_2:     sql.NullString{String: "c", Valid: true},
+	}
+}
 
 func TestLinkerFeed(t *testing.T) {
 	rows := []*db.GetAllLinkerItemsByCategoryIdWitherPosterUsernameAndCategoryTitleDescendingRow{
@@ -43,35 +58,17 @@ func TestLinkerFeed(t *testing.T) {
 	}
 }
 func TestLinkerApproveAddsToSearch(t *testing.T) {
-	t.Skip("event bus worker requires long wait; skipping")
-
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	queries := &db.QuerierStub{
+		GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow: linkerItemForSearch(),
+		AdminInsertQueuedLinkFromQueueReturn:                                    1,
 	}
-	mock.MatchExpectationsInOrder(false)
-	defer conn.Close()
-
-	queries := db.New(conn)
-
-	mock.ExpectExec("INSERT INTO linker").
-		WithArgs(int32(1)).
-		WillReturnResult(sqlmock.NewResult(1, 1))
-
-	rows := sqlmock.NewRows([]string{"id", "language_id", "author_id", "category_id", "thread_id", "title", "url", "description", "listed", "username", "title_2"}).
-		AddRow(1, 1, 1, 1, 0, "Foo", "http://foo", "Bar", time.Now(), "u", "c")
-	mock.ExpectQuery("SELECT l.id").WithArgs(int32(0), int32(1), sqlmock.AnyArg()).WillReturnRows(rows)
-
-	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").WithArgs("foo").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("INSERT INTO linker_search").WithArgs(int32(1), int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").WithArgs("bar").WillReturnResult(sqlmock.NewResult(2, 1))
-	mock.ExpectExec("INSERT INTO linker_search").WithArgs(int32(1), int32(2), int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("UPDATE linker SET last_index").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	bus := eventbus.NewBus()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go searchworker.Worker(ctx, bus, queries)
+	time.Sleep(10 * time.Millisecond)
 
 	req := httptest.NewRequest("POST", "/admin/queue?qid=1", nil)
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
@@ -87,19 +84,30 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 		t.Fatalf("publish: %v", err)
 	}
 
-	bus.Shutdown(context.Background())
-	cancel()
-	// Wait for the worker goroutine to exit before verifying expectations.
-	time.Sleep(1 * time.Second)
-	err = nil
-	for i := 0; i < 500; i++ {
-		err = mock.ExpectationsWereMet()
-		if err == nil {
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(queries.SystemSetLinkerLastIndexCalls) > 0 {
 			break
 		}
-		time.Sleep(20 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
-	if err != nil {
-		t.Fatalf("expectations: %v", err)
+	if err := bus.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	if len(queries.AdminInsertQueuedLinkFromQueueCalls) != 1 || queries.AdminInsertQueuedLinkFromQueueCalls[0] != 1 {
+		t.Fatalf("unexpected queued link insert calls: %+v", queries.AdminInsertQueuedLinkFromQueueCalls)
+	}
+	if len(queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserCalls) != 1 {
+		t.Fatalf("expected linker fetch, got %d", len(queries.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserCalls))
+	}
+	if len(queries.SystemCreateSearchWordCalls) != 2 {
+		t.Fatalf("expected two search words, got %d", len(queries.SystemCreateSearchWordCalls))
+	}
+	if len(queries.SystemAddToLinkerSearchCalls) != 2 {
+		t.Fatalf("expected two linker search inserts, got %d", len(queries.SystemAddToLinkerSearchCalls))
+	}
+	if len(queries.SystemSetLinkerLastIndexCalls) != 1 || queries.SystemSetLinkerLastIndexCalls[0] != 1 {
+		t.Fatalf("unexpected last index calls: %+v", queries.SystemSetLinkerLastIndexCalls)
 	}
 }

--- a/handlers/linker/permissions_test.go
+++ b/handlers/linker/permissions_test.go
@@ -5,21 +5,11 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/internal/db"
 )
 
 func TestUserCanCreateLink_Allowed(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-
-	q := db.New(conn)
-	mock.ExpectQuery("SELECT 1 FROM grants").
-		WithArgs(sqlmock.AnyArg(), "linker", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	q := &db.QuerierStub{}
 
 	ok, err := UserCanCreateLink(context.Background(), q, sql.NullInt32{Int32: 1, Valid: true}, 2)
 	if err != nil {
@@ -28,22 +18,17 @@ func TestUserCanCreateLink_Allowed(t *testing.T) {
 	if !ok {
 		t.Errorf("expected allowed")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.SystemCheckGrantCalls) != 1 {
+		t.Fatalf("expected one grant check, got %d", len(q.SystemCheckGrantCalls))
+	}
+	call := q.SystemCheckGrantCalls[0]
+	if call.Action != "post" || call.Section != "linker" {
+		t.Fatalf("unexpected grant params %+v", call)
 	}
 }
 
 func TestUserCanCreateLink_Denied(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-
-	q := db.New(conn)
-	mock.ExpectQuery("SELECT 1 FROM grants").
-		WithArgs(sqlmock.AnyArg(), "linker", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnError(sql.ErrNoRows)
+	q := &db.QuerierStub{SystemCheckGrantErr: sql.ErrNoRows}
 
 	ok, err := UserCanCreateLink(context.Background(), q, sql.NullInt32{Int32: 1, Valid: true}, 2)
 	if err != nil {
@@ -52,7 +37,7 @@ func TestUserCanCreateLink_Denied(t *testing.T) {
 	if ok {
 		t.Errorf("expected denied")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.SystemCheckGrantCalls) != 1 {
+		t.Fatalf("expected one grant check, got %d", len(q.SystemCheckGrantCalls))
 	}
 }

--- a/internal/db/querier_stub.go
+++ b/internal/db/querier_stub.go
@@ -52,6 +52,33 @@ type QuerierStub struct {
 	DeleteThreadsByTopicIDCalls []int32
 	DeleteThreadsByTopicIDErr   error
 
+	GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow   *GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow
+	GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingErr   error
+	GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingCalls []int32
+
+	GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow   *GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow
+	GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserErr   error
+	GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserCalls []GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams
+
+	GetCommentsBySectionThreadIdForUserRows  []*GetCommentsBySectionThreadIdForUserRow
+	GetCommentsBySectionThreadIdForUserErr   error
+	GetCommentsBySectionThreadIdForUserCalls []GetCommentsBySectionThreadIdForUserParams
+	GetThreadLastPosterAndPermsRow           *GetThreadLastPosterAndPermsRow
+	GetThreadLastPosterAndPermsErr           error
+	GetThreadLastPosterAndPermsCalls         []GetThreadLastPosterAndPermsParams
+	AdminInsertQueuedLinkFromQueueReturn     int64
+	AdminInsertQueuedLinkFromQueueErr        error
+	AdminInsertQueuedLinkFromQueueCalls      []int32
+	SystemCreateSearchWordReturnID           int64
+	SystemCreateSearchWordErr                error
+	SystemCreateSearchWordCalls              []string
+	SystemCreateSearchWordFn                 func(string) (int64, error)
+	SystemAddToLinkerSearchCalls             []SystemAddToLinkerSearchParams
+	SystemAddToLinkerSearchErr               error
+	SystemAddToLinkerSearchFn                func(SystemAddToLinkerSearchParams) error
+	SystemSetLinkerLastIndexCalls            []int32
+	SystemSetLinkerLastIndexErr              error
+
 	SystemCheckGrantReturns int32
 	SystemCheckGrantErr     error
 	SystemCheckGrantCalls   []SystemCheckGrantParams
@@ -90,6 +117,118 @@ func (s *QuerierStub) DeleteThreadsByTopicID(ctx context.Context, forumtopicIdfo
 	defer s.mu.Unlock()
 	s.DeleteThreadsByTopicIDCalls = append(s.DeleteThreadsByTopicIDCalls, forumtopicIdforumtopic)
 	return s.DeleteThreadsByTopicIDErr
+}
+
+func (s *QuerierStub) GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending(ctx context.Context, id int32) (*GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow, error) {
+	s.mu.Lock()
+	s.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingCalls = append(s.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingCalls, id)
+	row := s.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingRow
+	err := s.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingErr
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	if row == nil {
+		return nil, errors.New("GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescending not stubbed")
+	}
+	return row, nil
+}
+
+func (s *QuerierStub) GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUser(ctx context.Context, arg GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams) (*GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow, error) {
+	s.mu.Lock()
+	s.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserCalls = append(s.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserCalls, arg)
+	row := s.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow
+	err := s.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserErr
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	if row == nil {
+		return nil, errors.New("GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUser not stubbed")
+	}
+	return row, nil
+}
+
+func (s *QuerierStub) GetCommentsBySectionThreadIdForUser(ctx context.Context, arg GetCommentsBySectionThreadIdForUserParams) ([]*GetCommentsBySectionThreadIdForUserRow, error) {
+	s.mu.Lock()
+	s.GetCommentsBySectionThreadIdForUserCalls = append(s.GetCommentsBySectionThreadIdForUserCalls, arg)
+	rows := s.GetCommentsBySectionThreadIdForUserRows
+	err := s.GetCommentsBySectionThreadIdForUserErr
+	s.mu.Unlock()
+	if rows == nil {
+		rows = []*GetCommentsBySectionThreadIdForUserRow{}
+	}
+	return rows, err
+}
+
+func (s *QuerierStub) GetThreadLastPosterAndPerms(ctx context.Context, arg GetThreadLastPosterAndPermsParams) (*GetThreadLastPosterAndPermsRow, error) {
+	s.mu.Lock()
+	s.GetThreadLastPosterAndPermsCalls = append(s.GetThreadLastPosterAndPermsCalls, arg)
+	row := s.GetThreadLastPosterAndPermsRow
+	err := s.GetThreadLastPosterAndPermsErr
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	if row == nil {
+		return nil, errors.New("GetThreadLastPosterAndPerms not stubbed")
+	}
+	return row, nil
+}
+
+func (s *QuerierStub) AdminInsertQueuedLinkFromQueue(ctx context.Context, id int32) (int64, error) {
+	s.mu.Lock()
+	s.AdminInsertQueuedLinkFromQueueCalls = append(s.AdminInsertQueuedLinkFromQueueCalls, id)
+	ret := s.AdminInsertQueuedLinkFromQueueReturn
+	err := s.AdminInsertQueuedLinkFromQueueErr
+	s.mu.Unlock()
+	if err != nil {
+		return 0, err
+	}
+	if ret == 0 {
+		return 0, errors.New("AdminInsertQueuedLinkFromQueue not stubbed")
+	}
+	return ret, nil
+}
+
+func (s *QuerierStub) SystemCreateSearchWord(ctx context.Context, word string) (int64, error) {
+	s.mu.Lock()
+	s.SystemCreateSearchWordCalls = append(s.SystemCreateSearchWordCalls, word)
+	fn := s.SystemCreateSearchWordFn
+	ret := s.SystemCreateSearchWordReturnID
+	err := s.SystemCreateSearchWordErr
+	count := len(s.SystemCreateSearchWordCalls)
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(word)
+	}
+	if err != nil {
+		return 0, err
+	}
+	if ret == 0 {
+		ret = int64(count)
+	}
+	return ret, nil
+}
+
+func (s *QuerierStub) SystemAddToLinkerSearch(ctx context.Context, arg SystemAddToLinkerSearchParams) error {
+	s.mu.Lock()
+	s.SystemAddToLinkerSearchCalls = append(s.SystemAddToLinkerSearchCalls, arg)
+	fn := s.SystemAddToLinkerSearchFn
+	err := s.SystemAddToLinkerSearchErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(arg)
+	}
+	return err
+}
+
+func (s *QuerierStub) SystemSetLinkerLastIndex(ctx context.Context, linkerID int32) error {
+	s.mu.Lock()
+	s.SystemSetLinkerLastIndexCalls = append(s.SystemSetLinkerLastIndexCalls, linkerID)
+	err := s.SystemSetLinkerLastIndexErr
+	s.mu.Unlock()
+	return err
 }
 
 // SystemCheckGrant records the call and returns the configured response.


### PR DESCRIPTION
## Summary
- extend the shared `QuerierStub` with linker retrieval, comments, permissions, and search indexing hooks
- move linker handler tests to the stubbed queries with call history assertions and local templates
- confirm search indexing events from the approve task via the fake worker setup

## Testing
- go mod tidy
- go fmt ./...
- go vet ./...
- golangci-lint run
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd07ffe7c832fa0fc3d0c060d438f)