### PR TITLE
Add fakes for grant checks and news listings in tests

### DIFF
--- a/core/common/permissions.go
+++ b/core/common/permissions.go
@@ -14,6 +14,9 @@ func (cd *CoreData) HasGrant(section, item, action string, itemID int32) bool {
 	if cd.IsAdmin() {
 		return true
 	}
+	if cd.grantChecker != nil {
+		return cd.grantChecker(section, item, action, itemID)
+	}
 	if cd.queries == nil {
 		return false
 	}

--- a/handlers/news/newsIndexPermissions_test.go
+++ b/handlers/news/newsIndexPermissions_test.go
@@ -1,15 +1,11 @@
 package news
 
 import (
-	"database/sql"
 	"net/http/httptest"
-	"regexp"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/internal/db"
 )
 
 func TestCustomNewsIndexRoles(t *testing.T) {
@@ -27,39 +23,40 @@ func TestCustomNewsIndexRoles(t *testing.T) {
 		t.Errorf("admin should see add news when admin mode is enabled")
 	}
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	type grantCheck struct {
+		section string
+		item    string
+		action  string
+		itemID  int32
 	}
-	defer conn.Close()
-	ctx := req.Context()
-	cd = common.NewCoreData(ctx, db.New(conn), config.NewRuntimeConfig(), common.WithUserRoles([]string{"content writer"}))
+	var checks []grantCheck
+	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(),
+		common.WithUserRoles([]string{"content writer"}),
+		common.WithGrantChecker(func(section, item, action string, itemID int32) bool {
+			checks = append(checks, grantCheck{section: section, item: item, action: action, itemID: itemID})
+			return true
+		}))
 	cd.UserID = 1
-	mock.ExpectQuery("SELECT 1\\s+FROM grants g\\s+JOIN roles r").WillReturnError(sql.ErrNoRows)
-	mock.ExpectQuery("(?s)WITH role_ids.*SELECT 1 FROM grants").WillReturnRows(sqlmock.NewRows([]string{"result"}).AddRow(1))
-	CustomNewsIndex(cd, req.WithContext(ctx))
+	CustomNewsIndex(cd, req)
 	if !common.ContainsItem(cd.CustomIndexItems, "Add News") {
 		t.Errorf("content writer with grant should see add news")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("mock.ExpectationsWereMet: %v", err)
+	if len(checks) != 1 || checks[0] != (grantCheck{section: "news", item: "post", action: "post", itemID: 0}) {
+		t.Fatalf("grant checks = %+v, want one post grant check", checks)
 	}
 
-	conn, mock, err = sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
-	cd = common.NewCoreData(req.Context(), q, config.NewRuntimeConfig(), common.WithUserRoles([]string{"anyone"}))
-	mock.ExpectQuery(regexp.QuoteMeta("WITH role_ids AS (\n    SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = ?\n    UNION\n    SELECT id FROM roles WHERE name = 'anyone'\n)\nSELECT 1 FROM grants g\nWHERE g.section = ?\n  AND (g.item = ? OR g.item IS NULL)\n  AND g.action = ?\n  AND g.active = 1\n  AND (g.item_id = ? OR g.item_id IS NULL)\n  AND (g.user_id = ? OR g.user_id IS NULL)\n  AND (g.role_id IS NULL OR g.role_id IN (SELECT id FROM role_ids))\nLIMIT 1\n")).
-		WithArgs(int32(0), "news", sql.NullString{String: "post", Valid: true}, "post", sql.NullInt32{}, sql.NullInt32{}).
-		WillReturnError(sql.ErrNoRows)
+	checks = nil
+	cd = common.NewCoreData(req.Context(), nil, config.NewRuntimeConfig(),
+		common.WithUserRoles([]string{"anyone"}),
+		common.WithGrantChecker(func(section, item, action string, itemID int32) bool {
+			checks = append(checks, grantCheck{section: section, item: item, action: action, itemID: itemID})
+			return false
+		}))
 	CustomNewsIndex(cd, req)
 	if common.ContainsItem(cd.CustomIndexItems, "Add News") {
 		t.Errorf("user without grant should not see add news")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("grant expectations: %v", err)
+	if len(checks) != 1 || checks[0] != (grantCheck{section: "news", item: "post", action: "post", itemID: 0}) {
+		t.Fatalf("grant checks = %+v, want one post grant check", checks)
 	}
 }


### PR DESCRIPTION
## Summary
- allow CoreData to inject custom grant checkers and news fetchers for test scenarios
- filter fetched news through a shared helper that respects injected grant checks
- replace SQL-based news permission tests with fakes that assert expected grant lookups

## Testing
- go test ./...
- go vet ./...
- golangci-lint run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd0642c40832fb98468a9ae0f6377)