### PR TITLE
Add e2e notification tests for reply workflows and enrich thread event payloads

### DIFF
--- a/handlers/blogs/blogs_reply_notifications_test.go
+++ b/handlers/blogs/blogs_reply_notifications_test.go
@@ -1,0 +1,274 @@
+package blogs
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/mail"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/workers/emailqueue"
+)
+
+type blogQueries struct {
+	*db.QuerierStub
+	forumTopic *db.Forumtopic
+}
+
+func (q *blogQueries) SystemGetForumTopicByTitle(ctx context.Context, title sql.NullString) (*db.Forumtopic, error) {
+	return q.forumTopic, nil
+}
+
+type captureDLQ struct {
+	lastError string
+}
+
+func (c *captureDLQ) Record(ctx context.Context, message string) error {
+	c.lastError = message
+	return nil
+}
+
+type mockEmailProvider struct {
+	sentMessages [][]byte
+	recipients   []mail.Address
+}
+
+func (m *mockEmailProvider) Send(ctx context.Context, to mail.Address, rawEmailMessage []byte) error {
+	m.sentMessages = append(m.sentMessages, rawEmailMessage)
+	m.recipients = append(m.recipients, to)
+	return nil
+}
+
+func (m *mockEmailProvider) TestConfig(ctx context.Context) error { return nil }
+
+func TestBlogReply(t *testing.T) {
+	replierUID := int32(1)
+	subscriberUID := int32(2)
+	blogID := int32(5)
+	threadID := int32(66)
+	topicID := int32(77)
+	fixedTime := time.Date(2024, 4, 5, 6, 7, 0, 0, time.UTC)
+
+	qs := &blogQueries{
+		QuerierStub: &db.QuerierStub{
+			SystemCheckGrantReturns: 1,
+			GetPermissionsByUserIDFn: func(idusers int32) ([]*db.GetPermissionsByUserIDRow, error) {
+				return []*db.GetPermissionsByUserIDRow{}, nil
+			},
+			SystemGetUserByIDFn: func(ctx context.Context, idusers int32) (*db.SystemGetUserByIDRow, error) {
+				switch idusers {
+				case replierUID:
+					return &db.SystemGetUserByIDRow{
+						Idusers:  replierUID,
+						Username: sql.NullString{String: "replier", Valid: true},
+						Email:    sql.NullString{String: "replier@example.com", Valid: true},
+					}, nil
+				case subscriberUID:
+					return &db.SystemGetUserByIDRow{
+						Idusers:  subscriberUID,
+						Username: sql.NullString{String: "subscriber", Valid: true},
+						Email:    sql.NullString{String: "subscriber@example.com", Valid: true},
+					}, nil
+				}
+				return nil, sql.ErrNoRows
+			},
+			GetThreadLastPosterAndPermsFn: func(ctx context.Context, arg db.GetThreadLastPosterAndPermsParams) (*db.GetThreadLastPosterAndPermsRow, error) {
+				return &db.GetThreadLastPosterAndPermsRow{
+					Idforumthread:          threadID,
+					ForumtopicIdforumtopic: topicID,
+					Lastposterusername:     sql.NullString{String: "replier", Valid: true},
+					Comments:               sql.NullInt32{Int32: 3, Valid: true},
+				}, nil
+			},
+			GetForumTopicByIdFn: func(ctx context.Context, idforumtopic int32) (*db.Forumtopic, error) {
+				return &db.Forumtopic{Idforumtopic: topicID, Title: sql.NullString{String: BloggerTopicName, Valid: true}}, nil
+			},
+			GetBlogEntryForListerByIDRow: &db.GetBlogEntryForListerByIDRow{
+				Idblogs:       blogID,
+				ForumthreadID: sql.NullInt32{Int32: threadID, Valid: true},
+				LanguageID:    sql.NullInt32{Int32: 1, Valid: true},
+				Title:         "Test Blog",
+			},
+			ListSubscribersForPatternsReturn: map[string][]int32{
+				fmt.Sprintf("reply:/blogs/blog/%d/comments", blogID): {subscriberUID},
+			},
+			GetPreferenceForListerReturn: map[int32]*db.Preference{
+				replierUID: {AutoSubscribeReplies: true},
+			},
+			UpsertContentReadMarkerFn:                  func(ctx context.Context, arg db.UpsertContentReadMarkerParams) error { return nil },
+			ClearUnreadContentPrivateLabelExceptUserFn: func(ctx context.Context, arg db.ClearUnreadContentPrivateLabelExceptUserParams) error { return nil },
+			AdminDeletePendingEmailFn:                  func(ctx context.Context, id int32) error { return nil },
+			SystemMarkPendingEmailSentFn:               func(ctx context.Context, id int32) error { return nil },
+			CreateCommentInSectionForCommenterFn: func(ctx context.Context, arg db.CreateCommentInSectionForCommenterParams) (int64, error) {
+				return 777, nil
+			},
+		},
+		forumTopic: &db.Forumtopic{Idforumtopic: topicID, Title: sql.NullString{String: BloggerTopicName, Valid: true}},
+	}
+
+	qs.SystemListPendingEmailsFn = func(ctx context.Context, arg db.SystemListPendingEmailsParams) ([]*db.SystemListPendingEmailsRow, error) {
+		var rows []*db.SystemListPendingEmailsRow
+		if len(qs.InsertPendingEmailCalls) > 0 {
+			call := qs.InsertPendingEmailCalls[0]
+			rows = append(rows, &db.SystemListPendingEmailsRow{
+				ID:          1,
+				ToUserID:    call.ToUserID,
+				Body:        call.Body,
+				DirectEmail: call.DirectEmail,
+			})
+			qs.InsertPendingEmailCalls = qs.InsertPendingEmailCalls[1:]
+		}
+		return rows, nil
+	}
+
+	bus := eventbus.NewBus()
+	cfg := config.NewRuntimeConfig()
+	cfg.NotificationsEnabled = true
+	cfg.EmailEnabled = true
+	cfg.EmailFrom = "noreply@example.com"
+	cfg.HTTPHostname = "http://example.com"
+
+	mockProvider := &mockEmailProvider{}
+	n := notifications.New(
+		notifications.WithQueries(qs),
+		notifications.WithConfig(cfg),
+		notifications.WithEmailProvider(mockProvider),
+	)
+	cdlq := &captureDLQ{}
+	n.RegisterSync(bus, cdlq)
+
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test"
+	sess, _ := store.Get(httptest.NewRequest(http.MethodGet, "http://example.com", nil), core.SessionName)
+	sess.Values["UID"] = replierUID
+
+	evt := &eventbus.TaskEvent{
+		Data:    map[string]any{"Time": fixedTime},
+		UserID:  replierUID,
+		Path:    "/blogs/blog/5/comments",
+		Task:    replyBlogTask,
+		Outcome: eventbus.TaskOutcomeSuccess,
+	}
+	ctx := context.Background()
+	cd := common.NewCoreData(ctx, qs, cfg, common.WithSession(sess), common.WithEvent(evt), common.WithUserRoles([]string{"member"}))
+	cd.UserID = replierUID
+
+	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+
+	form := url.Values{"replytext": {"Hello Blog"}, "language": {"1"}}
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/blogs/blog/5/comments", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	req = mux.SetURLVars(req, map[string]string{"blog": "5"})
+
+	rr := httptest.NewRecorder()
+	replyBlogTask.Action(rr, req)
+
+	bus.Publish(*evt)
+
+	if cdlq.lastError != "" {
+		t.Errorf("sync process error: %s", cdlq.lastError)
+	}
+
+	var subscriberNotif string
+	for _, call := range qs.SystemCreateNotificationCalls {
+		if call.RecipientID == subscriberUID {
+			subscriberNotif = call.Message.String
+		}
+	}
+
+	expectedSubscriberNotif := fmt.Sprintf("New reply in %q by replier\n", BloggerTopicName)
+	if subscriberNotif != expectedSubscriberNotif {
+		t.Errorf("expected subscriber notif %q, got %q", expectedSubscriberNotif, subscriberNotif)
+	}
+
+	for emailqueue.ProcessPendingEmail(ctx, qs, mockProvider, cdlq, cfg) {
+	}
+
+	if len(mockProvider.sentMessages) != 1 {
+		t.Fatalf("expected 1 email sent, got %d", len(mockProvider.sentMessages))
+	}
+
+	msg, err := mail.ReadMessage(strings.NewReader(string(mockProvider.sentMessages[0])))
+	if err != nil {
+		t.Fatalf("parse email: %v", err)
+	}
+	if msg.Header.Get("Subject") != "[goa4web] New reply in "+BloggerTopicName {
+		t.Errorf("subscriber email subject mismatch: %s", msg.Header.Get("Subject"))
+	}
+	subBody := getEmailBody(t, msg)
+	expectedSubBody := fmt.Sprintf(
+		"Hi replier,\n\nA new reply was posted in %q (thread #%d) on %s.\nThere are now %d comments in the discussion.\n\nView it here:\n/blogs/blog/5/comments\n\n\nManage notifications: http://example.com/usr/subscriptions",
+		BloggerTopicName,
+		threadID,
+		fixedTime.Format(consts.DisplayDateTimeFormat),
+		3,
+	)
+	if subBody != expectedSubBody {
+		t.Errorf("subscriber email body mismatch: %q, want %q", subBody, expectedSubBody)
+	}
+
+	actionName, path, err := replyBlogTask.AutoSubscribePath(*evt)
+	if err != nil {
+		t.Errorf("AutoSubscribePath error: %v", err)
+	}
+	if actionName != "Reply" {
+		t.Errorf("expected action name Reply, got %q", actionName)
+	}
+	if path != fmt.Sprintf("/forum/topic/%d/thread/%d", topicID, threadID) {
+		t.Errorf("expected path /forum/topic/%d/thread/%d, got %q", topicID, threadID, path)
+	}
+}
+
+func getEmailBody(t *testing.T, msg *mail.Message) string {
+	t.Helper()
+	ct := msg.Header.Get("Content-Type")
+	if strings.Contains(ct, "multipart/alternative") {
+		_, params, err := mime.ParseMediaType(ct)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mr := multipart.NewReader(msg.Body, params["boundary"])
+		for {
+			p, err := mr.NextPart()
+			if err != nil {
+				break
+			}
+			pct := p.Header.Get("Content-Type")
+			if strings.Contains(pct, "text/plain") {
+				buf := new(bytes.Buffer)
+				if _, err := io.Copy(buf, p); err != nil {
+					t.Fatal(err)
+				}
+				return buf.String()
+			}
+		}
+	}
+
+	buf := new(bytes.Buffer)
+	if _, err := io.Copy(buf, msg.Body); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}

