### PR TITLE
Replace sqlmock with QuerierStub in forum tests and add private reply notification coverage

### DIFF
--- a/handlers/forum/forumAdminTopicPage_test.go
+++ b/handlers/forum/forumAdminTopicPage_test.go
@@ -2,14 +2,13 @@ package forum
 
 import (
 	"context"
+	"database/sql"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
 
 	"github.com/arran4/goa4web/config"
@@ -19,23 +18,24 @@ import (
 )
 
 func TestAdminTopicPage(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	mock.MatchExpectationsInOrder(false)
-
 	topicID := 4
-	rows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler"}).
-		AddRow(topicID, 0, 1, 0, "t", "d", 2, 3, time.Now(), "")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idforumtopic, lastposter, forumcategory_idforumcategory, language_id, title, description, threads, comments, lastaddition, handler FROM forumtopic WHERE idforumtopic = ?")).WillReturnRows(rows)
+	queries := &db.QuerierStub{
+		GetForumTopicByIdReturns: &db.Forumtopic{
+			Idforumtopic:                 int32(topicID),
+			ForumcategoryIdforumcategory: 1,
+			Title:                        sql.NullString{String: "t", Valid: true},
+			Description:                  sql.NullString{String: "d", Valid: true},
+			Threads:                      sql.NullInt32{Int32: 2, Valid: true},
+			Comments:                     sql.NullInt32{Int32: 3, Valid: true},
+			Lastaddition:                 sql.NullTime{Time: time.Now(), Valid: true},
+			Handler:                      "",
+		},
+		AdminListForumTopicGrantsByTopicIDReturns: []*db.AdminListForumTopicGrantsByTopicIDRow{
+			{ID: 1, Section: "forum", Action: "see", RoleName: sql.NullString{String: "Anyone", Valid: true}},
+		},
+	}
 
-	grantsRows := sqlmock.NewRows([]string{"id", "section", "action", "role_name", "username"}).
-		AddRow(1, "forum", "see", "Anyone", nil)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT g.id, g.section, g.action, r.name AS role_name, u.username FROM grants g")).WillReturnRows(grantsRows)
-
-	cd := common.NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), queries, config.NewRuntimeConfig())
 	r := httptest.NewRequest("GET", "/admin/forum/topics/topic/"+strconv.Itoa(topicID), nil)
 	r = mux.SetURLVars(r, map[string]string{"topic": strconv.Itoa(topicID)})
 	r = r.WithContext(context.WithValue(r.Context(), consts.KeyCoreData, cd))
@@ -44,33 +44,35 @@ func TestAdminTopicPage(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status: got %d want %d", w.Code, http.StatusOK)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
 }
 
 func TestAdminTopicEditFormPage(t *testing.T) {
-	conn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer conn.Close()
-	mock.MatchExpectationsInOrder(false)
-
 	topicID := 4
-	topicRows := sqlmock.NewRows([]string{"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler"}).
-		AddRow(topicID, 0, 1, 0, "t", "d", 2, 3, time.Now(), "")
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT idforumtopic, lastposter, forumcategory_idforumcategory, language_id, title, description, threads, comments, lastaddition, handler FROM forumtopic WHERE idforumtopic = ?")).WillReturnRows(topicRows)
+	queries := &db.QuerierStub{
+		GetForumTopicByIdReturns: &db.Forumtopic{
+			Idforumtopic:                 int32(topicID),
+			ForumcategoryIdforumcategory: 1,
+			Title:                        sql.NullString{String: "t", Valid: true},
+			Description:                  sql.NullString{String: "d", Valid: true},
+			Threads:                      sql.NullInt32{Int32: 2, Valid: true},
+			Comments:                     sql.NullInt32{Int32: 3, Valid: true},
+			Lastaddition:                 sql.NullTime{Time: time.Now(), Valid: true},
+			Handler:                      "",
+		},
+		GetAllForumCategoriesReturns: []*db.Forumcategory{
+			{
+				Idforumcategory:              1,
+				ForumcategoryIdforumcategory: 0,
+				Title:                        sql.NullString{String: "cat", Valid: true},
+				Description:                  sql.NullString{String: "desc", Valid: true},
+			},
+		},
+		AdminListRolesReturns: []*db.Role{
+			{ID: 1, Name: "role", CanLogin: true},
+		},
+	}
 
-	catRows := sqlmock.NewRows([]string{"idforumcategory", "forumcategory_idforumcategory", "language_id", "title", "description"}).
-		AddRow(1, 0, 0, "cat", "desc")
-	mock.ExpectQuery("SELECT").WillReturnRows(catRows)
-
-	roleRows := sqlmock.NewRows([]string{"id", "name", "can_login", "is_admin", "private_labels", "public_profile_allowed_at"}).
-		AddRow(1, "role", true, false, true, nil)
-	mock.ExpectQuery("SELECT").WillReturnRows(roleRows)
-
-	cd := common.NewCoreData(context.Background(), db.New(conn), config.NewRuntimeConfig())
+	cd := common.NewCoreData(context.Background(), queries, config.NewRuntimeConfig())
 	r := httptest.NewRequest("GET", "/admin/forum/topics/topic/"+strconv.Itoa(topicID)+"/edit", nil)
 	r = mux.SetURLVars(r, map[string]string{"topic": strconv.Itoa(topicID)})
 	r = r.WithContext(context.WithValue(r.Context(), consts.KeyCoreData, cd))
@@ -78,8 +80,5 @@ func TestAdminTopicEditFormPage(t *testing.T) {
 	AdminTopicEditFormPage(w, r)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status: got %d want %d", w.Code, http.StatusOK)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
 	}
 }

