### PR TITLE
Add reusable querier stubs for permission tests

### DIFF
--- a/core/common/testdata/querier_stub.go
+++ b/core/common/testdata/querier_stub.go
@@ -1,0 +1,27 @@
+package testdata
+
+import "github.com/arran4/goa4web/internal/db"
+
+// VisibleThreadLabels returns sample label rows for thread visibility tests.
+func VisibleThreadLabels(userID int32, labels ...string) []*db.ListContentPrivateLabelsRow {
+	rows := make([]*db.ListContentPrivateLabelsRow, 0, len(labels))
+	for _, l := range labels {
+		rows = append(rows, &db.ListContentPrivateLabelsRow{
+			Item:   "thread",
+			ItemID: 1,
+			UserID: userID,
+			Label:  l,
+			Invert: false,
+		})
+	}
+	return rows
+}
+
+// SampleSubscriptions returns subscription rows for a given user.
+func SampleSubscriptions(userID int32, patterns ...string) []*db.ListSubscriptionsByUserRow {
+	rows := make([]*db.ListSubscriptionsByUserRow, 0, len(patterns))
+	for idx, p := range patterns {
+		rows = append(rows, &db.ListSubscriptionsByUserRow{ID: int32(idx + 1), Pattern: p, Method: "internal"})
+	}
+	return rows
+}

--- a/handlers/faq/faqIndexPermissions_test.go
+++ b/handlers/faq/faqIndexPermissions_test.go
@@ -1,62 +1,48 @@
 package faq
 
 import (
-	"database/sql"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
-	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/testhelpers"
 )
 
 func TestCustomFAQIndexAsk(t *testing.T) {
 	req := httptest.NewRequest("GET", "/faq", nil)
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := testhelpers.NewQuerierStub(testhelpers.StubConfig{
+		Grants: map[string]bool{
+			testhelpers.GrantKey("faq", "question", "post"): true,
+		},
+	})
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
-
-	mock.ExpectQuery("SELECT 1 FROM grants").
-		WithArgs(sqlmock.AnyArg(), "faq", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	CustomFAQIndex(cd, req.WithContext(ctx))
 	if !common.ContainsItem(cd.CustomIndexItems, "Ask") {
 		t.Errorf("expected ask item")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.SystemCheckGrantCalls) != 1 {
+		t.Fatalf("expected 1 grant check, got %d", len(q.SystemCheckGrantCalls))
 	}
 }
 
 func TestCustomFAQIndexAskDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/faq", nil)
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := testhelpers.NewQuerierStub(testhelpers.StubConfig{
+		DefaultGrantAllowed: false,
+	})
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
-
-	mock.ExpectQuery("SELECT 1 FROM grants").
-		WithArgs(sqlmock.AnyArg(), "faq", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnError(sql.ErrNoRows)
 
 	CustomFAQIndex(cd, req.WithContext(ctx))
 	if common.ContainsItem(cd.CustomIndexItems, "Ask") {
 		t.Errorf("unexpected ask item")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.SystemCheckGrantCalls) != 1 {
+		t.Fatalf("expected 1 grant check, got %d", len(q.SystemCheckGrantCalls))
 	}
 }

--- a/handlers/forum/forumIndexPermissions_test.go
+++ b/handlers/forum/forumIndexPermissions_test.go
@@ -1,14 +1,14 @@
 package forum
 
 import (
-	"database/sql"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/config"
 	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/common/testdata"
 	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/testhelpers"
 	"github.com/gorilla/mux"
 )
 
@@ -16,25 +16,20 @@ func TestCustomForumIndexWriteReply(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2/thread/3", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "thread": "3"})
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := testhelpers.NewQuerierStub(testhelpers.StubConfig{
+		Grants: map[string]bool{
+			testhelpers.GrantKey("forum", "topic", "reply"): true,
+		},
+	})
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
-
-	mock.ExpectQuery(`WITH role_ids AS \( SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = \? UNION SELECT id FROM roles WHERE name = 'anyone' \) SELECT 1 FROM grants`).
-		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "reply", sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithUserRoles([]string{"user"}))
 
 	CustomForumIndex(cd, req.WithContext(ctx))
 	if !common.ContainsItem(cd.CustomIndexItems, "Write Reply") {
 		t.Errorf("expected write reply item")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.SystemCheckGrantCalls) != 1 {
+		t.Fatalf("expected 1 grant check, got %d", len(q.SystemCheckGrantCalls))
 	}
 }
 
