### PR TITLE
Add sqlmock helper for handler tests

### DIFF
--- a/handlers/auth/redirectBackPageHandler_test.go
+++ b/handlers/auth/redirectBackPageHandler_test.go
@@ -1,31 +1,18 @@
 package auth
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/core/consts"
-	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/handlers/handlertest"
 )
 
 func TestRedirectBackPageHandlerGETAlt(t *testing.T) {
-	conn, _, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
-
-	cd := common.NewCoreData(context.Background(), q, config.NewRuntimeConfig())
-	ctx := context.WithValue(context.Background(), consts.KeyCoreData, cd)
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
-	req = req.WithContext(ctx)
+	req, cd, _, cleanup := handlertest.RequestWithCoreData(t, req)
+	defer cleanup()
 	rr := httptest.NewRecorder()
 
 	h := redirectBackPageHandler{BackURL: "/foo", Method: http.MethodGet}

--- a/handlers/errorpage_test.go
+++ b/handlers/errorpage_test.go
@@ -1,32 +1,20 @@
 package handlers
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
-
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/core/consts"
-	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/handlers/handlertest"
 )
 
 func TestRenderErrorPageNotFoundOmitsInternalError(t *testing.T) {
-	conn, _, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-
 	req := httptest.NewRequest(http.MethodGet, "/missing", nil)
-	cd := common.NewCoreData(req.Context(), db.New(conn), config.NewRuntimeConfig())
-	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
-	req = req.WithContext(ctx)
+	req, cd, _, cleanup := handlertest.RequestWithCoreData(t, req)
+	defer cleanup()
 
 	data := struct {
 		*common.CoreData

--- a/handlers/handlertest/request.go
+++ b/handlers/handlertest/request.go
@@ -1,0 +1,36 @@
+package handlertest
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// NewCoreData creates a CoreData configured with a fake Querier backed by sqlmock.
+// A cleanup function is returned to close the mock database when the test finishes.
+func NewCoreData(t *testing.T, ctx context.Context, opts ...common.CoreOption) (*common.CoreData, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	cd := common.NewCoreData(ctx, db.New(conn), config.NewRuntimeConfig(), opts...)
+	return cd, mock, func() { conn.Close() }
+}
+
+// RequestWithCoreData attaches CoreData with a fake Querier to req's context.
+// The returned request includes the CoreData under consts.KeyCoreData.
+func RequestWithCoreData(t *testing.T, req *http.Request, opts ...common.CoreOption) (*http.Request, *common.CoreData, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	cd, mock, cleanup := NewCoreData(t, req.Context(), opts...)
+	cd.LoadSelectionsFromRequest(req)
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	return req.WithContext(ctx), cd, mock, cleanup
+}

--- a/handlers/news/search_test.go
+++ b/handlers/news/search_test.go
@@ -11,19 +11,12 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/arran4/goa4web/config"
-	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/handlers/handlertest"
 )
 
 func TestNewsSearchFiltersUnauthorized(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-
-	queries := db.New(conn)
+	cd, mock, cleanup := handlertest.NewCoreData(t, context.Background())
+	defer cleanup()
 
 	firstRows := sqlmock.NewRows([]string{"site_news_id"}).AddRow(1).AddRow(2)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT DISTINCT cs.site_news_id")).
@@ -44,7 +37,6 @@ func TestNewsSearchFiltersUnauthorized(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	ctx := req.Context()
 	req = req.WithContext(ctx)
-	cd := common.NewCoreData(context.Background(), queries, config.NewRuntimeConfig())
 	news, emptyWords, noResults, err := cd.SearchNews(req, 1)
 	if err != nil {
 		t.Fatalf("NewsSearch: %v", err)


### PR DESCRIPTION
## Summary
- add a shared handler test helper that constructs CoreData with a sqlmock-backed Querier and request context
- refactor handler suites to reuse the helper instead of duplicating sqlmock setup

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd07f840c832f919b1a83c9500c0f)