### PR TITLE
Fix textarea font styling to inherit from parent

### DIFF
--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -11,6 +11,8 @@ textarea {
         box-sizing: border-box;
         overflow-y: hidden;
         min-height: 5em;
+        font-size: inherit;
+        font-family: inherit;
 }
 
 #bottom {

--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -11,8 +11,7 @@ textarea {
         box-sizing: border-box;
         overflow-y: hidden;
         min-height: 5em;
-        font-size: inherit;
-        font-family: inherit;
+        font: inherit;
 }
 
 #bottom {


### PR DESCRIPTION
Fix textarea font styling to inherit from parent

Added `font-size: inherit;` and `font-family: inherit;` to the global `textarea` CSS block in `core/templates/assets/main.css`. This ensures that textareas throughout the application naturally match the typography of their parent elements, providing a more consistent visual experience with the surrounding text.

---
*PR created automatically by Jules for task [2000746049058281398](https://jules.google.com/task/2000746049058281398) started by @arran4*