--- a/handlers/imagebbs/imagebbs_reply_notifications_test.go
+++ b/handlers/imagebbs/imagebbs_reply_notifications_test.go
@@ -1,0 +1,277 @@
+package imagebbs
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/mail"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/workers/emailqueue"
+)
+
+type imageBbsQueries struct {
+	*db.QuerierStub
+	forumTopic *db.Forumtopic
+	imagePost  *db.GetImagePostByIDForListerRow
+}
+
+func (q *imageBbsQueries) SystemGetForumTopicByTitle(ctx context.Context, title sql.NullString) (*db.Forumtopic, error) {
+	return q.forumTopic, nil
+}
+
+func (q *imageBbsQueries) GetImagePostByIDForLister(ctx context.Context, arg db.GetImagePostByIDForListerParams) (*db.GetImagePostByIDForListerRow, error) {
+	return q.imagePost, nil
+}
+
+type captureDLQ struct {
+	lastError string
+}
+
+func (c *captureDLQ) Record(ctx context.Context, message string) error {
+	c.lastError = message
+	return nil
+}
+
+type mockEmailProvider struct {
+	sentMessages [][]byte
+	recipients   []mail.Address
+}
+
+func (m *mockEmailProvider) Send(ctx context.Context, to mail.Address, rawEmailMessage []byte) error {
+	m.sentMessages = append(m.sentMessages, rawEmailMessage)
+	m.recipients = append(m.recipients, to)
+	return nil
+}
+
+func (m *mockEmailProvider) TestConfig(ctx context.Context) error { return nil }
+
+func TestImageBbsReply(t *testing.T) {
+	replierUID := int32(1)
+	subscriberUID := int32(2)
+	boardID := int32(9)
+	threadID := int32(101)
+	topicID := int32(202)
+	fixedTime := time.Date(2024, 5, 6, 7, 8, 0, 0, time.UTC)
+
+	qs := &imageBbsQueries{
+		QuerierStub: &db.QuerierStub{
+			SystemCheckGrantReturns: 1,
+			GetPermissionsByUserIDFn: func(idusers int32) ([]*db.GetPermissionsByUserIDRow, error) {
+				return []*db.GetPermissionsByUserIDRow{}, nil
+			},
+			SystemGetUserByIDFn: func(ctx context.Context, idusers int32) (*db.SystemGetUserByIDRow, error) {
+				switch idusers {
+				case replierUID:
+					return &db.SystemGetUserByIDRow{
+						Idusers:  replierUID,
+						Username: sql.NullString{String: "replier", Valid: true},
+						Email:    sql.NullString{String: "replier@example.com", Valid: true},
+					}, nil
+				case subscriberUID:
+					return &db.SystemGetUserByIDRow{
+						Idusers:  subscriberUID,
+						Username: sql.NullString{String: "subscriber", Valid: true},
+						Email:    sql.NullString{String: "subscriber@example.com", Valid: true},
+					}, nil
+				}
+				return nil, sql.ErrNoRows
+			},
+			GetThreadLastPosterAndPermsFn: func(ctx context.Context, arg db.GetThreadLastPosterAndPermsParams) (*db.GetThreadLastPosterAndPermsRow, error) {
+				return &db.GetThreadLastPosterAndPermsRow{
+					Idforumthread:          threadID,
+					ForumtopicIdforumtopic: topicID,
+					Lastposterusername:     sql.NullString{String: "replier", Valid: true},
+					Comments:               sql.NullInt32{Int32: 6, Valid: true},
+				}, nil
+			},
+			GetForumTopicByIdFn: func(ctx context.Context, idforumtopic int32) (*db.Forumtopic, error) {
+				return &db.Forumtopic{Idforumtopic: topicID, Title: sql.NullString{String: ImageBBSTopicName, Valid: true}}, nil
+			},
+			ListSubscribersForPatternsReturn: map[string][]int32{
+				fmt.Sprintf("reply:/imagebbss/imagebbs/%d/comments", boardID): {subscriberUID},
+			},
+			GetPreferenceForListerReturn: map[int32]*db.Preference{
+				replierUID: {AutoSubscribeReplies: true},
+			},
+			UpsertContentReadMarkerFn:                  func(ctx context.Context, arg db.UpsertContentReadMarkerParams) error { return nil },
+			ClearUnreadContentPrivateLabelExceptUserFn: func(ctx context.Context, arg db.ClearUnreadContentPrivateLabelExceptUserParams) error { return nil },
+			AdminDeletePendingEmailFn:                  func(ctx context.Context, id int32) error { return nil },
+			SystemMarkPendingEmailSentFn:               func(ctx context.Context, id int32) error { return nil },
+			CreateCommentInSectionForCommenterFn: func(ctx context.Context, arg db.CreateCommentInSectionForCommenterParams) (int64, error) {
+				return 888, nil
+			},
+		},
+		forumTopic: &db.Forumtopic{Idforumtopic: topicID, Title: sql.NullString{String: ImageBBSTopicName, Valid: true}},
+		imagePost: &db.GetImagePostByIDForListerRow{
+			Idimagepost:   boardID,
+			ForumthreadID: threadID,
+		},
+	}
+
+	qs.SystemListPendingEmailsFn = func(ctx context.Context, arg db.SystemListPendingEmailsParams) ([]*db.SystemListPendingEmailsRow, error) {
+		var rows []*db.SystemListPendingEmailsRow
+		if len(qs.InsertPendingEmailCalls) > 0 {
+			call := qs.InsertPendingEmailCalls[0]
+			rows = append(rows, &db.SystemListPendingEmailsRow{
+				ID:          1,
+				ToUserID:    call.ToUserID,
+				Body:        call.Body,
+				DirectEmail: call.DirectEmail,
+			})
+			qs.InsertPendingEmailCalls = qs.InsertPendingEmailCalls[1:]
+		}
+		return rows, nil
+	}
+
+	bus := eventbus.NewBus()
+	cfg := config.NewRuntimeConfig()
+	cfg.NotificationsEnabled = true
+	cfg.EmailEnabled = true
+	cfg.EmailFrom = "noreply@example.com"
+	cfg.HTTPHostname = "http://example.com"
+
+	mockProvider := &mockEmailProvider{}
+	n := notifications.New(
+		notifications.WithQueries(qs),
+		notifications.WithConfig(cfg),
+		notifications.WithEmailProvider(mockProvider),
+	)
+	cdlq := &captureDLQ{}
+	n.RegisterSync(bus, cdlq)
+
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test"
+	sess, _ := store.Get(httptest.NewRequest(http.MethodGet, "http://example.com", nil), core.SessionName)
+	sess.Values["UID"] = replierUID
+
+	evt := &eventbus.TaskEvent{
+		Data:    map[string]any{"Time": fixedTime},
+		UserID:  replierUID,
+		Path:    "/imagebbss/imagebbs/9/comments",
+		Task:    replyTask,
+		Outcome: eventbus.TaskOutcomeSuccess,
+	}
+	ctx := context.Background()
+	cd := common.NewCoreData(ctx, qs, cfg, common.WithSession(sess), common.WithEvent(evt), common.WithUserRoles([]string{"member"}))
+	cd.UserID = replierUID
+
+	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+
+	form := url.Values{"replytext": {"Hello ImageBBS"}, "language": {"1"}}
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/imagebbss/imagebbs/9/comments", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	req = mux.SetURLVars(req, map[string]string{"board": "9"})
+
+	rr := httptest.NewRecorder()
+	replyTask.Action(rr, req)
+
+	bus.Publish(*evt)
+
+	if cdlq.lastError != "" {
+		t.Errorf("sync process error: %s", cdlq.lastError)
+	}
+
+	var subscriberNotif string
+	for _, call := range qs.SystemCreateNotificationCalls {
+		if call.RecipientID == subscriberUID {
+			subscriberNotif = call.Message.String
+		}
+	}
+
+	expectedSubscriberNotif := fmt.Sprintf("New reply in %q by replier\n", ImageBBSTopicName)
+	if subscriberNotif != expectedSubscriberNotif {
+		t.Errorf("expected subscriber notif %q, got %q", expectedSubscriberNotif, subscriberNotif)
+	}
+
+	for emailqueue.ProcessPendingEmail(ctx, qs, mockProvider, cdlq, cfg) {
+	}
+
+	if len(mockProvider.sentMessages) != 1 {
+		t.Fatalf("expected 1 email sent, got %d", len(mockProvider.sentMessages))
+	}
+
+	msg, err := mail.ReadMessage(strings.NewReader(string(mockProvider.sentMessages[0])))
+	if err != nil {
+		t.Fatalf("parse email: %v", err)
+	}
+	if msg.Header.Get("Subject") != "[goa4web] New reply in "+ImageBBSTopicName {
+		t.Errorf("subscriber email subject mismatch: %s", msg.Header.Get("Subject"))
+	}
+	subBody := getEmailBody(t, msg)
+	expectedSubBody := fmt.Sprintf(
+		"Hi replier,\n\nA new reply was posted in %q (thread #%d) on %s.\nThere are now %d comments in the discussion.\n\nView it here:\n/imagebbss/imagebbs/9/comments\n\n\nManage notifications: http://example.com/usr/subscriptions",
+		ImageBBSTopicName,
+		threadID,
+		fixedTime.Format(consts.DisplayDateTimeFormat),
+		6,
+	)
+	if subBody != expectedSubBody {
+		t.Errorf("subscriber email body mismatch: %q, want %q", subBody, expectedSubBody)
+	}
+
+	actionName, path, err := replyTask.AutoSubscribePath(*evt)
+	if err != nil {
+		t.Errorf("AutoSubscribePath error: %v", err)
+	}
+	if actionName != "Reply" {
+		t.Errorf("expected action name Reply, got %q", actionName)
+	}
+	if path != "/imagebbss/imagebbs/9/comments" {
+		t.Errorf("expected path /imagebbss/imagebbs/9/comments, got %q", path)
+	}
+}
+
+func getEmailBody(t *testing.T, msg *mail.Message) string {
+	t.Helper()
+	ct := msg.Header.Get("Content-Type")
+	if strings.Contains(ct, "multipart/alternative") {
+		_, params, err := mime.ParseMediaType(ct)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mr := multipart.NewReader(msg.Body, params["boundary"])
+		for {
+			p, err := mr.NextPart()
+			if err != nil {
+				break
+			}
+			pct := p.Header.Get("Content-Type")
+			if strings.Contains(pct, "text/plain") {
+				buf := new(bytes.Buffer)
+				if _, err := io.Copy(buf, p); err != nil {
+					t.Fatal(err)
+				}
+				return buf.String()
+			}
+		}
+	}
+
+	buf := new(bytes.Buffer)
+	if _, err := io.Copy(buf, msg.Body); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}

