### PR TITLE
Add FAQ insert stub result tracking

### DIFF
--- a/internal/db/querier_stub.go
+++ b/internal/db/querier_stub.go
@@ -7,6 +7,20 @@ import (
 	"sync"
 )
 
+// FakeSQLResult implements sql.Result for tests.
+type FakeSQLResult struct {
+	LastInsertIDValue int64
+	RowsAffectedValue int64
+}
+
+func (r FakeSQLResult) LastInsertId() (int64, error) {
+	return r.LastInsertIDValue, nil
+}
+
+func (r FakeSQLResult) RowsAffected() (int64, error) {
+	return r.RowsAffectedValue, nil
+}
+
 // QuerierStub records calls for selective db.Querier methods in tests.
 type QuerierStub struct {
 	Querier
@@ -44,7 +58,10 @@ type QuerierStub struct {
 	GetPreferenceForListerParams []int32
 	GetPreferenceForListerReturn map[int32]*Preference
 
-	InsertSubscriptionParams []InsertSubscriptionParams
+	InsertSubscriptionParams         []InsertSubscriptionParams
+	InsertFAQQuestionForWriterCalls  []InsertFAQQuestionForWriterParams
+	InsertFAQQuestionForWriterResult sql.Result
+	InsertFAQQuestionForWriterErr    error
 
 	ListSubscribersForPatternParams []ListSubscribersForPatternParams
 	ListSubscribersForPatternReturn map[string][]int32
@@ -237,6 +254,22 @@ func (s *QuerierStub) InsertSubscription(ctx context.Context, arg InsertSubscrip
 	defer s.mu.Unlock()
 	s.InsertSubscriptionParams = append(s.InsertSubscriptionParams, arg)
 	return nil
+}
+
+// InsertFAQQuestionForWriter records the call and returns the configured sql.Result.
+func (s *QuerierStub) InsertFAQQuestionForWriter(ctx context.Context, arg InsertFAQQuestionForWriterParams) (sql.Result, error) {
+	s.mu.Lock()
+	s.InsertFAQQuestionForWriterCalls = append(s.InsertFAQQuestionForWriterCalls, arg)
+	res := s.InsertFAQQuestionForWriterResult
+	err := s.InsertFAQQuestionForWriterErr
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return FakeSQLResult{}, nil
+	}
+	return res, nil
 }
 
 func (s *QuerierStub) ListSubscribersForPattern(ctx context.Context, arg ListSubscribersForPatternParams) ([]int32, error) {

--- a/internal/db/querier_stub_test.go
+++ b/internal/db/querier_stub_test.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+func TestQuerierStub_InsertFAQQuestionForWriter(t *testing.T) {
+	stub := &QuerierStub{
+		InsertFAQQuestionForWriterResult: FakeSQLResult{
+			LastInsertIDValue: 42,
+			RowsAffectedValue: 1,
+		},
+	}
+
+	params := InsertFAQQuestionForWriterParams{
+		Question: sql.NullString{String: "Why?", Valid: true},
+	}
+
+	res, err := stub.InsertFAQQuestionForWriter(context.Background(), params)
+	if err != nil {
+		t.Fatalf("InsertFAQQuestionForWriter returned error: %v", err)
+	}
+
+	if len(stub.InsertFAQQuestionForWriterCalls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(stub.InsertFAQQuestionForWriterCalls))
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("LastInsertId returned error: %v", err)
+	}
+	if id != 42 {
+		t.Fatalf("expected last insert ID 42, got %d", id)
+	}
+
+	affected, err := res.RowsAffected()
+	if err != nil {
+		t.Fatalf("RowsAffected returned error: %v", err)
+	}
+	if affected != 1 {
+		t.Fatalf("expected rows affected 1, got %d", affected)
+	}
+}


### PR DESCRIPTION
## Summary
- add a reusable FakeSQLResult to the Querier stub for FAQ insert operations
- expose FAQ insert call tracking and configurable results on the stub
- cover the new stubbed FAQ insert behavior with a unit test

## Testing
- go vet ./...
- go test ./...
- golangci-lint run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd07a47e8832fb41f732168ed85d5)