### PR TITLE
Add search indexing coverage for linker approval

### DIFF
--- a/handlers/linker/linkerPage_test.go
+++ b/handlers/linker/linkerPage_test.go
@@ -3,14 +3,15 @@ package linker
 import (
 	"context"
 	"database/sql"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http/httptest"
+	"sort"
+	"sync"
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/db"
 	"github.com/arran4/goa4web/internal/eventbus"
 	imagesign "github.com/arran4/goa4web/internal/images"
@@ -43,37 +44,20 @@ func TestLinkerFeed(t *testing.T) {
 	}
 }
 func TestLinkerApproveAddsToSearch(t *testing.T) {
-	t.Skip("event bus worker requires long wait; skipping")
-
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	mock.MatchExpectationsInOrder(false)
-	defer conn.Close()
-
-	queries := db.New(conn)
-
-	mock.ExpectExec("INSERT INTO linker").
-		WithArgs(int32(1)).
-		WillReturnResult(sqlmock.NewResult(1, 1))
-
-	rows := sqlmock.NewRows([]string{"id", "language_id", "author_id", "category_id", "thread_id", "title", "url", "description", "listed", "username", "title_2"}).
-		AddRow(1, 1, 1, 1, 0, "Foo", "http://foo", "Bar", time.Now(), "u", "c")
-	mock.ExpectQuery("SELECT l.id").WithArgs(int32(0), int32(1), sqlmock.AnyArg()).WillReturnRows(rows)
-
-	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").WithArgs("foo").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("INSERT INTO linker_search").WithArgs(int32(1), int32(1), int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("INSERT IGNORE INTO searchwordlist").WithArgs("bar").WillReturnResult(sqlmock.NewResult(2, 1))
-	mock.ExpectExec("INSERT INTO linker_search").WithArgs(int32(1), int32(2), int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("UPDATE linker SET last_index").WithArgs(int32(1)).WillReturnResult(sqlmock.NewResult(0, 1))
+	linkerID := int64(7)
+	queries := newLinkerIndexRecorder(linkerID, &db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow{
+		ID:          int32(linkerID),
+		Title:       sql.NullString{String: "Foo", Valid: true},
+		Description: sql.NullString{String: "Bar baz", Valid: true},
+		Username:    sql.NullString{String: "alice", Valid: true},
+	})
 
 	bus := eventbus.NewBus()
-
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go searchworker.Worker(ctx, bus, queries)
 
-	req := httptest.NewRequest("POST", "/admin/queue?qid=1", nil)
+	req := httptest.NewRequest("POST", "/admin/queue?qid=3", nil)
 	evt := &eventbus.TaskEvent{Data: map[string]any{}}
 	cd := common.NewCoreData(req.Context(), queries, config.NewRuntimeConfig())
 	cd.SetEvent(evt)
@@ -81,25 +65,170 @@ func TestLinkerApproveAddsToSearch(t *testing.T) {
 	ctxreq := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctxreq)
 	rr := httptest.NewRecorder()
-	AdminApproveTask.Action(rr, req)
+	if err := AdminApproveTask.Action(rr, req); err != nil {
+		t.Fatalf("action: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	if data, ok := evt.Data[searchworker.EventKey].(searchworker.IndexEventData); !ok {
+		t.Fatalf("expected index data in event")
+	} else {
+		if data.Type != searchworker.TypeLinker {
+			t.Fatalf("index type = %q, want %q", data.Type, searchworker.TypeLinker)
+		}
+		if data.ID != int32(linkerID) {
+			t.Fatalf("index id = %d, want %d", data.ID, linkerID)
+		}
+		if data.Text != "Foo Bar baz" {
+			t.Fatalf("index text = %q", data.Text)
+		}
+	}
 
 	if err := bus.Publish(*evt); err != nil {
 		t.Fatalf("publish: %v", err)
 	}
 
-	bus.Shutdown(context.Background())
+	select {
+	case <-queries.indexed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for index updates")
+	}
+
 	cancel()
-	// Wait for the worker goroutine to exit before verifying expectations.
-	time.Sleep(1 * time.Second)
-	err = nil
-	for i := 0; i < 500; i++ {
-		err = mock.ExpectationsWereMet()
-		if err == nil {
-			break
+	_ = bus.Shutdown(context.Background())
+
+	if got := queries.queuedIDs(); len(got) != 1 || got[0] != 3 {
+		t.Fatalf("queued IDs = %v", got)
+	}
+
+	if got := queries.createdWords(); !slicesEqual(got, []string{"bar", "baz", "foo"}) {
+		t.Fatalf("created words = %v", got)
+	}
+
+	calls := queries.searchCalls()
+	if len(calls) != 3 {
+		t.Fatalf("search calls = %v", calls)
+	}
+	for word, count := range map[string]int32{"foo": 1, "bar": 1, "baz": 1} {
+		if params, ok := calls[word]; !ok {
+			t.Fatalf("missing search call for %s", word)
+		} else if params.LinkerID != int32(linkerID) || params.WordCount != count {
+			t.Fatalf("search params for %s = %+v", word, params)
 		}
-		time.Sleep(20 * time.Millisecond)
 	}
-	if err != nil {
-		t.Fatalf("expectations: %v", err)
+
+	if got := queries.lastIndexIDs(); len(got) != 1 || got[0] != int32(linkerID) {
+		t.Fatalf("last index updates = %v", got)
 	}
+}
+
+type linkerIndexRecorder struct {
+	db.Querier
+	mu             sync.Mutex
+	queued         []int32
+	linkID         int64
+	link           *db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow
+	words          []string
+	wordIDs        map[string]int64
+	wordNames      map[int64]string
+	searchCallsLog []db.SystemAddToLinkerSearchParams
+	lastIndex      []int32
+	indexed        chan struct{}
+}
+
+func newLinkerIndexRecorder(linkID int64, link *db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow) *linkerIndexRecorder {
+	return &linkerIndexRecorder{
+		linkID:    linkID,
+		link:      link,
+		wordIDs:   map[string]int64{},
+		wordNames: map[int64]string{},
+		indexed:   make(chan struct{}, 1),
+	}
+}
+
+func (l *linkerIndexRecorder) AdminInsertQueuedLinkFromQueue(_ context.Context, id int32) (int64, error) {
+	l.mu.Lock()
+	l.queued = append(l.queued, id)
+	l.mu.Unlock()
+	return l.linkID, nil
+}
+
+func (l *linkerIndexRecorder) GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUser(context.Context, db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserParams) (*db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow, error) {
+	return l.link, nil
+}
+
+func (l *linkerIndexRecorder) SystemCreateSearchWord(_ context.Context, word string) (int64, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if id, ok := l.wordIDs[word]; ok {
+		return id, nil
+	}
+	id := int64(len(l.wordIDs) + 1)
+	l.wordIDs[word] = id
+	l.wordNames[id] = word
+	l.words = append(l.words, word)
+	return id, nil
+}
+
+func (l *linkerIndexRecorder) SystemAddToLinkerSearch(_ context.Context, params db.SystemAddToLinkerSearchParams) error {
+	l.mu.Lock()
+	l.searchCallsLog = append(l.searchCallsLog, params)
+	l.mu.Unlock()
+	return nil
+}
+
+func (l *linkerIndexRecorder) SystemSetLinkerLastIndex(_ context.Context, linkerID int32) error {
+	l.mu.Lock()
+	l.lastIndex = append(l.lastIndex, linkerID)
+	l.mu.Unlock()
+	select {
+	case l.indexed <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (l *linkerIndexRecorder) queuedIDs() []int32 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]int32(nil), l.queued...)
+}
+
+func (l *linkerIndexRecorder) createdWords() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	words := append([]string(nil), l.words...)
+	sort.Strings(words)
+	return words
+}
+
+func (l *linkerIndexRecorder) searchCalls() map[string]db.SystemAddToLinkerSearchParams {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	calls := map[string]db.SystemAddToLinkerSearchParams{}
+	for _, params := range l.searchCallsLog {
+		if word, ok := l.wordNames[int64(params.SearchwordlistIdsearchwordlist)]; ok {
+			calls[word] = params
+		}
+	}
+	return calls
+}
+
+func (l *linkerIndexRecorder) lastIndexIDs() []int32 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]int32(nil), l.lastIndex...)
+}
+
+func slicesEqual[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary
- add a Querier-based test for linker approval that exercises search indexing via the event bus
- verify emitted index metadata, search word creation, search table writes, and last-index updates

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd069bf98832fbef83447068a41c9)