--- a/handlers/forum/forumThreadPage_private_title_test.go
+++ b/handlers/forum/forumThreadPage_private_title_test.go
@@ -3,10 +3,14 @@ package forum
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"net/http"
 	"net/http/httptest"
+	"net/mail"
+	"net/url"
+	"strings"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 
@@ -15,27 +19,39 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/internal/lazy"
+	"github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/sharesign"
+	"github.com/arran4/goa4web/workers/emailqueue"
 )
 
 func TestThreadPagePrivateSetsTitle(t *testing.T) {
-	dbconn, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	queries := &db.QuerierStub{
+		GetThreadLastPosterAndPermsReturns: &db.GetThreadLastPosterAndPermsRow{
+			Idforumthread:          1,
+			Firstpost:              1,
+			Lastposter:             1,
+			ForumtopicIdforumtopic: 1,
+			Comments:               sql.NullInt32{},
+			Lastaddition:           sql.NullTime{},
+			Locked:                 sql.NullBool{},
+		},
+		GetForumTopicByIdForUserReturns: &db.GetForumTopicByIdForUserRow{
+			Idforumtopic:                 1,
+			ForumcategoryIdforumcategory: 1,
+			Title:                        sql.NullString{},
+			Description:                  sql.NullString{},
+			Threads:                      sql.NullInt32{},
+			Comments:                     sql.NullInt32{},
+			Lastaddition:                 sql.NullTime{},
+			Handler:                      "private",
+		},
+		ListPrivateTopicParticipantsByTopicIDForUserReturns: []*db.ListPrivateTopicParticipantsByTopicIDForUserRow{
+			{Idusers: 2, Username: sql.NullString{String: "Bob", Valid: true}},
+		},
+		GetCommentsByThreadIdForUserReturns: []*db.GetCommentsByThreadIdForUserRow{},
 	}
-	defer dbconn.Close()
-
-	mock.ExpectQuery("SELECT th.idforumthread").
-		WillReturnRows(sqlmock.NewRows([]string{
-			"idforumthread", "firstpost", "lastposter", "forumtopic_idforumtopic", "comments", "lastaddition", "locked", "LastPosterUsername",
-		}).AddRow(int32(1), int32(1), int32(1), int32(1), sql.NullInt32{}, sql.NullTime{}, sql.NullBool{}, sql.NullString{}))
-
-	mock.ExpectQuery("SELECT").
-		WillReturnRows(sqlmock.NewRows([]string{
-			"idforumtopic", "lastposter", "forumcategory_idforumcategory", "language_id", "title", "description", "threads", "comments", "lastaddition", "handler", "LastPosterUsername",
-		}).AddRow(int32(1), int32(1), int32(1), int32(1), sql.NullString{}, sql.NullString{}, sql.NullInt32{}, sql.NullInt32{}, sql.NullTime{}, "private", sql.NullString{}))
-
-	mock.ExpectQuery("SELECT").
-		WillReturnRows(sqlmock.NewRows([]string{"idusers", "username"}).AddRow(int32(2), sql.NullString{String: "Bob", Valid: true}))
 
 	origStore := core.Store
 	origName := core.SessionName
@@ -51,20 +67,249 @@ func TestThreadPagePrivateSetsTitle(t *testing.T) {
 	// Inject an invalid session to force GetSessionOrFail to fail before rendering.
 	ctx := context.WithValue(req.Context(), core.ContextValues("session"), "bad")
 
-	q := db.New(dbconn)
 	cfg := config.NewRuntimeConfig()
-	cd := common.NewCoreData(ctx, q, cfg)
+	cd := common.NewCoreData(ctx, queries, cfg)
+	cd.ShareSigner = sharesign.NewSigner(cfg, "secret")
 	cd.SetCurrentSection("privateforum")
 	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
 	req = req.WithContext(ctx)
 
 	rr := httptest.NewRecorder()
 	ThreadPageWithBasePath(rr, req, "/private")
-
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations: %v", err)
-	}
 	if cd.PageTitle == "" {
 		t.Fatalf("page title not set")
+	}
+}
+
+func TestThreadPagePrivateReplyNotifications(t *testing.T) {
+	replierUID := int32(1)
+	subscriberUID := int32(2)
+	adminUID := int32(99)
+	topicID := int32(5)
+	threadID := int32(42)
+
+	qs := &db.QuerierStub{
+		GetPermissionsByUserIDFn: func(idusers int32) ([]*db.GetPermissionsByUserIDRow, error) {
+			return []*db.GetPermissionsByUserIDRow{}, nil
+		},
+		SystemGetUserByIDFn: func(ctx context.Context, idusers int32) (*db.SystemGetUserByIDRow, error) {
+			switch idusers {
+			case replierUID:
+				return &db.SystemGetUserByIDRow{
+					Idusers:  replierUID,
+					Username: sql.NullString{String: "replier", Valid: true},
+					Email:    sql.NullString{String: "replier@example.com", Valid: true},
+				}, nil
+			case subscriberUID:
+				return &db.SystemGetUserByIDRow{
+					Idusers:  subscriberUID,
+					Username: sql.NullString{String: "subscriber", Valid: true},
+					Email:    sql.NullString{String: "subscriber@example.com", Valid: true},
+				}, nil
+			case adminUID:
+				return &db.SystemGetUserByIDRow{
+					Idusers:  adminUID,
+					Username: sql.NullString{String: "adminuser", Valid: true},
+					Email:    sql.NullString{String: "admin@example.com", Valid: true},
+				}, nil
+			}
+			return nil, sql.ErrNoRows
+		},
+		SystemGetUserByEmailFn: func(ctx context.Context, email string) (*db.SystemGetUserByEmailRow, error) {
+			if email == "admin@example.com" {
+				return &db.SystemGetUserByEmailRow{Idusers: adminUID}, nil
+			}
+			return nil, sql.ErrNoRows
+		},
+		CreateCommentInSectionForCommenterFn: func(ctx context.Context, arg db.CreateCommentInSectionForCommenterParams) (int64, error) {
+			return 999, nil
+		},
+		GetCommentByIdForUserRow: &db.GetCommentByIdForUserRow{
+			Idcomments: 999,
+		},
+		GetThreadBySectionThreadIDForReplierFn: func(ctx context.Context, arg db.GetThreadBySectionThreadIDForReplierParams) (*db.Forumthread, error) {
+			return &db.Forumthread{
+				Idforumthread:          threadID,
+				ForumtopicIdforumtopic: topicID,
+			}, nil
+		},
+		GetThreadLastPosterAndPermsFn: func(ctx context.Context, arg db.GetThreadLastPosterAndPermsParams) (*db.GetThreadLastPosterAndPermsRow, error) {
+			return &db.GetThreadLastPosterAndPermsRow{
+				Idforumthread:          threadID,
+				ForumtopicIdforumtopic: topicID,
+				Lastposterusername:     sql.NullString{String: "replier", Valid: true},
+				Comments:               sql.NullInt32{Int32: 1, Valid: true},
+			}, nil
+		},
+		GetForumTopicByIdForUserFn: func(ctx context.Context, arg db.GetForumTopicByIdForUserParams) (*db.GetForumTopicByIdForUserRow, error) {
+			return &db.GetForumTopicByIdForUserRow{
+				Idforumtopic: topicID,
+				Title:        sql.NullString{String: "Test Topic", Valid: true},
+				Handler:      "private",
+			}, nil
+		},
+		ListSubscribersForPatternsReturn: map[string][]int32{
+			fmt.Sprintf("reply:/private/topic/%d/thread/%d/*", topicID, threadID): {subscriberUID},
+		},
+		GetPreferenceForListerReturn: map[int32]*db.Preference{
+			replierUID:    {AutoSubscribeReplies: true},
+			subscriberUID: {AutoSubscribeReplies: true},
+		},
+		AdminListAdministratorEmailsReturns:        []string{"admin@example.com"},
+		UpsertContentReadMarkerFn:                  func(ctx context.Context, arg db.UpsertContentReadMarkerParams) error { return nil },
+		ClearUnreadContentPrivateLabelExceptUserFn: func(ctx context.Context, arg db.ClearUnreadContentPrivateLabelExceptUserParams) error { return nil },
+		AdminDeletePendingEmailFn:                  func(ctx context.Context, id int32) error { return nil },
+		SystemMarkPendingEmailSentFn:               func(ctx context.Context, id int32) error { return nil },
+	}
+
+	qs.SystemListPendingEmailsFn = func(ctx context.Context, arg db.SystemListPendingEmailsParams) ([]*db.SystemListPendingEmailsRow, error) {
+		var rows []*db.SystemListPendingEmailsRow
+		if len(qs.InsertPendingEmailCalls) > 0 {
+			call := qs.InsertPendingEmailCalls[0]
+			rows = append(rows, &db.SystemListPendingEmailsRow{
+				ID:          1,
+				ToUserID:    call.ToUserID,
+				Body:        call.Body,
+				DirectEmail: call.DirectEmail,
+			})
+			qs.InsertPendingEmailCalls = qs.InsertPendingEmailCalls[1:]
+		}
+		return rows, nil
+	}
+
+	bus := eventbus.NewBus()
+	cfg := config.NewRuntimeConfig()
+	cfg.NotificationsEnabled = true
+	cfg.AdminNotify = true
+	cfg.EmailEnabled = true
+	cfg.EmailFrom = "noreply@example.com"
+	cfg.HTTPHostname = "http://example.com"
+
+	mockProvider := &MockEmailProvider{}
+	n := notifications.New(
+		notifications.WithQueries(qs),
+		notifications.WithConfig(cfg),
+		notifications.WithEmailProvider(mockProvider),
+	)
+	cdlq := &captureDLQ{}
+	n.RegisterSync(bus, cdlq)
+
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test"
+	sess, _ := store.Get(httptest.NewRequest(http.MethodGet, "http://example.com", nil), core.SessionName)
+	sess.Values["UID"] = replierUID
+
+	task := replyTask
+	evt := &eventbus.TaskEvent{
+		Data:    map[string]any{},
+		UserID:  replierUID,
+		Path:    "/private/topic/5/thread/42/reply",
+		Task:    task,
+		Outcome: eventbus.TaskOutcomeSuccess,
+	}
+	ctx := context.Background()
+	cd := common.NewCoreData(ctx, qs, cfg, common.WithSession(sess), common.WithEvent(evt), common.WithUserRoles([]string{"member"}))
+	cd.UserID = replierUID
+	cd.ForumBasePath = "/private"
+
+	thread := &db.GetThreadLastPosterAndPermsRow{Idforumthread: threadID, ForumtopicIdforumtopic: topicID, Lastposterusername: sql.NullString{String: "replier", Valid: true}, Comments: sql.NullInt32{Int32: 1, Valid: true}}
+	topic := &db.GetForumTopicByIdForUserRow{Idforumtopic: topicID, Title: sql.NullString{String: "Test Topic", Valid: true}, Handler: "private"}
+	cd.SetCurrentThreadAndTopic(threadID, topicID)
+	_, _ = cd.ForumThreadByID(threadID, lazy.Set(thread))
+	_, _ = cd.ForumTopicByID(topicID, lazy.Set(topic))
+
+	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+
+	form := url.Values{"replytext": {"Hello World"}, "language": {"1"}}
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/private/topic/5/thread/42/reply", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	req = mux.SetURLVars(req, map[string]string{"topic": "5", "thread": "42"})
+
+	rr := httptest.NewRecorder()
+	task.Action(rr, req)
+
+	bus.Publish(*evt)
+
+	if cdlq.lastError != "" {
+		t.Errorf("sync process error: %s", cdlq.lastError)
+	}
+
+	var subscriberNotif, adminNotif string
+	for _, call := range qs.SystemCreateNotificationCalls {
+		if call.RecipientID == subscriberUID {
+			subscriberNotif = call.Message.String
+		}
+		if call.RecipientID == adminUID {
+			adminNotif = call.Message.String
+		}
+	}
+
+	expectedSubscriberNotif := "New reply in \"Test Topic\" by replier\n"
+	if subscriberNotif != expectedSubscriberNotif {
+		t.Errorf("expected subscriber notif %q, got %q", expectedSubscriberNotif, subscriberNotif)
+	}
+
+	expectedAdminNotif := "User replier replied to a forum thread.\nHello World\n"
+	if adminNotif != expectedAdminNotif {
+		t.Errorf("expected admin notif %q, got %q", expectedAdminNotif, adminNotif)
+	}
+
+	for emailqueue.ProcessPendingEmail(ctx, qs, mockProvider, cdlq, cfg) {
+	}
+
+	if len(mockProvider.SentMessages) != 2 {
+		t.Fatalf("expected 2 emails sent, got %d", len(mockProvider.SentMessages))
+	}
+
+	var subscriberEmail, adminEmail *mail.Message
+	for i, raw := range mockProvider.SentMessages {
+		msg, err := mail.ReadMessage(strings.NewReader(string(raw)))
+		if err != nil {
+			t.Fatalf("parse email %d: %v", i, err)
+		}
+		to := mockProvider.Recipients[i].Address
+		if to == "subscriber@example.com" {
+			subscriberEmail = msg
+		} else if to == "admin@example.com" {
+			adminEmail = msg
+		}
+	}
+
+	if subscriberEmail == nil {
+		t.Fatal("subscriber email not found")
+	}
+	if subscriberEmail.Header.Get("Subject") != "[goa4web] New forum reply" {
+		t.Errorf("subscriber email subject mismatch: %s", subscriberEmail.Header.Get("Subject"))
+	}
+	subBody := getEmailBody(t, subscriberEmail)
+	expectedSubBody := "Hi replier,\nYour reply has been posted.\n\nView comment:\n/private/topic/5/thread/42#c999\n\nManage notifications: http://example.com/usr/subscriptions"
+	if subBody != expectedSubBody {
+		t.Errorf("subscriber email body mismatch: %q, want %q", subBody, expectedSubBody)
+	}
+
+	if adminEmail == nil {
+		t.Fatal("admin email not found")
+	}
+	if adminEmail.Header.Get("Subject") != "[goa4web Admin] Forum reply posted" {
+		t.Errorf("admin email subject mismatch: %s", adminEmail.Header.Get("Subject"))
+	}
+	adminBody := getEmailBody(t, adminEmail)
+	expectedAdminBody := "User replier replied to a forum thread.\nHello World\n\nView comment:\n/private/topic/5/thread/42#c999\n\nManage notifications: http://example.com/usr/subscriptions"
+	if adminBody != expectedAdminBody {
+		t.Errorf("admin email body mismatch: %q, want %q", adminBody, expectedAdminBody)
+	}
+
+	actionName, path, err := task.AutoSubscribePath(*evt)
+	if err != nil {
+		t.Errorf("AutoSubscribePath error: %v", err)
+	}
+	if actionName != "Reply" {
+		t.Errorf("expected action name Reply, got %q", actionName)
+	}
+	if path != "/private/topic/5/thread/42" {
+		t.Errorf("expected path /private/topic/5/thread/42, got %q", path)
 	}
 }

