### PR TITLE
Use querier stub for news search test

### DIFF
--- a/handlers/news/search_test.go
+++ b/handlers/news/search_test.go
@@ -5,39 +5,33 @@ import (
 	"database/sql"
 	"net/http/httptest"
 	"net/url"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 )
 
 func TestNewsSearchFiltersUnauthorized(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	queries := &db.QuerierStub{
+		ListSiteNewsSearchFirstForListerReturns: []int32{1, 2},
+		GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountReturns: []*db.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow{
+			{
+				Writername:    sql.NullString{String: "bob", Valid: true},
+				Writerid:      sql.NullInt32{Int32: 1, Valid: true},
+				Idsitenews:    1,
+				ForumthreadID: 0,
+				LanguageID:    sql.NullInt32{Int32: 1, Valid: true},
+				UsersIdusers:  1,
+				News:          sql.NullString{String: "text", Valid: true},
+				Occurred:      sql.NullTime{Time: time.Unix(0, 0), Valid: true},
+				Timezone:      sql.NullString{String: time.Local.String(), Valid: true},
+				Comments:      sql.NullInt32{Int32: 0, Valid: true},
+			},
+		},
 	}
-	defer conn.Close()
-
-	queries := db.New(conn)
-
-	firstRows := sqlmock.NewRows([]string{"site_news_id"}).AddRow(1).AddRow(2)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT DISTINCT cs.site_news_id")).
-		WithArgs(int32(1), sql.NullString{String: "foo", Valid: true}, int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
-		WillReturnRows(firstRows)
-
-	newsRows := sqlmock.NewRows([]string{
-		"writerName", "writerId", "idsitenews", "forumthread_id",
-		"language_id", "users_idusers", "news", "occurred", "timezone",
-		"Comments",
-	}).AddRow("bob", 1, 1, 0, 1, 1, "text", time.Unix(0, 0), time.Local.String(), 0)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT u.username AS writerName")).
-		WithArgs(int32(1), int32(1), int32(2), int32(1), int32(1), sql.NullInt32{Int32: 1, Valid: true}).
-		WillReturnRows(newsRows)
 
 	form := url.Values{"searchwords": {"foo"}}
 	req := httptest.NewRequest("POST", "/", strings.NewReader(form.Encode()))
@@ -58,7 +52,10 @@ func TestNewsSearchFiltersUnauthorized(t *testing.T) {
 	if news[0].Idsitenews != 1 {
 		t.Errorf("unexpected id %d", news[0].Idsitenews)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(queries.ListSiteNewsSearchFirstForListerCalls) != 1 {
+		t.Fatalf("expected search first call, got %d", len(queries.ListSiteNewsSearchFirstForListerCalls))
+	}
+	if len(queries.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountCalls) != 1 {
+		t.Fatalf("expected news fetch call, got %d", len(queries.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountCalls))
 	}
 }

--- a/internal/db/querier_stub.go
+++ b/internal/db/querier_stub.go
@@ -69,6 +69,18 @@ type QuerierStub struct {
 	AdminListPrivateTopicParticipantsByTopicIDCalls   []sql.NullInt32
 	AdminListPrivateTopicParticipantsByTopicIDReturns []*AdminListPrivateTopicParticipantsByTopicIDRow
 	AdminListPrivateTopicParticipantsByTopicIDErr     error
+
+	ListSiteNewsSearchFirstForListerCalls   []ListSiteNewsSearchFirstForListerParams
+	ListSiteNewsSearchFirstForListerReturns []int32
+	ListSiteNewsSearchFirstForListerErr     error
+
+	ListSiteNewsSearchNextForListerCalls   []ListSiteNewsSearchNextForListerParams
+	ListSiteNewsSearchNextForListerReturns []int32
+	ListSiteNewsSearchNextForListerErr     error
+
+	GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountCalls   []GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountParams
+	GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountReturns []*GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow
+	GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountErr     error
 }
 
 func (s *QuerierStub) AdminListPrivateTopicParticipantsByTopicID(ctx context.Context, itemID sql.NullInt32) ([]*AdminListPrivateTopicParticipantsByTopicIDRow, error) {
@@ -196,6 +208,39 @@ func (s *QuerierStub) AdminListAdministratorEmails(ctx context.Context) ([]strin
 	s.AdminListAdministratorEmailsCalls++
 	s.mu.Unlock()
 	return s.AdminListAdministratorEmailsReturns, s.AdminListAdministratorEmailsErr
+}
+
+// ListSiteNewsSearchFirstForLister records the call and returns the configured response.
+func (s *QuerierStub) ListSiteNewsSearchFirstForLister(ctx context.Context, arg ListSiteNewsSearchFirstForListerParams) ([]int32, error) {
+	s.mu.Lock()
+	s.ListSiteNewsSearchFirstForListerCalls = append(s.ListSiteNewsSearchFirstForListerCalls, arg)
+	ret := s.ListSiteNewsSearchFirstForListerReturns
+	err := s.ListSiteNewsSearchFirstForListerErr
+	s.mu.Unlock()
+	return ret, err
+}
+
+// ListSiteNewsSearchNextForLister records the call and returns the configured response.
+func (s *QuerierStub) ListSiteNewsSearchNextForLister(ctx context.Context, arg ListSiteNewsSearchNextForListerParams) ([]int32, error) {
+	s.mu.Lock()
+	s.ListSiteNewsSearchNextForListerCalls = append(s.ListSiteNewsSearchNextForListerCalls, arg)
+	ret := s.ListSiteNewsSearchNextForListerReturns
+	err := s.ListSiteNewsSearchNextForListerErr
+	s.mu.Unlock()
+	return ret, err
+}
+
+// GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount records the call and returns the configured response.
+func (s *QuerierStub) GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount(ctx context.Context, arg GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountParams) ([]*GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountRow, error) {
+	s.mu.Lock()
+	s.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountCalls = append(s.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountCalls, arg)
+	ret := s.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountReturns
+	err := s.GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCountErr
+	s.mu.Unlock()
+	if ret == nil && err == nil {
+		return nil, errors.New("GetNewsPostsByIdsForUserWithWriterIdAndThreadCommentCount not stubbed")
+	}
+	return ret, err
 }
 
 // SystemGetTemplateOverride records the call and returns the configured response.


### PR DESCRIPTION
## Summary
- add news search queries and results helpers to the Querier stub
- refactor news search handler test to use the stubbed queries instead of sqlmock
- assert stub call counts to verify search flow

## Testing
- go test ./internal/db ./handlers/news

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd0679cd4832fb740df08b821250a)