### PR TITLE
feat: add smart link handling on paste into textareas

### DIFF
--- a/core/templates/assets/pasteimg.js
+++ b/core/templates/assets/pasteimg.js
@@ -16,6 +16,101 @@
         el.style.height = 'auto';
         el.style.height = el.scrollHeight + 'px';
     }
+    function handleImagePaste(e, item) {
+        e.preventDefault();
+        const file = item.getAsFile();
+        const id = uuidv4();
+        const placeholder = '[img uploading:'+id+']';
+        const pos = insertAtCaret(e.target, placeholder);
+        autoSize(e.target);
+        const fd = new FormData();
+        fd.append('image', file);
+        fd.append('id', id);
+        fd.append('task', 'Upload image');
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', uploadUrl);
+        const csrf = document.querySelector("input[name='csrf_token']");
+        if (csrf) {
+            xhr.setRequestHeader('X-CSRF-Token', csrf.value);
+        }
+        let last = 0;
+        xhr.upload.addEventListener('progress', ev => {
+            if(ev.lengthComputable){
+                const pct = Math.floor((ev.loaded/ev.total)*100);
+                if(pct - last >= 10){
+                    last = pct - pct%10;
+                    console.log('upload '+last+'%');
+                }
+            }
+        });
+        xhr.onload = function(){
+            if(xhr.status >= 200 && xhr.status < 300){
+                const ref = xhr.responseText;
+                const finalText = '[img '+ref+']';
+                const v = e.target.value;
+                e.target.value = v.substring(0,pos) + v.substring(pos).replace(placeholder, finalText);
+                e.target.setSelectionRange(pos+finalText.length, pos+finalText.length);
+                autoSize(e.target);
+            } else if (xhr.status === 403) {
+                const v = e.target.value;
+                e.target.value = v.substring(0,pos) + v.substring(pos).replace(placeholder, '');
+                e.target.setSelectionRange(pos, pos);
+                autoSize(e.target);
+            } else {
+                console.error('Image upload failed:', xhr.status, xhr.statusText, xhr.responseText);
+                const failedText = '[img upload failed]';
+                const v = e.target.value;
+                e.target.value = v.substring(0,pos) + v.substring(pos).replace(placeholder, failedText);
+                e.target.setSelectionRange(pos+failedText.length, pos+failedText.length);
+                autoSize(e.target);
+            }
+        };
+        xhr.onerror = function(){
+            console.error('Image upload failed: network error');
+            const failedText = '[img upload failed]';
+            const v = e.target.value;
+            e.target.value = v.substring(0,pos) + v.substring(pos).replace(placeholder, failedText);
+            e.target.setSelectionRange(pos+failedText.length, pos+failedText.length);
+            autoSize(e.target);
+        };
+        xhr.send(fd);
+    }
+
+    function handleUrlPaste(e) {
+        const pastedText = e.clipboardData.getData('text');
+        if (!pastedText || pastedText.trim() === '') {
+            return false;
+        }
+        const urlStr = pastedText.trim();
+        if (!/^https?:\/\/[^\s]+$/.test(urlStr)) {
+            return false;
+        }
+        try {
+            new URL(urlStr);
+        } catch (err) {
+            return false;
+        }
+
+        e.preventDefault();
+
+        const start = e.target.selectionStart;
+        const end = e.target.selectionEnd;
+        const selectedText = e.target.value.substring(start, end);
+        const cleanSelected = selectedText.trim();
+        const hasNewline = cleanSelected.includes('\n') || cleanSelected.includes('\r');
+
+        let replacement = '';
+        if (cleanSelected.length > 0 && !hasNewline) {
+            replacement = `[link ${urlStr} ${cleanSelected}]`;
+        } else {
+            replacement = `[link ${urlStr}]`;
+        }
+
+        e.target.setRangeText(replacement, start, end, 'end');
+        e.target.dispatchEvent(new Event('input', { bubbles: true }));
+        return true;
+    }
+
     function handlePaste(e){
         if (e.target.readOnly || e.target.disabled) {
             return;
@@ -32,93 +127,12 @@
             const item = items[i];
             if(item.kind === 'file' && item.type.startsWith('image/')){
                 hasImage = true;
-                e.preventDefault();
-                const file = item.getAsFile();
-                const id = uuidv4();
-                const placeholder = '[img uploading:'+id+']';
-                const pos = insertAtCaret(e.target, placeholder);
-                autoSize(e.target);
-                const fd = new FormData();
-                fd.append('image', file);
-                fd.append('id', id);
-                fd.append('task', 'Upload image');
-                const xhr = new XMLHttpRequest();
-                xhr.open('POST', uploadUrl);
-                const csrf = document.querySelector("input[name='csrf_token']");
-                if (csrf) {
-                    xhr.setRequestHeader('X-CSRF-Token', csrf.value);
-                }
-                let last = 0;
-                xhr.upload.addEventListener('progress', ev => {
-                    if(ev.lengthComputable){
-                        const pct = Math.floor((ev.loaded/ev.total)*100);
-                        if(pct - last >= 10){
-                            last = pct - pct%10;
-                            console.log('upload '+last+'%');
-                        }
-                    }
-                });
-                xhr.onload = function(){
-                    if(xhr.status >= 200 && xhr.status < 300){
-                        const ref = xhr.responseText;
-                        const finalText = '[img '+ref+']';
-                        const v = e.target.value;
-                        e.target.value = v.substring(0,pos) + v.substring(pos).replace(placeholder, finalText);
-                        e.target.setSelectionRange(pos+finalText.length, pos+finalText.length);
-                        autoSize(e.target);
-                    } else if (xhr.status === 403) {
-                        const v = e.target.value;
-                        e.target.value = v.substring(0,pos) + v.substring(pos).replace(placeholder, '');
-                        e.target.setSelectionRange(pos, pos);
-                        autoSize(e.target);
-                    } else {
-                        console.error('Image upload failed:', xhr.status, xhr.statusText, xhr.responseText);
-                        const failedText = '[img upload failed]';
-                        const v = e.target.value;
-                        e.target.value = v.substring(0,pos) + v.substring(pos).replace(placeholder, failedText);
-                        e.target.setSelectionRange(pos+failedText.length, pos+failedText.length);
-                        autoSize(e.target);
-                    }
-                };
-                xhr.onerror = function(){
-                    console.error('Image upload failed: network error');
-                    const failedText = '[img upload failed]';
-                    const v = e.target.value;
-                    e.target.value = v.substring(0,pos) + v.substring(pos).replace(placeholder, failedText);
-                    e.target.setSelectionRange(pos+failedText.length, pos+failedText.length);
-                    autoSize(e.target);
-                };
-                xhr.send(fd);
+                handleImagePaste(e, item);
             }
         }
 
         if (!hasImage) {
-            const pastedText = e.clipboardData.getData('text');
-            if (pastedText && pastedText.trim() !== '') {
-                const urlStr = pastedText.trim();
-                if (/^https?:\/\/[^\s]+$/.test(urlStr)) {
-                    try {
-                        new URL(urlStr);
-                        e.preventDefault();
-
-                        const start = e.target.selectionStart;
-                        const end = e.target.selectionEnd;
-                        const selectedText = e.target.value.substring(start, end);
-                        const cleanSelected = selectedText.trim();
-                        const hasNewline = cleanSelected.includes('\n') || cleanSelected.includes('\r');
-
-                        let replacement = '';
-                        if (cleanSelected.length > 0 && !hasNewline) {
-                            replacement = `[link ${urlStr} ${cleanSelected}]`;
-                        } else {
-                            replacement = `[link ${urlStr}]`;
-                        }
-
-                        e.target.setRangeText(replacement, start, end, 'end');
-                        e.target.dispatchEvent(new Event('input', { bubbles: true }));
-                    } catch (err) {}
-                }
-            }
+            handleUrlPaste(e);
         }
     }
     window.addEventListener('load', function(){

--- a/core/templates/assets/pasteimg.js
+++ b/core/templates/assets/pasteimg.js
@@ -17,11 +17,18 @@
         el.style.height = el.scrollHeight + 'px';
     }
     function handlePaste(e){
+        if (e.shiftKey) {
+            return;
+        }
+
         const items = e.clipboardData && e.clipboardData.items;
         if(!items) return;
+
+        let hasImage = false;
         for(let i=0;i<items.length;i++){
             const item = items[i];
             if(item.kind === 'file' && item.type.startsWith('image/')){
+                hasImage = true;
                 e.preventDefault();
                 const file = item.getAsFile();
                 const id = uuidv4();
@@ -79,6 +86,33 @@
                     autoSize(e.target);
                 };
                 xhr.send(fd);
+            }
+        }
+
+        if (!hasImage) {
+            const pastedText = (e.clipboardData || window.clipboardData).getData('text');
+            if (pastedText && pastedText.trim() !== '') {
+                const urlStr = pastedText.trim();
+                if (/^https?:\/\/[^\s]+$/.test(urlStr)) {
+                    try {
+                        new URL(urlStr);
+                        e.preventDefault();
+
+                        const start = e.target.selectionStart;
+                        const end = e.target.selectionEnd;
+                        const selectedText = e.target.value.substring(start, end);
+
+                        let replacement = '';
+                        if (selectedText.length > 0) {
+                            replacement = `[link ${urlStr} ${selectedText}]`;
+                        } else {
+                            replacement = `[link ${urlStr}]`;
+                        }
+
+                        e.target.setRangeText(replacement, start, end, 'end');
+                        autoSize(e.target);
+                    } catch (err) {}
+                }
             }
         }
     }

