### PR TITLE
Add test querier fake for grants and maintenance topics

### DIFF
--- a/core/common/testutil.go
+++ b/core/common/testutil.go
@@ -1,0 +1,65 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// QuerierFake wraps an optional db.Querier and provides stubbed responses for common grant and topic lookups in tests.
+type QuerierFake struct {
+	db.Querier
+
+	SystemCheckGrantErr       error
+	SystemCheckGrantCalls     []db.SystemCheckGrantParams
+	SystemCheckRoleGrantErr   error
+	SystemCheckRoleGrantCalls []db.SystemCheckRoleGrantParams
+
+	AdminListTopicsWithUserGrantsNoRolesRows  []*db.AdminListTopicsWithUserGrantsNoRolesRow
+	AdminListTopicsWithUserGrantsNoRolesCalls []interface{}
+}
+
+// SystemCheckGrant records the call and returns a stubbed or delegated result.
+func (q *QuerierFake) SystemCheckGrant(ctx context.Context, arg db.SystemCheckGrantParams) (int32, error) {
+	q.SystemCheckGrantCalls = append(q.SystemCheckGrantCalls, arg)
+	if q.Querier != nil {
+		return q.Querier.SystemCheckGrant(ctx, arg)
+	}
+	if q.SystemCheckGrantErr != nil {
+		return 0, q.SystemCheckGrantErr
+	}
+	return 1, nil
+}
+
+// SystemCheckRoleGrant records the call and returns a stubbed or delegated result.
+func (q *QuerierFake) SystemCheckRoleGrant(ctx context.Context, arg db.SystemCheckRoleGrantParams) (int32, error) {
+	q.SystemCheckRoleGrantCalls = append(q.SystemCheckRoleGrantCalls, arg)
+	if q.Querier != nil {
+		return q.Querier.SystemCheckRoleGrant(ctx, arg)
+	}
+	if q.SystemCheckRoleGrantErr != nil {
+		return 0, q.SystemCheckRoleGrantErr
+	}
+	return 1, nil
+}
+
+// AdminListTopicsWithUserGrantsNoRoles records the call and returns stubbed topics or a delegated result.
+func (q *QuerierFake) AdminListTopicsWithUserGrantsNoRoles(ctx context.Context, includeAdmin interface{}) ([]*db.AdminListTopicsWithUserGrantsNoRolesRow, error) {
+	q.AdminListTopicsWithUserGrantsNoRolesCalls = append(q.AdminListTopicsWithUserGrantsNoRolesCalls, includeAdmin)
+	if q.Querier != nil {
+		return q.Querier.AdminListTopicsWithUserGrantsNoRoles(ctx, includeAdmin)
+	}
+	return q.AdminListTopicsWithUserGrantsNoRolesRows, nil
+}
+
+// NewTestCoreData returns a CoreData configured for tests using a QuerierFake.
+// Use WithUserRoles or other CoreOption helpers to override defaults.
+func NewTestCoreData(t *testing.T, q db.Querier) *CoreData {
+	t.Helper()
+	if q == nil {
+		q = &QuerierFake{}
+	}
+	return NewCoreData(context.Background(), q, config.NewRuntimeConfig())
+}

--- a/core/common/testutil_test.go
+++ b/core/common/testutil_test.go
@@ -2,23 +2,63 @@ package common
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/internal/db"
 )
 
