### PR TITLE
Add template override support to querier stub

### DIFF
--- a/internal/db/querier_stub_test.go
+++ b/internal/db/querier_stub_test.go
@@ -1,0 +1,39 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+func TestQuerierStubTemplateOverrides(t *testing.T) {
+	q := &QuerierStub{}
+
+	if err := q.AdminSetTemplateOverride(context.Background(), AdminSetTemplateOverrideParams{Name: "t", Body: "body"}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if got := q.TemplateOverrides["t"]; got != "body" {
+		t.Fatalf("set body: %q", got)
+	}
+
+	body, err := q.SystemGetTemplateOverride(context.Background(), "t")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if body != "body" {
+		t.Fatalf("get body: %q", body)
+	}
+
+	if err := q.AdminDeleteTemplateOverride(context.Background(), "t"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, ok := q.TemplateOverrides["t"]; ok {
+		t.Fatalf("delete body still present")
+	}
+
+	_, err = q.SystemGetTemplateOverride(context.Background(), "t")
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected ErrNoRows, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add in-memory template override operations to the QuerierStub for template overrides
- return sql.ErrNoRows when missing overrides to mirror real queries
- add coverage validating the fake template override behavior

## Testing
- `go mod tidy`
- `go fmt ./...`
- `timeout 120 go vet ./...`
- `go test ./...`
- `golangci-lint run ./...`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd074fdec832fa07519d95dbb3801)