### PR TITLE
test: stub admin user queries without sqlmock

### DIFF
--- a/internal/db/queries_admin_users_test.go
+++ b/internal/db/queries_admin_users_test.go
@@ -2,25 +2,16 @@ package db
 
 import (
 	"context"
-	"regexp"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
 )
 
 func TestQueries_AdminListUsersFiltered(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := New(conn)
-
-	query := "SELECT u.idusers, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email, u.username FROM users u ORDER BY u.idusers LIMIT ? OFFSET ?"
-	rows := sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "bob@example.com", "bob")
-	mock.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs(int32(5), int32(0)).
-		WillReturnRows(rows)
+	q := newAdminUsersQuerier([]string{"idusers", "email", "username"}, []driver.Value{int32(1), "bob@example.com", "bob"})
 
 	res, err := q.AdminListUsersFiltered(context.Background(), AdminListUsersFilteredParams{Limit: 5, Offset: 0})
 	if err != nil {
@@ -29,25 +20,10 @@ func TestQueries_AdminListUsersFiltered(t *testing.T) {
 	if len(res) != 1 || res[0].Idusers != 1 || res[0].Email.String != "bob@example.com" || res[0].Username.String != "bob" {
 		t.Fatalf("unexpected result %+v", res)
 	}
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
 }
 
 func TestQueries_AdminSearchUsersFiltered(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := New(conn)
-
-	query := "SELECT u.idusers, (SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1) AS email, u.username FROM users u WHERE (LOWER(u.username) LIKE LOWER(?) OR LOWER((SELECT email FROM user_emails ue WHERE ue.user_id = u.idusers AND ue.verified_at IS NOT NULL ORDER BY ue.notification_priority DESC, ue.id LIMIT 1)) LIKE LOWER(?)) ORDER BY u.idusers LIMIT ? OFFSET ?"
-	rows := sqlmock.NewRows([]string{"idusers", "email", "username"}).AddRow(1, "bob@example.com", "bob")
-	mock.ExpectQuery(regexp.QuoteMeta(query)).
-		WithArgs("%bob%", "%bob%", int32(5), int32(0)).
-		WillReturnRows(rows)
+	q := newAdminUsersQuerier([]string{"idusers", "email", "username"}, []driver.Value{int32(1), "bob@example.com", "bob"})
 
 	res, err := q.AdminSearchUsersFiltered(context.Background(), AdminSearchUsersFilteredParams{Query: "bob", Limit: 5, Offset: 0})
 	if err != nil {
@@ -56,8 +32,66 @@ func TestQueries_AdminSearchUsersFiltered(t *testing.T) {
 	if len(res) != 1 || res[0].Idusers != 1 || res[0].Email.String != "bob@example.com" || res[0].Username.String != "bob" {
 		t.Fatalf("unexpected result %+v", res)
 	}
+}
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+func newAdminUsersQuerier(columns []string, rows ...[]driver.Value) *Queries {
+	conn := &adminUsersConnector{columns: columns, rows: rows}
+	db := sql.OpenDB(conn)
+
+	return New(db)
+}
+
+type adminUsersConnector struct {
+	columns []string
+	rows    [][]driver.Value
+}
+
+func (c *adminUsersConnector) Connect(context.Context) (driver.Conn, error) {
+	return &adminUsersConn{columns: c.columns, rows: c.rows}, nil
+}
+
+func (c *adminUsersConnector) Driver() driver.Driver { return adminUsersDriver{} }
+
+type adminUsersDriver struct{}
+
+func (adminUsersDriver) Open(string) (driver.Conn, error) { return nil, errors.New("use Connector") }
+
+type adminUsersConn struct {
+	columns []string
+	rows    [][]driver.Value
+}
+
+func (c *adminUsersConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *adminUsersConn) Close() error { return nil }
+
+func (c *adminUsersConn) Begin() (driver.Tx, error) { return nil, errors.New("not implemented") }
+
+func (c *adminUsersConn) QueryContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+	return &staticRows{columns: c.columns, rows: append([][]driver.Value(nil), c.rows...)}, nil
+}
+
+func (c *adminUsersConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	return nil, errors.New("not implemented")
+}
+
+type staticRows struct {
+	columns []string
+	rows    [][]driver.Value
+	pos     int
+}
+
+func (r *staticRows) Columns() []string { return r.columns }
+
+func (r *staticRows) Close() error { return nil }
+
+func (r *staticRows) Next(dest []driver.Value) error {
+	if r.pos >= len(r.rows) {
+		return io.EOF
 	}
+	copy(dest, r.rows[r.pos])
+	r.pos++
+	return nil
 }


### PR DESCRIPTION
## Summary
- replace sqlmock in admin user query tests with a simple Querier-driven fake
- supply deterministic rows and verify results directly without ExpectQuery
- keep tests focused on AdminListUsersFiltered and AdminSearchUsersFiltered behavior

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd078ecdc832fbb5eefe5d24bfddb)