### PR TITLE
Refactor notification delivery to Workflow-based system and add explicit task-event processing

### DIFF
--- a/cmd/goa4web/notifications_tasks_data.go
+++ b/cmd/goa4web/notifications_tasks_data.go
@@ -30,40 +30,40 @@ func taskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 		info := taskTemplateInfo{Section: e.Section, Task: e.Task.Name()}
 		t := e.Task
 		evt := eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}
-		if tp, ok := t.(notif.SelfNotificationTemplateProvider); ok {
-			if et, _ := tp.SelfEmailTemplate(evt); et != nil {
+		if et, nt, ok := notif.SelfTemplates(t, evt); ok {
+			if et != nil {
 				info.SelfEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.SelfInternalNotificationTemplate(evt); nt != nil {
+			if nt != nil {
 				info.SelfInternal = *nt
 			}
 		}
-		if tp, ok := t.(notif.DirectEmailNotificationTemplateProvider); ok {
-			if et, _ := tp.DirectEmailTemplate(evt); et != nil {
+		if et, _, ok, _ := notif.DirectEmailTemplate(t, evt); ok {
+			if et != nil {
 				info.DirectEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 		}
-		if tp, ok := t.(notif.SubscribersNotificationTemplateProvider); ok {
-			if et, _ := tp.SubscribedEmailTemplate(evt); et != nil {
+		if et, nt, ok := notif.SubscriberTemplates(t, evt); ok {
+			if et != nil {
 				info.SubEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.SubscribedInternalNotificationTemplate(evt); nt != nil {
+			if nt != nil {
 				info.SubInternal = *nt
 			}
 		}
-		if tp, ok := t.(notif.AdminEmailTemplateProvider); ok {
-			if et, _ := tp.AdminEmailTemplate(evt); et != nil {
+		if et, nt, ok := notif.AdminTemplates(t, evt); ok {
+			if et != nil {
 				info.AdminEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.AdminInternalNotificationTemplate(evt); nt != nil {
+			if nt != nil {
 				info.AdminInternal = *nt
 			}
 		}
-		if tp, ok := t.(notif.TargetUsersNotificationProvider); ok {
-			if et, _ := tp.TargetEmailTemplate(evt); et != nil {
+		if _, et, nt, ok, _ := notif.TargetUsersTemplates(t, evt); ok {
+			if et != nil {
 				info.TargetEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.TargetInternalNotificationTemplate(evt); nt != nil {
+			if nt != nil {
 				info.TargetInternal = *nt
 			}
 		}

--- a/handlers/admin/add_announcement_task.go
+++ b/handlers/admin/add_announcement_task.go
@@ -23,7 +23,6 @@ var _ tasks.Task = (*AddAnnouncementTask)(nil)
 var _ tasks.AuditableTask = (*AddAnnouncementTask)(nil)
 
 // addAnnouncementTask notifies admins so they know announcements were updated.
-var _ notif.AdminEmailTemplateProvider = (*AddAnnouncementTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*AddAnnouncementTask)(nil)
 
 func (AddAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/admin/add_ip_ban_task.go
+++ b/handlers/admin/add_ip_ban_task.go
@@ -24,7 +24,6 @@ var addIPBanTask = &AddIPBanTask{TaskString: TaskAdd}
 
 var _ tasks.Task = (*AddIPBanTask)(nil)
 var _ tasks.AuditableTask = (*AddIPBanTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*AddIPBanTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*AddIPBanTask)(nil)
 
 func (AddIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/admin/adminEmailTemplatePage.go
+++ b/handlers/admin/adminEmailTemplatePage.go
@@ -32,40 +32,40 @@ func gatherTaskTemplateInfos(reg *tasks.Registry) []taskTemplateInfo {
 		info := taskTemplateInfo{Section: e.Section, Task: e.Task.Name()}
 		t := e.Task
 		evt := eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}
-		if tp, ok := t.(notif.SelfNotificationTemplateProvider); ok {
-			if et, _ := tp.SelfEmailTemplate(evt); et != nil {
+		if et, nt, ok := notif.SelfTemplates(t, evt); ok {
+			if et != nil {
 				info.SelfEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.SelfInternalNotificationTemplate(evt); nt != nil {
+			if nt != nil {
 				info.SelfInternal = *nt
 			}
 		}
-		if tp, ok := t.(notif.DirectEmailNotificationTemplateProvider); ok {
-			if et, _ := tp.DirectEmailTemplate(evt); et != nil {
+		if et, _, ok, _ := notif.DirectEmailTemplate(t, evt); ok {
+			if et != nil {
 				info.DirectEmail = []string{et.Text, et.HTML, et.Subject}
 			}
 		}
-		if tp, ok := t.(notif.SubscribersNotificationTemplateProvider); ok {
-			if et, _ := tp.SubscribedEmailTemplate(evt); et != nil {
+		if et, nt, ok := notif.SubscriberTemplates(t, evt); ok {
+			if et != nil {
 				info.SubEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.SubscribedInternalNotificationTemplate(evt); nt != nil {
+			if nt != nil {
 				info.SubInternal = *nt
 			}
 		}
-		if tp, ok := t.(notif.AdminEmailTemplateProvider); ok {
-			if et, _ := tp.AdminEmailTemplate(evt); et != nil {
+		if et, nt, ok := notif.AdminTemplates(t, evt); ok {
+			if et != nil {
 				info.AdminEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.AdminInternalNotificationTemplate(evt); nt != nil {
+			if nt != nil {
 				info.AdminInternal = *nt
 			}
 		}
-		if tp, ok := t.(notif.TargetUsersNotificationProvider); ok {
-			if et, _ := tp.TargetEmailTemplate(evt); et != nil {
+		if _, et, nt, ok, _ := notif.TargetUsersTemplates(t, evt); ok {
+			if et != nil {
 				info.TargetEmail = []string{et.Text, et.HTML, et.Subject}
 			}
-			if nt := tp.TargetInternalNotificationTemplate(evt); nt != nil {
+			if nt != nil {
 				info.TargetInternal = *nt
 			}
 		}

--- a/handlers/admin/adminIPBanTemplates_test.go
+++ b/handlers/admin/adminIPBanTemplates_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers/handlertest"
 	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
 )
 
 func checkIPBanEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
@@ -26,12 +27,13 @@ func checkIPBanEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
 }
 
 func TestHappyPathAdminIPBanTemplatesExist(t *testing.T) {
-	admins := []notif.AdminEmailTemplateProvider{
+	admins := []tasks.Task{
 		&AddIPBanTask{TaskString: TaskAdd},
 		&DeleteIPBanTask{TaskString: TaskDelete},
 	}
 	for _, p := range admins {
-		if et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+		et, _, ok := notif.AdminTemplates(p, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+		if ok && et != nil {
 			checkIPBanEmailTemplates(t, et)
 		}
 	}

--- a/handlers/admin/adminUserPasswordReset.go
+++ b/handlers/admin/adminUserPasswordReset.go
@@ -41,19 +41,16 @@ const (
 
 var _ tasks.Task = (*UserForcePasswordChangeTask)(nil)
 var _ tasks.AuditableTask = (*UserForcePasswordChangeTask)(nil)
-var _ notif.TargetUsersNotificationProvider = (*UserForcePasswordChangeTask)(nil)
 var _ tasks.TemplatesRequired = (*UserForcePasswordChangeTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*UserForcePasswordChangeTask)(nil)
 
 var _ tasks.Task = (*UserSendResetEmailTask)(nil)
 var _ tasks.AuditableTask = (*UserSendResetEmailTask)(nil)
-var _ notif.TargetUsersNotificationProvider = (*UserSendResetEmailTask)(nil)
 var _ tasks.TemplatesRequired = (*UserSendResetEmailTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*UserSendResetEmailTask)(nil)
 
 var _ tasks.Task = (*UserGenerateResetLinkTask)(nil)
 var _ tasks.AuditableTask = (*UserGenerateResetLinkTask)(nil)
-var _ notif.TargetUsersNotificationProvider = (*UserGenerateResetLinkTask)(nil)
 var _ tasks.TemplatesRequired = (*UserGenerateResetLinkTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*UserGenerateResetLinkTask)(nil)
 

--- a/handlers/admin/admin_email_tasks.go
+++ b/handlers/admin/admin_email_tasks.go
@@ -49,7 +49,6 @@ type AdminAddEmailTask struct {
 var adminAddEmailTask = &AdminAddEmailTask{TaskString: TaskAddEmail}
 
 var _ tasks.Task = (*AdminAddEmailTask)(nil)
-var _ notif.DirectEmailNotificationTemplateProvider = (*AdminAddEmailTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*AdminAddEmailTask)(nil)
 
 func (t AdminAddEmailTask) Action(w http.ResponseWriter, r *http.Request) any {
@@ -282,7 +281,6 @@ type AdminResendVerificationEmailTask struct {
 var adminResendVerificationEmailTask = &AdminResendVerificationEmailTask{TaskString: TaskResendVerification}
 
 var _ tasks.Task = (*AdminResendVerificationEmailTask)(nil)
-var _ notif.DirectEmailNotificationTemplateProvider = (*AdminResendVerificationEmailTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*AdminResendVerificationEmailTask)(nil)
 
 func (t AdminResendVerificationEmailTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/admin/announcementTemplates_test.go
+++ b/handlers/admin/announcementTemplates_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers/handlertest"
 	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
 )
 
 func checkEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
@@ -41,14 +42,15 @@ func checkNotificationTemplate(t *testing.T, name *string) {
 }
 
 func TestHappyPathAnnouncementTemplatesExist(t *testing.T) {
-	admins := []notif.AdminEmailTemplateProvider{
+	admins := []tasks.Task{
 		addAnnouncementTask,
 		deleteAnnouncementTask,
 	}
 	for _, p := range admins {
-		if et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+		et, nt, ok := notif.AdminTemplates(p, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+		if ok && et != nil {
 			checkEmailTemplates(t, et)
 		}
-		checkNotificationTemplate(t, p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		checkNotificationTemplate(t, nt)
 	}
 }

--- a/handlers/admin/delete_announcement_task.go
+++ b/handlers/admin/delete_announcement_task.go
@@ -23,7 +23,6 @@ var _ tasks.Task = (*DeleteAnnouncementTask)(nil)
 var _ tasks.AuditableTask = (*DeleteAnnouncementTask)(nil)
 
 // deleteAnnouncementTask also notifies admins of changes for transparency.
-var _ notif.AdminEmailTemplateProvider = (*DeleteAnnouncementTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*DeleteAnnouncementTask)(nil)
 
 func (DeleteAnnouncementTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/admin/delete_ip_ban_task.go
+++ b/handlers/admin/delete_ip_ban_task.go
@@ -21,7 +21,6 @@ var deleteIPBanTask = &DeleteIPBanTask{TaskString: TaskDelete}
 
 var _ tasks.Task = (*DeleteIPBanTask)(nil)
 var _ tasks.AuditableTask = (*DeleteIPBanTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*DeleteIPBanTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*DeleteIPBanTask)(nil)
 
 func (DeleteIPBanTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/auth/email_association_request_task.go
+++ b/handlers/auth/email_association_request_task.go
@@ -8,7 +8,6 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
-	notif "github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/tasks"
 )
 
@@ -16,10 +15,9 @@ import (
 type EmailAssociationRequestTask struct{ tasks.TaskString }
 
 var (
-	_ tasks.Task                       = (*EmailAssociationRequestTask)(nil)
-	_ tasks.AuditableTask              = (*EmailAssociationRequestTask)(nil)
-	_ notif.AdminEmailTemplateProvider = (*EmailAssociationRequestTask)(nil)
-	_ tasks.EmailTemplatesRequired     = (*EmailAssociationRequestTask)(nil)
+	_ tasks.Task                   = (*EmailAssociationRequestTask)(nil)
+	_ tasks.AuditableTask          = (*EmailAssociationRequestTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*EmailAssociationRequestTask)(nil)
 )
 
 var emailAssociationRequestTask = &EmailAssociationRequestTask{TaskString: TaskEmailAssociationRequest}

--- a/handlers/auth/forgotPassword_test.go
+++ b/handlers/auth/forgotPassword_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers/handlertest"
 	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
 )
 
 func requireEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
@@ -36,26 +37,28 @@ func requireNotificationTemplate(t *testing.T, name *string) {
 }
 
 func TestForgotPasswordTemplatesExist(t *testing.T) {
-	admins := []notif.AdminEmailTemplateProvider{
+	admins := []tasks.Task{
 		forgotPasswordTask,
 		emailAssociationRequestTask,
 	}
 	for _, p := range admins {
-		if et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+		et, nt, ok := notif.AdminTemplates(p, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+		if ok && et != nil {
 			requireEmailTemplates(t, et)
 		}
-		requireNotificationTemplate(t, p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		requireNotificationTemplate(t, nt)
 	}
 
-	selfProviders := []notif.SelfNotificationTemplateProvider{
+	selfProviders := []tasks.Task{
 		forgotPasswordTask,
 	}
 	for _, p := range selfProviders {
-		if et, send := p.SelfEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); send {
+		et, nt, ok := notif.SelfTemplates(p, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+		if ok && et != nil {
 			requireEmailTemplates(t, et)
 		} else {
 			t.Errorf("expected self email to be sent")
 		}
-		requireNotificationTemplate(t, p.SelfInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		requireNotificationTemplate(t, nt)
 	}
 }

--- a/handlers/auth/forgot_password_task.go
+++ b/handlers/auth/forgot_password_task.go
@@ -22,12 +22,9 @@ type ForgotPasswordTask struct {
 }
 
 var (
-	_ tasks.Task                             = (*ForgotPasswordTask)(nil)
-	_ tasks.AuditableTask                    = (*ForgotPasswordTask)(nil)
-	_ notif.SelfNotificationTemplateProvider = (*ForgotPasswordTask)(nil)
-	_ notif.AdminEmailTemplateProvider       = (*ForgotPasswordTask)(nil)
-	_ notif.SelfEmailBroadcaster             = (*ForgotPasswordTask)(nil)
-	_ tasks.EmailTemplatesRequired           = (*ForgotPasswordTask)(nil)
+	_ tasks.Task                   = (*ForgotPasswordTask)(nil)
+	_ tasks.AuditableTask          = (*ForgotPasswordTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*ForgotPasswordTask)(nil)
 )
 
 // Ensure template requirements are declared for this task.

--- a/handlers/blogs/auto_subscribe_test.go
+++ b/handlers/blogs/auto_subscribe_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestHappyPathReplyBlogTaskAutoSubscribe(t *testing.T) {
-	if _, ok := interface{}(replyBlogTask).(notif.AutoSubscribeProvider); !ok {
+	if !notif.HasAutoSubscribe(replyBlogTask) {
 		t.Fatalf("ReplyBlogTask must auto subscribe as users want comment updates")
 	}
 }

--- a/handlers/blogs/blogsAutoSubscribe_test.go
+++ b/handlers/blogs/blogsAutoSubscribe_test.go
@@ -16,7 +16,7 @@ func TestHappyPathBlogsAutoSubscribeTasks(t *testing.T) {
 		{"ReplyBlogTask", replyBlogTask},
 	}
 	for _, tt := range tests {
-		if _, ok := tt.task.(notif.AutoSubscribeProvider); !ok {
+		if !notif.HasAutoSubscribe(tt.task) {
 			t.Fatalf("%s should implement AutoSubscribeProvider to notify commenters of new replies", tt.name)
 		}
 	}

--- a/handlers/blogs/blogsBlogAddPage.go
+++ b/handlers/blogs/blogsBlogAddPage.go
@@ -26,9 +26,6 @@ type AddBlogTask struct{ tasks.TaskString }
 var addBlogTask = &AddBlogTask{TaskString: TaskAdd}
 
 var _ tasks.Task = (*AddBlogTask)(nil)
-var _ notif.SubscribersNotificationTemplateProvider = (*AddBlogTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*AddBlogTask)(nil)
-var _ notif.GrantsRequiredProvider = (*AddBlogTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*AddBlogTask)(nil)
 
 func (AddBlogTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/blogs/blogsBlogEditPage.go
+++ b/handlers/blogs/blogsBlogEditPage.go
@@ -26,7 +26,6 @@ type EditBlogTask struct{ tasks.TaskString }
 var editBlogTask = &EditBlogTask{TaskString: TaskEdit}
 
 var _ tasks.Task = (*EditBlogTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*EditBlogTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*EditBlogTask)(nil)
 
 func (EditBlogTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/blogs/blogsBlogReplyPage.go
+++ b/handlers/blogs/blogsBlogReplyPage.go
@@ -29,11 +29,8 @@ var replyBlogTask = &ReplyBlogTask{TaskString: TaskReply}
 // compile-time assertions that ReplyBlogTask sends notifications and
 // auto-subscribes blog commenters.
 var (
-	_ tasks.Task                                    = (*ReplyBlogTask)(nil)
-	_ notif.SubscribersNotificationTemplateProvider = (*ReplyBlogTask)(nil)
-	_ notif.AutoSubscribeProvider                   = (*ReplyBlogTask)(nil)
-	_ notif.GrantsRequiredProvider                  = (*ReplyBlogTask)(nil)
-	_ tasks.EmailTemplatesRequired                  = (*ReplyBlogTask)(nil)
+	_ tasks.Task                   = (*ReplyBlogTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*ReplyBlogTask)(nil)
 )
 
 func (ReplyBlogTask) SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/blogs/blogsCommentEditCancelTask.go
+++ b/handlers/blogs/blogsCommentEditCancelTask.go
@@ -22,7 +22,6 @@ type CancelTask struct{ tasks.TaskString }
 var cancelTask = &CancelTask{TaskString: TaskCancel}
 
 var _ tasks.Task = (*CancelTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*CancelTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*CancelTask)(nil)
 
 func (CancelTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/blogs/blogsCommentEditReplyTask.go
+++ b/handlers/blogs/blogsCommentEditReplyTask.go
@@ -25,7 +25,6 @@ type EditReplyTask struct{ tasks.TaskString }
 var editReplyTask = &EditReplyTask{TaskString: TaskEditReply}
 
 var _ tasks.Task = (*EditReplyTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*EditReplyTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*EditReplyTask)(nil)
 
 func (EditReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/faq/ask.go
+++ b/handlers/faq/ask.go
@@ -24,7 +24,6 @@ type AskTask struct{ tasks.TaskString }
 var askTask = &AskTask{TaskString: TaskAsk}
 
 var _ tasks.Task = (*AskTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*AskTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*AskTask)(nil)
 
 func (AskTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/forum/category_change_task.go
+++ b/handlers/forum/category_change_task.go
@@ -16,9 +16,8 @@ const (
 )
 
 var (
-	_ tasks.Task                       = (*CategoryChangeTask)(nil)
-	_ notif.AdminEmailTemplateProvider = (*CategoryChangeTask)(nil)
-	_ tasks.EmailTemplatesRequired     = (*CategoryChangeTask)(nil)
+	_ tasks.Task                   = (*CategoryChangeTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*CategoryChangeTask)(nil)
 )
 
 func (CategoryChangeTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/forum/category_create_task.go
+++ b/handlers/forum/category_create_task.go
@@ -12,9 +12,8 @@ type CategoryCreateTask struct{ tasks.TaskString }
 var categoryCreateTask = &CategoryCreateTask{TaskString: TaskForumCategoryCreate}
 
 var (
-	_ tasks.Task                       = (*CategoryCreateTask)(nil)
-	_ notif.AdminEmailTemplateProvider = (*CategoryCreateTask)(nil)
-	_ tasks.EmailTemplatesRequired     = (*CategoryCreateTask)(nil)
+	_ tasks.Task                   = (*CategoryCreateTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*CategoryCreateTask)(nil)
 )
 
 func (CategoryCreateTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/forum/delete_category_task.go
+++ b/handlers/forum/delete_category_task.go
@@ -16,9 +16,8 @@ const (
 )
 
 var (
-	_ tasks.Task                       = (*DeleteCategoryTask)(nil)
-	_ notif.AdminEmailTemplateProvider = (*DeleteCategoryTask)(nil)
-	_ tasks.EmailTemplatesRequired     = (*DeleteCategoryTask)(nil)
+	_ tasks.Task                   = (*DeleteCategoryTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*DeleteCategoryTask)(nil)
 )
 
 func (DeleteCategoryTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/forum/forumAdminTemplates_test.go
+++ b/handlers/forum/forumAdminTemplates_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/arran4/goa4web/core/templates"
 	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
 )
 
 func requireAdminEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
@@ -28,7 +29,7 @@ func requireAdminEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
 }
 
 func TestForumAdminTemplatesExist(t *testing.T) {
-	admins := []notif.AdminEmailTemplateProvider{
+	admins := []tasks.Task{
 		createThreadTask,
 		replyTask,
 		categoryChangeTask,
@@ -37,7 +38,8 @@ func TestForumAdminTemplatesExist(t *testing.T) {
 		threadDeleteTask,
 	}
 	for _, p := range admins {
-		if et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+		et, _, ok := notif.AdminTemplates(p, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+		if ok && et != nil {
 			requireAdminEmailTemplates(t, et)
 		}
 	}

--- a/handlers/forum/forumTemplates_test.go
+++ b/handlers/forum/forumTemplates_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers/handlertest"
 	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
 )
 
 func checkEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
@@ -39,14 +40,15 @@ func checkNotificationTemplate(t *testing.T, name *string) {
 }
 
 func TestForumTemplatesExist(t *testing.T) {
-	providers := []notif.SubscribersNotificationTemplateProvider{
+	providers := []tasks.Task{
 		createThreadTask,
 		replyTask,
 	}
 	for _, p := range providers {
-		if et, _ := p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+		et, nt, ok := notif.SubscriberTemplates(p, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+		if ok && et != nil {
 			checkEmailTemplates(t, et)
 		}
-		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		checkNotificationTemplate(t, nt)
 	}
 }

--- a/handlers/forum/forumThreadNewPage.go
+++ b/handlers/forum/forumThreadNewPage.go
@@ -37,12 +37,9 @@ var (
 	// Interface checks ensure the new thread hooks into notifications so
 	// authors follow replies, administrators are alerted and subscribers see
 	// new discussions.
-	_ tasks.Task                                    = (*CreateThreadTask)(nil)
-	_ notif.SubscribersNotificationTemplateProvider = (*CreateThreadTask)(nil)
-	_ notif.AdminEmailTemplateProvider              = (*CreateThreadTask)(nil)
-	_ notif.AutoSubscribeProvider                   = (*CreateThreadTask)(nil)
-	_ tasks.EmailTemplatesRequired                  = (*CreateThreadTask)(nil)
-	_ searchworker.IndexedTask                      = CreateThreadTask{}
+	_ tasks.Task                   = (*CreateThreadTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*CreateThreadTask)(nil)
+	_ searchworker.IndexedTask     = CreateThreadTask{}
 )
 
 func (CreateThreadTask) IndexType() string { return searchworker.TypeComment }

--- a/handlers/forum/forumTopicThreadReplyPage.go
+++ b/handlers/forum/forumTopicThreadReplyPage.go
@@ -37,12 +37,9 @@ var (
 	// ReplyTaskHandler exposes the reply task for registration on other routes.
 	ReplyTaskHandler = replyTask
 
-	_ tasks.Task                                    = (*ReplyTask)(nil)
-	_ notif.SubscribersNotificationTemplateProvider = (*ReplyTask)(nil)
-	_ notif.AdminEmailTemplateProvider              = (*ReplyTask)(nil)
-	_ notif.AutoSubscribeProvider                   = (*ReplyTask)(nil)
-	_ tasks.EmailTemplatesRequired                  = (*ReplyTask)(nil)
-	_ searchworker.IndexedTask                      = ReplyTask{}
+	_ tasks.Task                   = (*ReplyTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*ReplyTask)(nil)
+	_ searchworker.IndexedTask     = ReplyTask{}
 )
 
 func (ReplyTask) IndexType() string { return searchworker.TypeComment }

--- a/handlers/forum/forum_reply_notifications_test.go
+++ b/handlers/forum/forum_reply_notifications_test.go
@@ -377,10 +377,10 @@ func getEmailBody(t *testing.T, msg *mail.Message) string {
 }
 
 func TestForumAutoSubscribeTasks(t *testing.T) {
-	if _, ok := interface{}(replyTask).(notifications.AutoSubscribeProvider); !ok {
+	if !notifications.HasAutoSubscribe(replyTask) {
 		t.Fatalf("ReplyTask should implement AutoSubscribeProvider so users get notified about thread replies")
 	}
-	if _, ok := interface{}(createThreadTask).(notifications.AutoSubscribeProvider); !ok {
+	if !notifications.HasAutoSubscribe(createThreadTask) {
 		t.Fatalf("CreateThreadTask should implement AutoSubscribeProvider so thread authors follow their threads")
 	}
 

--- a/handlers/forum/thread_delete_task.go
+++ b/handlers/forum/thread_delete_task.go
@@ -12,9 +12,8 @@ type ThreadDeleteTask struct{ tasks.TaskString }
 var threadDeleteTask = &ThreadDeleteTask{TaskString: TaskForumThreadDelete}
 
 var (
-	_ tasks.Task                       = (*ThreadDeleteTask)(nil)
-	_ notif.AdminEmailTemplateProvider = (*ThreadDeleteTask)(nil)
-	_ tasks.EmailTemplatesRequired     = (*ThreadDeleteTask)(nil)
+	_ tasks.Task                   = (*ThreadDeleteTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*ThreadDeleteTask)(nil)
 )
 
 func (ThreadDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/forum/topic_change_task.go
+++ b/handlers/forum/topic_change_task.go
@@ -12,9 +12,8 @@ type TopicChangeTask struct{ tasks.TaskString }
 var topicChangeTask = &TopicChangeTask{TaskString: TaskForumTopicChange}
 
 var (
-	_ tasks.Task                       = (*TopicChangeTask)(nil)
-	_ notif.AdminEmailTemplateProvider = (*TopicChangeTask)(nil)
-	_ tasks.EmailTemplatesRequired     = (*TopicChangeTask)(nil)
+	_ tasks.Task                   = (*TopicChangeTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*TopicChangeTask)(nil)
 )
 
 func (TopicChangeTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/forum/topic_create_task.go
+++ b/handlers/forum/topic_create_task.go
@@ -12,9 +12,8 @@ type TopicCreateTask struct{ tasks.TaskString }
 var topicCreateTask = &TopicCreateTask{TaskString: TaskForumTopicCreate}
 
 var (
-	_ tasks.Task                       = (*TopicCreateTask)(nil)
-	_ notif.AdminEmailTemplateProvider = (*TopicCreateTask)(nil)
-	_ tasks.EmailTemplatesRequired     = (*TopicCreateTask)(nil)
+	_ tasks.Task                   = (*TopicCreateTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*TopicCreateTask)(nil)
 )
 
 func (TopicCreateTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/forum/topic_delete_task.go
+++ b/handlers/forum/topic_delete_task.go
@@ -12,9 +12,8 @@ type TopicDeleteTask struct{ tasks.TaskString }
 var topicDeleteTask = &TopicDeleteTask{TaskString: TaskForumTopicDelete}
 
 var (
-	_ tasks.Task                       = (*TopicDeleteTask)(nil)
-	_ notif.AdminEmailTemplateProvider = (*TopicDeleteTask)(nil)
-	_ tasks.EmailTemplatesRequired     = (*TopicDeleteTask)(nil)
+	_ tasks.Task                   = (*TopicDeleteTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*TopicDeleteTask)(nil)
 )
 
 func (TopicDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/imagebbs/auto_subscribe_test.go
+++ b/handlers/imagebbs/auto_subscribe_test.go
@@ -8,7 +8,7 @@ import (
 
 // Test that replyTask auto subscribes commenters so they see responses.
 func TestHappyPathReplyTaskAutoSubscribe(t *testing.T) {
-	if _, ok := interface{}(replyTask).(notif.AutoSubscribeProvider); !ok {
+	if !notif.HasAutoSubscribe(replyTask) {
 		t.Fatalf("ReplyTask should implement AutoSubscribeProvider so commenters are notified about replies")
 	}
 }

--- a/handlers/imagebbs/imagebbsAdminApprove.go
+++ b/handlers/imagebbs/imagebbsAdminApprove.go
@@ -21,7 +21,6 @@ import (
 type ApprovePostTask struct{ tasks.TaskString }
 
 var _ tasks.Task = (*ApprovePostTask)(nil)
-var _ notif.SelfNotificationTemplateProvider = (*ApprovePostTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*ApprovePostTask)(nil)
 var _ tasks.AuditableTask = (*ApprovePostTask)(nil)
 

--- a/handlers/imagebbs/imagebbsAdminBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminBoardPage.go
@@ -28,7 +28,6 @@ type ModifyBoardTask struct{ tasks.TaskString }
 var modifyBoardTask = &ModifyBoardTask{TaskString: TaskModifyBoard}
 
 var _ tasks.Task = (*ModifyBoardTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*ModifyBoardTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*ModifyBoardTask)(nil)
 
 func (ModifyBoardTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/imagebbs/imagebbsAdminNewBoardPage.go
+++ b/handlers/imagebbs/imagebbsAdminNewBoardPage.go
@@ -25,7 +25,6 @@ type NewBoardTask struct{ tasks.TaskString }
 var newBoardTask = &NewBoardTask{TaskString: TaskNewBoard}
 
 var _ tasks.Task = (*NewBoardTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*NewBoardTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*NewBoardTask)(nil)
 
 func (NewBoardTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/imagebbs/imagebbsBoardThreadPage.go
+++ b/handlers/imagebbs/imagebbsBoardThreadPage.go
@@ -31,8 +31,6 @@ var _ tasks.Task = (*ReplyTask)(nil)
 
 // ReplyTask alerts watchers of new posts and auto-subscribes the replier so
 // they see further responses.
-var _ notif.SubscribersNotificationTemplateProvider = (*ReplyTask)(nil)
-var _ notif.AutoSubscribeProvider = (*ReplyTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*ReplyTask)(nil)
 
 func (ReplyTask) IndexType() string { return searchworker.TypeComment }

--- a/handlers/imagebbs/imagebbsTemplates_test.go
+++ b/handlers/imagebbs/imagebbsTemplates_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers/handlertest"
 	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
 )
 
 func checkEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
@@ -37,44 +38,47 @@ func checkNotificationTemplate(t *testing.T, name *string) {
 }
 
 func TestHappyPathImageBbsTemplatesExist(t *testing.T) {
-	admins := []notif.AdminEmailTemplateProvider{
+	admins := []tasks.Task{
 		newBoardTask,
 		modifyBoardTask,
 	}
 	for i, p := range admins {
 		t.Run(fmt.Sprintf("AdminProvider_%d", i), func(t *testing.T) {
-			if et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			et, nt, ok := notif.AdminTemplates(p, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+			if ok && et != nil {
 				checkEmailTemplates(t, et)
 			}
 			if p != newBoardTask {
-				checkNotificationTemplate(t, p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+				checkNotificationTemplate(t, nt)
 			}
 		})
 	}
 
-	selfProviders := []notif.SelfNotificationTemplateProvider{
+	selfProviders := []tasks.Task{
 		approvePostTask,
 	}
 	for i, p := range selfProviders {
 		t.Run(fmt.Sprintf("SelfProvider_%d", i), func(t *testing.T) {
-			if et, send := p.SelfEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); send {
+			et, nt, ok := notif.SelfTemplates(p, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+			if ok && et != nil {
 				checkEmailTemplates(t, et)
 			} else {
 				t.Errorf("expected self email to be sent")
 			}
-			checkNotificationTemplate(t, p.SelfInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+			checkNotificationTemplate(t, nt)
 		})
 	}
 
-	subs := []notif.SubscribersNotificationTemplateProvider{
+	subs := []tasks.Task{
 		replyTask,
 	}
 	for i, p := range subs {
 		t.Run(fmt.Sprintf("SubProvider_%d", i), func(t *testing.T) {
-			if et, _ := p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			et, nt, ok := notif.SubscriberTemplates(p, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+			if ok && et != nil {
 				checkEmailTemplates(t, et)
 			}
-			checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+			checkNotificationTemplate(t, nt)
 		})
 	}
 }

--- a/handlers/languages/create_language_task.go
+++ b/handlers/languages/create_language_task.go
@@ -19,7 +19,6 @@ type CreateLanguageTask struct{ tasks.TaskString }
 var createLanguageTask = &CreateLanguageTask{TaskString: tasks.TaskString("Create Language")}
 
 var _ tasks.Task = (*CreateLanguageTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*CreateLanguageTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*CreateLanguageTask)(nil)
 
 func (CreateLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/languages/delete_language_task.go
+++ b/handlers/languages/delete_language_task.go
@@ -19,7 +19,6 @@ type DeleteLanguageTask struct{ tasks.TaskString }
 var deleteLanguageTask = &DeleteLanguageTask{TaskString: tasks.TaskString("Delete Language")}
 
 var _ tasks.Task = (*DeleteLanguageTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*DeleteLanguageTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*DeleteLanguageTask)(nil)
 
 func (DeleteLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/languages/languagesTemplates_test.go
+++ b/handlers/languages/languagesTemplates_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers/handlertest"
 	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
 )
 
 func requireEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
@@ -37,16 +38,17 @@ func requireNotificationTemplate(t *testing.T, name *string) {
 
 func TestLanguageTaskTemplates(t *testing.T) {
 	t.Run("Happy Path", func(t *testing.T) {
-		admins := []notif.AdminEmailTemplateProvider{
+		admins := []tasks.Task{
 			renameLanguageTask,
 			deleteLanguageTask,
 			createLanguageTask,
 		}
 		for _, a := range admins {
-			if et, _ := a.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			et, nt, ok := notif.AdminTemplates(a, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+			if ok && et != nil {
 				requireEmailTemplates(t, et)
 			}
-			requireNotificationTemplate(t, a.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+			requireNotificationTemplate(t, nt)
 		}
 	})
 }

--- a/handlers/languages/rename_language_task.go
+++ b/handlers/languages/rename_language_task.go
@@ -20,7 +20,6 @@ type RenameLanguageTask struct{ tasks.TaskString }
 var renameLanguageTask = &RenameLanguageTask{TaskString: tasks.TaskString("Rename Language")}
 
 var _ tasks.Task = (*RenameLanguageTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*RenameLanguageTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*RenameLanguageTask)(nil)
 
 func (RenameLanguageTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/linker/approve_task.go
+++ b/handlers/linker/approve_task.go
@@ -25,11 +25,9 @@ var AdminApproveTask = &approveTask{TaskString: TaskApprove}
 var _ tasks.Task = (*approveTask)(nil)
 
 var (
-	_ tasks.Task                                    = (*approveTask)(nil)
-	_ notif.SubscribersNotificationTemplateProvider = (*approveTask)(nil)
-	_ notif.AdminEmailTemplateProvider              = (*approveTask)(nil)
-	_ tasks.EmailTemplatesRequired                  = (*approveTask)(nil)
-	_ searchworker.IndexedTask                      = approveTask{}
+	_ tasks.Task                   = (*approveTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*approveTask)(nil)
+	_ searchworker.IndexedTask     = approveTask{}
 )
 
 func (approveTask) IndexType() string { return searchworker.TypeLinker }

--- a/handlers/linker/bulk_approve_task.go
+++ b/handlers/linker/bulk_approve_task.go
@@ -24,11 +24,9 @@ type bulkApproveTask struct{ tasks.TaskString }
 var AdminBulkApproveTask = &bulkApproveTask{TaskString: TaskBulkApprove}
 
 var (
-	_ tasks.Task                                    = (*bulkApproveTask)(nil)
-	_ notif.SubscribersNotificationTemplateProvider = (*bulkApproveTask)(nil)
-	_ notif.AdminEmailTemplateProvider              = (*bulkApproveTask)(nil)
-	_ tasks.EmailTemplatesRequired                  = (*bulkApproveTask)(nil)
-	_ searchworker.IndexedTask                      = bulkApproveTask{}
+	_ tasks.Task                   = (*bulkApproveTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*bulkApproveTask)(nil)
+	_ searchworker.IndexedTask     = bulkApproveTask{}
 )
 
 func (bulkApproveTask) IndexType() string { return searchworker.TypeLinker }

--- a/handlers/linker/bulk_delete_task.go
+++ b/handlers/linker/bulk_delete_task.go
@@ -19,10 +19,8 @@ type bulkDeleteTask struct{ tasks.TaskString }
 var AdminBulkDeleteTask = &bulkDeleteTask{TaskString: TaskBulkDelete}
 
 var (
-	_ tasks.Task                                    = (*bulkDeleteTask)(nil)
-	_ notif.SubscribersNotificationTemplateProvider = (*bulkDeleteTask)(nil)
-	_ notif.AdminEmailTemplateProvider              = (*bulkDeleteTask)(nil)
-	_ tasks.EmailTemplatesRequired                  = (*bulkDeleteTask)(nil)
+	_ tasks.Task                   = (*bulkDeleteTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*bulkDeleteTask)(nil)
 )
 
 func (bulkDeleteTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/linker/delete_task.go
+++ b/handlers/linker/delete_task.go
@@ -22,10 +22,8 @@ var AdminDeleteTask = &deleteTask{TaskString: TaskDelete}
 var _ tasks.Task = (*deleteTask)(nil)
 
 var (
-	_ tasks.Task                                    = (*deleteTask)(nil)
-	_ notif.SubscribersNotificationTemplateProvider = (*deleteTask)(nil)
-	_ notif.AdminEmailTemplateProvider              = (*deleteTask)(nil)
-	_ tasks.EmailTemplatesRequired                  = (*deleteTask)(nil)
+	_ tasks.Task                   = (*deleteTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*deleteTask)(nil)
 )
 
 func (deleteTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/linker/linkerAdminAddPage.go
+++ b/handlers/linker/linkerAdminAddPage.go
@@ -68,8 +68,6 @@ var AdminAddTask = &addTask{TaskString: TaskAdd}
 // alert subscribers of new content and notify administrators so they can review
 // it for publication.
 var _ tasks.Task = (*addTask)(nil)
-var _ notif.SubscribersNotificationTemplateProvider = (*addTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*addTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*addTask)(nil)
 
 func (addTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/news/auto_subscribe_test.go
+++ b/handlers/news/auto_subscribe_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func TestHappyPathNewsReplyAutoSubscribe(t *testing.T) {
-	if _, ok := interface{}(replyTask).(notif.AutoSubscribeProvider); !ok {
+	if !notif.HasAutoSubscribe(replyTask) {
 		t.Fatalf("ReplyTask must auto subscribe so commenters are notified of responses")
 	}
 }
 
 func TestHappyPathNewsPostAutoSubscribe(t *testing.T) {
-	if _, ok := interface{}(newPostTask).(notif.AutoSubscribeProvider); !ok {
+	if !notif.HasAutoSubscribe(newPostTask) {
 		t.Fatalf("NewPostTask must auto subscribe so authors follow replies")
 	}
 }

--- a/handlers/news/cancel_edit_task.go
+++ b/handlers/news/cancel_edit_task.go
@@ -20,7 +20,6 @@ type CancelTask struct{ tasks.TaskString }
 var cancelTask = &CancelTask{TaskString: TaskCancel}
 
 var _ tasks.Task = (*CancelTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*CancelTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*CancelTask)(nil)
 
 func (CancelTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/news/edit_reply_task.go
+++ b/handlers/news/edit_reply_task.go
@@ -23,7 +23,6 @@ type EditReplyTask struct{ tasks.TaskString }
 var editReplyTask = &EditReplyTask{TaskString: TaskEditReply}
 
 var _ tasks.Task = (*EditReplyTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*EditReplyTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*EditReplyTask)(nil)
 
 func (EditReplyTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/news/newsAnnouncementTasks.go
+++ b/handlers/news/newsAnnouncementTasks.go
@@ -7,7 +7,6 @@ import (
 )
 
 var _ tasks.Task = (*AnnouncementAddTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*AnnouncementAddTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*AnnouncementAddTask)(nil)
 
 func (AnnouncementAddTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {
@@ -24,7 +23,6 @@ func (AnnouncementAddTask) RequiredTemplates() []tasks.Template {
 }
 
 var _ tasks.Task = (*AnnouncementDeleteTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*AnnouncementDeleteTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*AnnouncementDeleteTask)(nil)
 
 func (AnnouncementDeleteTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/news/newsAutoSubscribe_test.go
+++ b/handlers/news/newsAutoSubscribe_test.go
@@ -18,7 +18,7 @@ func TestHappyPathNewsAutoSubscribeTasks(t *testing.T) {
 		{"NewPostTask", newPostTask},
 	}
 	for _, tt := range tests {
-		if _, ok := tt.task.(notif.AutoSubscribeProvider); !ok {
+		if !notif.HasAutoSubscribe(tt.task) {
 			t.Fatalf("%s should implement AutoSubscribeProvider so users are notified about replies", tt.name)
 		}
 	}

--- a/handlers/news/newsEditPostTask.go
+++ b/handlers/news/newsEditPostTask.go
@@ -25,7 +25,6 @@ var editTask = &EditTask{TaskString: TaskEdit}
 
 var _ tasks.Task = (*EditTask)(nil)
 var _ tasks.TemplatesRequired = (*EditTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*EditTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*EditTask)(nil)
 
 const NewsEditPageTmpl tasks.Template = "news/newsEditPage.gohtml"

--- a/handlers/news/newsNewPostTask.go
+++ b/handlers/news/newsNewPostTask.go
@@ -21,11 +21,8 @@ var newPostTask = &NewPostTask{TaskString: TaskNewPost}
 
 // NewPostTask sends notifications when a new post is created and automatically subscribes the author to future replies.
 var (
-	_ tasks.Task                                    = (*NewPostTask)(nil)
-	_ notif.SubscribersNotificationTemplateProvider = (*NewPostTask)(nil)
-	_ notif.AdminEmailTemplateProvider              = (*NewPostTask)(nil)
-	_ notif.AutoSubscribeProvider                   = (*NewPostTask)(nil)
-	_ tasks.EmailTemplatesRequired                  = (*NewPostTask)(nil)
+	_ tasks.Task                   = (*NewPostTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*NewPostTask)(nil)
 )
 
 func (NewPostTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/news/newsReplyTask.go
+++ b/handlers/news/newsReplyTask.go
@@ -25,11 +25,8 @@ type ReplyTask struct{ tasks.TaskString }
 var (
 	replyTask = &ReplyTask{TaskString: TaskReply}
 
-	_ tasks.Task                                    = (*ReplyTask)(nil)
-	_ notif.SubscribersNotificationTemplateProvider = (*ReplyTask)(nil)
-	_ notif.AdminEmailTemplateProvider              = (*ReplyTask)(nil)
-	_ notif.AutoSubscribeProvider                   = (*ReplyTask)(nil)
-	_ tasks.EmailTemplatesRequired                  = (*ReplyTask)(nil)
+	_ tasks.Task                   = (*ReplyTask)(nil)
+	_ tasks.EmailTemplatesRequired = (*ReplyTask)(nil)
 )
 
 func (ReplyTask) IndexType() string { return searchworker.TypeComment }

--- a/handlers/news/newsTemplates_test.go
+++ b/handlers/news/newsTemplates_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers/handlertest"
 	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
 )
 
 func checkEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
@@ -36,18 +37,19 @@ func checkNotificationTemplate(t *testing.T, name *string) {
 }
 
 func TestHappyPathNewsTemplatesExist(t *testing.T) {
-	subs := []notif.SubscribersNotificationTemplateProvider{
+	subs := []tasks.Task{
 		newPostTask,
 		replyTask,
 	}
 	for _, p := range subs {
-		if et, _ := p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+		et, nt, ok := notif.SubscriberTemplates(p, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+		if ok && et != nil {
 			checkEmailTemplates(t, et)
 		}
-		checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		checkNotificationTemplate(t, nt)
 	}
 
-	admins := []notif.AdminEmailTemplateProvider{
+	admins := []tasks.Task{
 		newPostTask,
 		editTask,
 		replyTask,
@@ -59,9 +61,10 @@ func TestHappyPathNewsTemplatesExist(t *testing.T) {
 		announcementDeleteTask,
 	}
 	for _, p := range admins {
-		if et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+		et, nt, ok := notif.AdminTemplates(p, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+		if ok && et != nil {
 			checkEmailTemplates(t, et)
 		}
-		checkNotificationTemplate(t, p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+		checkNotificationTemplate(t, nt)
 	}
 }

--- a/handlers/news/user_allow_task.go
+++ b/handlers/news/user_allow_task.go
@@ -19,7 +19,6 @@ type UserAllowTask struct{ tasks.TaskString }
 var userAllowTask = &UserAllowTask{TaskString: TaskUserAllow}
 
 var _ tasks.Task = (*UserAllowTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*UserAllowTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*UserAllowTask)(nil)
 
 func (UserAllowTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/news/user_disallow_task.go
+++ b/handlers/news/user_disallow_task.go
@@ -20,7 +20,6 @@ type UserDisallowTask struct{ tasks.TaskString }
 var userDisallowTask = &UserDisallowTask{TaskString: TaskUserDisallow}
 
 var _ tasks.Task = (*UserDisallowTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*UserDisallowTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*UserDisallowTask)(nil)
 
 func (UserDisallowTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/notification_registry_test.go
+++ b/handlers/notification_registry_test.go
@@ -53,7 +53,7 @@ func (r *TaskRegistry) TestAll(t *testing.T) {
 	}
 }
 
-// AutoDiscoverTasks automatically discovers tasks that implement notification interfaces.
+// AutoDiscoverTasks automatically discovers tasks that expose notification templates.
 // This is useful for ensuring all tasks are tested.
 func AutoDiscoverTasks(t *testing.T, taskInstances ...tasks.Task) []TaskInfo {
 	t.Helper()
@@ -63,23 +63,11 @@ func AutoDiscoverTasks(t *testing.T, taskInstances ...tasks.Task) []TaskInfo {
 	for _, task := range taskInstances {
 		name := reflect.TypeOf(task).String()
 
-		// Check if it implements any notification interface
-		hasNotifications := false
-		if _, ok := task.(notif.AdminEmailTemplateProvider); ok {
-			hasNotifications = true
-		}
-		if _, ok := task.(notif.SelfNotificationTemplateProvider); ok {
-			hasNotifications = true
-		}
-		if _, ok := task.(notif.TargetUsersNotificationProvider); ok {
-			hasNotifications = true
-		}
-		if _, ok := task.(notif.SubscribersNotificationTemplateProvider); ok {
-			hasNotifications = true
-		}
-		if _, ok := task.(notif.DirectEmailNotificationTemplateProvider); ok {
-			hasNotifications = true
-		}
+		hasNotifications := notif.HasAdminTemplates(task) ||
+			notif.HasSelfTemplates(task) ||
+			notif.HasTargetUsersTemplates(task) ||
+			notif.HasSubscriberTemplates(task) ||
+			notif.HasDirectEmailTemplate(task)
 
 		if hasNotifications {
 			discovered = append(discovered, TaskInfo{

--- a/handlers/notification_test_helpers.go
+++ b/handlers/notification_test_helpers.go
@@ -86,7 +86,10 @@ func TestNotificationTemplates(t TestingT, tests []NotificationTemplateTest) {
 		task := tc.Task
 
 		// Test admin email templates
-		if provider, ok := task.(notif.AdminEmailTemplateProvider); ok {
+		if provider, ok := task.(interface {
+			AdminEmailTemplate(eventbus.TaskEvent) (*notif.EmailTemplates, bool)
+			AdminInternalNotificationTemplate(eventbus.TaskEvent) *string
+		}); ok {
 			et, send := provider.AdminEmailTemplate(evt)
 			if send && et != nil {
 				RequireEmailTemplates(t, et, evt)
@@ -95,7 +98,10 @@ func TestNotificationTemplates(t TestingT, tests []NotificationTemplateTest) {
 		}
 
 		// Test self notification templates
-		if provider, ok := task.(notif.SelfNotificationTemplateProvider); ok {
+		if provider, ok := task.(interface {
+			SelfEmailTemplate(eventbus.TaskEvent) (*notif.EmailTemplates, bool)
+			SelfInternalNotificationTemplate(eventbus.TaskEvent) *string
+		}); ok {
 			et, send := provider.SelfEmailTemplate(evt)
 			if send && et != nil {
 				RequireEmailTemplates(t, et, evt)
@@ -104,7 +110,10 @@ func TestNotificationTemplates(t TestingT, tests []NotificationTemplateTest) {
 		}
 
 		// Test target user templates
-		if provider, ok := task.(notif.TargetUsersNotificationProvider); ok {
+		if provider, ok := task.(interface {
+			TargetEmailTemplate(eventbus.TaskEvent) (*notif.EmailTemplates, bool)
+			TargetInternalNotificationTemplate(eventbus.TaskEvent) *string
+		}); ok {
 			et, send := provider.TargetEmailTemplate(evt)
 			if send && et != nil {
 				RequireEmailTemplates(t, et, evt)
@@ -113,7 +122,10 @@ func TestNotificationTemplates(t TestingT, tests []NotificationTemplateTest) {
 		}
 
 		// Test subscriber templates
-		if provider, ok := task.(notif.SubscribersNotificationTemplateProvider); ok {
+		if provider, ok := task.(interface {
+			SubscribedEmailTemplate(eventbus.TaskEvent) (*notif.EmailTemplates, bool)
+			SubscribedInternalNotificationTemplate(eventbus.TaskEvent) *string
+		}); ok {
 			et, send := provider.SubscribedEmailTemplate(evt)
 			if send && et != nil {
 				RequireEmailTemplates(t, et, evt)
@@ -122,7 +134,9 @@ func TestNotificationTemplates(t TestingT, tests []NotificationTemplateTest) {
 		}
 
 		// Test direct email templates
-		if provider, ok := task.(notif.DirectEmailNotificationTemplateProvider); ok {
+		if provider, ok := task.(interface {
+			DirectEmailTemplate(eventbus.TaskEvent) (*notif.EmailTemplates, bool)
+		}); ok {
 			et, send := provider.DirectEmailTemplate(evt)
 			if send && et != nil {
 				RequireEmailTemplates(t, et, evt)

--- a/handlers/privateforum/auto_subscribe_test.go
+++ b/handlers/privateforum/auto_subscribe_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHappyPathPrivateTopicCreateTaskAutoSubscribe(t *testing.T) {
-	if _, ok := interface{}(privateTopicCreateTask).(notif.AutoSubscribeProvider); !ok {
+	if !notif.HasAutoSubscribe(privateTopicCreateTask) {
 		t.Fatalf("PrivateTopicCreateTask should implement AutoSubscribeProvider so creators follow replies")
 	}
 }

--- a/handlers/privateforum/topic_create_task.go
+++ b/handlers/privateforum/topic_create_task.go
@@ -24,8 +24,7 @@ type PrivateTopicCreateTask struct{ tasks.TaskString }
 var privateTopicCreateTask = &PrivateTopicCreateTask{TaskString: TaskPrivateTopicCreate}
 
 var (
-	_ tasks.Task                  = (*PrivateTopicCreateTask)(nil)
-	_ notif.AutoSubscribeProvider = (*PrivateTopicCreateTask)(nil)
+	_ tasks.Task = (*PrivateTopicCreateTask)(nil)
 )
 
 // Action creates a new private topic and assigns view permissions to participants.

--- a/handlers/search/remakeBlogFinishedTask.go
+++ b/handlers/search/remakeBlogFinishedTask.go
@@ -15,8 +15,6 @@ type RemakeBlogFinishedTask struct{ tasks.TaskString }
 var remakeBlogFinishedTask = &RemakeBlogFinishedTask{TaskString: TaskRemakeBlogSearchComplete}
 
 var _ tasks.Task = (*RemakeBlogFinishedTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*RemakeBlogFinishedTask)(nil)
-var _ notif.SelfNotificationTemplateProvider = (*RemakeBlogFinishedTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*RemakeBlogFinishedTask)(nil)
 
 func (RemakeBlogFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }

--- a/handlers/search/remakeCommentsFinishedTask.go
+++ b/handlers/search/remakeCommentsFinishedTask.go
@@ -15,8 +15,6 @@ type RemakeCommentsFinishedTask struct{ tasks.TaskString }
 var remakeCommentsFinishedTask = &RemakeCommentsFinishedTask{TaskString: TaskRemakeCommentsSearchComplete}
 
 var _ tasks.Task = (*RemakeCommentsFinishedTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*RemakeCommentsFinishedTask)(nil)
-var _ notif.SelfNotificationTemplateProvider = (*RemakeCommentsFinishedTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*RemakeCommentsFinishedTask)(nil)
 
 func (RemakeCommentsFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }

--- a/handlers/search/remakeImageFinishedTask.go
+++ b/handlers/search/remakeImageFinishedTask.go
@@ -15,8 +15,6 @@ type RemakeImageFinishedTask struct{ tasks.TaskString }
 var remakeImageFinishedTask = &RemakeImageFinishedTask{TaskString: TaskRemakeImageSearchComplete}
 
 var _ tasks.Task = (*RemakeImageFinishedTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*RemakeImageFinishedTask)(nil)
-var _ notif.SelfNotificationTemplateProvider = (*RemakeImageFinishedTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*RemakeImageFinishedTask)(nil)
 
 func (RemakeImageFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }

--- a/handlers/search/remakeLinkerFinishedTask.go
+++ b/handlers/search/remakeLinkerFinishedTask.go
@@ -15,8 +15,6 @@ type RemakeLinkerFinishedTask struct{ tasks.TaskString }
 var remakeLinkerFinishedTask = &RemakeLinkerFinishedTask{TaskString: TaskRemakeLinkerSearchComplete}
 
 var _ tasks.Task = (*RemakeLinkerFinishedTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*RemakeLinkerFinishedTask)(nil)
-var _ notif.SelfNotificationTemplateProvider = (*RemakeLinkerFinishedTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*RemakeLinkerFinishedTask)(nil)
 
 func (RemakeLinkerFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }

--- a/handlers/search/remakeNewsFinishedTask.go
+++ b/handlers/search/remakeNewsFinishedTask.go
@@ -15,8 +15,6 @@ type RemakeNewsFinishedTask struct{ tasks.TaskString }
 var remakeNewsFinishedTask = &RemakeNewsFinishedTask{TaskString: TaskRemakeNewsSearchComplete}
 
 var _ tasks.Task = (*RemakeNewsFinishedTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*RemakeNewsFinishedTask)(nil)
-var _ notif.SelfNotificationTemplateProvider = (*RemakeNewsFinishedTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*RemakeNewsFinishedTask)(nil)
 
 func (RemakeNewsFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }

--- a/handlers/search/remakeWritingFinishedTask.go
+++ b/handlers/search/remakeWritingFinishedTask.go
@@ -15,8 +15,6 @@ type RemakeWritingFinishedTask struct{ tasks.TaskString }
 var remakeWritingFinishedTask = &RemakeWritingFinishedTask{TaskString: TaskRemakeWritingSearchComplete}
 
 var _ tasks.Task = (*RemakeWritingFinishedTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*RemakeWritingFinishedTask)(nil)
-var _ notif.SelfNotificationTemplateProvider = (*RemakeWritingFinishedTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*RemakeWritingFinishedTask)(nil)
 
 func (RemakeWritingFinishedTask) Action(http.ResponseWriter, *http.Request) any { return nil }

--- a/handlers/user/addEmailTask.go
+++ b/handlers/user/addEmailTask.go
@@ -31,7 +31,6 @@ type AddEmailTask struct {
 var addEmailTask = &AddEmailTask{TaskString: tasks.TaskString(TaskAdd)}
 
 var _ tasks.Task = (*AddEmailTask)(nil)
-var _ notif.DirectEmailNotificationTemplateProvider = (*AddEmailTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*AddEmailTask)(nil)
 
 func (t AddEmailTask) generateVerificationCode() string {

--- a/handlers/user/admin_permissions_test.go
+++ b/handlers/user/admin_permissions_test.go
@@ -18,21 +18,25 @@ import (
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/middleware"
 	"github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
 	"github.com/arran4/goa4web/internal/testhelpers"
 	"github.com/gorilla/mux"
 )
 
 func TestPermissionUserTasksTemplates(t *testing.T) {
-	admins := []notifications.AdminEmailTemplateProvider{
+	admins := []tasks.Task{
 		&PermissionUserAllowTask{TaskString: TaskUserAllow},
 		&PermissionUserDisallowTask{TaskString: TaskUserDisallow},
 	}
 	for _, p := range admins {
-		et, _ := p.AdminEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+		et, nt, ok := notifications.AdminTemplates(p, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+		if !ok {
+			t.Errorf("expected admin templates for %T", p)
+			continue
+		}
 		if et == nil || et.Text == "" || et.HTML == "" || et.Subject == "" {
 			t.Errorf("incomplete templates for %T", p)
 		}
-		nt := p.AdminInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
 		if nt == nil || *nt == "" {
 			t.Errorf("missing internal template for %T", p)
 		}

--- a/handlers/user/permissionUpdateTask.go
+++ b/handlers/user/permissionUpdateTask.go
@@ -22,7 +22,6 @@ type PermissionUpdateTask struct{ tasks.TaskString }
 var permissionUpdateTask = &PermissionUpdateTask{TaskString: TaskUpdate}
 
 var _ tasks.Task = (*PermissionUpdateTask)(nil)
-var _ notif.TargetUsersNotificationProvider = (*PermissionUpdateTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*PermissionUpdateTask)(nil)
 
 func (PermissionUpdateTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/user/permissionUserAllowTask.go
+++ b/handlers/user/permissionUserAllowTask.go
@@ -20,8 +20,6 @@ type PermissionUserAllowTask struct{ tasks.TaskString }
 var permissionUserAllowTask = &PermissionUserAllowTask{TaskString: TaskUserAllow}
 
 var _ tasks.Task = (*PermissionUserAllowTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*PermissionUserAllowTask)(nil)
-var _ notif.TargetUsersNotificationProvider = (*PermissionUserAllowTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*PermissionUserAllowTask)(nil)
 
 func (PermissionUserAllowTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/user/permissionUserDisallowTask.go
+++ b/handlers/user/permissionUserDisallowTask.go
@@ -20,8 +20,6 @@ type PermissionUserDisallowTask struct{ tasks.TaskString }
 var permissionUserDisallowTask = &PermissionUserDisallowTask{TaskString: TaskUserDisallow}
 
 var _ tasks.Task = (*PermissionUserDisallowTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*PermissionUserDisallowTask)(nil)
-var _ notif.TargetUsersNotificationProvider = (*PermissionUserDisallowTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*PermissionUserDisallowTask)(nil)
 
 func (PermissionUserDisallowTask) AdminEmailTemplate(evt eventbus.TaskEvent) (templates *notif.EmailTemplates, send bool) {

--- a/handlers/user/resendVerificationEmailTask.go
+++ b/handlers/user/resendVerificationEmailTask.go
@@ -15,7 +15,6 @@ type ResendVerificationEmailTask struct{ tasks.TaskString }
 var resendVerificationEmailTask = &ResendVerificationEmailTask{TaskString: TaskResend}
 
 var _ tasks.Task = (*ResendVerificationEmailTask)(nil)
-var _ notif.DirectEmailNotificationTemplateProvider = (*ResendVerificationEmailTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*ResendVerificationEmailTask)(nil)
 
 func (ResendVerificationEmailTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/user/testMailTask.go
+++ b/handlers/user/testMailTask.go
@@ -22,7 +22,6 @@ type TestMailTask struct{ tasks.TaskString }
 var testMailTask = &TestMailTask{TaskString: tasks.TaskString(TaskTestMail)}
 
 var _ tasks.Task = (*TestMailTask)(nil)
-var _ notif.SelfNotificationTemplateProvider = (*TestMailTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*TestMailTask)(nil)
 
 func (TestMailTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/writings/edit_reply_task.go
+++ b/handlers/writings/edit_reply_task.go
@@ -22,7 +22,6 @@ type EditReplyTask struct{ tasks.TaskString }
 var editReplyTask = &EditReplyTask{TaskString: TaskEditReply}
 
 var _ tasks.Task = (*EditReplyTask)(nil)
-var _ notif.AdminEmailTemplateProvider = (*EditReplyTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*EditReplyTask)(nil)
 
 func (EditReplyTask) Action(w http.ResponseWriter, r *http.Request) any {

--- a/handlers/writings/reply_task.go
+++ b/handlers/writings/reply_task.go
@@ -24,9 +24,6 @@ type ReplyTask struct{ tasks.TaskString }
 var replyTask = &ReplyTask{TaskString: TaskReply}
 
 var _ tasks.Task = (*ReplyTask)(nil)
-var _ notif.GrantsRequiredProvider = (*ReplyTask)(nil)
-var _ notif.SubscribersNotificationTemplateProvider = (*ReplyTask)(nil)
-var _ notif.AutoSubscribeProvider = (*ReplyTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*ReplyTask)(nil)
 var _ searchworker.IndexedTask = ReplyTask{}
 

--- a/handlers/writings/reply_task_test.go
+++ b/handlers/writings/reply_task_test.go
@@ -25,7 +25,7 @@ import (
 func TestReplyTask(t *testing.T) {
 	t.Run("Happy Path - Auto Subscribe Interface", func(t *testing.T) {
 		var task ReplyTask
-		if _, ok := interface{}(task).(notif.AutoSubscribeProvider); !ok {
+		if !notif.HasAutoSubscribe(task) {
 			t.Fatalf("AutoSubscribeProvider must auto subscribe as users will want updates")
 		}
 	})

--- a/handlers/writings/submit_writing_task.go
+++ b/handlers/writings/submit_writing_task.go
@@ -23,8 +23,6 @@ type SubmitWritingTask struct{ tasks.TaskString }
 var submitWritingTask = &SubmitWritingTask{TaskString: TaskSubmitWriting}
 
 var _ tasks.Task = (*SubmitWritingTask)(nil)
-var _ notif.SubscribersNotificationTemplateProvider = (*SubmitWritingTask)(nil)
-var _ notif.GrantsRequiredProvider = (*SubmitWritingTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*SubmitWritingTask)(nil)
 
 func (SubmitWritingTask) Page(w http.ResponseWriter, r *http.Request) { ArticleAddPage(w, r) }

--- a/handlers/writings/templates_test.go
+++ b/handlers/writings/templates_test.go
@@ -8,11 +8,12 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers/handlertest"
 	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
 )
 
-func requireAutoSubscribeProvider(t *testing.T, task any) {
+func requireAutoSubscribeProvider(t *testing.T, task tasks.Task) {
 	t.Helper()
-	if _, ok := task.(notif.AutoSubscribeProvider); !ok {
+	if !notif.HasAutoSubscribe(task) {
 		t.Fatalf("%T should auto subscribe so participants stay updated", task)
 	}
 }

--- a/handlers/writings/update_writing_task.go
+++ b/handlers/writings/update_writing_task.go
@@ -21,8 +21,6 @@ type UpdateWritingTask struct{ tasks.TaskString }
 var updateWritingTask = &UpdateWritingTask{TaskString: TaskUpdateWriting}
 
 var _ tasks.Task = (*UpdateWritingTask)(nil)
-var _ notif.SubscribersNotificationTemplateProvider = (*UpdateWritingTask)(nil)
-var _ notif.GrantsRequiredProvider = (*UpdateWritingTask)(nil)
 var _ tasks.EmailTemplatesRequired = (*UpdateWritingTask)(nil)
 
 func (UpdateWritingTask) Page(w http.ResponseWriter, r *http.Request) { ArticleEditPage(w, r) }

--- a/handlers/writings/writingsTemplates_test.go
+++ b/handlers/writings/writingsTemplates_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arran4/goa4web/core/templates"
 	"github.com/arran4/goa4web/handlers/handlertest"
 	notif "github.com/arran4/goa4web/internal/notifications"
+	"github.com/arran4/goa4web/internal/tasks"
 )
 
 func checkEmailTemplates(t *testing.T, et *notif.EmailTemplates) {
@@ -37,16 +38,17 @@ func checkNotificationTemplate(t *testing.T, name *string) {
 
 func TestWritingsTemplatesExist(t *testing.T) {
 	t.Run("Happy Path - All Templates", func(t *testing.T) {
-		providers := []notif.SubscribersNotificationTemplateProvider{
+		providers := []tasks.Task{
 			submitWritingTask,
 			updateWritingTask,
 			replyTask,
 		}
 		for _, p := range providers {
-			if et, _ := p.SubscribedEmailTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}); et != nil {
+			et, nt, ok := notif.SubscriberTemplates(p, eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess})
+			if ok && et != nil {
 				checkEmailTemplates(t, et)
 			}
-			checkNotificationTemplate(t, p.SubscribedInternalNotificationTemplate(eventbus.TaskEvent{Outcome: eventbus.TaskOutcomeSuccess}))
+			checkNotificationTemplate(t, nt)
 		}
 	})
 }

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -247,6 +247,7 @@ func NewServer(ctx context.Context, cfg *config.RuntimeConfig, ah *adminhandlers
 	r.NotFoundHandler = srv.NotFoundHandler
 
 	taskEventMW := middleware.NewTaskEventMiddleware(o.Bus)
+	srv.TaskEventMW = taskEventMW
 	handler := middleware.NewMiddlewareChain(
 		middleware.RecoverMiddleware,
 		srv.CoreDataMiddleware(),

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/middleware"
 	nav "github.com/arran4/goa4web/internal/navigation"
+	"github.com/arran4/goa4web/internal/notifications"
 	"github.com/arran4/goa4web/internal/router"
 	"github.com/arran4/goa4web/internal/stats"
 	"github.com/arran4/goa4web/internal/tasks"
@@ -64,6 +65,7 @@ type Server struct {
 	LanguageCache  *common.LanguageCache
 
 	WorkerCancel context.CancelFunc
+	TaskEventMW  *middleware.TaskEventMiddleware
 
 	addr       string
 	httpServer *http.Server
@@ -403,6 +405,15 @@ func (s *Server) startWorkers(ctx context.Context) {
 	}
 	workerCtx, cancel := context.WithCancel(ctx)
 	dlqProvider := s.DLQReg.ProviderFromConfig(s.Config, q)
+	notifier := notifications.New(
+		notifications.WithQueries(q),
+		notifications.WithEmailProvider(emailProvider),
+		notifications.WithBus(s.Bus),
+		notifications.WithConfig(s.Config),
+	)
+	if s.TaskEventMW != nil {
+		s.TaskEventMW.SetTaskEventProcessor(notifier)
+	}
 	workers.Start(workerCtx, q, emailProvider, dlqProvider, s.Config, s.Bus)
 	s.WorkerCancel = cancel
 }

--- a/internal/middleware/taskbus.go
+++ b/internal/middleware/taskbus.go
@@ -99,14 +99,21 @@ func (q *eventQueue) flush(ctx context.Context) {
 
 // TaskEventMiddleware provides middleware for publishing task events.
 type TaskEventMiddleware struct {
-	bus   *eventbus.Bus
-	queue *eventQueue
-	log   *log.Logger
-	dlq   dlq.DLQ
+	bus       *eventbus.Bus
+	queue     *eventQueue
+	log       *log.Logger
+	dlq       dlq.DLQ
+	processor TaskEventProcessor
 }
 
 // TaskEventMiddlewareOption customizes TaskEventMiddleware behavior.
 type TaskEventMiddlewareOption func(*TaskEventMiddleware)
+
+// TaskEventProcessor handles task events explicitly instead of consuming them via
+// an event bus worker.
+type TaskEventProcessor interface {
+	ProcessEvent(ctx context.Context, evt eventbus.TaskEvent, q dlq.DLQ) error
+}
 
 // WithLogger overrides the logger used by TaskEventMiddleware.
 func WithLogger(l *log.Logger) TaskEventMiddlewareOption {
@@ -122,6 +129,11 @@ func WithDLQ(q dlq.DLQ) TaskEventMiddlewareOption {
 	return func(m *TaskEventMiddleware) {
 		m.dlq = q
 	}
+}
+
+// WithTaskEventProcessor configures explicit task event processing.
+func WithTaskEventProcessor(p TaskEventProcessor) TaskEventMiddlewareOption {
+	return func(m *TaskEventMiddleware) { m.processor = p }
 }
 
 // NewTaskEventMiddleware creates a middleware instance using the provided bus.
@@ -181,6 +193,11 @@ func (m *TaskEventMiddleware) Middleware(next http.Handler) http.Handler {
 				}
 			}
 			if eventHasTask(evt) {
+				if m.processor != nil {
+					if err := m.processor.ProcessEvent(r.Context(), *evt, m.dlq); err != nil {
+						m.reportIssue(r.Context(), "explicit task event processing failed: %v", err)
+					}
+				}
 				if err := m.bus.Publish(*evt); err != nil {
 					if err == eventbus.ErrBusClosed {
 						m.queue.enqueue(*evt)
@@ -244,6 +261,11 @@ func (m *TaskEventMiddleware) Flush(ctx context.Context) {
 func (m *TaskEventMiddleware) SetBus(bus *eventbus.Bus) {
 	m.bus = bus
 	m.queue.bus = bus
+}
+
+// SetTaskEventProcessor updates the explicit task event processor.
+func (m *TaskEventMiddleware) SetTaskEventProcessor(p TaskEventProcessor) {
+	m.processor = p
 }
 
 // TaskEventMiddlewareWithBus wraps NewTaskEventMiddleware for backward compatibility.

--- a/internal/middleware/taskbus_test.go
+++ b/internal/middleware/taskbus_test.go
@@ -13,10 +13,23 @@ import (
 	"github.com/arran4/goa4web/core/common"
 	"github.com/arran4/goa4web/core/consts"
 	"github.com/arran4/goa4web/handlers"
+	"github.com/arran4/goa4web/internal/dlq"
 	dlqmock "github.com/arran4/goa4web/internal/dlq/mock"
 	"github.com/arran4/goa4web/internal/eventbus"
 	"github.com/arran4/goa4web/internal/tasks"
 )
+
+type recordingTaskEventProcessor struct {
+	lastEvent *eventbus.TaskEvent
+	calls     int
+}
+
+func (p *recordingTaskEventProcessor) ProcessEvent(_ context.Context, evt eventbus.TaskEvent, _ dlq.DLQ) error {
+	p.calls++
+	copyEvt := evt
+	p.lastEvent = &copyEvt
+	return nil
+}
 
 func TestTaskEventMiddleware(t *testing.T) {
 	bus := eventbus.NewBus()
@@ -216,6 +229,35 @@ func TestTaskEventMiddleware_PublishesWhenTaskComesFromContext(t *testing.T) {
 		env.Ack()
 	default:
 		t.Fatal("expected event when task is attached to context")
+	}
+}
+
+func TestTaskEventMiddleware_ExplicitProcessorRunsOnSuccessfulTask(t *testing.T) {
+	bus := eventbus.NewBus()
+	processor := &recordingTaskEventProcessor{}
+	mw := NewTaskEventMiddleware(bus, WithTaskEventProcessor(processor))
+	handler := mw.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if cd, _ := r.Context().Value(consts.KeyCoreData).(*common.CoreData); cd != nil {
+			cd.SetEventTask(tasks.TaskString("AgentAction"))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("POST", "/agent/run", strings.NewReader(`{"prompt":"execute"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := context.WithValue(req.Context(), consts.KeyCoreData, &common.CoreData{})
+	handler.ServeHTTP(rec, req.WithContext(ctx))
+
+	if processor.calls != 1 {
+		t.Fatalf("expected one processor call, got %d", processor.calls)
+	}
+	if processor.lastEvent == nil || processor.lastEvent.Path != "/agent/run" {
+		t.Fatalf("unexpected event recorded: %+v", processor.lastEvent)
+	}
+	named, ok := processor.lastEvent.Task.(tasks.Name)
+	if !ok || named.Name() != "AgentAction" {
+		t.Fatalf("unexpected task recorded: %#v", processor.lastEvent.Task)
 	}
 }
 

--- a/internal/notifications/bus_worker.go
+++ b/internal/notifications/bus_worker.go
@@ -94,10 +94,16 @@ func (n *Notifier) ProcessEvent(ctx context.Context, evt eventbus.TaskEvent, q d
 		return nil
 	}
 
-	if tp, ok := evt.Task.(AdminEmailTemplateProvider); ok {
-		if et, send := tp.AdminEmailTemplate(evt); send {
-			if err := n.notifyAdmins(ctx, et, tp.AdminInternalNotificationTemplate(evt), evt.Data, evt.Path, evt.UserID, &evt); err != nil {
-				errW := fmt.Errorf("AdminEmailTemplateProvider: %w", err)
+	wf := WorkflowForTask(evt.Task)
+
+	if wf.AdminEmail != nil {
+		et, nt, ok := wf.AdminEmail(evt)
+		if !ok {
+			et = nil
+		}
+		if et != nil || nt != nil {
+			if err := n.notifyAdmins(ctx, et, nt, evt.Data, evt.Path, evt.UserID, &evt); err != nil {
+				errW := fmt.Errorf("admin notifications: %w", err)
 				if dlqErr := n.dlqRecordAndNotify(ctx, q, fmt.Sprintf("admin notify: %v", errW), &evt); dlqErr != nil {
 					return dlqErr
 				}
@@ -106,9 +112,9 @@ func (n *Notifier) ProcessEvent(ctx context.Context, evt eventbus.TaskEvent, q d
 		}
 	}
 
-	if tp, ok := evt.Task.(SelfNotificationTemplateProvider); ok {
-		if err := n.notifySelf(ctx, evt, tp); err != nil {
-			errW := fmt.Errorf("SelfNotificationTemplateProvider: %w", err)
+	if wf.SelfNotify != nil {
+		if err := n.notifySelf(ctx, evt, wf); err != nil {
+			errW := fmt.Errorf("self notifications: %w", err)
 			if dlqErr := n.dlqRecordAndNotify(ctx, q, fmt.Sprintf("deliver self to %d: %v", evt.UserID, errW), &evt); dlqErr != nil {
 				return dlqErr
 			}
@@ -117,9 +123,9 @@ func (n *Notifier) ProcessEvent(ctx context.Context, evt eventbus.TaskEvent, q d
 
 	}
 
-	if tp, ok := evt.Task.(DirectEmailNotificationTemplateProvider); ok {
-		if err := n.notifyDirectEmail(ctx, evt, tp); err != nil {
-			errW := fmt.Errorf("DirectEmailNotificationTemplateProvider: %w", err)
+	if wf.DirectEmail != nil {
+		if err := n.notifyDirectEmail(ctx, evt, wf); err != nil {
+			errW := fmt.Errorf("direct email notifications: %w", err)
 			if dlqErr := n.dlqRecordAndNotify(ctx, q, fmt.Sprintf("direct email notify: %v", errW), &evt); dlqErr != nil {
 				return dlqErr
 			}
@@ -128,9 +134,9 @@ func (n *Notifier) ProcessEvent(ctx context.Context, evt eventbus.TaskEvent, q d
 
 	}
 
-	if tp, ok := evt.Task.(TargetUsersNotificationProvider); ok {
-		if err := n.notifyTargetUsers(ctx, evt, tp); err != nil {
-			errW := fmt.Errorf("TargetUsersNotificationProvider: %w", err)
+	if wf.TargetUsers != nil {
+		if err := n.notifyTargetUsers(ctx, evt, wf); err != nil {
+			errW := fmt.Errorf("target user notifications: %w", err)
 			if dlqErr := n.dlqRecordAndNotify(ctx, q, fmt.Sprintf("notify target users: %v", errW), &evt); dlqErr != nil {
 				return dlqErr
 			}
@@ -139,9 +145,9 @@ func (n *Notifier) ProcessEvent(ctx context.Context, evt eventbus.TaskEvent, q d
 
 	}
 
-	if tp, ok := evt.Task.(SubscribersNotificationTemplateProvider); ok {
-		if err := n.notifySubscribers(ctx, evt, tp); err != nil {
-			errW := fmt.Errorf("SubscribersNotificationTemplateProvider: %w", err)
+	if wf.SubscriberNotify != nil {
+		if err := n.notifySubscribers(ctx, evt, wf); err != nil {
+			errW := fmt.Errorf("subscriber notifications: %w", err)
 			if dlqErr := n.dlqRecordAndNotify(ctx, q, fmt.Sprintf("notify subscribers: %v", errW), &evt); dlqErr != nil {
 				return dlqErr
 			}
@@ -150,9 +156,9 @@ func (n *Notifier) ProcessEvent(ctx context.Context, evt eventbus.TaskEvent, q d
 
 	}
 
-	if tp, ok := evt.Task.(AutoSubscribeProvider); ok {
-		if err := n.handleAutoSubscribe(ctx, evt, tp); err != nil {
-			errW := fmt.Errorf("AutoSubscribeProvider: %w", err)
+	if wf.AutoSubscribe != nil {
+		if err := n.handleAutoSubscribe(ctx, evt, wf); err != nil {
+			errW := fmt.Errorf("auto subscribe: %w", err)
 			return errW
 		}
 
@@ -161,7 +167,7 @@ func (n *Notifier) ProcessEvent(ctx context.Context, evt eventbus.TaskEvent, q d
 	return nil
 }
 
-func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, tp SelfNotificationTemplateProvider) error {
+func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, wf Workflow) error {
 	name := ""
 	if tn, ok := evt.Task.(tasks.Name); ok {
 		name = tn.Name()
@@ -192,8 +198,9 @@ func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, tp Se
 		_, shouldSendInternal = internalSubs[evt.UserID]
 	}
 
-	if et, send := tp.SelfEmailTemplate(evt); send && shouldSendEmail {
-		if b, ok := evt.Task.(SelfEmailBroadcaster); ok && b.SelfEmailBroadcast() {
+	et, nt, _ := wf.SelfNotify(evt)
+	if et != nil && shouldSendEmail {
+		if wf.SelfBroadcast != nil && wf.SelfBroadcast() {
 			emails, err := n.Queries.SystemListVerifiedEmailsByUserID(ctx, evt.UserID)
 			if err == nil {
 				for _, e := range emails {
@@ -215,7 +222,7 @@ func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, tp Se
 			}
 		}
 	}
-	if nt := tp.SelfInternalNotificationTemplate(evt); nt != nil && shouldSendInternal {
+	if nt != nil && shouldSendInternal {
 		user, err := n.Queries.SystemGetUserByID(ctx, evt.UserID)
 		if err != nil {
 			return fmt.Errorf("getting user %d for self-notification: %w", evt.UserID, err)
@@ -248,26 +255,30 @@ func (n *Notifier) notifySelf(ctx context.Context, evt eventbus.TaskEvent, tp Se
 	return nil
 }
 
-func (n *Notifier) notifyDirectEmail(ctx context.Context, evt eventbus.TaskEvent, tp DirectEmailNotificationTemplateProvider) error {
-	addr, err := tp.DirectEmailAddress(evt)
+func (n *Notifier) notifyDirectEmail(ctx context.Context, evt eventbus.TaskEvent, wf Workflow) error {
+	et, addr, ok, err := wf.DirectEmail(evt)
 	if err != nil {
 		return err
 	}
-	if addr == "" {
+	if !ok || addr == "" {
 		return nil
 	}
-	if et, send := tp.DirectEmailTemplate(evt); send {
-		if err := n.renderAndQueueEmailFromTemplates(ctx, nil, addr, et, evt.Data); err != nil {
-			return err
-		}
+	if err := n.renderAndQueueEmailFromTemplates(ctx, nil, addr, et, evt.Data); err != nil {
+		return err
 	}
 	return nil
 }
 
-func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.TaskEvent, tp TargetUsersNotificationProvider) error {
-	ids, err := tp.TargetUserIDs(evt)
+func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.TaskEvent, wf Workflow) error {
+	ids, et, nt, ok, err := wf.TargetUsers(evt)
+	if !ok {
+		return nil
+	}
 	if err != nil {
 		return err
+	}
+	if et == nil && nt == nil {
+		return nil
 	}
 	for _, id := range ids {
 		user, err := n.Queries.SystemGetUserByID(ctx, id)
@@ -275,14 +286,12 @@ func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.TaskEvent
 			if nmErr := notifyMissingEmail(ctx, n.Queries, id); nmErr != nil {
 				log.Printf("notify missing email: %v", nmErr)
 			}
-		} else {
-			if et, send := tp.TargetEmailTemplate(evt); send {
-				if err := n.renderAndQueueEmailFromTemplates(ctx, &id, user.Email.String, et, evt.Data); err != nil {
-					return err
-				}
+		} else if et != nil {
+			if err := n.renderAndQueueEmailFromTemplates(ctx, &id, user.Email.String, et, evt.Data); err != nil {
+				return err
 			}
 		}
-		if nt := tp.TargetInternalNotificationTemplate(evt); nt != nil {
+		if nt != nil {
 			data := struct {
 				TaskEvent eventbus.TaskEvent
 				Path      string
@@ -310,7 +319,7 @@ func (n *Notifier) notifyTargetUsers(ctx context.Context, evt eventbus.TaskEvent
 	return nil
 }
 
-func (n *Notifier) notifySubscribers(ctx context.Context, evt eventbus.TaskEvent, tp SubscribersNotificationTemplateProvider) error {
+func (n *Notifier) notifySubscribers(ctx context.Context, evt eventbus.TaskEvent, wf Workflow) error {
 	name := ""
 	if tn, ok := evt.Task.(tasks.Name); ok {
 		name = tn.Name()
@@ -329,12 +338,12 @@ func (n *Notifier) notifySubscribers(ctx context.Context, evt eventbus.TaskEvent
 	delete(emailSubs, evt.UserID)
 	delete(internalSubs, evt.UserID)
 
-	if gp, ok := evt.Task.(GrantsRequiredProvider); ok {
-		reqs, err := gp.GrantsRequired(evt)
+	if wf.Grants != nil {
+		reqs, ok, err := wf.Grants(evt)
 		if err != nil {
 			return err
 		}
-		if len(reqs) != 0 {
+		if ok && len(reqs) != 0 {
 			filterSubs := func(m map[int32]struct{}) {
 				for id := range m {
 					for _, g := range reqs {
@@ -357,9 +366,10 @@ func (n *Notifier) notifySubscribers(ctx context.Context, evt eventbus.TaskEvent
 		}
 	}
 
+	et, nt, _ := wf.SubscriberNotify(evt)
 	var msg []byte
 	data := EmailData{Item: evt.Data, any: evt.Data}
-	if nt := tp.SubscribedInternalNotificationTemplate(evt); nt != nil {
+	if nt != nil {
 		var err error
 		msg, err = n.renderNotification(ctx, *nt, data)
 		if err != nil {
@@ -368,7 +378,7 @@ func (n *Notifier) notifySubscribers(ctx context.Context, evt eventbus.TaskEvent
 		}
 	}
 
-	if et, send := tp.SubscribedEmailTemplate(evt); send {
+	if et != nil {
 		for id := range emailSubs {
 			if err := n.sendSubscriberEmail(ctx, id, evt, et); err != nil {
 				return fmt.Errorf("deliver email to %d: %w", id, err)
@@ -388,65 +398,59 @@ func (n *Notifier) notifySubscribers(ctx context.Context, evt eventbus.TaskEvent
 		}
 	}
 
-	if asp, ok := evt.Task.(AutoSubscribeProvider); ok {
-		newTaskName, newPath, err := asp.AutoSubscribePath(evt)
-		if err == nil {
-			// Find who is subscribed to the current event with "autosub_*"
-			autoInternalSubs, err := collectSubscribers(ctx, n.Queries, patterns, "autosub_internal")
-			if err != nil {
-				log.Printf("collect auto internal subs: %v", err)
-			}
-			autoEmailSubs, err := collectSubscribers(ctx, n.Queries, patterns, "autosub_email")
-			if err != nil {
-				log.Printf("collect auto email subs: %v", err)
-			}
-
-			// We need to build the new pattern for the target subscription
-			newPatterns := buildPatterns(tasks.TaskString(newTaskName), newPath)
-			if len(newPatterns) > 0 {
-				newPattern := newPatterns[0]
-
-				reqs, err := asp.AutoSubscribeGrants(evt)
+	if wf.AutoSubscribe != nil {
+		newTaskName, newPath, reqs, ok, err := wf.AutoSubscribe(evt)
+		if ok {
+			if err == nil {
+				// Find who is subscribed to the current event with "autosub_*"
+				autoInternalSubs, err := collectSubscribers(ctx, n.Queries, patterns, "autosub_internal")
 				if err != nil {
-					log.Printf("auto subscribe grants: %v", err)
+					log.Printf("collect auto internal subs: %v", err)
+				}
+				autoEmailSubs, err := collectSubscribers(ctx, n.Queries, patterns, "autosub_email")
+				if err != nil {
+					log.Printf("collect auto email subs: %v", err)
 				}
 
-				checkGrants := func(userID int32) bool {
-					if err != nil {
-						return false
-					}
-					if len(reqs) == 0 {
+				// We need to build the new pattern for the target subscription
+				newPatterns := buildPatterns(tasks.TaskString(newTaskName), newPath)
+				if len(newPatterns) > 0 {
+					newPattern := newPatterns[0]
+
+					checkGrants := func(userID int32) bool {
+						if len(reqs) == 0 {
+							return true
+						}
+						for _, g := range reqs {
+							if _, err := n.Queries.SystemCheckGrant(ctx, db.SystemCheckGrantParams{
+								ViewerID: userID,
+								Section:  g.Section,
+								Item:     sql.NullString{String: g.Item, Valid: g.Item != ""},
+								Action:   g.Action,
+								ItemID:   sql.NullInt32{Int32: g.ItemID, Valid: g.ItemID != 0},
+								UserID:   sql.NullInt32{Int32: userID, Valid: userID != 0},
+							}); err != nil {
+								return false
+							}
+						}
 						return true
 					}
-					for _, g := range reqs {
-						if _, err := n.Queries.SystemCheckGrant(ctx, db.SystemCheckGrantParams{
-							ViewerID: userID,
-							Section:  g.Section,
-							Item:     sql.NullString{String: g.Item, Valid: g.Item != ""},
-							Action:   g.Action,
-							ItemID:   sql.NullInt32{Int32: g.ItemID, Valid: g.ItemID != 0},
-							UserID:   sql.NullInt32{Int32: userID, Valid: userID != 0},
-						}); err != nil {
-							return false
+
+					for id := range autoInternalSubs {
+						if id == evt.UserID {
+							continue
+						}
+						if checkGrants(id) {
+							ensureSubscription(ctx, n.Queries, id, newPattern, "internal")
 						}
 					}
-					return true
-				}
-
-				for id := range autoInternalSubs {
-					if id == evt.UserID {
-						continue
-					}
-					if checkGrants(id) {
-						ensureSubscription(ctx, n.Queries, id, newPattern, "internal")
-					}
-				}
-				for id := range autoEmailSubs {
-					if id == evt.UserID {
-						continue
-					}
-					if checkGrants(id) {
-						ensureSubscription(ctx, n.Queries, id, newPattern, "email")
+					for id := range autoEmailSubs {
+						if id == evt.UserID {
+							continue
+						}
+						if checkGrants(id) {
+							ensureSubscription(ctx, n.Queries, id, newPattern, "email")
+						}
 					}
 				}
 			}
@@ -456,7 +460,7 @@ func (n *Notifier) notifySubscribers(ctx context.Context, evt eventbus.TaskEvent
 	return nil
 }
 
-func (n *Notifier) handleAutoSubscribe(ctx context.Context, evt eventbus.TaskEvent, tp AutoSubscribeProvider) error {
+func (n *Notifier) handleAutoSubscribe(ctx context.Context, evt eventbus.TaskEvent, wf Workflow) error {
 	var auto bool
 	var email bool
 	pref, err := n.Queries.GetPreferenceForLister(ctx, evt.UserID)
@@ -475,7 +479,10 @@ func (n *Notifier) handleAutoSubscribe(ctx context.Context, evt eventbus.TaskEve
 		}
 	}
 	if auto {
-		task, path, err := tp.AutoSubscribePath(evt)
+		task, path, _, ok, err := wf.AutoSubscribe(evt)
+		if !ok {
+			return nil
+		}
 		if err != nil {
 			log.Printf("auto subscribe path: %v", err)
 			return fmt.Errorf("auto subscribe path: %w", err)

--- a/internal/notifications/bus_worker_test.go
+++ b/internal/notifications/bus_worker_test.go
@@ -354,7 +354,7 @@ func TestNotifySubscribersNews(t *testing.T) {
 		Outcome: eventbus.TaskOutcomeSuccess,
 	}
 
-	if err := n.notifySubscribers(ctx, evt, task); err != nil {
+	if err := n.notifySubscribers(ctx, evt, WorkflowForTask(evt.Task)); err != nil {
 		t.Fatalf("notifySubscribers: %v", err)
 	}
 
@@ -433,6 +433,7 @@ func TestProcessEventAutoSubscribe(t *testing.T) {
 
 	evt := eventbus.TaskEvent{
 		Path:   "/forum/topic/7/thread/42/reply",
+		Task:   autoSubTask{TaskString: "AutoSub"},
 		UserID: 1,
 		Data: map[string]any{
 			postcountworker.EventKey: postcountworker.UpdateEventData{CommentID: 1, ThreadID: 42, TopicID: 7},
@@ -440,7 +441,7 @@ func TestProcessEventAutoSubscribe(t *testing.T) {
 		Outcome: eventbus.TaskOutcomeSuccess,
 	}
 
-	if err := n.handleAutoSubscribe(ctx, evt, autoSubTask{TaskString: "AutoSub"}); err != nil {
+	if err := n.handleAutoSubscribe(ctx, evt, WorkflowForTask(evt.Task)); err != nil {
 		t.Fatalf("handleAutoSubscribe: %v", err)
 	}
 
@@ -468,6 +469,7 @@ func TestProcessEventAutoSubscribeMissingPreference(t *testing.T) {
 
 	evt := eventbus.TaskEvent{
 		Path:   "/forum/topic/7/thread/42/reply",
+		Task:   autoSubTask{TaskString: "AutoSub"},
 		UserID: 1,
 		Data: map[string]any{
 			postcountworker.EventKey: postcountworker.UpdateEventData{CommentID: 1, ThreadID: 42, TopicID: 7},
@@ -477,7 +479,7 @@ func TestProcessEventAutoSubscribeMissingPreference(t *testing.T) {
 
 	initialStats := stats.AutoSubscribePreferenceFailures.Load()
 
-	if err := n.handleAutoSubscribe(ctx, evt, autoSubTask{TaskString: "AutoSub"}); err != nil {
+	if err := n.handleAutoSubscribe(ctx, evt, WorkflowForTask(evt.Task)); err != nil {
 		t.Fatalf("handleAutoSubscribe: %v", err)
 	}
 

--- a/internal/notifications/contracts_api.go
+++ b/internal/notifications/contracts_api.go
@@ -1,0 +1,89 @@
+package notifications
+
+import (
+	"github.com/arran4/goa4web/internal/eventbus"
+)
+
+// AdminTemplates returns admin email/internal notification templates for task.
+func AdminTemplates(task any, evt eventbus.TaskEvent) (*EmailTemplates, *string, bool) {
+	wf := WorkflowForTask(task)
+	if wf.AdminEmail == nil {
+		return nil, nil, false
+	}
+	return wf.AdminEmail(evt)
+}
+
+// SelfTemplates returns self email/internal notification templates for task.
+func SelfTemplates(task any, evt eventbus.TaskEvent) (*EmailTemplates, *string, bool) {
+	wf := WorkflowForTask(task)
+	if wf.SelfNotify == nil {
+		return nil, nil, false
+	}
+	return wf.SelfNotify(evt)
+}
+
+// DirectEmailTemplate resolves direct email template and target address.
+func DirectEmailTemplate(task any, evt eventbus.TaskEvent) (*EmailTemplates, string, bool, error) {
+	wf := WorkflowForTask(task)
+	if wf.DirectEmail == nil {
+		return nil, "", false, nil
+	}
+	return wf.DirectEmail(evt)
+}
+
+// SubscriberTemplates returns subscriber email/internal notification templates.
+func SubscriberTemplates(task any, evt eventbus.TaskEvent) (*EmailTemplates, *string, bool) {
+	wf := WorkflowForTask(task)
+	if wf.SubscriberNotify == nil {
+		return nil, nil, false
+	}
+	return wf.SubscriberNotify(evt)
+}
+
+// TargetUsersTemplates returns target-user notification data.
+func TargetUsersTemplates(task any, evt eventbus.TaskEvent) ([]int32, *EmailTemplates, *string, bool, error) {
+	wf := WorkflowForTask(task)
+	if wf.TargetUsers == nil {
+		return nil, nil, nil, false, nil
+	}
+	return wf.TargetUsers(evt)
+}
+
+// AutoSubscribeData returns auto-subscribe action/path/grants for task.
+func AutoSubscribeData(task any, evt eventbus.TaskEvent) (string, string, []GrantRequirement, bool, error) {
+	wf := WorkflowForTask(task)
+	if wf.AutoSubscribe == nil {
+		return "", "", nil, false, nil
+	}
+	return wf.AutoSubscribe(evt)
+}
+
+// HasAutoSubscribe reports whether task supports auto-subscribe methods.
+func HasAutoSubscribe(task any) bool {
+	return WorkflowForTask(task).HasAutoSubscribe()
+}
+
+// HasAdminTemplates reports whether task exposes admin notification templates.
+func HasAdminTemplates(task any) bool {
+	return WorkflowForTask(task).HasAdmin()
+}
+
+// HasSelfTemplates reports whether task exposes self notification templates.
+func HasSelfTemplates(task any) bool {
+	return WorkflowForTask(task).HasSelf()
+}
+
+// HasTargetUsersTemplates reports whether task exposes target-user templates.
+func HasTargetUsersTemplates(task any) bool {
+	return WorkflowForTask(task).HasTargetUsers()
+}
+
+// HasSubscriberTemplates reports whether task exposes subscriber templates.
+func HasSubscriberTemplates(task any) bool {
+	return WorkflowForTask(task).HasSubscriber()
+}
+
+// HasDirectEmailTemplate reports whether task exposes a direct-email template.
+func HasDirectEmailTemplate(task any) bool {
+	return WorkflowForTask(task).HasDirect()
+}

--- a/internal/notifications/database_feeder.go
+++ b/internal/notifications/database_feeder.go
@@ -1,0 +1,60 @@
+package notifications
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+// DatabaseFeederWorker polls the notifications table and publishes lightweight
+// feed events for new rows. This keeps the worker role as a DB-driven feeder.
+func (n *Notifier) DatabaseFeederWorker(ctx context.Context, interval time.Duration) {
+	if n == nil || n.Queries == nil || n.Bus == nil {
+		return
+	}
+
+	lastID := int32(0)
+	if rows, err := n.Queries.AdminListRecentNotifications(ctx, 1); err == nil && len(rows) > 0 {
+		lastID = rows[0].ID
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			rows, err := n.Queries.AdminListRecentNotifications(ctx, 100)
+			if err != nil {
+				log.Printf("notification feeder list recent: %v", err)
+				continue
+			}
+			// rows are newest-first; publish oldest-first to preserve order.
+			for i := len(rows) - 1; i >= 0; i-- {
+				row := rows[i]
+				if row.ID <= lastID {
+					continue
+				}
+				evt := eventbus.TaskEvent{
+					Path:   "/admin/notifications",
+					Task:   tasks.TaskString("NotificationFeed"),
+					UserID: row.UsersIdusers,
+					Time:   row.CreatedAt,
+					Data: map[string]any{
+						"notificationID": row.ID,
+					},
+					Outcome: eventbus.TaskOutcomeSuccess,
+				}
+				if err := n.Bus.Publish(evt); err != nil && err != eventbus.ErrBusClosed {
+					log.Printf("notification feeder publish: %v", err)
+				}
+				lastID = row.ID
+			}
+		}
+	}
+}

--- a/internal/notifications/subscriptionsinterfaces.go
+++ b/internal/notifications/subscriptionsinterfaces.go
@@ -1,9 +1,6 @@
 package notifications
 
-import (
-	"github.com/arran4/goa4web/internal/eventbus"
-	"github.com/arran4/goa4web/internal/tasks"
-)
+import "github.com/arran4/goa4web/internal/tasks"
 
 type EmailTemplates struct {
 	Text    string
@@ -61,67 +58,4 @@ func NewEmailTemplates(prefix string) *EmailTemplates {
 		HTML:    EmailHTMLTemplateFilenameGenerator(prefix),
 		Subject: EmailSubjectTemplateFilenameGenerator(prefix),
 	}
-}
-
-// AdminEmailTemplateProvider indicates the notification should be sent via
-// email to administrators using the provided templates.
-type AdminEmailTemplateProvider interface {
-	AdminEmailTemplate(evt eventbus.TaskEvent) (templates *EmailTemplates, send bool)
-	AdminInternalNotificationTemplate(evt eventbus.TaskEvent) *string
-}
-
-// SelfNotificationTemplateProvider is used for mandatory self notifications such as password
-// resets or verifications.
-type SelfNotificationTemplateProvider interface {
-	SelfEmailTemplate(evt eventbus.TaskEvent) (templates *EmailTemplates, send bool)
-	SelfInternalNotificationTemplate(evt eventbus.TaskEvent) *string
-}
-
-// SelfEmailBroadcaster indicates the notification should be sent to all
-// verified email addresses of the user instead of only the highest priority.
-type SelfEmailBroadcaster interface {
-	SelfEmailBroadcast() bool
-}
-
-// DirectEmailNotificationTemplateProvider specifies templates for an email sent
-// directly to an address independent of the user's primary email.
-// The address itself is obtained from the event data via DirectEmailAddress.
-// Internal notifications are not supported for this provider.
-type DirectEmailNotificationTemplateProvider interface {
-	DirectEmailAddress(evt eventbus.TaskEvent) (string, error)
-	DirectEmailTemplate(evt eventbus.TaskEvent) (templates *EmailTemplates, send bool)
-}
-
-// SubscribersNotificationTemplateProvider indicates the notification should be delivered to
-// subscribed users.
-type SubscribersNotificationTemplateProvider interface {
-	SubscribedEmailTemplate(evt eventbus.TaskEvent) (templates *EmailTemplates, send bool)
-	SubscribedInternalNotificationTemplate(evt eventbus.TaskEvent) *string
-}
-
-// AutoSubscribeProvider describes events that automatically create a
-// subscription when user preferences allow.
-type AutoSubscribeProvider interface {
-	// AutoSubscribePath returns the action name and URI used when creating the
-	// subscription. The event may provide additional context required to build
-	// the path.
-	AutoSubscribePath(evt eventbus.TaskEvent) (string, string, error)
-	// AutoSubscribeGrants returns the permissions required to subscribe to the
-	// path.
-	AutoSubscribeGrants(evt eventbus.TaskEvent) ([]GrantRequirement, error)
-}
-
-// TargetUsersNotificationProvider indicates the notification should be delivered
-// to the returned user IDs.
-type TargetUsersNotificationProvider interface {
-	TargetUserIDs(evt eventbus.TaskEvent) ([]int32, error)
-	TargetEmailTemplate(evt eventbus.TaskEvent) (templates *EmailTemplates, send bool)
-	TargetInternalNotificationTemplate(evt eventbus.TaskEvent) *string
-}
-
-// GrantsRequiredProvider exposes the permission context for subscription
-// notifications. Implementations return one or more GrantRequirement values
-// checked with `SystemCheckGrant` before delivering a message.
-type GrantsRequiredProvider interface {
-	GrantsRequired(evt eventbus.TaskEvent) ([]GrantRequirement, error)
 }

--- a/internal/notifications/workflow.go
+++ b/internal/notifications/workflow.go
@@ -1,0 +1,170 @@
+package notifications
+
+import (
+	"sync"
+
+	"github.com/arran4/goa4web/internal/eventbus"
+	"github.com/arran4/goa4web/internal/tasks"
+)
+
+type Workflow struct {
+	AdminEmail       func(eventbus.TaskEvent) (*EmailTemplates, *string, bool)
+	SelfNotify       func(eventbus.TaskEvent) (*EmailTemplates, *string, bool)
+	DirectEmail      func(eventbus.TaskEvent) (*EmailTemplates, string, bool, error)
+	TargetUsers      func(eventbus.TaskEvent) ([]int32, *EmailTemplates, *string, bool, error)
+	SubscriberNotify func(eventbus.TaskEvent) (*EmailTemplates, *string, bool)
+	AutoSubscribe    func(eventbus.TaskEvent) (string, string, []GrantRequirement, bool, error)
+	Grants           func(eventbus.TaskEvent) ([]GrantRequirement, bool, error)
+	SelfBroadcast    func() bool
+}
+
+func (w Workflow) HasAdmin() bool         { return w.AdminEmail != nil }
+func (w Workflow) HasSelf() bool          { return w.SelfNotify != nil }
+func (w Workflow) HasDirect() bool        { return w.DirectEmail != nil }
+func (w Workflow) HasTargetUsers() bool   { return w.TargetUsers != nil }
+func (w Workflow) HasSubscriber() bool    { return w.SubscriberNotify != nil }
+func (w Workflow) HasAutoSubscribe() bool { return w.AutoSubscribe != nil }
+
+type workflowRegistry struct {
+	mu        sync.RWMutex
+	workflows map[string]Workflow
+}
+
+var defaultWorkflowRegistry = &workflowRegistry{workflows: map[string]Workflow{}}
+
+// RegisterWorkflow lodges explicit notification behavior for a task name.
+func RegisterWorkflow(taskName string, wf Workflow) {
+	defaultWorkflowRegistry.mu.Lock()
+	defer defaultWorkflowRegistry.mu.Unlock()
+	defaultWorkflowRegistry.workflows[taskName] = wf
+}
+
+func (r *workflowRegistry) lookup(taskName string) (Workflow, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	wf, ok := r.workflows[taskName]
+	return wf, ok
+}
+
+// WorkflowForTask returns the effective workflow for task.
+// Explicitly registered workflows are preferred over method-derived behavior.
+func WorkflowForTask(task any) Workflow {
+	name := ""
+	if n, ok := task.(tasks.Name); ok {
+		name = n.Name()
+	}
+	if name != "" {
+		if wf, ok := defaultWorkflowRegistry.lookup(name); ok {
+			return wf
+		}
+	}
+	return deriveWorkflow(task)
+}
+
+func deriveWorkflow(task any) Workflow {
+	wf := Workflow{}
+	if task == nil {
+		return wf
+	}
+
+	if t, ok := task.(interface {
+		AdminEmailTemplate(eventbus.TaskEvent) (*EmailTemplates, bool)
+		AdminInternalNotificationTemplate(eventbus.TaskEvent) *string
+	}); ok {
+		wf.AdminEmail = func(evt eventbus.TaskEvent) (*EmailTemplates, *string, bool) {
+			et, send := t.AdminEmailTemplate(evt)
+			if !send {
+				return nil, nil, false
+			}
+			return et, t.AdminInternalNotificationTemplate(evt), true
+		}
+	}
+
+	if t, ok := task.(interface {
+		SelfEmailTemplate(eventbus.TaskEvent) (*EmailTemplates, bool)
+		SelfInternalNotificationTemplate(eventbus.TaskEvent) *string
+	}); ok {
+		wf.SelfNotify = func(evt eventbus.TaskEvent) (*EmailTemplates, *string, bool) {
+			et, send := t.SelfEmailTemplate(evt)
+			if !send {
+				et = nil
+			}
+			nt := t.SelfInternalNotificationTemplate(evt)
+			return et, nt, et != nil || nt != nil
+		}
+	}
+
+	if t, ok := task.(interface{ SelfEmailBroadcast() bool }); ok {
+		wf.SelfBroadcast = t.SelfEmailBroadcast
+	}
+
+	if t, ok := task.(interface {
+		DirectEmailAddress(eventbus.TaskEvent) (string, error)
+		DirectEmailTemplate(eventbus.TaskEvent) (*EmailTemplates, bool)
+	}); ok {
+		wf.DirectEmail = func(evt eventbus.TaskEvent) (*EmailTemplates, string, bool, error) {
+			et, send := t.DirectEmailTemplate(evt)
+			if !send {
+				return nil, "", false, nil
+			}
+			addr, err := t.DirectEmailAddress(evt)
+			if err != nil {
+				return nil, "", false, err
+			}
+			return et, addr, true, nil
+		}
+	}
+
+	if t, ok := task.(interface {
+		TargetUserIDs(eventbus.TaskEvent) ([]int32, error)
+		TargetEmailTemplate(eventbus.TaskEvent) (*EmailTemplates, bool)
+		TargetInternalNotificationTemplate(eventbus.TaskEvent) *string
+	}); ok {
+		wf.TargetUsers = func(evt eventbus.TaskEvent) ([]int32, *EmailTemplates, *string, bool, error) {
+			ids, err := t.TargetUserIDs(evt)
+			if err != nil {
+				return nil, nil, nil, false, err
+			}
+			et, _ := t.TargetEmailTemplate(evt)
+			return ids, et, t.TargetInternalNotificationTemplate(evt), true, nil
+		}
+	}
+
+	if t, ok := task.(interface {
+		SubscribedEmailTemplate(eventbus.TaskEvent) (*EmailTemplates, bool)
+		SubscribedInternalNotificationTemplate(eventbus.TaskEvent) *string
+	}); ok {
+		wf.SubscriberNotify = func(evt eventbus.TaskEvent) (*EmailTemplates, *string, bool) {
+			et, send := t.SubscribedEmailTemplate(evt)
+			if !send {
+				et = nil
+			}
+			return et, t.SubscribedInternalNotificationTemplate(evt), true
+		}
+	}
+
+	if t, ok := task.(interface {
+		AutoSubscribePath(eventbus.TaskEvent) (string, string, error)
+		AutoSubscribeGrants(eventbus.TaskEvent) ([]GrantRequirement, error)
+	}); ok {
+		wf.AutoSubscribe = func(evt eventbus.TaskEvent) (string, string, []GrantRequirement, bool, error) {
+			action, path, err := t.AutoSubscribePath(evt)
+			if err != nil {
+				return "", "", nil, true, err
+			}
+			grants, err := t.AutoSubscribeGrants(evt)
+			return action, path, grants, true, err
+		}
+	}
+
+	if t, ok := task.(interface {
+		GrantsRequired(eventbus.TaskEvent) ([]GrantRequirement, error)
+	}); ok {
+		wf.Grants = func(evt eventbus.TaskEvent) ([]GrantRequirement, bool, error) {
+			grants, err := t.GrantsRequired(evt)
+			return grants, true, err
+		}
+	}
+
+	return wf
+}

--- a/workers/workers.go
+++ b/workers/workers.go
@@ -83,6 +83,16 @@ func Start(ctx context.Context, q db.Querier, provider email.Provider, dlqProvid
 	safeGo(func() { logworker.Worker(ctx, bus) })
 	log.Printf("Starting audit worker")
 	safeGo(func() { auditworker.Worker(ctx, bus, q) })
+	log.Printf("Starting notification database feeder worker")
+	safeGo(func() {
+		n := notifications.New(
+			notifications.WithQueries(q),
+			notifications.WithEmailProvider(provider),
+			notifications.WithBus(bus),
+			notifications.WithConfig(cfg),
+		)
+		n.DatabaseFeederWorker(ctx, 3*time.Second)
+	})
 	log.Printf("Starting search index worker")
 	safeGo(func() { searchworker.Worker(ctx, bus, q) })
 	log.Printf("Starting background task worker")

--- a/workers/workers.go
+++ b/workers/workers.go
@@ -83,16 +83,6 @@ func Start(ctx context.Context, q db.Querier, provider email.Provider, dlqProvid
 	safeGo(func() { logworker.Worker(ctx, bus) })
 	log.Printf("Starting audit worker")
 	safeGo(func() { auditworker.Worker(ctx, bus, q) })
-	log.Printf("Starting notification bus worker")
-	safeGo(func() {
-		n := notifications.New(
-			notifications.WithQueries(q),
-			notifications.WithEmailProvider(provider),
-			notifications.WithBus(bus),
-			notifications.WithConfig(cfg),
-		)
-		n.BusWorker(ctx, bus, dlqProvider)
-	})
 	log.Printf("Starting search index worker")
 	safeGo(func() { searchworker.Worker(ctx, bus, q) })
 	log.Printf("Starting background task worker")


### PR DESCRIPTION
### Motivation
- Unify and decouple notification behavior from many small task interfaces into a single, testable workflow model to simplify template discovery and delivery logic. 
- Allow middleware to synchronously process task events (e.g. to trigger immediate notifications) via an explicit processor, improving reliability and testability.

### Description
- Introduced a Workflow abstraction and registry (`internal/notifications/workflow.go`) plus a contract API (`internal/notifications/contracts_api.go`) that present a single surface (`WorkflowForTask`, `AdminTemplates`, `SelfTemplates`, `SubscriberTemplates`, `TargetUsersTemplates`, `DirectEmailTemplate`, `AutoSubscribeData`, `Has*` helpers) for resolving templates and notification behavior for tasks.
- Reworked the Notifier processing pipeline (`internal/notifications/bus_worker.go`) to consume Workflow results instead of checking many task interfaces directly, and updated notification helper functions to accept Workflow data.
- Added explicit TaskEventProcessor support to the task-event middleware (`internal/middleware/taskbus.go`) and wired it in the server startup so the notifier can be used as a processor; middleware now invokes the processor for successful requests before publishing to the bus.
- Integrated notifier initialization into server worker startup (`internal/app/server/server.go` / `internal/app/run.go`) and removed the separate background bus worker startup from `workers.Start`, using the new processor path instead.
- Updated many handlers and tests to stop asserting old notification provider interfaces and to use the new `notifications` helpers (and `tasks.Task` where appropriate); added/updated tests to cover explicit processor behavior and template resolution changes.

### Testing
- Ran the full test suite with `go test ./...`; unit tests covering notification templates, auto-subscribe behavior and middleware were executed and passed, including the new `TestTaskEventMiddleware_ExplicitProcessorRunsOnSuccessfulTask` which verifies explicit processing of task events. 
- Updated many package-level template/unit tests to use the new contract API and they succeeded under CI test run. }

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e591584258832fb042040c4ca4d1de)