### PR TITLE
feat: extract keywords and additional fallback descriptions in OpenGraph fetcher

### DIFF
--- a/internal/opengraph/fetch.go
+++ b/internal/opengraph/fetch.go
@@ -22,6 +22,7 @@ type Info struct {
 	Duration    string
 	UploadDate  string
 	Author      string
+	Keywords    string
 }
 
 // NewSafeClient returns an http.Client configured to block internal IP addresses.
@@ -122,25 +123,38 @@ func Parse(r io.Reader) (*Info, error) {
 					}
 				}
 				switch prop {
-				case "og:title":
+				case "og:title", "twitter:title":
 					if info.Title == "" {
 						info.Title = content
 					}
-				case "og:description":
+				case "og:description", "twitter:description":
 					if info.Description == "" {
 						info.Description = content
 					}
-				case "og:image":
+				case "og:image", "twitter:image":
 					if info.Image == "" {
 						info.Image = content
 					}
 				}
 
-				if info.Title == "" && name == "title" {
+				if name == "twitter:title" && info.Title == "" {
 					info.Title = content
 				}
-				if info.Description == "" && name == "description" {
+				if name == "twitter:description" && info.Description == "" {
 					info.Description = content
+				}
+				if name == "twitter:image" && info.Image == "" {
+					info.Image = content
+				}
+
+				if info.Title == "" && (name == "title" || itemprop == "title") {
+					info.Title = content
+				}
+				if info.Description == "" && (name == "description" || itemprop == "description") {
+					info.Description = content
+				}
+				if info.Image == "" && (name == "image" || itemprop == "image") {
+					info.Image = content
 				}
 
 				// Fallbacks for new fields
@@ -159,6 +173,31 @@ func Parse(r io.Reader) (*Info, error) {
 				}
 				if info.Author == "" && name == "author" {
 					info.Author = content
+				}
+
+				if name == "keywords" || itemprop == "keywords" || prop == "article:tag" {
+					parts := strings.Split(content, ",")
+					for _, p := range parts {
+						p = strings.TrimSpace(p)
+						if p == "" {
+							continue
+						}
+						if info.Keywords == "" {
+							info.Keywords = p
+						} else {
+							existing := strings.Split(info.Keywords, ", ")
+							found := false
+							for _, e := range existing {
+								if e == p {
+									found = true
+									break
+								}
+							}
+							if !found {
+								info.Keywords += ", " + p
+							}
+						}
+					}
 				}
 			} else if n.Data == "title" && info.Title == "" {
 				if n.FirstChild != nil {
@@ -210,32 +249,67 @@ func parseJSONLD(data string, info *Info) {
 			return ""
 		}
 
-		// Prioritize VideoObject, but could extract generic info too if empty
-		if typeVal == "VideoObject" || strings.EqualFold(typeVal, "VideoObject") {
+		// Broaden JSON-LD parsing to general types, as they can also hold generic info (WebPage, PodcastEpisode, Article, etc.)
+		if typeVal == "VideoObject" || strings.EqualFold(typeVal, "VideoObject") ||
+			typeVal == "WebPage" || strings.EqualFold(typeVal, "WebPage") ||
+			typeVal == "PodcastEpisode" || strings.EqualFold(typeVal, "PodcastEpisode") ||
+			typeVal == "Article" || strings.EqualFold(typeVal, "Article") ||
+			typeVal == "NewsArticle" || strings.EqualFold(typeVal, "NewsArticle") || typeVal != "" {
 			// We prioritize JSON-LD over meta tags, so overwrite or only set if empty?
 			// The request says "Prioritize JSON-LD". So we should overwrite if we found it here.
 			// However, parseJSONLD is called during traversal.
 
-			if t := getString("name"); t != "" {
+			if t := getString("name"); t != "" && (typeVal == "VideoObject" || info.Title == "") {
 				info.Title = t
 			}
-			if d := getString("description"); d != "" {
+			if t := getString("headline"); t != "" && info.Title == "" {
+				info.Title = t
+			}
+			if d := getString("description"); d != "" && (typeVal == "VideoObject" || info.Description == "") {
 				info.Description = d
 			}
-			if dur := getString("duration"); dur != "" {
+			if dur := getString("duration"); dur != "" && (typeVal == "VideoObject" || info.Duration == "") {
 				info.Duration = dur
 			}
-			if ud := getString("uploadDate"); ud != "" {
+			if ud := getString("uploadDate"); ud != "" && (typeVal == "VideoObject" || info.UploadDate == "") {
 				info.UploadDate = ud
 			}
-			if auth := getAuthor(); auth != "" {
+			if ud := getString("datePublished"); ud != "" && info.UploadDate == "" {
+				info.UploadDate = ud
+			}
+			if auth := getAuthor(); auth != "" && (typeVal == "VideoObject" || info.Author == "") {
 				info.Author = auth
 			}
 
-			if img := getString("thumbnailUrl"); img != "" {
+			if img := getString("thumbnailUrl"); img != "" && (typeVal == "VideoObject" || info.Image == "") {
 				info.Image = img
-			} else if img := getString("image"); img != "" {
+			} else if img := getString("image"); img != "" && (typeVal == "VideoObject" || info.Image == "") {
 				info.Image = img
+			}
+
+			if kw := getString("keywords"); kw != "" {
+				parts := strings.Split(kw, ",")
+				for _, p := range parts {
+					p = strings.TrimSpace(p)
+					if p == "" {
+						continue
+					}
+					if info.Keywords == "" {
+						info.Keywords = p
+					} else {
+						existing := strings.Split(info.Keywords, ", ")
+						found := false
+						for _, e := range existing {
+							if e == p {
+								found = true
+								break
+							}
+						}
+						if !found {
+							info.Keywords += ", " + p
+						}
+					}
+				}
 			}
 		}
 	}

--- a/internal/opengraph/fetch_test.go
+++ b/internal/opengraph/fetch_test.go
@@ -14,6 +14,19 @@ func TestFetch(t *testing.T) {
 		wantInfo Info
 	}{
 		{
+			name: "Keywords meta",
+			html: `<html>
+				<head>
+					<meta name="keywords" content="podcast, science">
+					<meta property="article:tag" content="health">
+					<meta itemprop="keywords" content="health, autism">
+				</head>
+			</html>`,
+			wantInfo: Info{
+				Keywords: "podcast, science, health, autism",
+			},
+		},
+		{
 			name: "JSON-LD VideoObject",
 			html: `<html>
 				<script type="application/ld+json">
@@ -149,6 +162,9 @@ func TestFetch(t *testing.T) {
 			}
 			if info.Author != tt.wantInfo.Author {
 				t.Errorf("Author = %v, want %v", info.Author, tt.wantInfo.Author)
+			}
+			if info.Keywords != tt.wantInfo.Keywords {
+				t.Errorf("Keywords = %v, want %v", info.Keywords, tt.wantInfo.Keywords)
 			}
 		})
 	}
@@ -326,6 +342,9 @@ func TestParse(t *testing.T) {
 				}
 				if info.Author != tt.wantInfo.Author {
 					t.Errorf("Author = %v, want %v", info.Author, tt.wantInfo.Author)
+				}
+				if info.Keywords != tt.wantInfo.Keywords {
+					t.Errorf("Keywords = %v, want %v", info.Keywords, tt.wantInfo.Keywords)
 				}
 			}
 		})

--- a/internal/opengraph/fetch_test2.go
+++ b/internal/opengraph/fetch_test2.go
@@ -1,0 +1,17 @@
+package opengraph
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse_Keywords(t *testing.T) {
+	html := `<html><head>
+		<meta name="keywords" content="podcast, science, health, autism">
+	</head><body></body></html>`
+	info, err := Parse(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("Parse() err = %v", err)
+	}
+	t.Logf("Info: %+v", info)
+}


### PR DESCRIPTION
This change addresses the need to support extracting keywords and handling more generic fallbacks for descriptions (like Twitter tags and broader JSON-LD entity types) when parsing metadata for the social media graph representations. Tests have been expanded to verify the new keyword functionality and logic.

---
*PR created automatically by Jules for task [16166139110192374177](https://jules.google.com/task/16166139110192374177) started by @arran4*