### PR TITLE
Adjust default unread/new private labels for thread authors

### DIFF
--- a/core/common/coredata_labels.go
+++ b/core/common/coredata_labels.go
@@ -153,17 +153,25 @@ func (cd *CoreData) PrivateLabels(item string, itemID int32, authorID int32) ([]
 		userLabels = append(userLabels, r.Label)
 	}
 	sort.Strings(userLabels)
+	labelSet := make(map[string]struct{}, len(userLabels))
+	for _, label := range userLabels {
+		labelSet[label] = struct{}{}
+	}
 	labels := make([]string, 0, len(userLabels)+2)
 	// Only threads, news articles, links, image board posts, blog entries,
 	// and writing articles receive default status labels.
-	if cd.UserID != 0 && authorID != cd.UserID {
+	if cd.UserID != 0 {
 		switch item {
 		case "thread", "news", "link", "imagebbs", "blog", "writing":
-			if !inverted["new"] {
-				labels = append(labels, "new")
+			if !inverted["new"] && authorID != cd.UserID {
+				if _, ok := labelSet["new"]; !ok {
+					labels = append(labels, "new")
+				}
 			}
 			if !inverted["unread"] {
-				labels = append(labels, "unread")
+				if _, ok := labelSet["unread"]; !ok {
+					labels = append(labels, "unread")
+				}
 			}
 		}
 	}

--- a/core/common/coredata_labels_test.go
+++ b/core/common/coredata_labels_test.go
@@ -110,8 +110,9 @@ func TestPrivateLabelsDefaultAndInversion(t *testing.T) {
 		if err != nil {
 			t.Fatalf("PrivateLabels default: %v", err)
 		}
-		if len(labels) != 0 {
-			t.Fatalf("default labels %+v, want empty", labels)
+		expected := []string{"unread"}
+		if !reflect.DeepEqual(labels, expected) {
+			t.Fatalf("default labels %+v, want %+v", labels, expected)
 		}
 	})
 


### PR DESCRIPTION
### Motivation
- Fix a bug where thread authors did not receive the expected `unread` status when other users replied to the thread while still ensuring `new` remains reserved for non-authors.
- Prevent duplicate default labels from being added when explicit private labels are already present for the user.
- Keep label behaviour consistent across content types that use default status labels (threads, news, links, imagebbs, blog, writing).

### Description
- Modified `PrivateLabels` in `core/common/coredata_labels.go` to always consider the current user when applying defaults and to only add `new` for non-authors while still adding `unread` for authors when appropriate.
- Added a `labelSet` derived from explicit user labels to avoid adding duplicate default labels when explicit labels already exist.
- Updated the unit test `TestPrivateLabelsDefaultAndInversion` in `core/common/coredata_labels_test.go` to expect `[]string{"unread"}` for thread authors by default.

### Testing
- Ran `go mod tidy` successfully to update module dependencies.
- Ran `go fmt ./...` successfully to format the code.
- Attempted `go vet ./...` but the run was interrupted and did not complete.
- Attempted `golangci-lint run` but the run was interrupted and did not complete; no full `go test ./...` suite was executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f90bba030832fac6f4500a99bab2c)