--- a/handlers/linker/approve_task.go
+++ b/handlers/linker/approve_task.go
@@ -73,6 +73,7 @@ func (approveTask) Action(w http.ResponseWriter, r *http.Request) any {
 			evt.Data["Username"] = link.Username.String
 			evt.Data["Moderator"] = mod
 			evt.Data["LinkURL"] = cd.AbsoluteURL(fmt.Sprintf("/linker/show/%d", lid))
+			evt.Data["UnsubURL"] = cd.AbsoluteURL("/usr/subscriptions")
 			evt.Data[searchworker.EventKey] = searchworker.IndexEventData{Type: searchworker.TypeLinker, ID: int32(lid), Text: text}
 		}
 	}

--- a/handlers/linker/linker_approve_notifications_test.go
+++ b/handlers/linker/linker_approve_notifications_test.go
@@ -1,0 +1,277 @@
+package linker
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/mail"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/workers/emailqueue"
+)
+
+type approveQueries struct {
+	*db.QuerierStub
+	queuedLinkID int64
+}
+
+func (q *approveQueries) AdminInsertQueuedLinkFromQueue(ctx context.Context, id int32) (int64, error) {
+	return q.queuedLinkID, nil
+}
+
+type captureDLQ struct {
+	lastError string
+}
+
+func (c *captureDLQ) Record(ctx context.Context, message string) error {
+	c.lastError = message
+	return nil
+}
+
+type mockEmailProvider struct {
+	sentMessages [][]byte
+	recipients   []mail.Address
+}
+
+func (m *mockEmailProvider) Send(ctx context.Context, to mail.Address, rawEmailMessage []byte) error {
+	m.sentMessages = append(m.sentMessages, rawEmailMessage)
+	m.recipients = append(m.recipients, to)
+	return nil
+}
+
+func (m *mockEmailProvider) TestConfig(ctx context.Context) error { return nil }
+
+func TestLinkerApprove(t *testing.T) {
+	moderatorUID := int32(1)
+	subscriberUID := int32(2)
+	adminUID := int32(99)
+	linkID := int64(7)
+
+	qs := &approveQueries{
+		QuerierStub: &db.QuerierStub{
+			SystemGetUserByIDFn: func(ctx context.Context, idusers int32) (*db.SystemGetUserByIDRow, error) {
+				switch idusers {
+				case moderatorUID:
+					return &db.SystemGetUserByIDRow{
+						Idusers:  moderatorUID,
+						Username: sql.NullString{String: "moderator", Valid: true},
+						Email:    sql.NullString{String: "moderator@example.com", Valid: true},
+					}, nil
+				case subscriberUID:
+					return &db.SystemGetUserByIDRow{
+						Idusers:  subscriberUID,
+						Username: sql.NullString{String: "subscriber", Valid: true},
+						Email:    sql.NullString{String: "subscriber@example.com", Valid: true},
+					}, nil
+				case adminUID:
+					return &db.SystemGetUserByIDRow{
+						Idusers:  adminUID,
+						Username: sql.NullString{String: "adminuser", Valid: true},
+						Email:    sql.NullString{String: "admin@example.com", Valid: true},
+					}, nil
+				}
+				return nil, sql.ErrNoRows
+			},
+			SystemGetUserByEmailFn: func(ctx context.Context, email string) (*db.SystemGetUserByEmailRow, error) {
+				if email == "admin@example.com" {
+					return &db.SystemGetUserByEmailRow{Idusers: adminUID}, nil
+				}
+				return nil, sql.ErrNoRows
+			},
+			GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow: &db.GetLinkerItemByIdWithPosterUsernameAndCategoryTitleDescendingForUserRow{
+				ID:          int32(linkID),
+				Title:       sql.NullString{String: "Example Link", Valid: true},
+				Description: sql.NullString{String: "Example Description", Valid: true},
+				Username:    sql.NullString{String: "subscriber", Valid: true},
+			},
+			ListSubscribersForPatternsReturn: map[string][]int32{
+				"approve:/admin/queue": {subscriberUID},
+			},
+			GetPreferenceForListerReturn: map[int32]*db.Preference{
+				moderatorUID: {AutoSubscribeReplies: true},
+			},
+			AdminListAdministratorEmailsReturns: []string{"admin@example.com"},
+			AdminDeletePendingEmailFn:           func(ctx context.Context, id int32) error { return nil },
+			SystemMarkPendingEmailSentFn:        func(ctx context.Context, id int32) error { return nil },
+		},
+		queuedLinkID: linkID,
+	}
+
+	qs.SystemListPendingEmailsFn = func(ctx context.Context, arg db.SystemListPendingEmailsParams) ([]*db.SystemListPendingEmailsRow, error) {
+		var rows []*db.SystemListPendingEmailsRow
+		if len(qs.InsertPendingEmailCalls) > 0 {
+			call := qs.InsertPendingEmailCalls[0]
+			rows = append(rows, &db.SystemListPendingEmailsRow{
+				ID:          1,
+				ToUserID:    call.ToUserID,
+				Body:        call.Body,
+				DirectEmail: call.DirectEmail,
+			})
+			qs.InsertPendingEmailCalls = qs.InsertPendingEmailCalls[1:]
+		}
+		return rows, nil
+	}
+
+	bus := eventbus.NewBus()
+	cfg := config.NewRuntimeConfig()
+	cfg.NotificationsEnabled = true
+	cfg.AdminNotify = true
+	cfg.EmailEnabled = true
+	cfg.EmailFrom = "noreply@example.com"
+	cfg.HTTPHostname = "http://example.com"
+
+	mockProvider := &mockEmailProvider{}
+	n := notifications.New(
+		notifications.WithQueries(qs),
+		notifications.WithConfig(cfg),
+		notifications.WithEmailProvider(mockProvider),
+	)
+	cdlq := &captureDLQ{}
+	n.RegisterSync(bus, cdlq)
+
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test"
+	sess, _ := store.Get(httptest.NewRequest(http.MethodGet, "http://example.com", nil), core.SessionName)
+	sess.Values["UID"] = moderatorUID
+
+	evt := &eventbus.TaskEvent{
+		Data:    map[string]any{},
+		UserID:  moderatorUID,
+		Path:    "/admin/queue",
+		Task:    AdminApproveTask,
+		Outcome: eventbus.TaskOutcomeSuccess,
+	}
+	ctx := context.Background()
+	cd := common.NewCoreData(ctx, qs, cfg, common.WithSession(sess), common.WithEvent(evt), common.WithUserRoles([]string{"administrator"}))
+	cd.UserID = moderatorUID
+
+	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/admin/queue?qid=3", nil)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	if err := AdminApproveTask.Action(rr, req); err != nil {
+		t.Fatalf("approve action error: %v", err)
+	}
+
+	bus.Publish(*evt)
+
+	if cdlq.lastError != "" {
+		t.Errorf("sync process error: %s", cdlq.lastError)
+	}
+
+	var subscriberNotif, adminNotif string
+	for _, call := range qs.SystemCreateNotificationCalls {
+		if call.RecipientID == subscriberUID {
+			subscriberNotif = call.Message.String
+		}
+		if call.RecipientID == adminUID {
+			adminNotif = call.Message.String
+		}
+	}
+
+	expectedSubscriberNotif := "Link \"Example Link\" approved by moderator.\n"
+	if subscriberNotif != expectedSubscriberNotif {
+		t.Errorf("expected subscriber notif %q, got %q", expectedSubscriberNotif, subscriberNotif)
+	}
+
+	expectedAdminNotif := "Moderator moderator approved the link \"Example Link\"\n"
+	if adminNotif != expectedAdminNotif {
+		t.Errorf("expected admin notif %q, got %q", expectedAdminNotif, adminNotif)
+	}
+
+	for emailqueue.ProcessPendingEmail(ctx, qs, mockProvider, cdlq, cfg) {
+	}
+
+	if len(mockProvider.sentMessages) != 2 {
+		t.Fatalf("expected 2 emails sent, got %d", len(mockProvider.sentMessages))
+	}
+
+	var subscriberEmail, adminEmail *mail.Message
+	for i, raw := range mockProvider.sentMessages {
+		msg, err := mail.ReadMessage(strings.NewReader(string(raw)))
+		if err != nil {
+			t.Fatalf("parse email %d: %v", i, err)
+		}
+		to := mockProvider.recipients[i].Address
+		if to == "subscriber@example.com" {
+			subscriberEmail = msg
+		} else if to == "admin@example.com" {
+			adminEmail = msg
+		}
+	}
+
+	if subscriberEmail == nil {
+		t.Fatal("subscriber email not found")
+	}
+	if subscriberEmail.Header.Get("Subject") != "[goa4web] Link approved" {
+		t.Errorf("subscriber email subject mismatch: %s", subscriberEmail.Header.Get("Subject"))
+	}
+	subBody := getEmailBody(t, subscriberEmail)
+	expectedSubBody := "Hi subscriber,\nYour link \"Example Link\" has been approved by moderator.\n\nView link:\n/linker/show/7\n\nManage notifications: /usr/subscriptions"
+	if subBody != expectedSubBody {
+		t.Errorf("subscriber email body mismatch: %q, want %q", subBody, expectedSubBody)
+	}
+
+	if adminEmail == nil {
+		t.Fatal("admin email not found")
+	}
+	if adminEmail.Header.Get("Subject") != "[goa4web Admin] Link approved" {
+		t.Errorf("admin email subject mismatch: %s", adminEmail.Header.Get("Subject"))
+	}
+	adminBody := getEmailBody(t, adminEmail)
+	expectedAdminBody := "Moderator moderator approved the link \"Example Link\".\n\nView link:\n/linker/show/7\n\nManage notifications: /usr/subscriptions"
+	if adminBody != expectedAdminBody {
+		t.Errorf("admin email body mismatch: %q, want %q", adminBody, expectedAdminBody)
+	}
+}
+
+func getEmailBody(t *testing.T, msg *mail.Message) string {
+	t.Helper()
+	ct := msg.Header.Get("Content-Type")
+	if strings.Contains(ct, "multipart/alternative") {
+		_, params, err := mime.ParseMediaType(ct)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mr := multipart.NewReader(msg.Body, params["boundary"])
+		for {
+			p, err := mr.NextPart()
+			if err != nil {
+				break
+			}
+			pct := p.Header.Get("Content-Type")
+			if strings.Contains(pct, "text/plain") {
+				buf := new(bytes.Buffer)
+				if _, err := io.Copy(buf, p); err != nil {
+					t.Fatal(err)
+				}
+				return buf.String()
+			}
+		}
+	}
+
+	buf := new(bytes.Buffer)
+	if _, err := io.Copy(buf, msg.Body); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}

