### PR TITLE
Use fake querier for user rename

### DIFF
--- a/cmd/goa4web/user_rename_test.go
+++ b/cmd/goa4web/user_rename_test.go
@@ -1,48 +1,57 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"database/sql"
 	"flag"
+	"log"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/arran4/goa4web/internal/db"
 )
 
 func TestUserRenameCmd(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name          string
-		args          []string
-		setupMocks    func(sqlmock.Sqlmock)
-		expectedError string
+		name           string
+		args           []string
+		setupFake      func(*fakeUserRenameQueries)
+		expectedLog    string
+		expectedUpdate *db.AdminUpdateUsernameByIDParams
+		expectedError  string
 	}{
 		{
-			name: "positional args",
-			args: []string{"alice", "alice2"},
-			setupMocks: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery("(?s).*SystemGetUserByUsername.*").
-					WithArgs(sql.NullString{String: "alice", Valid: true}).
-					WillReturnRows(sqlmock.NewRows([]string{"idusers", "username", "public_profile_enabled_at"}).AddRow(
-						int32(7), sql.NullString{String: "alice", Valid: true}, sql.NullTime{},
-					))
-				mock.ExpectExec("(?s).*AdminUpdateUsernameByID.*").
-					WithArgs(sql.NullString{String: "alice2", Valid: true}, int32(7)).
-					WillReturnResult(sqlmock.NewResult(0, 1))
+			name:        "positional args",
+			args:        []string{"alice", "alice2"},
+			expectedLog: "renamed alice to alice2",
+			expectedUpdate: &db.AdminUpdateUsernameByIDParams{
+				Username: sql.NullString{String: "alice2", Valid: true},
+				Idusers:  int32(7),
+			},
+			setupFake: func(fake *fakeUserRenameQueries) {
+				fake.user = &db.SystemGetUserByUsernameRow{
+					Idusers:                int32(7),
+					Username:               sql.NullString{String: "alice", Valid: true},
+					PublicProfileEnabledAt: sql.NullTime{},
+				}
 			},
 		},
 		{
-			name: "flag args",
-			args: []string{"-from", "bob", "-to", "bob2"},
-			setupMocks: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery("(?s).*SystemGetUserByUsername.*").
-					WithArgs(sql.NullString{String: "bob", Valid: true}).
-					WillReturnRows(sqlmock.NewRows([]string{"idusers", "username", "public_profile_enabled_at"}).AddRow(
-						int32(9), sql.NullString{String: "bob", Valid: true}, sql.NullTime{},
-					))
-				mock.ExpectExec("(?s).*AdminUpdateUsernameByID.*").
-					WithArgs(sql.NullString{String: "bob2", Valid: true}, int32(9)).
-					WillReturnResult(sqlmock.NewResult(0, 1))
+			name:        "flag args",
+			args:        []string{"-from", "bob", "-to", "bob2"},
+			expectedLog: "renamed bob to bob2",
+			expectedUpdate: &db.AdminUpdateUsernameByIDParams{
+				Username: sql.NullString{String: "bob2", Valid: true},
+				Idusers:  int32(9),
+			},
+			setupFake: func(fake *fakeUserRenameQueries) {
+				fake.user = &db.SystemGetUserByUsernameRow{
+					Idusers:                int32(9),
+					Username:               sql.NullString{String: "bob", Valid: true},
+					PublicProfileEnabledAt: sql.NullTime{},
+				}
 			},
 		},
 		{
@@ -64,17 +73,6 @@ func TestUserRenameCmd(t *testing.T) {
 
 			root := &rootCmd{fs: flag.NewFlagSet("prog", flag.ContinueOnError)}
 
-			var mock sqlmock.Sqlmock
-			if tc.setupMocks != nil {
-				conn, m, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
-				if err != nil {
-					t.Fatalf("sqlmock.New: %v", err)
-				}
-				mock = m
-				root.db = conn
-				tc.setupMocks(mock)
-			}
-
 			parent := &userCmd{rootCmd: root}
 			cmd, err := parseUserRenameCmd(parent, tc.args)
 			if tc.expectedError != "" && err != nil {
@@ -85,6 +83,16 @@ func TestUserRenameCmd(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("parseUserRenameCmd: %v", err)
+			}
+
+			var logBuf bytes.Buffer
+			restore := swapLogOutput(&logBuf)
+			defer restore()
+
+			if tc.setupFake != nil {
+				fake := &fakeUserRenameQueries{t: t}
+				tc.setupFake(fake)
+				cmd.queries = fake
 			}
 
 			err = cmd.Run()
@@ -100,11 +108,57 @@ func TestUserRenameCmd(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Run: %v", err)
 			}
-			if tc.setupMocks != nil {
-				if err := mock.ExpectationsWereMet(); err != nil {
-					t.Fatalf("unmet expectations: %v", err)
+			if tc.expectedLog != "" && !containsLine(logBuf.String(), tc.expectedLog) {
+				t.Fatalf("expected log output %q, got %q", tc.expectedLog, logBuf.String())
+			}
+			if tc.expectedUpdate != nil {
+				if cmd.queries.(*fakeUserRenameQueries).updated == nil {
+					t.Fatalf("expected update to be called")
+				}
+				if *cmd.queries.(*fakeUserRenameQueries).updated != *tc.expectedUpdate {
+					t.Fatalf("unexpected update args: %+v", *cmd.queries.(*fakeUserRenameQueries).updated)
 				}
 			}
 		})
 	}
+}
+
+type fakeUserRenameQueries struct {
+	t         *testing.T
+	user      *db.SystemGetUserByUsernameRow
+	getErr    error
+	updateErr error
+	updated   *db.AdminUpdateUsernameByIDParams
+}
+
+func (f *fakeUserRenameQueries) SystemGetUserByUsername(_ context.Context, username sql.NullString) (*db.SystemGetUserByUsernameRow, error) {
+	if f.user != nil && f.user.Username.String != username.String {
+		f.t.Fatalf("unexpected username lookup %q", username.String)
+	}
+	return f.user, f.getErr
+}
+
+func (f *fakeUserRenameQueries) AdminUpdateUsernameByID(_ context.Context, arg db.AdminUpdateUsernameByIDParams) error {
+	f.updated = &arg
+	return f.updateErr
+}
+
+func swapLogOutput(buf *bytes.Buffer) func() {
+	prevFlags := log.Flags()
+	prevOutput := log.Writer()
+	log.SetFlags(0)
+	log.SetOutput(buf)
+	return func() {
+		log.SetFlags(prevFlags)
+		log.SetOutput(prevOutput)
+	}
+}
+
+func containsLine(content, want string) bool {
+	for _, line := range bytes.Split([]byte(content), []byte("\n")) {
+		if string(bytes.TrimSpace(line)) == want {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- inject a user rename querier interface to allow tests to supply fakes
- replace sqlmock usage in the user rename command test with a purpose-built fake and log assertions

## Testing
- go mod tidy
- go fmt ./...
- go vet ./... *(interrupted due to long runtime)*
- golangci-lint run
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd05fa96c832fbe49595e57c0bcd9)