-// QuerierStub wraps a db.Querier for tests that need CoreData with stubbed queries.
-type QuerierStub struct {
-	db.Querier
+func TestQuerierFakeGrantStubs(t *testing.T) {
+	q := &QuerierFake{}
+	if _, err := q.SystemCheckGrant(context.Background(), db.SystemCheckGrantParams{}); err != nil {
+		t.Fatalf("default SystemCheckGrant returned error: %v", err)
+	}
+	if len(q.SystemCheckGrantCalls) != 1 {
+		t.Fatalf("expected 1 grant call, got %d", len(q.SystemCheckGrantCalls))
+	}
+
+	q.SystemCheckGrantErr = errors.New("deny")
+	if _, err := q.SystemCheckGrant(context.Background(), db.SystemCheckGrantParams{Action: "view"}); err == nil {
+		t.Fatalf("expected injected grant error")
+	}
+	if len(q.SystemCheckGrantCalls) != 2 {
+		t.Fatalf("expected 2 grant calls, got %d", len(q.SystemCheckGrantCalls))
+	}
+
+	if _, err := q.SystemCheckRoleGrant(context.Background(), db.SystemCheckRoleGrantParams{}); err != nil {
+		t.Fatalf("default role grant returned error: %v", err)
+	}
+	if len(q.SystemCheckRoleGrantCalls) != 1 {
+		t.Fatalf("expected 1 role grant call, got %d", len(q.SystemCheckRoleGrantCalls))
+	}
+
+	q.SystemCheckRoleGrantErr = errors.New("deny role")
+	if _, err := q.SystemCheckRoleGrant(context.Background(), db.SystemCheckRoleGrantParams{Action: "post"}); err == nil {
+		t.Fatalf("expected injected role grant error")
+	}
+	if len(q.SystemCheckRoleGrantCalls) != 2 {
+		t.Fatalf("expected 2 role grant calls, got %d", len(q.SystemCheckRoleGrantCalls))
+	}
 }
 
-// NewTestCoreData returns a CoreData configured for tests using a QuerierStub.
-// Use WithUserRoles or other CoreOption helpers to override defaults.
-func NewTestCoreData(t *testing.T, q db.Querier) *CoreData {
-	t.Helper()
-	if q == nil {
-		return NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
+func TestQuerierFakeTopicListing(t *testing.T) {
+	q := &QuerierFake{
+		AdminListTopicsWithUserGrantsNoRolesRows: []*db.AdminListTopicsWithUserGrantsNoRolesRow{
+			{Idforumtopic: 1},
+		},
 	}
-	return NewCoreData(context.Background(), QuerierStub{Querier: q}, config.NewRuntimeConfig())
+
+	rows, err := q.AdminListTopicsWithUserGrantsNoRoles(context.Background(), true)
+	if err != nil {
+		t.Fatalf("AdminListTopicsWithUserGrantsNoRoles error: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Idforumtopic != 1 {
+		t.Fatalf("unexpected topics returned: %+v", rows)
+	}
+	if len(q.AdminListTopicsWithUserGrantsNoRolesCalls) != 1 {
+		t.Fatalf("expected 1 topic listing call, got %d", len(q.AdminListTopicsWithUserGrantsNoRolesCalls))
+	}
+	if include, ok := q.AdminListTopicsWithUserGrantsNoRolesCalls[0].(bool); !ok || !include {
+		t.Fatalf("expected includeAdmin=true, got %#v", q.AdminListTopicsWithUserGrantsNoRolesCalls[0])
+	}
 }

--- a/handlers/admin/maintenancePage_test.go
+++ b/handlers/admin/maintenancePage_test.go
@@ -1,0 +1,47 @@
+package admin
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestAdminMaintenancePageListsTopics(t *testing.T) {
+	q := &common.QuerierFake{
+		AdminListTopicsWithUserGrantsNoRolesRows: []*db.AdminListTopicsWithUserGrantsNoRolesRow{
+			{Idforumtopic: 1, Title: sql.NullString{String: "Topic One", Valid: true}},
+			{Idforumtopic: 2, Title: sql.NullString{String: "Topic Two", Valid: true}},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/maintenance", nil)
+	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithUserRoles([]string{"administrator"}))
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	AdminMaintenancePage(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "Topic One (ID 1)") || !strings.Contains(body, "Topic Two (ID 2)") {
+		t.Fatalf("expected topic titles in response, got %s", body)
+	}
+
+	if len(q.AdminListTopicsWithUserGrantsNoRolesCalls) != 1 {
+		t.Fatalf("expected 1 topic listing call, got %d", len(q.AdminListTopicsWithUserGrantsNoRolesCalls))
+	}
+	if include, ok := q.AdminListTopicsWithUserGrantsNoRolesCalls[0].(bool); !ok || !include {
+		t.Fatalf("expected includeAdmin=true, got %#v", q.AdminListTopicsWithUserGrantsNoRolesCalls[0])
+	}
+}


### PR DESCRIPTION
## Summary
- add a reusable QuerierFake helper that stubs grant checks and admin topic listings for tests
- cover the fake with unit tests to confirm grant error wiring and topic call tracking
- exercise the admin maintenance page with the fake to verify topic rendering

## Testing
- go test ./...
- go vet ./...
- golangci-lint run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd0681e10832fa1857ab839674d41)