### PR TITLE
Add content label fake methods and update label tests

### DIFF
--- a/core/common/coredata_labels_test.go
+++ b/core/common/coredata_labels_test.go
@@ -2,94 +2,97 @@ package common_test
 
 import (
 	"reflect"
-	"regexp"
 	"testing"
-
-	"github.com/DATA-DOG/go-sqlmock"
 
 	common "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 )
 
 func TestSetThreadPublicLabels(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		ContentPublicLabels: map[string]map[int32]map[string]struct{}{
+			"thread": {
+				1: {"foo": {}, "bar": {}},
+			},
+		},
+		ContentLabelStatus: map[string]map[int32]map[string]struct{}{
+			"thread": {
+				1: {},
+			},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
 	cd := common.NewTestCoreData(t, q)
 	cd.UserID = 2
-
-	rows := sqlmock.NewRows([]string{"item", "item_id", "label"}).
-		AddRow("thread", 1, "foo").
-		AddRow("thread", 1, "bar")
-	mock.ExpectQuery("SELECT .* FROM content_public_labels").
-		WithArgs("thread", int32(1)).
-		WillReturnRows(rows)
-	mock.ExpectQuery("SELECT .* FROM content_label_status").
-		WithArgs("thread", int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "label"}))
-	mock.ExpectExec("INSERT IGNORE INTO content_public_labels").
-		WithArgs("thread", int32(1), "baz").
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("DELETE FROM content_public_labels").
-		WithArgs("thread", int32(1), "foo").
-		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	if err := cd.SetThreadPublicLabels(1, []string{"bar", "baz"}); err != nil {
 		t.Fatalf("SetThreadPublicLabels: %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+
+	labels := q.ContentPublicLabels["thread"][1]
+	if len(labels) != 2 {
+		t.Fatalf("labels %+v", labels)
+	}
+	if _, ok := labels["bar"]; !ok {
+		t.Fatalf("missing bar label %+v", labels)
+	}
+	if _, ok := labels["baz"]; !ok {
+		t.Fatalf("missing baz label %+v", labels)
+	}
+	if len(q.ListContentPublicLabelsCalls) != 1 {
+		t.Fatalf("list public labels calls = %d", len(q.ListContentPublicLabelsCalls))
+	}
+	if len(q.ListContentLabelStatusCalls) != 1 {
+		t.Fatalf("list author label calls = %d", len(q.ListContentLabelStatusCalls))
+	}
+	if len(q.AddContentPublicLabelCalls) != 1 || q.AddContentPublicLabelCalls[0].Label != "baz" {
+		t.Fatalf("add public calls %+v", q.AddContentPublicLabelCalls)
+	}
+	if len(q.RemoveContentPublicLabelCalls) != 1 || q.RemoveContentPublicLabelCalls[0].Label != "foo" {
+		t.Fatalf("remove public calls %+v", q.RemoveContentPublicLabelCalls)
 	}
 }
 
 func TestSetThreadPrivateLabels(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		ContentPrivateLabels: map[string]map[int32]map[int32]map[string]bool{
+			"thread": {
+				1: {
+					2: {"one": false, "two": false},
+				},
+			},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
 	cd := common.NewTestCoreData(t, q)
 	cd.UserID = 2
-
-	rows := sqlmock.NewRows([]string{"item", "item_id", "user_id", "label", "invert"}).
-		AddRow("thread", 1, 2, "one", false).
-		AddRow("thread", 1, 2, "two", false)
-	mock.ExpectQuery("SELECT .* FROM content_private_labels").
-		WithArgs("thread", int32(1), int32(2)).
-		WillReturnRows(rows)
-	mock.ExpectExec("INSERT IGNORE INTO content_private_labels").
-		WithArgs("thread", int32(1), int32(2), "three", false).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("DELETE FROM content_private_labels").
-		WithArgs("thread", int32(1), int32(2), "one").
-		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	if err := cd.SetThreadPrivateLabels(1, []string{"two", "three"}); err != nil {
 		t.Fatalf("SetThreadPrivateLabels: %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+
+	labels := q.ContentPrivateLabels["thread"][1][2]
+	twoInvert, ok := labels["two"]
+	if len(labels) != 2 || !ok || twoInvert {
+		t.Fatalf("private labels %+v", labels)
+	}
+	v, ok := labels["three"]
+	if !ok || v {
+		t.Fatalf("private labels %+v", labels)
+	}
+	if len(q.ListContentPrivateLabelsCalls) != 1 {
+		t.Fatalf("list private labels calls = %d", len(q.ListContentPrivateLabelsCalls))
+	}
+	if len(q.AddContentPrivateLabelCalls) != 1 || q.AddContentPrivateLabelCalls[0].Label != "three" || q.AddContentPrivateLabelCalls[0].Invert {
+		t.Fatalf("add private calls %+v", q.AddContentPrivateLabelCalls)
+	}
+	if len(q.RemoveContentPrivateLabelCalls) != 1 || q.RemoveContentPrivateLabelCalls[0].Label != "one" {
+		t.Fatalf("remove private calls %+v", q.RemoveContentPrivateLabelCalls)
 	}
 }
 
 func TestPrivateLabelsDefaultAndInversion(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := &db.QuerierStub{}
 	cd := common.NewTestCoreData(t, q)
 	cd.UserID = 2
-
-	// Default case: no stored rows should return new and unread labels.
-	mock.ExpectQuery("SELECT .* FROM content_private_labels").
-		WithArgs("thread", int32(1), int32(2)).
-		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "user_id", "label", "invert"}))
 
 	labels, err := cd.PrivateLabels("thread", 1)
 	if err != nil {
@@ -99,14 +102,18 @@ func TestPrivateLabelsDefaultAndInversion(t *testing.T) {
 	if !reflect.DeepEqual(labels, expected) {
 		t.Fatalf("default labels %+v, want %+v", labels, expected)
 	}
+	if len(q.ListContentPrivateLabelsCalls) != 1 {
+		t.Fatalf("list private labels calls = %d", len(q.ListContentPrivateLabelsCalls))
+	}
 
-	// Inversion case: storing an inverted new label removes it from the result.
-	rows := sqlmock.NewRows([]string{"item", "item_id", "user_id", "label", "invert"}).
-		AddRow("thread", 1, 2, "new", true).
-		AddRow("thread", 1, 2, "foo", false)
-	mock.ExpectQuery("SELECT .* FROM content_private_labels").
-		WithArgs("thread", int32(1), int32(2)).
-		WillReturnRows(rows)
+	q.ContentPrivateLabels = map[string]map[int32]map[int32]map[string]bool{
+		"thread": {
+			1: {
+				2: {"new": true, "foo": false},
+			},
+		},
+	}
+	q.ListContentPrivateLabelsCalls = nil
 
 	labels, err = cd.PrivateLabels("thread", 1)
 	if err != nil {
@@ -117,46 +124,47 @@ func TestPrivateLabelsDefaultAndInversion(t *testing.T) {
 		t.Fatalf("inverted labels %+v, want %+v", labels, expected)
 	}
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.ListContentPrivateLabelsCalls) != 1 {
+		t.Fatalf("list private labels calls after reset = %d", len(q.ListContentPrivateLabelsCalls))
 	}
 }
 
 func TestClearThreadPrivateLabelStatus(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		ContentPrivateLabels: map[string]map[int32]map[int32]map[string]bool{
+			"thread": {
+				1: {
+					1: {"unread": true, "keep": false},
+					2: {"unread": false},
+				},
+			},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
 	cd := common.NewTestCoreData(t, q)
-
-	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM content_private_labels")).
-		WithArgs("thread", int32(1), "unread").
-		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	if err := cd.ClearThreadPrivateLabelStatus(1); err != nil {
 		t.Fatalf("ClearThreadPrivateLabelStatus: %v", err)
 	}
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.SystemClearContentPrivateLabelCalls) != 1 {
+		t.Fatalf("system clear calls = %d", len(q.SystemClearContentPrivateLabelCalls))
+	}
+	remaining := q.ContentPrivateLabels["thread"][1]
+	if _, ok := remaining[1]["unread"]; ok {
+		t.Fatalf("expected unread cleared for user 1")
+	}
+	if _, ok := remaining[2]; ok {
+		t.Fatalf("expected user 2 labels cleared entirely")
+	}
+	if v, ok := remaining[1]["keep"]; !ok || v {
+		t.Fatalf("expected keep label retained for user 1")
 	}
 }
 
 func TestPrivateLabelsTopicExcludesStatus(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := &db.QuerierStub{}
 	cd := common.NewTestCoreData(t, q)
 	cd.UserID = 2
-
-	mock.ExpectQuery("SELECT .* FROM content_private_labels").
-		WithArgs("topic", int32(1), int32(2)).
-		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "user_id", "label", "invert"}))
 
 	labels, err := cd.PrivateLabels("topic", 1)
 	if err != nil {
@@ -166,41 +174,51 @@ func TestPrivateLabelsTopicExcludesStatus(t *testing.T) {
 		t.Fatalf("expected no labels for topic, got %+v", labels)
 	}
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.ListContentPrivateLabelsCalls) != 1 {
+		t.Fatalf("list private labels calls = %d", len(q.ListContentPrivateLabelsCalls))
 	}
 }
 
 func TestSetWritingPublicLabels(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		ContentLabelStatus: map[string]map[int32]map[string]struct{}{
+			"writing": {
+				5: {"a": {}, "b": {}},
+			},
+		},
+		ContentPublicLabels: map[string]map[int32]map[string]struct{}{
+			"writing": {
+				5: {},
+			},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
 	cd := common.NewTestCoreData(t, q)
 	cd.UserID = 2
-
-	mock.ExpectQuery("SELECT .* FROM content_public_labels").
-		WithArgs("writing", int32(5)).
-		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "label"}))
-	ownerRows := sqlmock.NewRows([]string{"item", "item_id", "label"}).
-		AddRow("writing", 5, "a").
-		AddRow("writing", 5, "b")
-	mock.ExpectQuery("SELECT .* FROM content_label_status").
-		WithArgs("writing", int32(5)).
-		WillReturnRows(ownerRows)
-	mock.ExpectExec("INSERT IGNORE INTO content_label_status").
-		WithArgs("writing", int32(5), "c").
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("DELETE FROM content_label_status").
-		WithArgs("writing", int32(5), "a").
-		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	if err := cd.SetWritingAuthorLabels(5, []string{"b", "c"}); err != nil {
 		t.Fatalf("SetWritingAuthorLabels: %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+
+	labels := q.ContentLabelStatus["writing"][5]
+	if len(labels) != 2 {
+		t.Fatalf("author labels %+v", labels)
+	}
+	if _, ok := labels["b"]; !ok {
+		t.Fatalf("missing b label %+v", labels)
+	}
+	if _, ok := labels["c"]; !ok {
+		t.Fatalf("missing c label %+v", labels)
+	}
+	if len(q.ListContentPublicLabelsCalls) != 1 {
+		t.Fatalf("list public labels calls = %d", len(q.ListContentPublicLabelsCalls))
+	}
+	if len(q.ListContentLabelStatusCalls) != 1 {
+		t.Fatalf("list author labels calls = %d", len(q.ListContentLabelStatusCalls))
+	}
+	if len(q.AddContentLabelStatusCalls) != 1 || q.AddContentLabelStatusCalls[0].Label != "c" {
+		t.Fatalf("add author calls %+v", q.AddContentLabelStatusCalls)
+	}
+	if len(q.RemoveContentLabelStatusCalls) != 1 || q.RemoveContentLabelStatusCalls[0].Label != "a" {
+		t.Fatalf("remove author calls %+v", q.RemoveContentLabelStatusCalls)
 	}
 }

--- a/internal/db/querier_stub.go
+++ b/internal/db/querier_stub.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sort"
 	"sync"
 )
 
