### PR TITLE
Add template override stub helpers and tests

### DIFF
--- a/handlers/admin/save_template_task_test.go
+++ b/handlers/admin/save_template_task_test.go
@@ -1,0 +1,36 @@
+package admin
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestSaveTemplateTaskRecordsOverride(t *testing.T) {
+	q := &db.QuerierStub{}
+	cfg := config.NewRuntimeConfig()
+	cd := common.NewCoreData(context.Background(), q, cfg)
+
+	req := httptest.NewRequest("POST", "/admin/email/template", strings.NewReader("name=reply.gotxt&body=custom"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(context.WithValue(req.Context(), consts.KeyCoreData, cd))
+
+	res := saveTemplateTask.Action(httptest.NewRecorder(), req)
+	if len(q.AdminSetTemplateOverrideCalls) != 1 {
+		t.Fatalf("expected template override call, got %d", len(q.AdminSetTemplateOverrideCalls))
+	}
+	call := q.AdminSetTemplateOverrideCalls[0]
+	if call.Name != "reply.gotxt" || call.Body != "custom" {
+		t.Fatalf("unexpected params: %#v", call)
+	}
+	if _, ok := res.(handlers.RefreshDirectHandler); !ok {
+		t.Fatalf("expected RefreshDirectHandler, got %T", res)
+	}
+}

--- a/internal/db/querier_stub.go
+++ b/internal/db/querier_stub.go
@@ -37,6 +37,11 @@ type QuerierStub struct {
 	SystemGetTemplateOverrideReturns string
 	SystemGetTemplateOverrideErr     error
 	SystemGetTemplateOverrideCalls   []string
+	SystemGetTemplateOverrideSeq     []string
+	systemGetTemplateOverrideIdx     int
+
+	AdminSetTemplateOverrideCalls []AdminSetTemplateOverrideParams
+	AdminSetTemplateOverrideErr   error
 
 	ListSubscribersForPatternsParams []ListSubscribersForPatternsParams
 	ListSubscribersForPatternsReturn map[string][]int32
@@ -202,8 +207,31 @@ func (s *QuerierStub) AdminListAdministratorEmails(ctx context.Context) ([]strin
 func (s *QuerierStub) SystemGetTemplateOverride(ctx context.Context, name string) (string, error) {
 	s.mu.Lock()
 	s.SystemGetTemplateOverrideCalls = append(s.SystemGetTemplateOverrideCalls, name)
+	idx := s.systemGetTemplateOverrideIdx
+	var body string
+	if len(s.SystemGetTemplateOverrideSeq) > 0 {
+		if idx >= len(s.SystemGetTemplateOverrideSeq) {
+			idx = len(s.SystemGetTemplateOverrideSeq) - 1
+		}
+		body = s.SystemGetTemplateOverrideSeq[idx]
+		if s.systemGetTemplateOverrideIdx < len(s.SystemGetTemplateOverrideSeq)-1 {
+			s.systemGetTemplateOverrideIdx++
+		}
+	} else {
+		body = s.SystemGetTemplateOverrideReturns
+	}
+	err := s.SystemGetTemplateOverrideErr
 	s.mu.Unlock()
-	return s.SystemGetTemplateOverrideReturns, s.SystemGetTemplateOverrideErr
+	return body, err
+}
+
+// AdminSetTemplateOverride records the call and returns the configured response.
+func (s *QuerierStub) AdminSetTemplateOverride(ctx context.Context, arg AdminSetTemplateOverrideParams) error {
+	s.mu.Lock()
+	s.AdminSetTemplateOverrideCalls = append(s.AdminSetTemplateOverrideCalls, arg)
+	err := s.AdminSetTemplateOverrideErr
+	s.mu.Unlock()
+	return err
 }
 
 func (s *QuerierStub) ListSubscribersForPatterns(ctx context.Context, arg ListSubscribersForPatternsParams) ([]int32, error) {

--- a/internal/notifications/templates_test.go
+++ b/internal/notifications/templates_test.go
@@ -1,0 +1,38 @@
+package notifications
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestRenderNotificationUsesSequentialOverrides(t *testing.T) {
+	ctx := context.Background()
+	q := &db.QuerierStub{
+		SystemGetTemplateOverrideSeq: []string{"first", "second"},
+	}
+	n := New(WithQueries(q), WithConfig(config.NewRuntimeConfig()))
+	filename := NotificationTemplateFilenameGenerator("reply")
+
+	body1, err := n.renderNotification(ctx, filename, map[string]any{})
+	if err != nil {
+		t.Fatalf("render first: %v", err)
+	}
+	if string(body1) != "first" {
+		t.Fatalf("expected first body, got %q", string(body1))
+	}
+
+	body2, err := n.renderNotification(ctx, filename, map[string]any{})
+	if err != nil {
+		t.Fatalf("render second: %v", err)
+	}
+	if string(body2) != "second" {
+		t.Fatalf("expected second body, got %q", string(body2))
+	}
+
+	if len(q.SystemGetTemplateOverrideCalls) != 2 {
+		t.Fatalf("expected 2 override lookups, got %d", len(q.SystemGetTemplateOverrideCalls))
+	}
+}


### PR DESCRIPTION
## Summary
- extend the db querier stub to return sequential template overrides and capture admin template updates
- add a notification rendering test that exercises successive override bodies
- verify SaveTemplateTask records template override writes

## Testing
- go mod tidy
- go fmt ./...
- go vet ./...
- golangci-lint run
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd0718f1c832f945bad0bb54728f5)