--- a/handlers/news/newsPostPage_test.go
+++ b/handlers/news/newsPostPage_test.go
@@ -2,16 +2,16 @@ package news
 
 import (
 	"context"
-	"github.com/arran4/goa4web/core/consts"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/arran4/goa4web/core/consts"
+
 	"github.com/arran4/goa4web/core/common"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 
@@ -20,12 +20,6 @@ import (
 )
 
 func TestNewsPostNewActionPage_InvalidForms(t *testing.T) {
-	dbconn, _, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer dbconn.Close()
-
 	store := sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = "test-session"
@@ -64,12 +58,6 @@ func TestNewsPostNewActionPage_InvalidForms(t *testing.T) {
 }
 
 func TestNewsPostEditActionPage_InvalidForms(t *testing.T) {
-	dbconn, _, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
-	}
-	defer dbconn.Close()
-
 	store := sessions.NewCookieStore([]byte("test"))
 	core.Store = store
 	core.SessionName = "test-session"

--- a/handlers/news/news_reply_notifications_test.go
+++ b/handlers/news/news_reply_notifications_test.go
@@ -1,0 +1,326 @@
+package news
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/mail"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/workers/emailqueue"
+)
+
+type newsQueries struct {
+	*db.QuerierStub
+	forumTopic *db.Forumtopic
+	newsPost   *db.GetNewsPostByIdWithWriterIdAndThreadCommentCountRow
+}
+
+func (q *newsQueries) SystemGetForumTopicByTitle(ctx context.Context, title sql.NullString) (*db.Forumtopic, error) {
+	return q.forumTopic, nil
+}
+
+func (q *newsQueries) GetNewsPostByIdWithWriterIdAndThreadCommentCount(ctx context.Context, arg db.GetNewsPostByIdWithWriterIdAndThreadCommentCountParams) (*db.GetNewsPostByIdWithWriterIdAndThreadCommentCountRow, error) {
+	return q.newsPost, nil
+}
+
+type captureDLQ struct {
+	lastError string
+}
+
+func (c *captureDLQ) Record(ctx context.Context, message string) error {
+	c.lastError = message
+	return nil
+}
+
+type mockEmailProvider struct {
+	sentMessages [][]byte
+	recipients   []mail.Address
+}
+
+func (m *mockEmailProvider) Send(ctx context.Context, to mail.Address, rawEmailMessage []byte) error {
+	m.sentMessages = append(m.sentMessages, rawEmailMessage)
+	m.recipients = append(m.recipients, to)
+	return nil
+}
+
+func (m *mockEmailProvider) TestConfig(ctx context.Context) error { return nil }
+
+func TestNewsReply(t *testing.T) {
+	replierUID := int32(1)
+	subscriberUID := int32(2)
+	adminUID := int32(99)
+	postID := int32(1)
+	threadID := int32(42)
+	topicID := int32(7)
+	fixedTime := time.Date(2024, 2, 3, 4, 5, 0, 0, time.UTC)
+
+	qs := &newsQueries{
+		QuerierStub: &db.QuerierStub{
+			SystemCheckGrantReturns: 1,
+			GetPermissionsByUserIDFn: func(idusers int32) ([]*db.GetPermissionsByUserIDRow, error) {
+				return []*db.GetPermissionsByUserIDRow{}, nil
+			},
+			SystemGetUserByIDFn: func(ctx context.Context, idusers int32) (*db.SystemGetUserByIDRow, error) {
+				switch idusers {
+				case replierUID:
+					return &db.SystemGetUserByIDRow{
+						Idusers:  replierUID,
+						Username: sql.NullString{String: "replier", Valid: true},
+						Email:    sql.NullString{String: "replier@example.com", Valid: true},
+					}, nil
+				case subscriberUID:
+					return &db.SystemGetUserByIDRow{
+						Idusers:  subscriberUID,
+						Username: sql.NullString{String: "subscriber", Valid: true},
+						Email:    sql.NullString{String: "subscriber@example.com", Valid: true},
+					}, nil
+				case adminUID:
+					return &db.SystemGetUserByIDRow{
+						Idusers:  adminUID,
+						Username: sql.NullString{String: "adminuser", Valid: true},
+						Email:    sql.NullString{String: "admin@example.com", Valid: true},
+					}, nil
+				}
+				return nil, sql.ErrNoRows
+			},
+			SystemGetUserByEmailFn: func(ctx context.Context, email string) (*db.SystemGetUserByEmailRow, error) {
+				if email == "admin@example.com" {
+					return &db.SystemGetUserByEmailRow{Idusers: adminUID}, nil
+				}
+				return nil, sql.ErrNoRows
+			},
+			GetThreadLastPosterAndPermsFn: func(ctx context.Context, arg db.GetThreadLastPosterAndPermsParams) (*db.GetThreadLastPosterAndPermsRow, error) {
+				return &db.GetThreadLastPosterAndPermsRow{
+					Idforumthread:          threadID,
+					ForumtopicIdforumtopic: topicID,
+					Lastposterusername:     sql.NullString{String: "replier", Valid: true},
+					Comments:               sql.NullInt32{Int32: 2, Valid: true},
+				}, nil
+			},
+			GetForumTopicByIdFn: func(ctx context.Context, idforumtopic int32) (*db.Forumtopic, error) {
+				return &db.Forumtopic{Idforumtopic: topicID, Title: sql.NullString{String: NewsTopicName, Valid: true}}, nil
+			},
+			ListSubscribersForPatternsReturn: map[string][]int32{
+				fmt.Sprintf("reply:/news/news/%d", postID): {subscriberUID},
+			},
+			GetPreferenceForListerReturn: map[int32]*db.Preference{
+				replierUID: {AutoSubscribeReplies: true},
+			},
+			AdminListAdministratorEmailsReturns:        []string{"admin@example.com"},
+			UpsertContentReadMarkerFn:                  func(ctx context.Context, arg db.UpsertContentReadMarkerParams) error { return nil },
+			ClearUnreadContentPrivateLabelExceptUserFn: func(ctx context.Context, arg db.ClearUnreadContentPrivateLabelExceptUserParams) error { return nil },
+			AdminDeletePendingEmailFn:                  func(ctx context.Context, id int32) error { return nil },
+			SystemMarkPendingEmailSentFn:               func(ctx context.Context, id int32) error { return nil },
+			CreateCommentInSectionForCommenterFn: func(ctx context.Context, arg db.CreateCommentInSectionForCommenterParams) (int64, error) {
+				return 999, nil
+			},
+		},
+		forumTopic: &db.Forumtopic{Idforumtopic: topicID, Title: sql.NullString{String: NewsTopicName, Valid: true}},
+		newsPost: &db.GetNewsPostByIdWithWriterIdAndThreadCommentCountRow{
+			Idsitenews:    postID,
+			ForumthreadID: threadID,
+			LanguageID:    sql.NullInt32{Int32: 1, Valid: true},
+		},
+	}
+
+	qs.SystemListPendingEmailsFn = func(ctx context.Context, arg db.SystemListPendingEmailsParams) ([]*db.SystemListPendingEmailsRow, error) {
+		var rows []*db.SystemListPendingEmailsRow
+		if len(qs.InsertPendingEmailCalls) > 0 {
+			call := qs.InsertPendingEmailCalls[0]
+			rows = append(rows, &db.SystemListPendingEmailsRow{
+				ID:          1,
+				ToUserID:    call.ToUserID,
+				Body:        call.Body,
+				DirectEmail: call.DirectEmail,
+			})
+			qs.InsertPendingEmailCalls = qs.InsertPendingEmailCalls[1:]
+		}
+		return rows, nil
+	}
+
+	bus := eventbus.NewBus()
+	cfg := config.NewRuntimeConfig()
+	cfg.NotificationsEnabled = true
+	cfg.AdminNotify = true
+	cfg.EmailEnabled = true
+	cfg.EmailFrom = "noreply@example.com"
+	cfg.HTTPHostname = "http://example.com"
+
+	mockProvider := &mockEmailProvider{}
+	n := notifications.New(
+		notifications.WithQueries(qs),
+		notifications.WithConfig(cfg),
+		notifications.WithEmailProvider(mockProvider),
+	)
+	cdlq := &captureDLQ{}
+	n.RegisterSync(bus, cdlq)
+
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test"
+	sess, _ := store.Get(httptest.NewRequest(http.MethodGet, "http://example.com", nil), core.SessionName)
+	sess.Values["UID"] = replierUID
+
+	evt := &eventbus.TaskEvent{
+		Data:    map[string]any{"Time": fixedTime},
+		UserID:  replierUID,
+		Path:    "/news/news/1",
+		Task:    replyTask,
+		Outcome: eventbus.TaskOutcomeSuccess,
+	}
+	ctx := context.Background()
+	cd := common.NewCoreData(ctx, qs, cfg, common.WithSession(sess), common.WithEvent(evt), common.WithUserRoles([]string{"member"}))
+	cd.UserID = replierUID
+
+	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+
+	form := url.Values{"replytext": {"Hello News"}, "language": {"1"}}
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/news/news/1", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	req = mux.SetURLVars(req, map[string]string{"news": "1"})
+
+	rr := httptest.NewRecorder()
+	replyTask.Action(rr, req)
+
+	bus.Publish(*evt)
+
+	if cdlq.lastError != "" {
+		t.Errorf("sync process error: %s", cdlq.lastError)
+	}
+
+	var subscriberNotif, adminNotif string
+	for _, call := range qs.SystemCreateNotificationCalls {
+		if call.RecipientID == subscriberUID {
+			subscriberNotif = call.Message.String
+		}
+		if call.RecipientID == adminUID {
+			adminNotif = call.Message.String
+		}
+	}
+
+	expectedSubscriberNotif := fmt.Sprintf("New reply in %q by replier\n", NewsTopicName)
+	if subscriberNotif != expectedSubscriberNotif {
+		t.Errorf("expected subscriber notif %q, got %q", expectedSubscriberNotif, subscriberNotif)
+	}
+
+	expectedAdminNotif := "User replier replied to a news post\n\n"
+	if adminNotif != expectedAdminNotif {
+		t.Errorf("expected admin notif %q, got %q", expectedAdminNotif, adminNotif)
+	}
+
+	for emailqueue.ProcessPendingEmail(ctx, qs, mockProvider, cdlq, cfg) {
+	}
+
+	if len(mockProvider.sentMessages) != 2 {
+		t.Fatalf("expected 2 emails sent, got %d", len(mockProvider.sentMessages))
+	}
+
+	var subscriberEmail, adminEmail *mail.Message
+	for i, raw := range mockProvider.sentMessages {
+		msg, err := mail.ReadMessage(strings.NewReader(string(raw)))
+		if err != nil {
+			t.Fatalf("parse email %d: %v", i, err)
+		}
+		to := mockProvider.recipients[i].Address
+		if to == "subscriber@example.com" {
+			subscriberEmail = msg
+		} else if to == "admin@example.com" {
+			adminEmail = msg
+		}
+	}
+
+	if subscriberEmail == nil {
+		t.Fatal("subscriber email not found")
+	}
+	if subscriberEmail.Header.Get("Subject") != "[goa4web] New reply in "+NewsTopicName {
+		t.Errorf("subscriber email subject mismatch: %s", subscriberEmail.Header.Get("Subject"))
+	}
+	subBody := getEmailBody(t, subscriberEmail)
+	expectedSubBody := fmt.Sprintf(
+		"Hi replier,\n\nA new reply was posted in %q (thread #%d) on %s.\nThere are now %d comments in the discussion.\n\nView it here:\n/news/news/1\n\n\nManage notifications: http://example.com/usr/subscriptions",
+		NewsTopicName,
+		threadID,
+		fixedTime.Format(consts.DisplayDateTimeFormat),
+		2,
+	)
+	if subBody != expectedSubBody {
+		t.Errorf("subscriber email body mismatch: %q, want %q", subBody, expectedSubBody)
+	}
+
+	if adminEmail == nil {
+		t.Fatal("admin email not found")
+	}
+	if adminEmail.Header.Get("Subject") != "[goa4web Admin] News comment posted" {
+		t.Errorf("admin email subject mismatch: %s", adminEmail.Header.Get("Subject"))
+	}
+	adminBody := getEmailBody(t, adminEmail)
+	expectedAdminBody := "User replier replied to a news post.\n\nView post:\n/news/news/1\n\nManage notifications: http://example.com/usr/subscriptions"
+	if adminBody != expectedAdminBody {
+		t.Errorf("admin email body mismatch: %q, want %q", adminBody, expectedAdminBody)
+	}
+
+	actionName, path, err := replyTask.AutoSubscribePath(*evt)
+	if err != nil {
+		t.Errorf("AutoSubscribePath error: %v", err)
+	}
+	if actionName != "Reply" {
+		t.Errorf("expected action name Reply, got %q", actionName)
+	}
+	if path != fmt.Sprintf("/forum/topic/%d/thread/%d", topicID, threadID) {
+		t.Errorf("expected path /forum/topic/%d/thread/%d, got %q", topicID, threadID, path)
+	}
+}
+
+func getEmailBody(t *testing.T, msg *mail.Message) string {
+	t.Helper()
+	ct := msg.Header.Get("Content-Type")
+	if strings.Contains(ct, "multipart/alternative") {
+		_, params, err := mime.ParseMediaType(ct)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mr := multipart.NewReader(msg.Body, params["boundary"])
+		for {
+			p, err := mr.NextPart()
+			if err != nil {
+				break
+			}
+			pct := p.Header.Get("Content-Type")
+			if strings.Contains(pct, "text/plain") {
+				buf := new(bytes.Buffer)
+				if _, err := io.Copy(buf, p); err != nil {
+					t.Fatal(err)
+				}
+				return buf.String()
+			}
+		}
+	}
+
+	buf := new(bytes.Buffer)
+	if _, err := io.Copy(buf, msg.Body); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -104,6 +104,7 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		return fmt.Errorf("create comment fail %w", handlers.ErrRedirectOnSamePageHandler(err))
 	}
 
+	endURL := cd.AbsoluteURL(fmt.Sprintf("/writings/article/%d", writing.Idwriting))
 	if err := cd.HandleThreadUpdated(r.Context(), common.ThreadUpdatedEvent{
 		ThreadID:             threadID,
 		TopicID:              topicID,
@@ -111,6 +112,8 @@ func (ReplyTask) Action(w http.ResponseWriter, r *http.Request) any {
 		LabelItem:            "writing",
 		LabelItemID:          writing.Idwriting,
 		CommentText:          text,
+		CommentURL:           endURL,
+		PostURL:              endURL,
 		ClearUnreadForOthers: true,
 		MarkThreadRead:       true,
 		IncludePostCount:     true,

--- a/handlers/writings/writings_reply_notifications_test.go
+++ b/handlers/writings/writings_reply_notifications_test.go
@@ -1,0 +1,275 @@
+package writings
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/mail"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+
+	"github.com/arran4/goa4web/config"
+	"github.com/arran4/goa4web/core"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/db"
+	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/workers/emailqueue"
+)
+
+type writingsQueries struct {
+	*db.QuerierStub
+	forumTopic *db.Forumtopic
+}
+
+func (q *writingsQueries) SystemGetForumTopicByTitle(ctx context.Context, title sql.NullString) (*db.Forumtopic, error) {
+	return q.forumTopic, nil
+}
+
+type captureDLQ struct {
+	lastError string
+}
+
+func (c *captureDLQ) Record(ctx context.Context, message string) error {
+	c.lastError = message
+	return nil
+}
+
+type mockEmailProvider struct {
+	sentMessages [][]byte
+	recipients   []mail.Address
+}
+
+func (m *mockEmailProvider) Send(ctx context.Context, to mail.Address, rawEmailMessage []byte) error {
+	m.sentMessages = append(m.sentMessages, rawEmailMessage)
+	m.recipients = append(m.recipients, to)
+	return nil
+}
+
+func (m *mockEmailProvider) TestConfig(ctx context.Context) error { return nil }
+
+func TestWritingReply(t *testing.T) {
+	replierUID := int32(1)
+	subscriberUID := int32(2)
+	writingID := int32(3)
+	threadID := int32(22)
+	topicID := int32(33)
+	fixedTime := time.Date(2024, 3, 4, 5, 6, 0, 0, time.UTC)
+
+	qs := &writingsQueries{
+		QuerierStub: &db.QuerierStub{
+			SystemCheckGrantReturns: 1,
+			GetPermissionsByUserIDFn: func(idusers int32) ([]*db.GetPermissionsByUserIDRow, error) {
+				return []*db.GetPermissionsByUserIDRow{}, nil
+			},
+			SystemGetUserByIDFn: func(ctx context.Context, idusers int32) (*db.SystemGetUserByIDRow, error) {
+				switch idusers {
+				case replierUID:
+					return &db.SystemGetUserByIDRow{
+						Idusers:  replierUID,
+						Username: sql.NullString{String: "replier", Valid: true},
+						Email:    sql.NullString{String: "replier@example.com", Valid: true},
+					}, nil
+				case subscriberUID:
+					return &db.SystemGetUserByIDRow{
+						Idusers:  subscriberUID,
+						Username: sql.NullString{String: "subscriber", Valid: true},
+						Email:    sql.NullString{String: "subscriber@example.com", Valid: true},
+					}, nil
+				}
+				return nil, sql.ErrNoRows
+			},
+			GetThreadLastPosterAndPermsFn: func(ctx context.Context, arg db.GetThreadLastPosterAndPermsParams) (*db.GetThreadLastPosterAndPermsRow, error) {
+				return &db.GetThreadLastPosterAndPermsRow{
+					Idforumthread:          threadID,
+					ForumtopicIdforumtopic: topicID,
+					Lastposterusername:     sql.NullString{String: "replier", Valid: true},
+					Comments:               sql.NullInt32{Int32: 4, Valid: true},
+				}, nil
+			},
+			GetForumTopicByIdFn: func(ctx context.Context, idforumtopic int32) (*db.Forumtopic, error) {
+				return &db.Forumtopic{Idforumtopic: topicID, Title: sql.NullString{String: WritingTopicName, Valid: true}}, nil
+			},
+			GetWritingForListerByIDRow: &db.GetWritingForListerByIDRow{
+				Idwriting:     writingID,
+				ForumthreadID: threadID,
+				LanguageID:    sql.NullInt32{Int32: 1, Valid: true},
+				Title:         sql.NullString{String: "Test Writing", Valid: true},
+			},
+			ListSubscribersForPatternsReturn: map[string][]int32{
+				fmt.Sprintf("reply:/writings/article/%d", writingID): {subscriberUID},
+			},
+			GetPreferenceForListerReturn: map[int32]*db.Preference{
+				replierUID: {AutoSubscribeReplies: true},
+			},
+			UpsertContentReadMarkerFn:                  func(ctx context.Context, arg db.UpsertContentReadMarkerParams) error { return nil },
+			ClearUnreadContentPrivateLabelExceptUserFn: func(ctx context.Context, arg db.ClearUnreadContentPrivateLabelExceptUserParams) error { return nil },
+			AdminDeletePendingEmailFn:                  func(ctx context.Context, id int32) error { return nil },
+			SystemMarkPendingEmailSentFn:               func(ctx context.Context, id int32) error { return nil },
+			CreateCommentInSectionForCommenterFn: func(ctx context.Context, arg db.CreateCommentInSectionForCommenterParams) (int64, error) {
+				return 555, nil
+			},
+		},
+		forumTopic: &db.Forumtopic{Idforumtopic: topicID, Title: sql.NullString{String: WritingTopicName, Valid: true}},
+	}
+
+	qs.SystemListPendingEmailsFn = func(ctx context.Context, arg db.SystemListPendingEmailsParams) ([]*db.SystemListPendingEmailsRow, error) {
+		var rows []*db.SystemListPendingEmailsRow
+		if len(qs.InsertPendingEmailCalls) > 0 {
+			call := qs.InsertPendingEmailCalls[0]
+			rows = append(rows, &db.SystemListPendingEmailsRow{
+				ID:          1,
+				ToUserID:    call.ToUserID,
+				Body:        call.Body,
+				DirectEmail: call.DirectEmail,
+			})
+			qs.InsertPendingEmailCalls = qs.InsertPendingEmailCalls[1:]
+		}
+		return rows, nil
+	}
+
+	bus := eventbus.NewBus()
+	cfg := config.NewRuntimeConfig()
+	cfg.NotificationsEnabled = true
+	cfg.EmailEnabled = true
+	cfg.EmailFrom = "noreply@example.com"
+	cfg.HTTPHostname = "http://example.com"
+
+	mockProvider := &mockEmailProvider{}
+	n := notifications.New(
+		notifications.WithQueries(qs),
+		notifications.WithConfig(cfg),
+		notifications.WithEmailProvider(mockProvider),
+	)
+	cdlq := &captureDLQ{}
+	n.RegisterSync(bus, cdlq)
+
+	store := sessions.NewCookieStore([]byte("test"))
+	core.Store = store
+	core.SessionName = "test"
+	sess, _ := store.Get(httptest.NewRequest(http.MethodGet, "http://example.com", nil), core.SessionName)
+	sess.Values["UID"] = replierUID
+
+	evt := &eventbus.TaskEvent{
+		Data:    map[string]any{"Time": fixedTime},
+		UserID:  replierUID,
+		Path:    "/writings/article/3",
+		Task:    replyTask,
+		Outcome: eventbus.TaskOutcomeSuccess,
+	}
+	ctx := context.Background()
+	cd := common.NewCoreData(ctx, qs, cfg, common.WithSession(sess), common.WithEvent(evt), common.WithUserRoles([]string{"member"}))
+	cd.UserID = replierUID
+	cd.SetCurrentWriting(writingID)
+
+	ctx = context.WithValue(ctx, core.ContextValues("session"), sess)
+	ctx = context.WithValue(ctx, consts.KeyCoreData, cd)
+
+	form := url.Values{"replytext": {"Hello Writing"}, "language": {"1"}}
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/writings/article/3", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(ctx)
+	req = mux.SetURLVars(req, map[string]string{"writing": "3"})
+
+	rr := httptest.NewRecorder()
+	replyTask.Action(rr, req)
+
+	bus.Publish(*evt)
+
+	if cdlq.lastError != "" {
+		t.Errorf("sync process error: %s", cdlq.lastError)
+	}
+
+	var subscriberNotif string
+	for _, call := range qs.SystemCreateNotificationCalls {
+		if call.RecipientID == subscriberUID {
+			subscriberNotif = call.Message.String
+		}
+	}
+
+	expectedSubscriberNotif := fmt.Sprintf("New reply in %q by replier\n", WritingTopicName)
+	if subscriberNotif != expectedSubscriberNotif {
+		t.Errorf("expected subscriber notif %q, got %q", expectedSubscriberNotif, subscriberNotif)
+	}
+
+	for emailqueue.ProcessPendingEmail(ctx, qs, mockProvider, cdlq, cfg) {
+	}
+
+	if len(mockProvider.sentMessages) != 1 {
+		t.Fatalf("expected 1 email sent, got %d", len(mockProvider.sentMessages))
+	}
+
+	msg, err := mail.ReadMessage(strings.NewReader(string(mockProvider.sentMessages[0])))
+	if err != nil {
+		t.Fatalf("parse email: %v", err)
+	}
+	if msg.Header.Get("Subject") != "[goa4web] New reply in "+WritingTopicName {
+		t.Errorf("subscriber email subject mismatch: %s", msg.Header.Get("Subject"))
+	}
+	subBody := getEmailBody(t, msg)
+	expectedSubBody := fmt.Sprintf(
+		"Hi replier,\n\nA new reply was posted in %q (thread #%d) on %s.\nThere are now %d comments in the discussion.\n\nView it here:\n/writings/article/3\n\n\nManage notifications: http://example.com/usr/subscriptions",
+		WritingTopicName,
+		threadID,
+		fixedTime.Format(consts.DisplayDateTimeFormat),
+		4,
+	)
+	if subBody != expectedSubBody {
+		t.Errorf("subscriber email body mismatch: %q, want %q", subBody, expectedSubBody)
+	}
+
+	actionName, path, err := replyTask.AutoSubscribePath(*evt)
+	if err != nil {
+		t.Errorf("AutoSubscribePath error: %v", err)
+	}
+	if actionName != "Reply" {
+		t.Errorf("expected action name Reply, got %q", actionName)
+	}
+	if path != fmt.Sprintf("/forum/topic/%d/thread/%d", topicID, threadID) {
+		t.Errorf("expected path /forum/topic/%d/thread/%d, got %q", topicID, threadID, path)
+	}
+}
+
+func getEmailBody(t *testing.T, msg *mail.Message) string {
+	t.Helper()
+	ct := msg.Header.Get("Content-Type")
+	if strings.Contains(ct, "multipart/alternative") {
+		_, params, err := mime.ParseMediaType(ct)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mr := multipart.NewReader(msg.Body, params["boundary"])
+		for {
+			p, err := mr.NextPart()
+			if err != nil {
+				break
+			}
+			pct := p.Header.Get("Content-Type")
+			if strings.Contains(pct, "text/plain") {
+				buf := new(bytes.Buffer)
+				if _, err := io.Copy(buf, p); err != nil {
+					t.Fatal(err)
+				}
+				return buf.String()
+			}
+		}
+	}
+
+	buf := new(bytes.Buffer)
+	if _, err := io.Copy(buf, msg.Body); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}


### PR DESCRIPTION
### Motivation
- Ensure notification templates and end-to-end notification flows are exercised for reply/approve workflows across multiple handlers. 
- Make `ThreadUpdatedEvent` produce a richer, consistent event payload (time, topic title, thread, and URL) so notification templates have the data they need. 
- Replace `sqlmock` where it was unnecessary in page tests to keep handler tests focused on page behaviour. 
- Surface missing notification-related fields (`CommentURL`/`PostURL`/`UnsubURL`) when composing events so emails/notifications render predictable links.

### Description
- Added end-to-end notification tests for news, writings, blogs, imagebbs, and linker handlers that verify internal notifications and rendered email content using realistic `eventbus.TaskEvent` data (new files under `handlers/*/*_reply_notifications_test.go` and `handlers/linker/linker_approve_notifications_test.go`).
- Enriched `HandleThreadUpdated` to populate default `Time`, attempt to resolve `TopicTitle` and `Thread` when missing, and to set a fallback `URL` from `CommentURL`/`PostURL`/`ThreadURL` (changes in `core/common/thread_sideeffects.go`).
- Populated reply post URLs for writings (`endURL`) and added an unsubscribe URL (`UnsubURL`) for linker approve events so notification templates receive the expected link values (changes in `handlers/writings/reply_task.go` and `handlers/linker/approve_task.go`).
- Removed unnecessary `sqlmock` setup from the news post invalid-forms tests and simplified those tests to use in-memory `CoreData` (`handlers/news/newsPostPage_test.go`).

### Testing
- Ran `go mod tidy` which completed successfully. 
- Ran `go fmt ./...`, `go vet ./...`, and `golangci-lint run` which produced no blocking issues. 
- Ran the test suite with `go test ./...` and verified the new notification tests and existing handler tests passed in the final run. 
- Verified templates render in tests by exercising `emailqueue.ProcessPendingEmail` and checking produced messages matched expected subjects and bodies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69624a870e4c832f94e13cb69ca45f1b)