### PR TITLE
Add icons to navigation menu

### DIFF
--- a/core/common/coredata.go
+++ b/core/common/coredata.go
@@ -73,6 +73,7 @@ func (lc *LanguageCache) Invalidate() {
 
 // IndexItem represents a navigation item linking to site sections.
 type IndexItem struct {
+	Icon         template.HTML
 	Name         string
 	Link         string
 	TemplateName string

--- a/core/templates/site/index.gohtml
+++ b/core/templates/site/index.gohtml
@@ -29,7 +29,7 @@
     {{- end }}
     {{ if cd.HasAdminRole }}
         {{ if cd.AdminMode }}
-            <a href="{{ addmode "/admin" }}">Admin Dashboard</a><br>
+            <a href="{{ addmode "/admin" }}">⚙️ Admin Dashboard</a><br>
         {{ end }}
     {{ end }}
 {{- end}}

--- a/core/templates/site/index.gohtml
+++ b/core/templates/site/index.gohtml
@@ -7,7 +7,7 @@
             {{ if ne $i.TemplateName "" }}
                 {{ include $i.TemplateName $i.TemplateData }}
             {{ else }}
-                <a href="{{ addmode $i.Link }}">{{ if $i.Icon }}{{ $i.Icon }} {{ end }}{{ $i.Name }}</a><br>
+                <a href="{{ addmode $i.Link }}" style="text-decoration: none;">{{ if $i.Icon }}{{ $i.Icon }}&nbsp;{{ end }}<span style="text-decoration: underline;">{{ $i.Name }}</span></a><br>
             {{ end }}
         {{- else }}
             {{- $advanced = true }}
@@ -21,7 +21,7 @@
                     {{ if ne $i.TemplateName "" }}
                         {{ include $i.TemplateName $i.TemplateData }}
                     {{ else }}
-                        <a href="{{ addmode $i.Link }}">{{ if $i.Icon }}{{ $i.Icon }} {{ end }}{{ $i.Name }}</a><br>
+                        <a href="{{ addmode $i.Link }}" style="text-decoration: none;">{{ if $i.Icon }}{{ $i.Icon }}&nbsp;{{ end }}<span style="text-decoration: underline;">{{ $i.Name }}</span></a><br>
                     {{ end }}
                 {{- end }}
             {{- end }}
@@ -29,7 +29,7 @@
     {{- end }}
     {{ if cd.HasAdminRole }}
         {{ if cd.AdminMode }}
-            <a href="{{ addmode "/admin" }}">⚙️ Admin Dashboard</a><br>
+            <a href="{{ addmode "/admin" }}" style="text-decoration: none;">⚙️&nbsp;<span style="text-decoration: underline;">Admin Dashboard</span></a><br>
         {{ end }}
     {{ end }}
 {{- end}}

--- a/core/templates/site/index.gohtml
+++ b/core/templates/site/index.gohtml
@@ -7,7 +7,7 @@
             {{ if ne $i.TemplateName "" }}
                 {{ include $i.TemplateName $i.TemplateData }}
             {{ else }}
-                <a href="{{ addmode $i.Link }}">{{ $i.Name }}</a><br>
+                <a href="{{ addmode $i.Link }}">{{ if $i.Icon }}{{ $i.Icon }} {{ end }}{{ $i.Name }}</a><br>
             {{ end }}
         {{- else }}
             {{- $advanced = true }}
@@ -21,7 +21,7 @@
                     {{ if ne $i.TemplateName "" }}
                         {{ include $i.TemplateName $i.TemplateData }}
                     {{ else }}
-                        <a href="{{ addmode $i.Link }}">{{ $i.Name }}</a><br>
+                        <a href="{{ addmode $i.Link }}">{{ if $i.Icon }}{{ $i.Icon }} {{ end }}{{ $i.Name }}</a><br>
                     {{ end }}
                 {{- end }}
             {{- end }}

--- a/core/templates/site/indexItems.gohtml
+++ b/core/templates/site/indexItems.gohtml
@@ -1,5 +1,5 @@
 {{- define "indexItems"}}
     {{ range $i := cd.IndexItems }}
-        <a href="{{ addmode $i.Link }}" {{ if eq $i.Link "/usr/notifications" }}id="notif-index"{{ end }}>{{ $i.Name }}</a><br>
+        <a href="{{ addmode $i.Link }}" {{ if eq $i.Link "/usr/notifications" }}id="notif-index"{{ end }} style="text-decoration: none;">{{ if $i.Icon }}{{ $i.Icon }}&nbsp;{{ end }}<span style="text-decoration: underline;">{{ $i.Name }}</span></a><br>
     {{ end }}
 {{- end}}

--- a/core/templates/site/indexItems.gohtml
+++ b/core/templates/site/indexItems.gohtml
@@ -1,5 +1,5 @@
 {{- define "indexItems"}}
     {{ range $i := cd.IndexItems }}
-        <a href="{{ addmode $i.Link }}" {{ if eq $i.Link "/usr/notifications" }}id="notif-index"{{ end }}>{{ $i.Name }}</a><br>
+        <a href="{{ addmode $i.Link }}" {{ if eq $i.Link "/usr/notifications" }}id="notif-index"{{ end }}>{{ if $i.Icon }}{{ $i.Icon }} {{ end }}{{ $i.Name }}</a><br>
     {{ end }}
 {{- end}}

--- a/core/templates/site/indexItems.gohtml
+++ b/core/templates/site/indexItems.gohtml
@@ -1,5 +1,5 @@
 {{- define "indexItems"}}
     {{ range $i := cd.IndexItems }}
-        <a href="{{ addmode $i.Link }}" {{ if eq $i.Link "/usr/notifications" }}id="notif-index"{{ end }}>{{ if $i.Icon }}{{ $i.Icon }} {{ end }}{{ $i.Name }}</a><br>
+        <a href="{{ addmode $i.Link }}" {{ if eq $i.Link "/usr/notifications" }}id="notif-index"{{ end }}>{{ $i.Name }}</a><br>
     {{ end }}
 {{- end}}

--- a/core/templates/site/userPanel.gohtml
+++ b/core/templates/site/userPanel.gohtml
@@ -1,9 +1,9 @@
 {{ define "userPanel" }}
     <hr>
     {{ if cd.UserID }}
-        <a href="/usr">⚙️ Preferences</a><br>
-        <a href="/usr/notifications" id="notif-index">🔔 Notifications{{ if gt cd.NotificationCount 0 }} ({{ cd.NotificationCount }}){{ end }}</a><br>
-        <a href="/usr/logout">🚪 Logout</a><br>
+        <a href="/usr" style="text-decoration: none;">⚙️&nbsp;<span style="text-decoration: underline;">Preferences</span></a><br>
+        <a href="/usr/notifications" id="notif-index" style="text-decoration: none;">🔔&nbsp;<span style="text-decoration: underline;">Notifications</span>{{ if gt cd.NotificationCount 0 }} <span style="text-decoration: underline;">({{ cd.NotificationCount }})</span>{{ end }}</a><br>
+        <a href="/usr/logout" style="text-decoration: none;">🚪&nbsp;<span style="text-decoration: underline;">Logout</span></a><br>
     {{ end }}
     <hr>
 {{ end }}

--- a/core/templates/site/userPanel.gohtml
+++ b/core/templates/site/userPanel.gohtml
@@ -1,9 +1,9 @@
 {{ define "userPanel" }}
     <hr>
     {{ if cd.UserID }}
-        <a href="/usr">Preferences</a><br>
-        <a href="/usr/notifications" id="notif-index">Notifications{{ if gt cd.NotificationCount 0 }} ({{ cd.NotificationCount }}){{ end }}</a><br>
-        <a href="/usr/logout">Logout</a><br>
+        <a href="/usr">⚙️ Preferences</a><br>
+        <a href="/usr/notifications" id="notif-index">🔔 Notifications{{ if gt cd.NotificationCount 0 }} ({{ cd.NotificationCount }}){{ end }}</a><br>
+        <a href="/usr/logout">🚪 Logout</a><br>
     {{ end }}
     <hr>
 {{ end }}

--- a/handlers/blogs/customindex.go
+++ b/handlers/blogs/customindex.go
@@ -33,14 +33,14 @@ func BlogsGeneralIndexItems(cd *common.CoreData, r *http.Request) []common.Index
 
 	if cd.IsAdmin() {
 		items = append(items, common.IndexItem{
-			Name: "Blogs Admin",
+			Name: "Blogs Admin", Icon: "⚙️",
 			Link: "/admin/blogs",
 		})
 	}
 	userCanPost := cd.HasGrant("blogs", "entry", "post", 0)
 	if userCanPost {
 		items = append(items, common.IndexItem{
-			Name: "Write blog",
+			Name: "Write blog", Icon: "✍️",
 			Link: "/blogs/add",
 		})
 	}

--- a/handlers/blogs/routes.go
+++ b/handlers/blogs/routes.go
@@ -17,7 +17,7 @@ import (
 // RegisterRoutes attaches the public blog endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) []navpkg.RouterOptions {
 	opts := []navpkg.RouterOptions{
-		navpkg.NewIndexLinkWithViewPermission("Blogs", "/blogs", SectionWeight, "blogs", "entry"),
+		navpkg.NewIndexLinkWithViewPermission("Blogs", "/blogs", "📝", SectionWeight, "blogs", "entry"),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("Blogs"), "Blogs", "/admin/blogs", SectionWeight),
 	}
 	br := r.PathPrefix("/blogs").Subrouter()

--- a/handlers/bookmarks/routes.go
+++ b/handlers/bookmarks/routes.go
@@ -15,7 +15,7 @@ import (
 // RegisterRoutes attaches the bookmarks endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) []navpkg.RouterOptions {
 	opts := []navpkg.RouterOptions{
-		navpkg.NewIndexLink("Bookmarks", "/bookmarks", SectionWeight),
+		navpkg.NewIndexLink("Bookmarks", "/bookmarks", "🔖", SectionWeight),
 	}
 	br := r.PathPrefix("/bookmarks").Subrouter()
 	br.NotFoundHandler = http.HandlerFunc(handlers.RenderNotFoundOrLogin)

--- a/handlers/faq/page.go
+++ b/handlers/faq/page.go
@@ -40,7 +40,7 @@ func CustomFAQIndex(data *common.CoreData, r *http.Request) {
 	data.CustomIndexItems = []common.IndexItem{}
 	if data.HasGrant("faq", "question", "post", 0) {
 		data.CustomIndexItems = append(data.CustomIndexItems, common.IndexItem{
-			Name: "Ask",
+			Name: "Ask", Icon: "❓",
 			Link: "/faq/ask",
 		})
 	}

--- a/handlers/faq/routes.go
+++ b/handlers/faq/routes.go
@@ -19,7 +19,7 @@ func noTask() mux.MatcherFunc {
 // RegisterRoutes attaches the public FAQ endpoints to the router.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) []navpkg.RouterOptions {
 	opts := []navpkg.RouterOptions{
-		navpkg.NewIndexLinkWithViewPermission("Help", "/faq", SectionWeight, "faq", "question/answer"),
+		navpkg.NewIndexLinkWithViewPermission("Help", "/faq", "❓", SectionWeight, "faq", "question/answer"),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("Help"), "Help Questions", "/admin/faq/questions", SectionWeight),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("Help"), "FAQ Templates", "/admin/faq/templates", SectionWeight+1),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("Help"), "Help Categories", "/admin/faq/categories", SectionWeight+2),

--- a/handlers/forum/customindex.go
+++ b/handlers/forum/customindex.go
@@ -51,7 +51,7 @@ func ForumCustomIndexItems(cd *common.CoreData, r *http.Request) []common.IndexI
 		if hasThreadUnread(cd, threadID) {
 			items = append(items,
 				common.IndexItem{
-					Name: "Mark as read",
+					Name: "Mark as read", Icon: "✔️",
 					Link: markThreadReadLink(base, threadID, r.URL.RequestURI()),
 				},
 				common.IndexItem{
@@ -67,7 +67,7 @@ func ForumCustomIndexItems(cd *common.CoreData, r *http.Request) []common.IndexI
 		if tid, err := strconv.Atoi(topicID); err == nil && cd.HasGrant(section, "topic", "reply", int32(tid)) {
 			items = append(items,
 				common.IndexItem{
-					Name: "Write Reply",
+					Name: "Write Reply", Icon: "✍️",
 					Link: fmt.Sprintf("%s/topic/%s/thread/%s#reply", base, topicID, threadID),
 				},
 			)
@@ -89,7 +89,7 @@ func ForumCustomIndexItems(cd *common.CoreData, r *http.Request) []common.IndexI
 	if threadID == "" && topicID != "" {
 		if cd.IsAdmin() && cd.IsAdminMode() {
 			items = append(items, common.IndexItem{
-				Name: "Admin Edit Topic",
+				Name: "Admin Edit Topic", Icon: "⚙️",
 				Link: fmt.Sprintf("/admin/forum/topics/topic/%s/edit", topicID),
 			})
 		}
@@ -126,7 +126,7 @@ func ForumCustomIndexItems(cd *common.CoreData, r *http.Request) []common.IndexI
 				} else {
 					items = append(items,
 						common.IndexItem{
-							Name: "Subscribe To Topic",
+							Name: "Subscribe To Topic", Icon: "🔔",
 							Link: fmt.Sprintf("%s/topic/%s/subscribe", base, topicID),
 						},
 					)

--- a/handlers/forum/routes.go
+++ b/handlers/forum/routes.go
@@ -17,7 +17,7 @@ import (
 // RegisterRoutes attaches the public forum endpoints to r.
 func RegisterRoutes(r *mux.Router, cfg *config.RuntimeConfig) []navpkg.RouterOptions {
 	opts := []navpkg.RouterOptions{
-		navpkg.NewIndexLinkWithViewPermission("Forum", "/forum", SectionWeight, "forum", "category"),
+		navpkg.NewIndexLinkWithViewPermission("Forum", "/forum", "💬", SectionWeight, "forum", "category"),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("Forum"), "Forum", "/admin/forum", SectionWeight),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("Forum"), "Flagged Posts", "/admin/forum/flagged", SectionWeight+1),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("Forum"), "Moderator Logs", "/admin/forum/logs", SectionWeight+2),

--- a/handlers/imagebbs/routes.go
+++ b/handlers/imagebbs/routes.go
@@ -15,7 +15,7 @@ import (
 // RegisterRoutes attaches the public image board endpoints to r.
 func RegisterRoutes(r *mux.Router, cfg *config.RuntimeConfig) []navpkg.RouterOptions {
 	opts := []navpkg.RouterOptions{
-		navpkg.NewIndexLinkWithViewPermission("ImageBBS", "/imagebbs", SectionWeight, "imagebbs", "board"),
+		navpkg.NewIndexLinkWithViewPermission("ImageBBS", "/imagebbs", `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-image"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><circle cx="8.5" cy="8.5" r="1.5"></circle><polyline points="21 15 16 10 5 21"></polyline></svg>`, SectionWeight, "imagebbs", "board"),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("ImageBBS"), "ImageBBS", "/admin/imagebbs", SectionWeight),
 	}
 	ibr := r.PathPrefix("/imagebbs").Subrouter()

--- a/handlers/linker/routes.go
+++ b/handlers/linker/routes.go
@@ -17,7 +17,7 @@ var legacyRedirectsEnabled = true
 // RegisterRoutes attaches the public linker endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) []navpkg.RouterOptions {
 	opts := []navpkg.RouterOptions{
-		navpkg.NewIndexLinkWithViewPermission("Linker", "/linker", SectionWeight, "linker", "category"),
+		navpkg.NewIndexLinkWithViewPermission("Linker", "/linker", "🔗", SectionWeight, "linker", "category"),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("Linker"), "Linker", "/admin/linker", SectionWeight),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("Linker"), "Categories", "/admin/linker/categories", SectionWeight+1),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("Linker"), "Links", "/admin/linker/links", SectionWeight+2),

--- a/handlers/news/customindex.go
+++ b/handlers/news/customindex.go
@@ -33,7 +33,7 @@ func NewsGeneralIndexItems(cd *common.CoreData, r *http.Request) []common.IndexI
 
 	if CanPostNews(cd) {
 		items = append(items, common.IndexItem{
-			Name: "Add News",
+			Name: "Add News", Icon: "➕",
 			Link: "/news/post",
 		})
 	}

--- a/handlers/news/routes.go
+++ b/handlers/news/routes.go
@@ -18,7 +18,7 @@ import (
 // RegisterRoutes attaches the public news endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) []navpkg.RouterOptions {
 	opts := []navpkg.RouterOptions{
-		navpkg.NewIndexLinkWithViewPermission("News", "/", SectionWeight, "news", "post"),
+		navpkg.NewIndexLinkWithViewPermission("News", "/", "📰", SectionWeight, "news", "post"),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("News"), "News", "/admin/news", SectionWeight),
 	}
 	r.Use(handlers.IndexMiddleware(CustomNewsIndex), handlers.SectionMiddleware("news"))

--- a/handlers/privateforum/customindex.go
+++ b/handlers/privateforum/customindex.go
@@ -18,7 +18,7 @@ var CustomIndex = func(cd *common.CoreData, r *http.Request) {
 
 	if topicID == "" {
 		items = []common.IndexItem{{
-			Name: "Create New private topic",
+			Name: "Create New private topic", Icon: "🔒",
 			Link: "/private/topic/new",
 		}}
 	} else {

--- a/handlers/privateforum/routes.go
+++ b/handlers/privateforum/routes.go
@@ -16,7 +16,7 @@ import (
 // RegisterRoutes attaches the private forum endpoints to r.
 func RegisterRoutes(r *mux.Router, cfg *config.RuntimeConfig) []navpkg.RouterOptions {
 	opts := []navpkg.RouterOptions{
-		navpkg.NewIndexLinkWithViewPermission("Private", "/private", SectionWeight, "privateforum", "topic"),
+		navpkg.NewIndexLinkWithViewPermission("Private", "/private", "🔒", SectionWeight, "privateforum", "topic"),
 	}
 	pr := r.PathPrefix("/private").Subrouter()
 	pr.NotFoundHandler = http.HandlerFunc(handlers.RenderNotFoundOrLogin)

--- a/handlers/search/routes.go
+++ b/handlers/search/routes.go
@@ -12,7 +12,7 @@ import (
 // RegisterRoutes attaches the search endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) []navpkg.RouterOptions {
 	opts := []navpkg.RouterOptions{
-		navpkg.NewIndexLink("Search", "/search", SectionWeight),
+		navpkg.NewIndexLink("Search", "/search", `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-search"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`, SectionWeight),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("Search"), "Search", "/admin/search", SectionWeight),
 	}
 	sr := r.PathPrefix("/search").Subrouter()

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -19,7 +19,7 @@ var legacyRedirectsEnabled = true
 // RegisterRoutes attaches the public writings endpoints to r.
 func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) []navpkg.RouterOptions {
 	opts := []navpkg.RouterOptions{
-		navpkg.NewIndexLinkWithViewPermission("Writings", "/writings", SectionWeight, "writing", "category"),
+		navpkg.NewIndexLinkWithViewPermission("Writings", "/writings", "✍", SectionWeight, "writing", "category"),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("Writings"), "Writings", "/admin/writings", SectionWeight),
 		navpkg.NewAdminControlCenterLink(navpkg.AdminCCCategory("Writings"), "Categories", "/admin/writings/categories", SectionWeight+1),
 	}

--- a/internal/navigation/options.go
+++ b/internal/navigation/options.go
@@ -1,5 +1,7 @@
 package navigation
 
+import "html/template"
+
 // RouterOptions defines an option that can apply changes to the navigation registry.
 type RouterOptions interface {
 	Apply(*Registry)
@@ -9,34 +11,36 @@ type RouterOptions interface {
 type IndexLinkOption struct {
 	Name   string
 	URL    string
+	Icon   template.HTML
 	Weight int
 }
 
 func (o *IndexLinkOption) Apply(r *Registry) {
-	r.RegisterIndexLink(o.Name, o.URL, o.Weight)
+	r.RegisterIndexLink(o.Name, o.URL, o.Icon, o.Weight)
 }
 
 // NewIndexLink creates a new IndexLinkOption.
-func NewIndexLink(name, url string, weight int) RouterOptions {
-	return &IndexLinkOption{Name: name, URL: url, Weight: weight}
+func NewIndexLink(name, url string, icon template.HTML, weight int) RouterOptions {
+	return &IndexLinkOption{Name: name, URL: url, Icon: icon, Weight: weight}
 }
 
 // IndexLinkWithViewPermissionOption represents an index link registration with view permission.
 type IndexLinkWithViewPermissionOption struct {
 	Name        string
 	URL         string
+	Icon        template.HTML
 	Weight      int
 	ViewSection string
 	ViewItem    string
 }
 
 func (o *IndexLinkWithViewPermissionOption) Apply(r *Registry) {
-	r.RegisterIndexLinkWithViewPermission(o.Name, o.URL, o.Weight, o.ViewSection, o.ViewItem)
+	r.RegisterIndexLinkWithViewPermission(o.Name, o.URL, o.Icon, o.Weight, o.ViewSection, o.ViewItem)
 }
 
 // NewIndexLinkWithViewPermission creates a new IndexLinkWithViewPermissionOption.
-func NewIndexLinkWithViewPermission(name, url string, weight int, section, item string) RouterOptions {
-	return &IndexLinkWithViewPermissionOption{Name: name, URL: url, Weight: weight, ViewSection: section, ViewItem: item}
+func NewIndexLinkWithViewPermission(name, url string, icon template.HTML, weight int, section, item string) RouterOptions {
+	return &IndexLinkWithViewPermissionOption{Name: name, URL: url, Icon: icon, Weight: weight, ViewSection: section, ViewItem: item}
 }
 
 // AdminControlCenterLinkOption represents an admin control center link registration.

--- a/internal/navigation/options.go
+++ b/internal/navigation/options.go
@@ -11,7 +11,7 @@ type RouterOptions interface {
 type IndexLinkOption struct {
 	Name   string
 	URL    string
-	Icon   template.HTML
+	Icon        template.HTML
 	Weight int
 }
 

--- a/internal/navigation/registry.go
+++ b/internal/navigation/registry.go
@@ -1,6 +1,7 @@
 package navigation
 
 import (
+	"html/template"
 	"sort"
 	"strings"
 
@@ -40,6 +41,7 @@ type link struct {
 	section     string
 	name        string
 	link        string
+	icon        template.HTML
 	weight      int
 	viewSection string
 	viewItem    string
@@ -55,14 +57,14 @@ type Registry struct {
 func NewRegistry() *Registry { return &Registry{} }
 
 // RegisterIndexLink registers an entry for the site's index navigation.
-func (r *Registry) RegisterIndexLink(name, url string, weight int) {
-	r.index = append(r.index, link{name: name, link: url, weight: weight})
+func (r *Registry) RegisterIndexLink(name, url string, icon template.HTML, weight int) {
+	r.index = append(r.index, link{name: name, link: url, icon: icon, weight: weight})
 }
 
 // RegisterIndexLinkWithViewPermission registers an entry for the site's index navigation that
 // requires view permission for the provided section and item.
-func (r *Registry) RegisterIndexLinkWithViewPermission(name, url string, weight int, section, item string) {
-	r.index = append(r.index, link{name: name, link: url, weight: weight, viewSection: section, viewItem: item})
+func (r *Registry) RegisterIndexLinkWithViewPermission(name, url string, icon template.HTML, weight int, section, item string) {
+	r.index = append(r.index, link{name: name, link: url, icon: icon, weight: weight, viewSection: section, viewItem: item})
 }
 
 // RegisterAdminControlCenter registers a link for the admin control center menu in the given section.
@@ -97,7 +99,7 @@ func (r *Registry) IndexItemsWithPermission(canView func(section, item string) b
 				continue
 			}
 		}
-		items = append(items, common.IndexItem{Name: e.name, Link: e.link})
+		items = append(items, common.IndexItem{Name: e.name, Link: e.link, Icon: e.icon})
 	}
 	return items
 }
@@ -109,7 +111,7 @@ func (r *Registry) AdminLinks() []common.IndexItem {
 	sort.Slice(entries, func(i, j int) bool { return entries[i].weight < entries[j].weight })
 	items := make([]common.IndexItem, 0, len(entries))
 	for _, e := range entries {
-		items = append(items, common.IndexItem{Name: e.name, Link: e.link})
+		items = append(items, common.IndexItem{Name: e.name, Link: e.link, Icon: e.icon})
 	}
 	return items
 }
@@ -164,7 +166,7 @@ func (r *Registry) AdminSections() []common.AdminSection {
 		}
 
 		// Add item to leaf
-		current.Links = append(current.Links, common.IndexItem{Name: e.name, Link: e.link})
+		current.Links = append(current.Links, common.IndexItem{Name: e.name, Link: e.link, Icon: e.icon})
 	}
 
 	// Optimization/Merge pass + Conversion
@@ -207,14 +209,14 @@ func SetDefaultRegistry(r *Registry) {
 }
 
 // RegisterIndexLink registers an entry for the site's index navigation using the default registry.
-func RegisterIndexLink(name, url string, weight int) {
-	defaultRegistry.RegisterIndexLink(name, url, weight)
+func RegisterIndexLink(name, url string, icon template.HTML, weight int) {
+	defaultRegistry.RegisterIndexLink(name, url, icon, weight)
 }
 
 // RegisterIndexLinkWithViewPermission registers an entry for the site's index navigation using the default registry that
 // requires view permission for the provided section and item.
-func RegisterIndexLinkWithViewPermission(name, url string, weight int, section, item string) {
-	defaultRegistry.RegisterIndexLinkWithViewPermission(name, url, weight, section, item)
+func RegisterIndexLinkWithViewPermission(name, url string, icon template.HTML, weight int, section, item string) {
+	defaultRegistry.RegisterIndexLinkWithViewPermission(name, url, icon, weight, section, item)
 }
 
 // RegisterAdminControlCenter registers a link for the admin control center menu using the default registry.

--- a/internal/navigation/registry_test.go
+++ b/internal/navigation/registry_test.go
@@ -8,8 +8,8 @@ func TestIndexItemsOrdering(t *testing.T) {
 	defaultRegistry = NewRegistry()
 	t.Cleanup(func() { defaultRegistry = NewRegistry() })
 
-	RegisterIndexLink("b", "/b", 20)
-	RegisterIndexLink("a", "/a", 10)
+	RegisterIndexLink("b", "/b", "", 20)
+	RegisterIndexLink("a", "/a", "", 10)
 	RegisterAdminControlCenter("sec", "b", "/admin/b", 20)
 	RegisterAdminControlCenter("sec", "a", "/admin/a", 10)
 
@@ -49,8 +49,8 @@ func TestIndexItemsPermissionFilter(t *testing.T) {
 	defaultRegistry = NewRegistry()
 	t.Cleanup(func() { defaultRegistry = NewRegistry() })
 
-	RegisterIndexLinkWithViewPermission("protected", "/protected", 5, "news", "post")
-	RegisterIndexLink("public", "/public", 10)
+	RegisterIndexLinkWithViewPermission("protected", "/protected", "", 5, "news", "post")
+	RegisterIndexLink("public", "/public", "", 10)
 
 	items := IndexItemsWithPermission(func(section, item string) bool {
 		return section == "news" && item == "post"


### PR DESCRIPTION
Adds support for rendering icons alongside left-hand side menu navigation links using a mix of Emoji, Unicode, and Embedded SVGs.

- Updated `IndexItem` struct in `core/common/coredata.go` to include `Icon template.HTML`.
- Updated `internal/navigation/registry.go` and `internal/navigation/options.go` to support adding an icon when registering an index link.
- Updated route handlers across all modules to supply an appropriate icon.
- Updated `core/templates/site/indexItems.gohtml` to optionally render the icon.

---
*PR created automatically by Jules for task [8909302686767607544](https://jules.google.com/task/8909302686767607544) started by @arran4*