### PR TITLE
Fix textarea autosize scroll jumping

### DIFF
--- a/core/templates/assets/pasteimg.js
+++ b/core/templates/assets/pasteimg.js
@@ -13,8 +13,11 @@
         return start;
     }
     function autoSize(el){
+        const scrollX = window.scrollX;
+        const scrollY = window.scrollY;
         el.style.height = 'auto';
         el.style.height = el.scrollHeight + 'px';
+        window.scrollTo(scrollX, scrollY);
     }
     function handleImagePaste(e, item) {
         e.preventDefault();

--- a/core/templates/assets/pasteimg.js
+++ b/core/templates/assets/pasteimg.js
@@ -13,11 +13,27 @@
         return start;
     }
     function autoSize(el){
+        const scrollableParents = [];
+        let parent = el.parentNode;
+        while (parent && parent instanceof HTMLElement && parent !== document.body && parent !== document.documentElement) {
+            if (parent.scrollHeight > parent.clientHeight || parent.scrollWidth > parent.clientWidth) {
+                scrollableParents.push({
+                    el: parent,
+                    top: parent.scrollTop,
+                    left: parent.scrollLeft
+                });
+            }
+            parent = parent.parentNode;
+        }
         const scrollX = window.scrollX;
         const scrollY = window.scrollY;
         el.style.height = 'auto';
         el.style.height = el.scrollHeight + 'px';
         window.scrollTo(scrollX, scrollY);
+        scrollableParents.forEach(p => {
+            p.el.scrollTop = p.top;
+            p.el.scrollLeft = p.left;
+        });
     }
     function handleImagePaste(e, item) {
         e.preventDefault();


### PR DESCRIPTION
Fixes an issue where typing in dynamically resizing textareas (like forum replies) causes the page scroll position to unexpectedly jump.

The `autoSize` function temporarily sets the element's height to 'auto' to calculate its new `scrollHeight`. This can temporarily reduce the page height, prompting the browser to adjust the scroll position. The fix stores `window.scrollX` and `window.scrollY` before this operation and instantly restores them afterwards.

---
*PR created automatically by Jules for task [694660586023075133](https://jules.google.com/task/694660586023075133) started by @arran4*