### PR TITLE
Reset unread labels on thread updates and container items

### DIFF
--- a/core/common/thread_sideeffects.go
+++ b/core/common/thread_sideeffects.go
@@ -22,6 +22,9 @@ type ThreadUpdatedEvent struct {
 	Username   string
 	Author     string
 
+	LabelItem   string
+	LabelItemID int32
+
 	CommentText string
 	CommentURL  string
 	PostURL     string
@@ -45,6 +48,11 @@ func (cd *CoreData) HandleThreadUpdated(ctx context.Context, event ThreadUpdated
 			if err := cd.ClearThreadUnreadForOthers(event.ThreadID); err != nil {
 				errs = append(errs, fmt.Errorf("clear unread labels: %w", err))
 			}
+			if event.LabelItem != "" && event.LabelItemID != 0 {
+				if err := cd.ClearUnreadForOthers(event.LabelItem, event.LabelItemID); err != nil {
+					errs = append(errs, fmt.Errorf("clear item unread labels: %w", err))
+				}
+			}
 		}
 		if event.MarkThreadRead {
 			if err := cd.SetThreadReadMarker(event.ThreadID, event.CommentID); err != nil {
@@ -55,6 +63,11 @@ func (cd *CoreData) HandleThreadUpdated(ctx context.Context, event ThreadUpdated
 			// Passing false, false means: Not New, Not Unread.
 			if err := cd.SetThreadPrivateLabelStatus(event.ThreadID, false, false); err != nil {
 				errs = append(errs, fmt.Errorf("set private label status: %w", err))
+			}
+			if event.LabelItem != "" && event.LabelItemID != 0 {
+				if err := cd.SetPrivateLabelStatus(event.LabelItem, event.LabelItemID, false, false); err != nil {
+					errs = append(errs, fmt.Errorf("set item private label status: %w", err))
+				}
 			}
 		}
 	}

--- a/core/common/thread_sideeffects_test.go
+++ b/core/common/thread_sideeffects_test.go
@@ -1,0 +1,65 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/internal/db"
+)
+
+func TestHandleThreadUpdatedMarksThreadAndItemLabels(t *testing.T) {
+	ctx := context.Background()
+	queries := &db.QuerierStub{}
+	cd := NewCoreData(ctx, queries, config.NewRuntimeConfig())
+	cd.UserID = 5
+
+	err := cd.HandleThreadUpdated(ctx, ThreadUpdatedEvent{
+		ThreadID:             12,
+		CommentID:            7,
+		LabelItem:            "news",
+		LabelItemID:          99,
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+	})
+	if err != nil {
+		t.Fatalf("HandleThreadUpdated: %v", err)
+	}
+
+	if len(queries.ClearUnreadContentPrivateLabelExceptUserCalls) != 2 {
+		t.Fatalf("expected 2 clear unread calls, got %d", len(queries.ClearUnreadContentPrivateLabelExceptUserCalls))
+	}
+	seenClear := map[string]int32{}
+	for _, call := range queries.ClearUnreadContentPrivateLabelExceptUserCalls {
+		seenClear[call.Item] = call.ItemID
+	}
+	if seenClear["thread"] != 12 {
+		t.Fatalf("expected thread unread clear for 12, got %d", seenClear["thread"])
+	}
+	if seenClear["news"] != 99 {
+		t.Fatalf("expected news unread clear for 99, got %d", seenClear["news"])
+	}
+
+	if len(queries.UpsertContentReadMarkerCalls) != 1 {
+		t.Fatalf("expected 1 read marker call, got %d", len(queries.UpsertContentReadMarkerCalls))
+	}
+	if got := queries.UpsertContentReadMarkerCalls[0]; got.Item != "thread" || got.ItemID != 12 {
+		t.Fatalf("unexpected read marker call: %+v", got)
+	}
+
+	if len(queries.AddContentPrivateLabelCalls) != 4 {
+		t.Fatalf("expected 4 label upserts, got %d", len(queries.AddContentPrivateLabelCalls))
+	}
+	seenLabels := map[string]map[string]bool{}
+	for _, call := range queries.AddContentPrivateLabelCalls {
+		if seenLabels[call.Item] == nil {
+			seenLabels[call.Item] = map[string]bool{}
+		}
+		seenLabels[call.Item][call.Label] = call.Invert
+	}
+	for _, item := range []string{"thread", "news"} {
+		if labels := seenLabels[item]; !labels["new"] || !labels["unread"] {
+			t.Fatalf("expected %s new/unread labels inverted, got %+v", item, labels)
+		}
+	}
+}

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -192,13 +192,17 @@ func (ReplyBlogTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         pthid,
-		TopicID:          ptid,
-		CommentID:        int32(cid),
-		CommentText:      text,
-		CommentURL:       cd.AbsoluteURL(endUrl),
-		IncludePostCount: true,
-		IncludeSearch:    true,
+		ThreadID:             pthid,
+		TopicID:              ptid,
+		CommentID:            int32(cid),
+		LabelItem:            "blog",
+		LabelItemID:          int32(bid),
+		CommentText:          text,
+		CommentURL:           cd.AbsoluteURL(endUrl),
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
+		IncludeSearch:        true,
 		AdditionalData: map[string]any{
 			"target": notif.Target{Type: "blog", ID: int32(bid)},
 		},

--- a/handlers/blogs/blogsCommentEditReplyTask.go
+++ b/handlers/blogs/blogsCommentEditReplyTask.go
@@ -83,11 +83,15 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         thread.Idforumthread,
-		TopicID:          thread.ForumtopicIdforumtopic,
-		CommentID:        int32(commentId),
-		CommentURL:       cd.AbsoluteURL(fmt.Sprintf("/blogs/blog/%d/comments", blogId)),
-		IncludePostCount: true,
+		ThreadID:             thread.Idforumthread,
+		TopicID:              thread.ForumtopicIdforumtopic,
+		CommentID:            int32(commentId),
+		LabelItem:            "blog",
+		LabelItemID:          int32(blogId),
+		CommentURL:           cd.AbsoluteURL(fmt.Sprintf("/blogs/blog/%d/comments", blogId)),
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
 	}); err != nil {
 		log.Printf("blog comment edit side effects: %v", err)
 	}

