### PR TITLE
Refactor dbstart migration testing

### DIFF
--- a/internal/app/dbstart/dbstart.go
+++ b/internal/app/dbstart/dbstart.go
@@ -131,7 +131,11 @@ func CheckUploadDir(cfg *config.RuntimeConfig) *common.UserError {
 
 // EnsureSchema creates core tables if they do not exist and inserts a version row.
 func EnsureSchema(ctx context.Context, db *sql.DB) error {
-	version, err := ensureVersionTable(ctx, db)
+	return ensureSchemaWithStore(ctx, sqlSchemaStore{db: db})
+}
+
+func ensureSchemaWithStore(ctx context.Context, store schemaStore) error {
+	version, err := ensureVersionTable(ctx, store)
 	if err != nil {
 		return err
 	}

--- a/internal/app/dbstart/ensure_schema_test.go
+++ b/internal/app/dbstart/ensure_schema_test.go
@@ -2,54 +2,28 @@ package dbstart
 
 import (
 	"context"
-	"regexp"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/handlers"
 )
 
 func TestEnsureSchemaVersionMatch(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
+	store := &fakeStore{version: handlers.ExpectedSchemaVersion, hasVersion: true}
 
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
-		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(handlers.ExpectedSchemaVersion))
-
-	if err := EnsureSchema(context.Background(), conn); err != nil {
+	if err := ensureSchemaWithStore(context.Background(), store); err != nil {
 		t.Fatalf("ensureSchema: %v", err)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
 	}
 }
 
 func TestEnsureSchemaVersionMismatch(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
+	store := &fakeStore{version: handlers.ExpectedSchemaVersion - 1, hasVersion: true}
 
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
-		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(handlers.ExpectedSchemaVersion - 1))
-
-	err = EnsureSchema(context.Background(), conn)
+	err := ensureSchemaWithStore(context.Background(), store)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
 	expected := RenderSchemaMismatch(handlers.ExpectedSchemaVersion-1, handlers.ExpectedSchemaVersion)
 	if err.Error() != expected {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
 	}
 }

--- a/internal/app/dbstart/migrate.go
+++ b/internal/app/dbstart/migrate.go
@@ -12,16 +12,37 @@ import (
 	"strings"
 )
 
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+type schemaStore interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) rowScanner
+}
+
+type sqlSchemaStore struct {
+	db *sql.DB
+}
+
+func (s sqlSchemaStore) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return s.db.ExecContext(ctx, query, args...)
+}
+
+func (s sqlSchemaStore) QueryRowContext(ctx context.Context, query string, args ...any) rowScanner {
+	return s.db.QueryRowContext(ctx, query, args...)
+}
+
 // ensureVersionTable creates the schema_version table when missing and
 // returns the current version number stored in the table.
-func ensureVersionTable(ctx context.Context, db *sql.DB) (int, error) {
-	if _, err := db.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)"); err != nil {
+func ensureVersionTable(ctx context.Context, store schemaStore) (int, error) {
+	if _, err := store.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)"); err != nil {
 		return 0, fmt.Errorf("create schema_version: %w", err)
 	}
 	var version int
