### PR TITLE
Refactor dbstart tests to use fake querier

### DIFF
--- a/internal/app/dbstart/dbstart.go
+++ b/internal/app/dbstart/dbstart.go
@@ -131,7 +131,11 @@ func CheckUploadDir(cfg *config.RuntimeConfig) *common.UserError {
 
 // EnsureSchema creates core tables if they do not exist and inserts a version row.
 func EnsureSchema(ctx context.Context, db *sql.DB) error {
-	version, err := ensureVersionTable(ctx, db)
+	return ensureSchemaWithQuerier(ctx, sqlDBQuerier{db: db})
+}
+
+func ensureSchemaWithQuerier(ctx context.Context, q execQuerier) error {
+	version, err := ensureVersionTable(ctx, q)
 	if err != nil {
 		return err
 	}

--- a/internal/app/dbstart/ensure_schema_test.go
+++ b/internal/app/dbstart/ensure_schema_test.go
@@ -2,54 +2,28 @@ package dbstart
 
 import (
 	"context"
-	"regexp"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/handlers"
 )
 
 func TestEnsureSchemaVersionMatch(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
+	fq := &fakeQuerier{versionValue: handlers.ExpectedSchemaVersion}
 
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
-		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(handlers.ExpectedSchemaVersion))
-
-	if err := EnsureSchema(context.Background(), conn); err != nil {
+	if err := ensureSchemaWithQuerier(context.Background(), fq); err != nil {
 		t.Fatalf("ensureSchema: %v", err)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
 	}
 }
 
 func TestEnsureSchemaVersionMismatch(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
+	fq := &fakeQuerier{versionValue: handlers.ExpectedSchemaVersion - 1}
 
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)")).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT version FROM schema_version")).
-		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(handlers.ExpectedSchemaVersion - 1))
-
-	err = EnsureSchema(context.Background(), conn)
+	err := ensureSchemaWithQuerier(context.Background(), fq)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
 	expected := RenderSchemaMismatch(handlers.ExpectedSchemaVersion-1, handlers.ExpectedSchemaVersion)
 	if err.Error() != expected {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
 	}
 }

--- a/internal/app/dbstart/fake_querier_test.go
+++ b/internal/app/dbstart/fake_querier_test.go
@@ -1,0 +1,52 @@
+package dbstart
+
+import (
+	"context"
+	"database/sql"
+)
+
+type execCall struct {
+	query string
+	args  []any
+}
+
+type fakeQuerier struct {
+	versionValue   int
+	scanErr        error
+	scannedVersion bool
+	execLog        []execCall
+}
+
+func (f *fakeQuerier) ExecContext(_ context.Context, query string, args ...any) (sql.Result, error) {
+	f.execLog = append(f.execLog, execCall{query: query, args: args})
+	return sqlmockResult{}, nil
+}
+
+func (f *fakeQuerier) QueryRowContext(_ context.Context, _ string, _ ...any) rowScanner {
+	return fakeRow{scan: func(dest ...any) error {
+		if f.scanErr != nil {
+			return f.scanErr
+		}
+		if len(dest) > 0 {
+			switch v := dest[0].(type) {
+			case *int:
+				*v = f.versionValue
+			}
+		}
+		f.scannedVersion = true
+		return nil
+	}}
+}
+
+type fakeRow struct {
+	scan func(dest ...any) error
+}
+
+func (f fakeRow) Scan(dest ...any) error {
+	return f.scan(dest...)
+}
+
+type sqlmockResult struct{}
+
+func (sqlmockResult) LastInsertId() (int64, error) { return 0, nil }
+func (sqlmockResult) RowsAffected() (int64, error) { return 0, nil }

--- a/internal/app/dbstart/migrate_test.go
+++ b/internal/app/dbstart/migrate_test.go
@@ -5,36 +5,27 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"testing/fstest"
 )
 
 func TestApply(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-
 	mfs := fstest.MapFS{
 		"0002.mysql.sql": {Data: []byte("CREATE TABLE t (id int);")},
 	}
 
-	mock.ExpectExec("CREATE TABLE IF NOT EXISTS schema_version").
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery("SELECT version FROM schema_version").
-		WillReturnError(sql.ErrNoRows)
-	mock.ExpectExec("INSERT INTO schema_version").
-		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("CREATE TABLE t").
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec("UPDATE schema_version SET version = ?").WithArgs(2).
-		WillReturnResult(sqlmock.NewResult(0, 1))
+	fq := &fakeQuerier{scanErr: sql.ErrNoRows}
 
-	if err := Apply(context.Background(), conn, mfs, false, "mysql"); err != nil {
+	if err := applyWithQuerier(context.Background(), fq, mfs, false, "mysql"); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+
+	if len(fq.execLog) != 4 {
+		t.Fatalf("expected 4 exec calls, got %d", len(fq.execLog))
+	}
+	if got := fq.execLog[0]; got.query != "CREATE TABLE IF NOT EXISTS schema_version (version INT NOT NULL)" {
+		t.Fatalf("unexpected first exec %q", got.query)
+	}
+	if got := fq.execLog[len(fq.execLog)-1]; got.query != "UPDATE schema_version SET version = ?" || got.args[0] != 2 {
+		t.Fatalf("unexpected final exec %+v", got)
 	}
 }


### PR DESCRIPTION
## Summary
- introduce lightweight fake querier for dbstart tests to capture exec calls and version scans
- refactor migration and schema tests to assert logical outcomes using the fake instead of SQL string expectations
- expose helpers in migration code to support the new testing surface while keeping behaviour unchanged

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd05b197c832fb63177d19828c770)