--- a/handlers/forum/comment_edit_action_task.go
+++ b/handlers/forum/comment_edit_action_task.go
@@ -47,10 +47,12 @@ func (topicThreadCommentEditActionTask) Action(w http.ResponseWriter, r *http.Re
 	}
 
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         threadRow.Idforumthread,
-		TopicID:          topicRow.Idforumtopic,
-		CommentID:        int32(commentID),
-		IncludePostCount: true,
+		ThreadID:             threadRow.Idforumthread,
+		TopicID:              topicRow.Idforumtopic,
+		CommentID:            int32(commentID),
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
 	}); err != nil {
 		log.Printf("thread comment update side effects: %v", err)
 	}

--- a/handlers/forum/forumTopicThreadCommentEditPage.go
+++ b/handlers/forum/forumTopicThreadCommentEditPage.go
@@ -43,11 +43,13 @@ func TopicThreadCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         threadRow.Idforumthread,
-		TopicID:          topicRow.Idforumtopic,
-		CommentID:        int32(commentId),
-		CommentURL:       cd.AbsoluteURL(fmt.Sprintf("/forum/topic/%d/thread/%d#comment-%d", topicRow.Idforumtopic, threadRow.Idforumthread, commentId)),
-		IncludePostCount: true,
+		ThreadID:             threadRow.Idforumthread,
+		TopicID:              topicRow.Idforumtopic,
+		CommentID:            int32(commentId),
+		CommentURL:           cd.AbsoluteURL(fmt.Sprintf("/forum/topic/%d/thread/%d#comment-%d", topicRow.Idforumtopic, threadRow.Idforumthread, commentId)),
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
 	}); err != nil {
 		log.Printf("thread comment edit side effects: %v", err)
 	}

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -203,13 +203,17 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         pthid,
-		TopicID:          ptid,
-		CommentID:        int32(cid),
-		CommentText:      text,
-		CommentURL:       cd.AbsoluteURL(endUrl),
-		IncludePostCount: true,
-		IncludeSearch:    true,
+		ThreadID:             pthid,
+		TopicID:              ptid,
+		CommentID:            int32(cid),
+		LabelItem:            "imagebbs",
+		LabelItemID:          int32(bid),
+		CommentText:          text,
+		CommentURL:           cd.AbsoluteURL(endUrl),
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
+		IncludeSearch:        true,
 	}); err != nil {
 		log.Printf("imagebbs reply side effects: %v", err)
 	}

