### PR TITLE
Only publish task events when a task is present; add detection and tests

### DIFF
--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -100,6 +100,7 @@ func (q *eventQueue) flush(ctx context.Context) {
 type TaskEventMiddleware struct {
 	bus   *eventbus.Bus
 	queue *eventQueue
+	log   *log.Logger
 }
 
 // NewTaskEventMiddleware creates a middleware instance using the provided bus.
@@ -110,6 +111,7 @@ func NewTaskEventMiddleware(bus *eventbus.Bus) *TaskEventMiddleware {
 	return &TaskEventMiddleware{
 		bus:   bus,
 		queue: newEventQueue(maxQueuedTaskEvents, bus),
+		log:   log.Default(),
 	}
 }
 
@@ -146,16 +148,21 @@ func (m *TaskEventMiddleware) Middleware(next http.Handler) http.Handler {
 			evt.Outcome = eventbus.TaskOutcomeSuccess
 		}
 		if sr.status < http.StatusBadRequest {
+			if !eventHasTask(evt) {
+				if task := strings.TrimSpace(r.PostFormValue("task")); task != "" {
+					evt.Task = tasks.TaskString(task)
+				}
+			}
 			if eventHasTask(evt) {
 				if err := m.bus.Publish(*evt); err != nil {
 					if err == eventbus.ErrBusClosed {
 						m.queue.enqueue(*evt)
 					} else {
-						log.Printf("publish task event: %v", err)
+						m.log.Printf("publish task event: %v", err)
 					}
 				}
-			} else {
-				log.Printf("TaskEventMiddleware: successful request without attached task for %s %s", r.Method, r.URL.Path)
+			} else if isStateChangingMethod(r.Method) {
+				m.log.Printf("TaskEventMiddleware: successful state-changing request without attached task for %s %s", r.Method, r.URL.Path)
 			}
 		}
 		m.queue.flush(r.Context())
@@ -172,6 +179,15 @@ func eventHasTask(evt *eventbus.TaskEvent) bool {
 	}
 	name := strings.TrimSpace(named.Name())
 	return name != "" && name != "MISSING"
+}
+
+func isStateChangingMethod(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
 }
 
 // Events returns a copy of the currently queued events.

--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/arran4/goa4web/core/common"
 	coreconsts "github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/internal/dlq"
 	"github.com/arran4/goa4web/internal/eventbus"
 )
 
@@ -101,18 +102,44 @@ type TaskEventMiddleware struct {
 	bus   *eventbus.Bus
 	queue *eventQueue
 	log   *log.Logger
+	dlq   dlq.DLQ
+}
+
+// TaskEventMiddlewareOption customizes TaskEventMiddleware behavior.
+type TaskEventMiddlewareOption func(*TaskEventMiddleware)
+
+// WithLogger overrides the logger used by TaskEventMiddleware.
+func WithLogger(l *log.Logger) TaskEventMiddlewareOption {
+	return func(m *TaskEventMiddleware) {
+		if l != nil {
+			m.log = l
+		}
+	}
+}
+
+// WithDLQ configures optional DLQ reporting for middleware warnings/errors.
+func WithDLQ(q dlq.DLQ) TaskEventMiddlewareOption {
+	return func(m *TaskEventMiddleware) {
+		m.dlq = q
+	}
 }
 
 // NewTaskEventMiddleware creates a middleware instance using the provided bus.
-func NewTaskEventMiddleware(bus *eventbus.Bus) *TaskEventMiddleware {
+func NewTaskEventMiddleware(bus *eventbus.Bus, opts ...TaskEventMiddlewareOption) *TaskEventMiddleware {
 	if bus == nil {
 		panic("TaskEventMiddleware requires a bus")
 	}
-	return &TaskEventMiddleware{
+	m := &TaskEventMiddleware{
 		bus:   bus,
 		queue: newEventQueue(maxQueuedTaskEvents, bus),
 		log:   log.Default(),
 	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(m)
+		}
+	}
+	return m
 }
 
 func (r *statusRecorder) WriteHeader(code int) {
@@ -158,15 +185,26 @@ func (m *TaskEventMiddleware) Middleware(next http.Handler) http.Handler {
 					if err == eventbus.ErrBusClosed {
 						m.queue.enqueue(*evt)
 					} else {
-						m.log.Printf("publish task event: %v", err)
+						m.reportIssue(r.Context(), "publish task event: %v", err)
 					}
 				}
 			} else if isStateChangingMethod(r.Method) {
-				m.log.Printf("TaskEventMiddleware: successful state-changing request without attached task for %s %s", r.Method, r.URL.Path)
+				m.reportIssue(r.Context(), "TaskEventMiddleware: successful state-changing request without attached task for %s %s", r.Method, r.URL.Path)
 			}
 		}
 		m.queue.flush(r.Context())
 	})
