### PR TITLE
Pin sqlc version in CI to resolve go module issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install sqlc
-        run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+        run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0
       - name: Generate code
         run: sqlc generate
       - name: Check for changes


### PR DESCRIPTION
Pin `sqlc` installation version to `v1.30.0` in CI to avoid `go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest` attempting to install version `v1.31.0`, which requires a newer version of Go (1.26.0) than what the project is currently using (1.25.5). This resolves the CI issue where the Go toolchain upgrade fails due to unsupported `replace` directives.

---
*PR created automatically by Jules for task [8489410982503500335](https://jules.google.com/task/8489410982503500335) started by @arran4*