-	err := db.QueryRowContext(ctx, "SELECT version FROM schema_version").Scan(&version)
+	err := store.QueryRowContext(ctx, "SELECT version FROM schema_version").Scan(&version)
 	if err == sql.ErrNoRows {
-		if _, err := db.ExecContext(ctx, "INSERT INTO schema_version (version) VALUES (?)", 1); err != nil {
+		if _, err := store.ExecContext(ctx, "INSERT INTO schema_version (version) VALUES (?)", 1); err != nil {
 			return 0, fmt.Errorf("init schema_version: %w", err)
 		}
 		version = 1
@@ -35,7 +56,11 @@ func ensureVersionTable(ctx context.Context, db *sql.DB) (int, error) {
 // each one in order, updating the schema_version table after every successful
 // script. When verbose is true, progress information is printed to stdout.
 func Apply(ctx context.Context, db *sql.DB, f fs.FS, verbose bool, driver string) error {
-	version, err := ensureVersionTable(ctx, db)
+	return apply(ctx, sqlSchemaStore{db: db}, f, verbose, driver)
+}
+
+func apply(ctx context.Context, store schemaStore, f fs.FS, verbose bool, driver string) error {
+	version, err := ensureVersionTable(ctx, store)
 	if err != nil {
 		return err
 	}
@@ -70,10 +95,10 @@ func Apply(ctx context.Context, db *sql.DB, f fs.FS, verbose bool, driver string
 		if verbose {
 			fmt.Printf("applying %s\n", path)
 		}
-		if err := executeFile(ctx, db, f, path, verbose); err != nil {
+		if err := executeFile(ctx, store, f, path, verbose); err != nil {
 			return fmt.Errorf("execute %s: %w", path, err)
 		}
-		if _, err := db.ExecContext(ctx, "UPDATE schema_version SET version = ?", n); err != nil {
+		if _, err := store.ExecContext(ctx, "UPDATE schema_version SET version = ?", n); err != nil {
 			return fmt.Errorf("update schema_version: %w", err)
 		}
 		if verbose {
@@ -91,7 +116,11 @@ func Apply(ctx context.Context, db *sql.DB, f fs.FS, verbose bool, driver string
 	return nil
 }
 
-func executeFile(ctx context.Context, db *sql.DB, f fs.FS, path string, verbose bool) error {
+type execStore interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+func executeFile(ctx context.Context, db execStore, f fs.FS, path string, verbose bool) error {
 	data, err := fs.ReadFile(f, path)
 	if err != nil {
 		return err

--- a/internal/app/dbstart/migrate_test.go
+++ b/internal/app/dbstart/migrate_test.go
@@ -2,39 +2,31 @@ package dbstart
 
 import (
 	"context"
-	"database/sql"
 	"testing"
-
-	"github.com/DATA-DOG/go-sqlmock"
 	"testing/fstest"
 )
 
 func TestApply(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-
 	mfs := fstest.MapFS{
 		"0002.mysql.sql": {Data: []byte("CREATE TABLE t (id int);")},
 	}
 
-	mock.ExpectExec("CREATE TABLE IF NOT EXISTS schema_version").
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery("SELECT version FROM schema_version").
-		WillReturnError(sql.ErrNoRows)
-	mock.ExpectExec("INSERT INTO schema_version").
-		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("CREATE TABLE t").
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec("UPDATE schema_version SET version = ?").WithArgs(2).
-		WillReturnResult(sqlmock.NewResult(0, 1))
+	store := &fakeStore{version: 1, hasVersion: true}
 
-	if err := Apply(context.Background(), conn, mfs, false, "mysql"); err != nil {
+	if err := apply(context.Background(), store, mfs, false, "mysql"); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if store.version != 2 {
+		t.Fatalf("expected schema version 2, got %d", store.version)
+	}
+	foundMigration := false
+	for _, exec := range store.execs {
+		if exec == "CREATE TABLE t (id int) []" {
+			foundMigration = true
+			break
+		}
+	}
+	if !foundMigration {
+		t.Fatalf("expected migration statement to be executed, got %v", store.execs)
 	}
 }

--- a/internal/app/dbstart/store_test.go
+++ b/internal/app/dbstart/store_test.go
@@ -1,0 +1,66 @@
+package dbstart
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+type fakeResult struct{}
+
+func (fakeResult) LastInsertId() (int64, error) { return 0, nil }
+func (fakeResult) RowsAffected() (int64, error) { return 0, nil }
+
+type fakeRow struct {
+	version int
+	err     error
+}
+
+func (r fakeRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	if len(dest) == 0 {
+		return nil
+	}
+	ptr, ok := dest[0].(*int)
+	if !ok {
+		return fmt.Errorf("expected *int destination, got %T", dest[0])
+	}
+	*ptr = r.version
+	return nil
+}
+
+type fakeStore struct {
+	version    int
+	hasVersion bool
+	execs      []string
+}
+
+func (f *fakeStore) ExecContext(_ context.Context, query string, args ...any) (sql.Result, error) {
+	f.execs = append(f.execs, fmt.Sprintf("%s %v", query, args))
+	switch {
+	case strings.HasPrefix(query, "INSERT INTO schema_version"):
+		f.version = 1
+		f.hasVersion = true
+	case strings.HasPrefix(query, "UPDATE schema_version SET version = ?"):
+		if len(args) > 0 {
+			switch n := args[0].(type) {
+			case int:
+				f.version = n
+			case int64:
+				f.version = int(n)
+			}
+			f.hasVersion = true
+		}
+	}
+	return fakeResult{}, nil
+}
+
+func (f *fakeStore) QueryRowContext(_ context.Context, _ string, _ ...any) rowScanner {
+	if !f.hasVersion {
+		return fakeRow{err: sql.ErrNoRows}
+	}
+	return fakeRow{version: f.version}
+}


### PR DESCRIPTION
## Summary
- introduce schema store abstractions so version checks and migrations can be exercised without SQL mocks
- add fake store helpers and update schema and migration tests to assert behavior via in-memory state
- expose an internal EnsureSchema helper for reuse in tests while preserving existing API

## Testing
- go test ./...
- go vet ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd074d260832f87a8672a123d8d7f)