### PR TITLE
Add writer list fakes for pagination tests

### DIFF
--- a/handlers/writings/writingsWriterListPage.go
+++ b/handlers/writings/writingsWriterListPage.go
@@ -71,5 +71,5 @@ func WriterListPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	handlers.TemplateHandler(w, r, "writerListPage.gohtml", data)
+	handlers.TemplateHandler(w, r, "writings/writerListPage.gohtml", data)
 }

--- a/handlers/writings/writingsWriterListPage_test.go
+++ b/handlers/writings/writingsWriterListPage_test.go
@@ -2,31 +2,34 @@ package writings
 
 import (
 	"context"
-	"github.com/arran4/goa4web/core/consts"
+	"database/sql"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/db"
 )
 
 func TestWriterListPage_List(t *testing.T) {
-	t.Skip("environment not fully configured")
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	t.Helper()
+	q := &db.QuerierStub{
+		ListWritersForListerReturns: []*db.ListWritersForListerRow{
+			{Username: sql.NullString{String: "alice", Valid: true}, Count: 3},
+			{Username: sql.NullString{String: "bob", Valid: true}, Count: 2},
+			{Username: sql.NullString{String: "carol", Valid: true}, Count: 1},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
-
-	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
-	mock.ExpectQuery(".*").WillReturnRows(rows)
 
 	req := httptest.NewRequest("GET", "/writings/writers", nil)
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd.Config.PageSizeDefault = 2
+	cd.Config.PageSizeMin = 1
+	cd.Config.PageSizeMax = 10
 	cd.UserID = 1
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -34,40 +37,78 @@ func TestWriterListPage_List(t *testing.T) {
 
 	WriterListPage(rr, req)
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
-	if rr.Result().StatusCode != 200 {
+	if rr.Result().StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+	if len(q.ListWritersForListerCalls) != 1 {
+		t.Fatalf("calls=%d", len(q.ListWritersForListerCalls))
+	}
+	call := q.ListWritersForListerCalls[0]
+	if call.Limit != int32(cd.PageSize()+1) || call.Offset != 0 {
+		t.Fatalf("unexpected args %#v", call)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "alice") || !strings.Contains(body, "bob") {
+		t.Fatalf("expected writers in body: %s", body)
+	}
+	if strings.Contains(body, "carol") {
+		t.Fatalf("expected page to cap results: %s", body)
+	}
+	if cd.NextLink != "/writings/writers?offset=2" {
+		t.Fatalf("next link=%s", cd.NextLink)
+	}
+	if cd.PrevLink != "" {
+		t.Fatalf("prev link=%s", cd.PrevLink)
 	}
 }
 
 func TestWriterListPage_Search(t *testing.T) {
-	t.Skip("environment not fully configured")
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	t.Helper()
+	q := &db.QuerierStub{
+		ListWritersSearchForListerReturns: []*db.ListWritersSearchForListerRow{
+			{Username: sql.NullString{String: "bob", Valid: true}, Count: 2},
+			{Username: sql.NullString{String: "bobby", Valid: true}, Count: 1},
+			{Username: sql.NullString{String: "robert", Valid: true}, Count: 4},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
 
-	rows := sqlmock.NewRows([]string{"username", "count"}).AddRow("bob", 2)
-	mock.ExpectQuery(".*").WillReturnRows(rows)
-
-	req := httptest.NewRequest("GET", "/writings/writers?search=bob", nil)
+	req := httptest.NewRequest("GET", "/writings/writers?search=bob&offset=2", nil)
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
-	cd.UserID = 1
+	cd.Config.PageSizeDefault = 2
+	cd.Config.PageSizeMin = 1
+	cd.Config.PageSizeMax = 10
+	cd.UserID = 99
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 
 	WriterListPage(rr, req)
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
-	if rr.Result().StatusCode != 200 {
+	if rr.Result().StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", rr.Result().StatusCode)
+	}
+	if len(q.ListWritersSearchForListerCalls) != 1 {
+		t.Fatalf("search calls=%d", len(q.ListWritersSearchForListerCalls))
+	}
+	call := q.ListWritersSearchForListerCalls[0]
+	if call.Query != "%bob%" || call.Offset != 2 || call.Limit != int32(cd.PageSize()+1) {
+		t.Fatalf("unexpected search args %#v", call)
+	}
+	if len(q.ListWritersForListerCalls) != 0 {
+		t.Fatalf("unexpected list calls=%d", len(q.ListWritersForListerCalls))
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "bob") || !strings.Contains(body, "bobby") {
+		t.Fatalf("expected search writers in body: %s", body)
+	}
+	if strings.Contains(body, "robert") {
+		t.Fatalf("expected search results capped to page size: %s", body)
+	}
+	if cd.NextLink != "/writings/writers?search=bob&offset=4" {
+		t.Fatalf("next link=%s", cd.NextLink)
+	}
+	if cd.PrevLink != "/writings/writers?search=bob&offset=0" {
+		t.Fatalf("prev link=%s", cd.PrevLink)
 	}
 }

--- a/internal/db/querier_stub.go
+++ b/internal/db/querier_stub.go
@@ -62,6 +62,11 @@ type QuerierStub struct {
 	SystemCheckRoleGrantCalls   []SystemCheckRoleGrantParams
 	SystemCheckRoleGrantFn      func(SystemCheckRoleGrantParams) (int32, error)
 
+	GetPermissionsByUserIDReturns []*GetPermissionsByUserIDRow
+	GetPermissionsByUserIDErr     error
+	GetPermissionsByUserIDCalls   []int32
+	GetPermissionsByUserIDFn      func(int32) ([]*GetPermissionsByUserIDRow, error)
+
 	AdminListForumTopicGrantsByTopicIDCalls   []sql.NullInt32
 	AdminListForumTopicGrantsByTopicIDReturns []*AdminListForumTopicGrantsByTopicIDRow
 	AdminListForumTopicGrantsByTopicIDErr     error
@@ -69,6 +74,16 @@ type QuerierStub struct {
 	AdminListPrivateTopicParticipantsByTopicIDCalls   []sql.NullInt32
 	AdminListPrivateTopicParticipantsByTopicIDReturns []*AdminListPrivateTopicParticipantsByTopicIDRow
 	AdminListPrivateTopicParticipantsByTopicIDErr     error
+
+	ListWritersForListerCalls   []ListWritersForListerParams
+	ListWritersForListerReturns []*ListWritersForListerRow
+	ListWritersForListerErr     error
+	ListWritersForListerFn      func(ListWritersForListerParams) ([]*ListWritersForListerRow, error)
+
+	ListWritersSearchForListerCalls   []ListWritersSearchForListerParams
+	ListWritersSearchForListerReturns []*ListWritersSearchForListerRow
+	ListWritersSearchForListerErr     error
+	ListWritersSearchForListerFn      func(ListWritersSearchForListerParams) ([]*ListWritersSearchForListerRow, error)
 }
 
 func (s *QuerierStub) AdminListPrivateTopicParticipantsByTopicID(ctx context.Context, itemID sql.NullInt32) ([]*AdminListPrivateTopicParticipantsByTopicIDRow, error) {
@@ -76,6 +91,32 @@ func (s *QuerierStub) AdminListPrivateTopicParticipantsByTopicID(ctx context.Con
 	defer s.mu.Unlock()
 	s.AdminListPrivateTopicParticipantsByTopicIDCalls = append(s.AdminListPrivateTopicParticipantsByTopicIDCalls, itemID)
 	return s.AdminListPrivateTopicParticipantsByTopicIDReturns, s.AdminListPrivateTopicParticipantsByTopicIDErr
+}
+
+func (s *QuerierStub) ListWritersForLister(ctx context.Context, arg ListWritersForListerParams) ([]*ListWritersForListerRow, error) {
+	s.mu.Lock()
+	s.ListWritersForListerCalls = append(s.ListWritersForListerCalls, arg)
+	fn := s.ListWritersForListerFn
+	ret := s.ListWritersForListerReturns
+	err := s.ListWritersForListerErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(arg)
+	}
+	return ret, err
+}
+
+func (s *QuerierStub) ListWritersSearchForLister(ctx context.Context, arg ListWritersSearchForListerParams) ([]*ListWritersSearchForListerRow, error) {
+	s.mu.Lock()
+	s.ListWritersSearchForListerCalls = append(s.ListWritersSearchForListerCalls, arg)
+	fn := s.ListWritersSearchForListerFn
+	ret := s.ListWritersSearchForListerReturns
+	err := s.ListWritersSearchForListerErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(arg)
+	}
+	return ret, err
 }
 
 func (s *QuerierStub) AdminListForumTopicGrantsByTopicID(ctx context.Context, itemID sql.NullInt32) ([]*AdminListForumTopicGrantsByTopicIDRow, error) {
@@ -130,6 +171,20 @@ func (s *QuerierStub) SystemCheckRoleGrant(ctx context.Context, arg SystemCheckR
 		ret = 1
 	}
 	return ret, nil
+}
+
+// GetPermissionsByUserID records the call and returns the configured response.
+func (s *QuerierStub) GetPermissionsByUserID(ctx context.Context, idusers int32) ([]*GetPermissionsByUserIDRow, error) {
+	s.mu.Lock()
+	s.GetPermissionsByUserIDCalls = append(s.GetPermissionsByUserIDCalls, idusers)
+	fn := s.GetPermissionsByUserIDFn
+	ret := s.GetPermissionsByUserIDReturns
+	err := s.GetPermissionsByUserIDErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(idusers)
+	}
+	return ret, err
 }
 
 // SystemGetUserByID records the call and returns the configured response.


### PR DESCRIPTION
## Summary
- add fake writer list and search responses to the QuerierStub for handler tests
- update the writer list handler to render the correct template path
- add pagination and search coverage for writer listings using stubbed responses

## Testing
- go vet ./...
- golangci-lint run
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd07ac66c832f83d370f1316b3887)