### PR TITLE
Link footer version to GitHub release

### DIFF
--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -128,6 +128,7 @@ func GetTemplateFuncs(opts ...any) template.FuncMap {
 		"dict":                      Dict,
 		"toJSON":                    ToJSON,
 		"version":                   func() string { return goa4web.Version },
+		"versionReleaseURL":         versionReleaseURL,
 		"lower":                     strings.ToLower,
 		"default": func(def any, item any) any {
 			switch v := item.(type) {
@@ -308,6 +309,14 @@ func GetTemplateFuncs(opts ...any) template.FuncMap {
 	}
 
 	return funcs
+}
+
+func versionReleaseURL() string {
+	version := strings.TrimSpace(goa4web.Version)
+	if version == "" || version == "dev" {
+		return ""
+	}
+	return "https://github.com/arran4/goa4web/releases/tag/" + url.PathEscape(version)
 }
 
 // A4Code2String converts a4code to plain text words.

--- a/core/common/funcs.go
+++ b/core/common/funcs.go
@@ -311,9 +311,9 @@ func GetTemplateFuncs(opts ...any) template.FuncMap {
 	return funcs
 }
 
-func versionReleaseURL() string {
-	version := strings.TrimSpace(goa4web.Version)
-	if version == "" || version == "dev" {
+func versionReleaseURL(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" || strings.ToLower(version) == "dev" {
 		return ""
 	}
 	return "https://github.com/arran4/goa4web/releases/tag/" + url.PathEscape(version)

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -162,6 +162,29 @@ func TestFooterLinksReleaseVersion(t *testing.T) {
 	}
 }
 
+func TestFooterDoesNotLinkDevVersionCaseInsensitive(t *testing.T) {
+	origVersion := goa4web.Version
+	goa4web.Version = "DEV"
+	defer func() {
+		goa4web.Version = origVersion
+	}()
+
+	cd := &common.CoreData{}
+	tmpl := templates.GetCompiledSiteTemplates(cd.Funcs(httptest.NewRequest("GET", "/", nil)), templates.WithSilence(true))
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "footer", nil); err != nil {
+		t.Fatalf("ExecuteTemplate footer: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "releases/tag/") {
+		t.Fatalf("footer linked dev version: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "Version DEV") {
+		t.Fatalf("footer missing plain dev version in %s", buf.String())
+	}
+}
+
 func TestA4Code2HTMLIncludesSourceOffsets(t *testing.T) {
 	funcs := common.GetTemplateFuncs()
 	render, ok := funcs["a4code2html"].(func(string) template.HTML)

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -1,6 +1,7 @@
 package common_test
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"html/template"
@@ -9,7 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/arran4/goa4web"
 	"github.com/arran4/goa4web/core/consts"
+	"github.com/arran4/goa4web/core/templates"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/arran4/goa4web/core/common"
@@ -135,6 +138,27 @@ func TestTemplateFuncsCSRFToken(t *testing.T) {
 	}
 	if _, ok := funcs["csrf"]; ok {
 		t.Errorf("csrf func should not be present")
+	}
+}
+
+func TestFooterLinksReleaseVersion(t *testing.T) {
+	origVersion := goa4web.Version
+	goa4web.Version = "v1.2.3"
+	defer func() {
+		goa4web.Version = origVersion
+	}()
+
+	cd := &common.CoreData{}
+	tmpl := templates.GetCompiledSiteTemplates(cd.Funcs(httptest.NewRequest("GET", "/", nil)), templates.WithSilence(true))
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "footer", nil); err != nil {
+		t.Fatalf("ExecuteTemplate footer: %v", err)
+	}
+
+	want := `<a href="https://github.com/arran4/goa4web/releases/tag/v1.2.3">v1.2.3</a>`
+	if !strings.Contains(buf.String(), want) {
+		t.Fatalf("footer missing version release link %q in %s", want, buf.String())
 	}
 }
 

--- a/core/common/funcs_test.go
+++ b/core/common/funcs_test.go
@@ -141,6 +141,46 @@ func TestTemplateFuncsCSRFToken(t *testing.T) {
 	}
 }
 
+func TestVersionReleaseURL(t *testing.T) {
+	funcs := common.GetTemplateFuncs()
+	releaseURL, ok := funcs["versionReleaseURL"].(func(string) string)
+	if !ok {
+		t.Fatalf("versionReleaseURL func missing or has unexpected type")
+	}
+
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{
+			name:    "release version",
+			version: " v1.2.3 ",
+			want:    "https://github.com/arran4/goa4web/releases/tag/v1.2.3",
+		},
+		{
+			name:    "dev version",
+			version: "dev",
+		},
+		{
+			name:    "mixed case dev version",
+			version: " DeV ",
+		},
+		{
+			name:    "blank version",
+			version: "   ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := releaseURL(tt.version); got != tt.want {
+				t.Fatalf("versionReleaseURL(%q) = %q, want %q", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFooterLinksReleaseVersion(t *testing.T) {
 	origVersion := goa4web.Version
 	goa4web.Version = "v1.2.3"
@@ -159,29 +199,6 @@ func TestFooterLinksReleaseVersion(t *testing.T) {
 	want := `<a href="https://github.com/arran4/goa4web/releases/tag/v1.2.3">v1.2.3</a>`
 	if !strings.Contains(buf.String(), want) {
 		t.Fatalf("footer missing version release link %q in %s", want, buf.String())
-	}
-}
-
-func TestFooterDoesNotLinkDevVersionCaseInsensitive(t *testing.T) {
-	origVersion := goa4web.Version
-	goa4web.Version = "DEV"
-	defer func() {
-		goa4web.Version = origVersion
-	}()
-
-	cd := &common.CoreData{}
-	tmpl := templates.GetCompiledSiteTemplates(cd.Funcs(httptest.NewRequest("GET", "/", nil)), templates.WithSilence(true))
-
-	var buf bytes.Buffer
-	if err := tmpl.ExecuteTemplate(&buf, "footer", nil); err != nil {
-		t.Fatalf("ExecuteTemplate footer: %v", err)
-	}
-
-	if strings.Contains(buf.String(), "releases/tag/") {
-		t.Fatalf("footer linked dev version: %s", buf.String())
-	}
-	if !strings.Contains(buf.String(), "Version DEV") {
-		t.Fatalf("footer missing plain dev version in %s", buf.String())
 	}
 }
 

--- a/core/templates/site/footer.gohtml
+++ b/core/templates/site/footer.gohtml
@@ -2,7 +2,7 @@
 <div>
         Date and time is now: {{now}}<br>
         <em>Arran 2004-2005, 2023-2025; All works on this page copyrighted to their respective authors.</em><br>
-        {{ $version := version }}{{ $releaseURL := versionReleaseURL }}
+        {{ $version := version }}{{ $releaseURL := versionReleaseURL $version }}
         <a href="https://github.com/arran4/goa4web">GitHub</a> Version {{if $releaseURL}}<a href="{{ $releaseURL }}">{{ $version }}</a>{{else}}{{ $version }}{{end}}
 </div>
 {{end}}

--- a/core/templates/site/footer.gohtml
+++ b/core/templates/site/footer.gohtml
@@ -2,6 +2,7 @@
 <div>
         Date and time is now: {{now}}<br>
         <em>Arran 2004-2005, 2023-2025; All works on this page copyrighted to their respective authors.</em><br>
-        <a href="https://github.com/arran4/goa4web">GitHub</a> Version {{version}}
+        {{ $version := version }}{{ $releaseURL := versionReleaseURL }}
+        <a href="https://github.com/arran4/goa4web">GitHub</a> Version {{if $releaseURL}}<a href="{{ $releaseURL }}">{{ $version }}</a>{{else}}{{ $version }}{{end}}
 </div>
 {{end}}


### PR DESCRIPTION
## Summary
- Link released footer versions to the matching GitHub release tag
- Keep dev builds displayed as plain text
- Add a footer rendering regression test

## Tests
- go fmt ./...
- go vet ./...
- go test ./...