### PR TITLE
🧪 Add test for AllowedExtension in internal/images/validation.go

### DIFF
--- a/internal/images/validation_test.go
+++ b/internal/images/validation_test.go
@@ -50,3 +50,29 @@ func TestValidID(t *testing.T) {
 		}
 	}
 }
+
+func TestAllowedExtension(t *testing.T) {
+	tests := []struct {
+		ext  string
+		want bool
+	}{
+		{ext: ".jpg", want: true},
+		{ext: ".jpeg", want: true},
+		{ext: ".png", want: true},
+		{ext: ".gif", want: true},
+		{ext: ".JPG", want: true},
+		{ext: ".Png", want: true},
+		{ext: ".bmp", want: false},
+		{ext: "jpg", want: false},
+		{ext: "", want: false},
+		{ext: ".txt", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ext, func(t *testing.T) {
+			if got := AllowedExtension(tt.ext); got != tt.want {
+				t.Errorf("AllowedExtension(%q) = %v, want %v", tt.ext, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the `AllowedExtension` function in `internal/images/validation.go` which was previously lacking coverage.
📊 **Coverage:** The table-driven tests now cover valid cases (like `.jpg`, `.png`), mixed case inputs (`.JPG`), invalid extensions (`.bmp`, `.txt`), and edge cases like missing dots (`jpg`) and empty string.
✨ **Result:** Increased code reliability and confidence for future refactoring of image validation logic.

---
*PR created automatically by Jules for task [16813545502946245375](https://jules.google.com/task/16813545502946245375) started by @arran4*