### PR TITLE
Fix preview not assigning different colored boxes for quoteof targets

### DIFF
--- a/handlers/preview.go
+++ b/handlers/preview.go
@@ -2,9 +2,13 @@ package handlers
 
 import (
 	"fmt"
-	"github.com/arran4/goa4web/a4code/a4code2html"
+	"html/template"
 	"io"
 	"net/http"
+
+	"github.com/arran4/goa4web/a4code/a4code2html"
+	"github.com/arran4/goa4web/core/common"
+	"github.com/arran4/goa4web/core/consts"
 )
 
 func PreviewPage(w http.ResponseWriter, r *http.Request) {
@@ -21,12 +25,22 @@ func PreviewPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	conv := a4code2html.New()
-	conv.SetInput(string(body))
-
-	// Set headers for partial HTML content
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
+	if cd, ok := r.Context().Value(consts.KeyCoreData).(*common.CoreData); ok {
+		if fn, ok := cd.Funcs(r)["a4code2html"].(func(string) template.HTML); ok {
+			htmlOut := fn(string(body))
+			if _, err := fmt.Fprint(w, htmlOut); err != nil {
+				fmt.Printf("Error processing preview: %v\n", err)
+				http.Error(w, "Error processing preview", http.StatusInternalServerError)
+			}
+			return
+		}
+	}
+
+	// Fallback if CoreData or function is missing
+	conv := a4code2html.New()
+	conv.SetInput(string(body))
 	if _, err := io.Copy(w, conv.Process()); err != nil {
 		fmt.Printf("Error processing preview: %v\n", err)
 		http.Error(w, "Error processing preview", http.StatusInternalServerError)


### PR DESCRIPTION
Updates `handlers.PreviewPage` to extract the `a4code2html` function from `cd.Funcs(r)`, giving the preview parser access to the application's `UserColorMapper` and other contextual settings. This ensures `quoteof` targets get their distinct, hash-based colored boxes in previews just like in actual posts.

---
*PR created automatically by Jules for task [1275806765603122278](https://jules.google.com/task/1275806765603122278) started by @arran4*