### PR TITLE
Refactor private forum index link to "Go to topic"

### DIFF
--- a/handlers/forum/customindex.go
+++ b/handlers/forum/customindex.go
@@ -60,10 +60,12 @@ func ForumCustomIndexItems(cd *common.CoreData, r *http.Request) []common.IndexI
 				},
 			)
 		}
-		items = append(items, common.IndexItem{
-			Name: "Go to topic",
-			Link: fmt.Sprintf("%s/topic/%s", base, topicID),
-		})
+		if section != "privateforum" {
+			items = append(items, common.IndexItem{
+				Name: "Go to topic",
+				Link: fmt.Sprintf("%s/topic/%s", base, topicID),
+			})
+		}
 		if tid, err := strconv.Atoi(topicID); err == nil && cd.HasGrant(section, "topic", "reply", int32(tid)) {
 			items = append(items,
 				common.IndexItem{

--- a/handlers/privateforum/customindex.go
+++ b/handlers/privateforum/customindex.go
@@ -25,7 +25,7 @@ var CustomIndex = func(cd *common.CoreData, r *http.Request) {
 	} else {
 		if threadID != "" {
 			items = append(items, common.IndexItem{
-				Name: "Go to topic",
+				Name: "Go back",
 				Link: fmt.Sprintf("/private/topic/%s", topicID),
 			})
 		}

--- a/handlers/privateforum/customindex.go
+++ b/handlers/privateforum/customindex.go
@@ -14,6 +14,7 @@ import (
 var CustomIndex = func(cd *common.CoreData, r *http.Request) {
 	vars := mux.Vars(r)
 	topicID := vars["topic"]
+	threadID := vars["thread"]
 	items := []common.IndexItem{}
 
 	if topicID == "" {
@@ -22,10 +23,12 @@ var CustomIndex = func(cd *common.CoreData, r *http.Request) {
 			Link: "/private/topic/new",
 		}}
 	} else {
-		items = append(items, common.IndexItem{
-			Name: "Go back to Private Forum",
-			Link: "/private",
-		})
+		if threadID != "" {
+			items = append(items, common.IndexItem{
+				Name: "Go to topic",
+				Link: fmt.Sprintf("/private/topic/%s", topicID),
+			})
+		}
 		if tid, err := strconv.Atoi(topicID); err == nil {
 			if cd.HasGrant("privateforum", "topic", "edit", int32(tid)) {
 				items = append(items, common.IndexItem{

--- a/handlers/privateforum/customindex.go
+++ b/handlers/privateforum/customindex.go
@@ -25,7 +25,7 @@ var CustomIndex = func(cd *common.CoreData, r *http.Request) {
 	} else {
 		if threadID != "" {
 			items = append(items, common.IndexItem{
-				Name: "Go back",
+				Name: "Private topic list",
 				Link: fmt.Sprintf("/private/topic/%s", topicID),
 			})
 		}


### PR DESCRIPTION
As requested by the user, the redundant "Go back to Private Forum" link in the private forum left-hand side menu has been removed. It has been replaced by a "Go to topic" link that displays at the top of the menu, specifically when the user is viewing a thread, providing clearer context for navigating back. To prevent duplicate links, the generic forum handler was updated to suppress its standard "Go to topic" link when rendering within the private forum section.

---
*PR created automatically by Jules for task [3745174013852785793](https://jules.google.com/task/3745174013852785793) started by @arran4*