--- a/handlers/forum/forum_reply_notifications_test.go
+++ b/handlers/forum/forum_reply_notifications_test.go
@@ -51,8 +51,8 @@ func (m *MockEmailProvider) Send(ctx context.Context, to mail.Address, rawEmailM
 
 func (m *MockEmailProvider) TestConfig(ctx context.Context) error { return nil }
 
-// TestForumReplyNotifications verifies that forum reply use correct templates with real event data and exact string matching.
-func TestForumReplyNotifications(t *testing.T) {
+// TestForumReply verifies that forum reply use correct templates with real event data and exact string matching.
+func TestForumReply(t *testing.T) {
 	replierUID := int32(1)
 	subscriberUID := int32(2)
 	adminUID := int32(99)

--- a/handlers/news/newsPostPage_labels_test.go
+++ b/handlers/news/newsPostPage_labels_test.go
@@ -41,7 +41,7 @@ func TestNewsPostPageLabelBars(t *testing.T) {
 		"add":         func(a, b int) int { return a + b },
 		"since":       func(time.Time, time.Time) string { return "" },
 		"assetHash":   func(s string) string { return s },
-		"dict":        func(values ...interface{}) (map[string]interface{}, error) {
+		"dict": func(values ...interface{}) (map[string]interface{}, error) {
 			if len(values)%2 != 0 {
 				return nil, errors.New("invalid dict call")
 			}
@@ -117,7 +117,7 @@ func TestNewsPostPagePrivateLabelsOnce(t *testing.T) {
 		"add":         func(a, b int) int { return a + b },
 		"since":       func(time.Time, time.Time) string { return "" },
 		"assetHash":   func(s string) string { return s },
-		"dict":        func(values ...interface{}) (map[string]interface{}, error) {
+		"dict": func(values ...interface{}) (map[string]interface{}, error) {
 			if len(values)%2 != 0 {
 				return nil, errors.New("invalid dict call")
 			}

--- a/internal/db/querier_stub.go
+++ b/internal/db/querier_stub.go
@@ -216,6 +216,10 @@ type QuerierStub struct {
 	GetForumTopicByIdForUserCalls   []GetForumTopicByIdForUserParams
 	GetForumTopicByIdForUserReturns *GetForumTopicByIdForUserRow
 	GetForumTopicByIdForUserErr     error
+	GetForumTopicByIdFn             func(context.Context, int32) (*Forumtopic, error)
+	GetForumTopicByIdCalls          []int32
+	GetForumTopicByIdReturns        *Forumtopic
+	GetForumTopicByIdErr            error
 
 	ListPrivateTopicParticipantsByTopicIDForUserFn func(context.Context, ListPrivateTopicParticipantsByTopicIDForUserParams) ([]*ListPrivateTopicParticipantsByTopicIDForUserRow, error)
 
@@ -254,6 +258,15 @@ type QuerierStub struct {
 	GetAllForumCategoriesReturns []*Forumcategory
 	GetAllForumCategoriesErr     error
 	GetAllForumCategoriesFn      func(context.Context, GetAllForumCategoriesParams) ([]*Forumcategory, error)
+	GetForumCategoryByIdCalls    []GetForumCategoryByIdParams
+	GetForumCategoryByIdReturns  *Forumcategory
+	GetForumCategoryByIdErr      error
+	GetForumCategoryByIdFn       func(context.Context, GetForumCategoryByIdParams) (*Forumcategory, error)
+
+	GetAllForumTopicsByCategoryIdForUserWithLastPosterNameCalls   []GetAllForumTopicsByCategoryIdForUserWithLastPosterNameParams
+	GetAllForumTopicsByCategoryIdForUserWithLastPosterNameReturns []*GetAllForumTopicsByCategoryIdForUserWithLastPosterNameRow
+	GetAllForumTopicsByCategoryIdForUserWithLastPosterNameErr     error
+	GetAllForumTopicsByCategoryIdForUserWithLastPosterNameFn      func(context.Context, GetAllForumTopicsByCategoryIdForUserWithLastPosterNameParams) ([]*GetAllForumTopicsByCategoryIdForUserWithLastPosterNameRow, error)
 
 	SystemCheckRoleGrantReturns int32
 	SystemCheckRoleGrantErr     error
@@ -292,6 +305,40 @@ type QuerierStub struct {
 	AdminListPrivateTopicParticipantsByTopicIDCalls   []sql.NullInt32
 	AdminListPrivateTopicParticipantsByTopicIDReturns []*AdminListPrivateTopicParticipantsByTopicIDRow
 	AdminListPrivateTopicParticipantsByTopicIDErr     error
+
+	AdminCreateForumCategoryCalls   []AdminCreateForumCategoryParams
+	AdminCreateForumCategoryReturns int64
+	AdminCreateForumCategoryErr     error
+	AdminCreateForumCategoryFn      func(context.Context, AdminCreateForumCategoryParams) (int64, error)
+
+	AdminUpdateForumCategoryCalls []AdminUpdateForumCategoryParams
+	AdminUpdateForumCategoryErr   error
+	AdminUpdateForumCategoryFn    func(context.Context, AdminUpdateForumCategoryParams) error
+
+	AdminCountForumTopicsCalls   int
+	AdminCountForumTopicsReturns int64
+	AdminCountForumTopicsErr     error
+	AdminCountForumTopicsFn      func(context.Context) (int64, error)
+
+	AdminListForumTopicsCalls   []AdminListForumTopicsParams
+	AdminListForumTopicsReturns []*Forumtopic
+	AdminListForumTopicsErr     error
+	AdminListForumTopicsFn      func(context.Context, AdminListForumTopicsParams) ([]*Forumtopic, error)
+
+	AdminGetTopicGrantsCalls   []sql.NullInt32
+	AdminGetTopicGrantsReturns []*AdminGetTopicGrantsRow
+	AdminGetTopicGrantsErr     error
+	AdminGetTopicGrantsFn      func(context.Context, sql.NullInt32) ([]*AdminGetTopicGrantsRow, error)
+
+	AdminListRolesCalls   int
+	AdminListRolesReturns []*Role
+	AdminListRolesErr     error
+	AdminListRolesFn      func(context.Context) ([]*Role, error)
+
+	ListGrantsCalls   int
+	ListGrantsReturns []*Grant
+	ListGrantsErr     error
+	ListGrantsFn      func(context.Context) ([]*Grant, error)
 
 	ListWritersForListerCalls   []ListWritersForListerParams
 	ListWritersForListerReturns []*ListWritersForListerRow
@@ -719,6 +766,96 @@ func (s *QuerierStub) AdminListPrivateTopicParticipantsByTopicID(ctx context.Con
 	return s.AdminListPrivateTopicParticipantsByTopicIDReturns, s.AdminListPrivateTopicParticipantsByTopicIDErr
 }
 
+func (s *QuerierStub) AdminCreateForumCategory(ctx context.Context, arg AdminCreateForumCategoryParams) (int64, error) {
+	s.mu.Lock()
+	s.AdminCreateForumCategoryCalls = append(s.AdminCreateForumCategoryCalls, arg)
+	fn := s.AdminCreateForumCategoryFn
+	ret := s.AdminCreateForumCategoryReturns
+	err := s.AdminCreateForumCategoryErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, arg)
+	}
+	return ret, err
+}
+
+func (s *QuerierStub) AdminUpdateForumCategory(ctx context.Context, arg AdminUpdateForumCategoryParams) error {
+	s.mu.Lock()
+	s.AdminUpdateForumCategoryCalls = append(s.AdminUpdateForumCategoryCalls, arg)
+	fn := s.AdminUpdateForumCategoryFn
+	err := s.AdminUpdateForumCategoryErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, arg)
+	}
+	return err
+}
+
+func (s *QuerierStub) AdminCountForumTopics(ctx context.Context) (int64, error) {
+	s.mu.Lock()
+	s.AdminCountForumTopicsCalls++
+	fn := s.AdminCountForumTopicsFn
+	ret := s.AdminCountForumTopicsReturns
+	err := s.AdminCountForumTopicsErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(ctx)
+	}
+	return ret, err
+}
+
+func (s *QuerierStub) AdminListForumTopics(ctx context.Context, arg AdminListForumTopicsParams) ([]*Forumtopic, error) {
+	s.mu.Lock()
+	s.AdminListForumTopicsCalls = append(s.AdminListForumTopicsCalls, arg)
+	fn := s.AdminListForumTopicsFn
+	ret := s.AdminListForumTopicsReturns
+	err := s.AdminListForumTopicsErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, arg)
+	}
+	return ret, err
+}
+
+func (s *QuerierStub) AdminGetTopicGrants(ctx context.Context, topicID sql.NullInt32) ([]*AdminGetTopicGrantsRow, error) {
+	s.mu.Lock()
+	s.AdminGetTopicGrantsCalls = append(s.AdminGetTopicGrantsCalls, topicID)
+	fn := s.AdminGetTopicGrantsFn
+	ret := s.AdminGetTopicGrantsReturns
+	err := s.AdminGetTopicGrantsErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, topicID)
+	}
+	return ret, err
+}
+
+func (s *QuerierStub) AdminListRoles(ctx context.Context) ([]*Role, error) {
+	s.mu.Lock()
+	s.AdminListRolesCalls++
+	fn := s.AdminListRolesFn
+	ret := s.AdminListRolesReturns
+	err := s.AdminListRolesErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(ctx)
+	}
+	return ret, err
+}
+
+func (s *QuerierStub) ListGrants(ctx context.Context) ([]*Grant, error) {
+	s.mu.Lock()
+	s.ListGrantsCalls++
+	fn := s.ListGrantsFn
+	ret := s.ListGrantsReturns
+	err := s.ListGrantsErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(ctx)
+	}
+	return ret, err
+}
+
 func (s *QuerierStub) ListWritersForLister(ctx context.Context, arg ListWritersForListerParams) ([]*ListWritersForListerRow, error) {
 	s.mu.Lock()
 	s.ListWritersForListerCalls = append(s.ListWritersForListerCalls, arg)
@@ -911,6 +1048,32 @@ func (s *QuerierStub) GetAllForumCategories(ctx context.Context, arg GetAllForum
 	return s.GetAllForumCategoriesReturns, s.GetAllForumCategoriesErr
 }
 
+func (s *QuerierStub) GetForumCategoryById(ctx context.Context, arg GetForumCategoryByIdParams) (*Forumcategory, error) {
+	s.mu.Lock()
+	s.GetForumCategoryByIdCalls = append(s.GetForumCategoryByIdCalls, arg)
+	fn := s.GetForumCategoryByIdFn
+	row := s.GetForumCategoryByIdReturns
+	err := s.GetForumCategoryByIdErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, arg)
+	}
+	return row, err
+}
+
+func (s *QuerierStub) GetAllForumTopicsByCategoryIdForUserWithLastPosterName(ctx context.Context, arg GetAllForumTopicsByCategoryIdForUserWithLastPosterNameParams) ([]*GetAllForumTopicsByCategoryIdForUserWithLastPosterNameRow, error) {
+	s.mu.Lock()
+	s.GetAllForumTopicsByCategoryIdForUserWithLastPosterNameCalls = append(s.GetAllForumTopicsByCategoryIdForUserWithLastPosterNameCalls, arg)
+	fn := s.GetAllForumTopicsByCategoryIdForUserWithLastPosterNameFn
+	rows := s.GetAllForumTopicsByCategoryIdForUserWithLastPosterNameReturns
+	err := s.GetAllForumTopicsByCategoryIdForUserWithLastPosterNameErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, arg)
+	}
+	return rows, err
+}
+
 // SystemCheckRoleGrant records the call and returns the configured response.
 func (s *QuerierStub) SystemCheckRoleGrant(ctx context.Context, arg SystemCheckRoleGrantParams) (int32, error) {
 	s.mu.Lock()
@@ -976,6 +1139,19 @@ func (s *QuerierStub) GetForumTopicByIdForUser(ctx context.Context, arg GetForum
 		return fn(ctx, arg)
 	}
 	return s.GetForumTopicByIdForUserReturns, s.GetForumTopicByIdForUserErr
+}
+
+func (s *QuerierStub) GetForumTopicById(ctx context.Context, idforumtopic int32) (*Forumtopic, error) {
+	s.mu.Lock()
+	s.GetForumTopicByIdCalls = append(s.GetForumTopicByIdCalls, idforumtopic)
+	fn := s.GetForumTopicByIdFn
+	row := s.GetForumTopicByIdReturns
+	err := s.GetForumTopicByIdErr
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, idforumtopic)
+	}
+	return row, err
 }
 
 func (s *QuerierStub) ListPrivateTopicParticipantsByTopicIDForUser(ctx context.Context, arg ListPrivateTopicParticipantsByTopicIDForUserParams) ([]*ListPrivateTopicParticipantsByTopicIDForUserRow, error) {

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -184,11 +184,13 @@ func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, tp Se
 	}
 	if nt := tp.SelfInternalNotificationTemplate(evt); nt != nil {
 		data := struct {
-			Path string
-			Item any
+			Path      string
+			Item      any
+			TaskEvent eventbus.TaskEvent
 		}{
-			Path: evt.Path,
-			Item: evt.Data,
+			Path:      evt.Path,
+			Item:      evt.Data,
+			TaskEvent: evt,
 		}
 		msg, err := n.renderNotification(ctx, *nt, data)
 		if err != nil {
@@ -243,11 +245,13 @@ func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.TaskEvent
 		}
 		if nt := tp.TargetInternalNotificationTemplate(evt); nt != nil {
 			data := struct {
-				Path string
-				Item any
+				Path      string
+				Item      any
+				TaskEvent eventbus.TaskEvent
 			}{
-				Path: evt.Path,
-				Item: evt.Data,
+				Path:      evt.Path,
+				Item:      evt.Data,
+				TaskEvent: evt,
 			}
 			msg, err := n.renderNotification(ctx, *nt, data)
 			if err != nil {


### PR DESCRIPTION
### Motivation

- Modernise forum and privateforum page tests to be less brittle by removing `sqlmock` expectations where SQL behaviour is not the focus.
- Provide explicit end-to-end style coverage for thread reply side-effects (subscriptions, internal notifications, and emails) for private forum threads.
- Allow notification templates to access richer event data by surfacing the originating `TaskEvent` to internal notification templates.
- Simplify test wiring by using the repository `db.QuerierStub` abstraction instead of real DB mocks.

### Description

- Replaced `sqlmock` usage with `db.QuerierStub` fixtures across multiple tests under `handlers/forum` and `handlers/privateforum`, and adjusted helper signatures to accept `db.Querier` where needed. 
- Extended `internal/db/querier_stub.go` with additional fields and method implementations used by the updated tests (forum/admin topic/category/topic-list helpers, admin queries, pending email/listing, etc.).
- Added an e2e-style private-thread reply test `TestThreadPagePrivateReplyNotifications` in `handlers/forum/forumThreadPage_private_title_test.go`, and renamed the existing `TestForumReplyNotifications` test to `TestForumReply` to keep naming consistent; the new test exercises comment creation, bus publish, notifications and email queue processing. 
- Updated `internal/notifications/bus_worker.go` so internal notification render data includes the originating `TaskEvent` under `TaskEvent`, enabling templates to reference `.TaskEvent` when rendering messages.

### Testing

- Ran `go fmt ./...` and `go vet ./...` and resolved formatting/vet issues; both completed successfully. 
- Ran the full test suite with `go test ./...` and verified the modified handler and notification tests passed. 
- Executed `go mod tidy` to refresh module dependencies prior to running tests. 
- Ran `golangci-lint run` and addressed issues until the lint run reported no problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69621b6210fc832fa951b3f004f9f631)