### PR TITLE
Add fake querier for bookmark handler tests

### DIFF
--- a/handlers/bookmarks/mine_test.go
+++ b/handlers/bookmarks/mine_test.go
@@ -3,13 +3,12 @@ package bookmarks
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"strings"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/sessions"
 
@@ -20,6 +19,53 @@ import (
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/db"
 )
+
+type fakeBookmarksQuerier struct {
+	db.Querier
+	row *db.GetBookmarksForUserRow
+	err error
+}
+
+func (f fakeBookmarksQuerier) GetBookmarksForUser(ctx context.Context, usersID int32) (*db.GetBookmarksForUserRow, error) {
+	return f.row, f.err
+}
+
+func (f fakeBookmarksQuerier) GetPermissionsByUserID(ctx context.Context, usersID int32) ([]*db.GetPermissionsByUserIDRow, error) {
+	return nil, nil
+}
+
+func (f fakeBookmarksQuerier) SystemCheckRoleGrant(ctx context.Context, arg db.SystemCheckRoleGrantParams) (int32, error) {
+	return 0, errors.New("not granted")
+}
+
+func newBookmarksRequest(t *testing.T, q db.Querier) *http.Request {
+	t.Helper()
+
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test-session"
+
+	req := httptest.NewRequest("GET", "/bookmarks/mine", nil)
+	sess, err := store.Get(req, core.SessionName)
+	if err != nil {
+		t.Fatalf("session: %v", err)
+	}
+	sess.Values["UID"] = int32(1)
+
+	w := httptest.NewRecorder()
+	if err := sess.Save(req, w); err != nil {
+		t.Fatalf("save session: %v", err)
+	}
+	for _, c := range w.Result().Cookies() {
+		req.AddCookie(c)
+	}
+
+	ctx := req.Context()
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithSession(sess))
+	cd.UserID = 1
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+	return req.WithContext(ctx)
+}
 
 func TestParseColumns(t *testing.T) {
 	tests := []struct {
@@ -72,34 +118,7 @@ func TestParseColumns(t *testing.T) {
 }
 
 func TestMinePage_NoBookmarks(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-
-	queries := db.New(conn)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT Idbookmarks, list\nFROM bookmarks\nWHERE users_idusers = ?")).
-		WithArgs(int32(1)).WillReturnError(sql.ErrNoRows)
-
-	store := sessions.NewCookieStore([]byte("test"))
-	core.Store = store
-	core.SessionName = "test-session"
-
-	req := httptest.NewRequest("GET", "/bookmarks/mine", nil)
-	sess, _ := store.Get(req, core.SessionName)
-	sess.Values["UID"] = int32(1)
-	w := httptest.NewRecorder()
-	sess.Save(req, w)
-	for _, c := range w.Result().Cookies() {
-		req.AddCookie(c)
-	}
-
-	ctx := req.Context()
-	cd := common.NewCoreData(ctx, queries, config.NewRuntimeConfig(), common.WithSession(sess))
-	cd.UserID = 1
-	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
-	req = req.WithContext(ctx)
+	req := newBookmarksRequest(t, fakeBookmarksQuerier{err: sql.ErrNoRows})
 
 	rr := httptest.NewRecorder()
 	MinePage(rr, req)
@@ -107,10 +126,35 @@ func TestMinePage_NoBookmarks(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d", rr.Code)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
 	if !strings.Contains(rr.Body.String(), "No bookmarks saved") {
 		t.Fatalf("body=%q", rr.Body.String())
+	}
+}
+
+func TestMinePage_RenderBookmarks(t *testing.T) {
+	bookmarks := &db.GetBookmarksForUserRow{
+		List: sql.NullString{
+			String: "Category: Reference\nhttps://example.com Example\nCategory: Search\nhttps://search.example Search\n",
+			Valid:  true,
+		},
+	}
+	req := newBookmarksRequest(t, fakeBookmarksQuerier{row: bookmarks})
+
+	rr := httptest.NewRecorder()
+	MinePage(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d", rr.Code)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{
+		"<h2>Reference</h2>",
+		`<a href="https://example.com" target="_blank">Example</a>`,
+		"<h2>Search</h2>",
+		`<a href="https://search.example" target="_blank">Search</a>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in body=%q", want, body)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- add a lightweight fake Querier for bookmark lookups used in handler tests
- centralize bookmark handler request setup so tests configure sessions and core data consistently
- add coverage that renders stubbed bookmark rows to verify page content

## Testing
- go fmt ./...
- go vet ./...
- golangci-lint run
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd061c824832f8bee081b465401c8)