### PR TITLE
Fix Wikipedia OpenGraph fetching by setting User-Agent

### DIFF
--- a/internal/opengraph/fetch.go
+++ b/internal/opengraph/fetch.go
@@ -69,7 +69,12 @@ func Fetch(urlStr string, client *http.Client) (*Info, error) {
 
 		client = NewSafeClient()
 	}
-	resp, err := client.Get(urlStr)
+	req, err := http.NewRequest("GET", urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "goa4web/1.0 (+https://github.com/arran4/goa4web)")
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/opengraph/fetch.go
+++ b/internal/opengraph/fetch.go
@@ -80,7 +80,11 @@ func Fetch(urlStr string, client *http.Client) (*Info, error) {
 	}
 	defer resp.Body.Close()
 
-	doc, err := html.Parse(io.LimitReader(resp.Body, 5*1024*1024))
+	return Parse(io.LimitReader(resp.Body, 5*1024*1024))
+}
+
+func Parse(r io.Reader) (*Info, error) {
+	doc, err := html.Parse(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/opengraph/fetch_wikipedia_test.go
+++ b/internal/opengraph/fetch_wikipedia_test.go
@@ -1,0 +1,46 @@
+package opengraph
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchWikipediaReal(t *testing.T) {
+	html := `<!DOCTYPE html> <html class="client-nojs vector-feature-language-in-header-enabled vector-feature-language-in-main-menu-disabled vector-feature-language-in-main-page-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-1 vector-feature-appearance-pinned-clientpref-1 skin-theme-clientpref-day vector-sticky-header-enabled vector-toc-available skin-thumbsize-clientpref-standard" lang="en" dir="ltr"> <head> <meta charset="UTF-8"> <title>Gödel, Escher, Bach - Wikipedia</title> <meta name="generator" content="MediaWiki 1.47.0-wmf.4"> <meta name="referrer" content="origin"> <meta name="referrer" content="origin-when-cross-origin"> <meta name="robots" content="max-image-preview:standard"> <meta name="format-detection" content="telephone=no"> <meta property="og:image" content="https://upload.wikimedia.org/wikipedia/commons/8/8b/Godel%2C_Escher%2C_Bach_%28first_edition%29.jpg"> <meta property="og:image:width" content="780"> <meta property="og:image:height" content="1200"> <meta name="viewport" content="width=1120"> <meta property="og:title" content="Gödel, Escher, Bach - Wikipedia"> <meta property="og:type" content="website"> </head>`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(html))
+	}))
+	defer server.Close()
+
+	info, err := Fetch(server.URL, http.DefaultClient)
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+
+	if info.Title != "Gödel, Escher, Bach - Wikipedia" {
+		t.Errorf("Title = %q, want %q", info.Title, "Gödel, Escher, Bach - Wikipedia")
+	}
+	if info.Image != "https://upload.wikimedia.org/wikipedia/commons/8/8b/Godel%2C_Escher%2C_Bach_%28first_edition%29.jpg" {
+		t.Errorf("Image = %q", info.Image)
+	}
+}
+
+func TestFetchUserAgent(t *testing.T) {
+	var userAgent string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent = r.Header.Get("User-Agent")
+		w.Write([]byte(`<!DOCTYPE html><html><head><title>Test</title></head></html>`))
+	}))
+	defer server.Close()
+
+	_, err := Fetch(server.URL, http.DefaultClient)
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+
+	if userAgent != "goa4web/1.0 (+https://github.com/arran4/goa4web)" {
+		t.Errorf("User-Agent = %q, want %q", userAgent, "goa4web/1.0 (+https://github.com/arran4/goa4web)")
+	}
+}

--- a/internal/opengraph/fetch_wikipedia_test.go
+++ b/internal/opengraph/fetch_wikipedia_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-func TestFetchWikipediaReal(t *testing.T) {
-	html := `<!DOCTYPE html> <html class="client-nojs vector-feature-language-in-header-enabled vector-feature-language-in-main-menu-disabled vector-feature-language-in-main-page-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-1 vector-feature-appearance-pinned-clientpref-1 skin-theme-clientpref-day vector-sticky-header-enabled vector-toc-available skin-thumbsize-clientpref-standard" lang="en" dir="ltr"> <head> <meta charset="UTF-8"> <title>Gödel, Escher, Bach - Wikipedia</title> <meta name="generator" content="MediaWiki 1.47.0-wmf.4"> <meta name="referrer" content="origin"> <meta name="referrer" content="origin-when-cross-origin"> <meta name="robots" content="max-image-preview:standard"> <meta name="format-detection" content="telephone=no"> <meta property="og:image" content="https://upload.wikimedia.org/wikipedia/commons/8/8b/Godel%2C_Escher%2C_Bach_%28first_edition%29.jpg"> <meta property="og:image:width" content="780"> <meta property="og:image:height" content="1200"> <meta name="viewport" content="width=1120"> <meta property="og:title" content="Gödel, Escher, Bach - Wikipedia"> <meta property="og:type" content="website"> </head>`
+func TestFetchWikipedia(t *testing.T) {
+	html := `<!DOCTYPE html><html><head><title>Gödel, Escher, Bach - Wikipedia</title><meta property="og:image" content="https://upload.wikimedia.org/wikipedia/commons/8/8b/Godel%2C_Escher%2C_Bach_%28first_edition%29.jpg"><meta property="og:title" content="Gödel, Escher, Bach - Wikipedia"></head>`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(html))

--- a/internal/opengraph/fetch_wikipedia_test.go
+++ b/internal/opengraph/fetch_wikipedia_test.go
@@ -4,19 +4,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"strings"
 )
 
 func TestFetchWikipedia(t *testing.T) {
 	html := `<!DOCTYPE html><html><head><title>Gödel, Escher, Bach - Wikipedia</title><meta property="og:image" content="https://upload.wikimedia.org/wikipedia/commons/8/8b/Godel%2C_Escher%2C_Bach_%28first_edition%29.jpg"><meta property="og:title" content="Gödel, Escher, Bach - Wikipedia"></head>`
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(html))
-	}))
-	defer server.Close()
-
-	info, err := Fetch(server.URL, http.DefaultClient)
+	info, err := Parse(strings.NewReader(html))
 	if err != nil {
-		t.Fatalf("Fetch() error = %v", err)
+		t.Fatalf("Parse() error = %v", err)
 	}
 
 	if info.Title != "Gödel, Escher, Bach - Wikipedia" {


### PR DESCRIPTION
Fixes an issue where social media / open graph data was not properly loading for Wikipedia. This was caused by Wikipedia blocking requests with the default Go HTTP client User-Agent.

Changes:
- Modified `internal/opengraph/fetch.go` to use `http.NewRequest` instead of `client.Get`.
- Set a custom `User-Agent` header (`goa4web/1.0 (+https://github.com/arran4/goa4web)`).
- Added test coverage in `internal/opengraph/fetch_wikipedia_test.go` including a test that asserts the correct parsing of Wikipedia OpenGraph data and a test that asserts the User-Agent header is properly set.

---
*PR created automatically by Jules for task [6756446002894836320](https://jules.google.com/task/6756446002894836320) started by @arran4*