### PR TITLE
Extract YouTube watch times and show on cards

### DIFF
--- a/core/common/link_provider.go
+++ b/core/common/link_provider.go
@@ -1,13 +1,64 @@
 package common
 
+
 import (
 	"context"
 	"fmt"
 	"html"
 	"strings"
+	"strconv"
+	"regexp"
 
 	"github.com/arran4/goa4web/a4code/a4code2html"
 )
+
+func formatDuration(duration string) string {
+	if duration == "" {
+		return ""
+	}
+
+	var totalSeconds int
+
+	if sec, err := strconv.Atoi(duration); err == nil {
+		totalSeconds = sec
+	} else if strings.HasPrefix(duration, "PT") {
+		re := regexp.MustCompile(`PT(?:([0-9]+)H)?(?:([0-9]+)M)?(?:([0-9]+)S)?`)
+		matches := re.FindStringSubmatch(duration)
+		if matches != nil {
+			if matches[1] != "" {
+				h, _ := strconv.Atoi(matches[1])
+				totalSeconds += h * 3600
+			}
+			if matches[2] != "" {
+				m, _ := strconv.Atoi(matches[2])
+				totalSeconds += m * 60
+			}
+			if matches[3] != "" {
+				s, _ := strconv.Atoi(matches[3])
+				totalSeconds += s
+			}
+		} else {
+            return duration
+        }
+	} else {
+		return duration
+	}
+
+	if totalSeconds == 0 {
+		return ""
+	}
+
+	h := totalSeconds / 3600
+	m := (totalSeconds % 3600) / 60
+	s := totalSeconds % 60
+
+	if h > 0 {
+		return fmt.Sprintf("%d:%02d:%02d", h, m, s)
+	}
+	return fmt.Sprintf("%d:%02d", m, s)
+}
+
+
 
 type Goa4WebLinkProvider struct {
 	cd  *CoreData
@@ -49,7 +100,7 @@ func (p *Goa4WebLinkProvider) RenderLink(rawURL string, isBlock bool, isImmediat
 		targetURL = p.cd.SignLinkURL(rawURL)
 	}
 
-	var title, description, imageURL, faviconURL string
+	var title, description, imageURL, faviconURL, duration string
 	var hasData bool
 
 	if p.cd.Queries() != nil {
@@ -59,6 +110,7 @@ func (p *Goa4WebLinkProvider) RenderLink(rawURL string, isBlock bool, isImmediat
 			title = link.CardTitle.String
 			description = link.CardDescription.String
 			imageURL = link.CardImage.String
+			duration = link.CardDuration.String
 			if link.CardImageCache.Valid && link.CardImageCache.String != "" {
 				imageURL = p.cd.MapImageURL("img", link.CardImageCache.String)
 			}
@@ -133,7 +185,16 @@ func (p *Goa4WebLinkProvider) RenderLink(rawURL string, isBlock bool, isImmediat
 	if imageURL != "" {
 		safeImg, imgOk := a4code2html.SanitizeURL(imageURL)
 		if imgOk {
-			imageHTML = fmt.Sprintf(`<img src="%s" class="external-link-image" />`, safeImg)
+			if duration != "" {
+				formattedDuration := formatDuration(duration)
+				if formattedDuration != "" {
+					imageHTML = fmt.Sprintf(`<div class="external-link-image-container"><img src="%s" class="external-link-image" /><span class="external-link-duration">%s</span></div>`, safeImg, html.EscapeString(formattedDuration))
+				} else {
+					imageHTML = fmt.Sprintf(`<img src="%s" class="external-link-image" />`, safeImg)
+				}
+			} else {
+				imageHTML = fmt.Sprintf(`<img src="%s" class="external-link-image" />`, safeImg)
+			}
 		}
 	}
 

--- a/core/common/link_provider_duration_test.go
+++ b/core/common/link_provider_duration_test.go
@@ -1,0 +1,77 @@
+package common
+
+import (
+	"testing"
+)
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration string
+		want     string
+	}{
+		{
+			name:     "empty duration",
+			duration: "",
+			want:     "",
+		},
+		{
+			name:     "raw seconds - minutes",
+			duration: "120",
+			want:     "2:00",
+		},
+		{
+			name:     "raw seconds - hours",
+			duration: "3665",
+			want:     "1:01:05",
+		},
+		{
+			name:     "ISO8601 - seconds only",
+			duration: "PT45S",
+			want:     "0:45",
+		},
+		{
+			name:     "ISO8601 - minutes only",
+			duration: "PT1M",
+			want:     "1:00",
+		},
+		{
+			name:     "ISO8601 - minutes and seconds",
+			duration: "PT2M3S",
+			want:     "2:03",
+		},
+		{
+			name:     "ISO8601 - hours, minutes and seconds",
+			duration: "PT1H2M3S",
+			want:     "1:02:03",
+		},
+		{
+			name:     "ISO8601 - hours only",
+			duration: "PT2H",
+			want:     "2:00:00",
+		},
+		{
+			name:     "invalid format",
+			duration: "invalid",
+			want:     "invalid",
+		},
+		{
+			name:     "zero seconds",
+			duration: "PT0S",
+			want:     "",
+		},
+		{
+			name:     "zero seconds raw",
+			duration: "0",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatDuration(tt.duration); got != tt.want {
+				t.Errorf("formatDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/templates/assets/main.css
+++ b/core/templates/assets/main.css
@@ -1261,13 +1261,33 @@ kbd {
     background-color: #f0f0f0;
 }
 
-.external-link-image {
+
+.external-link-image-container {
+    position: relative;
     width: 150px;
     height: 150px;
-    object-fit: cover;
     flex-shrink: 0;
+}
+
+.external-link-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
     background-color: #ccc;
 }
+
+.external-link-duration {
+    position: absolute;
+    bottom: 8px;
+    right: 8px;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: white;
+    padding: 2px 4px;
+    border-radius: 4px;
+    font-size: 0.8em;
+    font-weight: bold;
+}
+
 
 .external-link-content {
     padding: 1em;

--- a/internal/opengraph/fetch.go
+++ b/internal/opengraph/fetch.go
@@ -106,6 +106,31 @@ func Parse(r io.Reader) (*Info, error) {
 				if isLD && n.FirstChild != nil {
 					parseJSONLD(n.FirstChild.Data, info)
 				}
+
+				var scriptBody strings.Builder
+				for c := n.FirstChild; c != nil; c = c.NextSibling {
+					if c.Type == html.TextNode {
+						scriptBody.WriteString(c.Data)
+					}
+				}
+				if scriptStr := scriptBody.String(); scriptStr != "" {
+					if jsonText, ok := extractAssignedJSONObject(scriptStr, "ytInitialPlayerResponse"); ok {
+						var pr struct {
+							VideoDetails struct {
+								LengthSeconds string `json:"lengthSeconds"`
+								Title         string `json:"title"`
+							} `json:"videoDetails"`
+						}
+						if err := json.Unmarshal([]byte(jsonText), &pr); err == nil {
+							if pr.VideoDetails.LengthSeconds != "" && info.Duration == "" {
+								info.Duration = pr.VideoDetails.LengthSeconds
+							}
+							if pr.VideoDetails.Title != "" && info.Title == "" {
+								info.Title = pr.VideoDetails.Title
+							}
+						}
+					}
+				}
 			} else if n.Data == "meta" {
 				var prop, content, name, itemprop string
 				for _, a := range n.Attr {
@@ -324,4 +349,76 @@ func parseJSONLD(data string, info *Info) {
 			}
 		}
 	}
+}
+
+func extractAssignedJSONObject(script string, variableName string) (string, bool) {
+	pos := strings.Index(script, variableName)
+	if pos < 0 {
+		return "", false
+	}
+
+	eq := strings.IndexByte(script[pos:], '=')
+	if eq < 0 {
+		return "", false
+	}
+
+	startSearch := pos + eq + 1
+
+	start := strings.IndexByte(script[startSearch:], '{')
+	if start < 0 {
+		return "", false
+	}
+
+	start += startSearch
+
+	end, ok := findMatchingJSONBrace(script, start)
+	if !ok {
+		return "", false
+	}
+
+	return script[start : end+1], true
+}
+
+func findMatchingJSONBrace(s string, start int) (int, bool) {
+	if start < 0 || start >= len(s) || s[start] != '{' {
+		return 0, false
+	}
+
+	depth := 0
+	inString := false
+	escaped := false
+
+	for i := start; i < len(s); i++ {
+		ch := s[i]
+
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+
+			switch ch {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+
+			continue
+		}
+
+		switch ch {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i, true
+			}
+		}
+	}
+
+	return 0, false
 }


### PR DESCRIPTION
Adds support for extracting YouTube video durations during OpenGraph fetching by parsing the `ytInitialPlayerResponse` JSON blob and displaying the formatted duration on Link Cards.

---
*PR created automatically by Jules for task [13860761542438627348](https://jules.google.com/task/13860761542438627348) started by @arran4*