@@ -11,6 +12,30 @@ import (
 type QuerierStub struct {
 	Querier
 	mu sync.Mutex
+
+	ContentLabelStatus                  map[string]map[int32]map[string]struct{}
+	ContentPrivateLabels                map[string]map[int32]map[int32]map[string]bool
+	ContentPublicLabels                 map[string]map[int32]map[string]struct{}
+	AddContentLabelStatusErr            error
+	AddContentLabelStatusCalls          []AddContentLabelStatusParams
+	AddContentPrivateLabelErr           error
+	AddContentPrivateLabelCalls         []AddContentPrivateLabelParams
+	AddContentPublicLabelErr            error
+	AddContentPublicLabelCalls          []AddContentPublicLabelParams
+	ListContentLabelStatusErr           error
+	ListContentLabelStatusCalls         []ListContentLabelStatusParams
+	ListContentPrivateLabelsErr         error
+	ListContentPrivateLabelsCalls       []ListContentPrivateLabelsParams
+	ListContentPublicLabelsErr          error
+	ListContentPublicLabelsCalls        []ListContentPublicLabelsParams
+	RemoveContentLabelStatusErr         error
+	RemoveContentLabelStatusCalls       []RemoveContentLabelStatusParams
+	RemoveContentPrivateLabelErr        error
+	RemoveContentPrivateLabelCalls      []RemoveContentPrivateLabelParams
+	RemoveContentPublicLabelErr         error
+	RemoveContentPublicLabelCalls       []RemoveContentPublicLabelParams
+	SystemClearContentPrivateLabelErr   error
+	SystemClearContentPrivateLabelCalls []SystemClearContentPrivateLabelParams
 
 	SystemGetUserByIDRow   *SystemGetUserByIDRow
 	SystemGetUserByIDErr   error
@@ -69,6 +94,299 @@ type QuerierStub struct {
 	AdminListPrivateTopicParticipantsByTopicIDCalls   []sql.NullInt32
 	AdminListPrivateTopicParticipantsByTopicIDReturns []*AdminListPrivateTopicParticipantsByTopicIDRow
 	AdminListPrivateTopicParticipantsByTopicIDErr     error
+}
+
+func (s *QuerierStub) ensurePublicLabelSetLocked(item string, itemID int32) map[string]struct{} {
+	if s.ContentPublicLabels == nil {
+		s.ContentPublicLabels = make(map[string]map[int32]map[string]struct{})
+	}
+	itemMap, ok := s.ContentPublicLabels[item]
+	if !ok {
+		itemMap = make(map[int32]map[string]struct{})
+		s.ContentPublicLabels[item] = itemMap
+	}
+	labels, ok := itemMap[itemID]
+	if !ok {
+		labels = make(map[string]struct{})
+		itemMap[itemID] = labels
+	}
+	return labels
+}
+
+func (s *QuerierStub) publicLabelSet(item string, itemID int32) map[string]struct{} {
+	itemMap := s.ContentPublicLabels[item]
+	if itemMap == nil {
+		return nil
+	}
+	return itemMap[itemID]
+}
+
+func (s *QuerierStub) ensureAuthorLabelSetLocked(item string, itemID int32) map[string]struct{} {
+	if s.ContentLabelStatus == nil {
+		s.ContentLabelStatus = make(map[string]map[int32]map[string]struct{})
+	}
+	itemMap, ok := s.ContentLabelStatus[item]
+	if !ok {
+		itemMap = make(map[int32]map[string]struct{})
+		s.ContentLabelStatus[item] = itemMap
+	}
+	labels, ok := itemMap[itemID]
+	if !ok {
+		labels = make(map[string]struct{})
+		itemMap[itemID] = labels
+	}
+	return labels
+}
+
+func (s *QuerierStub) authorLabelSet(item string, itemID int32) map[string]struct{} {
+	itemMap := s.ContentLabelStatus[item]
+	if itemMap == nil {
+		return nil
+	}
+	return itemMap[itemID]
+}
+
+func (s *QuerierStub) ensurePrivateLabelSetLocked(item string, itemID int32, userID int32) map[string]bool {
+	if s.ContentPrivateLabels == nil {
+		s.ContentPrivateLabels = make(map[string]map[int32]map[int32]map[string]bool)
+	}
+	itemMap, ok := s.ContentPrivateLabels[item]
+	if !ok {
+		itemMap = make(map[int32]map[int32]map[string]bool)
+		s.ContentPrivateLabels[item] = itemMap
+	}
+	userMap, ok := itemMap[itemID]
+	if !ok {
+		userMap = make(map[int32]map[string]bool)
+		itemMap[itemID] = userMap
+	}
+	labels, ok := userMap[userID]
+	if !ok {
+		labels = make(map[string]bool)
+		userMap[userID] = labels
+	}
+	return labels
+}
+
+func (s *QuerierStub) privateLabelSet(item string, itemID int32, userID int32) map[string]bool {
+	itemMap := s.ContentPrivateLabels[item]
+	if itemMap == nil {
+		return nil
+	}
+	userMap := itemMap[itemID]
+	if userMap == nil {
+		return nil
+	}
+	return userMap[userID]
+}
+
+// AddContentPublicLabel records the call and stores the label for later retrieval.
+func (s *QuerierStub) AddContentPublicLabel(ctx context.Context, arg AddContentPublicLabelParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.AddContentPublicLabelCalls = append(s.AddContentPublicLabelCalls, arg)
+	if s.AddContentPublicLabelErr != nil {
+		return s.AddContentPublicLabelErr
+	}
+	labels := s.ensurePublicLabelSetLocked(arg.Item, arg.ItemID)
+	labels[arg.Label] = struct{}{}
+	return nil
+}
+
+// ListContentPublicLabels records the call and returns stored public labels.
+func (s *QuerierStub) ListContentPublicLabels(ctx context.Context, arg ListContentPublicLabelsParams) ([]*ListContentPublicLabelsRow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ListContentPublicLabelsCalls = append(s.ListContentPublicLabelsCalls, arg)
+	if s.ListContentPublicLabelsErr != nil {
+		return nil, s.ListContentPublicLabelsErr
+	}
+	var res []*ListContentPublicLabelsRow
+	labels := s.publicLabelSet(arg.Item, arg.ItemID)
+	if len(labels) == 0 {
+		return res, nil
+	}
+	names := make([]string, 0, len(labels))
+	for label := range labels {
+		names = append(names, label)
+	}
+	sort.Strings(names)
+	for _, l := range names {
+		res = append(res, &ListContentPublicLabelsRow{Item: arg.Item, ItemID: arg.ItemID, Label: l})
+	}
+	return res, nil
+}
+
+// RemoveContentPublicLabel records the call and removes the label from the store.
+func (s *QuerierStub) RemoveContentPublicLabel(ctx context.Context, arg RemoveContentPublicLabelParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.RemoveContentPublicLabelCalls = append(s.RemoveContentPublicLabelCalls, arg)
+	if s.RemoveContentPublicLabelErr != nil {
+		return s.RemoveContentPublicLabelErr
+	}
+	if itemMap := s.ContentPublicLabels[arg.Item]; itemMap != nil {
+		if labels := itemMap[arg.ItemID]; labels != nil {
+			delete(labels, arg.Label)
+			if len(labels) == 0 {
+				delete(itemMap, arg.ItemID)
+			}
+		}
+		if len(itemMap) == 0 {
+			delete(s.ContentPublicLabels, arg.Item)
+		}
+	}
+	return nil
+}
+
+// AddContentLabelStatus records the call and stores the author label for later retrieval.
+func (s *QuerierStub) AddContentLabelStatus(ctx context.Context, arg AddContentLabelStatusParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.AddContentLabelStatusCalls = append(s.AddContentLabelStatusCalls, arg)
+	if s.AddContentLabelStatusErr != nil {
+		return s.AddContentLabelStatusErr
+	}
+	labels := s.ensureAuthorLabelSetLocked(arg.Item, arg.ItemID)
+	labels[arg.Label] = struct{}{}
+	return nil
+}
+
+// ListContentLabelStatus records the call and returns stored author labels.
+func (s *QuerierStub) ListContentLabelStatus(ctx context.Context, arg ListContentLabelStatusParams) ([]*ListContentLabelStatusRow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ListContentLabelStatusCalls = append(s.ListContentLabelStatusCalls, arg)
+	if s.ListContentLabelStatusErr != nil {
+		return nil, s.ListContentLabelStatusErr
+	}
+	var res []*ListContentLabelStatusRow
+	labels := s.authorLabelSet(arg.Item, arg.ItemID)
+	if len(labels) == 0 {
+		return res, nil
+	}
+	names := make([]string, 0, len(labels))
+	for label := range labels {
+		names = append(names, label)
+	}
+	sort.Strings(names)
+	for _, l := range names {
+		res = append(res, &ListContentLabelStatusRow{Item: arg.Item, ItemID: arg.ItemID, Label: l})
+	}
+	return res, nil
+}
+
+// RemoveContentLabelStatus records the call and removes the author label from the store.
+func (s *QuerierStub) RemoveContentLabelStatus(ctx context.Context, arg RemoveContentLabelStatusParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.RemoveContentLabelStatusCalls = append(s.RemoveContentLabelStatusCalls, arg)
+	if s.RemoveContentLabelStatusErr != nil {
+		return s.RemoveContentLabelStatusErr
+	}
+	if itemMap := s.ContentLabelStatus[arg.Item]; itemMap != nil {
+		if labels := itemMap[arg.ItemID]; labels != nil {
+			delete(labels, arg.Label)
+			if len(labels) == 0 {
+				delete(itemMap, arg.ItemID)
+			}
+		}
+		if len(itemMap) == 0 {
+			delete(s.ContentLabelStatus, arg.Item)
+		}
+	}
+	return nil
+}
+
+// AddContentPrivateLabel records the call and stores the private label for later retrieval.
+func (s *QuerierStub) AddContentPrivateLabel(ctx context.Context, arg AddContentPrivateLabelParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.AddContentPrivateLabelCalls = append(s.AddContentPrivateLabelCalls, arg)
+	if s.AddContentPrivateLabelErr != nil {
+		return s.AddContentPrivateLabelErr
+	}
+	labels := s.ensurePrivateLabelSetLocked(arg.Item, arg.ItemID, arg.UserID)
+	labels[arg.Label] = arg.Invert
+	return nil
+}
+
+// ListContentPrivateLabels records the call and returns stored private labels.
+func (s *QuerierStub) ListContentPrivateLabels(ctx context.Context, arg ListContentPrivateLabelsParams) ([]*ListContentPrivateLabelsRow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ListContentPrivateLabelsCalls = append(s.ListContentPrivateLabelsCalls, arg)
+	if s.ListContentPrivateLabelsErr != nil {
+		return nil, s.ListContentPrivateLabelsErr
+	}
+	var res []*ListContentPrivateLabelsRow
+	labels := s.privateLabelSet(arg.Item, arg.ItemID, arg.UserID)
+	if len(labels) == 0 {
+		return res, nil
+	}
+	names := make([]string, 0, len(labels))
+	for label := range labels {
+		names = append(names, label)
+	}
+	sort.Strings(names)
+	for _, l := range names {
+		res = append(res, &ListContentPrivateLabelsRow{Item: arg.Item, ItemID: arg.ItemID, UserID: arg.UserID, Label: l, Invert: labels[l]})
+	}
+	return res, nil
+}
+
+// RemoveContentPrivateLabel records the call and removes the private label from the store.
+func (s *QuerierStub) RemoveContentPrivateLabel(ctx context.Context, arg RemoveContentPrivateLabelParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.RemoveContentPrivateLabelCalls = append(s.RemoveContentPrivateLabelCalls, arg)
+	if s.RemoveContentPrivateLabelErr != nil {
+		return s.RemoveContentPrivateLabelErr
+	}
+	if itemMap := s.ContentPrivateLabels[arg.Item]; itemMap != nil {
+		if userMap := itemMap[arg.ItemID]; userMap != nil {
+			if labels := userMap[arg.UserID]; labels != nil {
+				delete(labels, arg.Label)
+				if len(labels) == 0 {
+					delete(userMap, arg.UserID)
+				}
+			}
+			if len(userMap) == 0 {
+				delete(itemMap, arg.ItemID)
+			}
+		}
+		if len(itemMap) == 0 {
+			delete(s.ContentPrivateLabels, arg.Item)
+		}
+	}
+	return nil
+}
+
+// SystemClearContentPrivateLabel records the call and removes the label for all users.
+func (s *QuerierStub) SystemClearContentPrivateLabel(ctx context.Context, arg SystemClearContentPrivateLabelParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.SystemClearContentPrivateLabelCalls = append(s.SystemClearContentPrivateLabelCalls, arg)
+	if s.SystemClearContentPrivateLabelErr != nil {
+		return s.SystemClearContentPrivateLabelErr
+	}
+	if itemMap := s.ContentPrivateLabels[arg.Item]; itemMap != nil {
+		if userMap := itemMap[arg.ItemID]; userMap != nil {
+			for uid, labels := range userMap {
+				delete(labels, arg.Label)
+				if len(labels) == 0 {
+					delete(userMap, uid)
+				}
+			}
+			if len(userMap) == 0 {
+				delete(itemMap, arg.ItemID)
+			}
+		}
+		if len(itemMap) == 0 {
+			delete(s.ContentPrivateLabels, arg.Item)
+		}
+	}
+	return nil
 }
 
 func (s *QuerierStub) AdminListPrivateTopicParticipantsByTopicID(ctx context.Context, itemID sql.NullInt32) ([]*AdminListPrivateTopicParticipantsByTopicIDRow, error) {


### PR DESCRIPTION
## Summary
- add in-memory content label methods to the DB querier stub so tests can upsert and list labels while recording calls
- rewrite core data label tests to use the stub and assert stored labels and call counts

## Testing
- go test ./...
- go vet ./...
- golangci-lint run ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd07a07c8832fb859d1948abe4703)