### PR TITLE
Add content label querier fake for tests

### DIFF
--- a/core/common/coredata_labels_test.go
+++ b/core/common/coredata_labels_test.go
@@ -2,94 +2,74 @@ package common_test
 
 import (
 	"reflect"
-	"regexp"
 	"testing"
-
-	"github.com/DATA-DOG/go-sqlmock"
 
 	common "github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/internal/db"
 )
 
 func TestSetThreadPublicLabels(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		ContentPublicLabelsRows: map[string][]*db.ListContentPublicLabelsRow{
+			"thread:1": {
+				{Item: "thread", ItemID: 1, Label: "foo"},
+				{Item: "thread", ItemID: 1, Label: "bar"},
+			},
+		},
+		ContentLabelStatusRows: map[string][]*db.ListContentLabelStatusRow{
+			"thread:1": {},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
 	cd := common.NewTestCoreData(t, q)
 	cd.UserID = 2
-
-	rows := sqlmock.NewRows([]string{"item", "item_id", "label"}).
-		AddRow("thread", 1, "foo").
-		AddRow("thread", 1, "bar")
-	mock.ExpectQuery("SELECT .* FROM content_public_labels").
-		WithArgs("thread", int32(1)).
-		WillReturnRows(rows)
-	mock.ExpectQuery("SELECT .* FROM content_label_status").
-		WithArgs("thread", int32(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "label"}))
-	mock.ExpectExec("INSERT IGNORE INTO content_public_labels").
-		WithArgs("thread", int32(1), "baz").
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("DELETE FROM content_public_labels").
-		WithArgs("thread", int32(1), "foo").
-		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	if err := cd.SetThreadPublicLabels(1, []string{"bar", "baz"}); err != nil {
 		t.Fatalf("SetThreadPublicLabels: %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+
+	if got := len(q.ListContentPublicLabelsCalls); got != 1 {
+		t.Fatalf("public label lookup calls %d, want 1", got)
+	}
+	if got := q.AddContentPublicLabelCalls; len(got) != 1 || got[0].Label != "baz" {
+		t.Fatalf("public label inserts %+v, want [baz]", got)
+	}
+	if got := q.RemoveContentPublicLabelCalls; len(got) != 1 || got[0].Label != "foo" {
+		t.Fatalf("public label removals %+v, want [foo]", got)
 	}
 }
 
 func TestSetThreadPrivateLabels(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		ContentPrivateLabelsRows: map[string][]*db.ListContentPrivateLabelsRow{
+			"thread:1:2": {
+				{Item: "thread", ItemID: 1, UserID: 2, Label: "one"},
+				{Item: "thread", ItemID: 1, UserID: 2, Label: "two"},
+			},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
 	cd := common.NewTestCoreData(t, q)
 	cd.UserID = 2
-
-	rows := sqlmock.NewRows([]string{"item", "item_id", "user_id", "label", "invert"}).
-		AddRow("thread", 1, 2, "one", false).
-		AddRow("thread", 1, 2, "two", false)
-	mock.ExpectQuery("SELECT .* FROM content_private_labels").
-		WithArgs("thread", int32(1), int32(2)).
-		WillReturnRows(rows)
-	mock.ExpectExec("INSERT IGNORE INTO content_private_labels").
-		WithArgs("thread", int32(1), int32(2), "three", false).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("DELETE FROM content_private_labels").
-		WithArgs("thread", int32(1), int32(2), "one").
-		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	if err := cd.SetThreadPrivateLabels(1, []string{"two", "three"}); err != nil {
 		t.Fatalf("SetThreadPrivateLabels: %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+
+	if got := q.AddContentPrivateLabelCalls; len(got) != 1 || got[0].Label != "three" || got[0].Invert {
+		t.Fatalf("private label inserts %+v, want [three false]", got)
+	}
+	if got := q.RemoveContentPrivateLabelCalls; len(got) != 1 || got[0].Label != "one" {
+		t.Fatalf("private label removals %+v, want [one]", got)
 	}
 }
 
 func TestPrivateLabelsDefaultAndInversion(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		ContentPrivateLabelsRows: map[string][]*db.ListContentPrivateLabelsRow{
+			"thread:1:2": {},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
 	cd := common.NewTestCoreData(t, q)
 	cd.UserID = 2
-
-	// Default case: no stored rows should return new and unread labels.
-	mock.ExpectQuery("SELECT .* FROM content_private_labels").
-		WithArgs("thread", int32(1), int32(2)).
-		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "user_id", "label", "invert"}))
 
 	labels, err := cd.PrivateLabels("thread", 1)
 	if err != nil {
@@ -101,12 +81,10 @@ func TestPrivateLabelsDefaultAndInversion(t *testing.T) {
 	}
 
 	// Inversion case: storing an inverted new label removes it from the result.
-	rows := sqlmock.NewRows([]string{"item", "item_id", "user_id", "label", "invert"}).
-		AddRow("thread", 1, 2, "new", true).
-		AddRow("thread", 1, 2, "foo", false)
-	mock.ExpectQuery("SELECT .* FROM content_private_labels").
-		WithArgs("thread", int32(1), int32(2)).
-		WillReturnRows(rows)
+	q.ContentPrivateLabelsRows["thread:1:2"] = []*db.ListContentPrivateLabelsRow{
+		{Item: "thread", ItemID: 1, UserID: 2, Label: "new", Invert: true},
+		{Item: "thread", ItemID: 1, UserID: 2, Label: "foo"},
+	}
 
 	labels, err = cd.PrivateLabels("thread", 1)
 	if err != nil {
@@ -116,47 +94,31 @@ func TestPrivateLabelsDefaultAndInversion(t *testing.T) {
 	if !reflect.DeepEqual(labels, expected) {
 		t.Fatalf("inverted labels %+v, want %+v", labels, expected)
 	}
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
 }
 
 func TestClearThreadPrivateLabelStatus(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	q := db.New(conn)
+	q := &db.QuerierStub{}
 	cd := common.NewTestCoreData(t, q)
-
-	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM content_private_labels")).
-		WithArgs("thread", int32(1), "unread").
-		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	if err := cd.ClearThreadPrivateLabelStatus(1); err != nil {
 		t.Fatalf("ClearThreadPrivateLabelStatus: %v", err)
 	}
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+	if got := q.SystemClearContentPrivateLabelCalls; len(got) != 1 {
+		t.Fatalf("clear label status calls %+v, want 1 call", got)
+	} else if got[0].Label != "unread" || got[0].Item != "thread" || got[0].ItemID != 1 {
+		t.Fatalf("clear label status args %+v, want thread:1 unread", got[0])
 	}
 }
 
 func TestPrivateLabelsTopicExcludesStatus(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		ContentPrivateLabelsRows: map[string][]*db.ListContentPrivateLabelsRow{
+			"topic:1:2": {},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
 	cd := common.NewTestCoreData(t, q)
 	cd.UserID = 2
-
-	mock.ExpectQuery("SELECT .* FROM content_private_labels").
-		WithArgs("topic", int32(1), int32(2)).
-		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "user_id", "label", "invert"}))
 
 	labels, err := cd.PrivateLabels("topic", 1)
 	if err != nil {
@@ -165,42 +127,31 @@ func TestPrivateLabelsTopicExcludesStatus(t *testing.T) {
 	if len(labels) != 0 {
 		t.Fatalf("expected no labels for topic, got %+v", labels)
 	}
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
 }
 
 func TestSetWritingPublicLabels(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	q := &db.QuerierStub{
+		ContentPublicLabelsRows: map[string][]*db.ListContentPublicLabelsRow{
+			"writing:5": {},
+		},
+		ContentLabelStatusRows: map[string][]*db.ListContentLabelStatusRow{
+			"writing:5": {
+				{Item: "writing", ItemID: 5, Label: "a"},
+				{Item: "writing", ItemID: 5, Label: "b"},
+			},
+		},
 	}
-	defer conn.Close()
-	q := db.New(conn)
 	cd := common.NewTestCoreData(t, q)
 	cd.UserID = 2
-
-	mock.ExpectQuery("SELECT .* FROM content_public_labels").
-		WithArgs("writing", int32(5)).
-		WillReturnRows(sqlmock.NewRows([]string{"item", "item_id", "label"}))
-	ownerRows := sqlmock.NewRows([]string{"item", "item_id", "label"}).
-		AddRow("writing", 5, "a").
-		AddRow("writing", 5, "b")
-	mock.ExpectQuery("SELECT .* FROM content_label_status").
-		WithArgs("writing", int32(5)).
-		WillReturnRows(ownerRows)
-	mock.ExpectExec("INSERT IGNORE INTO content_label_status").
-		WithArgs("writing", int32(5), "c").
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("DELETE FROM content_label_status").
-		WithArgs("writing", int32(5), "a").
-		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	if err := cd.SetWritingAuthorLabels(5, []string{"b", "c"}); err != nil {
 		t.Fatalf("SetWritingAuthorLabels: %v", err)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
+
+	if got := q.AddContentLabelStatusCalls; len(got) != 1 || got[0].Label != "c" {
+		t.Fatalf("author label inserts %+v, want [c]", got)
+	}
+	if got := q.RemoveContentLabelStatusCalls; len(got) != 1 || got[0].Label != "a" {
+		t.Fatalf("author label removals %+v, want [a]", got)
 	}
 }

--- a/core/common/testutil_test.go
+++ b/core/common/testutil_test.go
@@ -20,5 +20,5 @@ func NewTestCoreData(t *testing.T, q db.Querier) *CoreData {
 	if q == nil {
 		return NewCoreData(context.Background(), nil, config.NewRuntimeConfig())
 	}
-	return NewCoreData(context.Background(), QuerierStub{Querier: q}, config.NewRuntimeConfig())
+	return NewCoreData(context.Background(), q, config.NewRuntimeConfig())
 }

--- a/internal/db/querier_stub.go
+++ b/internal/db/querier_stub.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"sync"
 )
 
@@ -11,6 +12,33 @@ import (
 type QuerierStub struct {
 	Querier
 	mu sync.Mutex
+
+	// Content label operations
+	ContentPublicLabelsRows                       map[string][]*ListContentPublicLabelsRow
+	ContentLabelStatusRows                        map[string][]*ListContentLabelStatusRow
+	ContentPrivateLabelsRows                      map[string][]*ListContentPrivateLabelsRow
+	ListContentPublicLabelsCalls                  []ListContentPublicLabelsParams
+	ListContentPublicLabelsErr                    error
+	ListContentLabelStatusCalls                   []ListContentLabelStatusParams
+	ListContentLabelStatusErr                     error
+	ListContentPrivateLabelsCalls                 []ListContentPrivateLabelsParams
+	ListContentPrivateLabelsErr                   error
+	AddContentPublicLabelCalls                    []AddContentPublicLabelParams
+	AddContentPublicLabelErr                      error
+	RemoveContentPublicLabelCalls                 []RemoveContentPublicLabelParams
+	RemoveContentPublicLabelErr                   error
+	AddContentLabelStatusCalls                    []AddContentLabelStatusParams
+	AddContentLabelStatusErr                      error
+	RemoveContentLabelStatusCalls                 []RemoveContentLabelStatusParams
+	RemoveContentLabelStatusErr                   error
+	AddContentPrivateLabelCalls                   []AddContentPrivateLabelParams
+	AddContentPrivateLabelErr                     error
+	RemoveContentPrivateLabelCalls                []RemoveContentPrivateLabelParams
+	RemoveContentPrivateLabelErr                  error
+	ClearUnreadContentPrivateLabelExceptUserCalls []ClearUnreadContentPrivateLabelExceptUserParams
+	ClearUnreadContentPrivateLabelExceptUserErr   error
+	SystemClearContentPrivateLabelCalls           []SystemClearContentPrivateLabelParams
+	SystemClearContentPrivateLabelErr             error
 
 	SystemGetUserByIDRow   *SystemGetUserByIDRow
 	SystemGetUserByIDErr   error
@@ -69,6 +97,115 @@ type QuerierStub struct {
 	AdminListPrivateTopicParticipantsByTopicIDCalls   []sql.NullInt32
 	AdminListPrivateTopicParticipantsByTopicIDReturns []*AdminListPrivateTopicParticipantsByTopicIDRow
 	AdminListPrivateTopicParticipantsByTopicIDErr     error
+}
+
+func contentLabelKey(item string, itemID int32) string {
+	return fmt.Sprintf("%s:%d", item, itemID)
+}
+
+func contentLabelKeyWithUser(item string, itemID, userID int32) string {
+	return fmt.Sprintf("%s:%d:%d", item, itemID, userID)
+}
+
+func (s *QuerierStub) ListContentPublicLabels(ctx context.Context, arg ListContentPublicLabelsParams) ([]*ListContentPublicLabelsRow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ListContentPublicLabelsCalls = append(s.ListContentPublicLabelsCalls, arg)
+	if s.ListContentPublicLabelsErr != nil {
+		return nil, s.ListContentPublicLabelsErr
+	}
+	if s.ContentPublicLabelsRows != nil {
+		if rows, ok := s.ContentPublicLabelsRows[contentLabelKey(arg.Item, arg.ItemID)]; ok {
+			return rows, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *QuerierStub) ListContentLabelStatus(ctx context.Context, arg ListContentLabelStatusParams) ([]*ListContentLabelStatusRow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ListContentLabelStatusCalls = append(s.ListContentLabelStatusCalls, arg)
+	if s.ListContentLabelStatusErr != nil {
+		return nil, s.ListContentLabelStatusErr
+	}
+	if s.ContentLabelStatusRows != nil {
+		if rows, ok := s.ContentLabelStatusRows[contentLabelKey(arg.Item, arg.ItemID)]; ok {
+			return rows, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *QuerierStub) AddContentPublicLabel(ctx context.Context, arg AddContentPublicLabelParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.AddContentPublicLabelCalls = append(s.AddContentPublicLabelCalls, arg)
+	return s.AddContentPublicLabelErr
+}
+
+func (s *QuerierStub) RemoveContentPublicLabel(ctx context.Context, arg RemoveContentPublicLabelParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.RemoveContentPublicLabelCalls = append(s.RemoveContentPublicLabelCalls, arg)
+	return s.RemoveContentPublicLabelErr
+}
+
+func (s *QuerierStub) AddContentLabelStatus(ctx context.Context, arg AddContentLabelStatusParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.AddContentLabelStatusCalls = append(s.AddContentLabelStatusCalls, arg)
+	return s.AddContentLabelStatusErr
+}
+
+func (s *QuerierStub) RemoveContentLabelStatus(ctx context.Context, arg RemoveContentLabelStatusParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.RemoveContentLabelStatusCalls = append(s.RemoveContentLabelStatusCalls, arg)
+	return s.RemoveContentLabelStatusErr
+}
+
+func (s *QuerierStub) ListContentPrivateLabels(ctx context.Context, arg ListContentPrivateLabelsParams) ([]*ListContentPrivateLabelsRow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ListContentPrivateLabelsCalls = append(s.ListContentPrivateLabelsCalls, arg)
+	if s.ListContentPrivateLabelsErr != nil {
+		return nil, s.ListContentPrivateLabelsErr
+	}
+	if s.ContentPrivateLabelsRows != nil {
+		if rows, ok := s.ContentPrivateLabelsRows[contentLabelKeyWithUser(arg.Item, arg.ItemID, arg.UserID)]; ok {
+			return rows, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *QuerierStub) AddContentPrivateLabel(ctx context.Context, arg AddContentPrivateLabelParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.AddContentPrivateLabelCalls = append(s.AddContentPrivateLabelCalls, arg)
+	return s.AddContentPrivateLabelErr
+}
+
+func (s *QuerierStub) RemoveContentPrivateLabel(ctx context.Context, arg RemoveContentPrivateLabelParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.RemoveContentPrivateLabelCalls = append(s.RemoveContentPrivateLabelCalls, arg)
+	return s.RemoveContentPrivateLabelErr
+}
+
+func (s *QuerierStub) ClearUnreadContentPrivateLabelExceptUser(ctx context.Context, arg ClearUnreadContentPrivateLabelExceptUserParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ClearUnreadContentPrivateLabelExceptUserCalls = append(s.ClearUnreadContentPrivateLabelExceptUserCalls, arg)
+	return s.ClearUnreadContentPrivateLabelExceptUserErr
+}
+
+func (s *QuerierStub) SystemClearContentPrivateLabel(ctx context.Context, arg SystemClearContentPrivateLabelParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.SystemClearContentPrivateLabelCalls = append(s.SystemClearContentPrivateLabelCalls, arg)
+	return s.SystemClearContentPrivateLabelErr
 }
 
 func (s *QuerierStub) AdminListPrivateTopicParticipantsByTopicID(ctx context.Context, itemID sql.NullInt32) ([]*AdminListPrivateTopicParticipantsByTopicIDRow, error) {


### PR DESCRIPTION
## Summary
- add content label tracking to the shared QuerierStub so tests can supply rows and record calls
- refactor label-related core and handler tests to use the new fake instead of sqlmock
- allow NewTestCoreData to accept custom fakes directly for label assertions

## Testing
- go vet ./...
- go test ./...
- golangci-lint run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd057c910832faa84ca4f7a320e28)