@@ -42,23 +37,15 @@ func TestCustomForumIndexMarkReadLinks(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2/thread/3", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "thread": "3"})
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := testhelpers.NewQuerierStub(testhelpers.StubConfig{
+		Grants: map[string]bool{
+			testhelpers.GrantKey("forum", "topic", "reply"): true,
+		},
+		PrivateLabels: testdata.VisibleThreadLabels(7),
+	})
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithUserRoles([]string{"user"}))
 	cd.UserID = 7
-
-	mock.ExpectQuery("SELECT item, item_id, user_id, label, invert\\s+FROM content_private_labels").
-		WithArgs("thread", int32(3), int32(7)).
-		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "user_id", "label", "invert"}).
-			AddRow("thread", 3, 7, "unread", false))
-	mock.ExpectQuery(`WITH role_ids AS \( SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = \? UNION SELECT id FROM roles WHERE name = 'anyone' \) SELECT 1 FROM grants`).
-		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "reply", sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	CustomForumIndex(cd, req.WithContext(ctx))
 
@@ -67,8 +54,8 @@ func TestCustomForumIndexMarkReadLinks(t *testing.T) {
 			t.Errorf("expected %s item", name)
 		}
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.ListContentPrivateLabelsCalls) != 1 {
+		t.Fatalf("expected 1 private label query, got %d", len(q.ListContentPrivateLabelsCalls))
 	}
 }
 
@@ -76,24 +63,18 @@ func TestCustomForumIndexHidesMarkReadWhenClear(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2/thread/3", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "thread": "3"})
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := testhelpers.NewQuerierStub(testhelpers.StubConfig{
+		Grants: map[string]bool{
+			testhelpers.GrantKey("forum", "topic", "reply"): true,
+		},
+		PrivateLabels: []*db.ListContentPrivateLabelsRow{
+			{Item: "thread", ItemID: 3, UserID: 7, Label: "unread", Invert: true},
+			{Item: "thread", ItemID: 3, UserID: 7, Label: "new", Invert: true},
+		},
+	})
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithUserRoles([]string{"user"}))
 	cd.UserID = 7
-
-	mock.ExpectQuery("SELECT item, item_id, user_id, label, invert\\s+FROM content_private_labels").
-		WithArgs("thread", int32(3), int32(7)).
-		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "user_id", "label", "invert"}).
-			AddRow("thread", 3, 7, "unread", true).
-			AddRow("thread", 3, 7, "new", true))
-	mock.ExpectQuery(`WITH role_ids AS \( SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = \? UNION SELECT id FROM roles WHERE name = 'anyone' \) SELECT 1 FROM grants`).
-		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "reply", sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 
 	CustomForumIndex(cd, req.WithContext(ctx))
 
@@ -102,8 +83,8 @@ func TestCustomForumIndexHidesMarkReadWhenClear(t *testing.T) {
 			t.Errorf("unexpected %s item", name)
 		}
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.ListContentPrivateLabelsCalls) != 1 {
+		t.Fatalf("expected 1 private label query, got %d", len(q.ListContentPrivateLabelsCalls))
 	}
 }
 
@@ -111,25 +92,18 @@ func TestCustomForumIndexWriteReplyDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2/thread/3", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "thread": "3"})
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := testhelpers.NewQuerierStub(testhelpers.StubConfig{
+		DefaultGrantAllowed: false,
+	})
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
-
-	mock.ExpectQuery(`WITH role_ids AS \( SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = \? UNION SELECT id FROM roles WHERE name = 'anyone' \) SELECT 1 FROM grants`).
-		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "reply", sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnError(sql.ErrNoRows)
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithUserRoles([]string{"user"}))
 
 	CustomForumIndex(cd, req.WithContext(ctx))
 	if common.ContainsItem(cd.CustomIndexItems, "Write Reply") {
 		t.Errorf("unexpected write reply item")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.SystemCheckGrantCalls) != 1 {
+		t.Fatalf("expected 1 grant check, got %d", len(q.SystemCheckGrantCalls))
 	}
 }
 
