### PR TITLE
Add in-memory pending email stub

### DIFF
--- a/internal/email/emaildefaults/email_test.go
+++ b/internal/email/emaildefaults/email_test.go
@@ -5,12 +5,9 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
-	"github.com/arran4/goa4web/workers/emailqueue"
 	"net/mail"
-	"regexp"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/db"
 	mockdlq "github.com/arran4/goa4web/internal/dlq/mock"
@@ -20,6 +17,7 @@ import (
 	logProv "github.com/arran4/goa4web/internal/email/log"
 	mockemail "github.com/arran4/goa4web/internal/email/mock"
 	smtpProv "github.com/arran4/goa4web/internal/email/smtp"
+	"github.com/arran4/goa4web/workers/emailqueue"
 	"strings"
 )
 
@@ -88,20 +86,16 @@ func TestLoadEmailConfigFromFileValues(t *testing.T) {
 	}
 }
 func TestInsertPendingEmail(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-
-	q := db.New(conn)
-	mock.ExpectExec("INSERT INTO pending_emails").WithArgs(sql.NullInt32{Int32: 1, Valid: true}, "body", false).WillReturnResult(sqlmock.NewResult(1, 1))
-
+	q := &db.QuerierStub{}
 	if err := q.InsertPendingEmail(context.Background(), db.InsertPendingEmailParams{ToUserID: sql.NullInt32{Int32: 1, Valid: true}, Body: "body", DirectEmail: false}); err != nil {
 		t.Fatalf("insert: %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	emails := q.PendingEmails()
+	if len(emails) != 1 {
+		t.Fatalf("expected pending email, got %d", len(emails))
+	}
+	if emails[0].ID == 0 || !emails[0].ToUserID.Valid || emails[0].Body != "body" || emails[0].DirectEmail {
+		t.Fatalf("unexpected pending email: %+v", emails[0])
 	}
 }
 
@@ -109,29 +103,29 @@ func TestEmailQueueWorker(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
 	cfg.EmailEnabled = true
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		SystemGetUserByIDRow: &db.SystemGetUserByIDRow{
+			Idusers:                2,
+			Email:                  sql.NullString{String: "bob@example.com", Valid: true},
+			Username:               sql.NullString{String: "bob", Valid: true},
+			PublicProfileEnabledAt: sql.NullTime{},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
-	rows := sqlmock.NewRows([]string{"id", "to_user_id", "body", "error_count", "direct_email"}).AddRow(1, 2, "b", 0, false)
-	mock.ExpectQuery("SELECT id, to_user_id, body, error_count, direct_email").WillReturnRows(rows)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
-		WithArgs(int32(2)).
-		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(2, "e", "bob", nil))
-	mock.ExpectExec("UPDATE pending_emails SET sent_at").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
+	if err := q.InsertPendingEmail(context.Background(), db.InsertPendingEmailParams{ToUserID: sql.NullInt32{Int32: 2, Valid: true}, Body: "b", DirectEmail: false}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
 
 	rec := &mockemail.Provider{}
 	if !emailqueue.ProcessPendingEmail(context.Background(), q, rec, nil, cfg) {
 		t.Fatal("no email processed")
 	}
 
-	if len(rec.Messages) != 1 || rec.Messages[0].To.String() != "\"bob\" <e@>" {
+	if len(rec.Messages) != 1 || rec.Messages[0].To.String() != "\"bob\" <bob@example.com>" {
 		t.Fatalf("got %#v", rec.Messages)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	emails := q.PendingEmails()
+	if len(emails) != 1 || !emails[0].SentAt.Valid {
+		t.Fatalf("pending email not marked sent: %+v", emails)
 	}
 }
 
@@ -149,20 +143,26 @@ func TestProcessPendingEmailDLQ(t *testing.T) {
 	cfg := config.NewRuntimeConfig()
 	cfg.EmailEnabled = true
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		SystemGetUserByIDRow: &db.SystemGetUserByIDRow{
+			Idusers:                2,
+			Email:                  sql.NullString{String: "a@test", Valid: true},
+			Username:               sql.NullString{String: "a", Valid: true},
+			PublicProfileEnabledAt: sql.NullTime{},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
-	rows := sqlmock.NewRows([]string{"id", "to_user_id", "body", "error_count", "direct_email"}).AddRow(1, 2, "b", 4, false)
-	mock.ExpectQuery("SELECT id, to_user_id, body, error_count, direct_email").WillReturnRows(rows)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.idusers, ue.email, u.username, u.public_profile_enabled_at FROM users u LEFT JOIN user_emails ue ON ue.id = ( SELECT id FROM user_emails ue2 WHERE ue2.user_id = u.idusers AND ue2.verified_at IS NOT NULL ORDER BY ue2.notification_priority DESC, ue2.id LIMIT 1 ) WHERE u.idusers = ?")).
-		WithArgs(int32(2)).
-		WillReturnRows(sqlmock.NewRows([]string{"idusers", "email", "username", "public_profile_enabled_at"}).AddRow(2, "a@test", "a", nil))
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE pending_emails SET error_count = error_count + 1 WHERE id = ?")).WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectQuery("SELECT error_count FROM pending_emails WHERE id = ?").WithArgs(int32(1)).WillReturnRows(sqlmock.NewRows([]string{"error_count"}).AddRow(5))
-	mock.ExpectExec("DELETE FROM pending_emails WHERE id = ?").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(1, 1))
+	if err := q.InsertPendingEmail(context.Background(), db.InsertPendingEmailParams{ToUserID: sql.NullInt32{Int32: 2, Valid: true}, Body: "b", DirectEmail: false}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	pending := q.PendingEmails()
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending email, got %d", len(pending))
+	}
+	for i := 0; i < 4; i++ {
+		if err := q.SystemIncrementPendingEmailError(context.Background(), pending[0].ID); err != nil {
+			t.Fatalf("increment: %v", err)
+		}
+	}
 
 	p := errProvider{}
 	dlqRec := &mockdlq.Provider{}
@@ -177,8 +177,8 @@ func TestProcessPendingEmailDLQ(t *testing.T) {
 	if !strings.Contains(msg, "b") || !strings.Contains(msg, "fail") {
 		t.Fatalf("unexpected dlq message: %s", msg)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.PendingEmails()) != 0 {
+		t.Fatalf("expected queue to be empty, got %d entries", len(q.PendingEmails()))
 	}
 }
 


### PR DESCRIPTION
## Summary
- add in-memory pending email lifecycle support to the QuerierStub for pending email tests
- refactor email default tests to rely on the stubbed pending email state instead of SQL mocks

## Testing
- go mod tidy
- go fmt ./...
- go vet ./...
- golangci-lint run ./...
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd07ef798832f89cb061e66c879bb)