### PR TITLE
Add grant check stubs for matcher tests

### DIFF
--- a/handlers/matchers_test.go
+++ b/handlers/matchers_test.go
@@ -4,17 +4,15 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"github.com/arran4/goa4web/core/consts"
-	"github.com/arran4/goa4web/internal/db"
 	"net/http/httptest"
-	"regexp"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
 )
 
 func TestRequiredGrantAllowed(t *testing.T) {
@@ -43,16 +41,10 @@ func TestRequiredGrantDenied(t *testing.T) {
 
 func TestRequireGrantAllowed(t *testing.T) {
 	req := httptest.NewRequest("GET", "/news/1/edit", nil)
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		SystemCheckGrantStubs: []db.SystemCheckGrantStub{{Result: 1}},
 	}
-	defer conn.Close()
-	mock.ExpectQuery(regexp.QuoteMeta("WITH role_ids AS (\n    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?\n    UNION\n    SELECT id FROM roles WHERE name = 'anyone'\n)\nSELECT 1 FROM grants g\nWHERE g.section = ?\n  AND (g.item = ? OR g.item IS NULL)\n  AND g.action = ?\n  AND g.active = 1\n  AND (g.item_id = ? OR g.item_id IS NULL)\n  AND (g.user_id = ? OR g.user_id IS NULL)\n  AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))\nLIMIT 1\n")).
-		WithArgs(int32(1), "news", sql.NullString{String: "post", Valid: true}, "edit", sql.NullInt32{Int32: 1, Valid: true}, sql.NullInt32{Int32: 1, Valid: true}).
-		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
-
-	cd := common.NewCoreData(req.Context(), db.New(conn), config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
 	cd.UserID = 1
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -61,23 +53,27 @@ func TestRequireGrantAllowed(t *testing.T) {
 	if !RequireGrantForPathInt("news", "post", "edit", "news")(req, match) {
 		t.Fatalf("expected grant-based matcher to allow request")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("grant expectations: %v", err)
+	if got := len(q.SystemCheckGrantCalls); got != 1 {
+		t.Fatalf("expected 1 grant check, got %d", got)
+	}
+	call := q.SystemCheckGrantCalls[0]
+	if call.Section != "news" || call.Action != "edit" {
+		t.Fatalf("unexpected grant check: %+v", call)
+	}
+	if call.ItemID.Int32 != 1 || !call.ItemID.Valid {
+		t.Fatalf("expected item ID 1, got %+v", call.ItemID)
+	}
+	if call.UserID.Int32 != 1 || !call.UserID.Valid {
+		t.Fatalf("expected user ID 1, got %+v", call.UserID)
 	}
 }
 
 func TestRequireGrantDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/news/2/edit", nil)
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		SystemCheckGrantStubs: []db.SystemCheckGrantStub{{Err: sql.ErrNoRows}},
 	}
-	defer conn.Close()
-	mock.ExpectQuery(regexp.QuoteMeta("WITH role_ids AS (\n    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?\n    UNION\n    SELECT id FROM roles WHERE name = 'anyone'\n)\nSELECT 1 FROM grants g\nWHERE g.section = ?\n  AND (g.item = ? OR g.item IS NULL)\n  AND g.action = ?\n  AND g.active = 1\n  AND (g.item_id = ? OR g.item_id IS NULL)\n  AND (g.user_id = ? OR g.user_id IS NULL)\n  AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))\nLIMIT 1\n")).
-		WithArgs(int32(2), "news", sql.NullString{String: "post", Valid: true}, "edit", sql.NullInt32{Int32: 2, Valid: true}, sql.NullInt32{Int32: 2, Valid: true}).
-		WillReturnError(sql.ErrNoRows)
-
-	cd := common.NewCoreData(req.Context(), db.New(conn), config.NewRuntimeConfig())
+	cd := common.NewCoreData(req.Context(), q, config.NewRuntimeConfig())
 	cd.UserID = 2
 	ctx := context.WithValue(req.Context(), consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
@@ -86,7 +82,14 @@ func TestRequireGrantDenied(t *testing.T) {
 	if RequireGrantForPathInt("news", "post", "edit", "news")(req, match) {
 		t.Fatalf("expected grant-based matcher to reject request")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("grant expectations: %v", err)
+	if got := len(q.SystemCheckGrantCalls); got != 1 {
+		t.Fatalf("expected 1 grant check, got %d", got)
+	}
+	call := q.SystemCheckGrantCalls[0]
+	if call.ItemID.Int32 != 2 || !call.ItemID.Valid {
+		t.Fatalf("expected item ID 2, got %+v", call.ItemID)
+	}
+	if call.UserID.Int32 != 2 || !call.UserID.Valid {
+		t.Fatalf("expected user ID 2, got %+v", call.UserID)
 	}
 }


### PR DESCRIPTION
## Summary
- extend the db.QuerierStub with queued grant check responses and permission lookups used by permission checks
- update handler matcher tests to rely on the stubbed grant checks and assert the recorded call details instead of sqlmock

## Testing
- go mod tidy
- go fmt ./...
- go vet ./...
- golangci-lint run
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd065bf68832fa3da909fbb7e737b)