### PR TITLE
Add querier stub for CoreData middleware tests

### DIFF
--- a/internal/app/server/coredata_middleware_test.go
+++ b/internal/app/server/coredata_middleware_test.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core"
 	"github.com/arran4/goa4web/core/common"
@@ -24,24 +22,15 @@ import (
 func TestCoreDataMiddlewareUserRoles(t *testing.T) {
 	navReg := nav.NewRegistry()
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
 	cfg := config.NewRuntimeConfig()
-	defer conn.Close()
-	mock.MatchExpectationsInOrder(false)
-
-	mock.ExpectExec("INSERT INTO sessions").WithArgs("sessid", int32(1)).
-		WillReturnResult(sqlmock.NewResult(1, 1))
-	rows := sqlmock.NewRows([]string{"iduser_roles", "users_idusers", "role_id", "name"}).
-		AddRow(1, 1, 2, "moderator")
-	mock.ExpectQuery(regexp.QuoteMeta("FROM user_roles")).WithArgs(int32(1)).
-		WillReturnRows(rows)
+	q := querierStub{
+		roles: []*db.GetPermissionsByUserIDRow{
+			{Name: "moderator"},
+		},
+	}
 
 	session := &sessions.Session{ID: "sessid", Values: map[interface{}]interface{}{"UID": int32(1)}}
 	req := httptest.NewRequest("GET", "/", nil)
-	q := db.New(conn)
 	cd := common.NewCoreData(req.Context(), q, cfg)
 	ctx := context.WithValue(req.Context(), core.ContextValues("session"), session)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -56,8 +45,9 @@ func TestCoreDataMiddlewareUserRoles(t *testing.T) {
 	signer := imagesign.NewSigner(cfg, "k")
 	linkSigner := linksign.NewSigner(cfg, "k")
 	srv := New(
-		WithDB(conn),
 		WithConfig(cfg),
+		WithQuerier(q),
+		WithSessionManager(sessionManagerStub{}),
 		WithEmailRegistry(reg),
 		WithImageSigner(signer),
 		WithLinkSigner(linkSigner),
@@ -69,29 +59,16 @@ func TestCoreDataMiddlewareUserRoles(t *testing.T) {
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {
 		t.Fatalf("roles mismatch (-want +got):\n%s", diff)
 	}
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
 }
 
 func TestCoreDataMiddlewareAnonymous(t *testing.T) {
 	navReg := nav.NewRegistry()
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
 	cfg := config.NewRuntimeConfig()
-	defer conn.Close()
-	mock.MatchExpectationsInOrder(false)
-
-	mock.ExpectExec("DELETE FROM sessions").WithArgs("sessid").
-		WillReturnResult(sqlmock.NewResult(0, 0))
+	q := querierStub{}
 
 	session := &sessions.Session{ID: "sessid"}
 	req := httptest.NewRequest("GET", "/", nil)
-	q := db.New(conn)
 	cd := common.NewCoreData(req.Context(), q, cfg)
 	ctx := context.WithValue(req.Context(), core.ContextValues("session"), session)
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
@@ -106,8 +83,9 @@ func TestCoreDataMiddlewareAnonymous(t *testing.T) {
 	signer := imagesign.NewSigner(cfg, "k")
 	linkSigner := linksign.NewSigner(cfg, "k")
 	srv := New(
-		WithDB(conn),
 		WithConfig(cfg),
+		WithQuerier(q),
+		WithSessionManager(sessionManagerStub{}),
 		WithEmailRegistry(reg),
 		WithImageSigner(signer),
 		WithLinkSigner(linkSigner),
@@ -119,8 +97,22 @@ func TestCoreDataMiddlewareAnonymous(t *testing.T) {
 	if diff := cmp.Diff(want, cdOut.UserRoles()); diff != "" {
 		t.Fatalf("roles mismatch (-want +got):\n%s", diff)
 	}
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
 }
+
+type querierStub struct {
+	db.Querier
+	roles []*db.GetPermissionsByUserIDRow
+}
+
+func (q querierStub) GetPermissionsByUserID(ctx context.Context, userID int32) ([]*db.GetPermissionsByUserIDRow, error) {
+	return q.roles, nil
+}
+
+func (querierStub) GetUnreadNotificationCountForLister(context.Context, int32) (int64, error) {
+	return 0, nil
+}
+
+type sessionManagerStub struct{}
+
+func (sessionManagerStub) InsertSession(context.Context, string, int32) error { return nil }
+func (sessionManagerStub) DeleteSessionByID(context.Context, string) error    { return nil }


### PR DESCRIPTION
## Summary
- allow the server to accept an injected querier so tests can run without a backing database
- switch the CoreData middleware tests to a stubbed querier and session manager instead of sqlmock expectations

## Testing
- go test ./internal/app/server
- go vet ./internal/app/server
- go vet ./... (terminated manually after running too long)
- golangci-lint run (terminated manually after running too long)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd05ea42c832f80e4d10a2efb55bc)