--- a/handlers/linker/edit_reply_task.go
+++ b/handlers/linker/edit_reply_task.go
@@ -78,10 +78,14 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         thread.Idforumthread,
-		TopicID:          thread.ForumtopicIdforumtopic,
-		CommentID:        int32(commentId),
-		IncludePostCount: true,
+		ThreadID:             thread.Idforumthread,
+		TopicID:              thread.ForumtopicIdforumtopic,
+		CommentID:            int32(commentId),
+		LabelItem:            "link",
+		LabelItemID:          int32(linkId),
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
 	}); err != nil {
 		log.Printf("linker comment edit side effects: %v", err)
 	}

--- a/handlers/linker/linkerCommentsPage.go
+++ b/handlers/linker/linkerCommentsPage.go
@@ -297,13 +297,17 @@ func (replyTask) Action(w http.ResponseWriter, r *http.Request) any {
 	}
 
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         pthid,
-		TopicID:          ptid,
-		CommentID:        int32(cid),
-		CommentText:      text,
-		CommentURL:       cd.AbsoluteURL(endUrl),
-		IncludePostCount: true,
-		IncludeSearch:    true,
+		ThreadID:             pthid,
+		TopicID:              ptid,
+		CommentID:            int32(cid),
+		LabelItem:            "link",
+		LabelItemID:          int32(linkId),
+		CommentText:          text,
+		CommentURL:           cd.AbsoluteURL(endUrl),
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
+		IncludeSearch:        true,
 	}); err != nil {
 		log.Printf("linker comment side effects: %v", err)
 	}

--- a/handlers/linker/linkerShowPage.go
+++ b/handlers/linker/linkerShowPage.go
@@ -194,13 +194,17 @@ func ShowReplyPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         pthid,
-		TopicID:          ptid,
-		CommentID:        int32(cid),
-		CommentText:      text,
-		CommentURL:       cd.AbsoluteURL(endUrl),
-		IncludePostCount: true,
-		IncludeSearch:    true,
+		ThreadID:             pthid,
+		TopicID:              ptid,
+		CommentID:            int32(cid),
+		LabelItem:            "link",
+		LabelItemID:          int32(linkId),
+		CommentText:          text,
+		CommentURL:           cd.AbsoluteURL(endUrl),
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
+		IncludeSearch:        true,
 	}); err != nil {
 		log.Printf("linker reply side effects: %v", err)
 	}

--- a/handlers/news/edit_reply_task.go
+++ b/handlers/news/edit_reply_task.go
@@ -57,11 +57,15 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("update comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         ti.ThreadID,
-		TopicID:          ti.TopicID,
-		CommentID:        int32(commentId),
-		CommentURL:       cd.AbsoluteURL(fmt.Sprintf("/news/news/%d", postId)),
-		IncludePostCount: true,
+		ThreadID:             ti.ThreadID,
+		TopicID:              ti.TopicID,
+		CommentID:            int32(commentId),
+		LabelItem:            "news",
+		LabelItemID:          int32(postId),
+		CommentURL:           cd.AbsoluteURL(fmt.Sprintf("/news/news/%d", postId)),
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
 	}); err != nil {
 		log.Printf("news comment edit side effects: %v", err)
 	}

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -108,25 +108,25 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if err := cd.SetPrivateLabelStatus("news", int32(pid), false, false); err != nil {
-		return fmt.Errorf("mark read %w", handlers.ErrRedirectOnSamePageHandler(err))
-	}
-
 	endURL := cd.AbsoluteURL(fmt.Sprintf("/news/news/%d", pid))
 	username := ""
 	if user, err := cd.CurrentUser(); err == nil && user != nil {
 		username = user.Username.String
 	}
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         ti.ThreadID,
-		TopicID:          ti.TopicID,
-		CommentID:        int32(cid),
-		CommentText:      text,
-		CommentURL:       endURL,
-		PostURL:          endURL,
-		Username:         username,
-		IncludePostCount: true,
-		IncludeSearch:    true,
+		ThreadID:             ti.ThreadID,
+		TopicID:              ti.TopicID,
+		CommentID:            int32(cid),
+		LabelItem:            "news",
+		LabelItemID:          int32(pid),
+		CommentText:          text,
+		CommentURL:           endURL,
+		PostURL:              endURL,
+		Username:             username,
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
+		IncludeSearch:        true,
 	}); err != nil {
 		log.Printf("news reply side effects: %v", err)
 	}