@@ -137,25 +111,20 @@ func TestCustomForumIndexCreateThread(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "category": "1"})
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := testhelpers.NewQuerierStub(testhelpers.StubConfig{
+		Grants: map[string]bool{
+			testhelpers.GrantKey("forum", "topic", "post"): true,
+		},
+	})
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
-
-	mock.ExpectQuery(`WITH role_ids AS \( SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = \? UNION SELECT id FROM roles WHERE name = 'anyone' \) SELECT 1 FROM grants`).
-		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithUserRoles([]string{"user"}))
 
 	CustomForumIndex(cd, req.WithContext(ctx))
 	if !common.ContainsItem(cd.CustomIndexItems, "New Thread") {
 		t.Errorf("expected create thread item")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.SystemCheckGrantCalls) != 1 {
+		t.Fatalf("expected 1 grant check, got %d", len(q.SystemCheckGrantCalls))
 	}
 }
 
@@ -177,25 +146,18 @@ func TestCustomForumIndexCreateThreadDenied(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "category": "1"})
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := testhelpers.NewQuerierStub(testhelpers.StubConfig{
+		DefaultGrantAllowed: false,
+	})
 	ctx := req.Context()
 	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
-
-	mock.ExpectQuery(`WITH role_ids AS \( SELECT DISTINCT ur.role_id AS id FROM user_roles ur WHERE ur.users_idusers = \? UNION SELECT id FROM roles WHERE name = 'anyone' \) SELECT 1 FROM grants`).
-		WithArgs(sqlmock.AnyArg(), "forum", sqlmock.AnyArg(), "post", sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnError(sql.ErrNoRows)
 
 	CustomForumIndex(cd, req.WithContext(ctx))
 	if common.ContainsItem(cd.CustomIndexItems, "New Thread") {
 		t.Errorf("unexpected create thread item")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.SystemCheckGrantCalls) != 1 {
+		t.Fatalf("expected 1 grant check, got %d", len(q.SystemCheckGrantCalls))
 	}
 }
 
@@ -203,26 +165,17 @@ func TestCustomForumIndexSubscribeLink(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "category": "1"})
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := testhelpers.NewQuerierStub(testhelpers.StubConfig{})
 	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithUserRoles([]string{"user"}))
 	cd.UserID = 1
-
-	mock.ExpectQuery("SELECT id, pattern, method FROM subscriptions").
-		WithArgs(int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "pattern", "method"}))
 
 	CustomForumIndex(cd, req.WithContext(ctx))
 	if !common.ContainsItem(cd.CustomIndexItems, "Subscribe To Topic") {
 		t.Errorf("expected subscribe item")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.ListSubscriptionsByUserCalls) != 1 {
+		t.Fatalf("expected 1 subscription query, got %d", len(q.ListSubscriptionsByUserCalls))
 	}
 }
 
@@ -230,26 +183,19 @@ func TestCustomForumIndexUnsubscribeLink(t *testing.T) {
 	req := httptest.NewRequest("GET", "/forum/topic/2", nil)
 	req = mux.SetURLVars(req, map[string]string{"topic": "2", "category": "1"})
 
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
-	ctx := req.Context()
-	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig())
-	cd.UserID = 1
-
 	pattern := topicSubscriptionPattern(2)
-	mock.ExpectQuery("SELECT id, pattern, method FROM subscriptions").
-		WithArgs(int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "pattern", "method"}).AddRow(1, pattern, "internal"))
+	q := testhelpers.NewQuerierStub(testhelpers.StubConfig{
+		Subscriptions: testdata.SampleSubscriptions(1, pattern),
+	})
+	ctx := req.Context()
+	cd := common.NewCoreData(ctx, q, config.NewRuntimeConfig(), common.WithUserRoles([]string{"user"}))
+	cd.UserID = 1
 
 	CustomForumIndex(cd, req.WithContext(ctx))
 	if !common.ContainsItem(cd.CustomIndexItems, "Unsubscribe From Topic") {
 		t.Errorf("expected unsubscribe item")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if len(q.ListSubscriptionsByUserCalls) != 1 {
+		t.Fatalf("expected 1 subscription query, got %d", len(q.ListSubscriptionsByUserCalls))
 	}
 }

