### PR TITLE
🧹 Extract writing article view access enforcement into a middleware

### DIFF
--- a/handlers/writings/matchers.go
+++ b/handlers/writings/matchers.go
@@ -66,3 +66,35 @@ func RequireWritingAuthor(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
+
+// RequireWritingViewAccess ensures the user has permission to view the article
+// specified in the URL path. It sets the current thread and topic on success.
+func RequireWritingViewAccess(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData)
+		if !ok {
+			handlers.RenderErrorPage(w, r, common.ErrInternalServerError)
+			return
+		}
+
+		cd.LoadSelectionsFromRequest(r)
+		writing, err := cd.Article()
+		if err != nil {
+			log.Printf("get writing for access check: %v", err)
+			handlers.RenderErrorPage(w, r, handlers.ErrNotFound)
+			return
+		}
+		if writing == nil {
+			handlers.RenderErrorPage(w, r, handlers.ErrNotFound)
+			return
+		}
+
+		cd.SetCurrentThreadAndTopic(writing.ForumthreadID, 0)
+		if !(cd.HasGrant("writing", "article", "view", writing.Idwriting) || cd.SelectedThreadCanReply()) {
+			handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/handlers/writings/routes.go
+++ b/handlers/writings/routes.go
@@ -43,7 +43,7 @@ func RegisterRoutes(r *mux.Router, _ *config.RuntimeConfig) []navpkg.RouterOptio
 	wr.HandleFunc("/shared/article/{writing}/ts/{ts}/sign/{sign}", SharedPreviewPage).Methods("GET", "HEAD")
 	wr.HandleFunc("/shared/article/{writing}/nonce/{nonce}/sign/{sign}", SharedPreviewPage).Methods("GET", "HEAD")
 
-	wr.HandleFunc("/article/{writing}", ArticlePage).Methods("GET")
+	wr.Handle("/article/{writing}", RequireWritingViewAccess(http.HandlerFunc(ArticlePage))).Methods("GET")
 	wr.HandleFunc("/article/{writing}", handlers.TaskHandler(replyTask)).Methods("POST").MatcherFunc(replyTask.Matcher())
 	wr.Handle("/article/{writing}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(handlers.TaskHandler(editReplyTask)))).Methods("POST").MatcherFunc(editReplyTask.Matcher())
 	wr.Handle("/article/{writing}/comment/{comment}", comments.RequireCommentAuthor(http.HandlerFunc(handlers.TaskHandler(cancelTask)))).Methods("POST").MatcherFunc(cancelTask.Matcher())

--- a/handlers/writings/writingsArticlePage.go
+++ b/handlers/writings/writingsArticlePage.go
@@ -52,12 +52,7 @@ func ArticlePage(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderErrorPage(w, r, fmt.Errorf("No writing found"))
 		return
 	}
-	cd.SetCurrentThreadAndTopic(writing.ForumthreadID, 0)
-	if !(cd.HasGrant("writing", "article", "view", writing.Idwriting) || cd.SelectedThreadCanReply()) {
-		// TODO: Fix: Add enforced Access in router rather than task
-		handlers.RenderErrorPage(w, r, handlers.ErrForbidden)
-		return
-	}
+
 	dateSuffix := ""
 	if writing.Published.Valid {
 		dateSuffix = fmt.Sprintf(" - %s", cd.FormatLocalTime(writing.Published.Time))


### PR DESCRIPTION
🎯 What: Extracted the explicit permissions and grant checking from ArticlePage into a new RequireWritingViewAccess middleware.
💡 Why: Applying access control logic via middleware in the router enhances modularity, prevents repetitive checks, cleans up handler code, and aligns with the project's refactoring direction (as noted in the existing TODO).
✅ Verification: Verified by running the entire test suite. Ensured related handler tests continue to pass.
✨ Result: Enhanced the separation of concerns by putting routing access policies inside the router and allowing the handler code to just serve the contents.

---
*PR created automatically by Jules for task [11981797674243607285](https://jules.google.com/task/11981797674243607285) started by @arran4*