--- a/core/templates/assets/pasteimg.js
+++ b/core/templates/assets/pasteimg.js
@@ -17,6 +17,9 @@
         el.style.height = el.scrollHeight + 'px';
     }
     function handlePaste(e){
+        if (e.target.readOnly || e.target.disabled) {
+            return;
+        }
         if (e.shiftKey) {
             return;
         }
@@ -90,7 +93,7 @@
         }
 
         if (!hasImage) {
-            const pastedText = (e.clipboardData || window.clipboardData).getData('text');
+            const pastedText = e.clipboardData.getData('text');
             if (pastedText && pastedText.trim() !== '') {
                 const urlStr = pastedText.trim();
                 if (/^https?:\/\/[^\s]+$/.test(urlStr)) {
@@ -101,16 +104,18 @@
                         const start = e.target.selectionStart;
                         const end = e.target.selectionEnd;
                         const selectedText = e.target.value.substring(start, end);
+                        const cleanSelected = selectedText.trim();
+                        const hasNewline = cleanSelected.includes('\n') || cleanSelected.includes('\r');
 
                         let replacement = '';
-                        if (selectedText.length > 0) {
-                            replacement = `[link ${urlStr} ${selectedText}]`;
+                        if (cleanSelected.length > 0 && !hasNewline) {
+                            replacement = `[link ${urlStr} ${cleanSelected}]`;
                         } else {
                             replacement = `[link ${urlStr}]`;
                         }
 
                         e.target.setRangeText(replacement, start, end, 'end');
-                        autoSize(e.target);
+                        e.target.dispatchEvent(new Event('input', { bubbles: true }));
                     } catch (err) {}
                 }
             }

--- a/plan.md
+++ b/plan.md
@@ -1,1 +1,0 @@
-1. Refactor `handlePaste` to avoid deep nesting and implement a routing approach (early exits or delegating to specific handler functions like `handleImagePaste` and `handleUrlPaste`).

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,1 @@
+1. Refactor `handlePaste` to avoid deep nesting and implement a routing approach (early exits or delegating to specific handler functions like `handleImagePaste` and `handleUrlPaste`).


### PR DESCRIPTION
Resolves #2425 by adding smart link handling when a user pastes a URL into a textarea.
- If the user pastes a valid HTTP/HTTPS URL, the application automatically formats it as `[link <url>]`
- If the user has text selected while pasting the URL, it wraps the text as `[link <url> <selected_text>]`
- Holding down the `Shift` key (e.g. `Shift+V`, `Ctrl+Shift+V`, `Right Click -> Paste + Shift`) completely bypasses the smart behavior and executes a normal text paste.

---
*PR created automatically by Jules for task [3012050287474009422](https://jules.google.com/task/3012050287474009422) started by @arran4*