--- a/internal/db/querier_stub.go
+++ b/internal/db/querier_stub.go
@@ -34,6 +34,15 @@ type QuerierStub struct {
 	AdminListAdministratorEmailsReturns []string
 	AdminListAdministratorEmailsCalls   int
 
+	ListContentPrivateLabelsReturns []*ListContentPrivateLabelsRow
+	ListContentPrivateLabelsErr     error
+	ListContentPrivateLabelsCalls   []ListContentPrivateLabelsParams
+	ListContentPrivateLabelsFn      func(ListContentPrivateLabelsParams) ([]*ListContentPrivateLabelsRow, error)
+
+	ListSubscriptionsByUserReturns []*ListSubscriptionsByUserRow
+	ListSubscriptionsByUserErr     error
+	ListSubscriptionsByUserCalls   []int32
+
 	SystemGetTemplateOverrideReturns string
 	SystemGetTemplateOverrideErr     error
 	SystemGetTemplateOverrideCalls   []string
@@ -196,6 +205,30 @@ func (s *QuerierStub) AdminListAdministratorEmails(ctx context.Context) ([]strin
 	s.AdminListAdministratorEmailsCalls++
 	s.mu.Unlock()
 	return s.AdminListAdministratorEmailsReturns, s.AdminListAdministratorEmailsErr
+}
+
+// ListContentPrivateLabels records the call and returns the configured response or a custom function.
+func (s *QuerierStub) ListContentPrivateLabels(ctx context.Context, arg ListContentPrivateLabelsParams) ([]*ListContentPrivateLabelsRow, error) {
+	s.mu.Lock()
+	s.ListContentPrivateLabelsCalls = append(s.ListContentPrivateLabelsCalls, arg)
+	fn := s.ListContentPrivateLabelsFn
+	ret := s.ListContentPrivateLabelsReturns
+	err := s.ListContentPrivateLabelsErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(arg)
+	}
+	return ret, err
+}
+
+// ListSubscriptionsByUser records the call and returns configured rows.
+func (s *QuerierStub) ListSubscriptionsByUser(ctx context.Context, userID int32) ([]*ListSubscriptionsByUserRow, error) {
+	s.mu.Lock()
+	s.ListSubscriptionsByUserCalls = append(s.ListSubscriptionsByUserCalls, userID)
+	ret := s.ListSubscriptionsByUserReturns
+	err := s.ListSubscriptionsByUserErr
+	s.mu.Unlock()
+	return ret, err
 }
 
 // SystemGetTemplateOverride records the call and returns the configured response.

--- a/internal/testhelpers/querier_stub.go
+++ b/internal/testhelpers/querier_stub.go
@@ -1,0 +1,48 @@
+package testhelpers
+
+import (
+	"database/sql"
+
+	"github.com/arran4/goa4web/internal/db"
+)
+
+// StubConfig describes the preconfigured responses for a QuerierStub used in tests.
+type StubConfig struct {
+	Grants map[string]bool
+	// DefaultGrantAllowed controls the fallback grant decision when a specific key is not present.
+	DefaultGrantAllowed bool
+
+	PrivateLabels []*db.ListContentPrivateLabelsRow
+	Subscriptions []*db.ListSubscriptionsByUserRow
+}
+
+// GrantKey returns the lookup key used to define grant expectations.
+func GrantKey(section, item, action string) string {
+	return section + "|" + item + "|" + action
+}
+
+// NewQuerierStub builds a db.QuerierStub configured with common grant and query responses.
+func NewQuerierStub(cfg StubConfig) *db.QuerierStub {
+	stub := &db.QuerierStub{
+		ListContentPrivateLabelsReturns: cfg.PrivateLabels,
+		ListSubscriptionsByUserReturns:  cfg.Subscriptions,
+	}
+
+	stub.SystemCheckGrantFn = func(arg db.SystemCheckGrantParams) (int32, error) {
+		item := ""
+		if arg.Item.Valid {
+			item = arg.Item.String
+		}
+		key := GrantKey(arg.Section, item, arg.Action)
+		allowed, ok := cfg.Grants[key]
+		if !ok {
+			allowed = cfg.DefaultGrantAllowed
+		}
+		if allowed {
+			return 1, nil
+		}
+		return 0, sql.ErrNoRows
+	}
+
+	return stub
+}


### PR DESCRIPTION
## Summary
- add reusable Querier stub configuration helpers to cover grant checks, private labels, and subscriptions in tests
- refactor FAQ and forum index permission tests to use stubbed responses instead of SQL expectations
- provide shared test data helpers for subscription and label rows to simplify subtest setup

## Testing
- ⚠️ `go test ./...` *(interrupted after long runtime; reran targeted packages)*
- ✅ `go test ./handlers/faq ./handlers/forum`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd0588904832f87cc62bf7ae08456)