--- a/handlers/writings/edit_reply_task.go
+++ b/handlers/writings/edit_reply_task.go
@@ -54,10 +54,14 @@ func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("update comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         thread.Idforumthread,
-		TopicID:          thread.ForumtopicIdforumtopic,
-		CommentID:        comment.Idcomments,
-		IncludePostCount: true,
+		ThreadID:             thread.Idforumthread,
+		TopicID:              thread.ForumtopicIdforumtopic,
+		CommentID:            comment.Idcomments,
+		LabelItem:            "writing",
+		LabelItemID:          writing.Idwriting,
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
 	}); err != nil {
 		log.Printf("writing comment edit side effects: %v", err)
 	}

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -104,17 +104,17 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
-	if err := cd.ClearUnreadForOthers("writing", writing.Idwriting); err != nil {
-		log.Printf("clear unread labels: %v", err)
-	}
-
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         threadID,
-		TopicID:          topicID,
-		CommentID:        int32(cid),
-		CommentText:      text,
-		IncludePostCount: true,
-		IncludeSearch:    true,
+		ThreadID:             threadID,
+		TopicID:              topicID,
+		CommentID:            int32(cid),
+		LabelItem:            "writing",
+		LabelItemID:          writing.Idwriting,
+		CommentText:          text,
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
+		IncludeSearch:        true,
 		AdditionalData: map[string]any{
 			"target": notif.Target{Type: "writing", ID: writing.Idwriting},
 		},

--- a/handlers/writings/writingsArticleCommentEditPage.go
+++ b/handlers/writings/writingsArticleCommentEditPage.go
@@ -44,10 +44,14 @@ func ArticleCommentEditActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         thread.Idforumthread,
-		TopicID:          thread.ForumtopicIdforumtopic,
-		CommentID:        comment.Idcomments,
-		IncludePostCount: true,
+		ThreadID:             thread.Idforumthread,
+		TopicID:              thread.ForumtopicIdforumtopic,
+		CommentID:            comment.Idcomments,
+		LabelItem:            "writing",
+		LabelItemID:          writing.Idwriting,
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
 	}); err != nil {
 		log.Printf("writing comment edit side effects: %v", err)
 	}

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -173,17 +173,17 @@ func ArticleReplyActionPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := cd.ClearUnreadForOthers("writing", writing.Idwriting); err != nil {
-		log.Printf("clear unread labels: %v", err)
-	}
-
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
-		ThreadID:         threadID,
-		TopicID:          topicID,
-		CommentID:        int32(cid),
-		CommentText:      text,
-		IncludePostCount: true,
-		IncludeSearch:    true,
+		ThreadID:             threadID,
+		TopicID:              topicID,
+		CommentID:            int32(cid),
+		LabelItem:            "writing",
+		LabelItemID:          writing.Idwriting,
+		CommentText:          text,
+		ClearUnreadForOthers: true,
+		MarkThreadRead:       true,
+		IncludePostCount:     true,
+		IncludeSearch:        true,
 		AdditionalData: map[string]any{
 			"target": notifications.Target{Type: "writing", ID: writing.Idwriting},
 		},


### PR DESCRIPTION
### Motivation
- Ensure that when a user posts or edits a comment, the thread's unread flag is cleared for everyone except the poster and the poster's read state is set, following the inverse-label semantics used by the app. 
- Apply the same unread/read logic to any container item that owns the thread (e.g. `news`, `writing`, `blog`, `link`, `imagebbs`) so container-level labels remain consistent. 
- Centralise these side effects in the existing `HandleThreadUpdated` flow so callers only need to provide the container context. 

### Description
- Added `LabelItem` and `LabelItemID` to `ThreadUpdatedEvent` and updated `HandleThreadUpdated` to clear inverted `unread` labels and set private label status for both the thread and the provided container item when requested. 
- Updated reply and comment-edit handlers across sections (`news`, `blogs`, `writings`, `linker`, `imagebbs`, forum comment edits) to populate `LabelItem`/`LabelItemID` and set `ClearUnreadForOthers` and `MarkThreadRead` on the `ThreadUpdatedEvent`. 
- Removed some callers' direct ad-hoc unread clears in favour of the unified event-driven behaviour. 
- Added `core/common/thread_sideeffects_test.go` to verify that `HandleThreadUpdated` issues the expected query calls for clearing unread labels, upserting read markers, and creating inverted private labels for both `thread` and a container item. 

### Testing
- Ran `go test ./...` and unit tests completed successfully. 
- Ran `go mod tidy` and `go fmt ./...` to clean modules and format sources. 
- `go vet ./...` and `golangci-lint run` were invoked but did not complete within the run (interrupted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f5357d020832fbb599b86c4ca8e7b)