+}
+
+func (m *TaskEventMiddleware) reportIssue(ctx context.Context, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	m.log.Print(msg)
+	if m.dlq == nil {
+		return
+	}
+	if err := m.dlq.Record(ctx, msg); err != nil {
+		m.log.Printf("task middleware dlq record: %v", err)
+	}
 }
 
 func eventHasTask(evt *eventbus.TaskEvent) bool {

--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -125,7 +125,6 @@ func (r *statusRecorder) WriteHeader(code int) {
 // Middleware returns a http.Handler middleware that records task events.
 func (m *TaskEventMiddleware) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		task := r.PostFormValue("task")
 		cd, ok := r.Context().Value(coreconsts.KeyCoreData).(*common.CoreData)
 		if !ok || cd == nil {
 			log.Panicf("TaskEventMiddleware: missing CoreData for %s", r.URL.Path)
@@ -146,17 +145,33 @@ func (m *TaskEventMiddleware) Middleware(next http.Handler) http.Handler {
 		if sr.status < http.StatusBadRequest && evt.Outcome == "" {
 			evt.Outcome = eventbus.TaskOutcomeSuccess
 		}
-		if task != "" && sr.status < http.StatusBadRequest {
-			if err := m.bus.Publish(*evt); err != nil {
-				if err == eventbus.ErrBusClosed {
-					m.queue.enqueue(*evt)
-				} else {
-					log.Printf("publish task event: %v", err)
+		if sr.status < http.StatusBadRequest {
+			if eventHasTask(evt) {
+				if err := m.bus.Publish(*evt); err != nil {
+					if err == eventbus.ErrBusClosed {
+						m.queue.enqueue(*evt)
+					} else {
+						log.Printf("publish task event: %v", err)
+					}
 				}
+			} else {
+				log.Printf("TaskEventMiddleware: successful request without attached task for %s %s", r.Method, r.URL.Path)
 			}
 		}
 		m.queue.flush(r.Context())
 	})
+}
+
+func eventHasTask(evt *eventbus.TaskEvent) bool {
+	if evt == nil || evt.Task == nil {
+		return false
+	}
+	named, ok := evt.Task.(tasks.Name)
+	if !ok {
+		return true
+	}
+	name := strings.TrimSpace(named.Name())
+	return name != "" && name != "MISSING"
 }
 
 // Events returns a copy of the currently queued events.

--- a/internal/middleware/taskbus_test.go
+++ b/internal/middleware/taskbus_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
+	dlqmock "github.com/arran4/goa4web/internal/dlq/mock"
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/tasks"
 )
@@ -251,9 +252,8 @@ func TestTaskEventMiddleware_PublishesWhenTaskComesFromFormValue(t *testing.T) {
 
 func TestTaskEventMiddleware_LogsWhenStateChangeSuccessHasNoTask(t *testing.T) {
 	bus := eventbus.NewBus()
-	mw := NewTaskEventMiddleware(bus)
 	var buf bytes.Buffer
-	mw.log = log.New(&buf, "", 0)
+	mw := NewTaskEventMiddleware(bus, WithLogger(log.New(&buf, "", 0)))
 	handler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -279,9 +279,8 @@ func TestTaskEventMiddleware_LogsWhenStateChangeSuccessHasNoTask(t *testing.T) {
 
 func TestTaskEventMiddleware_DoesNotLogForGetWithoutTask(t *testing.T) {
 	bus := eventbus.NewBus()
-	mw := NewTaskEventMiddleware(bus)
 	var buf bytes.Buffer
-	mw.log = log.New(&buf, "", 0)
+	mw := NewTaskEventMiddleware(bus, WithLogger(log.New(&buf, "", 0)))
 	handler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -294,6 +293,29 @@ func TestTaskEventMiddleware_DoesNotLogForGetWithoutTask(t *testing.T) {
 
 	if buf.Len() != 0 {
 		t.Fatalf("expected no missing-task logs for GET request, got %q", buf.String())
+	}
+}
+
+func TestTaskEventMiddleware_RecordsMissingTaskToDLQWhenConfigured(t *testing.T) {
+	bus := eventbus.NewBus()
+	mockDLQ := &dlqmock.Provider{}
+	mw := NewTaskEventMiddleware(bus, WithDLQ(mockDLQ))
+	handler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("PATCH", "/agent/run", strings.NewReader(`{"prompt":"execute"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, &common.CoreData{})
+
+	handler.ServeHTTP(rec, req.WithContext(ctx))
+
+	if len(mockDLQ.Records) != 1 {
+		t.Fatalf("expected one DLQ record, got %d", len(mockDLQ.Records))
+	}
+	if !strings.Contains(mockDLQ.Records[0].Message, "successful state-changing request without attached task") {
+		t.Fatalf("unexpected DLQ message: %q", mockDLQ.Records[0].Message)
 	}
 }
 

--- a/internal/middleware/taskbus_test.go
+++ b/internal/middleware/taskbus_test.go
@@ -218,17 +218,45 @@ func TestTaskEventMiddleware_PublishesWhenTaskComesFromContext(t *testing.T) {
 	}
 }
 
-func TestTaskEventMiddleware_LogsWhenSuccessHasNoTask(t *testing.T) {
+func TestTaskEventMiddleware_PublishesWhenTaskComesFromFormValue(t *testing.T) {
 	bus := eventbus.NewBus()
 	mw := NewTaskEventMiddleware(bus)
 	handler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
+	req := httptest.NewRequest("POST", "/legacy/form-task", strings.NewReader("task=LegacyAction"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, &common.CoreData{})
+
+	ch := bus.Subscribe(eventbus.TaskMessageType)
+	handler.ServeHTTP(rec, req.WithContext(ctx))
+
+	select {
+	case env := <-ch:
+		evt, ok := env.Msg.(eventbus.TaskEvent)
+		if !ok {
+			t.Fatalf("wrong type %T", env.Msg)
+		}
+		named, ok := evt.Task.(tasks.Name)
+		if !ok || named.Name() != "LegacyAction" {
+			t.Fatalf("unexpected task %+v", evt.Task)
+		}
+		env.Ack()
+	default:
+		t.Fatal("expected event when task comes from form value")
+	}
+}
+
+func TestTaskEventMiddleware_LogsWhenStateChangeSuccessHasNoTask(t *testing.T) {
+	bus := eventbus.NewBus()
+	mw := NewTaskEventMiddleware(bus)
 	var buf bytes.Buffer
-	originalOutput := log.Writer()
-	log.SetOutput(&buf)
-	defer log.SetOutput(originalOutput)
+	mw.log = log.New(&buf, "", 0)
+	handler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
 
 	req := httptest.NewRequest("POST", "/agent/run", strings.NewReader(`{"prompt":"execute"}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -244,8 +272,28 @@ func TestTaskEventMiddleware_LogsWhenSuccessHasNoTask(t *testing.T) {
 	default:
 	}
 
-	if !strings.Contains(buf.String(), "successful request without attached task") {
+	if !strings.Contains(buf.String(), "successful state-changing request without attached task") {
 		t.Fatalf("expected missing-task warning log, got %q", buf.String())
+	}
+}
+
+func TestTaskEventMiddleware_DoesNotLogForGetWithoutTask(t *testing.T) {
+	bus := eventbus.NewBus()
+	mw := NewTaskEventMiddleware(bus)
+	var buf bytes.Buffer
+	mw.log = log.New(&buf, "", 0)
+	handler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/page", nil)
+	rec := httptest.NewRecorder()
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, &common.CoreData{})
+
+	handler.ServeHTTP(rec, req.WithContext(ctx))
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no missing-task logs for GET request, got %q", buf.String())
 	}
 }
 

--- a/internal/middleware/taskbus_test.go
+++ b/internal/middleware/taskbus_test.go
@@ -1,8 +1,10 @@
 package middleware
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -19,6 +21,9 @@ func TestTaskEventMiddleware(t *testing.T) {
 	bus := eventbus.NewBus()
 	mw := NewTaskEventMiddleware(bus)
 	successHandler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData); cd != nil {
+			cd.SetEventTask(tasks.TaskString("Add"))
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	req := httptest.NewRequest("POST", "/admin/p", strings.NewReader("task=Add"))
@@ -34,7 +39,7 @@ func TestTaskEventMiddleware(t *testing.T) {
 			t.Fatalf("wrong type %T", env.Msg)
 		}
 		named, ok := evt.Task.(tasks.Name)
-		if !ok || named.Name() != "MISSING" || evt.Path != "/admin/p" {
+		if !ok || named.Name() != "Add" || evt.Path != "/admin/p" {
 			t.Fatalf("unexpected event %+v", evt)
 		}
 		env.Ack()
@@ -64,6 +69,9 @@ func TestTaskEventMiddleware(t *testing.T) {
 	}
 
 	failureHandler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData); cd != nil {
+			cd.SetEventTask(tasks.TaskString("Add"))
+		}
 		w.WriteHeader(http.StatusInternalServerError)
 		handlers.RenderErrorPage(w, r, fmt.Errorf("fail"))
 	}))
@@ -83,6 +91,7 @@ func TestTaskEventMiddleware(t *testing.T) {
 	// ensure handlers can attach event data
 	itemHandler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+			cd.SetEventTask(tasks.TaskString("Add"))
 			if evt := cd.Event(); evt != nil {
 				if evt.Data == nil {
 					evt.Data = map[string]any{}
@@ -146,6 +155,9 @@ func TestTaskEventQueue(t *testing.T) {
 	}
 
 	handler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData); cd != nil {
+			cd.SetEventTask(tasks.TaskString("Add"))
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -169,6 +181,71 @@ func TestTaskEventQueue(t *testing.T) {
 		env.Ack()
 	default:
 		t.Fatalf("expected flushed event")
+	}
+}
+
+func TestTaskEventMiddleware_PublishesWhenTaskComesFromContext(t *testing.T) {
+	bus := eventbus.NewBus()
+	mw := NewTaskEventMiddleware(bus)
+	handler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData); cd != nil {
+			cd.SetEventTask(tasks.TaskString("AgentAction"))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("POST", "/agent/run", strings.NewReader(`{"prompt":"execute"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, &common.CoreData{})
+
+	ch := bus.Subscribe(eventbus.TaskMessageType)
+	handler.ServeHTTP(rec, req.WithContext(ctx))
+
+	select {
+	case env := <-ch:
+		evt, ok := env.Msg.(eventbus.TaskEvent)
+		if !ok {
+			t.Fatalf("wrong type %T", env.Msg)
+		}
+		named, ok := evt.Task.(tasks.Name)
+		if !ok || named.Name() != "AgentAction" {
+			t.Fatalf("unexpected task %+v", evt.Task)
+		}
+		env.Ack()
+	default:
+		t.Fatal("expected event when task is attached to context")
+	}
+}
+
+func TestTaskEventMiddleware_LogsWhenSuccessHasNoTask(t *testing.T) {
+	bus := eventbus.NewBus()
+	mw := NewTaskEventMiddleware(bus)
+	handler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	var buf bytes.Buffer
+	originalOutput := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(originalOutput)
+
+	req := httptest.NewRequest("POST", "/agent/run", strings.NewReader(`{"prompt":"execute"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, &common.CoreData{})
+
+	ch := bus.Subscribe(eventbus.TaskMessageType)
+	handler.ServeHTTP(rec, req.WithContext(ctx))
+
+	select {
+	case env := <-ch:
+		t.Fatalf("did not expect event for missing task, got %T", env.Msg)
+	default:
+	}
+
+	if !strings.Contains(buf.String(), "successful request without attached task") {
+		t.Fatalf("expected missing-task warning log, got %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Stop relying on form values for task detection and avoid publishing placeholder `MISSING` tasks for successful requests.  
- Support handlers that attach a task to the request via `CoreData` and provide clearer logging when a successful request has no task attached.

### Description

- Removed use of `r.PostFormValue("task")` and added `eventHasTask` helper which checks `evt.Task` and treats `tasks.Name("MISSING")` as absent.  
- Changed middleware to publish events only when `eventHasTask(evt)` is true and to log a warning when a successful request finished without an attached task.  
- Updated tests to attach tasks via `CoreData` using `cd.SetEventTask(...)` instead of relying on form input.  
- Added two new tests: `TestTaskEventMiddleware_PublishesWhenTaskComesFromContext` and `TestTaskEventMiddleware_LogsWhenSuccessHasNoTask`.  
- Adjusted imports in the test file (`bytes`, `log`) and updated an existing expectation to assert the correct task name instead of the `MISSING` sentinel.

### Testing

- Ran the middleware package tests with `go test ./internal/middleware -v`, which executed the updated and new tests and they passed.  
- Ran the package test suite across the repository with `go test ./...` and observed no test failures in the affected packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e60c5158832f90a64cc6f86d5eed)